### PR TITLE
fix(showcase): unbreak D5 voice for langgraph-typescript and langroid

### DIFF
--- a/showcase/integrations/langgraph-typescript/src/agent/package-lock.json
+++ b/showcase/integrations/langgraph-typescript/src/agent/package-lock.json
@@ -8,20 +8,176 @@
       "name": "langgraph-typescript-agent",
       "version": "0.0.1",
       "dependencies": {
-        "@copilotkit/sdk-js": "1.51.4",
-        "@langchain/core": "^1.0.1",
-        "@langchain/langgraph": "1.0.2",
+        "@copilotkit/sdk-js": "1.56.5",
+        "@langchain/core": "1.1.41",
+        "@langchain/langgraph": "1.2.9",
         "@langchain/langgraph-api": "1.1.17",
         "@langchain/langgraph-checkpoint": "1.0.0",
-        "@langchain/langgraph-sdk": "^1.6.5",
-        "@langchain/openai": "^1.1.3",
-        "langchain": "^1.3.3",
+        "@langchain/langgraph-sdk": "1.6.5",
+        "@langchain/openai": "1.4.4",
+        "langchain": "1.3.4",
         "tsx": "^4.19.3",
         "typescript": "^5.6.3",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/node": "^22.9.0"
+      }
+    },
+    "node_modules/@ag-ui/client": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
+      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.53",
+        "@ag-ui/encoder": "0.0.53",
+        "@ag-ui/proto": "0.0.53",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/client/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@ag-ui/core": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.53.tgz",
+      "integrity": "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/encoder": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.53.tgz",
+      "integrity": "sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.53",
+        "@ag-ui/proto": "0.0.53"
+      }
+    },
+    "node_modules/@ag-ui/langgraph": {
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.31.tgz",
+      "integrity": "sha512-mK24pfQZiV5SlnDLhTka+873gw7QQOAWXqqDSnwkuyoQQQFX7KC8xZR+4Da2dWqyVhbhNPx+amE16X7twS1wcg==",
+      "dependencies": {
+        "@langchain/core": "^1.1.40",
+        "@langchain/langgraph-sdk": "^1.8.8",
+        "langchain": ">=1.2.0",
+        "partial-json": "^0.1.7",
+        "rxjs": "7.8.1"
+      },
+      "peerDependencies": {
+        "@ag-ui/client": ">=0.0.42",
+        "@ag-ui/core": ">=0.0.42"
+      }
+    },
+    "node_modules/@ag-ui/langgraph/node_modules/@langchain/langgraph-sdk": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.10.tgz",
+      "integrity": "sha512-wrB3rkRw5KAmsqezwvKP3midT4qJrV6Hj9XJMYo+cbvXC4HYpSAmyY/VriSyeTFRbLG/OP/pY2Yz+9Z54nSaXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1",
+        "uuid": "^13.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ag-ui/langgraph/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/@ag-ui/langgraph/node_modules/p-queue": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
+      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ag-ui/langgraph/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ag-ui/langgraph/node_modules/uuid": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@ag-ui/proto": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.53.tgz",
+      "integrity": "sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.53",
+        "@bufbuild/protobuf": "^2.2.5",
+        "@protobuf-ts/protoc": "^2.11.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -59,6 +215,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
@@ -83,16 +245,21 @@
         "commander": "~13.1.0"
       }
     },
