### PR TITLE
Baseline: align column order with Matrix

### DIFF
--- a/showcase/shell-dashboard/src/lib/sort-order.ts
+++ b/showcase/shell-dashboard/src/lib/sort-order.ts
@@ -5,14 +5,16 @@ export const sortOrder: Record<string, number> = {
 
   "google-adk": 30,
   "ms-agent-python": 31,
+  "maf-python": 31,
   "ms-agent-dotnet": 32,
+  "maf-dotnet": 32,
   strands: 33,
   "aws-fast-langgraph": 34,
   "aws-fast-strands": 35,
 
   mastra: 60,
   "crewai-crews": 61,
-  crewai: 62,
+  crewai: 61,
   "pydantic-ai": 63,
   "claude-sdk-python": 64,
   "claude-sdk-typescript": 65,


### PR DESCRIPTION
Aliases Baseline-specific slugs (crewai, maf-python, maf-dotnet) to the same sort positions as their Matrix counterparts (crewai-crews, ms-agent-python, ms-agent-dotnet) so columns appear in the same order across both tabs.