### PR TITLE
fix(showcase): drop hardcoded white chat background that broke dark mode

### DIFF
--- a/showcase/STYLING-GUIDE.md
+++ b/showcase/STYLING-GUIDE.md
@@ -47,11 +47,12 @@ CopilotKit v2 components use `cpk:` prefixed Tailwind classes internally. To ove
   border-radius: 0.75rem;
   border: 1px solid var(--copilot-kit-separator-color) !important;
 }
-
-.copilotKitChat {
-  background-color: #fff !important;
-}
 ```
+
+> Do NOT hardcode `.copilotKitChat { background-color: #fff !important; }` in
+> these overrides. It overrides demo-level theming (e.g. beautiful-chat's dark
+> mode toggle) and forces white in every theme. Let the v2 styles + per-demo
+> `ThemeProvider` handle chat backgrounds.
 
 ```tsx
 // layout.tsx

--- a/showcase/integrations/built-in-agent/src/app/copilotkit-overrides.css
+++ b/showcase/integrations/built-in-agent/src/app/copilotkit-overrides.css
@@ -7,7 +7,3 @@
   border-top-right-radius: 0.75rem;
   border: 1px solid var(--copilot-kit-separator-color) !important;
 }
-
-.copilotKitChat {
-  background-color: #fff !important;
-}

--- a/showcase/integrations/langgraph-python/src/app/copilotkit-overrides.css
+++ b/showcase/integrations/langgraph-python/src/app/copilotkit-overrides.css
@@ -4,7 +4,3 @@
   border-radius: 0.75rem;
   border: 1px solid var(--copilot-kit-separator-color) !important;
 }
-
-.copilotKitChat {
-  background-color: #fff !important;
-}

--- a/showcase/integrations/langgraph-typescript/src/app/copilotkit-overrides.css
+++ b/showcase/integrations/langgraph-typescript/src/app/copilotkit-overrides.css
@@ -7,7 +7,3 @@
   border-top-right-radius: 0.75rem;
   border: 1px solid var(--copilot-kit-separator-color) !important;
 }
-
-.copilotKitChat {
-  background-color: #fff !important;
-}

--- a/showcase/integrations/mastra/src/app/copilotkit-overrides.css
+++ b/showcase/integrations/mastra/src/app/copilotkit-overrides.css
@@ -7,7 +7,3 @@
   border-top-right-radius: 0.75rem;
   border: 1px solid var(--copilot-kit-separator-color) !important;
 }
-
-.copilotKitChat {
-  background-color: #fff !important;
-}

--- a/showcase/shared/starter-template/app/copilotkit-overrides.css
+++ b/showcase/shared/starter-template/app/copilotkit-overrides.css
@@ -4,7 +4,3 @@
   border-radius: 0.75rem;
   border: 1px solid var(--copilot-kit-separator-color) !important;
 }
-
-.copilotKitChat {
-  background-color: #fff !important;
-}


### PR DESCRIPTION
## Summary

- `showcase/integrations/{langgraph-python,langgraph-typescript,mastra,built-in-agent}/src/app/copilotkit-overrides.css` (and the starter template that seeds new integrations) all forced `.copilotKitChat { background-color: #fff !important; }`. The `!important` won over the per-demo `ThemeProvider`, so the `beautiful-chat` demo rendered a white chat panel in dark mode.
- `langgraph-fastapi` has no overrides file and was already correct — this PR brings the other four to parity by deleting just the offending rule (the `.copilotKitInput` border styles are kept).
- Updated `showcase/STYLING-GUIDE.md` with a warning so the example block doesn't get pasted back in.

## Test plan

- [ ] Open `/demos/beautiful-chat` in `langgraph-python` with the OS in dark mode — chat background follows the dark theme (no white panel).
- [ ] Same check for `langgraph-typescript`, `mastra`, and `built-in-agent`.
- [ ] `langgraph-fastapi` unchanged (regression check on the working baseline).
- [ ] Light mode in all four still renders correctly (chat picks up the v2 light tokens).