+    "node_modules/@copilotkit/license-verifier": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.2.0.tgz",
+      "integrity": "sha512-hliCifqy5a65YTozgRckuQmvBEQlt4L2PhbpSDY6fb/TKqPHyNDJgItRSnOpxOVDqvEfHEbUUqw3NaD88ZtdJA=="
+    },
     "node_modules/@copilotkit/sdk-js": {
-      "version": "1.51.4",
-      "resolved": "https://registry.npmjs.org/@copilotkit/sdk-js/-/sdk-js-1.51.4.tgz",
-      "integrity": "sha512-GTwN0nsdUww5lZzWSS2haSSqdrKqZZbIxp3V+sAOfIEVTMJY552At1XmoOpLz+UiRbv9Mk21UJ5yghlFOIHh0g==",
+      "version": "1.56.5",
+      "resolved": "https://registry.npmjs.org/@copilotkit/sdk-js/-/sdk-js-1.56.5.tgz",
+      "integrity": "sha512-v4jZdZaiRVH+xtJYBSjltiTWih6JKgG0Gk2ospxxrHLDKEGcwvm+GtQIpwf0Arb5nqFa5OnxV62EPC70IXRAdg==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "1.51.4"
+        "@ag-ui/langgraph": "0.0.31",
+        "@copilotkit/shared": "1.56.5"
       },
       "peerDependencies": {
-        "@langchain/community": "^0.3.58",
         "@langchain/core": ">=0.4.0 <2.0.0",
         "@langchain/langgraph": ">=0.4.0 <2.0.0",
         "langchain": ">=1.0.0",
@@ -101,19 +268,37 @@
       }
     },
     "node_modules/@copilotkit/shared": {
-      "version": "1.51.4",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.51.4.tgz",
-      "integrity": "sha512-njIHsNGeH1AtrLBnqTup3GwGyBosg3VQEmAnxEs6JVNkvVfWxJO9OfVziPBnwZT5cXnMFkpo8zhfT5WSKllXLQ==",
+      "version": "1.56.5",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.56.5.tgz",
+      "integrity": "sha512-jK2iEa+jRgWYXOw/v09RaU9txX5wNAYIrGl/SO405uzbC5mi0cYgXhJ3PC+VjNM7rlH//LRqa0+ELJO0UBwfPA==",
       "license": "MIT",
       "dependencies": {
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/license-verifier": "0.2.0",
         "@segment/analytics-node": "^2.1.2",
+        "@standard-schema/spec": "^1.0.0",
         "chalk": "4.1.2",
         "graphql": "^16.8.1",
-        "uuid": "^10.0.0",
-        "zod": "^3.23.3"
+        "partial-json": "^0.1.7",
+        "uuid": "^11.1.0",
+        "zod": "^3.23.3",
+        "zod-to-json-schema": "^3.23.5"
       },
       "peerDependencies": {
-        "@ag-ui/core": "^0.0.43"
+        "@ag-ui/core": ">=0.0.48"
+      }
+    },
+    "node_modules/@copilotkit/shared/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -611,9 +796,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.40",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.40.tgz",
-      "integrity": "sha512-RJ41GQEMxr9ZEZNoIiPgW0+v9nAY6FEZGlk+MjBghr2GR8He50abLam0XCe1aqUJjuKbqt2lUD6M+6SZ+2NIJg==",
+      "version": "1.1.41",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
+      "integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -646,21 +831,22 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.0.2.tgz",
-      "integrity": "sha512-syxzzWTnmpCL+RhUEvalUeOXFoZy/KkzHa2Da2gKf18zsf9Dkbh3rfnRDrTyUGS1XSTejq07s4rg1qntdEDs2A==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.9.tgz",
+      "integrity": "sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.0",
-        "@langchain/langgraph-sdk": "~1.0.0",
+        "@langchain/langgraph-checkpoint": "^1.0.1",
+        "@langchain/langgraph-sdk": "~1.8.9",
+        "@standard-schema/spec": "1.1.0",
         "uuid": "^10.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.0.1",
-        "zod": "^3.25.32 || ^4.1.0",
+        "@langchain/core": "^1.1.40",
+        "zod": "^3.25.32 || ^4.2.0",
         "zod-to-json-schema": "^3.x"
       },
       "peerDependenciesMeta": {
@@ -728,9 +914,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.9.tgz",
-      "integrity": "sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.6.5.tgz",
+      "integrity": "sha512-JjprmbhgCnoNJ9DUKcvrEU+C9FfKsNGyT3ooqWxAY5Cx2qofhXmDJOpTCqqbxfDHPKG0RjTs5HgVK3WW5M6Big==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.15",
@@ -741,9 +927,7 @@
       "peerDependencies": {
         "@langchain/core": "^1.1.16",
         "react": "^18 || ^19",
-        "react-dom": "^18 || ^19",
-        "svelte": "^4.0.0 || ^5.0.0",
-        "vue": "^3.0.0"
+        "react-dom": "^18 || ^19"
       },
       "peerDependenciesMeta": {
         "@langchain/core": {
@@ -753,12 +937,6 @@
           "optional": true
         },
         "react-dom": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
           "optional": true
         }
       }
@@ -829,20 +1007,38 @@
         "node": "^18.19.0 || >=20.16.0"
       }
     },
-    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.0.3.tgz",
-      "integrity": "sha512-6M4i0XsVO5Eb2vv/3OtIPHW3UqO4zYyXl6AOfS0Jf6d7JiWiSXqzLN8UoS0hpu1ItkcW1j575CRiP/6jn6XXFg==",
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
+      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
       "license": "MIT",
       "dependencies": {
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^9.0.0"
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.0.1",
+        "@langchain/core": "^1.0.1"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.10.tgz",
+      "integrity": "sha512-wrB3rkRw5KAmsqezwvKP3midT4qJrV6Hj9XJMYo+cbvXC4HYpSAmyY/VriSyeTFRbLG/OP/pY2Yz+9Z54nSaXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1",
+        "uuid": "^13.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
         "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "@langchain/core": {
@@ -853,33 +1049,60 @@
         },
         "react-dom": {
           "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
         }
       }
     },
     "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
