### PR TITLE
Baseline: impossible no tags, zebra stripes, rename Matrix→Coverage

### DIFF
--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -185,7 +185,7 @@ export default function Page() {
               : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
           }`}
         >
-          Matrix
+          Coverage
         </button>
         <button
           type="button"

--- a/showcase/shell-dashboard/src/components/baseline-grid.tsx
+++ b/showcase/shell-dashboard/src/components/baseline-grid.tsx
@@ -113,13 +113,22 @@ function CategorySection({
         onToggle={toggle}
       />
       {isOpen &&
-        featureSlugs.map((featureSlug) => (
+        featureSlugs.map((featureSlug, idx) => {
+          const stripe = idx % 2 === 1;
+          const stripeBg = stripe
+            ? "color-mix(in srgb, var(--bg-surface) 50%, var(--bg-muted))"
+            : undefined;
+          return (
           <tr
             key={featureSlug}
             className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
+            style={stripeBg ? { backgroundColor: stripeBg } : undefined}
           >
             {/* Feature name — sticky left */}
-            <td className="sticky left-0 z-10 bg-[var(--bg-surface)] px-4 py-2 border-r border-[var(--border)] align-top min-w-[140px]">
+            <td
+              className="sticky left-0 z-10 px-4 py-2 border-r border-[var(--border)] align-top min-w-[140px]"
+              style={{ backgroundColor: stripeBg ?? "var(--bg-surface)" }}
+            >
               <span className="text-[11px] font-medium text-[var(--text)]">
                 {slugToTitle(featureSlug)}
               </span>
@@ -164,7 +173,8 @@ function CategorySection({
               );
             })}
           </tr>
-        ))}
+          );
+        })}
     </Fragment>
   );
 }

--- a/showcase/shell-dashboard/src/components/baseline-popover.tsx
+++ b/showcase/shell-dashboard/src/components/baseline-popover.tsx
@@ -92,11 +92,9 @@ export function BaselinePopover({
   /* ---- status change handler ---- */
   function handleStatusClick(s: BaselineStatus) {
     setStatus(s);
-    if (s === "works" || s === "unknown") {
-      // No tags for these statuses
+    if (s !== "possible") {
       setSelectedTags(new Set());
-    } else if ((s === "possible" || s === "impossible") && selectedTags.size === 0) {
-      // Default to "all" when switching to a tag-enabled status with no tags
+    } else if (s === "possible" && selectedTags.size === 0) {
       setSelectedTags(new Set<BaselineTag>(["all"]));
     }
   }
@@ -146,8 +144,8 @@ export function BaselinePopover({
     });
   }
 
-  // Tags enabled for "possible" (needs work) and "impossible" (can't be done without X)
-  const tagsDisabled = status === "works" || status === "unknown";
+  // Tags only enabled for "possible". Impossible = impossible, no qualifiers.
+  const tagsDisabled = status !== "possible";
 
   return (
     <div


### PR DESCRIPTION
Three changes:
- Impossible = impossible, no tag qualifiers. Tags disabled for all non-possible statuses.
- Zebra stripe rows matching Coverage tab pattern (color-mix alternate rows).
- Rename 'Matrix' tab to 'Coverage'.