### PR TITLE
fix(showcase): CLI Start above Beautiful Chat, normal styling

### DIFF
--- a/showcase/shared/feature-registry.json
+++ b/showcase/shared/feature-registry.json
@@ -48,15 +48,6 @@
   ],
   "features": [
     {
-      "id": "beautiful-chat",
-      "name": "Beautiful Chat",
-      "category": "dev-ex",
-      "description": "Canonical polished starter chat (same as /examples/integrations/langgraph-python)",
-      "kind": "primary",
-      "og_docs_url": "https://docs.copilotkit.ai/agentic-chat-ui",
-      "shell_docs_path": "/agentic-chat-ui"
-    },
-    {
       "id": "cli-start",
       "name": "CLI Start Command",
       "category": "dev-ex",
@@ -64,6 +55,15 @@
       "kind": "docs-only",
       "og_docs_url": "https://docs.copilotkit.ai/quickstart",
       "shell_docs_path": "/quickstart"
+    },
+    {
+      "id": "beautiful-chat",
+      "name": "Beautiful Chat",
+      "category": "dev-ex",
+      "description": "Canonical polished starter chat (same as /examples/integrations/langgraph-python)",
+      "kind": "primary",
+      "og_docs_url": "https://docs.copilotkit.ai/agentic-chat-ui",
+      "shell_docs_path": "/agentic-chat-ui"
     },
     {
       "id": "agentic-chat",

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -253,7 +253,7 @@ function CategorySection({
         cat.features.map((feature, idx) => {
           const testing = feature.kind === "testing";
           const docsOnly = feature.kind === "docs-only";
-          const muted = testing || docsOnly;
+          const muted = testing;
           const stripe = idx % 2 === 1;
           const refCell = showRefDepth
             ? refCellsByFeature.get(feature.id)


### PR DESCRIPTION
Moved CLI Start Command to first row in Dev Ex. Removed docs-only greyed/italic treatment so it matches primary feature styling.