### PR TITLE
Baseline: match Coverage partner names/slugs, 200ms tooltips

### DIFF
--- a/showcase/shell-dashboard/src/app/globals.css
+++ b/showcase/shell-dashboard/src/app/globals.css
@@ -47,3 +47,34 @@ a:hover {
 tr.grid-row:hover > td {
   background-color: var(--bg-hover) !important;
 }
+
+/* Fast tooltips — 200ms delay (native title is ~400ms and not configurable).
+   Apply data-tip="text" to any element. */
+[data-tip] {
+  position: relative;
+}
+[data-tip]::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: 50%;
+  bottom: 100%;
+  transform: translateX(-50%);
+  padding: 3px 7px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: pre;
+  color: var(--text);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s;
+  z-index: 60;
+}
+[data-tip]:hover::after {
+  opacity: 1;
+  transition-delay: 0.2s;
+}

--- a/showcase/shell-dashboard/src/components/baseline-cell.tsx
+++ b/showcase/shell-dashboard/src/components/baseline-cell.tsx
@@ -19,7 +19,7 @@ function TagBadge({ tag }: { tag: BaselineTag }) {
     <span
       data-tag={tag}
       data-testid={`tag-badge-${tag}`}
-      title={cfg.title}
+      data-tip={cfg.title}
       style={{
         display: "inline-flex",
         alignItems: "center",
@@ -70,7 +70,7 @@ export function BaselineCellView({
   return (
     <div
       className={editing ? "cursor-pointer" : undefined}
-      title={cellTitle}
+      data-tip={cellTitle}
       style={{
         display: "inline-flex",
         alignItems: "center",
@@ -78,7 +78,7 @@ export function BaselineCellView({
       }}
       onClick={editing ? onClick : undefined}
     >
-      <span style={{ fontSize: 12, lineHeight: 1 }} title={statusCfg.title}>{statusCfg.emoji}</span>
+      <span style={{ fontSize: 12, lineHeight: 1 }} data-tip={statusCfg.title}>{statusCfg.emoji}</span>
 
       {tags.length > 0 && (
         <span

--- a/showcase/shell-dashboard/src/lib/baseline-types.ts
+++ b/showcase/shell-dashboard/src/lib/baseline-types.ts
@@ -226,16 +226,18 @@ export const FEATURE_CATEGORIES: Record<string, string[]> = {
 /* ------------------------------------------------------------------ */
 
 export const BASELINE_PARTNERS: readonly { name: string; slug: string }[] = [
-  { name: "LangChain - Python", slug: "langchain-python" },
+  { name: "LangGraph (Python)", slug: "langgraph-python" },
+  { name: "LangGraph (TypeScript)", slug: "langgraph-typescript" },
+  { name: "LangGraph (FastAPI)", slug: "langgraph-fastapi" },
   { name: "Google ADK", slug: "google-adk" },
-  { name: "MAF - Python", slug: "maf-python" },
-  { name: "MAF - .Net", slug: "maf-dotnet" },
+  { name: "MS Agent Framework (Python)", slug: "ms-agent-python" },
+  { name: "MS Agent Framework (.NET)", slug: "ms-agent-dotnet" },
   { name: "Strands", slug: "strands" },
   { name: "Mastra", slug: "mastra" },
-  { name: "CrewAI", slug: "crewai" },
+  { name: "CrewAI", slug: "crewai-crews" },
   { name: "PydanticAI", slug: "pydantic-ai" },
-  { name: "Claude Agents SDK - Python", slug: "claude-sdk-python" },
-  { name: "Claude Agents SDK - TS", slug: "claude-sdk-typescript" },
+  { name: "Claude Agents SDK (Python)", slug: "claude-sdk-python" },
+  { name: "Claude Agents SDK (TS)", slug: "claude-sdk-typescript" },
   { name: "Agno", slug: "agno" },
   { name: "AG2", slug: "ag2" },
   { name: "LlamaIndex", slug: "llamaindex" },
@@ -249,6 +251,4 @@ export const BASELINE_PARTNERS: readonly { name: string; slug: string }[] = [
   { name: "OpenAI Agents SDK", slug: "openai-agents-sdk" },
   { name: "n8n", slug: "n8n" },
   { name: "Cloudflare", slug: "cloudflare" },
-  { name: "LangChain - TypeScript", slug: "langchain-typescript" },
-  { name: "LangChain - FastAPI", slug: "langchain-fastapi" },
 ];

--- a/showcase/shell-dashboard/src/lib/sort-order.ts
+++ b/showcase/shell-dashboard/src/lib/sort-order.ts
@@ -1,7 +1,10 @@
 export const sortOrder: Record<string, number> = {
   "langgraph-python": 10,
+  "langchain-python": 10,
   "langgraph-typescript": 11,
+  "langchain-typescript": 11,
   "langgraph-fastapi": 12,
+  "langchain-fastapi": 12,
 
   "google-adk": 30,
   "ms-agent-python": 31,


### PR DESCRIPTION
- Partner names and slugs now match Coverage exactly (LangGraph not LangChain, MS Agent Framework not MAF, CrewAI uses crewai-crews)
- CSS-based tooltips at 200ms delay (half the native 400ms title attribute delay)
- Sort order aliases for langchain→langgraph positions