### PR TITLE
Dashboard: add dark/light/system theme toggle

### DIFF
--- a/showcase/shell-dashboard/src/app/globals.css
+++ b/showcase/shell-dashboard/src/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 
+/* ── Light theme (default) ────────────────────────────────────────── */
 :root {
   --bg: #ffffff;
   --bg-surface: #ffffff;
@@ -15,6 +16,44 @@
   --ok: #059669;
   --amber: #d97706;
   --danger: #dc2626;
+}
+
+/* ── Dark theme ───────────────────────────────────────────────────── */
+[data-theme="dark"] {
+  --bg: #0f1117;
+  --bg-surface: #1a1d27;
+  --bg-muted: #22252f;
+  --bg-hover: #2a2d3a;
+  --border: #2e3140;
+  --border-strong: #3d4155;
+  --text: #e4e6ed;
+  --text-secondary: #a0a6b6;
+  --text-muted: #6b7280;
+  --accent: #5b8def;
+  --accent-hover: #4a7de8;
+  --ok: #34d399;
+  --amber: #fbbf24;
+  --danger: #f87171;
+}
+
+/* ── System-auto: dark when no explicit theme set ─────────────────── */
+@media (prefers-color-scheme: dark) {
+  [data-theme="system"] {
+    --bg: #0f1117;
+    --bg-surface: #1a1d27;
+    --bg-muted: #22252f;
+    --bg-hover: #2a2d3a;
+    --border: #2e3140;
+    --border-strong: #3d4155;
+    --text: #e4e6ed;
+    --text-secondary: #a0a6b6;
+    --text-muted: #6b7280;
+    --accent: #5b8def;
+    --accent-hover: #4a7de8;
+    --ok: #34d399;
+    --amber: #fbbf24;
+    --danger: #f87171;
+  }
 }
 
 * {

--- a/showcase/shell-dashboard/src/app/layout.tsx
+++ b/showcase/shell-dashboard/src/app/layout.tsx
@@ -12,13 +12,35 @@ export const metadata: Metadata = {
   },
 };
 
+/**
+ * Inline script that runs before React hydrates to prevent flash of wrong
+ * theme. Reads localStorage and sets data-theme on <html> synchronously.
+ */
+const themeInitScript = `
+(function(){
+  try {
+    var t = localStorage.getItem("dashboard:theme");
+    if (t === "light" || t === "dark") {
+      document.documentElement.setAttribute("data-theme", t);
+    } else {
+      document.documentElement.setAttribute("data-theme", "system");
+    }
+  } catch(e) {
+    document.documentElement.setAttribute("data-theme", "system");
+  }
+})();
+`;
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -14,6 +14,7 @@ import { OverlayToggleBar } from "@/components/overlay-toggle-bar";
 import { ComposedCell } from "@/components/composed-cell";
 import { AdaptiveStatsBar } from "@/components/adaptive-stats-bar";
 import { AdaptiveLegend } from "@/components/adaptive-legend";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { BaselineTab } from "@/components/baseline-tab";
 import type { ParityTier } from "@/components/parity-badge";
 import { getDocsStatus } from "@/lib/docs-status";
@@ -211,6 +212,9 @@ export default function Page() {
         >
           Ops
         </button>
+        <div className="ml-auto flex items-center pr-1">
+          <ThemeToggle />
+        </div>
       </div>
 
       {activeTab === "matrix" && (

--- a/showcase/shell-dashboard/src/components/theme-toggle.tsx
+++ b/showcase/shell-dashboard/src/components/theme-toggle.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+type ThemeMode = "system" | "light" | "dark";
+
+const STORAGE_KEY = "dashboard:theme";
+
+/** Resolve effective theme for the system mode. */
+function systemPrefersDark(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+}
+
+/** Apply the data-theme attribute on <html>. */
+function applyTheme(mode: ThemeMode) {
+  const html = document.documentElement;
+  if (mode === "system") {
+    html.setAttribute("data-theme", "system");
+  } else {
+    html.setAttribute("data-theme", mode);
+  }
+}
+
+const MODES: ThemeMode[] = ["system", "light", "dark"];
+
+const LABELS: Record<ThemeMode, string> = {
+  system: "Auto",
+  light: "Light",
+  dark: "Dark",
+};
+
+/** Compact SVG icons — 14px, no external deps. */
+function MonitorIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </svg>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+const ICONS: Record<ThemeMode, React.ReactNode> = {
+  system: <MonitorIcon />,
+  light: <SunIcon />,
+  dark: <MoonIcon />,
+};
+
+export function ThemeToggle() {
+  const [mode, setMode] = useState<ThemeMode>("system");
+
+  // On mount, read persisted preference and apply.
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
+    const initial = stored && MODES.includes(stored) ? stored : "system";
+    setMode(initial);
+    applyTheme(initial);
+  }, []);
+
+  // Listen to system preference changes when in system mode.
+  useEffect(() => {
+    if (mode !== "system") return;
+
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [mode]);
+
+  const cycle = useCallback(() => {
+    const idx = MODES.indexOf(mode);
+    const next = MODES[(idx + 1) % MODES.length];
+    setMode(next);
+    applyTheme(next);
+    localStorage.setItem(STORAGE_KEY, next);
+  }, [mode]);
+
+  return (
+    <button
+      type="button"
+      data-testid="theme-toggle"
+      onClick={cycle}
+      title={`Theme: ${LABELS[mode]}`}
+      className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px]
+        text-[var(--text-muted)] hover:text-[var(--text-secondary)]
+        border border-[var(--border)] hover:border-[var(--border-strong)]
+        bg-[var(--bg-surface)] hover:bg-[var(--bg-hover)]
+        transition-colors cursor-pointer select-none"
+    >
+      {ICONS[mode]}
+      <span>{LABELS[mode]}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
Adds a theme toggle to the dashboard tab bar (upper right). Three modes: System (follows OS preference), Light, Dark. Persists to localStorage. No flash of wrong theme on load (inline script in layout.tsx reads preference before hydration).