### PR TITLE
docs: document new --isolate behavior for showcase test

### DIFF
--- a/showcase/DEBUGGING.md
+++ b/showcase/DEBUGGING.md
@@ -276,6 +276,39 @@ showcase diff-logs aimock --since last-test --grep "fixture"
 
 This filters out all log output from before your test started, showing only what happened during the test run itself.
 
+## Isolated Test Runs (`--isolate`)
+
+The `--isolate` flag on `showcase test` lets you run tests without interfering with an already-running local stack (or other isolated runs). It works by creating temporary overlay files rather than mutating originals in place.
+
+### How it works
+
+1. **Temp overlay directory**: `apply_isolation` copies `docker-compose.local.yml` and `shared/local-ports.json` to `$TMPDIR/showcase-isolate-$$/`. The originals are never touched. Shell variables (`COMPOSE_FILE`, `COMPOSE_CMD`, `PORTS_FILE`) and the `LOCAL_PORTS_FILE` env var passed to the TS harness all point at the temp copies.
+
+2. **Slot-based port allocation**: Concurrent `--isolate` runs acquire unique port ranges via atomic `mkdir /tmp/showcase-isolate-slots/N`. Slot 0 adds a +200 offset to all ports, slot 1 adds +400, slot 2 adds +600, etc. Up to 46 concurrent isolated runs are supported. Each slot directory contains a `pid` file for stale-slot detection.
+
+3. **Project name scoping**: Each isolated run passes `--project-name <name>` to docker compose, so containers, networks, and volumes are fully namespaced. No collision with the base `showcase` project or other isolated runs.
+
+4. **Cleanup**: `restore_isolation` removes the temp directory and releases the slot. It is registered via `trap EXIT` before any mutation occurs, so cleanup runs even on crashes or `Ctrl-C`.
+
+### Parallel runs are safe
+
+Multiple agents or terminal sessions can each run `showcase test <slug> --isolate` simultaneously. Each gets its own port range and project namespace. No coordination is needed beyond the atomic slot allocation.
+
+### Troubleshooting
+
+- **Wrong ports / stale compose state**: If you see `.iso-bak` files next to `docker-compose.local.yml` or `shared/local-ports.json`, those are leftovers from the OLD isolate behavior (which mutated files in place). Remove them and restore originals:
+
+  ```sh
+  git checkout showcase/docker-compose.local.yml showcase/shared/local-ports.json
+  rm -f showcase/docker-compose.local.yml.iso-bak showcase/shared/local-ports.json.iso-bak
+  ```
+
+  The new isolate behavior auto-detects and cleans up these stale backups on startup, but a manual restore is the safest fix if things look wrong.
+
+- **Temp files**: Overlay directories live at `$TMPDIR/showcase-isolate-*/`. They are cleaned up on normal exit; if a run was killed with `SIGKILL`, the directory may linger. Safe to remove manually.
+
+- **Slot directories**: Located at `/tmp/showcase-isolate-slots/`. Each numbered subdirectory is a claimed slot. If slots accumulate from killed processes, clean them with `rm -rf /tmp/showcase-isolate-slots/*`.
+
 ## Environment Variables
 
 | Variable            | Purpose                                                                            | Default                                                                         |

--- a/showcase/RUNBOOK.md
+++ b/showcase/RUNBOOK.md
@@ -120,6 +120,31 @@ Rate limit: 5 minutes per probe ID.
 
 When `package.json` changes (new deps, version bumps), volume mounts don't cover `node_modules`. You MUST rebuild the Docker image: `bin/showcase rebuild <slug>`, then re-test. A passing `bin/showcase test` against a volume-mounted container does NOT validate the build.
 
+## Isolated Test Runs (`--isolate`)
+
+Use `--isolate` when another agent or terminal session is already running showcase locally. It prevents port collisions and container name conflicts by scoping everything into a temporary overlay.
+
+```
+bin/showcase test <slug> --d5 --isolate
+```
+
+### Operational notes
+
+- **Required when sharing a machine**: If any other session has `showcase up` running, use `--isolate` to avoid stomping on its containers and ports.
+- **Parallel runs supported**: Up to 46 concurrent `--isolate` runs. Each gets a unique port range (slot 0 = +200, slot 1 = +400, ...) and a scoped docker compose project name.
+- **Originals are never modified**: The flag writes temp copies of `docker-compose.local.yml` and `shared/local-ports.json` to `$TMPDIR/showcase-isolate-$$/`. If the process crashes, originals are untouched.
+- **Cleanup is automatic**: The temp directory and slot are released on exit (via `trap EXIT`). If a run was killed with `SIGKILL`, clean up manually:
+
+  ```sh
+  # Remove orphaned containers from a specific isolated run:
+  docker compose --project-name <name> down
+
+  # Clear all stale slot reservations:
+  rm -rf /tmp/showcase-isolate-slots/*
+  ```
+
+- **Stale `.iso-bak` files**: If you see `docker-compose.local.yml.iso-bak` or `local-ports.json.iso-bak`, those are leftovers from the old (pre-PR#4570) isolate behavior. The new code auto-restores them on startup, but you can also clean up manually with `git checkout` on the affected files.
+
 ## Anti-Patterns
 
 Earned by bugs. Do not repeat.


### PR DESCRIPTION
## Summary

- Add "Isolated Test Runs" section to `showcase/DEBUGGING.md` covering how `--isolate` works (temp overlays, slot-based ports, project name scoping), parallel safety, and troubleshooting stale state from the old behavior.
- Add "Isolated Test Runs" section to `showcase/RUNBOOK.md` with operational notes: when to use `--isolate`, parallel run limits, orphan container cleanup, and stale slot cleanup.

Documents the rewrite from PR #4570, which replaced the old in-place mutation approach with temp overlay files that never touch originals.

## Test plan

- [ ] Verify DEBUGGING.md renders correctly on GitHub
- [ ] Verify RUNBOOK.md renders correctly on GitHub
- [ ] Confirm section placement matches existing document structure and style