### PR TITLE
fix(showcase): bring google-adk beautiful-chat to canonical parity

### DIFF
--- a/showcase/integrations/google-adk/manifest.yaml
+++ b/showcase/integrations/google-adk/manifest.yaml
@@ -424,15 +424,18 @@ demos:
       - src/app/api/copilotkit-byoc-json-render/route.ts
   - id: beautiful-chat
     name: Beautiful Chat
-    description: Canonical polished starter chat — brand fonts, theme tokens, suggestion pills
+    description: Canonical flagship starter — brand fonts, suggestion pills, charts, flight cards, meeting picker, todo canvas, dynamic A2UI, MCP Excalidraw
     tags:
       - chat-ui
     route: /demos/beautiful-chat
     animated_preview_url:
     highlight:
       - src/agents/beautiful_chat_agent.py
+      - src/agents/beautiful_chat_data/db.csv
       - src/app/demos/beautiful-chat/page.tsx
-      - src/app/api/copilotkit/route.ts
+      - src/app/demos/beautiful-chat/hooks/use-generative-ui-examples.tsx
+      - src/app/demos/beautiful-chat/declarative-generative-ui/renderers.tsx
+      - src/app/api/copilotkit-beautiful-chat/route.ts
   - id: multimodal
     name: Multimodal Attachments
     description: Image and PDF uploads via CopilotChat attachments, processed by a Gemini multimodal agent

--- a/showcase/integrations/google-adk/package.json
+++ b/showcase/integrations/google-adk/package.json
@@ -20,6 +20,7 @@
     "@hashbrownai/react": "0.5.0-beta.4",
     "@json-render/core": "0.18.0",
     "@json-render/react": "0.18.0",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "next": "^15.5.15",
     "openai": "^5.9.0",
     "react": "^19.0.0",

