### PR TITLE
Baseline: guard against unknown tag values to prevent crash

### DIFF
--- a/showcase/shell-dashboard/src/components/baseline-cell.tsx
+++ b/showcase/shell-dashboard/src/components/baseline-cell.tsx
@@ -13,6 +13,8 @@ import {
 
 function TagBadge({ tag }: { tag: BaselineTag }) {
   const cfg = TAG_BADGE_CONFIG[tag];
+  // Defensive: skip unknown tags rather than crashing on undefined .bgColor
+  if (!cfg) return null;
   return (
     <span
       data-tag={tag}


### PR DESCRIPTION
Adds a null check in TagBadge — if a tag value from PB doesn't exist in TAG_BADGE_CONFIG, skip it instead of crashing on undefined.bgColor. Prevents the 'Application error: client-side exception' crash when PB data has unexpected tag values.