### PR TITLE
Baseline: fix key mismatch (colon vs slash separator)

### DIFF
--- a/showcase/shell-dashboard/src/components/baseline-grid.tsx
+++ b/showcase/shell-dashboard/src/components/baseline-grid.tsx
@@ -127,7 +127,7 @@ function CategorySection({
 
             {/* Partner cells */}
             {partners.map((partner) => {
-              const key = `${partner.slug}/${featureSlug}`;
+              const key = `${partner.slug}:${featureSlug}`;
               const cell = cells.get(key);
               const status = cell?.status ?? "unknown";
               const tags = cell?.tags ?? [];


### PR DESCRIPTION
Grid looked up cells with `partner/feature` but PB stores keys as `partner:feature`. All cells showed as unknown despite data being loaded (stats were correct because they iterated the Map values, not the lookup).