--- a/showcase/integrations/google-adk/qa/beautiful-chat.md
+++ b/showcase/integrations/google-adk/qa/beautiful-chat.md
@@ -1,0 +1,90 @@
+# QA: Beautiful Chat — Google ADK
+
+## Prerequisites
+
+- Demo is deployed and accessible at `/demos/beautiful-chat` on the dashboard host
+- Agent backend is healthy (`/api/health`); `GOOGLE_API_KEY` is set on Railway
+- Note: the demo source contains no `data-testid` attributes. Checks below rely on verbatim visible text and DOM structure.
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/beautiful-chat`; verify the page renders within 3s with the CopilotKit logo (`img[alt="CopilotKit"]`, src `/copilotkit-logo.svg`) top-left of the chat pane
+- [ ] Verify the `Chat` / `App` mode pill is fixed top-right, `Chat` active (highlighted) by default, and the right-side canvas region is collapsed (width 0)
+- [ ] Verify the `CopilotChat` input is rendered with no disclaimer text below it
+- [ ] Verify all 9 suggestion pills are visible with verbatim titles:
+  - "Pie Chart (Controlled Generative UI)"
+  - "Bar Chart (Controlled Generative UI)"
+  - "Schedule Meeting (Human In The Loop)"
+  - "Search Flights (A2UI Fixed Schema)"
+  - "Sales Dashboard (A2UI Dynamic)"
+  - "Excalidraw Diagram (MCP App)"
+  - "Calculator App (Open Generative UI)"
+  - "Toggle Theme (Frontend Tools)"
+  - "Task Manager (Shared State)"
+- [ ] Send "Hello" and verify an assistant text response appears within 10s
+
+### 2. Feature-Specific Checks
+
+#### Mode Toggle (frontend tools `enableAppMode` / `enableChatMode`)
+
+- [ ] Click `App`; verify the canvas expands to ~2/3 width showing the TodoList empty state: pencil emoji, heading "No todos yet", subtext "Create your first task to get started", enabled "Add a task" button
+- [ ] Click `Chat`; verify the canvas collapses back to width 0
+
+#### Shared State — Task Manager (agent tool `manage_todos`)
+
+- [ ] Click the "Task Manager (Shared State)" pill; verify the mode auto-switches to App and within 15s the "To Do" column renders exactly 3 todo cards (each with emoji, title, description)
+- [ ] Verify the "Done" column is empty (shows "No completed todos yet")
+- [ ] Click a todo's checkbox; verify the card moves from "To Do" to "Done"
+
+#### Controlled Generative UI — Pie Chart (agent tool `query_data` + frontend component `pieChart`)
+
+- [ ] Click "Pie Chart (Controlled Generative UI)"; within 15s verify a pie-chart card renders in-transcript with a non-empty `CardTitle` and `CardDescription`
+- [ ] Verify the donut SVG renders at least 2 `<circle>` slice elements inside the card
+- [ ] Verify the legend renders one row per slice: colored dot, label, comma-formatted value, and a percentage ending in "%"; percentages sum to 100%
+
+#### Controlled Generative UI — Bar Chart (agent tool `query_data` + frontend component `barChart`)
+
+- [ ] Click "Bar Chart (Controlled Generative UI)"; within 15s verify a bar-chart card renders with `CardTitle`, `CardDescription`, and a bar-chart icon in the header
+- [ ] Verify the recharts `ResponsiveContainer` (height 280px) renders at least 2 bar rectangles with X-axis labels matching the `label` field values; bars animate in via the `barSlideIn` keyframe on first render
+
+#### Human-in-the-Loop — Schedule Meeting (frontend tool `scheduleTime`)
+
+- [ ] Click "Schedule Meeting (Human In The Loop)"; within 15s verify a MeetingTimePicker card renders with a clock icon, a heading (agent-supplied reason or default "Schedule a Meeting"), 3 time-slot buttons each with date + time + a "30 min" duration badge, and a "None of these work" ghost button
+- [ ] Click a time slot; verify the card switches to the confirmed state with heading "Meeting Scheduled", the chosen date/time, and a green check icon
+- [ ] Re-trigger, click "None of these work"; verify the card shows heading "No Time Selected" and subtext "Looking for a better time that works for you"
+
+#### A2UI Fixed Schema — Search Flights (agent tool `search_flights`)
+
+- [ ] Click "Search Flights (A2UI Fixed Schema)"; within 20s verify exactly 2 flight cards render in-transcript, each with airline name, airline logo image, flight number, origin/destination, date, departure/arrival times, duration, a colored status dot, a status label (e.g. "On Time"), and a price starting with "$"
+
+#### A2UI Dynamic — Sales Dashboard (agent tool `generate_a2ui`)
+
+- [ ] Click "Sales Dashboard (A2UI Dynamic)"; within 30s verify a dynamic dashboard surface renders containing total-revenue metric, new-customers metric, conversion-rate metric, a pie chart (revenue by category), and a bar chart (monthly sales)
+
+#### MCP App — Excalidraw Diagram
+
+- [ ] Click "Excalidraw Diagram (MCP App)"; within 30s verify an Excalidraw embed renders a diagram with a router, 2 switches, and 4 computers (no console errors referencing the MCP server URL)
+
+#### Open Generative UI — Calculator App
+
+- [ ] Click "Calculator App (Open Generative UI)"; within 30s verify a sandboxed calculator UI renders with digit/operator buttons plus labeled metric shortcut buttons
+- [ ] Click a metric shortcut button; verify its value is inserted into the calculator display
+
+#### Frontend Tool — Toggle Theme (`toggleTheme`)
+
+- [ ] Click "Toggle Theme (Frontend Tools)"; verify the `html` element's `class` attribute toggles between containing `dark` and not containing `dark`, and the CopilotKit logo inverts via the `dark:invert` class
+
+### 3. Error Handling
+
+- [ ] Attempt to send an empty message; verify it is a no-op (no user bubble, no assistant response)
+- [ ] Send a ~500-character message; verify it wraps in-transcript without horizontal scroll or layout break
+- [ ] With the backend stopped, send a message; verify the UI surfaces a visible error path rather than hanging silently, and DevTools → Console shows no uncaught errors during any flow above
+
+## Expected Results
+
+- Chat loads within 3 seconds; plain-text response within 10 seconds
+- Controlled charts (pie/bar) render within 15 seconds of prompt; A2UI surfaces within 20–30 seconds
+- No UI layout breaks, no flash of unstyled content, no uncaught console errors
+- All 4 backend agent tools (`manage_todos`, `query_data`, `search_flights`, `generate_a2ui`) are exercised by at least one check above

--- a/showcase/integrations/google-adk/src/agents/beautiful_chat_agent.py
+++ b/showcase/integrations/google-adk/src/agents/beautiful_chat_agent.py
@@ -1,53 +1,156 @@
-"""Agent backing the Beautiful Chat demo.
+"""Agent backing the Beautiful Chat flagship demo.
 
-A canonical "polished starter" agent — has the sales-pipeline tools
-(query_data, search_flights, schedule_meeting) so the demo can showcase
-chart cards, flight cards, and meeting picker UIs alongside the brand
-fonts, theme tokens, and suggestion pills on the frontend.
+Canonical pattern (mirrors langgraph-python and ms-agent-python beautiful-chat):
+
+- `query_data` returns rows from a small CSV; the frontend `pieChart` /
+  `barChart` components render the result.
+- `search_flights` returns A2UI fixed-schema operations for the FlightCard
+  catalog component.
+- `generate_a2ui` is the dynamic-A2UI tool — it delegates to the secondary
+  Gemini planner already wired in `agents/main.py`.
+- `manage_todos` writes to shared session state under key `todos` with
+  schema `{id, title, description, emoji, status}`. Streaming is enabled
+  in `registry.py` via PredictStateMapping so the canvas TodoList renders
+  the list as it grows.
+
+The frontend registers `scheduleTime` (HITL), `pieChart`, `barChart`, and
+`toggleTheme` via `useHumanInTheLoop` / `useComponent` / `useFrontendTool`
+in `src/app/demos/beautiful-chat/hooks/use-generative-ui-examples.tsx`.
+The system prompt below references those tool names verbatim so Gemini
+learns to invoke them.
 """
 
 from __future__ import annotations
 
+import uuid
+from textwrap import dedent
+
 from google.adk.agents import LlmAgent
+from google.adk.agents.callback_context import CallbackContext
 from google.adk.tools import ToolContext
 
 from agents.shared_chat import get_model
 
-# Shared tool implementations (via tools symlink -> ../../shared/python/tools)
+# Reuse the secondary-LLM A2UI planner already wired up in `agents.main`
+# (uses google.genai with forced tool_config — keeps the package on Gemini
+# end-to-end, no OpenAI dependency).
+from agents.main import generate_a2ui
+
+# Shared tool implementations live under `showcase/shared/python/tools/`
+# and are exposed via the `tools` symlink at the package root.
 from tools import (
     query_data_impl,
     search_flights_impl,
-    schedule_meeting_impl,
 )
 
 
 def query_data(tool_context: ToolContext, query: str) -> list:
-    """Query financial data — returns rows for pie / bar charts."""
+    """Query the sales database. Takes natural language. Always call before
+    showing a chart or graph (the frontend pieChart / barChart components
+    consume the rows returned here)."""
+    del tool_context  # state not needed for read-only query
     return query_data_impl(query)
 
 
 def search_flights(tool_context: ToolContext, flights: list[dict]) -> dict:
-    """Search for flights — returns 2-3 candidate cards."""
+    """Search for flights and display the results as rich A2UI cards.
+
+    Return EXACTLY 2 flights. Each flight must have these fields:
+
+    - airline: e.g. "United Airlines"
+    - airlineLogo: Google favicon URL,
+      "https://www.google.com/s2/favicons?domain={airline_domain}&sz=128"
+      (united.com, delta.com, aa.com, alaskaair.com, ...)
+    - flightNumber: e.g. "UA123"
+    - origin: 3-letter airport code, e.g. "SFO"
+    - destination: 3-letter airport code, e.g. "JFK"
+    - date: short readable form, e.g. "Tue, Apr 15" — use a near-future date
+    - departureTime: 24h time, e.g. "08:00"
+    - arrivalTime: 24h time, e.g. "16:30"
+    - duration: e.g. "5h 30m"
+    - status: "On Time" or "Delayed" or "Cancelled"
+    - statusColor: hex string for the status dot — "#22c55e" for On Time,
+      "#eab308" for Delayed, "#ef4444" for Cancelled
+    - price: e.g. "$349"
+    - currency: e.g. "USD"
+    """
+    del tool_context  # the catalog/surface is owned by the runtime middleware
     return search_flights_impl(flights)
 
 
-def schedule_meeting(
-    tool_context: ToolContext, reason: str, duration_minutes: int = 30
-) -> dict:
-    """Schedule a meeting (the user picks a time via the UI)."""
-    return schedule_meeting_impl(reason, duration_minutes)
+def manage_todos(tool_context: ToolContext, todos: list[dict]) -> dict:
+    """Replace the entire list of todos with the provided values.
+
+    Always include EVERY todo you want to keep (this is a wholesale replace,
+    not a diff). Each todo needs:
+
+    - id: stable string id; omit to have one assigned
+    - title: short title
+    - description: 1-2 sentence description
+    - emoji: one of 🎯 🔥 ✅ 💡 🚀
+    - status: "pending" or "completed"
+    """
+    normalized: list[dict] = []
+    for todo in todos:
+        normalized.append(
+            {
+                "id": todo.get("id") or str(uuid.uuid4()),
+                "title": todo.get("title", ""),
+                "description": todo.get("description", ""),
+                "emoji": todo.get("emoji", "🎯"),
+                "status": todo.get("status", "pending"),
+            }
+        )
+    tool_context.state["todos"] = normalized
+    return {"status": "ok", "count": len(normalized)}
 
 
-_INSTRUCTION = (
-    "You are a polished sales assistant. Use query_data for charts, "
-    "search_flights for flight options (return 2-3 plausible flights), "
-    "and schedule_meeting when the user wants to book time. Provide a "
-    "short textual summary after each tool call."
-)
+def _on_before_agent(callback_context: CallbackContext):
+    """Initialize `state["todos"]` so useAgent reads `[]` instead of `undefined`
+    on first render of the canvas TodoList."""
+    if "todos" not in callback_context.state:
+        callback_context.state["todos"] = []
+    return None
+
+
+_INSTRUCTION = dedent(
+    """
+    You are a polished, professional sales-team demo assistant. Keep
+    responses to 1-2 sentences.
+
+    Tool guidance (call the right tool — never paste structured content as
+    plain text):
+
+    - Charts: call `query_data` first to fetch the rows, then render with
+      the frontend `pieChart` or `barChart` component (they appear in your
+      tool list — pass `data`, `title`, and a brief `description`).
+    - Flights: call `search_flights` with EXACTLY 2 flight objects matching
+      the schema in the tool description. The frontend renders an A2UI
+      flight card list automatically.
+    - Dashboards & rich UI: call `generate_a2ui` for any dashboard, report,
+      or summary (metrics, charts, tables, cards). A secondary planner
+      designs the surface; the runtime renders it inline.
+    - Meetings: when the user asks to schedule, book, or pick a time, call
+      the `scheduleTime` frontend tool — DO NOT ask the user for approval
+      yourself, the tool's picker UI handles that.
+    - Todos: when the user wants to enable app mode, work with todos, or
+      manage tasks, call `enableAppMode` first (frontend tool), then
+      `manage_todos` with the FULL list (id, title, description, emoji,
+      status). Never send partial updates.
+    - Theme: call the `toggleTheme` frontend tool to flip light/dark.
+    - MCP / Excalidraw: when the user asks for a diagram, call the
+      Excalidraw MCP tool that the runtime exposes.
+
+    After executing a tool, send a brief final message summarizing what
+    changed.
+    """
+).strip()
+
 
 beautiful_chat_agent = LlmAgent(
     name="BeautifulChatAgent",
     model=get_model(),
     instruction=_INSTRUCTION,
-    tools=[query_data, search_flights, schedule_meeting],
+    tools=[query_data, search_flights, manage_todos, generate_a2ui],
+    before_agent_callback=_on_before_agent,
 )

--- a/showcase/integrations/google-adk/src/agents/beautiful_chat_data/db.csv
+++ b/showcase/integrations/google-adk/src/agents/beautiful_chat_data/db.csv
@@ -1,0 +1,41 @@
+date,category,subcategory,amount,type,notes
+2026-01-05,Revenue,Enterprise Subscriptions,28000,income,3 new enterprise customers (Acme Corp, TechFlow, DataViz Inc)
+2026-01-05,Revenue,Pro Tier Upgrades,18000,income,24 users upgraded from free to pro
+2026-01-08,Revenue,API Usage Overages,9500,income,High API usage from top 5 customers
+2026-01-10,Expenses,Engineering Salaries,42000,expense,7 engineers + 2 contractors
+2026-01-10,Expenses,Product Team,18000,expense,PM and 2 designers
+2026-01-12,Expenses,AWS Infrastructure,8200,expense,Increased compute for new AI features
+2026-01-15,Expenses,Marketing - Paid Ads,12000,expense,Google Ads and LinkedIn campaigns
+2026-01-18,Revenue,Consulting Services,14500,income,Custom integration for Acme Corp
+2026-01-20,Expenses,Customer Success,15000,expense,3 CSMs + support tools (Intercom)
+2026-01-22,Expenses,AI Model Costs,4200,expense,OpenAI API usage for product features
+2026-01-25,Revenue,Marketplace Sales,12800,income,Template and plugin sales
+2026-01-28,Expenses,Office & Equipment,3500,expense,New laptops and coworking spaces
+2026-02-03,Revenue,Enterprise Subscriptions,31000,income,2 new customers + expansion from TechFlow
+2026-02-03,Revenue,Pro Tier Upgrades,22500,income,31 upgrades + reduced churn
+2026-02-05,Revenue,API Usage Overages,11800,income,DataViz Inc heavy API usage spike
+2026-02-07,Expenses,Engineering Salaries,42000,expense,Same headcount as January
+2026-02-07,Expenses,Product Team,18000,expense,No changes to product team
+2026-02-10,Expenses,AWS Infrastructure,9500,expense,Traffic spike from viral social post
+2026-02-12,Expenses,Marketing - Paid Ads,15000,expense,Increased ad spend for Q1 push
+2026-02-14,Revenue,Consulting Services,18000,income,2 custom projects (TechFlow + new client)
+2026-02-18,Expenses,Customer Success,16500,expense,Hired 1 additional CSM
+2026-02-20,Expenses,AI Model Costs,5800,expense,Increased usage from new AI features launch
+2026-02-22,Revenue,Marketplace Sales,14200,income,Top template hit featured list
+2026-02-25,Expenses,Conference & Travel,4500,expense,Team attended SaaS Conference 2026
+2026-02-27,Revenue,Partnership Revenue,11500,income,Referral fees from integration partners
+2026-03-02,Revenue,Enterprise Subscriptions,35000,income,Major win: Fortune 500 customer signed
+2026-03-02,Revenue,Pro Tier Upgrades,26000,income,42 upgrades - best month yet
+2026-03-05,Revenue,API Usage Overages,13200,income,Consistent high usage across top tier
+2026-03-08,Expenses,Engineering Salaries,48000,expense,Hired 1 senior engineer for AI team
+2026-03-08,Expenses,Product Team,21000,expense,Promoted designer to senior level
+2026-03-10,Expenses,AWS Infrastructure,11000,expense,Scaled infrastructure for enterprise client
+2026-03-12,Expenses,Marketing - Paid Ads,18000,expense,Doubled down on successful campaigns
+2026-03-14,Revenue,Consulting Services,21500,income,Fortune 500 onboarding + 2 other projects
+2026-03-16,Expenses,Customer Success,19500,expense,Hired dedicated enterprise CSM
+2026-03-18,Expenses,AI Model Costs,7200,expense,Fortune 500 client heavy AI usage
+2026-03-20,Revenue,Marketplace Sales,15800,income,3 new templates in top 10
+2026-03-22,Expenses,Sales & BD,12000,expense,Hired first sales rep for enterprise
+2026-03-24,Revenue,Partnership Revenue,14200,income,New integration partnerships launched
+2026-03-26,Expenses,Security & Compliance,6500,expense,SOC 2 audit and security tools
+2026-03-28,Revenue,Training & Workshops,10200,income,Conducted 2 customer training sessions

--- a/showcase/integrations/google-adk/src/agents/beautiful_chat_data/schemas/flight_schema.json
+++ b/showcase/integrations/google-adk/src/agents/beautiful_chat_data/schemas/flight_schema.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "root",
+    "component": "Row",
+    "children": {
+      "componentId": "flight-card",
+      "path": "/flights"
+    },
+    "gap": 16
+  },
+  {
+    "id": "flight-card",
+    "component": "FlightCard",
+    "airline": { "path": "airline" },
+    "airlineLogo": { "path": "airlineLogo" },
+    "flightNumber": { "path": "flightNumber" },
+    "origin": { "path": "origin" },
+    "destination": { "path": "destination" },
+    "date": { "path": "date" },
+    "departureTime": { "path": "departureTime" },
+    "arrivalTime": { "path": "arrivalTime" },
+    "duration": { "path": "duration" },
+    "status": { "path": "status" },
+    "price": { "path": "price" },
+    "action": {
+      "event": {
+        "name": "book_flight",
+        "context": {
+          "flightNumber": { "path": "flightNumber" },
+          "origin": { "path": "origin" },
+          "destination": { "path": "destination" },
+          "price": { "path": "price" }
+        }
+      }
+    }
+  }
+]

--- a/showcase/integrations/google-adk/src/agents/registry.py
+++ b/showcase/integrations/google-adk/src/agents/registry.py
@@ -167,7 +167,20 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
     "open_gen_ui": AgentSpec(open_gen_ui_agent),
     "open_gen_ui_advanced": AgentSpec(open_gen_ui_advanced_agent),
     # ----- Beautiful chat -----
-    "beautiful_chat": AgentSpec(beautiful_chat_agent),
+    # PredictStateMapping streams `state["todos"]` as `manage_todos.todos`
+    # arguments arrive, so the canvas TodoList renders cards as the agent
+    # is still composing them — same UX as langgraph-python's beautiful-chat
+    # via StateStreamingMiddleware.
+    "beautiful_chat": AgentSpec(
+        beautiful_chat_agent,
+        predict_state=[
+            PredictStateMapping(
+                state_key="todos",
+                tool="manage_todos",
+                tool_argument="todos",
+            ),
+        ],
+    ),
     # ----- Auth (uses simple chat — auth gate is in route.ts) -----
     "auth": AgentSpec(_simple_chat),
     # ----- Interrupt-adapted demos (Strategy B: useFrontendTool) -----

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -1,0 +1,79 @@
+// Dedicated runtime for the Beautiful Chat flagship showcase cell.
+//
+// Beautiful Chat simultaneously exercises A2UI (dynamic + fixed schema),
+// Open Generative UI, and MCP Apps. The main `/api/copilotkit` runtime
+// keeps those global flags OFF so per-demo `useFrontendTool` /
+// `useComponent` registrations in non-flagship cells stay isolated. This
+// route enables the combined-runtime shape for the one cell that needs it.
+//
+// References:
+// - showcase/integrations/langgraph-python/src/app/api/copilotkit-beautiful-chat/route.ts
+// - showcase/integrations/ms-agent-python/src/app/api/copilotkit-beautiful-chat/route.ts
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+// agent_server.py mounts the ADK middleware at /<agent_name>; the registry
+// uses underscore form (`beautiful_chat`) so the backend path matches.
+function createBeautifulChatAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/beautiful_chat` });
+}
+
+const agents: Record<string, AbstractAgent> = {
+  // The page's <CopilotKit agent="beautiful_chat"> resolves here.
+  beautiful_chat: createBeautifulChatAgent(),
+  // Internal components (example-canvas, headless-chat) call `useAgent()`
+  // with no args, which defaults to agentId "default". Alias to the same
+  // agent so those component hooks resolve instead of throwing
+  // "Agent 'default' not found".
+  default: createBeautifulChatAgent(),
+};
+
+const runtime = new CopilotRuntime({
+  // @ts-expect-error -- see main route.ts; published types reject plain Records.
+  agents,
+  // Canonical: openGenerativeUI: true, a2ui.injectA2UITool: false, mcpApps.
+  openGenerativeUI: true,
+  a2ui: {
+    // The backend agent owns `generate_a2ui`, so we must NOT inject the
+    // runtime's default A2UI tool on top (that would double-bind the tool
+    // slot and confuse the LLM).
+    injectA2UITool: false,
+  },
+  mcpApps: {
+    servers: [
+      {
+        type: "http",
+        url: process.env.MCP_SERVER_URL || "https://mcp.excalidraw.com",
+        // Stable serverId so persisted threads keep restoring the same MCP
+        // server across URL changes.
+        serverId: "beautiful_chat_mcp",
+      },
+    ],
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-beautiful-chat",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error("[copilotkit-beautiful-chat]", e);
+    return NextResponse.json(
+      { error: e.message, stack: e.stack },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/README.md
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/README.md
@@ -1,0 +1,45 @@
+# Beautiful Chat (MS Agent Framework)
+
+Flagship MS Agent Framework showcase that combines A2UI (fixed + dynamic),
+Open Generative UI, MCP Apps, shared state (todos), and HITL in a single
+polished sales-dashboard demo.
+
+## Architecture
+
+- **Frontend** (`src/app/demos/beautiful-chat/`):
+  - `page.tsx` wires `<CopilotKit>` with the demonstration A2UI catalog and
+    enables `openGenerativeUI`.
+  - `components/example-layout` swaps between a chat view and an app view
+    via frontend tools (`enableAppMode` / `enableChatMode`).
+  - `components/example-canvas` renders the shared-state todos kanban.
+  - `hooks/use-generative-ui-examples` registers controlled generative UI
+    (`pieChart`, `barChart`), HITL (`scheduleTime` via `MeetingTimePicker`),
+    frontend tools (`toggleTheme`), and default tool rendering (`ToolReasoning`).
+  - `hooks/use-example-suggestions` wires the suggestion pills.
+  - `declarative-generative-ui/renderers.tsx` assembles the A2UI component
+    catalog used for dynamic dashboards and fixed flight cards.
+- **Runtime** (`src/app/api/copilotkit-beautiful-chat/route.ts`):
+  Dedicated route enabling `openGenerativeUI: true`,
+  `a2ui.injectA2UITool: false`, and `mcpApps` pointed at Excalidraw by
+  default. Proxies to the Python agent server at `/beautiful-chat`.
+- **Agent** (`src/agents/beautiful_chat.py`):
+  `AgentFrameworkAgent` backed by `OpenAIChatClient` with the tool surface
+  for the demo: `manage_todos`, `query_data` (served from
+  `beautiful_chat_data/db.csv`), `search_flights` (fixed-schema A2UI),
+  and `generate_a2ui` (dynamic A2UI via a secondary LLM call).
+- **Mounting**: see `src/agent_server.py` -- the beautiful-chat agent is
+  mounted on `/beautiful-chat` before the catch-all `/` endpoint.
+
+## Data
+
+Sales CSV + flight A2UI schema ship under
+`src/agents/beautiful_chat_data/`. The agent reads the CSV at module load
+time to avoid per-request file I/O.
+
+## Notes on framework parity
+
+The canonical reference is LangGraph + Python (see
+`showcase/integrations/langgraph-python/src/app/demos/beautiful-chat/`).
+The MS Agent Framework port preserves the frontend tree verbatim and
+reimplements the tool surface on `agent_framework.Agent` with the shared
+Python tool helpers in `showcase/shared/python/tools/`.

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-canvas/index.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-canvas/index.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useAgent } from "@copilotkit/react-core/v2";
+import { TodoList } from "./todo-list";
+
+export function ExampleCanvas() {
+  const { agent } = useAgent();
+
+  return (
+    <div className="h-full overflow-y-auto bg-[--background]">
+      <div className="max-w-4xl mx-auto px-8 py-10 h-full">
+        <TodoList
+          todos={agent.state?.todos || []}
+          onUpdate={(updatedTodos) => agent.setState({ todos: updatedTodos })}
+          isAgentRunning={agent.isRunning}
+        />
+      </div>
+    </div>
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-canvas/todo-card.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-canvas/todo-card.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Card } from "../ui/card";
+import { Checkbox } from "../ui/checkbox";
+import { Button } from "../ui/button";
+import { X } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+interface Todo {
+  id: string;
+  title: string;
+  description: string;
+  emoji: string;
+  status: "pending" | "completed";
+}
+
+interface TodoCardProps {
+  todo: Todo;
+  onToggleStatus: (todo: Todo) => void;
+  onDelete: (todo: Todo) => void;
+  onUpdateTitle: (todoId: string, title: string) => void;
+  onUpdateDescription: (todoId: string, description: string) => void;
+  onUpdateEmoji: (todoId: string, emoji: string) => void;
+}
+
+const EMOJI_OPTIONS = ["✅", "🔥", "🎯", "💡", "🚀"];
+
+export function TodoCard({
+  todo,
+  onToggleStatus,
+  onDelete,
+  onUpdateTitle,
+  onUpdateDescription,
+  onUpdateEmoji,
+}: TodoCardProps) {
+  const [editingField, setEditingField] = useState<
+    "title" | "description" | null
+  >(null);
+  const [editValue, setEditValue] = useState("");
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const isCompleted = todo.status === "completed";
+  const truncatedDescription =
+    todo.description.length > 120
+      ? todo.description.slice(0, 120) + "..."
+      : todo.description;
+
+  const startEdit = (field: "title" | "description") => {
+    setEditingField(field);
+    setEditValue(field === "title" ? todo.title : todo.description);
+  };
+
+  const saveEdit = (field: "title" | "description") => {
+    if (editValue.trim()) {
+      if (field === "title") {
+        onUpdateTitle(todo.id, editValue.trim());
+      } else {
+        onUpdateDescription(todo.id, editValue.trim());
+      }
+    }
+    setEditingField(null);
+    setEditValue("");
+  };
+
+  const cancelEdit = () => {
+    setEditingField(null);
+    setEditValue("");
+  };
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+      textareaRef.current.style.height =
+        textareaRef.current.scrollHeight + "px";
+    }
+  }, [editValue]);
+
+  return (
+    <Card
+      className={cn(
+        "group relative p-5 transition-all duration-150",
+        isCompleted && "opacity-60",
+      )}
+    >
+      {/* Delete — top right on hover */}
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => onDelete(todo)}
+        className="absolute top-3 right-3 h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+        aria-label="Delete todo"
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+
+      {/* Emoji avatar */}
+      <div className="relative inline-block mb-3">
+        <button
+          onClick={() => setShowEmojiPicker(!showEmojiPicker)}
+          className={cn(
+            "block text-3xl leading-none cursor-pointer rounded-xl p-2 transition-colors",
+            isCompleted ? "bg-[var(--muted)]" : "bg-[var(--secondary)]",
+          )}
+          aria-label="Change emoji"
+        >
+          {todo.emoji}
+        </button>
+
+        {showEmojiPicker && (
+          <div className="absolute top-0 left-full ml-2 z-10 flex gap-1 p-1.5 rounded-full bg-[var(--card)] border border-[var(--border)] shadow-lg">
+            {EMOJI_OPTIONS.map((emoji) => (
+              <button
+                key={emoji}
+                onClick={() => {
+                  onUpdateEmoji(todo.id, emoji);
+                  setShowEmojiPicker(false);
+                }}
+                className="text-lg w-8 h-8 flex items-center justify-center rounded-full cursor-pointer transition-colors hover:bg-[var(--secondary)]"
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Title */}
+      <div className="flex items-start gap-3">
+        <Checkbox
+          checked={isCompleted}
+          onCheckedChange={() => onToggleStatus(todo)}
+          className="mt-[2px]"
+        />
+
+        <div className="flex-1 min-w-0">
+          {editingField === "title" ? (
+            <input
+              type="text"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={() => saveEdit("title")}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") saveEdit("title");
+                if (e.key === "Escape") cancelEdit();
+              }}
+              className="w-full text-base font-semibold focus:outline-none bg-transparent text-[var(--foreground)] border-b-2 border-[var(--primary)] pb-[2px]"
+              autoFocus
+              aria-label="Edit todo title"
+            />
+          ) : (
+            <div
+              onClick={() => startEdit("title")}
+              className={cn(
+                "text-base font-semibold cursor-text break-words leading-snug",
+                isCompleted
+                  ? "text-[var(--muted-foreground)] line-through"
+                  : "text-[var(--foreground)]",
+              )}
+            >
+              {todo.title}
+            </div>
+          )}
+
+          {editingField === "description" ? (
+            <textarea
+              ref={textareaRef}
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={() => saveEdit("description")}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") cancelEdit();
+              }}
+              className="w-full mt-1.5 text-sm leading-relaxed focus:outline-none resize-none bg-transparent text-[var(--muted-foreground)] border-b-2 border-[var(--primary)] pb-[2px]"
+              rows={1}
+              autoFocus
+              aria-label="Edit todo description"
+            />
+          ) : (
+            <p
+              onClick={() => startEdit("description")}
+              className={cn(
+                "mt-1.5 text-sm leading-relaxed cursor-text",
+                isCompleted
+                  ? "text-[var(--muted-foreground)] line-through"
+                  : "text-[var(--muted-foreground)]",
+              )}
+            >
+              {truncatedDescription}
+            </p>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-canvas/todo-column.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-canvas/todo-column.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { TodoCard } from "./todo-card";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Plus } from "lucide-react";
+
+interface Todo {
+  id: string;
+  title: string;
+  description: string;
+  emoji: string;
+  status: "pending" | "completed";
+}
+
+interface TodoColumnProps {
+  title: string;
+  todos: Todo[];
+  emptyMessage: string;
+  showAddButton?: boolean;
+  onAddTodo?: () => void;
+  onToggleStatus: (todo: Todo) => void;
+  onDelete: (todo: Todo) => void;
+  onUpdateTitle: (todoId: string, title: string) => void;
+  onUpdateDescription: (todoId: string, description: string) => void;
+  onUpdateEmoji: (todoId: string, emoji: string) => void;
+  isAgentRunning: boolean;
+}
+
+export function TodoColumn({
+  title,
+  todos,
+  emptyMessage,
+  showAddButton = false,
+  onAddTodo,
+  onToggleStatus,
+  onDelete,
+  onUpdateTitle,
+  onUpdateDescription,
+  onUpdateEmoji,
+  isAgentRunning,
+}: TodoColumnProps) {
+  return (
+    <section aria-label={`${title} column`} className="flex-1 min-w-0">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-bold tracking-tight text-[var(--foreground)]">
+            {title}
+          </h2>
+          <Badge variant="secondary">{todos.length}</Badge>
+        </div>
+        {showAddButton && onAddTodo && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onAddTodo}
+            disabled={isAgentRunning}
+            aria-label="Add new todo"
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      {/* Cards */}
+      <div className="space-y-3">
+        {todos.length === 0 ? (
+          <div className="text-center text-sm rounded-[var(--radius)] border-2 border-dashed border-[var(--border)] p-5 min-h-[151px] flex items-center justify-center text-[var(--muted-foreground)]">
+            {emptyMessage}
+          </div>
+        ) : (
+          todos.map((todo) => (
+            <TodoCard
+              key={todo.id}
+              todo={todo}
+              onToggleStatus={onToggleStatus}
+              onDelete={onDelete}
+              onUpdateTitle={onUpdateTitle}
+              onUpdateDescription={onUpdateDescription}
+              onUpdateEmoji={onUpdateEmoji}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-canvas/todo-list.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-canvas/todo-list.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { TodoColumn } from "./todo-column";
+import { Button } from "../ui/button";
+
+interface Todo {
+  id: string;
+  title: string;
+  description: string;
+  emoji: string;
+  status: "pending" | "completed";
+}
+
+interface TodoListProps {
+  todos: Todo[];
+  onUpdate: (todos: Todo[]) => void;
+  isAgentRunning: boolean;
+}
+
+export function TodoList({ todos, onUpdate, isAgentRunning }: TodoListProps) {
+  const pendingTodos = todos.filter((t) => t.status === "pending");
+  const completedTodos = todos.filter((t) => t.status === "completed");
+
+  const toggleStatus = (todo: Todo) => {
+    const updated = todos.map((t) =>
+      t.id === todo.id
+        ? {
+            ...t,
+            status: (t.status === "completed" ? "pending" : "completed") as
+              | "pending"
+              | "completed",
+          }
+        : t,
+    );
+    onUpdate(updated);
+  };
+
+  const deleteTodo = (todo: Todo) => {
+    onUpdate(todos.filter((t) => t.id !== todo.id));
+  };
+
+  const updateTitle = (todoId: string, title: string) => {
+    const updated = todos.map((t) => (t.id === todoId ? { ...t, title } : t));
+    onUpdate(updated);
+  };
+
+  const updateDescription = (todoId: string, description: string) => {
+    const updated = todos.map((t) =>
+      t.id === todoId ? { ...t, description } : t,
+    );
+    onUpdate(updated);
+  };
+
+  const updateEmoji = (todoId: string, emoji: string) => {
+    const updated = todos.map((t) => (t.id === todoId ? { ...t, emoji } : t));
+    onUpdate(updated);
+  };
+
+  const addTodo = () => {
+    const newTodo: Todo = {
+      id: crypto.randomUUID(),
+      title: "New Todo",
+      description: "Add a description",
+      emoji: "🎯",
+      status: "pending",
+    };
+    onUpdate([...todos, newTodo]);
+  };
+
+  if (!todos || todos.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4">
+        <div className="text-5xl">✏️</div>
+        <p className="text-base font-semibold text-[--foreground]">
+          No todos yet
+        </p>
+        <p className="text-sm text-[--muted-foreground]">
+          Create your first task to get started
+        </p>
+        <Button onClick={addTodo} disabled={isAgentRunning} className="mt-2">
+          Add a task
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-8 h-full">
+      <TodoColumn
+        title="To Do"
+        todos={pendingTodos}
+        emptyMessage="No pending todos"
+        showAddButton
+        onAddTodo={addTodo}
+        onToggleStatus={toggleStatus}
+        onDelete={deleteTodo}
+        onUpdateTitle={updateTitle}
+        onUpdateDescription={updateDescription}
+        onUpdateEmoji={updateEmoji}
+        isAgentRunning={isAgentRunning}
+      />
+      <TodoColumn
+        title="Done"
+        todos={completedTodos}
+        emptyMessage="No completed todos yet"
+        onToggleStatus={toggleStatus}
+        onDelete={deleteTodo}
+        onUpdateTitle={updateTitle}
+        onUpdateDescription={updateDescription}
+        onUpdateEmoji={updateEmoji}
+        isAgentRunning={isAgentRunning}
+      />
+    </div>
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-layout/index.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-layout/index.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { ReactNode, useState } from "react";
+import { ModeToggle } from "./mode-toggle";
+import { useFrontendTool } from "@copilotkit/react-core";
+
+interface ExampleLayoutProps {
+  chatContent: ReactNode;
+  appContent: ReactNode;
+}
+
+export function ExampleLayout({ chatContent, appContent }: ExampleLayoutProps) {
+  const [mode, setMode] = useState<"chat" | "app">("chat");
+
+  useFrontendTool({
+    name: "enableAppMode",
+    description:
+      "Enable app mode, make sure its open when interacting with todos.",
+    handler: async () => {
+      setMode("app");
+    },
+  });
+
+  useFrontendTool({
+    name: "enableChatMode",
+    description: "Enable chat mode",
+    handler: async () => {
+      setMode("chat");
+    },
+  });
+
+  return (
+    <div className="h-full flex flex-row">
+      <ModeToggle mode={mode} onModeChange={setMode} />
+
+      {/* Chat Content */}
+      <div
+        className={`max-h-full flex flex-col ${
+          mode === "app"
+            ? "w-1/3 px-6 max-lg:hidden" // Hide on mobile in app mode
+            : "flex-1 max-lg:px-4"
+        }`}
+      >
+        <div className="shrink-0 pt-6 pl-6 pb-2 max-lg:pl-4 max-lg:pt-4">
+          <img
+            src="/copilotkit-logo.svg"
+            alt="CopilotKit"
+            className="h-7 dark:invert"
+          />
+        </div>
+        <div className="flex-1 min-h-0 overflow-y-auto">{chatContent}</div>
+      </div>
+
+      {/* State Panel */}
+      <div
+        className={`h-full overflow-hidden ${
+          mode === "app"
+            ? "w-2/3 max-lg:w-full border-l border-[var(--border)] max-lg:border-l-0" // Full width on mobile
+            : "w-0 border-l-0"
+        }`}
+      >
+        <div className="w-full lg:w-[66.666vw] h-full">{appContent}</div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-layout/mode-toggle.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/example-layout/mode-toggle.tsx
@@ -1,0 +1,31 @@
+interface ModeToggleProps {
+  mode: "chat" | "app";
+  onModeChange: (mode: "chat" | "app") => void;
+}
+
+export function ModeToggle({ mode, onModeChange }: ModeToggleProps) {
+  return (
+    <div className="fixed top-4 right-4 z-50 flex rounded-full border border-[var(--border)] bg-[var(--secondary)] p-0.5 max-lg:top-2 max-lg:right-2 max-lg:scale-90">
+      <button
+        onClick={() => onModeChange("chat")}
+        className={`px-4 py-1.5 rounded-full text-[13px] font-medium transition-all cursor-pointer ${
+          mode === "chat"
+            ? "bg-[var(--card)] text-[var(--card-foreground)] shadow-sm"
+            : "text-[var(--muted-foreground)]"
+        }`}
+      >
+        Chat
+      </button>
+      <button
+        onClick={() => onModeChange("app")}
+        className={`px-4 py-1.5 rounded-full text-[13px] font-medium transition-all cursor-pointer ${
+          mode === "app"
+            ? "bg-[var(--card)] text-[var(--card-foreground)] shadow-sm"
+            : "text-[var(--muted-foreground)]"
+        }`}
+      >
+        App
+      </button>
+    </div>
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/generative-ui/charts/bar-chart.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/generative-ui/charts/bar-chart.tsx
@@ -1,0 +1,164 @@
+import { useRef } from "react";
+import {
+  BarChart as RechartsBarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Rectangle,
+} from "recharts";
+import { z } from "zod";
+import { CHART_COLORS, CHART_CONFIG } from "./config";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "../../ui/card";
+import { BarChart3 } from "lucide-react";
+
+export const BarChartProps = z.object({
+  title: z.string().describe("Chart title"),
+  description: z.string().describe("Brief description or subtitle"),
+  data: z.array(
+    z.object({
+      label: z.string(),
+      value: z.number(),
+    }),
+  ),
+});
+
+type BarChartProps = z.infer<typeof BarChartProps>;
+
+/** Tracks seen indices so only NEW bars get the fade-in animation. */
+function useSeenIndices() {
+  const seen = useRef(new Set<number>());
+  return {
+    isNew(index: number) {
+      if (seen.current.has(index)) return false;
+      seen.current.add(index);
+      return true;
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function AnimatedBar(props: any) {
+  const { isNew, ...rest } = props;
+  return (
+    <g
+      style={
+        isNew
+          ? {
+              animation: "barSlideIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both",
+            }
+          : undefined
+      }
+    >
+      <Rectangle {...rest} />
+    </g>
+  );
+}
+
+export function BarChart({ title, description, data }: BarChartProps) {
+  const { isNew } = useSeenIndices();
+
+  if (!data || !Array.isArray(data) || data.length === 0) {
+    return (
+      <Card className="max-w-2xl mx-auto my-4">
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <BarChart3 className="h-4 w-4 text-[var(--muted-foreground)]" />
+            <CardTitle>{title}</CardTitle>
+          </div>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-[var(--muted-foreground)] text-center py-8 text-sm">
+            No data available
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="max-w-2xl mx-auto my-4 overflow-hidden">
+      {/* Scoped keyframe — no globals.css needed */}
+      <style>{`
+        @keyframes barSlideIn {
+          from { transform: translateY(40px); opacity: 0; }
+          20% { opacity: 1; }
+          to { transform: translateY(0); opacity: 1; }
+        }
+      `}</style>
+      <CardHeader className="pb-2">
+        <div className="flex items-center gap-2">
+          <div className="flex items-center justify-center h-6 w-6 rounded-md bg-[var(--secondary)]">
+            <BarChart3 className="h-3.5 w-3.5 text-[var(--muted-foreground)]" />
+          </div>
+          <CardTitle>{title}</CardTitle>
+        </div>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="pt-2">
+        <ResponsiveContainer width="100%" height={280}>
+          <RechartsBarChart
+            data={data}
+            margin={{ top: 12, right: 12, bottom: 4, left: -8 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke="var(--border)"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+              stroke="var(--border)"
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+              stroke="var(--border)"
+              tickLine={false}
+              axisLine={false}
+            />
+            <Tooltip
+              contentStyle={CHART_CONFIG.tooltipStyle}
+              cursor={{ fill: "var(--secondary)", opacity: 0.5 }}
+            />
+            <Bar
+              isAnimationActive={false}
+              dataKey="value"
+              radius={[6, 6, 0, 0]}
+              maxBarSize={48}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              shape={
+                ((props: any) => (
+                  <AnimatedBar
+                    {...props}
+                    isNew={isNew(props.index as number)}
+                  />
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                )) as any
+              }
+            >
+              {data.map((_, index) => (
+                <Cell
+                  key={index}
+                  fill={CHART_COLORS[index % CHART_COLORS.length]}
+                />
+              ))}
+            </Bar>
+          </RechartsBarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/generative-ui/charts/config.ts
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/generative-ui/charts/config.ts
@@ -1,0 +1,25 @@
+/**
+ * CopilotKit brand chart palette — Plus Jakarta Sans / brand color system.
+ */
+export const CHART_COLORS = [
+  "#BEC2FF", // lilac-400
+  "#85ECCE", // mint-400
+  "#FFAC4D", // orange-400
+  "#FFF388", // yellow-400
+  "#189370", // mint-800
+  "#EEE6FE", // primary-100
+  "#FA5F67", // red-400
+] as const;
+
+export const CHART_CONFIG = {
+  tooltipStyle: {
+    backgroundColor: "var(--card)",
+    border: "1px solid var(--border)",
+    borderRadius: "10px",
+    padding: "10px 14px",
+    color: "var(--foreground)",
+    fontSize: "13px",
+    fontFamily: "var(--font-body)",
+    boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
+  },
+};

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/generative-ui/charts/pie-chart.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/generative-ui/charts/pie-chart.tsx
@@ -1,0 +1,155 @@
+import { z } from "zod";
+import { CHART_COLORS } from "./config";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "../../ui/card";
+
+export const PieChartProps = z.object({
+  title: z.string().describe("Chart title"),
+  description: z.string().describe("Brief description or subtitle"),
+  data: z.array(
+    z.object({
+      label: z.string(),
+      value: z.number(),
+    }),
+  ),
+});
+
+type PieChartProps = z.infer<typeof PieChartProps>;
+
+/** Custom SVG donut chart built with <circle> + stroke-dasharray. */
+function DonutChart({
+  data,
+  size = 240,
+  strokeWidth = 40,
+}: {
+  data: { label: string; value: number }[];
+  size?: number;
+  strokeWidth?: number;
+}) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const center = size / 2;
+
+  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
+
+  // Calculate each slice's arc length and starting position
+  let accumulated = 0;
+  const slices = data.map((item, index) => {
+    const val = Number(item.value) || 0;
+    const ratio = total > 0 ? val / total : 0;
+    const arc = ratio * circumference;
+    const startAt = accumulated;
+    accumulated += arc;
+    return {
+      ...item,
+      arc,
+      gap: circumference - arc,
+      // Negative dashoffset shifts the dash forward (clockwise) to the correct position
+      dashoffset: -startAt,
+      color: CHART_COLORS[index % CHART_COLORS.length],
+    };
+  });
+
+  return (
+    <svg
+      width="100%"
+      viewBox={`0 0 ${size} ${size}`}
+      className="block mx-auto"
+      style={{ maxWidth: size, transform: "scaleX(-1)" }}
+    >
+      {/* Background ring */}
+      <circle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        stroke="var(--secondary)"
+        strokeWidth={strokeWidth}
+      />
+      {/* Data slices */}
+      {slices.map((slice, i) => (
+        <circle
+          key={i}
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={slice.color}
+          strokeWidth={strokeWidth}
+          strokeDasharray={`${slice.arc} ${slice.gap}`}
+          strokeDashoffset={slice.dashoffset}
+          strokeLinecap="butt"
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+      ))}
+    </svg>
+  );
+}
+
+export function PieChart({ title, description, data }: PieChartProps) {
+  if (!data || !Array.isArray(data) || data.length === 0) {
+    return (
+      <Card className="max-w-lg mx-auto my-4">
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-[var(--muted-foreground)] text-center py-8 text-sm">
+            No data available
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
+
+  return (
+    <Card className="max-w-lg mx-auto my-4 overflow-hidden">
+      <CardHeader className="pb-0">
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="pt-4">
+        <DonutChart data={data} />
+
+        {/* Legend */}
+        <div className="space-y-2 pt-4">
+          {data.map((item, index) => {
+            const val = Number(item.value) || 0;
+            const pct = total > 0 ? ((val / total) * 100).toFixed(0) : 0;
+            return (
+              <div
+                key={index}
+                className="flex items-center gap-3 text-sm transition-opacity duration-300 ease-out"
+                style={{ opacity: 1 }}
+              >
+                <span
+                  className="inline-block h-3 w-3 rounded-full shrink-0"
+                  style={{
+                    backgroundColor: CHART_COLORS[index % CHART_COLORS.length],
+                  }}
+                />
+                <span className="flex-1 text-[var(--foreground)] truncate">
+                  {item.label}
+                </span>
+                <span className="text-[var(--muted-foreground)] tabular-nums">
+                  {val.toLocaleString()}
+                </span>
+                <span className="text-[var(--muted-foreground)] text-sm w-10 text-right tabular-nums">
+                  {pct}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/generative-ui/meeting-time-picker.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/generative-ui/meeting-time-picker.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+import { Card, CardContent } from "../ui/card";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { Spinner } from "../ui/spinner";
+import { Check, X, Clock, ChevronRight } from "lucide-react";
+
+export interface TimeSlot {
+  date: string;
+  time: string;
+  duration?: string;
+}
+
+export interface MeetingTimePickerProps {
+  status: "inProgress" | "executing" | "complete";
+  respond?: (response: string) => void;
+  reasonForScheduling?: string;
+  meetingDuration?: number;
+  title?: string;
+  timeSlots?: TimeSlot[];
+}
+
+export function MeetingTimePicker({
+  status,
+  respond,
+  reasonForScheduling,
+  meetingDuration,
+  title = "Schedule a Meeting",
+  timeSlots = [
+    { date: "Tomorrow", time: "2:00 PM", duration: "30 min" },
+    { date: "Friday", time: "10:00 AM", duration: "30 min" },
+    { date: "Next Monday", time: "3:00 PM", duration: "30 min" },
+  ],
+}: MeetingTimePickerProps) {
+  const displayTitle = reasonForScheduling || title;
+  const slots = meetingDuration
+    ? timeSlots.map((slot) => ({ ...slot, duration: `${meetingDuration} min` }))
+    : timeSlots;
+  const [selectedSlot, setSelectedSlot] = useState<TimeSlot | null>(null);
+  const [declined, setDeclined] = useState(false);
+
+  const handleSelectSlot = (slot: TimeSlot) => {
+    setSelectedSlot(slot);
+    respond?.(
+      `Meeting scheduled for ${slot.date} at ${slot.time}${slot.duration ? ` (${slot.duration})` : ""}.`,
+    );
+  };
+
+  const handleDecline = () => {
+    setDeclined(true);
+    respond?.(
+      "The user declined all proposed meeting times. Please suggest alternative times or ask for their availability.",
+    );
+  };
+
+  // Confirmed state
+  if (selectedSlot) {
+    return (
+      <Card className="max-w-md w-full mx-auto mb-4 overflow-hidden">
+        <CardContent className="p-6">
+          <div className="flex flex-col items-center text-center gap-3">
+            <div className="flex items-center justify-center h-10 w-10 rounded-full bg-[#189370]">
+              <Check className="h-5 w-5 text-white" strokeWidth={3} />
+            </div>
+            <div>
+              <h3 className="text-lg font-bold text-[var(--foreground)]">
+                Meeting Scheduled
+              </h3>
+              <p className="text-sm text-[var(--muted-foreground)] mt-1">
+                {selectedSlot.date} at {selectedSlot.time}
+              </p>
+            </div>
+            {selectedSlot.duration && (
+              <Badge variant="secondary">
+                <Clock className="h-3 w-3 mr-1" />
+                {selectedSlot.duration}
+              </Badge>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Declined state
+  if (declined) {
+    return (
+      <Card className="max-w-md w-full mx-auto mb-4 overflow-hidden">
+        <CardContent className="p-6">
+          <div className="flex flex-col items-center text-center gap-3">
+            <div className="flex items-center justify-center h-12 w-12 rounded-full bg-[var(--secondary)]">
+              <X className="h-6 w-6 text-[var(--muted-foreground)]" />
+            </div>
+            <div>
+              <h3 className="text-lg font-bold text-[var(--foreground)]">
+                No Time Selected
+              </h3>
+              <p className="text-sm text-[var(--muted-foreground)] mt-1">
+                Looking for a better time that works for you
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Selection state
+  return (
+    <Card className="max-w-md w-full mx-auto mb-4 overflow-hidden">
+      <CardContent className="p-6">
+        <div className="flex flex-col items-center text-center mb-5">
+          <div className="flex items-center justify-center h-12 w-12 rounded-full bg-[var(--accent)] mb-3">
+            <Clock className="h-6 w-6 text-[#BEC2FF]" />
+          </div>
+          <h3 className="text-lg font-bold text-[var(--foreground)]">
+            {displayTitle}
+          </h3>
+          <p className="text-sm text-[var(--muted-foreground)] mt-1">
+            {status === "inProgress"
+              ? "Finding available times..."
+              : "Pick a time that works for you"}
+          </p>
+        </div>
+
+        {status === "inProgress" && (
+          <div className="flex justify-center py-6">
+            <Spinner size="lg" />
+          </div>
+        )}
+
+        {status === "executing" && (
+          <div className="space-y-3">
+            {slots.map((slot, index) => (
+              <button
+                key={index}
+                onClick={() => handleSelectSlot(slot)}
+                className="group w-full px-6 py-5 rounded-[var(--radius)]
+                  border border-[var(--border)]
+                  hover:border-[var(--ring)] hover:bg-[var(--accent)]
+                  transition-all duration-150 cursor-pointer
+                  flex items-center gap-4"
+              >
+                <div className="flex-1 text-left">
+                  <div className="font-semibold text-base text-[var(--foreground)]">
+                    {slot.date}
+                  </div>
+                  <div className="text-sm text-[var(--muted-foreground)] mt-0.5">
+                    {slot.time}
+                  </div>
+                </div>
+                {slot.duration && (
+                  <Badge
+                    variant="secondary"
+                    className="shrink-0 text-sm px-3 py-1"
+                  >
+                    {slot.duration}
+                  </Badge>
+                )}
+                <ChevronRight className="h-4 w-4 text-[var(--muted-foreground)] opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+              </button>
+            ))}
+
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full mt-1 text-xs text-[var(--muted-foreground)]"
+              onClick={handleDecline}
+            >
+              None of these work
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/headless-chat.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/headless-chat.tsx
@@ -1,0 +1,37 @@
+import { useAgent } from "@copilotkit/react-core/v2";
+import { useCallback, useState } from "react";
+
+export const HeadlessChat = () => {
+  const { agent } = useAgent();
+  const [message, setMessage] = useState("");
+
+  const sendMessage = useCallback(
+    (message: string) => {
+      agent.addMessage({
+        role: "user",
+        id: crypto.randomUUID(),
+        content: message,
+      });
+      agent.runAgent();
+      setMessage("");
+    },
+    [agent],
+  );
+
+  return (
+    <div>
+      <h1>Chat</h1>
+      {agent.messages.map((message) => (
+        <div key={message.id}>
+          <p>{JSON.stringify(message.content)}</p>
+        </div>
+      ))}
+      <input
+        type="text"
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+      />
+      <button onClick={() => sendMessage(message)}>Send</button>
+    </div>
+  );
+};

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/tool-rendering.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/tool-rendering.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Wrench, Check, ChevronDown } from "lucide-react";
+import { Spinner } from "./ui/spinner";
+
+interface ToolReasoningProps {
+  name: string;
+  args?: object | unknown;
+  status: string;
+}
+
+function formatValue(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.length} items]`;
+  if (typeof value === "object" && value !== null)
+    return `{${Object.keys(value).length} keys}`;
+  if (typeof value === "string") return `"${value}"`;
+  return String(value);
+}
+
+export function ToolReasoning({ name, args, status }: ToolReasoningProps) {
+  const entries = args ? Object.entries(args) : [];
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+  const isRunning = status === "executing" || status === "inProgress";
+
+  // Auto-open while executing, auto-close when complete
+  useEffect(() => {
+    if (!detailsRef.current) return;
+    detailsRef.current.open = isRunning;
+  }, [isRunning]);
+
+  const statusIcon = isRunning ? (
+    <Spinner size="sm" className="h-3 w-3" />
+  ) : (
+    <Check className="h-3 w-3 text-emerald-500" />
+  );
+
+  return (
+    <div className="my-1.5">
+      {entries.length > 0 ? (
+        <details ref={detailsRef} open className="group">
+          <summary className="flex items-center gap-2 cursor-pointer list-none text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors">
+            {statusIcon}
+            <Wrench className="h-3 w-3" />
+            <span
+              className="font-medium"
+              style={{ fontFamily: "var(--font-code)" }}
+            >
+              {name}
+            </span>
+            <ChevronDown className="h-3 w-3 ml-auto transition-transform group-open:rotate-180" />
+          </summary>
+          <div className="ml-5 mt-1.5 rounded-md bg-[var(--secondary)] px-3 py-2 space-y-1">
+            {entries.map(([key, value]) => (
+              <div
+                key={key}
+                className="flex gap-2 min-w-0 text-xs"
+                style={{ fontFamily: "var(--font-code)" }}
+              >
+                <span className="text-[var(--muted-foreground)] shrink-0">
+                  {key}:
+                </span>
+                <span className="text-[var(--foreground)] truncate">
+                  {formatValue(value)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </details>
+      ) : (
+        <div className="flex items-center gap-2 text-sm text-[var(--muted-foreground)]">
+          {statusIcon}
+          <Wrench className="h-3 w-3" />
+          <span
+            className="font-medium"
+            style={{ fontFamily: "var(--font-code)" }}
+          >
+            {name}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/badge.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/badge.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-[var(--primary)] text-[var(--primary-foreground)]",
+        secondary:
+          "border-transparent bg-[var(--secondary)] text-[var(--secondary-foreground)]",
+        outline: "border-[var(--border)] text-[var(--foreground)]",
+      },
+    },
+    defaultVariants: {
+      variant: "secondary",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/button.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/button.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius)] text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90",
+        secondary:
+          "bg-[var(--secondary)] text-[var(--secondary-foreground)] hover:opacity-80",
+        outline:
+          "border border-[var(--border)] bg-[var(--background)] hover:bg-[var(--secondary)]",
+        ghost:
+          "hover:bg-[var(--secondary)] hover:text-[var(--secondary-foreground)]",
+        destructive:
+          "bg-[var(--destructive)] text-[var(--destructive-foreground)] hover:opacity-90",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-6",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/card.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/card.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-[var(--radius)] border border-[var(--border)] bg-[var(--card)] text-[var(--card-foreground)] shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-[var(--muted-foreground)]", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+};

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/checkbox.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/checkbox.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+const Checkbox = React.forwardRef<
+  React.ComponentRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-5 w-5 shrink-0 rounded-md border border-[var(--border)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[var(--primary)] data-[state=checked]:text-[var(--primary-foreground)] data-[state=checked]:border-transparent cursor-pointer transition-colors",
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+      <Check className="h-3.5 w-3.5" strokeWidth={3} />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/input.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => (
+    <input
+      type={type}
+      className={cn(
+        "flex h-9 w-full rounded-[var(--radius)] border border-[var(--input)] bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-[var(--muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/separator.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/separator.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import { cn } from "../../lib/utils";
+
+const Separator = React.forwardRef<
+  React.ComponentRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref,
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-[var(--border)]",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/spinner.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/components/ui/spinner.tsx
@@ -1,0 +1,24 @@
+import { cn } from "../../lib/utils";
+
+interface SpinnerProps {
+  className?: string;
+  size?: "sm" | "md" | "lg";
+}
+
+const sizeMap = {
+  sm: "h-4 w-4 border-2",
+  md: "h-6 w-6 border-2",
+  lg: "h-8 w-8 border-3",
+};
+
+export function Spinner({ className, size = "md" }: SpinnerProps) {
+  return (
+    <span
+      className={cn(
+        "inline-block rounded-full border-[var(--muted)] border-t-[var(--primary)] animate-spin",
+        sizeMap[size],
+        className,
+      )}
+    />
+  );
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/declarative-generative-ui/definitions.ts
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/declarative-generative-ui/definitions.ts
@@ -1,0 +1,184 @@
+/**
+ * Demonstration Catalog — Component Definitions
+ *
+ * Platform-agnostic definitions: component names, props (Zod), descriptions.
+ * This is the contract between the app and the AI agent. Agents receive these
+ * definitions as context so they know what components are available.
+ *
+ * Renderers (React, React Native, etc.) import these definitions and provide
+ * platform-specific implementations, type-checked against the Zod schemas.
+ */
+
+import { z } from "zod";
+
+/**
+ * Dynamic string: accepts either a literal string or a data-model path binding
+ * like `{ path: "airline" }`. The GenericBinder resolves path bindings to the
+ * actual value at render time.
+ */
+const DynString = z.union([z.string(), z.object({ path: z.string() })]);
+
+export const demonstrationCatalogDefinitions = {
+  Title: {
+    description: "A heading. Use for section titles and page headers.",
+    props: z.object({
+      text: z.string(),
+      level: z.string().optional(),
+    }),
+  },
+
+  // Text: removed — the basic catalog's Text uses DynamicStringSchema
+  // which supports path bindings (e.g. { path: "flights[*].airline" }).
+  // Overriding it with z.string() breaks fixed-schema data binding.
+
+  Row: {
+    description: "Horizontal layout container.",
+    props: z.object({
+      gap: z.number().optional(),
+      align: z.string().optional(),
+      justify: z.string().optional(),
+      // Union with { componentId, path } so GenericBinder treats this as
+      // STRUCTURAL and resolves template children from the data model.
+      children: z.union([
+        z.array(z.string()),
+        z.object({ componentId: z.string(), path: z.string() }),
+      ]),
+    }),
+  },
+
+  Column: {
+    description: "Vertical layout container.",
+    props: z.object({
+      gap: z.number().optional(),
+      align: z.string().optional(),
+      // Same union as Row — required for template children support.
+      children: z.union([
+        z.array(z.string()),
+        z.object({ componentId: z.string(), path: z.string() }),
+      ]),
+    }),
+  },
+
+  DashboardCard: {
+    description:
+      "A card container with title and optional subtitle. Has a 'child' slot for content (chart, metrics, etc). Use 'child' with a single component ID.",
+    props: z.object({
+      title: z.string(),
+      subtitle: z.string().optional(),
+      child: z.string().optional(),
+    }),
+  },
+
+  Metric: {
+    description:
+      "A key metric display with label, value, and optional trend indicator. Great for KPIs and stats.",
+    props: z.object({
+      label: z.string(),
+      value: z.string(),
+      trend: z.enum(["up", "down", "neutral"]).optional(),
+      trendValue: z.string().optional(),
+    }),
+  },
+
+  PieChart: {
+    description:
+      "A pie/donut chart. Provide data as array of {label, value, color} objects.",
+    props: z.object({
+      data: z.array(
+        z.object({
+          label: z.string(),
+          value: z.number(),
+          color: z.string().optional(),
+        }),
+      ),
+      innerRadius: z.number().optional(),
+    }),
+  },
+
+  BarChart: {
+    description:
+      "A bar chart. Provide data as array of {label, value} objects.",
+    props: z.object({
+      data: z.array(z.object({ label: z.string(), value: z.number() })),
+      color: z.string().optional(),
+    }),
+  },
+
+  Badge: {
+    description:
+      "A small status badge/tag. Use for labels, statuses, categories.",
+    props: z.object({
+      text: z.string(),
+      variant: z
+        .enum(["success", "warning", "error", "info", "neutral"])
+        .optional(),
+    }),
+  },
+
+  DataTable: {
+    description: "A data table with columns and rows.",
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      rows: z.array(z.record(z.any())),
+    }),
+  },
+
+  Button: {
+    description:
+      "An interactive button with an action event. Use 'child' with a Text component ID for the label. 'action' is dispatched on click.",
+    props: z.object({
+      child: z
+        .string()
+        .describe(
+          "The ID of the child component (e.g. a Text component for the label).",
+        ),
+      variant: z.enum(["primary", "secondary", "ghost"]).optional(),
+      // Union with { event } so GenericBinder resolves this as ACTION → callable () => void.
+      action: z
+        .union([
+          z.object({
+            event: z.object({
+              name: z.string(),
+              context: z.record(z.any()).optional(),
+            }),
+          }),
+          z.null(),
+        ])
+        .optional(),
+    }),
+  },
+
+  FlightCard: {
+    description:
+      "A rich flight result card. Displays airline, flight number, route, times, duration, status, and price. Use inside a Row for side-by-side layout.",
+    props: z.object({
+      airline: DynString,
+      airlineLogo: DynString,
+      flightNumber: DynString,
+      origin: DynString,
+      destination: DynString,
+      date: DynString,
+      departureTime: DynString,
+      arrivalTime: DynString,
+      duration: DynString,
+      status: DynString,
+      statusColor: DynString.optional(),
+      price: DynString,
+      action: z
+        .union([
+          z.object({
+            event: z.object({
+              name: z.string(),
+              context: z.record(z.any()).optional(),
+            }),
+          }),
+          z.null(),
+        ])
+        .optional(),
+    }),
+  },
+};
+
+/** Type helper for renderers */
+export type DemonstrationCatalogDefinitions =
+  typeof demonstrationCatalogDefinitions;

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/declarative-generative-ui/renderers.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/declarative-generative-ui/renderers.tsx
@@ -1,0 +1,605 @@
+/**
+ * A2UI Catalog — React Renderers
+ *
+ * Each renderer maps a component name from definitions.ts to a React
+ * implementation. Props are type-checked against the Zod schemas.
+ *
+ * To add a component: define its schema in definitions.ts, then add a
+ * renderer here. See README.md "Adding a custom component" for details.
+ *
+ * The assembled catalog is registered in layout.tsx via
+ * <CopilotKit a2ui={{ catalog: demonstrationCatalog }}>.
+ */
+"use client";
+
+import React, { useState, type JSX } from "react";
+import {
+  PieChart as RechartsPie,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  BarChart as RechartsBar,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import {
+  createCatalog,
+  type CatalogRenderers,
+} from "@copilotkit/a2ui-renderer";
+import {
+  demonstrationCatalogDefinitions,
+  type DemonstrationCatalogDefinitions,
+} from "./definitions";
+
+// ─── Theme-aware colors ─────────────────────────────────────────────
+
+const c = {
+  card: "var(--card)",
+  cardFg: "var(--card-foreground)",
+  border: "var(--border)",
+  muted: "var(--muted-foreground)",
+  divider: "color-mix(in srgb, var(--border) 50%, var(--card))",
+  shadow: "0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04)",
+  btnBg: "color-mix(in srgb, var(--muted) 40%, var(--card))",
+  btnDoneBg: "color-mix(in srgb, #22c55e 10%, var(--card))",
+};
+
+function ActionButton({
+  label,
+  doneLabel,
+  action,
+  children: child,
+}: {
+  label: string;
+  doneLabel: string;
+  action: any;
+  children?: React.ReactNode;
+}) {
+  const [done, setDone] = useState(false);
+  return (
+    <button
+      disabled={done}
+      style={{
+        width: "100%",
+        padding: "10px 16px",
+        borderRadius: "10px",
+        border: done ? "1px solid #bbf7d0" : `1px solid ${c.border}`,
+        background: done ? c.btnDoneBg : c.btnBg,
+        color: done ? "#059669" : c.cardFg,
+        fontSize: "0.85rem",
+        fontWeight: 500,
+        cursor: done ? "default" : "pointer",
+        transition: "all 0.2s ease",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "6px",
+      }}
+      onClick={() => {
+        if (!done) {
+          action?.();
+          setDone(true);
+        }
+      }}
+    >
+      {done && (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#059669"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      )}
+      {done ? doneLabel : (child ?? label)}
+    </button>
+  );
+}
+
+// ─── Renderers (type-checked against schema definitions) ────────────
+
+const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefinitions> =
+  {
+    Title: ({ props }) => {
+      const Tag = (
+        props.level === "h1" ? "h1" : props.level === "h3" ? "h3" : "h2"
+      ) as keyof JSX.IntrinsicElements;
+      const sizes: Record<string, string> = {
+        h1: "1.75rem",
+        h2: "1.25rem",
+        h3: "1rem",
+      };
+      return (
+        <Tag
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            fontSize: sizes[props.level ?? "h2"],
+            color: c.cardFg,
+            letterSpacing: "-0.01em",
+          }}
+        >
+          {props.text}
+        </Tag>
+      );
+    },
+
+    // Text: removed — use the basic catalog's Text (supports DynamicStringSchema
+    // for path bindings in fixed-schema templates).
+
+    Row: ({ props, children }) => {
+      const justifyMap: Record<string, string> = {
+        start: "flex-start",
+        center: "center",
+        end: "flex-end",
+        spaceBetween: "space-between",
+      };
+      const items = Array.isArray(props.children) ? props.children : [];
+      return (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            gap: `${props.gap ?? 16}px`,
+            alignItems: props.align ?? "stretch",
+            justifyContent:
+              justifyMap[props.justify ?? "start"] ?? "flex-start",
+            flexWrap: "wrap",
+            width: "100%",
+          }}
+        >
+          {items.map((item: any, i: number) => {
+            if (typeof item === "string")
+              return (
+                <div
+                  key={`${item}-${i}`}
+                  style={{ flex: "1 1 0", minWidth: 0 }}
+                >
+                  {children(item)}
+                </div>
+              );
+            if (item && typeof item === "object" && "id" in item)
+              return (
+                <div
+                  key={`${item.id}-${i}`}
+                  style={{ flex: "1 1 0", minWidth: 0 }}
+                >
+                  {(children as any)(item.id, item.basePath)}
+                </div>
+              );
+            return null;
+          })}
+        </div>
+      );
+    },
+
+    Column: ({ props, children }) => {
+      const items = Array.isArray(props.children) ? props.children : [];
+      return (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: `${props.gap ?? 12}px`,
+            width: "100%",
+          }}
+        >
+          {items.map((item: any, i: number) => {
+            if (typeof item === "string")
+              return (
+                <React.Fragment key={`${item}-${i}`}>
+                  {children(item)}
+                </React.Fragment>
+              );
+            if (item && typeof item === "object" && "id" in item)
+              return (
+                <React.Fragment key={`${item.id}-${i}`}>
+                  {(children as any)(item.id, item.basePath)}
+                </React.Fragment>
+              );
+            return null;
+          })}
+        </div>
+      );
+    },
+
+    DashboardCard: ({ props, children }) => (
+      <div
+        style={{
+          background: c.card,
+          borderRadius: "12px",
+          border: `1px solid ${c.border}`,
+          padding: "20px",
+          boxShadow: c.shadow,
+          display: "flex",
+          flexDirection: "column",
+          gap: "12px",
+        }}
+      >
+        <div>
+          <div style={{ fontWeight: 600, fontSize: "0.9rem", color: c.cardFg }}>
+            {props.title}
+          </div>
+          {props.subtitle && (
+            <div
+              style={{
+                fontSize: "0.75rem",
+                color: c.muted,
+                marginTop: "2px",
+              }}
+            >
+              {props.subtitle}
+            </div>
+          )}
+        </div>
+        {props.child && children(props.child)}
+      </div>
+    ),
+
+    Metric: ({ props }) => {
+      const trendColors: Record<string, string> = {
+        up: "#059669",
+        down: "#dc2626",
+        neutral: c.muted,
+      };
+      const trendIcons: Record<string, string> = {
+        up: "↑",
+        down: "↓",
+        neutral: "→",
+      };
+      return (
+        <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+          <span
+            style={{
+              fontSize: "0.75rem",
+              color: c.muted,
+              fontWeight: 500,
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+            }}
+          >
+            {props.label}
+          </span>
+          <div style={{ display: "flex", alignItems: "baseline", gap: "8px" }}>
+            <span
+              style={{
+                fontSize: "1.5rem",
+                fontWeight: 700,
+                color: c.cardFg,
+                letterSpacing: "-0.02em",
+              }}
+            >
+              {props.value}
+            </span>
+            {props.trend && props.trendValue && (
+              <span
+                style={{
+                  fontSize: "0.8rem",
+                  fontWeight: 500,
+                  color: trendColors[props.trend] ?? c.muted,
+                }}
+              >
+                {trendIcons[props.trend]} {props.trendValue}
+              </span>
+            )}
+          </div>
+        </div>
+      );
+    },
+
+    PieChart: ({ props }) => {
+      const COLORS = [
+        "#3b82f6",
+        "#8b5cf6",
+        "#ec4899",
+        "#f59e0b",
+        "#10b981",
+        "#6366f1",
+      ];
+      const data = props.data ?? [];
+      return (
+        <div style={{ width: "100%", height: 200 }}>
+          <ResponsiveContainer>
+            <RechartsPie>
+              <Pie
+                data={data}
+                dataKey="value"
+                nameKey="label"
+                cx="50%"
+                cy="50%"
+                innerRadius={props.innerRadius ?? 40}
+                outerRadius={80}
+                paddingAngle={2}
+              >
+                {data.map((entry: any, i: number) => (
+                  <Cell
+                    key={i}
+                    fill={entry.color ?? COLORS[i % COLORS.length]}
+                  />
+                ))}
+              </Pie>
+              <Tooltip />
+            </RechartsPie>
+          </ResponsiveContainer>
+        </div>
+      );
+    },
+
+    BarChart: ({ props }) => {
+      const data = props.data ?? [];
+      return (
+        <div style={{ width: "100%", height: 200 }}>
+          <ResponsiveContainer>
+            <RechartsBar data={data}>
+              <CartesianGrid strokeDasharray="3 3" stroke={c.divider} />
+              <XAxis dataKey="label" tick={{ fontSize: 11, fill: c.muted }} />
+              <YAxis tick={{ fontSize: 11, fill: c.muted }} />
+              <Tooltip />
+              <Bar
+                dataKey="value"
+                fill={props.color ?? "#3b82f6"}
+                radius={[4, 4, 0, 0]}
+              />
+            </RechartsBar>
+          </ResponsiveContainer>
+        </div>
+      );
+    },
+
+    Badge: ({ props }) => {
+      const variants: Record<string, { bg: string; color: string }> = {
+        success: { bg: "#dcfce7", color: "#166534" },
+        warning: { bg: "#fef3c7", color: "#92400e" },
+        error: { bg: "#fee2e2", color: "#991b1b" },
+        info: { bg: "#dbeafe", color: "#1e40af" },
+        neutral: { bg: "var(--muted)", color: c.cardFg },
+      };
+      const v = variants[props.variant ?? "neutral"] ?? variants.neutral;
+      return (
+        <span
+          style={{
+            display: "inline-block",
+            padding: "2px 8px",
+            borderRadius: "9999px",
+            fontSize: "0.7rem",
+            fontWeight: 500,
+            background: v.bg,
+            color: v.color,
+          }}
+        >
+          {props.text}
+        </span>
+      );
+    },
+
+    DataTable: ({ props }) => {
+      const cols = props.columns ?? [];
+      const rows = props.rows ?? [];
+      return (
+        <div style={{ overflowX: "auto", width: "100%" }}>
+          <table
+            style={{
+              width: "100%",
+              borderCollapse: "collapse",
+              fontSize: "0.8rem",
+            }}
+          >
+            <thead>
+              <tr>
+                {cols.map((col: any) => (
+                  <th
+                    key={col.key}
+                    style={{
+                      textAlign: "left",
+                      padding: "8px 12px",
+                      borderBottom: `2px solid ${c.border}`,
+                      color: c.muted,
+                      fontWeight: 600,
+                      fontSize: "0.7rem",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.05em",
+                    }}
+                  >
+                    {col.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row: any, i: number) => (
+                <tr key={i} style={{ borderBottom: `1px solid ${c.divider}` }}>
+                  {cols.map((col: any) => (
+                    <td
+                      key={col.key}
+                      style={{ padding: "8px 12px", color: c.cardFg }}
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    },
+
+    Button: ({ props, children }) => {
+      return (
+        <ActionButton label="Click" doneLabel="Done" action={props.action}>
+          {props.child ? children(props.child) : null}
+        </ActionButton>
+      );
+    },
+
+    FlightCard: ({ props: rawProps }) => {
+      // The binder resolves path bindings to strings at runtime.
+      const props = rawProps as Record<string, any>;
+      const statusColors: Record<string, string> = {
+        "On Time": "#22c55e",
+        Delayed: "#eab308",
+        Cancelled: "#ef4444",
+      };
+      const dotColor =
+        props.statusColor ?? statusColors[props.status] ?? "#22c55e";
+
+      return (
+        <div
+          style={{
+            border: `1px solid ${c.border}`,
+            borderRadius: "16px",
+            padding: "20px",
+            background: c.card,
+            color: c.cardFg,
+            minWidth: 260,
+            maxWidth: 340,
+            flex: "1 1 260px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "12px",
+            boxShadow: c.shadow,
+          }}
+        >
+          {/* Header: airline + price */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <img
+                src={props.airlineLogo}
+                alt={props.airline}
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: "50%",
+                  objectFit: "contain",
+                }}
+              />
+              <span style={{ fontWeight: 600, fontSize: "0.95rem" }}>
+                {props.airline}
+              </span>
+            </div>
+            <span style={{ fontWeight: 700, fontSize: "1.15rem" }}>
+              {props.price}
+            </span>
+          </div>
+
+          {/* Meta */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              fontSize: "0.8rem",
+              color: c.muted,
+            }}
+          >
+            <span>{props.flightNumber}</span>
+            <span>{props.date}</span>
+          </div>
+
+          <hr
+            style={{
+              border: "none",
+              borderTop: `1px solid ${c.divider}`,
+              margin: 0,
+            }}
+          />
+
+          {/* Times */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <span style={{ fontWeight: 700, fontSize: "1.1rem" }}>
+              {props.departureTime}
+            </span>
+            <span style={{ fontSize: "0.75rem", color: c.muted }}>
+              {props.duration}
+            </span>
+            <span style={{ fontWeight: 700, fontSize: "1.1rem" }}>
+              {props.arrivalTime}
+            </span>
+          </div>
+
+          {/* Route */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              fontSize: "0.95rem",
+              fontWeight: 600,
+            }}
+          >
+            <span>{props.origin}</span>
+            <span style={{ color: c.muted }}>→</span>
+            <span>{props.destination}</span>
+          </div>
+
+          <div
+            style={{
+              marginTop: "auto",
+              display: "flex",
+              flexDirection: "column",
+              gap: "12px",
+            }}
+          >
+            <hr
+              style={{
+                border: "none",
+                borderTop: `1px solid ${c.divider}`,
+                margin: 0,
+              }}
+            />
+
+            {/* Status */}
+            <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+              <span
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  background: dotColor,
+                  display: "inline-block",
+                }}
+              />
+              <span style={{ fontSize: "0.8rem", color: c.muted }}>
+                {props.status}
+              </span>
+            </div>
+
+            <ActionButton
+              label="Select"
+              doneLabel="Selected"
+              action={props.action}
+            />
+          </div>
+        </div>
+      );
+    },
+  };
+
+// ─── Assembled Catalog ───────────────────────────────────────────────
+
+export const demonstrationCatalog = createCatalog(
+  demonstrationCatalogDefinitions,
+  demonstrationCatalogRenderers,
+  {
+    catalogId: "copilotkit://app-dashboard-catalog",
+  },
+);

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/hooks/index.ts
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/hooks/index.ts
@@ -1,0 +1,3 @@
+export * from "./use-example-suggestions";
+export * from "./use-generative-ui-examples";
+export * from "./use-theme";

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/hooks/use-example-suggestions.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/hooks/use-example-suggestions.tsx
@@ -1,0 +1,69 @@
+/**
+ * Suggestion pills shown in the chat UI. Each suggestion triggers a specific
+ * demo feature when clicked.
+ *
+ * Ordered from most constrained (fixed UI) to most open (freeform UI).
+ *
+ * Showcase mode (showcase.json) controls which pills are visually highlighted.
+ * Highlight styling: globals.css (.a2ui-highlight, .opengenui-highlight)
+ * A2UI agent tools: agent/src/a2ui_fixed_schema.py, a2ui_dynamic_schema.py
+ * A2UI catalog: src/app/declarative-generative-ui/
+ */
+import { useConfigureSuggestions } from "@copilotkit/react-core/v2";
+import showcaseConfig from "../showcase.json";
+
+const showcase = showcaseConfig.showcase;
+
+export const useExampleSuggestions = () => {
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Pie Chart (Controlled Generative UI)",
+        message:
+          "Show me a pie chart of our revenue distribution by category. Use the query_data tool to fetch the data first, then render it with the pieChart component.",
+      },
+      {
+        title: "Bar Chart (Controlled Generative UI)",
+        message:
+          "Show me a bar chart of our expenses by category. Use the query_data tool to fetch the data first, then render it with the barChart component.",
+      },
+      {
+        title: "Schedule Meeting (Human In The Loop)",
+        message:
+          "I'd like to schedule a 30-minute meeting to learn about CopilotKit. Please use the scheduleTime tool to let me pick a time.",
+      },
+      {
+        title: "Search Flights (A2UI Fixed Schema)",
+        message: "Find flights from SFO to JFK for next Tuesday.",
+        className: showcase === "a2ui" ? "a2ui-highlight" : undefined,
+      },
+      {
+        title: "Sales Dashboard (A2UI Dynamic)",
+        message:
+          "First use the query_data tool to fetch the financial sales data, then using A2UI, show me a sales dashboard with total revenue, new customers, and conversion rate metrics. Include a pie chart of revenue by category and a bar chart of monthly sales.",
+        className: showcase === "a2ui" ? "a2ui-highlight" : undefined,
+      },
+      {
+        title: "Excalidraw Diagram (MCP App)",
+        message:
+          "Use Excalidraw to create a simple network diagram showing a router connected to two switches, each connected to two computers.",
+      },
+      {
+        title: "Calculator App (Open Generative UI)",
+        message:
+          "Using the generateSandboxedUi tool, build a modern calculator with standard buttons plus labeled metric shortcut buttons that insert their values into the display when clicked. Use sample company data.",
+        className: showcase === "opengenui" ? "opengenui-highlight" : undefined,
+      },
+      {
+        title: "Toggle Theme (Frontend Tools)",
+        message: "Toggle the app theme using the toggleTheme tool.",
+      },
+      {
+        title: "Task Manager (Shared State)",
+        message:
+          "Enable app mode and add three todos about learning CopilotKit: one about reading the docs, one about building a prototype, and one about exploring agent state.",
+      },
+    ],
+    available: "always",
+  });
+};

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/hooks/use-generative-ui-examples.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/hooks/use-generative-ui-examples.tsx
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import { useTheme } from "./use-theme";
+
+import {
+  useComponent,
+  useFrontendTool,
+  useHumanInTheLoop,
+  useDefaultRenderTool,
+} from "@copilotkit/react-core/v2";
+
+import {
+  PieChart,
+  PieChartProps,
+} from "../components/generative-ui/charts/pie-chart";
+import {
+  BarChart,
+  BarChartProps,
+} from "../components/generative-ui/charts/bar-chart";
+import { MeetingTimePicker } from "../components/generative-ui/meeting-time-picker";
+import { ToolReasoning } from "../components/tool-rendering";
+
+export const useGenerativeUIExamples = () => {
+  const { theme, setTheme } = useTheme();
+
+  // Human-in-the-Loop (frontend tool requiring user decision)
+  useHumanInTheLoop({
+    name: "scheduleTime",
+    description: "Use human-in-the-loop to schedule a meeting with the user.",
+    parameters: z.object({
+      reasonForScheduling: z
+        .string()
+        .describe("Reason for scheduling, very brief - 5 words."),
+      meetingDuration: z
+        .number()
+        .describe("Duration of the meeting in minutes"),
+    }),
+    render: ({ respond, status, args }) => {
+      return <MeetingTimePicker status={status} respond={respond} {...args} />;
+    },
+  });
+
+  // Controlled Generative UI (frontend-defined chart components)
+  useComponent({
+    name: "pieChart",
+    description: "Controlled Generative UI that displays data as a pie chart.",
+    parameters: PieChartProps,
+    render: PieChart,
+  });
+
+  useComponent({
+    name: "barChart",
+    description: "Controlled Generative UI that displays data as a bar chart.",
+    parameters: BarChartProps,
+    render: BarChart,
+  });
+
+  // Default Tool Rendering (backend tool UI)
+  const ignoredTools = [
+    "render_a2ui", // Rendered by A2UI streaming, not as a tool card
+    "generate_a2ui", // Legacy: rendered by A2UI, not as a tool card
+    "log_a2ui_event", // Internal A2UI event tracker
+  ];
+  useDefaultRenderTool({
+    render: ({ name, status, parameters }) => {
+      if (ignoredTools.includes(name)) return <></>;
+      return <ToolReasoning name={name} status={status} args={parameters} />;
+    },
+  });
+
+  // Frontend Tools (direct frontend state manipulation)
+  useFrontendTool(
+    {
+      name: "toggleTheme",
+      description: "Frontend tool for toggling the theme of the app.",
+      parameters: z.object({}),
+      handler: async () => {
+        const isDark = document.documentElement.classList.contains("dark");
+        setTheme(isDark ? "light" : "dark");
+      },
+    },
+    [theme, setTheme],
+  );
+};

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/hooks/use-theme.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/hooks/use-theme.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "dark" | "light" | "system";
+
+const ThemeContext = createContext<{
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+}>({
+  theme: "system",
+  setTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("system");
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove("light", "dark");
+
+    if (theme === "system") {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      const apply = () => {
+        root.classList.remove("light", "dark");
+        root.classList.add(mq.matches ? "dark" : "light");
+      };
+      apply();
+      mq.addEventListener("change", apply);
+      return () => mq.removeEventListener("change", apply);
+    }
+
+    root.classList.add(theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => useContext(ThemeContext);

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/lib/a2ui-theme.css
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/lib/a2ui-theme.css
@@ -1,0 +1,162 @@
+:root {
+  --n-100: #ffffff;
+  --n-99: #fcfcfc;
+  --n-98: #f9f9f9;
+  --n-95: #f1f1f1;
+  --n-90: #e2e2e2;
+  --n-80: #c6c6c6;
+  --n-70: #ababab;
+  --n-60: #919191;
+  --n-50: #777777;
+  --n-40: #5e5e5e;
+  --n-35: #525252;
+  --n-30: #474747;
+  --n-25: #3b3b3b;
+  --n-20: #303030;
+  --n-15: #262626;
+  --n-10: #1b1b1b;
+  --n-5: #111111;
+  --n-0: #000000;
+
+  --p-100: #ffffff;
+  --p-99: #fffbff;
+  --p-98: #fcf8ff;
+  --p-95: #f2efff;
+  --p-90: #e1e0ff;
+  --p-80: #c0c1ff;
+  --p-70: #a0a3ff;
+  --p-60: #8487ea;
+  --p-50: #6a6dcd;
+  --p-40: #5154b3;
+  --p-35: #4447a6;
+  --p-30: #383b99;
+  --p-25: #2c2e8d;
+  --p-20: #202182;
+  --p-15: #131178;
+  --p-10: #06006c;
+  --p-5: #03004d;
+  --p-0: #000000;
+
+  --s-100: #ffffff;
+  --s-99: #fffbff;
+  --s-98: #fcf8ff;
+  --s-95: #f2efff;
+  --s-90: #e2e0f9;
+  --s-80: #c6c4dd;
+  --s-70: #aaa9c1;
+  --s-60: #8f8fa5;
+  --s-50: #75758b;
+  --s-40: #5d5c72;
+  --s-35: #515165;
+  --s-30: #454559;
+  --s-25: #393a4d;
+  --s-20: #2e2f42;
+  --s-15: #242437;
+  --s-10: #191a2c;
+  --s-5: #0f0f21;
+  --s-0: #000000;
+
+  --t-100: #ffffff;
+  --t-99: #fffbff;
+  --t-98: #fff8f9;
+  --t-95: #ffecf4;
+  --t-90: #ffd8ec;
+  --t-80: #e9b9d3;
+  --t-70: #cc9eb8;
+  --t-60: #af849d;
+  --t-50: #946b83;
+  --t-40: #79536a;
+  --t-35: #6c475d;
+  --t-30: #5f3c51;
+  --t-25: #523146;
+  --t-20: #46263a;
+  --t-15: #3a1b2f;
+  --t-10: #2e1125;
+  --t-5: #22071a;
+  --t-0: #000000;
+
+  --nv-100: #ffffff;
+  --nv-99: #fffbff;
+  --nv-98: #fcf8ff;
+  --nv-95: #f2effa;
+  --nv-90: #e4e1ec;
+  --nv-80: #c8c5d0;
+  --nv-70: #acaab4;
+  --nv-60: #918f9a;
+  --nv-50: #777680;
+  --nv-40: #5e5d67;
+  --nv-35: #52515b;
+  --nv-30: #46464f;
+  --nv-25: #3b3b43;
+  --nv-20: #303038;
+  --nv-15: #25252d;
+  --nv-10: #1b1b23;
+  --nv-5: #101018;
+  --nv-0: #000000;
+
+  --e-100: #ffffff;
+  --e-99: #fffbff;
+  --e-98: #fff8f7;
+  --e-95: #ffedea;
+  --e-90: #ffdad6;
+  --e-80: #ffb4ab;
+  --e-70: #ff897d;
+  --e-60: #ff5449;
+  --e-50: #de3730;
+  --e-40: #ba1a1a;
+  --e-35: #a80710;
+  --e-30: #93000a;
+  --e-25: #7e0007;
+  --e-20: #690005;
+  --e-15: #540003;
+  --e-10: #410002;
+  --e-5: #2d0001;
+  --e-0: #000000;
+
+  --primary: #137fec;
+  --text-color: #fff;
+  --background-light: #f6f7f8;
+  --background-dark: #101922;
+  --border-color: oklch(
+    from var(--background-light) l c h / calc(alpha * 0.15)
+  );
+  --elevated-background-light: oklch(
+    from var(--background-light) l c h / calc(alpha * 0.05)
+  );
+  --bb-grid-size: 4px;
+  --bb-grid-size-2: calc(var(--bb-grid-size) * 2);
+  --bb-grid-size-3: calc(var(--bb-grid-size) * 3);
+  --bb-grid-size-4: calc(var(--bb-grid-size) * 4);
+  --bb-grid-size-5: calc(var(--bb-grid-size) * 5);
+  --bb-grid-size-6: calc(var(--bb-grid-size) * 6);
+  --bb-grid-size-7: calc(var(--bb-grid-size) * 7);
+  --bb-grid-size-8: calc(var(--bb-grid-size) * 8);
+  --bb-grid-size-9: calc(var(--bb-grid-size) * 9);
+  --bb-grid-size-10: calc(var(--bb-grid-size) * 10);
+  --bb-grid-size-11: calc(var(--bb-grid-size) * 11);
+  --bb-grid-size-12: calc(var(--bb-grid-size) * 12);
+  --bb-grid-size-13: calc(var(--bb-grid-size) * 13);
+  --bb-grid-size-14: calc(var(--bb-grid-size) * 14);
+  --bb-grid-size-15: calc(var(--bb-grid-size) * 15);
+  --bb-grid-size-16: calc(var(--bb-grid-size) * 16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  --font-family: "Google Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-family-flex:
+    "Google Sans Flex", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-family-mono:
+    "Google Sans Code", "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+  background: var(--background-light);
+  font-family: var(--font-family);
+  margin: 0;
+  padding: 0;
+  width: 100svw;
+  height: 100svh;
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/lib/utils.ts
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/page.tsx
@@ -1,61 +1,64 @@
 "use client";
 
-import React from "react";
-import {
-  CopilotKit,
-  CopilotChat,
-  useConfigureSuggestions,
-} from "@copilotkit/react-core/v2";
+/**
+ * Beautiful Chat — the flagship CopilotKit showcase cell, ported from the
+ * canonical reference (mirrors langgraph-python and ms-agent-python).
+ *
+ * Runtime: this cell uses its own dedicated runtime endpoint
+ * (`/api/copilotkit-beautiful-chat`) so it can enable `openGenerativeUI`,
+ * `a2ui` with `injectA2UITool: false`, and `mcpApps` simultaneously — the
+ * combined-runtime shape the canonical starter uses — without bleeding those
+ * global flags into other cells sharing the main `/api/copilotkit` endpoint.
+ *
+ * Backend: the Python ADK agent is `beautiful_chat_agent`
+ * (src/agents/beautiful_chat_agent.py). The agent_server.py mounts it at
+ * `/beautiful_chat`; the runtime route below proxies the agent id
+ * `beautiful_chat` to that path.
+ */
 
-export default function BeautifulChatDemo() {
+import React from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+
+import { ExampleLayout } from "./components/example-layout";
+import { ExampleCanvas } from "./components/example-canvas";
+import { useGenerativeUIExamples, useExampleSuggestions } from "./hooks";
+import { ThemeProvider } from "./hooks/use-theme";
+import { demonstrationCatalog } from "./declarative-generative-ui/renderers";
+
+export default function BeautifulChatPage() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="beautiful_chat">
-      <DemoContent />
-    </CopilotKit>
+    <ThemeProvider>
+      <CopilotKit
+        runtimeUrl="/api/copilotkit-beautiful-chat"
+        agent="beautiful_chat"
+        a2ui={{ catalog: demonstrationCatalog }}
+        openGenerativeUI={{}}
+        /*
+         * `useSingleEndpoint` defaults to true (the single-POST-endpoint
+         * protocol). The canonical reference sets it to false to use the
+         * v2 multi-endpoint protocol (GET /info + POST /agent/{name}/connect),
+         * which requires a Hono-based endpoint via `createCopilotEndpoint`.
+         * The 4085 showcase uses `copilotRuntimeNextJSAppRouterEndpoint`
+         * (single-endpoint), which matches the other 4085 cells — so we
+         * use its default behavior here. Functionally equivalent for this demo.
+         */
+      >
+        <HomePage />
+      </CopilotKit>
+    </ThemeProvider>
   );
 }
 
-function DemoContent() {
-  useConfigureSuggestions({
-    suggestions: [
-      { title: "Sales pulse", message: "Show me Q3 revenue split by region." },
-      {
-        title: "Find flights",
-        message: "Find flights from SFO to JFK next Friday.",
-      },
-      {
-        title: "Book a sync",
-        message: "Book me a 30-minute sync with our designer.",
-      },
-    ],
-    available: "always",
-  });
+function HomePage() {
+  useGenerativeUIExamples();
+  useExampleSuggestions();
 
   return (
-    <div className="min-h-screen w-full bg-gradient-to-br from-[#fef9f3] via-[#f6efff] to-[#e9f3ff]">
-      <header className="px-8 pt-10 pb-6 max-w-5xl mx-auto">
-        <div className="flex items-center gap-2 text-sm text-slate-500">
-          <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
-          Beautiful chat — Google ADK
-        </div>
-        <h1 className="mt-2 text-3xl md:text-4xl font-semibold tracking-tight bg-gradient-to-r from-[#1e1b4b] via-[#5b21b6] to-[#1d4ed8] bg-clip-text text-transparent">
-          Sales copilot, polished by default
-        </h1>
-        <p className="mt-2 text-slate-600 max-w-2xl">
-          Brand fonts, theme tokens, suggestion pills, and live charts —
-          delivered by a Gemini 2.5 Flash agent with the canonical
-          sales-pipeline tools wired up on the backend.
-        </p>
-      </header>
-      <main className="max-w-5xl mx-auto px-8 pb-12">
-        <div className="rounded-3xl bg-white/70 backdrop-blur-sm border border-white/80 shadow-xl shadow-slate-200/40 overflow-hidden h-[600px]">
-          <CopilotChat
-            agentId="beautiful_chat"
-            className="h-full"
-            labels={{ chatInputPlaceholder: "Ask the sales copilot..." }}
-          />
-        </div>
-      </main>
-    </div>
+    <ExampleLayout
+      chatContent={
+        <CopilotChat input={{ disclaimer: () => null, className: "pb-6" }} />
+      }
+      appContent={<ExampleCanvas />}
+    />
   );
 }

--- a/showcase/integrations/google-adk/src/app/demos/beautiful-chat/showcase.json
+++ b/showcase/integrations/google-adk/src/app/demos/beautiful-chat/showcase.json
@@ -1,0 +1,3 @@
+{
+  "showcase": "default"
+}


### PR DESCRIPTION
## Summary

The google-adk integration's beautiful-chat demo was a 61-line placeholder with three throwaway suggestion pills and no UI for any of the agent's tools. Reported behaviour:

- *"Find flights from SFO to JFK next Friday"* → infinite loading
- *"Q3 revenue split by region"* → plain text only, no chart
- *"Book me a 30-minute sync with our designer"* → "meeting is booked" text, no picker

Every other integration ships the full canonical flagship cell. This PR brings google-adk to parity, mirroring `ms-agent-python` and `langgraph-python`.

## What changed

- **Frontend**: replaced `page.tsx` placeholder with the full canonical tree — components, hooks, declarative-generative-ui catalog, lib, `showcase.json`, README — wired to a dedicated `/api/copilotkit-beautiful-chat` runtime.
- **Runtime route**: new `src/app/api/copilotkit-beautiful-chat/route.ts` with `openGenerativeUI: true`, `a2ui.injectA2UITool: false`, and `mcpApps` pointed at Excalidraw. Without those flags the agent's tool results had nothing to render against.
- **Agent** (`src/agents/beautiful_chat_agent.py`): rewritten with the canonical tools (`query_data`, `search_flights`, `manage_todos`) and reuses `generate_a2ui` from `agents/main.py` (forced Gemini tool call — no OpenAI dep). System prompt now references the frontend tools the page registers (`scheduleTime`, `pieChart`, `barChart`, `enableAppMode`, `toggleTheme`); `search_flights` carries the full flight schema in its description.
- **Streaming todos**: added `PredictStateMapping(state_key="todos", tool="manage_todos", tool_argument="todos")` in `registry.py` so the canvas TodoList streams as the agent composes the list.
- **Self-contained data**: copied `beautiful_chat_data/{db.csv, schemas/flight_schema.json}` so the cell doesn't depend on shared state.
- **Deps**: added `@radix-ui/react-checkbox` (other transitives resolve via `--legacy-peer-deps`, matching siblings).
- **Docs / wiring**: added `qa/beautiful-chat.md`; refreshed manifest highlight paths.

## Verified end-to-end

Headed-browser run against real Gemini 2.5 Flash on `localhost:3103/demos/beautiful-chat`:

- ✅ **Sales pulse → pie chart**: agent calls `query_data`, frontend `pieChart` renders the donut card with legend (28,000 / 55%, 22,500 / 45%).
- ✅ **Book a sync → MeetingTimePicker**: `scheduleTime` HITL renders the picker with three time slots and "None of these work" footer.
- 🟡 **Find flights**: no longer loops. Agent calls `search_flights` and completes in ~6s with a text summary. **FlightCards still don't render visually** because of a pre-existing google-adk A2UI surface activity bug that also affects the unrelated `/demos/a2ui-fixed-schema` demo. Out of scope for this PR — needs separate investigation in the runtime/HttpAgent path.

## Known follow-ups (separate issues)

1. **A2UI surface activity rendering** — google-adk's `display_flight` (a2ui-fixed-schema) and `search_flights` (beautiful-chat) both emit correct `ACTIVITY_SNAPSHOT` events with `activityType: "a2ui-surface"`, but the activities are not promoted to renderable messages in the chat thread. Reproducible on `/demos/a2ui-fixed-schema` independently of this PR.
2. **Aimock fixture loop** — `showcase/aimock/feature-parity.json`'s `userMessage: "flights from SFO to JFK"` fixture matches every turn (no `hasToolResult` guard). After a successful tool result it re-matches and returns the same tool call, causing the runtime to hit the 500-call ceiling and surface "Max number of llm calls limit of 500 exceeded". Needs paired `hasToolResult: false` (tool call) + `hasToolResult: true` (text follow-up) fixtures matching the d5-all.json pattern.
3. **Tool-not-found toast** — when Gemini calls `pieChart` / `scheduleTime` (frontend-only tools), the runtime emits a "Tool not found" error toast even though the chart/picker still renders via `useComponent` / `useHumanInTheLoop`. Cosmetic UX wart in the runtime's tool-resolution path.

## Test plan

- [x] `bin/showcase build google-adk` succeeds
- [x] `bin/showcase up google-adk` brings the container up healthy
- [x] `/demos/beautiful-chat` loads with all 9 canonical pills
- [x] Sales pulse → pie chart renders
- [x] Book a sync → MeetingTimePicker renders
- [x] Find flights → agent completes (no hang); cards still gated on follow-up A2UI bug