-    "node_modules/@langchain/langgraph/node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+    "node_modules/@langchain/langgraph/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/langgraph/node_modules/p-queue": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
+      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
       "license": "MIT",
       "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@langchain/openai": {
@@ -918,6 +1141,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@protobuf-ts/protoc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.11.1.tgz",
+      "integrity": "sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "protoc": "protoc.js"
       }
     },
     "node_modules/@segment/analytics-core": {
@@ -1100,9 +1332,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1118,9 +1347,6 @@
       "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1138,9 +1364,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1156,9 +1379,6 @@
       "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1197,6 +1417,64 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
@@ -1259,16 +1537,16 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
-    },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@typescript/vfs": {
@@ -1586,6 +1864,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
     "node_modules/copy-anything": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
@@ -1827,6 +2111,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
     },
     "node_modules/fecha": {
       "version": "4.2.3",
@@ -2083,12 +2373,12 @@
       "license": "MIT"
     },
     "node_modules/langchain": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.3.3.tgz",
-      "integrity": "sha512-X6RgeeAmr6pve/s7EHPAx2CIyqyDWt//VBp9Sd8k2Bpr+p/NWFGAg+WoeknAbwUaDMWgSn2OLM8kGPdPQr+MRw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.3.4.tgz",
+      "integrity": "sha512-umrD+ZC6vr0Q0U1lC5PoIMMQqgnP+7QhaIdAXCeZiSX2GPVBiVR7Ed2ZR+3MPvz1yWrRtIm17wPaovkND+wOXg==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph": "^1.2.8",
+        "@langchain/langgraph": "^1.2.9",
         "@langchain/langgraph-checkpoint": "^1.0.1",
         "langsmith": ">=0.5.0 <1.0.0",
         "uuid": "^11.1.0",
@@ -2098,32 +2388,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.40"
-      }
-    },
-    "node_modules/langchain/node_modules/@langchain/langgraph": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.9.tgz",
-      "integrity": "sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.1",
-        "@langchain/langgraph-sdk": "~1.8.9",
-        "@standard-schema/spec": "1.1.0",
-        "uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@langchain/core": "^1.1.40",
-        "zod": "^3.25.32 || ^4.2.0",
-        "zod-to-json-schema": "^3.x"
-      },
-      "peerDependenciesMeta": {
-        "zod-to-json-schema": {
-          "optional": true
-        }
+        "@langchain/core": "^1.1.41"
       }
     },
     "node_modules/langchain/node_modules/@langchain/langgraph-checkpoint": {
@@ -2142,19 +2407,6 @@
       }
     },
     "node_modules/langchain/node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/langchain/node_modules/@langchain/langgraph/node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
