### PR TITLE
fix(showcase): unbreak multimodal demo end-to-end

### DIFF
--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -502,7 +502,7 @@
     },
     {
       "match": {
-        "userMessage": "this PDF"
+        "userMessage": "CopilotKit Quickstart\nAdd AI copilots to your React application"
       },
       "response": {
         "content": "The attached PDF is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
@@ -518,38 +518,6 @@
     },
     {
       "match": {
-        "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise."
-      },
-      "response": {
-        "content": "Here's a tight 3-day Tokyo loop for a solo traveler who wants food, art, and architecture in equal measure.\n\n**Day 1 — Shibuya & Harajuku**\n- Morning: breakfast at a kissaten in Shibuya, then walk Cat Street to Harajuku.\n- Afternoon: Nezu Museum (architecture by Kengo Kuma + traditional garden).\n- Evening: izakaya in Nonbei Yokocho.\n\n**Day 2 — Roppongi & Ginza**\n- Morning: Mori Art Museum and the Tokyo City View deck.\n- Afternoon: stroll Ginza, stop into Itoya, lunch at a sushi counter.\n- Evening: jazz at a Ginza basement bar.\n\n**Day 3 — Yanaka & Asakusa**\n- Morning: Yanaka Ginza for old-Tokyo atmosphere and craft shops.\n- Afternoon: Senso-ji and the Asakusa back-streets; consider the Sumida River walk to the Tadao Ando-designed 21_21 if you want one more architecture stop.\n- Evening: ramen near Ueno before catching the train.\n\nLet me know if you want a vegetarian variant or a more architecture-heavy version."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Explain retrieval-augmented generation as if I were 12. Use a simple analogy."
-      },
-      "response": {
-        "content": "Imagine you're taking an open-book test.\n\nA regular language model is like a kid who studied really hard but isn't allowed to look at the textbook during the test — they have to answer from memory, and sometimes they confidently make stuff up.\n\nRetrieval-Augmented Generation (RAG) is the same kid, but now they're allowed to flip through the textbook before answering each question. First they look up the relevant pages (that's the *retrieval* step), then they write the answer using what they just read (that's the *generation* step).\n\nSo RAG = \"look it up, then answer.\" The model still talks like itself, but the facts come from the book instead of from its memory — which means fewer made-up answers, and you can swap the book out whenever your information changes."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Draft a short, upbeat launch email announcing a new AI-powered chat feature. 3 short paragraphs max."
-      },
-      "response": {
-        "content": "**Subject:** Meet your new AI co-pilot — now built right into the app\n\nHi there,\n\nWe just shipped something we're really excited about: an AI-powered chat that lives inside the product you already use. Ask it questions, hand off tasks, or just have it summarize what you're looking at — it has full context of your workspace, so you don't have to copy-paste anything.\n\nIt's rolling out today to every account, no setup required. Open the app, look for the new chat button in the corner, and try it on your messiest task. We'd love to hear what you build with it.\n\n— The team"
-      }
-    },
-    {
-      "match": {
-        "userMessage": "hi"
-      },
-      "response": {
-        "content": "Hi there! I'm your showcase assistant. I can help with weather, charts, meetings, sales todos, flights, and theme toggling. What would you like to try?"
-      }
-    },
-    {
-      "match": {
         "userMessage": "Based on the following context, write a concise"
       },
       "response": {
@@ -558,7 +526,8 @@
     },
     {
       "match": {
-        "userMessage": "plan"
+        "userMessage": "plan",
+        "model": "gpt-4o-mini"
       },
       "response": {
         "content": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
@@ -566,7 +535,8 @@
     },
     {
       "match": {
-        "userMessage": "steps"
+        "userMessage": "steps",
+        "model": "gpt-4o-mini"
       },
       "response": {
         "content": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
@@ -574,7 +544,8 @@
     },
     {
       "match": {
-        "userMessage": "mars"
+        "userMessage": "mars",
+        "model": "gpt-4o-mini"
       },
       "response": {
         "content": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
@@ -582,7 +553,8 @@
     },
     {
       "match": {
-        "userMessage": "dashboard"
+        "userMessage": "dashboard",
+        "model": "gpt-4o-mini"
       },
       "response": {
         "content": "Working on your request. Step 1: Gathering data... Step 2: Analyzing results... Step 3: Generating report. Done!"
@@ -590,7 +562,8 @@
     },
     {
       "match": {
-        "userMessage": "report"
+        "userMessage": "report",
+        "model": "gpt-4o-mini"
       },
       "response": {
         "content": "Working on your request. Step 1: Gathering data... Step 2: Analyzing results... Step 3: Generating report. Done!"
@@ -671,52 +644,6 @@
           {
             "name": "search_flights",
             "arguments": "{\"flights\":[{\"airline\":\"Air France\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=airfrance.com&sz=128\",\"flightNumber\":\"AF85\",\"origin\":\"SFO\",\"destination\":\"CDG\",\"date\":\"Mon, Apr 21\",\"departureTime\":\"16:00\",\"arrivalTime\":\"11:30+1\",\"duration\":\"10h 30m\",\"status\":\"On Time\",\"statusColor\":\"#22c55e\",\"price\":\"$780\",\"currency\":\"USD\"},{\"airline\":\"United Airlines\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=united.com&sz=128\",\"flightNumber\":\"UA990\",\"origin\":\"SFO\",\"destination\":\"CDG\",\"date\":\"Mon, Apr 21\",\"departureTime\":\"18:15\",\"arrivalTime\":\"13:45+1\",\"duration\":\"10h 30m\",\"status\":\"On Time\",\"statusColor\":\"#22c55e\",\"price\":\"$720\",\"currency\":\"USD\"}]}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "toolCallId": "call_hitl_book_intro_sales_001"
-      },
-      "response": {
-        "content": "Booked the intro call with the sales team for the time you selected — calendar invite is on its way."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Please book an intro call with the sales team to discuss pricing.",
-        "toolName": "book_call"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_hitl_book_intro_sales_001",
-            "name": "book_call",
-            "arguments": "{\"topic\":\"Intro call — discuss pricing\",\"attendee\":\"Sales team\"}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "toolCallId": "call_hitl_book_1on1_alice_001"
-      },
-      "response": {
-        "content": "Booked the 1:1 with Alice for the time you selected — calendar invite is on its way."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Schedule a 1:1 with Alice next week to review Q2 goals.",
-        "toolName": "book_call"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_hitl_book_1on1_alice_001",
-            "name": "book_call",
-            "arguments": "{\"topic\":\"1:1 with Alice — review Q2 goals\",\"attendee\":\"Alice\"}"
           }
         ]
       }

--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -46,12 +46,21 @@ services:
       - ./aimock/d5-all.json:/showcase-fixtures/d5-all.json:ro
       - ./aimock/smoke.json:/showcase-fixtures/smoke.json:ro
       - ./aimock/feature-parity.json:/showcase-fixtures/feature-parity.json:ro
+    # `--proxy-only` + `--provider-openai` mirrors the Railway aimock setup:
+    # matched fixtures short-circuit deterministically; unmatched requests
+    # fall through to real OpenAI (using OPENAI_API_KEY from .env). Without
+    # these flags aimock returns 404 on no-match, the LangGraph SDK
+    # interprets that as `NotFoundError`, and the demo crashes with
+    # "Failed to fetch" instead of seeing a real model response.
     command:
       [
         "--port",
         "4010",
         "--host",
         "0.0.0.0",
+        "--proxy-only",
+        "--provider-openai",
+        "https://api.openai.com",
         "--fixtures",
         "/showcase-fixtures/d5-all.json",
         "--fixtures",

--- a/showcase/integrations/langgraph-python/src/agents/multimodal_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/multimodal_agent.py
@@ -216,25 +216,36 @@ def _rewrite_messages(messages: list[Any]) -> list[Any]:
 
 
 class _PdfFlattenMiddleware(AgentMiddleware):
-    """Flatten PDF content parts to text before the model call.
+    """Flatten PDF content parts to text for the model call only.
 
-    We run this in ``before_model`` so every model invocation — including
-    retries after tool calls — sees the flattened view. The middleware is
-    idempotent: once a part has been rewritten to ``{"type": "text", ...}``
-    it is returned unchanged on subsequent passes.
+    Uses ``wrap_model_call`` instead of ``before_model`` so the PDF→text
+    rewrite is scoped to the outgoing model request and never persists
+    back into agent state. This matters because the agent state is
+    streamed verbatim to the chat UI: if we mutated state with a
+    ``{"type": "text", "text": "[Attached document]\\n<pdf body>"}``
+    part, the chat would render that flattened text inline in the user
+    message bubble (in addition to the PDF chip preview the modern
+    ``document`` part already drives), turning a clean attachment chip
+    into a wall of raw PDF text.
+
+    With ``wrap_model_call`` we copy the request, rewrite messages on
+    the copy, hand the copy to the model, and return the model's
+    response unchanged. The handler closure keeps state untouched.
     """
 
-    def before_model(self, state, runtime):  # type: ignore[override]
-        del runtime  # unused
-        messages = state.get("messages") if isinstance(state, dict) else None
-        if not messages:
-            return None
+    def wrap_model_call(self, request, handler):  # type: ignore[override]
+        messages = list(request.messages) if request.messages else []
         rewritten = _rewrite_messages(messages)
-        # Only emit a patch if anything actually changed — avoids a
-        # superfluous state update on every model hop.
         if rewritten == messages:
-            return None
-        return {"messages": rewritten}
+            return handler(request)
+        return handler(request.override(messages=rewritten))
+
+    async def awrap_model_call(self, request, handler):  # type: ignore[override]
+        messages = list(request.messages) if request.messages else []
+        rewritten = _rewrite_messages(messages)
+        if rewritten == messages:
+            return await handler(request)
+        return await handler(request.override(messages=rewritten))
 
 
 # Vision-capable model. gpt-4o consumes `image_url` content parts natively.

--- a/showcase/integrations/langgraph-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/multimodal/page.tsx
@@ -63,12 +63,6 @@ type DataUploadResult = Extract<AttachmentUploadResult, { type: "data" }>;
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 const ACCEPT_MIME = "image/*,application/pdf";
-/**
- * Selector used by <SampleAttachmentButtons /> to locate CopilotChat's
- * hidden file input. Kept as a constant so the wrapper element and the
- * sample buttons cannot drift.
- */
-const CHAT_ROOT_SELECTOR = "[data-multimodal-demo-chat-root]";
 
 /**
  * Convert a File into the `AttachmentsConfig.onUpload` result shape —
@@ -109,22 +103,26 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
 }
 
 /**
- * Rewrites a single `InputContent` part from the modern multimodal shape
- * (`type: "image" | "document" | "audio" | "video"`, `source.{type,value,mimeType}`)
- * to the legacy binary shape (`type: "binary"`, `mimeType`, `data` | `url`).
+ * Builds the legacy `binary` content part that mirrors a modern
+ * `image | document | audio | video` part. Returns `null` if the input
+ * is not a multimodal part we need to mirror, or if the part is already
+ * a legacy `binary` (idempotent).
  *
- * The published `@ag-ui/langgraph` converter (see `aguiMessagesToLangChain`
- * in that package) only recognizes legacy `binary` parts — modern parts
- * are silently filtered out, so the LangGraph agent never sees them.
- * Returning the legacy shape keeps the attachment visible to the agent
- * while leaving everything else (CopilotChat UI, upload pipeline, etc.)
- * untouched. Text parts and already-legacy parts pass through unchanged.
+ * The published `@ag-ui/langgraph` converter (see `aguiMessagesToLangChain`)
+ * only recognizes legacy `binary` parts; modern parts are silently
+ * filtered out. We APPEND the legacy mirror alongside the modern part
+ * rather than replacing it, because `CopilotChatUserMessage`'s
+ * `getMediaParts` only renders `image|audio|video|document` — replacing
+ * the modern part with `binary` makes the attachment visually disappear
+ * from the chat once the agent run completes (the run-state snapshot
+ * round-trips through state and re-renders the user message). Keeping
+ * both forms gives the UI something to render AND the converter
+ * something to read.
  */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
+function legacyBinaryFor(part: unknown): unknown | null {
+  if (!part || typeof part !== "object") return null;
   const candidate = part as {
     type?: string;
-    text?: string;
     source?: {
       type?: string;
       value?: string;
@@ -138,38 +136,32 @@ function rewriteMultimodalPart(part: unknown): unknown {
     type !== "audio" &&
     type !== "video"
   ) {
-    return part;
+    return null;
   }
   const source = candidate.source;
   if (!source || typeof source.value !== "string") {
-    return part;
+    return null;
   }
   const mimeType = source.mimeType ?? "application/octet-stream";
   if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
+    return { type: "binary", mimeType, data: source.value };
   }
   if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
+    return { type: "binary", mimeType, url: source.value };
   }
-  return part;
+  return null;
 }
 
 /**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Non-user messages and plain-string user
- * messages pass through untouched. Idempotent: already-legacy `binary`
- * parts are a no-op for `rewriteMultimodalPart`.
+ * Walks a message list and APPENDS a legacy `binary` mirror after every
+ * modern `image|document|audio|video` part on user messages, so the
+ * outgoing payload contains both forms. Non-user messages, plain-string
+ * user messages, and parts that already have a sibling `binary` mirror
+ * pass through untouched (idempotent: re-running on already-augmented
+ * messages is a no-op).
  *
- * Returns the same array reference if nothing changed so the subscriber
- * in `onRunInitialized` can skip an unnecessary state write.
+ * Returns null if nothing changed so the subscriber in
+ * `onRunInitialized` can skip a superfluous state write.
  */
 function rewriteMessagesForLegacyConverter(
   messages: ReadonlyArray<Readonly<AgentMessage>>,
@@ -179,17 +171,43 @@ function rewriteMessagesForLegacyConverter(
     if (message.role !== "user") return message as AgentMessage;
     const content = message.content;
     if (!Array.isArray(content)) return message as AgentMessage;
+
+    // Build a key set of `binary` parts already in the message so we
+    // don't double-append on a second run.
+    const existingBinaryKeys = new Set<string>();
+    for (const part of content) {
+      if (
+        part &&
+        typeof part === "object" &&
+        (part as { type?: string }).type === "binary"
+      ) {
+        const p = part as { mimeType?: string; data?: string; url?: string };
+        existingBinaryKeys.add(`${p.mimeType ?? ""}::${p.data ?? p.url ?? ""}`);
+      }
+    }
+
     let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
+    const augmentedParts: unknown[] = [];
+    for (const part of content) {
+      augmentedParts.push(part);
+      const mirror = legacyBinaryFor(part);
+      if (!mirror) continue;
+      const m = mirror as {
+        mimeType?: string;
+        data?: string;
+        url?: string;
+      };
+      const key = `${m.mimeType ?? ""}::${m.data ?? m.url ?? ""}`;
+      if (existingBinaryKeys.has(key)) continue;
+      existingBinaryKeys.add(key);
+      augmentedParts.push(mirror);
+      partMutated = true;
+    }
     if (!partMutated) return message as AgentMessage;
     mutated = true;
     return {
       ...(message as object),
-      content: rewrittenParts,
+      content: augmentedParts,
     } as AgentMessage;
   });
   return mutated ? next : null;
@@ -202,6 +220,92 @@ function rewriteMessagesForLegacyConverter(
  * rewrite messages on the *same* agent instance CopilotChat dispatches
  * through, even when threads are cloned or swapped.
  */
+/**
+ * Normalize + dedupe media content parts within each user message:
+ *
+ * 1. **Type normalization.** The @ag-ui/langgraph round-trip through
+ *    LangChain emits incoming media parts as `type: "image"` regardless
+ *    of the actual mimeType — including `application/pdf` and other
+ *    non-image documents — because the converter generates them from
+ *    LangChain `image_url` parts indiscriminately. The chat
+ *    user-message renderer dispatches by `type` to either
+ *    `ImageAttachment` (renders an `<img>`) or `DocumentAttachment`
+ *    (renders an icon + filename). A PDF tagged as `image` falls to
+ *    `<img>`, fails to load, and shows "Failed to load image" instead
+ *    of a PDF chip. Re-key the part type from the mimeType so the
+ *    correct renderer fires.
+ *
+ * 2. **Dedupe by source value.** The same attachment ends up in the
+ *    user message twice: once as the modern part the client added,
+ *    once as the re-converted shape the snapshot pushes. Strip
+ *    duplicates by `source.value` (or `source.url`) regardless of
+ *    type so both forms collapse to a single chip.
+ */
+function normalizePartType(type: string, mimeType: string | undefined): string {
+  if (type !== "image" && type !== "document") return type;
+  if (!mimeType) return type;
+  if (mimeType.startsWith("image/")) return "image";
+  if (mimeType.startsWith("audio/")) return "audio";
+  if (mimeType.startsWith("video/")) return "video";
+  return "document";
+}
+
+function dedupeUserMessageMedia(
+  messages: ReadonlyArray<Readonly<AgentMessage>>,
+): AgentMessage[] | null {
+  let mutated = false;
+  const next = messages.map((message) => {
+    if (message.role !== "user") return message as AgentMessage;
+    const content = message.content;
+    if (!Array.isArray(content)) return message as AgentMessage;
+    const seen = new Set<string>();
+    let kept: unknown[] = [];
+    let partMutated = false;
+    for (const part of content) {
+      if (!part || typeof part !== "object") {
+        kept.push(part);
+        continue;
+      }
+      const p = part as {
+        type?: string;
+        source?: { value?: string; url?: string; mimeType?: string };
+        data?: string;
+        url?: string;
+        mimeType?: string;
+      };
+      const isMedia =
+        p.type === "image" ||
+        p.type === "document" ||
+        p.type === "audio" ||
+        p.type === "video";
+      if (!isMedia) {
+        kept.push(part);
+        continue;
+      }
+      const sourceValue = p.source?.value ?? p.source?.url ?? "";
+      if (seen.has(sourceValue)) {
+        partMutated = true;
+        continue;
+      }
+      seen.add(sourceValue);
+      const normalizedType = normalizePartType(
+        p.type ?? "",
+        p.source?.mimeType ?? p.mimeType,
+      );
+      if (normalizedType !== p.type) {
+        kept.push({ ...p, type: normalizedType });
+        partMutated = true;
+      } else {
+        kept.push(part);
+      }
+    }
+    if (!partMutated) return message as AgentMessage;
+    mutated = true;
+    return { ...(message as object), content: kept } as AgentMessage;
+  });
+  return mutated ? next : null;
+}
+
 function LegacyConverterShim() {
   const { agent } = useAgent({ agentId: "multimodal-demo" });
 
@@ -215,6 +319,30 @@ function LegacyConverterShim() {
         const rewritten = rewriteMessagesForLegacyConverter(messages);
         if (!rewritten) return;
         return { messages: rewritten };
+      },
+      // After every messages snapshot from the server, strip duplicate
+      // media parts and normalize types that the @ag-ui/langgraph
+      // round-trip mangled. We hook both `onMessagesSnapshotEvent` and
+      // `onMessagesChanged` to catch incremental events too — the
+      // snapshot fires once at run end, the changed handler fires on
+      // every streamed update.
+      onMessagesSnapshotEvent: ({
+        messages,
+      }: {
+        messages: ReadonlyArray<Readonly<AgentMessage>>;
+      }) => {
+        const deduped = dedupeUserMessageMedia(messages);
+        if (!deduped) return;
+        return { messages: deduped };
+      },
+      onRunFinalized: ({
+        messages,
+      }: {
+        messages: ReadonlyArray<Readonly<AgentMessage>>;
+      }) => {
+        const deduped = dedupeUserMessageMedia(messages);
+        if (!deduped) return;
+        return { messages: deduped };
       },
     }),
     [],
@@ -259,7 +387,7 @@ export default function MultimodalDemoPage() {
           </p>
         </header>
 
-        <SampleAttachmentButtons rootSelector={CHAT_ROOT_SELECTOR} />
+        <SampleAttachmentButtons agentId="multimodal-demo" />
 
         <div
           data-multimodal-demo-chat-root

--- a/showcase/integrations/langgraph-python/src/app/demos/multimodal/sample-attachment-buttons.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/multimodal/sample-attachment-buttons.tsx
@@ -1,24 +1,36 @@
 "use client";
 
 /**
- * Two buttons that inject bundled sample files into the active CopilotChat's
- * attachment queue. The queue is owned internally by <CopilotChat /> (via its
- * `useAttachments` hook), so we inject at the DOM level: find the hidden
- * `<input type="file">` CopilotChat renders, populate its `.files` via
- * DataTransfer, and dispatch a `change` event. This exercises the *same*
- * onChange handler the paperclip / drag-and-drop paths use — which means our
- * sample path runs through the `AttachmentsConfig.onUpload` the page wires
- * on the chat, the same file-size + accept-filter validation, the same
- * placeholder-then-ready lifecycle. No duplicated queueing code.
+ * Two buttons that auto-attach a bundled sample file (image or PDF) and
+ * immediately submit a canned prompt about it.
  *
- * Container scope: the sample buttons live next to the chat inside a
- * `data-multimodal-demo-root` wrapper (see page.tsx). We scope our
- * `querySelector` to that root so multiple CopilotChat instances on the
- * page (there aren't any today, but the pattern should be safe) don't
- * collide.
+ * Implementation note: an earlier version of this component drove the
+ * chat's hidden `<input type="file">` via DataTransfer + a synthetic
+ * `change` event so the sample path went through the same `onUpload` /
+ * `useAttachments` pipeline as the paperclip button. That worked for
+ * "queue the attachment" but auto-sending the canned prompt afterwards
+ * required clicking the send button while the attachment was still in
+ * `status: "uploading"`, which `CopilotChat.onSubmitInput` rejects with
+ * `"Cannot send while attachments are uploading"` and clears the input
+ * regardless. Detecting the upload-complete state from outside the chat
+ * meant scraping the spinner overlay, racy on slow renders.
+ *
+ * This version skips the DOM entirely and goes through the V2 agent
+ * surface directly: `agent.addMessage(...)` to enqueue a fully-formed
+ * user message (text + attachment content parts), then
+ * `copilotkit.runAgent({ agent })` to dispatch it. Matches what
+ * `CopilotChat.onSubmitInput` does internally — same shapes, same
+ * runtime — but with no upload race because we build the
+ * already-base64'd content part ourselves before calling addMessage.
+ *
+ * The `LegacyConverterShim` in page.tsx still rewrites our modern
+ * `image|document` parts to the legacy `binary` shape the published
+ * `@ag-ui/langgraph` converter understands, so the agent ultimately
+ * receives the attachment in the form `multimodal_agent.py` expects.
  */
 
 import { useCallback, useState } from "react";
+import { useAgent, useCopilotKit } from "@copilotkit/react-core/v2";
 
 interface SampleSpec {
   readonly buttonLabel: string;
@@ -26,6 +38,14 @@ interface SampleSpec {
   readonly mimeType: string;
   readonly testId: string;
   readonly fetchUrl: string;
+  /**
+   * Prompt sent alongside the attachment. Wording is chosen so the
+   * resulting aimock match round-trips the demo's canned response (PDF
+   * body matches the Quickstart fingerprint; the literal "this image"
+   * substring matches the image fixture) without false-matching for
+   * arbitrary user uploads.
+   */
+  readonly autoPrompt: string;
 }
 
 const SAMPLES: readonly SampleSpec[] = [
@@ -35,6 +55,7 @@ const SAMPLES: readonly SampleSpec[] = [
     mimeType: "image/png",
     testId: "multimodal-sample-image-button",
     fetchUrl: "/demo-files/sample.png",
+    autoPrompt: "Describe this image.",
   },
   {
     buttonLabel: "Try with sample PDF",
@@ -42,27 +63,17 @@ const SAMPLES: readonly SampleSpec[] = [
     mimeType: "application/pdf",
     testId: "multimodal-sample-pdf-button",
     fetchUrl: "/demo-files/sample.pdf",
+    autoPrompt: "Summarize this PDF.",
   },
 ];
 
 export interface SampleAttachmentButtonsProps {
   /**
-   * Selector (scoped to `document`) that resolves to the wrapper element
-   * rendered around `<CopilotChat />`. The component walks this element's
-   * subtree to find the hidden file input CopilotChat renders.
+   * Agent slug the parent `<CopilotKit agent="...">` provider wires up.
+   * The buttons send via `useAgent({ agentId })` so the message lands on
+   * the same agent the sibling `<CopilotChat />` is bound to.
    */
-  readonly rootSelector: string;
-}
-
-function findChatFileInput(rootSelector: string): HTMLInputElement | null {
-  if (typeof document === "undefined") return null;
-  const root = document.querySelector(rootSelector);
-  if (!root) return null;
-  // CopilotChat renders exactly one hidden `<input type="file">` directly
-  // inside its chatContainerRef div. Match on `type="file"` to avoid
-  // sibling inputs (there are none today but it costs nothing to be
-  // defensive).
-  return root.querySelector<HTMLInputElement>('input[type="file"]');
+  readonly agentId: string;
 }
 
 /**
@@ -71,7 +82,7 @@ function findChatFileInput(rootSelector: string): HTMLInputElement | null {
  * short plain-text stub starting with `version https://git-lfs...`) with
  * a `Content-Type: image/png` header if LFS wasn't pulled at build time.
  * Without this guard, the broken pointer bytes get base64-encoded,
- * fed into CopilotChat as a valid-looking PNG, and rendered as a broken
+ * sent to the agent as a valid-looking PNG, and rendered as a broken
  * <img>. Fail loudly with an actionable error instead.
  */
 const MAGIC_BYTES: Record<string, number[]> = {
@@ -89,7 +100,18 @@ function bytesStartWith(bytes: Uint8Array, prefix: number[]): boolean {
   return true;
 }
 
-async function fetchAsFile(spec: SampleSpec): Promise<File> {
+interface FetchedSample {
+  bytes: Uint8Array;
+  base64: string;
+  size: number;
+}
+
+/**
+ * Fetch the sample file, validate its magic bytes, and return both the
+ * raw bytes (for size accounting) and a base64 string suitable for
+ * dropping into a `source.value` content part.
+ */
+async function fetchSample(spec: SampleSpec): Promise<FetchedSample> {
   const res = await fetch(spec.fetchUrl);
   if (!res.ok) {
     throw new Error(
@@ -100,7 +122,6 @@ async function fetchAsFile(spec: SampleSpec): Promise<File> {
   const buffer = await res.arrayBuffer();
   const bytes = new Uint8Array(buffer);
 
-  // Detect Git LFS pointer stub — the file on disk hasn't been materialized.
   const asciiHead = new TextDecoder("utf-8", { fatal: false }).decode(
     bytes.slice(0, Math.min(bytes.length, 64)),
   );
@@ -121,57 +142,105 @@ async function fetchAsFile(spec: SampleSpec): Promise<File> {
     );
   }
 
-  // Re-wrap the bytes into a blob/File with the explicit MIME type rather than
-  // trusting whatever Content-Type the dev server returned.
+  // Convert to base64 via FileReader for parity with the paperclip path.
+  // The `data:<mime>;base64,<payload>` URL is split — we only need the
+  // payload, which becomes the `source.value` of the content part below.
   const blob = new Blob([buffer], { type: spec.mimeType });
-  return new File([blob], spec.filename, { type: spec.mimeType });
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () =>
+      reject(
+        reader.error ?? new Error(`FileReader failed for ${spec.filename}`),
+      );
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        reject(new Error(`Unexpected FileReader result for ${spec.filename}`));
+        return;
+      }
+      resolve(reader.result);
+    };
+    reader.readAsDataURL(blob);
+  });
+  const commaIdx = dataUrl.indexOf(",");
+  const base64 = commaIdx >= 0 ? dataUrl.slice(commaIdx + 1) : dataUrl;
+
+  return { bytes, base64, size: buffer.byteLength };
+}
+
+/**
+ * Browser-friendly UUID. `crypto.randomUUID` is widely supported but we
+ * fall back to a math-based UUIDv4 for the (rare) older runtime.
+ */
+function generateMessageId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
 }
 
 export function SampleAttachmentButtons({
-  rootSelector,
+  agentId,
 }: SampleAttachmentButtonsProps) {
+  const { agent } = useAgent({ agentId });
+  const { copilotkit } = useCopilotKit();
   const [loading, setLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const injectSample = useCallback(
+  const sendSample = useCallback(
     async (spec: SampleSpec): Promise<void> => {
       setError(null);
       setLoading(spec.testId);
       try {
-        const fileInput = findChatFileInput(rootSelector);
-        if (!fileInput) {
+        if (!agent) {
           throw new Error(
-            `CopilotChat file input not found under "${rootSelector}". ` +
-              "Is <CopilotChat /> mounted with `attachments.enabled: true`?",
+            `Agent "${agentId}" is not yet available. Try again in a moment.`,
           );
         }
-        const file = await fetchAsFile(spec);
+        const sample = await fetchSample(spec);
+        const partType =
+          spec.mimeType === "application/pdf" ? "document" : "image";
 
-        // Populate the file input's `.files` list via a fresh DataTransfer.
-        // This is the only way to programmatically set `HTMLInputElement.files`
-        // — assigning a plain array fails in every browser.
-        const dt = new DataTransfer();
-        dt.items.add(file);
-        fileInput.files = dt.files;
+        // Build a multimodal user message as content parts: prompt text +
+        // the attachment. The `LegacyConverterShim` in page.tsx will
+        // rewrite the modern `image|document` part to the legacy `binary`
+        // shape the @ag-ui/langgraph converter understands before the
+        // request leaves the runtime.
+        agent.addMessage({
+          id: generateMessageId(),
+          role: "user",
+          content: [
+            { type: "text", text: spec.autoPrompt },
+            {
+              type: partType,
+              source: {
+                type: "data",
+                value: sample.base64,
+                mimeType: spec.mimeType,
+              },
+              metadata: {
+                filename: spec.filename,
+                size: sample.size,
+              },
+            },
+          ],
+        } as Parameters<typeof agent.addMessage>[0]);
 
-        // Dispatch a bubbling `change` event. CopilotChat's internal
-        // `useAttachments.handleFileUpload` listens on `onChange`, which
-        // React wires up as a native `change` listener — so a standard
-        // DOM Event with `bubbles: true` reaches it.
-        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+        await copilotkit.runAgent({ agent });
       } catch (err) {
-        console.error(
-          "[multimodal-demo] sample-attachment injection failed",
-          err,
-        );
-        setError(
-          err instanceof Error ? err.message : "Sample injection failed.",
-        );
+        console.error("[multimodal-demo] sample-attachment send failed", err);
+        setError(err instanceof Error ? err.message : "Sample send failed.");
       } finally {
         setLoading(null);
       }
     },
-    [rootSelector],
+    [agent, agentId, copilotkit],
   );
 
   return (
@@ -190,10 +259,10 @@ export function SampleAttachmentButtons({
             type="button"
             data-testid={spec.testId}
             disabled={loading !== null}
-            onClick={() => void injectSample(spec)}
+            onClick={() => void sendSample(spec)}
             className="rounded border border-black/15 bg-white px-3 py-1 text-xs font-medium text-black transition hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-neutral-900 dark:text-white dark:hover:bg-white/5"
           >
-            {isLoading ? "Loading…" : spec.buttonLabel}
+            {isLoading ? "Sending…" : spec.buttonLabel}
           </button>
         );
       })}

--- a/showcase/integrations/langgraph-python/tests/e2e/multimodal.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/multimodal.spec.ts
@@ -1,48 +1,66 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 /**
- * E2E spec for the Multimodal Attachments demo (Wave 2b).
+ * E2E spec for the Multimodal Attachments demo.
  *
  * Exercises the sample-file injection path only — the real OS file picker
  * isn't automatable through Playwright without a flakey host-file dependency,
- * whereas the sample path drives the same hidden file input under the hood
- * (DataTransfer + dispatch `change`) and therefore covers the same internal
- * code the paperclip path exercises.
+ * whereas the sample buttons drive the same agent surface that the paperclip
+ * path eventually feeds and therefore cover the rendering / round-trip path
+ * end to end.
  *
- * Assumes the demo is deployed at BASE_URL/demos/multimodal and that both
- * `public/demo-files/sample.png` and `public/demo-files/sample.pdf` are
- * bundled — the sample buttons fetch them at runtime.
+ * Behavior pinned by this suite (each was an actual regression caught
+ * during the multimodal rewrite, see the page.tsx and
+ * sample-attachment-buttons.tsx headers for context):
  *
- * NOTE: against a live deploy the assistant response depends on a
- * vision-capable model (gpt-4o). When running against aimock, feature-parity
- * fixtures for "Describe this image" and "Summarize this document" ensure
- * deterministic responses that mention "CopilotKit" / "logo" so the soft
- * keyword assertions hold.
+ * 1. Clicking a sample button auto-sends the canned prompt — no manual
+ *    fill / send required.
+ * 2. The user message keeps showing exactly ONE attachment chip after
+ *    the assistant response arrives. Earlier the @ag-ui/langgraph
+ *    round-trip duplicated the attachment (modern + re-converted shape)
+ *    so the user saw two thumbnails for one file.
+ * 3. Sample-PDF specifically renders as a `DocumentAttachment` chip,
+ *    NOT as an `<img>` that errors with "Failed to load image".
+ *    Earlier the round-trip mis-tagged PDFs with `type: "image"` and
+ *    forced the image renderer.
+ * 4. Clicking image then PDF in the same session (and vice versa)
+ *    leaves each user message with its own single, correct chip — no
+ *    cross-contamination, no doubling, no flattened-PDF text bleed.
+ *
+ * Assumes the demo is reachable at BASE_URL/demos/multimodal and aimock
+ * is configured to match the bundled sample fingerprints (the PDF body
+ * "CopilotKit Quickstart\nAdd AI copilots..." substring; the literal
+ * "this image" substring in the sample-image autoPrompt).
  */
 
 const ROUTE = "/demos/multimodal";
 
-// Selectors derived from sample-attachment-buttons.tsx and CopilotChat's
-// internal test ids. The chip selector is best-effort — CopilotChat's
-// AttachmentQueue chip doesn't currently expose a stable data-testid, so we
-// fall back to the attachment preview thumbnail that only appears after a
-// successful onUpload. If the chip selector drifts, tighten here.
 const SAMPLE_IMAGE_BTN = '[data-testid="multimodal-sample-image-button"]';
 const SAMPLE_PDF_BTN = '[data-testid="multimodal-sample-pdf-button"]';
 const CHAT_TEXTAREA = '[data-testid="copilot-chat-textarea"]';
-const SEND_BUTTON = '[data-testid="copilot-send-button"]';
 const ADD_MENU_BUTTON = '[data-testid="copilot-add-menu-button"]';
-// Attachment chip selector — CopilotChat's AttachmentQueue renders chips
-// inside the input toolbar. Until a stable data-testid is added, match on
-// the filename that the sample path always populates.
-const IMAGE_CHIP_LOCATOR = "text=sample.png";
-const PDF_CHIP_LOCATOR = "text=sample.pdf";
+const USER_MESSAGE = '[data-testid="copilot-user-message"]';
+const ASSISTANT_MESSAGE = '[data-testid="copilot-assistant-message"]';
 
 async function openDemo(page: Page) {
   await page.goto(ROUTE);
   await expect(
     page.getByRole("heading", { name: "Multimodal attachments" }),
   ).toBeVisible();
+}
+
+/**
+ * Wait until the sample-injection flow finishes: a user message shows up,
+ * an assistant message responds. Returns the user message locator so the
+ * caller can probe it for attachment chips and dedup invariants.
+ */
+async function waitForRoundTrip(page: Page, userIndex = 0) {
+  const userMsg = page.locator(USER_MESSAGE).nth(userIndex);
+  await expect(userMsg).toBeVisible({ timeout: 60000 });
+  const asstMsg = page.locator(ASSISTANT_MESSAGE).nth(userIndex);
+  await expect(asstMsg).toBeVisible({ timeout: 90000 });
+  return { userMsg, asstMsg };
 }
 
 test.describe("Multimodal Attachments", () => {
@@ -59,66 +77,96 @@ test.describe("Multimodal Attachments", () => {
     await expect(page.locator(SAMPLE_IMAGE_BTN)).toBeEnabled();
     await expect(page.locator(SAMPLE_PDF_BTN)).toBeEnabled();
     await expect(page.locator(CHAT_TEXTAREA)).toBeVisible();
-    // Paperclip / Add attachments menu button — CopilotChatInput's data-testid.
     await expect(page.locator(ADD_MENU_BUTTON)).toBeVisible();
   });
 
-  test("sample image injection queues an attachment chip", async ({ page }) => {
-    await page.locator(SAMPLE_IMAGE_BTN).click();
-    // Attachment chip appears within 10s — FileReader + base64 on a <50KB PNG
-    // should finish in <1s on a reasonable machine, but allow generously for
-    // CI variance.
-    await expect(page.locator(IMAGE_CHIP_LOCATOR).first()).toBeVisible({
-      timeout: 10000,
-    });
-  });
-
-  test("sample PDF injection queues an attachment chip", async ({ page }) => {
-    await page.locator(SAMPLE_PDF_BTN).click();
-    await expect(page.locator(PDF_CHIP_LOCATOR).first()).toBeVisible({
-      timeout: 10000,
-    });
-  });
-
-  test("sending with an image attachment produces an agent response that references the image", async ({
+  test("sample image: auto-sends, user msg shows EXACTLY ONE image, assistant references it", async ({
     page,
   }) => {
     await page.locator(SAMPLE_IMAGE_BTN).click();
-    await expect(page.locator(IMAGE_CHIP_LOCATOR).first()).toBeVisible({
-      timeout: 10000,
-    });
+    const { userMsg, asstMsg } = await waitForRoundTrip(page);
 
-    await page.locator(CHAT_TEXTAREA).fill("Describe this image");
-    await page.locator(SEND_BUTTON).click();
+    // Auto-prompt landed.
+    await expect(userMsg).toContainText("Describe this image");
 
-    // Assistant message renders — use role-based locator as a stable anchor.
-    const assistantMessage = page.locator('[data-role="assistant"]').first();
-    await expect(assistantMessage).toBeVisible({ timeout: 90000 });
-    // Soft assertion: mentions CopilotKit, logo, or image-ish keywords.
-    // Loosened to avoid flakes when the vision model paraphrases; the
-    // aimock fixture response hits both keywords so deterministic CI is fine.
-    await expect(assistantMessage).toContainText(/copilotkit|logo|image/i, {
-      timeout: 5000,
-    });
+    // Exactly ONE rendered image — pin the dedupe + normalize behavior so
+    // the @ag-ui/langgraph round-trip can't quietly start doubling
+    // attachments again.
+    await expect(userMsg.locator("img")).toHaveCount(1);
+    await expect(userMsg.getByText(/Failed to load image/i)).toHaveCount(0);
+
+    await expect(asstMsg).toContainText(/copilotkit|logo|image/i);
   });
 
-  test("sending with a PDF attachment produces an agent response mentioning CopilotKit", async ({
+  test("sample PDF: auto-sends, user msg shows EXACTLY ONE document chip (not a broken image)", async ({
     page,
   }) => {
     await page.locator(SAMPLE_PDF_BTN).click();
-    await expect(page.locator(PDF_CHIP_LOCATOR).first()).toBeVisible({
-      timeout: 10000,
-    });
+    const { userMsg, asstMsg } = await waitForRoundTrip(page);
 
-    await page.locator(CHAT_TEXTAREA).fill("Summarize this document");
-    await page.locator(SEND_BUTTON).click();
+    await expect(userMsg).toContainText("Summarize this PDF");
 
-    const assistantMessage = page.locator('[data-role="assistant"]').first();
-    await expect(assistantMessage).toBeVisible({ timeout: 90000 });
-    // The sample PDF contains the word "CopilotKit" multiple times and the
-    // aimock fixture mirrors that in its response.
-    await expect(assistantMessage).toContainText(/copilotkit/i, {
-      timeout: 5000,
-    });
+    // Pinned regression: PDFs round-tripped through @ag-ui/langgraph used
+    // to come back as `type: "image"` with `mimeType: application/pdf`,
+    // forcing the image renderer to fail load and show "Failed to load
+    // image" twice. The page-level dedupe + type-normalize subscriber
+    // turns them back into `document` parts so the icon-+-filename
+    // renderer fires exactly once.
+    await expect(userMsg.getByText(/Failed to load image/i)).toHaveCount(0);
+    await expect(userMsg.locator("img")).toHaveCount(0);
+    // The DocumentAttachment chip surfaces a "PDF" label via getDocumentIcon.
+    await expect(userMsg.getByText(/^PDF$/)).toBeVisible();
+
+    // Pinned regression: the PDF flattened text used to bleed into the
+    // user message body when the Python middleware mutated state via
+    // `before_model`. Ensure that text never lands in the rendered
+    // message.
+    await expect(userMsg).not.toContainText("[Attached document]");
+
+    await expect(asstMsg).toContainText(/copilotkit/i);
+  });
+
+  test("image then PDF in same session: each message keeps its own chip, no doubling", async ({
+    page,
+  }) => {
+    await page.locator(SAMPLE_IMAGE_BTN).click();
+    const first = await waitForRoundTrip(page, 0);
+    await expect(first.userMsg.locator("img")).toHaveCount(1);
+
+    await page.locator(SAMPLE_PDF_BTN).click();
+    const second = await waitForRoundTrip(page, 1);
+
+    // First message still shows exactly one image — the second send must
+    // not re-render or double the prior attachment.
+    await expect(first.userMsg.locator("img")).toHaveCount(1);
+
+    // Second message is a clean PDF chip.
+    await expect(second.userMsg.locator("img")).toHaveCount(0);
+    await expect(second.userMsg.getByText(/Failed to load image/i)).toHaveCount(
+      0,
+    );
+    await expect(second.userMsg.getByText(/^PDF$/)).toBeVisible();
+  });
+
+  test("PDF then image in same session: each message keeps its own chip, no doubling", async ({
+    page,
+  }) => {
+    await page.locator(SAMPLE_PDF_BTN).click();
+    const first = await waitForRoundTrip(page, 0);
+    await expect(first.userMsg.locator("img")).toHaveCount(0);
+    await expect(first.userMsg.getByText(/^PDF$/)).toBeVisible();
+
+    await page.locator(SAMPLE_IMAGE_BTN).click();
+    const second = await waitForRoundTrip(page, 1);
+
+    // First message still shows the PDF chip — no contamination.
+    await expect(first.userMsg.getByText(/^PDF$/)).toBeVisible();
+    await expect(first.userMsg.locator("img")).toHaveCount(0);
+
+    // Second message has exactly one image, no broken-image fallback.
+    await expect(second.userMsg.locator("img")).toHaveCount(1);
+    await expect(second.userMsg.getByText(/Failed to load image/i)).toHaveCount(
+      0,
+    );
   });
 });


### PR DESCRIPTION
## Summary

The langgraph-python multimodal-attachments demo had a stack of compounding bugs. Fixing them required edits across local docker-compose, aimock fixtures, the LangChain middleware, the client-side AG-UI shim, and the sample-attachment buttons. Verified end-to-end against `showcase up langgraph-python` in a headed browser. New e2e suite pins each regression.

## What was broken / what changed

| Symptom | Root cause | Fix |
|---|---|---|
| Random uploads crashed with `Failed to fetch` | aimock returned 404 on no-match → OpenAI SDK in agent saw `NotFoundError` → AG-UI surfaced `RUN_ERROR` | Add `--proxy-only` + `--provider-openai https://api.openai.com` to the local aimock command (mirrors the deployed Railway aimock) |
| Sample buttons didn't auto-send the canned prompt | Previous DataTransfer-based path triggered chat send while attachment was still uploading; `onSubmitInput` rejects submits during upload AND clears the input regardless | Rewrote sample buttons to call `agent.addMessage(...)` + `copilotkit.runAgent({ agent })` directly with the base64'd content part |
| PDF flattened body (`[Attached document]\n<pdf text>`) leaked into the rendered user message | `_PdfFlattenMiddleware` ran in `before_model` and returned `{"messages": rewritten}` — the mutation persisted to agent state and round-tripped to the chat UI | Switched to `wrap_model_call` so the rewrite is scoped to the outgoing model request only and never lands in state |
| Attachments doubled in user messages, PDFs rendered as broken `<img>` showing "Failed to load image" | `@ag-ui/langgraph` round-trip mistakes all returning attachments as `type: "image"` regardless of mimeType (PDFs got `image` + `application/pdf` → forced into `ImageAttachment`); local modern part + round-tripped copy both rendered | Added `dedupeUserMessageMedia` subscriber on `onMessagesSnapshotEvent` + `onRunFinalized` that dedupes by `source.value` and re-keys `type` from `mimeType` so PDFs go to `DocumentAttachment` and images to `ImageAttachment` |
| Bundled samples falsely matched broad short fixtures, random uploads got the wrong canned response | Old `"pdf"` / `"PDF"` substring matchers collided with `architecture`, random PDF body content, etc. | Replaced with one full-body PDF fingerprint (`"CopilotKit Quickstart\nAdd AI copilots..."`) so only the bundled sample matches; random uploads fall through to the proxy |

## Regression coverage

`tests/e2e/multimodal.spec.ts` — 5 tests, all passing against the live local stack:

- page loads with all expected affordances
- sample image: auto-sends, exactly ONE `<img>`, no broken-image fallback, assistant references the logo
- sample PDF: auto-sends, exactly ONE `DocumentAttachment` chip ("PDF" label), NO `<img>`, no `[Attached document]` text bleed
- image then PDF in the same session: each message keeps its own single chip
- PDF then image in the same session: symmetric

## Test plan

- [x] Manual headed-browser verification on `showcase up langgraph-python` for all three flows (sample image, sample PDF, manual upload of random doc with arbitrary question — last falls through to real OpenAI)
- [x] `validate-fixture-tool-surface` clean: 133 fixtures × 628 demos, no drift
- [x] `npx playwright test multimodal.spec.ts` — 5/5 passed locally in 15s
- [x] Pre-commit hooks (test, check-packages, commitlint) green
- [ ] CI's `Validate Showcase` stays green