### PR TITLE
Baseline tab: batch SSE, larger page size, footer buffer

### DIFF
--- a/showcase/shell-dashboard/src/components/baseline-tab.tsx
+++ b/showcase/shell-dashboard/src/components/baseline-tab.tsx
@@ -144,7 +144,9 @@ export function BaselineTab() {
         </div>
       </div>
 
-      <BaselineGrid cells={cells} editing={editing} onUpdate={updateCell} />
+      <div className="flex-1 min-h-0 overflow-auto pb-12">
+        <BaselineGrid cells={cells} editing={editing} onUpdate={updateCell} />
+      </div>
       <BaselineLegend />
       <BaselineToastContainer />
 

--- a/showcase/shell-dashboard/src/hooks/useBaseline.ts
+++ b/showcase/shell-dashboard/src/hooks/useBaseline.ts
@@ -135,24 +135,37 @@ export function useBaseline(): UseBaselineResult {
         setError(null);
         attempts = 0;
 
+        // Batch SSE updates to avoid per-event re-renders (825 records
+        // seeding = 825 individual SSE events = 825 Map clones + grid
+        // re-renders without batching). Buffer events and flush every 100ms.
+        const sseBuf: Array<{ action: string; record: BaselineCell }> = [];
+        let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+        function flushSseBuf() {
+          flushTimer = null;
+          if (sseBuf.length === 0 || !alive) return;
+          const batch = sseBuf.splice(0);
+          setCells((prev) => {
+            const next = new Map(prev);
+            for (const evt of batch) {
+              if (evt.action === "delete") {
+                next.delete(evt.record.key);
+              } else {
+                next.set(evt.record.key, evt.record);
+              }
+            }
+            return next;
+          });
+        }
+
         const unsub = await pb
           .collection("baseline")
           .subscribe<BaselineCell>("*", (e) => {
             try {
               if (!alive) return;
-              if (e.action === "delete") {
-                setCells((prev) => {
-                  const next = new Map(prev);
-                  next.delete(e.record.key);
-                  return next;
-                });
-              } else {
-                // create or update
-                setCells((prev) => {
-                  const next = new Map(prev);
-                  next.set(e.record.key, e.record);
-                  return next;
-                });
+              sseBuf.push({ action: e.action, record: e.record });
+              if (!flushTimer) {
+                flushTimer = setTimeout(flushSseBuf, 100);
               }
             } catch (cbErr) {
               // eslint-disable-next-line no-console

--- a/showcase/shell-dashboard/src/hooks/useBaseline.ts
+++ b/showcase/shell-dashboard/src/hooks/useBaseline.ts
@@ -28,8 +28,10 @@ export interface UseBaselineResult {
 /*  Constants                                                          */
 /* ------------------------------------------------------------------ */
 
-const PAGE_SIZE = 200;
-const MAX_PAGES = 10;
+// Baseline has ~825 records — fetch in a single request to avoid
+// sequential round-trip latency (5 × 200 = 5 round trips to Railway PB).
+const PAGE_SIZE = 1000;
+const MAX_PAGES = 2;
 const MAX_RECONNECT_ATTEMPTS = 3;
 const RECONNECT_BACKOFF_BASE_MS = 1000;
 const RECONNECT_BACKOFF_MAX_MS = 8000;


### PR DESCRIPTION
Three perf/UX fixes:
- Increase PB fetch page size from 200→1000 (single round-trip for 825 records)
- Batch SSE updates every 100ms instead of per-event re-renders (seed creates 825 events)
- Add pb-12 footer buffer matching Matrix tab scroll pattern