@@ -2350,9 +2602,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2372,9 +2621,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2396,9 +2642,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2418,9 +2661,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2675,6 +2915,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2829,15 +3075,6 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -2848,6 +3085,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -3511,6 +3757,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/untruncate-json": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/untruncate-json/-/untruncate-json-0.0.1.tgz",
+      "integrity": "sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3645,6 +3897,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-voice/[[...slug]]/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-voice/[[...slug]]/route.ts
@@ -40,7 +40,11 @@ const LANGGRAPH_URL =
 
 const voiceDemoAgent = new LangGraphAgent({
   deploymentUrl: `${LANGGRAPH_URL}/`,
-  graphId: "sample_agent",
+  // server.mjs registers the chat graph under "starterAgent" (matching the
+  // main copilotkit/route.ts default). The langgraph.json file lists
+  // sample_agent as an alias but the runtime server only registers
+  // starterAgent, so the voice route must use the same name.
+  graphId: "starterAgent",
 });
 
 /**

--- a/showcase/integrations/langroid/src/agent_server.py
+++ b/showcase/integrations/langroid/src/agent_server.py
@@ -59,6 +59,18 @@ async def run_agent(request: Request):
     return await handle_run(request)
 
 
+@app.post("/voice")
+async def run_voice(request: Request):
+    """Voice demo endpoint — chat without tools.
+
+    The /demos/voice page does not register frontend tools; if the LLM
+    returns a tool call, the run finishes with no text and the assistant
+    message lands empty. Disable tools for this endpoint so aimock's
+    text-only fallback fixture is matched and we get a direct answer.
+    """
+    return await handle_run(request, disable_tools=True)
+
+
 # Per-demo endpoints for cells that need state-aware behavior the unified
 # agent does not provide. Each handler implements its own AG-UI SSE
 # pipeline (RUN_STARTED / STATE_SNAPSHOT / TEXT_* / TOOL_CALL_* / RUN_FINISHED)

--- a/showcase/integrations/langroid/src/agents/agui_adapter.py
+++ b/showcase/integrations/langroid/src/agents/agui_adapter.py
@@ -465,8 +465,16 @@ async def _call_openai(
     return response.choices[0].message
 
 
-async def handle_run(request: Request) -> StreamingResponse:
-    """Handle an AG-UI /run endpoint — parse input, run agent, stream events."""
+async def handle_run(
+    request: Request, *, disable_tools: bool = False
+) -> StreamingResponse:
+    """Handle an AG-UI /run endpoint — parse input, run agent, stream events.
+
+    When ``disable_tools`` is True, the OpenAI call omits tool definitions.
+    Used by the /voice demo so aimock's tool-free fallback fixture is matched
+    (returning a direct text answer) instead of a tool-call response that
+    the frontend would not execute.
+    """
     # Parse request body defensively. A malformed body (bad JSON, missing
     # required fields, wrong types) previously propagated up as a raw
     # FastAPI 422/500 with no correlation id — hard to match back to a
@@ -529,7 +537,7 @@ async def handle_run(request: Request) -> StreamingResponse:
         run_input.messages or [], system_prompt
     )
     model = os.getenv("LANGROID_MODEL", "gpt-4.1")
-    oai_tools = _get_openai_tools()
+    oai_tools = [] if disable_tools else _get_openai_tools()
 
     # Compute the effective thread_id ONCE so every event emitted for this
     # run (RUN_STARTED, RUN_FINISHED, ...) references the same thread.

--- a/showcase/integrations/langroid/src/app/api/copilotkit-voice/[[...slug]]/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-voice/[[...slug]]/route.ts
@@ -34,7 +34,10 @@ import OpenAI from "openai";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
-const voiceDemoAgent = new HttpAgent({ url: `${AGENT_URL}/` });
+// Point at the tool-free /voice endpoint so aimock returns a direct text
+// answer instead of a tool call that the frontend cannot execute (the voice
+// page does not register any frontend tools).
+const voiceDemoAgent = new HttpAgent({ url: `${AGENT_URL}/voice/` });
 
 /**
  * Transcription service wrapper that reports a clean, typed auth error when


### PR DESCRIPTION
## Summary

Brings 2 of the 5 red D5 voice probes to green and verifies the other 3 already pass locally.

- **langgraph-typescript**: voice route used `graphId: \"sample_agent\"` but `server.mjs` only registers `starterAgent`. `langgraph.json` listed both as aliases of the same graph, but the LangGraph runtime deduplicates duplicate-target entries and only the last name (`starterAgent`) survives. Switched the voice route to `starterAgent` so the deployment can resolve the agent.
- **langroid**: voice route hit the default `/` endpoint which calls the LLM with the backend tools registered. Aimock returned a `get_weather` tool call, but the voice page registers no frontend tools, so the run finished with empty content (matching the production \"got ' '\" symptom). Added a `/voice` endpoint that calls `handle_run(disable_tools=True)`, and pointed the voice route at `/voice/`.
- Regenerated `showcase/integrations/langgraph-typescript/src/agent/package-lock.json` — it was out of sync with `package.json` (missing `@ag-ui/*`, `@copilotkit/license-verifier`, `partial-json`, etc.) and blocked `npm ci` in the Docker build.

## Why

Production PocketBase showed 5 red D5 voice records (`d5:<slug>/voice`):
- `claude-sdk-python` / `claude-sdk-typescript` — `/transcribe → 500` (env-var drift in production; passes locally as-is)
- `ms-agent-python` — empty assistant response (passes locally as-is; production was running stale code)
- `langgraph-typescript` — `\"No agent found with graph ID sample_agent\"` (real bug, fixed here)
- `langroid` — empty assistant message text (real bug, fixed here)

## Scope

- The langroid `disable_tools` parameter is keyword-only with default `False`, so the existing `/` endpoint and all 9 test call sites that pass `handle_run(req)` positionally are unchanged.
- The langgraph-typescript change only touches the voice route; the main `copilotkit/route.ts` continues to use `starterAgent` as before.

## Test plan

- [x] D5 voice probe runs green locally for all 5 slugs (`langgraph-typescript`, `ms-agent-python`, `claude-sdk-python`, `claude-sdk-typescript`, `langroid`)
- [x] Manual headed-browser confirmation: \"Play sample\" → transcription → Tokyo weather response on each slug
- [ ] PocketBase `d5:*/voice` records flip to green after the next deploy