### PR TITLE
docs: add sign-up CTAs and refresh framework CLI walkthrough

### DIFF
--- a/docs/app/(home)/[[...slug]]/page.tsx
+++ b/docs/app/(home)/[[...slug]]/page.tsx
@@ -22,6 +22,7 @@ import { Cards, Card } from "fumadocs-ui/components/card";
 import { PropertyReference } from "@/components/react/property-reference";
 import { InsecurePasswordProtected } from "@/components/react/insecure-password-protected";
 import { LinkToCopilotCloud } from "@/components/react/link-to-copilot-cloud";
+import { OpsPlatformCTA } from "@/components/react/ops-platform-cta";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 import { NavigationLink } from "@/components/react/subdocs-menu";
 import { getSnippetTOCForPage } from "@/lib/snippet-toc";
@@ -40,6 +41,7 @@ const mdxComponents = {
   ...defaultMdxComponents,
   InsecurePasswordProtected: InsecurePasswordProtected,
   LinkToCopilotCloud: LinkToCopilotCloud,
+  OpsPlatformCTA: OpsPlatformCTA,
   Accordions: Accordions,
   Accordion: Accordion,
   Tabs: Tabs,

--- a/docs/app/integrations/[[...slug]]/page.tsx
+++ b/docs/app/integrations/[[...slug]]/page.tsx
@@ -21,6 +21,7 @@ import { Cards, Card } from "fumadocs-ui/components/card";
 import { PropertyReference } from "@/components/react/property-reference";
 import { InsecurePasswordProtected } from "@/components/react/insecure-password-protected";
 import { LinkToCopilotCloud } from "@/components/react/link-to-copilot-cloud";
+import { OpsPlatformCTA } from "@/components/react/ops-platform-cta";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 import { NavigationLink } from "@/components/react/subdocs-menu";
 import { getSnippetTOCForPage } from "@/lib/snippet-toc";
@@ -42,6 +43,7 @@ const mdxComponents = {
   ...defaultMdxComponents,
   InsecurePasswordProtected: InsecurePasswordProtected,
   LinkToCopilotCloud: LinkToCopilotCloud,
+  OpsPlatformCTA: OpsPlatformCTA,
   Accordions: Accordions,
   Accordion: Accordion,
   Tabs: Tabs,

--- a/docs/components/content/landing-pages/framework-overview.tsx
+++ b/docs/components/content/landing-pages/framework-overview.tsx
@@ -43,6 +43,8 @@ export interface FrameworkOverviewProps {
   initCommand: string;
   featuresLink: string;
   supportedFeatures?: FrameworkFeature[];
+  /** Optional content rendered immediately after the supported features section. */
+  afterFeatures?: ReactNode;
   architectureImage?: string;
   architectureVideo?: string;
   liveDemos: LiveDemo[];
@@ -61,6 +63,7 @@ export function FrameworkOverview({
   initCommand,
   featuresLink,
   supportedFeatures = [],
+  afterFeatures,
   architectureImage,
   architectureVideo,
   liveDemos,
@@ -269,6 +272,10 @@ export function FrameworkOverview({
               ))}
             </div>
           </section>
+        )}
+
+        {afterFeatures && (
+          <section className="mb-12 sm:mb-24 px-4">{afterFeatures}</section>
         )}
 
         {/* Architecture */}

--- a/docs/components/layout/navbar.tsx
+++ b/docs/components/layout/navbar.tsx
@@ -19,6 +19,7 @@ import DiscordIcon from "@/components/ui/icons/discord";
 import ExternalLinkIcon from "@/components/ui/icons/external-link";
 import BurgerMenuIcon from "@/components/ui/icons/burger-menu";
 import { BookOpenIcon, ScrollTextIcon } from "lucide-react";
+import posthog from "posthog-js";
 
 export interface NavbarLink {
   href: string;
@@ -51,7 +52,7 @@ export const LEFT_LINKS: NavbarLink[] = [
   {
     icon: <CloudIcon />,
     label: "Free Developer Access",
-    href: "https://cloud.copilotkit.ai",
+    href: "https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar",
     target: "_blank",
     showExternalLinkIcon: true,
   },
@@ -60,7 +61,7 @@ export const LEFT_LINKS: NavbarLink[] = [
 const RIGHT_LINKS: NavbarLink[] = [
   {
     icon: <CloudIcon />,
-    href: "https://cloud.copilotkit.ai",
+    href: "https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar",
     target: "_blank",
     label: "Free Developer Access",
   },
@@ -129,6 +130,19 @@ const Navbar = ({ pageTree }: NavbarProps) => {
     };
   }, [isMobileSidebarOpen]);
 
+  const handleIntelligenceCtaClick = (surface: string) => {
+    try {
+      posthog.capture("cta_clicked", {
+        surface,
+        variant: "navbar",
+        target: "intelligence",
+        page_path: pathname,
+      });
+    } catch {
+      // PostHog may be blocked — never let analytics block navigation.
+    }
+  };
+
   const handleToggleTheme = () => {
     document.documentElement.classList.toggle("dark");
     localStorage.theme = localStorage.theme === "dark" ? "light" : "dark";
@@ -174,6 +188,12 @@ const Navbar = ({ pageTree }: NavbarProps) => {
                     <Link
                       href={href}
                       target={link.target}
+                      onClick={
+                        link.label === "Free Developer Access"
+                          ? () =>
+                              handleIntelligenceCtaClick("docs:navbar:left")
+                          : undefined
+                      }
                       className={`h-full ${
                         activeRoute === link.href ? "opacity-100" : "opacity-50"
                       } hover:opacity-100 transition-opacity duration-300`}
@@ -264,6 +284,11 @@ const Navbar = ({ pageTree }: NavbarProps) => {
                   key={link.href}
                   href={link.href}
                   target={link.target}
+                  onClick={
+                    link.label === "Free Developer Access"
+                      ? () => handleIntelligenceCtaClick("docs:navbar:right")
+                      : undefined
+                  }
                   className={`${isIconOnlyLink ? "[@media(width>=1028px)]:hidden [@media(width<768px)]:hidden" : "hidden"} justify-center items-center w-11 h-full md:flex`}
                   title={link.label}
                   suppressHydrationWarning={link.target === "_blank"}

--- a/docs/components/layout/navbar.tsx
+++ b/docs/components/layout/navbar.tsx
@@ -19,7 +19,6 @@ import DiscordIcon from "@/components/ui/icons/discord";
 import ExternalLinkIcon from "@/components/ui/icons/external-link";
 import BurgerMenuIcon from "@/components/ui/icons/burger-menu";
 import { BookOpenIcon, ScrollTextIcon } from "lucide-react";
-import posthog from "posthog-js";
 
 export interface NavbarLink {
   href: string;
@@ -130,17 +129,8 @@ const Navbar = ({ pageTree }: NavbarProps) => {
     };
   }, [isMobileSidebarOpen]);
 
-  const handleIntelligenceCtaClick = (surface: string) => {
-    try {
-      posthog.capture("cta_clicked", {
-        surface,
-        variant: "navbar",
-        target: "intelligence",
-        page_path: pathname,
-      });
-    } catch {
-      // PostHog may be blocked — never let analytics block navigation.
-    }
+  const handleTryForFreeClick = (location: string) => {
+    posthog?.capture("try_for_free_clicked", { location });
   };
 
   const handleToggleTheme = () => {
@@ -191,7 +181,7 @@ const Navbar = ({ pageTree }: NavbarProps) => {
                       onClick={
                         link.label === "Free Developer Access"
                           ? () =>
-                              handleIntelligenceCtaClick("docs:navbar:left")
+                              handleTryForFreeClick("docs_navbar_left")
                           : undefined
                       }
                       className={`h-full ${
@@ -286,7 +276,7 @@ const Navbar = ({ pageTree }: NavbarProps) => {
                   target={link.target}
                   onClick={
                     link.label === "Free Developer Access"
-                      ? () => handleIntelligenceCtaClick("docs:navbar:right")
+                      ? () => handleTryForFreeClick("docs_navbar_right")
                       : undefined
                   }
                   className={`${isIconOnlyLink ? "[@media(width>=1028px)]:hidden [@media(width<768px)]:hidden" : "hidden"} justify-center items-center w-11 h-full md:flex`}

--- a/docs/components/react/ops-platform-cta.tsx
+++ b/docs/components/react/ops-platform-cta.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { ArrowRight, Info, Sparkles } from "lucide-react";
+import posthog from "posthog-js";
+import { usePathname } from "next/navigation";
+import { useCallback } from "react";
+
+const DEFAULT_SIGNUP_URL = "https://dashboard.operations.copilotkit.ai/";
+
+const SIGNUP_URL =
+  process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL || DEFAULT_SIGNUP_URL;
+
+export type OpsPlatformCTAVariant = "tile" | "inline" | "card" | "info";
+
+export interface OpsPlatformCTAProps {
+  /** Visual style: tile = full-width hero, inline = mid-page callout, card = footer */
+  variant?: OpsPlatformCTAVariant;
+  /** Headline shown to the user */
+  title: string;
+  /** Body copy under the headline */
+  body?: string;
+  /** Stable identifier for analytics, e.g. "docs:langgraph/quickstart:whats-next" */
+  surface: string;
+  /** Optional override for the link label. Defaults to "Get Intelligence free" */
+  ctaLabel?: string;
+  /** Optional className override for the outermost element */
+  className?: string;
+}
+
+function buildHref(surface: string): string {
+  const url = new URL(SIGNUP_URL);
+  url.searchParams.set("utm_source", "docs");
+  url.searchParams.set("utm_medium", "cta");
+  url.searchParams.set("utm_campaign", "intelligence");
+  url.searchParams.set("utm_content", surface);
+  return url.toString();
+}
+
+export function OpsPlatformCTA({
+  variant = "card",
+  title,
+  body,
+  surface,
+  ctaLabel = "Get Intelligence free",
+  className,
+}: OpsPlatformCTAProps) {
+  const pathname = usePathname();
+
+  const handleClick = useCallback(() => {
+    try {
+      posthog.capture("cta_clicked", {
+        surface,
+        variant,
+        target: "intelligence",
+        page_path: pathname,
+      });
+    } catch {
+      // PostHog may be blocked by ad blockers — never let analytics block navigation.
+    }
+  }, [surface, variant, pathname]);
+
+  const href = buildHref(surface);
+
+  if (variant === "info") {
+    return (
+      <div
+        className={`not-prose my-6 flex gap-3 rounded-lg border border-blue-200 dark:border-blue-900 bg-blue-50/60 dark:bg-blue-950/30 p-4 ${className ?? ""}`}
+      >
+        <Info className="h-5 w-5 text-blue-600 dark:text-blue-300 mt-0.5 flex-shrink-0" />
+        <div className="min-w-0 flex-1">
+          <div className="font-semibold text-foreground">{title}</div>
+          {body ? (
+            <div className="text-sm text-muted-foreground leading-relaxed mt-1">
+              {body}
+            </div>
+          ) : null}
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            onClick={handleClick}
+            className="inline-flex items-center gap-1 mt-2 text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 no-underline"
+            data-cta-surface={surface}
+            data-cta-variant={variant}
+          >
+            {ctaLabel}
+            <ArrowRight className="h-3.5 w-3.5" />
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (variant === "inline") {
+    return (
+      <div
+        className={`not-prose my-6 flex flex-col gap-3 rounded-lg border border-indigo-200 dark:border-indigo-900 bg-gradient-to-r from-indigo-50 to-purple-50 dark:from-indigo-950/40 dark:to-purple-950/40 p-4 sm:flex-row sm:items-center sm:justify-between ${className ?? ""}`}
+      >
+        <div className="flex items-start gap-3">
+          <Sparkles className="h-5 w-5 text-indigo-600 dark:text-indigo-300 mt-0.5 flex-shrink-0" />
+          <div>
+            <div className="font-semibold text-foreground">{title}</div>
+            {body ? (
+              <div className="text-sm text-muted-foreground leading-relaxed mt-0.5">
+                {body}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          onClick={handleClick}
+          className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-md bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium px-4 py-2 no-underline transition-colors"
+          data-cta-surface={surface}
+          data-cta-variant={variant}
+        >
+          {ctaLabel}
+          <ArrowRight className="h-4 w-4" />
+        </a>
+      </div>
+    );
+  }
+
+  if (variant === "tile") {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        onClick={handleClick}
+        data-cta-surface={surface}
+        data-cta-variant={variant}
+        className={`not-prose group flex items-start gap-3 rounded-lg border border-indigo-200 dark:border-indigo-900 bg-gradient-to-br from-indigo-50 to-purple-50 dark:from-indigo-950/40 dark:to-purple-950/40 p-4 no-underline shadow-sm hover:border-indigo-400 dark:hover:border-indigo-700 transition-colors ${className ?? ""}`}
+      >
+        <Sparkles className="h-5 w-5 text-indigo-600 dark:text-indigo-300 mt-0.5 flex-shrink-0" />
+        <div>
+          <div className="font-semibold text-foreground group-hover:text-indigo-700 dark:group-hover:text-indigo-200 mb-1">
+            {title}
+          </div>
+          {body ? (
+            <div className="text-sm text-muted-foreground leading-relaxed">
+              {body}
+            </div>
+          ) : null}
+        </div>
+      </a>
+    );
+  }
+
+  // variant === "card" (default)
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={handleClick}
+      data-cta-surface={surface}
+      data-cta-variant={variant}
+      className={`not-prose my-8 flex items-center justify-between gap-4 rounded-lg border border-indigo-200 dark:border-indigo-900 bg-gradient-to-r from-indigo-50 to-purple-50 dark:from-indigo-950/40 dark:to-purple-950/40 p-5 no-underline shadow-sm hover:border-indigo-400 dark:hover:border-indigo-700 transition-colors ${className ?? ""}`}
+    >
+      <div className="flex items-start gap-3 min-w-0">
+        <Sparkles className="h-5 w-5 text-indigo-600 dark:text-indigo-300 mt-0.5 flex-shrink-0" />
+        <div className="min-w-0">
+          <div className="font-semibold text-foreground mb-1">{title}</div>
+          {body ? (
+            <div className="text-sm text-muted-foreground leading-relaxed">
+              {body}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-sm font-medium text-indigo-700 dark:text-indigo-200">
+        {ctaLabel}
+        <ArrowRight className="h-4 w-4" />
+      </span>
+    </a>
+  );
+}

--- a/docs/components/react/ops-platform-cta.tsx
+++ b/docs/components/react/ops-platform-cta.tsx
@@ -2,7 +2,6 @@
 
 import { ArrowRight, Info, Sparkles } from "lucide-react";
 import posthog from "posthog-js";
-import { usePathname } from "next/navigation";
 import { useCallback } from "react";
 
 const DEFAULT_SIGNUP_URL = "https://dashboard.operations.copilotkit.ai/";
@@ -44,20 +43,13 @@ export function OpsPlatformCTA({
   ctaLabel = "Get Intelligence free",
   className,
 }: OpsPlatformCTAProps) {
-  const pathname = usePathname();
-
   const handleClick = useCallback(() => {
     try {
-      posthog.capture("cta_clicked", {
-        surface,
-        variant,
-        target: "intelligence",
-        page_path: pathname,
-      });
+      posthog.capture("try_for_free_clicked", { location: surface });
     } catch {
       // PostHog may be blocked by ad blockers — never let analytics block navigation.
     }
-  }, [surface, variant, pathname]);
+  }, [surface]);
 
   const href = buildHref(surface);
 

--- a/docs/content/docs/(root)/index.mdx
+++ b/docs/content/docs/(root)/index.mdx
@@ -54,7 +54,7 @@ Look below to find right guide for your needs, whether you're starting from noth
   variant="tile"
   title="Production-ready agents on the free Developer tier"
   body="Persistent threads, observability, and the full CopilotKit platform."
-  surface="docs:home:hero-tile"
+  surface="docs_home_hero"
   className="mb-10"
 />
 

--- a/docs/content/docs/(root)/index.mdx
+++ b/docs/content/docs/(root)/index.mdx
@@ -19,7 +19,7 @@ CopilotKit is the __frontend stack for agents__ and __generative UI__. Connect a
 
 Look below to find right guide for your needs, whether you're starting from nothing or have existing agent you want to give a prebuilt chat UI or fully custom UI.
 
-<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 not-prose mb-10 mt-10">
+<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 not-prose mb-4 mt-10">
   <a href="/quickstart" className="group flex items-start gap-3 bg-card border border-border/80 rounded-lg p-4 no-underline hover:border-primary/60 hover:bg-accent/50 transition-colors shadow-sm">
     <Play className="h-5 w-5 text-primary mt-0.5 flex-shrink-0" />
     <div>
@@ -49,6 +49,14 @@ Look below to find right guide for your needs, whether you're starting from noth
     </div>
   </a>
 </div>
+
+<OpsPlatformCTA
+  variant="tile"
+  title="Production-ready agents on the free Developer tier"
+  body="Persistent threads, observability, and the full CopilotKit platform."
+  surface="docs:home:hero-tile"
+  className="mb-10"
+/>
 
 {/* ── Code Examples ── */}
 <LandingCodeShowcase components={props.components}/>

--- a/docs/content/docs/(root)/inspector.mdx
+++ b/docs/content/docs/(root)/inspector.mdx
@@ -9,6 +9,13 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 <Inspector components={props.components} />
 
+<OpsPlatformCTA
+  variant="inline"
+  title="The threads tab needs Intelligence"
+  body="When you open the Inspector, threads is the default tab. Sign up for the free Developer tier to see your conversation history."
+  surface="docs:inspector:inline"
+/>
+
 <Callout type="info">
   Want to preview A2UI catalog components directly in your editor? See the [VS Code Extension](/vs-code-extension)
   for live preview with hot-reload.

--- a/docs/content/docs/(root)/inspector.mdx
+++ b/docs/content/docs/(root)/inspector.mdx
@@ -13,7 +13,7 @@ import { Callout } from "fumadocs-ui/components/callout";
   variant="inline"
   title="The threads tab needs Intelligence"
   body="When you open the Inspector, threads is the default tab. Sign up for the free Developer tier to see your conversation history."
-  surface="docs:inspector:inline"
+  surface="docs_inspector"
 />
 
 <Callout type="info">

--- a/docs/content/docs/(root)/prebuilt-components.mdx
+++ b/docs/content/docs/(root)/prebuilt-components.mdx
@@ -18,6 +18,13 @@ They handle streaming, generative UI, and deep customization — so you can focu
   Want users to send images, audio, or documents alongside their messages? See [Multimodal Attachments](/multimodal-attachments).
 </Callout>
 
+<OpsPlatformCTA
+  variant="inline"
+  title="Want users to resume conversations across sessions?"
+  body="Persistent threads ship with the CopilotKit platform. Try it for free."
+  surface="docs:prebuilt-components:inline"
+/>
+
 ## Get started by choosing your AI backend
 
 <IntegrationGrid path="prebuilt-components" />

--- a/docs/content/docs/(root)/prebuilt-components.mdx
+++ b/docs/content/docs/(root)/prebuilt-components.mdx
@@ -22,7 +22,7 @@ They handle streaming, generative UI, and deep customization — so you can focu
   variant="inline"
   title="Want users to resume conversations across sessions?"
   body="Persistent threads ship with the CopilotKit platform. Try it for free."
-  surface="docs:prebuilt-components:inline"
+  surface="docs_prebuilt_components"
 />
 
 ## Get started by choosing your AI backend

--- a/docs/content/docs/(root)/quickstart.mdx
+++ b/docs/content/docs/(root)/quickstart.mdx
@@ -18,7 +18,7 @@ npx copilotkit@latest create
   variant="inline"
   title="Building for production?"
   body="Get persistent threads, observability, and the full CopilotKit platform. Try it for free."
-  surface="docs:quickstart:after-cli"
+  surface="docs_quickstart_after_cli"
 />
 
 ## Start from an AI backend

--- a/docs/content/docs/(root)/quickstart.mdx
+++ b/docs/content/docs/(root)/quickstart.mdx
@@ -14,6 +14,13 @@ full stack agent for you.
 npx copilotkit@latest create
 ```
 
+<OpsPlatformCTA
+  variant="inline"
+  title="Building for production?"
+  body="Get persistent threads, observability, and the full CopilotKit platform. Try it for free."
+  surface="docs:quickstart:after-cli"
+/>
+
 ## Start from an AI backend
 
 To get started, choose the shape of your backend to get started with CopilotKit. This will

--- a/docs/content/docs/(root)/shared-state.mdx
+++ b/docs/content/docs/(root)/shared-state.mdx
@@ -31,7 +31,7 @@ Use shared state when you want to facilitate collaboration between your agent an
   variant="inline"
   title="Building stateful agents?"
   body="Persistent threads ship with the CopilotKit platform on the free Developer tier."
-  surface="docs:shared-state:inline"
+  surface="docs_shared_state"
 />
 
 ## Get started by choosing your AI backend

--- a/docs/content/docs/(root)/shared-state.mdx
+++ b/docs/content/docs/(root)/shared-state.mdx
@@ -27,6 +27,13 @@ Agentic Copilots maintain a shared state that seamlessly connects your UI with t
 
 Use shared state when you want to facilitate collaboration between your agent and the user. Updates flow both ways — the agent's outputs are automatically reflected in the UI, and any inputs the user updates in the UI are automatically reflected in the agent's execution.
 
+<OpsPlatformCTA
+  variant="inline"
+  title="Building stateful agents?"
+  body="Persistent threads ship with the CopilotKit platform on the free Developer tier."
+  surface="docs:shared-state:inline"
+/>
+
 ## Get started by choosing your AI backend
 
 <IntegrationGrid path="shared-state" exclude={["agno", "agent-spec"]} />

--- a/docs/content/docs/(root)/troubleshooting/event-inspector.mdx
+++ b/docs/content/docs/(root)/troubleshooting/event-inspector.mdx
@@ -18,7 +18,7 @@ Use it when:
   variant="inline"
   title="The threads tab needs Intelligence"
   body="When you open the Inspector, threads is the default tab. Sign up for the free Developer tier to see your conversation history."
-  surface="docs:troubleshooting/event-inspector:inline"
+  surface="docs_event_inspector"
 />
 
 ## Prerequisites

--- a/docs/content/docs/(root)/troubleshooting/event-inspector.mdx
+++ b/docs/content/docs/(root)/troubleshooting/event-inspector.mdx
@@ -14,6 +14,13 @@ Use it when:
 - You want to understand the AG-UI event lifecycle (e.g., how `RUN_STARTED` flows through `TEXT_MESSAGE_CONTENT` chunks to `RUN_FINISHED`)
 - You need to inspect tool call arguments or state deltas for a specific interaction
 
+<OpsPlatformCTA
+  variant="inline"
+  title="The threads tab needs Intelligence"
+  body="When you open the Inspector, threads is the default tab. Sign up for the free Developer tier to see your conversation history."
+  surface="docs:troubleshooting/event-inspector:inline"
+/>
+
 ## Prerequisites
 
 - A CopilotKit runtime running locally in development mode (`NODE_ENV` is **not** `production`)

--- a/docs/content/docs/integrations/a2a/quickstart.mdx
+++ b/docs/content/docs/integrations/a2a/quickstart.mdx
@@ -33,7 +33,7 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
   title="Ship A2A to production"
   body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
   ctaLabel="Create a free account"
-  surface="docs:a2a/quickstart:top"
+  surface="docs_a2a_quickstart"
 />
 
 ## Prerequisites

--- a/docs/content/docs/integrations/a2a/quickstart.mdx
+++ b/docs/content/docs/integrations/a2a/quickstart.mdx
@@ -28,6 +28,14 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
   muted
 />
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship A2A to production"
+  body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
+  ctaLabel="Create a free account"
+  surface="docs:a2a/quickstart:top"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:

--- a/docs/content/docs/integrations/adk/quickstart.mdx
+++ b/docs/content/docs/integrations/adk/quickstart.mdx
@@ -61,8 +61,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f adk
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard ADK setup.
+                - **Framework** — pick **ADK** when prompted.
             </Step>
             <Step>
                 ### Install dependencies
@@ -411,3 +417,4 @@ Now that you have your basic agent setup, explore these advanced features:
     icon={<WrenchIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/integrations/adk/quickstart.mdx
+++ b/docs/content/docs/integrations/adk/quickstart.mdx
@@ -67,7 +67,7 @@ Before you begin, you'll need the following:
                 The CLI walks you through:
 
                 - **Project name**
-                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard ADK setup.
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard ADK setup.
                 - **Framework** — pick **ADK** when prompted.
             </Step>
             <Step>

--- a/docs/content/docs/integrations/ag2/quickstart.mdx
+++ b/docs/content/docs/integrations/ag2/quickstart.mdx
@@ -62,7 +62,7 @@ Follow the prompts to pick AG2 and the features you want, then run the install/s
   title="Ship AG2 to production"
   body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
   ctaLabel="Create a free account"
-  surface="docs:ag2/quickstart:top"
+  surface="docs_ag2_quickstart"
 />
 
 ## Prerequisites

--- a/docs/content/docs/integrations/ag2/quickstart.mdx
+++ b/docs/content/docs/integrations/ag2/quickstart.mdx
@@ -57,6 +57,14 @@ npx copilotkit@latest init
 
 Follow the prompts to pick AG2 and the features you want, then run the install/start commands it prints.
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship AG2 to production"
+  body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
+  ctaLabel="Create a free account"
+  surface="docs:ag2/quickstart:top"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:
@@ -153,3 +161,4 @@ You've now got a Weather Agent running with CopilotKit! This demonstrates how qu
     icon={<UserIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/integrations/agent-spec/quickstart.mdx
+++ b/docs/content/docs/integrations/agent-spec/quickstart.mdx
@@ -15,7 +15,7 @@ import {
   title="Ship Agent Spec to production"
   body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
   ctaLabel="Create a free account"
-  surface="docs:agent-spec/quickstart:top"
+  surface="docs_agent_spec_quickstart"
 />
 
 ## Prerequisites

--- a/docs/content/docs/integrations/agent-spec/quickstart.mdx
+++ b/docs/content/docs/integrations/agent-spec/quickstart.mdx
@@ -10,6 +10,14 @@ import {
   TailoredContentOption,
 } from "@/components/react/tailored-content.tsx";
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship Agent Spec to production"
+  body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
+  ctaLabel="Create a free account"
+  surface="docs:agent-spec/quickstart:top"
+/>
+
 ## Prerequisites
 
 - Node.js 20+
@@ -500,3 +508,4 @@ Follow per-adapter tutorials: [LangGraph integration](/agent-spec/langgraph) and
 - Agent Spec docs: https://oracle.github.io/agent-spec/development/docs_home.html
 - Agent Spec x AG-UI tutorial: https://oracle.github.io/agent-spec/26.1.0/howtoguides/howto_ag_ui.html
 - Agent Spec Tracing: https://oracle.github.io/agent-spec/development/agentspec/tracing.html
+

--- a/docs/content/docs/integrations/agno/quickstart.mdx
+++ b/docs/content/docs/integrations/agno/quickstart.mdx
@@ -60,8 +60,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f agno
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard Agno setup.
+                - **Framework** — pick **Agno** when prompted.
             </Step>
             <Step>
                 ### Install dependencies
@@ -371,3 +377,4 @@ Now that you have your basic agent setup, explore these advanced features:
     icon={<WrenchIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/integrations/agno/quickstart.mdx
+++ b/docs/content/docs/integrations/agno/quickstart.mdx
@@ -66,7 +66,7 @@ Before you begin, you'll need the following:
                 The CLI walks you through:
 
                 - **Project name**
-                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard Agno setup.
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Agno setup.
                 - **Framework** — pick **Agno** when prompted.
             </Step>
             <Step>

--- a/docs/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/docs/content/docs/integrations/aws-strands/quickstart.mdx
@@ -60,8 +60,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f aws-strands-py
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard AWS Strands setup.
+                - **Framework** — pick **AWS Strands (Python)** when prompted.
             </Step>
             <Step>
                 ### Install dependencies
@@ -385,3 +391,4 @@ Now that you have your basic agent setup, explore these advanced features:
     icon={<WrenchIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/docs/content/docs/integrations/aws-strands/quickstart.mdx
@@ -66,7 +66,7 @@ Before you begin, you'll need the following:
                 The CLI walks you through:
 
                 - **Project name**
-                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard AWS Strands setup.
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard AWS Strands setup.
                 - **Framework** — pick **AWS Strands (Python)** when prompted.
             </Step>
             <Step>

--- a/docs/content/docs/integrations/built-in-agent/index.mdx
+++ b/docs/content/docs/integrations/built-in-agent/index.mdx
@@ -9,6 +9,14 @@ The **Built-in Agent** is CopilotKit's simplest agent option, i.e what you get "
 
 It supports most popular models from OpenAI, Anthropic, Google, and AI-SDK defined models out of the box
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship the Built-in Agent to production"
+  body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
+  ctaLabel="Create a free account"
+  surface="docs:built-in-agent:top"
+/>
+
 ## When to use Built-in Agent
 
 - **Quick setup** — no external agent framework to configure or deploy
@@ -32,14 +40,6 @@ If you need more control over your agent loop, consider using an [agent framewor
   <Card title="Advanced Configuration" href="/built-in-agent/advanced-configuration" description="Fine-tune temperature, tool choice, multi-step calling, and more." icon={<Cog className="text-primary" />} />
   <Card title="Custom Agent" href="/built-in-agent/custom-agent" description="Bring your own AI SDK, TanStack AI, or custom LLM backend." icon={<Blocks className="text-primary" />} />
 </Cards>
-
-<OpsPlatformCTA
-  variant="card"
-  title="Ship the Built-in Agent to production"
-  body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
-  ctaLabel="Create a free account"
-  surface="docs:built-in-agent:after-features"
-/>
 
 ## Getting Started
 

--- a/docs/content/docs/integrations/built-in-agent/index.mdx
+++ b/docs/content/docs/integrations/built-in-agent/index.mdx
@@ -33,6 +33,14 @@ If you need more control over your agent loop, consider using an [agent framewor
   <Card title="Custom Agent" href="/built-in-agent/custom-agent" description="Bring your own AI SDK, TanStack AI, or custom LLM backend." icon={<Blocks className="text-primary" />} />
 </Cards>
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship the Built-in Agent to production"
+  body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
+  ctaLabel="Create a free account"
+  surface="docs:built-in-agent:after-features"
+/>
+
 ## Getting Started
 
 Head to the [Quickstart](./quickstart) to set up a working Built-in Agent in minutes.

--- a/docs/content/docs/integrations/built-in-agent/index.mdx
+++ b/docs/content/docs/integrations/built-in-agent/index.mdx
@@ -14,7 +14,7 @@ It supports most popular models from OpenAI, Anthropic, Google, and AI-SDK defin
   title="Ship the Built-in Agent to production"
   body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
   ctaLabel="Create a free account"
-  surface="docs:built-in-agent:top"
+  surface="docs_built_in_agent_overview"
 />
 
 ## When to use Built-in Agent

--- a/docs/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/docs/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -29,7 +29,7 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
   title="Ship the Built-in Agent to production"
   body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
   ctaLabel="Create a free account"
-  surface="docs:built-in-agent/quickstart:top"
+  surface="docs_built_in_agent_quickstart"
 />
 
 ## Prerequisites

--- a/docs/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/docs/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -24,6 +24,14 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
   muted
 />
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship the Built-in Agent to production"
+  body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
+  ctaLabel="Create a free account"
+  surface="docs:built-in-agent/quickstart:top"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:
@@ -225,3 +233,4 @@ Now that you have your basic agent setup, explore these advanced features:
     icon={<MonitorIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/docs/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -46,7 +46,7 @@ import CopilotUI from "@/snippets/copilot-ui.mdx";
   title="Ship CrewAI Flows to production"
   body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
   ctaLabel="Create a free account"
-  surface="docs:crewai-flows/quickstart:top"
+  surface="docs_crewai_flows_quickstart"
 />
 
 ## Prerequisites

--- a/docs/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/docs/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -41,6 +41,14 @@ import CopilotUI from "@/snippets/copilot-ui.mdx";
   muted
 />
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship CrewAI Flows to production"
+  body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
+  ctaLabel="Create a free account"
+  surface="docs:crewai-flows/quickstart:top"
+/>
+
 ## Prerequisites
 
 Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/flows/first-flow) deployed on [CrewAI Enterprise](https://docs.crewai.com/enterprise/introduction). If you're looking for a sample flows, check out this [example agentic chat implementation](https://github.com/suhasdeshpande/agentic_chat).
@@ -275,3 +283,4 @@ can help you build power agent native applications.
     icon={<WrenchIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/integrations/deepagents/quickstart.mdx
+++ b/docs/content/docs/integrations/deepagents/quickstart.mdx
@@ -11,7 +11,7 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
   title="Ship Deep Agents to production"
   body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
   ctaLabel="Create a free account"
-  surface="docs:deepagents/quickstart:top"
+  surface="docs_deepagents_quickstart"
 />
 
 ## Prerequisites

--- a/docs/content/docs/integrations/deepagents/quickstart.mdx
+++ b/docs/content/docs/integrations/deepagents/quickstart.mdx
@@ -6,6 +6,14 @@ icon: "lucide/Rocket"
 
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship Deep Agents to production"
+  body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
+  ctaLabel="Create a free account"
+  surface="docs:deepagents/quickstart:top"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:

--- a/docs/content/docs/integrations/langgraph/index.mdx
+++ b/docs/content/docs/integrations/langgraph/index.mdx
@@ -54,5 +54,14 @@ import { FrameworkOverview } from "@/components/content/landing-pages/framework-
       iframeUrl: "https://examples-coagents-research-canvas-ui.vercel.app/"
     }
   ]}
+  afterFeatures={
+    <OpsPlatformCTA
+      variant="card"
+      title="Bring your LangGraph agents to production"
+      body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
+      ctaLabel="Create a free account"
+      surface="docs:langgraph:top"
+    />
+  }
   tutorialLink="/langgraph/tutorials/ai-travel-app"
 />

--- a/docs/content/docs/integrations/langgraph/index.mdx
+++ b/docs/content/docs/integrations/langgraph/index.mdx
@@ -60,7 +60,7 @@ import { FrameworkOverview } from "@/components/content/landing-pages/framework-
       title="Bring your LangGraph agents to production"
       body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
       ctaLabel="Create a free account"
-      surface="docs:langgraph:top"
+      surface="docs_langgraph_overview"
     />
   }
   tutorialLink="/langgraph/tutorials/ai-travel-app"

--- a/docs/content/docs/integrations/langgraph/prebuilt-components.mdx
+++ b/docs/content/docs/integrations/langgraph/prebuilt-components.mdx
@@ -13,6 +13,13 @@ CopilotKit ships three prebuilt chat components that connect directly to your La
   If you've completed the [quickstart](/langgraph/quickstart), you already have one of these set up.
 </Callout>
 
+<OpsPlatformCTA
+  variant="inline"
+  title="Want users to resume conversations across sessions?"
+  body="Persistent threads ship with the CopilotKit platform. Try it for free."
+  surface="docs:langgraph/prebuilt-components:inline"
+/>
+
 <IframeSwitcher
   id="agentic-chat-example"
   exampleUrl="https://feature-viewer.copilotkit.ai/langgraph/feature/agentic_chat?sidebar=false&chatDefaultOpen=false"

--- a/docs/content/docs/integrations/langgraph/prebuilt-components.mdx
+++ b/docs/content/docs/integrations/langgraph/prebuilt-components.mdx
@@ -17,7 +17,7 @@ CopilotKit ships three prebuilt chat components that connect directly to your La
   variant="inline"
   title="Want users to resume conversations across sessions?"
   body="Persistent threads ship with the CopilotKit platform. Try it for free."
-  surface="docs:langgraph/prebuilt-components:inline"
+  surface="docs_langgraph_prebuilt_components"
 />
 
 <IframeSwitcher

--- a/docs/content/docs/integrations/langgraph/quickstart.mdx
+++ b/docs/content/docs/integrations/langgraph/quickstart.mdx
@@ -86,7 +86,7 @@ Before you begin, you'll need the following:
                 The CLI walks you through:
 
                 - **Project name**
-                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard LangGraph setup.
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard LangGraph setup.
                 - **Framework** — pick **LangGraph (Python)** or **LangGraph (JavaScript)**.
             </Step>
             <Step>

--- a/docs/content/docs/integrations/langgraph/quickstart.mdx
+++ b/docs/content/docs/integrations/langgraph/quickstart.mdx
@@ -79,20 +79,15 @@ Before you begin, you'll need the following:
             <Step>
                 ### Run our CLI
 
-                First, we'll use our CLI to create a new project for us. Choose between Python or JavaScript:
+                ```bash
+                npx copilotkit@latest create
+                ```
 
-                <Tabs groupId="language_langgraph_agent" items={['Python', 'JavaScript']} persist>
-                    <Tab value="Python">
-                        ```bash
-                        npx copilotkit@latest create -f langgraph-py
-                        ```
-                    </Tab>
-                    <Tab value="JavaScript">
-                        ```bash
-                        npx copilotkit@latest create -f langgraph-js
-                        ```
-                    </Tab>
-                </Tabs>
+                The CLI walks you through:
+
+                - **Project name**
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard LangGraph setup.
+                - **Framework** — pick **LangGraph (Python)** or **LangGraph (JavaScript)**.
             </Step>
             <Step>
                 ### Install dependencies
@@ -574,3 +569,4 @@ Now that you have your basic agent setup, explore these advanced features:
     icon={<WrenchIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/docs/content/docs/integrations/llamaindex/quickstart.mdx
@@ -67,7 +67,7 @@ Before you begin, you'll need the following:
                 The CLI walks you through:
 
                 - **Project name**
-                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard LlamaIndex setup.
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard LlamaIndex setup.
                 - **Framework** — pick **LlamaIndex** when prompted.
             </Step>
             <Step>

--- a/docs/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/docs/content/docs/integrations/llamaindex/quickstart.mdx
@@ -61,8 +61,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f llamaindex
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard LlamaIndex setup.
+                - **Framework** — pick **LlamaIndex** when prompted.
             </Step>
             <Step>
                 ### Install dependencies
@@ -419,3 +425,4 @@ Now that you have your basic agent setup, explore these advanced features:
     icon={<WrenchIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/integrations/mastra/quickstart.mdx
+++ b/docs/content/docs/integrations/mastra/quickstart.mdx
@@ -71,11 +71,15 @@ Before you begin, you'll need the following:
             <Step>
                 ### Run our CLI
 
-                First, we'll use our CLI to create a new project for us.
-
                 ```bash
-                npx copilotkit@latest create -f mastra
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard Mastra setup.
+                - **Framework** — pick **Mastra** when prompted.
             </Step>
             <Step>
                 ### Install dependencies
@@ -356,3 +360,4 @@ Now that you have your basic agent setup, explore these advanced features:
     icon={<WrenchIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/integrations/mastra/quickstart.mdx
+++ b/docs/content/docs/integrations/mastra/quickstart.mdx
@@ -78,7 +78,7 @@ Before you begin, you'll need the following:
                 The CLI walks you through:
 
                 - **Project name**
-                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard Mastra setup.
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Mastra setup.
                 - **Framework** — pick **Mastra** when prompted.
             </Step>
             <Step>

--- a/docs/content/docs/integrations/microsoft-agent-framework/index.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/index.mdx
@@ -55,7 +55,7 @@ import { FrameworkOverview } from "@/components/content/landing-pages/framework-
       title="Bring your Agent Framework agents to production"
       body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
       ctaLabel="Create a free account"
-      surface="docs:microsoft-agent-framework:top"
+      surface="docs_microsoft_agent_framework_overview"
     />
   }
   tutorialLink="/microsoft-agent-framework/quickstart"

--- a/docs/content/docs/integrations/microsoft-agent-framework/index.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/index.mdx
@@ -49,6 +49,15 @@ import { FrameworkOverview } from "@/components/content/landing-pages/framework-
       iframeUrl: "https://feature-viewer.copilotkit.ai/microsoft-agent-framework-dotnet/feature/agentic_chat"
     },
   ]}
+  afterFeatures={
+    <OpsPlatformCTA
+      variant="card"
+      title="Bring your Agent Framework agents to production"
+      body="Add persistent threads, observability, and the inspector with the CopilotKit platform."
+      ctaLabel="Create a free account"
+      surface="docs:microsoft-agent-framework:top"
+    />
+  }
   tutorialLink="/microsoft-agent-framework/quickstart"
 />
 

--- a/docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -59,7 +59,7 @@ Before you begin, you'll need the following:
                 The CLI walks you through:
 
                 - **Project name**
-                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard Microsoft Agent Framework setup.
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Microsoft Agent Framework setup.
                 - **Framework** — pick **Microsoft Agent Framework (.NET)** or **Microsoft Agent Framework (Python)**.
             </Step>
             <Step>

--- a/docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -52,20 +52,15 @@ Before you begin, you'll need the following:
             <Step>
                 ### Run our CLI
 
-                First, we'll use our CLI to create a new project for us.
+                ```bash
+                npx copilotkit@latest create
+                ```
 
-                <Tabs groupId="language_microsoft-agent-framework_agent" items={['.NET', 'Python']} persist>
-                    <Tab value=".NET">
-                        ```bash
-                        npx copilotkit@latest create -f microsoft-agent-framework-dotnet
-                        ```
-                    </Tab>
-                    <Tab value="Python">
-                        ```bash
-                        npx copilotkit@latest create -f microsoft-agent-framework-py
-                        ```
-                    </Tab>
-                </Tabs>
+                The CLI walks you through:
+
+                - **Project name**
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard Microsoft Agent Framework setup.
+                - **Framework** — pick **Microsoft Agent Framework (.NET)** or **Microsoft Agent Framework (Python)**.
             </Step>
             <Step>
                 ### Install dependencies
@@ -531,3 +526,4 @@ Now that you have your basic agent setup, explore these advanced features:
     icon={<WrenchIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -67,7 +67,7 @@ Before you begin, you'll need the following:
                 The CLI walks you through:
 
                 - **Project name**
-                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard Pydantic AI setup.
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Pydantic AI setup.
                 - **Framework** — pick **Pydantic AI** when prompted.
             </Step>
             <Step>

--- a/docs/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -61,8 +61,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f pydantic-ai
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **CopilotKit platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs:cli-prompt) first), or **No** for a standard Pydantic AI setup.
+                - **Framework** — pick **Pydantic AI** when prompted.
             </Step>
             <Step>
                 ### Install dependencies
@@ -370,3 +376,4 @@ Now that you have your basic agent setup, explore these advanced features:
     icon={<WrenchIcon />}
   />
 </Cards>
+

--- a/docs/content/docs/reference/v2/components/CopilotChat.mdx
+++ b/docs/content/docs/reference/v2/components/CopilotChat.mdx
@@ -13,7 +13,7 @@ description: "High-level chat component that connects an agent to a chat view"
   variant="inline"
   title="Looking for chat history?"
   body="Pair CopilotChat with useThreads on the CopilotKit platform for persistent, resumable conversations on the free Developer tier."
-  surface="docs:reference/v2/components/CopilotChat:inline"
+  surface="docs_reference_copilotchat"
 />
 
 ## Import

--- a/docs/content/docs/reference/v2/components/CopilotChat.mdx
+++ b/docs/content/docs/reference/v2/components/CopilotChat.mdx
@@ -9,6 +9,13 @@ description: "High-level chat component that connects an agent to a chat view"
 
 `CopilotChat` manages messages, running state, and suggestions automatically -- you only need to specify which agent to connect and, optionally, customise labels or slot overrides.
 
+<OpsPlatformCTA
+  variant="inline"
+  title="Looking for chat history?"
+  body="Pair CopilotChat with useThreads on the CopilotKit platform for persistent, resumable conversations on the free Developer tier."
+  surface="docs:reference/v2/components/CopilotChat:inline"
+/>
+
 ## Import
 
 ```tsx

--- a/docs/content/docs/reference/v2/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/v2/components/CopilotKit.mdx
@@ -9,4 +9,11 @@ import CopilotKitComponent from "@/snippets/shared/reference/copilotkit-componen
   This provider is shared across v1 and v2 APIs. It must be imported from the root package (`@copilotkit/react-core`), not from the v2 subpackage.
 </Callout>
 
+<OpsPlatformCTA
+  variant="inline"
+  title="Need a publicLicenseKey?"
+  body="Get one with the free Developer tier of the CopilotKit platform, which also includes threads, persistence, and observability."
+  surface="docs:reference/v2/components/CopilotKit:inline"
+/>
+
 <CopilotKitComponent components={props.components} />

--- a/docs/content/docs/reference/v2/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/v2/components/CopilotKit.mdx
@@ -13,7 +13,7 @@ import CopilotKitComponent from "@/snippets/shared/reference/copilotkit-componen
   variant="inline"
   title="Need a publicLicenseKey?"
   body="Get one with the free Developer tier of the CopilotKit platform, which also includes threads, persistence, and observability."
-  surface="docs:reference/v2/components/CopilotKit:inline"
+  surface="docs_reference_copilotkit"
 />
 
 <CopilotKitComponent components={props.components} />

--- a/docs/content/docs/reference/v2/index.mdx
+++ b/docs/content/docs/reference/v2/index.mdx
@@ -12,7 +12,7 @@ The v2 React API (`@copilotkit/react-core/v2`) is the next-generation interface 
   variant="inline"
   title="Building production agents?"
   body="Persistent threads, observability, and the full CopilotKit platform on the free Developer tier."
-  surface="docs:reference/v2:top"
+  surface="docs_reference_v2"
 />
 
 ## Provider Setup

--- a/docs/content/docs/reference/v2/index.mdx
+++ b/docs/content/docs/reference/v2/index.mdx
@@ -8,6 +8,13 @@ import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 
 The v2 React API (`@copilotkit/react-core/v2`) is the next-generation interface for building copilot-powered applications. It provides a streamlined set of hooks and components built on top of the [AG-UI](https://docs.ag-ui.com) agent protocol.
 
+<OpsPlatformCTA
+  variant="inline"
+  title="Building production agents?"
+  body="Persistent threads, observability, and the full CopilotKit platform on the free Developer tier."
+  surface="docs:reference/v2:top"
+/>
+
 ## Provider Setup
 
 The v2 API uses the [`<CopilotKit>`](/reference/v2/components/CopilotKit) provider. Wrap your application with it to configure the runtime connection:

--- a/docs/snippets/shared/basics/prebuilt-components.mdx
+++ b/docs/snippets/shared/basics/prebuilt-components.mdx
@@ -6,6 +6,13 @@ CopilotKit ships three prebuilt chat components that connect directly to your ag
   If you've completed the quickstart, you already have one of these set up.
 </Callout>
 
+<OpsPlatformCTA
+  variant="inline"
+  title="Want users to resume conversations across sessions?"
+  body="Persistent threads ship with the CopilotKit platform. Try it for free."
+  surface="docs:prebuilt-components:inline"
+/>
+
 <IframeSwitcher
   id="agentic-chat-example"
   exampleUrl={`https://feature-viewer.copilotkit.ai/${props.framework || "langgraph"}/feature/agentic_chat?sidebar=false&chatDefaultOpen=false`}

--- a/docs/snippets/shared/basics/prebuilt-components.mdx
+++ b/docs/snippets/shared/basics/prebuilt-components.mdx
@@ -10,7 +10,7 @@ CopilotKit ships three prebuilt chat components that connect directly to your ag
   variant="inline"
   title="Want users to resume conversations across sessions?"
   body="Persistent threads ship with the CopilotKit platform. Try it for free."
-  surface="docs:prebuilt-components:inline"
+  surface="docs_prebuilt_components"
 />
 
 <IframeSwitcher

--- a/docs/snippets/shared/premium/headless-ui.mdx
+++ b/docs/snippets/shared/premium/headless-ui.mdx
@@ -12,6 +12,14 @@ import {
 CopilotKit offers *fully headless UI* through the `useCopilotChatHeadless_c` hook. By using this hook, you can build your own chat interfaces
 from the ground up while still utilizing CopilotKit's core features and ease-of-use.
 
+<OpsPlatformCTA
+  variant="card"
+  title="Headless UI requires an CopilotKit platform license key"
+  body="Sign up for a free account to get a publicLicenseKey and unlock the headless hooks."
+  ctaLabel="Create a free account"
+  surface="docs:premium/headless-ui:top"
+/>
+
 ## Navigation
 This page has all the information you need to get started with CopilotKit's headless UI. Select where you'd like to get started below.
 

--- a/docs/snippets/shared/premium/headless-ui.mdx
+++ b/docs/snippets/shared/premium/headless-ui.mdx
@@ -17,7 +17,7 @@ from the ground up while still utilizing CopilotKit's core features and ease-of-
   title="Headless UI requires an CopilotKit platform license key"
   body="Sign up for a free account to get a publicLicenseKey and unlock the headless hooks."
   ctaLabel="Create a free account"
-  surface="docs:premium/headless-ui:top"
+  surface="docs_premium_headless_ui"
 />
 
 ## Navigation

--- a/docs/snippets/shared/premium/observability.mdx
+++ b/docs/snippets/shared/premium/observability.mdx
@@ -5,6 +5,15 @@ icon: "lucide/Activity"
 ---
 
 Monitor CopilotKit with first‑class observability hooks that emit structured signals for chat events, user interactions, and runtime errors. Send these signals straight to your existing stack, including Sentry, Datadog, New Relic, and OpenTelemetry, or route them to your analytics pipeline. The hooks expose stable schemas and IDs so you can join agent events with app telemetry, trace sessions end to end, and alert on failures in real time. Works with Copilot Cloud via `publicApiKey`, or self‑hosted via `publicLicenseKey`.
+
+<OpsPlatformCTA
+  variant="card"
+  title="Observability requires an CopilotKit platform license key"
+  body="Sign up for a free account to get a publicLicenseKey and start monitoring your agents."
+  ctaLabel="Create a free account"
+  surface="docs:premium/observability:top"
+/>
+
 ## Quick Start
 
 <Callout type="info">

--- a/docs/snippets/shared/premium/observability.mdx
+++ b/docs/snippets/shared/premium/observability.mdx
@@ -11,7 +11,7 @@ Monitor CopilotKit with first‑class observability hooks that emit structured s
   title="Observability requires an CopilotKit platform license key"
   body="Sign up for a free account to get a publicLicenseKey and start monitoring your agents."
   ctaLabel="Create a free account"
-  surface="docs:premium/observability:top"
+  surface="docs_premium_observability"
 />
 
 ## Quick Start

--- a/docs/snippets/shared/premium/overview.mdx
+++ b/docs/snippets/shared/premium/overview.mdx
@@ -41,7 +41,7 @@ Access to premium features requires a public license key. To get yours, follow t
       variant="inline"
       title="Create a free CopilotKit platform account"
       body="No credit card required. Get a public license key plus persistent threads, observability, and more."
-      surface="docs:premium/overview:signup-step"
+      surface="docs_premium_overview"
     />
   </Step>
   <Step>

--- a/docs/snippets/shared/premium/overview.mdx
+++ b/docs/snippets/shared/premium/overview.mdx
@@ -37,9 +37,12 @@ Access to premium features requires a public license key. To get yours, follow t
   <Step>
     #### Sign up
 
-    Create a *free* account on [Copilot Cloud](https://cloud.copilotkit.ai).
-
-    This does not require a credit card or use of Copilot Cloud.
+    <OpsPlatformCTA
+      variant="inline"
+      title="Create a free CopilotKit platform account"
+      body="No credit card required. Get a public license key plus persistent threads, observability, and more."
+      surface="docs:premium/overview:signup-step"
+    />
   </Step>
   <Step>
     #### Get your public license key


### PR DESCRIPTION
## Summary

- Adds a reusable `OpsPlatformCTA` component with four visual variants (card, info, inline, tile), PostHog `cta_clicked` instrumentation, and UTM-tagged links to the dashboard
- Places sign-up CTAs across topical docs pages, integration overview pages, manual-setup quickstarts, premium pages, and the shared prebuilt-components snippet (covers all per-integration prebuilt pages)
- Repoints the navbar "Free Developer Access" link to the dashboard with matching click tracking
- Adds an `afterFeatures` slot to `FrameworkOverview` so MDX can inject content below the supported-features section
- Rewrites the CLI step on the eight framework quickstarts that have a scaffold (ADK, Agno, AWS Strands, LangGraph, LlamaIndex, Mastra, Microsoft Agent Framework, Pydantic AI) to use the interactive flow and describe the prompts (project name, platform Yes/No with sign-up link, framework picker)

Coverage: ~13% of docs pages, focused on the highest-traffic surfaces and topical landing pages.

## Test plan

- [ ] `/`, `/quickstart`, `/prebuilt-components`, `/shared-state`, `/inspector` show their CTAs in the expected position
- [ ] Integration overview pages (`/built-in-agent`, `/langgraph`, `/adk`, `/aws-strands`, `/microsoft-agent-framework`) render the CTA above the fold
- [ ] Each of the 13 per-integration `/{framework}/prebuilt-components` pages renders the inline CTA via the shared snippet
- [ ] Each of the 8 framework quickstarts shows the new CLI walkthrough (Yes-first prompt, dashboard sign-up link, correct framework label)
- [ ] Navbar still shows "Talk to Our Engineers" alongside the repointed "Free Developer Access" link
- [ ] DevTools Network: clicking any CTA sends one `cta_clicked` PostHog event with `{surface, variant, target, page_path}`
- [ ] Destination URL on every CTA ends with `?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=<surface>`