### PR TITLE
fix(aimock): add HITL 1:1-with-Alice fixture before broad Alice match

### DIFF
--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -653,8 +653,15 @@
     },
     {
       "match": {
-        "userMessage": "Please book an intro call with the sales team to discuss pricing.",
-        "hasToolResult": false
+        "toolCallId": "call_hitl_book_intro_sales_001"
+      },
+      "response": {
+        "content": "Booked the intro call with the sales team for the time you selected — calendar invite is on its way."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Please book an intro call with the sales team to discuss pricing."
       },
       "response": {
         "toolCalls": [
@@ -668,17 +675,15 @@
     },
     {
       "match": {
-        "userMessage": "Please book an intro call with the sales team to discuss pricing.",
-        "hasToolResult": true
+        "toolCallId": "call_hitl_book_1on1_alice_001"
       },
       "response": {
-        "content": "Booked the intro call with the sales team for the time you selected — calendar invite is on its way."
+        "content": "Booked the 1:1 with Alice for the time you selected — calendar invite is on its way."
       }
     },
     {
       "match": {
-        "userMessage": "Schedule a 1:1 with Alice next week to review Q2 goals.",
-        "hasToolResult": false
+        "userMessage": "Schedule a 1:1 with Alice next week to review Q2 goals."
       },
       "response": {
         "toolCalls": [
@@ -688,15 +693,6 @@
             "arguments": "{\"topic\":\"1:1 with Alice — review Q2 goals\",\"attendee\":\"Alice\"}"
           }
         ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Schedule a 1:1 with Alice next week to review Q2 goals.",
-        "hasToolResult": true
-      },
-      "response": {
-        "content": "Booked the 1:1 with Alice for the time you selected — calendar invite is on its way."
       }
     },
     {

--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -653,6 +653,30 @@
     },
     {
       "match": {
+        "userMessage": "Schedule a 1:1 with Alice next week to review Q2 goals.",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_hitl_book_1on1_alice_001",
+            "name": "book_call",
+            "arguments": "{\"topic\":\"1:1 with Alice — review Q2 goals\",\"attendee\":\"Alice\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Schedule a 1:1 with Alice next week to review Q2 goals.",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Booked the 1:1 with Alice for the time you selected — calendar invite is on its way."
+      }
+    },
+    {
+      "match": {
         "userMessage": "alice"
       },
       "response": {

--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -653,6 +653,30 @@
     },
     {
       "match": {
+        "userMessage": "Please book an intro call with the sales team to discuss pricing.",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_hitl_book_intro_sales_001",
+            "name": "book_call",
+            "arguments": "{\"topic\":\"Intro call — discuss pricing\",\"attendee\":\"Sales team\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Please book an intro call with the sales team to discuss pricing.",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Booked the intro call with the sales team for the time you selected — calendar invite is on its way."
+      }
+    },
+    {
+      "match": {
         "userMessage": "Schedule a 1:1 with Alice next week to review Q2 goals.",
         "hasToolResult": false
       },

--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -661,7 +661,8 @@
     },
     {
       "match": {
-        "userMessage": "Please book an intro call with the sales team to discuss pricing."
+        "userMessage": "Please book an intro call with the sales team to discuss pricing.",
+        "toolName": "book_call"
       },
       "response": {
         "toolCalls": [
@@ -683,7 +684,8 @@
     },
     {
       "match": {
-        "userMessage": "Schedule a 1:1 with Alice next week to review Q2 goals."
+        "userMessage": "Schedule a 1:1 with Alice next week to review Q2 goals.",
+        "toolName": "book_call"
       },
       "response": {
         "toolCalls": [

--- a/showcase/integrations/ag2/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/ag2/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/ag2/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/ag2/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/agno/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/agno/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/agno/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/agno/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/claude-sdk-python/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/claude-sdk-python/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/claude-sdk-python/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/claude-sdk-python/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/claude-sdk-typescript/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/claude-sdk-typescript/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/claude-sdk-typescript/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/claude-sdk-typescript/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/crewai-crews/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/crewai-crews/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/crewai-crews/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/crewai-crews/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/google-adk/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/google-adk/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/langgraph-fastapi/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/langgraph-fastapi/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/langgraph-fastapi/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/langgraph-fastapi/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/langgraph-python/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/langgraph-python/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/hitl-in-chat.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("HITL in chat — booking flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/hitl-in-chat");
+  });
+
+  test("page loads with chat input", async ({ page }) => {
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+  });
+
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
+
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
+  });
+
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
+
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+});

--- a/showcase/integrations/langgraph-python/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/hitl-in-chat.spec.ts
@@ -64,4 +64,37 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/langgraph-typescript/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/langgraph-typescript/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/langroid/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/langroid/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/langroid/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/langroid/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/llamaindex/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/llamaindex/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/llamaindex/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/llamaindex/tests/e2e/hitl-in-chat.spec.ts
@@ -1,21 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("HITL In-Chat (useHumanInTheLoop)", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/demos/hitl-in-chat");
   });
 
-  test("page loads with chat input and suggestions", async ({ page }) => {
+  test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("meeting request renders TimePickerCard inline", async ({ page }) => {
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Please book an intro call with the sales team");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
+
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
+  });
+
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
+
+    // The picked-state card replaces the slot grid.
     await expect(
-      page.locator('[data-testid="time-picker-card"]').first(),
-    ).toBeVisible({ timeout: 45000 });
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/mastra/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/mastra/tests/e2e/hitl-in-chat.spec.ts
@@ -1,8 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("HITL In-Chat (useHumanInTheLoop)", () => {
-  test("chat input is visible", async ({ page }) => {
+test.describe("HITL in chat — booking flow", () => {
+  test.beforeEach(async ({ page }) => {
     await page.goto("/demos/hitl-in-chat");
+  });
+
+  test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+  });
+
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
+
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
+  });
+
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
+
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/mastra/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/mastra/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/ms-agent-dotnet/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/ms-agent-dotnet/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/ms-agent-dotnet/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/ms-agent-dotnet/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/ms-agent-python/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/ms-agent-python/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/ms-agent-python/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/ms-agent-python/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/pydantic-ai/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/pydantic-ai/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/pydantic-ai/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/pydantic-ai/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/spring-ai/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/spring-ai/tests/e2e/hitl-in-chat.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("In-Chat HITL", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/demos/hitl-in-chat");
   });
@@ -9,15 +9,92 @@ test.describe("In-Chat HITL", () => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
+
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
+  });
+
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
+
+    // The picked-state card replaces the slot grid.
     await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/spring-ai/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/spring-ai/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });

--- a/showcase/integrations/strands/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/strands/tests/e2e/hitl-in-chat.spec.ts
@@ -1,89 +1,100 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("Human in the Loop", () => {
+test.describe("HITL in chat — booking flow", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/demos/hitl");
+    await page.goto("/demos/hitl-in-chat");
   });
 
   test("page loads with chat input", async ({ page }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(
-      page.locator(".copilotKitAssistantMessage").first(),
-    ).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("task request shows step selector with checkboxes", async ({ page }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a plan with steps to organize a team offsite event",
-    );
-    await input.press("Enter");
-
-    // The HITL demo surfaces a single StepSelector card regardless of whether the
-    // underlying flow is an interrupt hook or a frontend HITL tool — assert on that.
-    const stepSelector = page.locator('[data-testid="select-steps"]');
-    await expect(stepSelector.first()).toBeVisible({ timeout: 60000 });
-
-    // Should have at least one step item with a checkbox
-    const stepItems = page.locator('[data-testid="step-item"]');
-    await expect(stepItems.first()).toBeVisible({ timeout: 5000 });
-
-    // Each step should have a checkbox input
-    const checkbox = stepItems.first().locator('input[type="checkbox"]');
-    await expect(checkbox).toBeVisible();
-
-    // Each step should have descriptive text
-    const stepText = stepItems.first().locator('[data-testid="step-text"]');
-    await expect(stepText).not.toBeEmpty();
-  });
-
-  test("step selector shows enabled count and has action button", async ({
+  // Regression: the broad `userMessage: "Alice"` fixture in
+  // showcase/aimock/feature-parity.json was intercepting this suggestion and
+  // returning a generic "Nice to meet you, Alice! ... Tokyo" greeting, so the
+  // book_call HITL flow never fired. The fixture pair added in the same PR
+  // as this test (full-sentence userMessage match, ordered before the broad
+  // Alice match) routes the suggestion to a `book_call` toolCall, which is
+  // what makes the time-picker card render.
+  test("'Schedule a 1:1 with Alice' suggestion renders the time-picker", async ({
     page,
   }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan the steps to write a quarterly report");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    const stepSelector = page.locator('[data-testid="select-steps"]').first();
-    await expect(stepSelector).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a count indicator (e.g., "3/3 selected")
-    await expect(stepSelector.getByText(/\d+\/\d+\s*selected/)).toBeVisible();
+    // The Tokyo greeting starts with "Nice to meet you, Alice" — if any
+    // assistant message contains that, the broad Alice fixture won and the
+    // fix has regressed.
+    await expect(page.getByText(/Nice to meet you, Alice/i)).toHaveCount(0);
 
-    // Should have either a "Perform Steps" button (interrupt) or Confirm/Reject buttons (HITL)
-    const actionButton = stepSelector.locator("button").first();
-    await expect(actionButton).toBeVisible();
+    // The card should advertise the booking and the attendee parsed by the
+    // fixture's toolCall arguments.
+    await expect(card.getByText(/With Alice/i)).toBeVisible();
+
+    // At least one selectable time slot is present.
+    const slots = page.locator('[data-testid="time-picker-slot"]');
+    expect(await slots.count()).toBeGreaterThan(0);
   });
 
-  test("can approve a step selection and agent continues", async ({ page }) => {
+  test("picking a time slot resolves the HITL with a confirmation", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Plan a trip to mars in 5 steps");
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
     await input.press("Enter");
 
-    // Wait for step selector
-    const selector = page.locator('[data-testid="select-steps"]');
-    await expect(selector).toBeVisible({ timeout: 60000 });
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await expect(slot).toBeVisible({ timeout: 60000 });
+    await slot.click();
 
-    // Find and click the action button (Perform Steps / Confirm)
-    const actionBtn = page.locator(
-      'button:has-text("Perform"), button:has-text("Confirm")',
+    // The picked-state card replaces the slot grid.
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Agent's follow-up confirmation arrives next.
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  // The other suggestion in the demo. Same HITL flow, different
+  // attendee/topic. Pinned here so a missing/regressed aimock fixture for
+  // this suggestion (or a wiring regression in this integration's
+  // useHumanInTheLoop binding) fails CI loudly instead of silently falling
+  // through to "the agent rambled at me with no toolCall."
+  test("'Book a call with sales' suggestion runs the HITL flow end-to-end", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
     );
-    await expect(actionBtn.first()).toBeVisible({ timeout: 5000 });
-    await actionBtn.first().click();
+    await input.press("Enter");
 
-    // After approval, the step selector's action button should disappear
-    // (StepSelector unmounts after onConfirm; StepsFeedback replaces buttons with
-    // the "Accepted" or "Rejected" banner). Assert on a post-click transition
-    // that does NOT match the pre-click "N/N selected" counter text.
-    await expect(actionBtn.first()).not.toBeVisible({ timeout: 10000 });
+    const card = page.locator('[data-testid="time-picker-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
+    await expect(card.getByText(/Sales team/i)).toBeVisible();
+
+    const slot = page.locator('[data-testid="time-picker-slot"]').first();
+    await slot.click();
+
+    await expect(
+      page.locator('[data-testid="time-picker-picked"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/strands/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/strands/tests/e2e/hitl-in-chat.spec.ts
@@ -97,4 +97,56 @@ test.describe("HITL in chat — booking flow", () => {
         .first(),
     ).toBeVisible({ timeout: 30000 });
   });
+
+  // Regression: the second booking flow in a single chat session used to
+  // skip the picker entirely and jump straight to "Booked ..." text. Cause
+  // was the aimock confirmation fixture being keyed on `hasToolResult: true`
+  // — once the first flow finished, the conversation had a tool message in
+  // history, so on the second user message the confirmation fixture matched
+  // before the toolCall fixture (which required `hasToolResult: false`) had
+  // a chance to fire. Fix re-keyed confirmation fixtures on `toolCallId`
+  // (matches only when the LAST message is a tool result with that id) and
+  // dropped the `hasToolResult: false` constraint on the toolCall fixtures.
+  // This test explicitly walks both flows in one page session — if the
+  // multi-flow regression returns, the second time-picker never renders and
+  // this test fails at step 2.
+  test("both suggestions render the picker when run back-to-back without refresh", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const card = page.locator('[data-testid="time-picker-card"]');
+
+    // Flow 1: Alice
+    await input.fill("Schedule a 1:1 with Alice next week to review Q2 goals.");
+    await input.press("Enter");
+    await expect(card.first()).toBeVisible({ timeout: 60000 });
+    await page.locator('[data-testid="time-picker-slot"]').first().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*Alice/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // Flow 2: sales — same page, no refresh.
+    await input.fill(
+      "Please book an intro call with the sales team to discuss pricing.",
+    );
+    await input.press("Enter");
+
+    // A SECOND picker card must appear. If the regression returns, no new
+    // card renders and the agent jumps straight to confirmation text.
+    await expect(card).toHaveCount(2, { timeout: 60000 });
+    await expect(card.last().getByText(/Sales team/i)).toBeVisible();
+
+    // Pick a slot in the new card and verify the sales-specific
+    // confirmation arrives.
+    await page.locator('[data-testid="time-picker-slot"]').last().click();
+    await expect(
+      page
+        .locator('[data-role="assistant"]')
+        .filter({ hasText: /Booked.*sales team/i })
+        .first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
 });


### PR DESCRIPTION
## Summary

The hitl-in-chat demo's **"Schedule a 1:1 with Alice next week to review Q2 goals."** suggestion was being intercepted by the broad `userMessage: "Alice"` matcher used by the memory/context demo, which returns a generic "Nice to meet you, Alice! I see you're in Tokyo — wonderful city..." greeting. The HITL flow never fired and the user saw a nonsensical reply.

Aimock's matcher uses `text.includes(match.userMessage)` (substring) + first-fixture-wins by file order, so any message containing "Alice" hijacked the suggestion before the HITL flow could trigger.

## Fix

Added a fixture pair earlier in `showcase/aimock/feature-parity.json` with the **full suggestion sentence** as the matcher:

- `hasToolResult: false` → returns a `book_call` toolCall, letting the frontend `useHumanInTheLoop` render the time-picker.
- `hasToolResult: true` → returns the booking confirmation message.

The substring-match-on-full-sentence is effectively exact — no other realistic user message will contain that whole sentence — so the broad `Alice` / `alice` fixtures stay scoped to the memory demo where the user actually says "I'm Alice" or similar.

## Test plan

- [ ] Click "Schedule a 1:1 with Alice next week to review Q2 goals." in the langgraph-python hitl-in-chat demo against an aimock-backed deployment → expect the time-picker card to render and a booking confirmation after picking a slot.
- [ ] The memory/context demo (where users type "I'm Alice") still gets the Tokyo greeting — broad fixtures unchanged.
- [x] Pre-commit hooks pass (test, check-packages, commitlint).