### PR TITLE
Disable Showcase Eval Check until fixed

### DIFF
--- a/.github/workflows/showcase_eval_check.yml
+++ b/.github/workflows/showcase_eval_check.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   create-check:
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:


### PR DESCRIPTION
## Summary
- Adds `if: false` to the `create-check` job in `showcase_eval_check.yml`
- The check is failing on every PR (see screenshot in conversation)
- Easy to re-enable: just remove the `if: false` line

## Test plan
- [ ] Verify new PRs no longer show the failing "Showcase: Eval Check" check