### PR TITLE
Coverage + Baseline: full-row hover highlight including sticky column

### DIFF
--- a/showcase/shell-dashboard/src/app/globals.css
+++ b/showcase/shell-dashboard/src/app/globals.css
@@ -40,3 +40,10 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+/* Row hover highlight — overrides inline backgroundColor on sticky cells
+   so the entire row (including the frozen feature-name column) highlights
+   on hover. Used by both Coverage and Baseline grids. */
+tr.grid-row:hover > td {
+  background-color: var(--bg-hover) !important;
+}

--- a/showcase/shell-dashboard/src/components/baseline-grid.tsx
+++ b/showcase/shell-dashboard/src/components/baseline-grid.tsx
@@ -122,7 +122,7 @@ function CategorySection({
           return (
           <tr
             key={featureSlug}
-            className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
+            className="grid-row border-t border-[var(--border)]"
             style={stripeBg ? { backgroundColor: stripeBg } : undefined}
           >
             {/* Feature name — sticky left */}

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -276,7 +276,7 @@ const CategorySection = React.memo(function CategorySection({
           return (
             <tr
               key={feature.id}
-              className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
+              className="grid-row border-t border-[var(--border)]"
               style={stripe ? STRIPE_STYLE : undefined}
             >
               <td


### PR DESCRIPTION
Adds a CSS rule that highlights the entire row on hover, including the sticky feature-name column (which previously stayed unlit because its inline backgroundColor overrode the TR hover). Uses a `grid-row` class on both Coverage and Baseline `<tr>` elements with `!important` override via globals.css.