### PR TITLE
Baseline: add tooltips to status, tags, and cells

### DIFF
--- a/showcase/shell-dashboard/src/components/baseline-cell.tsx
+++ b/showcase/shell-dashboard/src/components/baseline-cell.tsx
@@ -19,6 +19,7 @@ function TagBadge({ tag }: { tag: BaselineTag }) {
     <span
       data-tag={tag}
       data-testid={`tag-badge-${tag}`}
+      title={cfg.title}
       style={{
         display: "inline-flex",
         alignItems: "center",
@@ -58,32 +59,26 @@ export function BaselineCellView({
 }: BaselineCellViewProps) {
   const statusCfg = STATUS_CONFIG[status];
 
+  // Build a summary tooltip for the whole cell
+  const tagNames = tags
+    .map((t) => TAG_BADGE_CONFIG[t]?.title ?? t)
+    .join(", ");
+  const cellTitle = tags.length > 0
+    ? `${statusCfg.title}\n${tagNames}`
+    : statusCfg.title;
+
   return (
     <div
       className={editing ? "cursor-pointer" : undefined}
+      title={cellTitle}
       style={{
         display: "inline-flex",
         alignItems: "center",
         gap: tags.length > 0 ? 3 : 0,
       }}
       onClick={editing ? onClick : undefined}
-      onMouseOver={
-        editing
-          ? (e) => {
-              (e.currentTarget as HTMLElement).style.backgroundColor =
-                "var(--bg-muted)";
-            }
-          : undefined
-      }
-      onMouseOut={
-        editing
-          ? (e) => {
-              (e.currentTarget as HTMLElement).style.backgroundColor = "";
-            }
-          : undefined
-      }
     >
-      <span style={{ fontSize: 12, lineHeight: 1 }}>{statusCfg.emoji}</span>
+      <span style={{ fontSize: 12, lineHeight: 1 }} title={statusCfg.title}>{statusCfg.emoji}</span>
 
       {tags.length > 0 && (
         <span

--- a/showcase/shell-dashboard/src/lib/baseline-types.ts
+++ b/showcase/shell-dashboard/src/lib/baseline-types.ts
@@ -57,15 +57,15 @@ export const INDIVIDUAL_TAGS: readonly BaselineTag[] = TAGS.filter(
 
 export const TAG_BADGE_CONFIG: Record<
   BaselineTag,
-  { label: string; color: string; bgColor: string }
+  { label: string; title: string; color: string; bgColor: string }
 > = {
-  cpk: { label: "C", color: "#c084fc", bgColor: "rgba(168,85,247,0.2)" },
-  agui: { label: "A", color: "#93c5fd", bgColor: "rgba(96,165,250,0.2)" },
-  int: { label: "I", color: "#fca5a5", bgColor: "rgba(248,113,113,0.2)" },
-  demo: { label: "▶", color: "#6ee7b7", bgColor: "rgba(52,211,153,0.2)" },
-  docs: { label: "D", color: "#fcd34d", bgColor: "rgba(251,191,36,0.2)" },
-  tests: { label: "T", color: "#d4a76a", bgColor: "rgba(180,140,100,0.2)" },
-  all: { label: "✱", color: "#9ca3af", bgColor: "rgba(107,112,128,0.25)" },
+  cpk: { label: "C", title: "Needs CopilotKit change", color: "#c084fc", bgColor: "rgba(168,85,247,0.2)" },
+  agui: { label: "A", title: "Needs AG-UI change", color: "#93c5fd", bgColor: "rgba(96,165,250,0.2)" },
+  int: { label: "I", title: "Needs integration change", color: "#fca5a5", bgColor: "rgba(248,113,113,0.2)" },
+  demo: { label: "▶", title: "Needs a demo", color: "#6ee7b7", bgColor: "rgba(52,211,153,0.2)" },
+  docs: { label: "D", title: "Needs docs", color: "#fcd34d", bgColor: "rgba(251,191,36,0.2)" },
+  tests: { label: "T", title: "Needs tests", color: "#d4a76a", bgColor: "rgba(180,140,100,0.2)" },
+  all: { label: "✱", title: "Needs everything", color: "#9ca3af", bgColor: "rgba(107,112,128,0.25)" },
 };
 
 /* ------------------------------------------------------------------ */
@@ -74,25 +74,29 @@ export const TAG_BADGE_CONFIG: Record<
 
 export const STATUS_CONFIG: Record<
   BaselineStatus,
-  { emoji: string; color: string; bgColor: string }
+  { emoji: string; title: string; color: string; bgColor: string }
 > = {
   works: {
     emoji: "✅",
+    title: "Works — no work needed",
     color: "var(--ok)",
     bgColor: "rgba(52,211,153,0.15)",
   },
   possible: {
     emoji: "🛠️",
+    title: "Possible — needs work",
     color: "var(--amber)",
     bgColor: "rgba(251,191,36,0.12)",
   },
   impossible: {
     emoji: "❌",
+    title: "Impossible — cannot be done",
     color: "var(--danger)",
     bgColor: "rgba(248,113,113,0.12)",
   },
   unknown: {
     emoji: "❓",
+    title: "Unknown — needs investigation",
     color: "var(--unknown,#a78bfa)",
     bgColor: "rgba(167,139,250,0.12)",
   },


### PR DESCRIPTION
Hover any cell to see status description. Hover individual tag badges to see what work is needed (e.g. 'Needs CopilotKit change', 'Needs a demo'). Cell tooltip shows the combined summary.