### PR TITLE
Coverage: depth chip green=max, remove D5 false positives

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Unit tests for DepthChip — renders correct text + class for D0-D6,
- * unshipped, and regression states.
+ * unshipped, unsupported, regression, and relative-to-maxDepth color logic.
  */
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
@@ -18,47 +18,113 @@ describe("DepthChip", () => {
     },
   );
 
+  // ── D0 is always gray regardless of maxDepth ──
+
   it("renders D0 with gray background class", () => {
     const { getByTestId } = render(<DepthChip depth={0} status="wired" />);
     const chip = getByTestId("depth-chip");
     expect(chip.className).toContain("text-muted");
   });
 
-  it("renders D1 with amber background class", () => {
-    const { getByTestId } = render(<DepthChip depth={1} status="wired" />);
+  it("renders D0 with gray even when maxDepth=0", () => {
+    const { getByTestId } = render(<DepthChip depth={0} status="wired" maxDepth={0} />);
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("text-muted");
+  });
+
+  // ── Relative color: depth >= maxDepth = green ──
+
+  it("renders D4 green when maxDepth=4 (at ceiling)", () => {
+    const { getByTestId } = render(<DepthChip depth={4} status="wired" maxDepth={4} />);
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("emerald");
+  });
+
+  it("renders D5 green when maxDepth=5 (at ceiling)", () => {
+    const { getByTestId } = render(<DepthChip depth={5} status="wired" maxDepth={5} />);
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("emerald");
+  });
+
+  it("renders D6 green when maxDepth=6 (at ceiling)", () => {
+    const { getByTestId } = render(<DepthChip depth={6} status="wired" maxDepth={6} />);
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("emerald");
+  });
+
+  // ── Relative color: 1-2 levels below maxDepth = amber ──
+
+  it("renders D4 amber when maxDepth=5 (1 below ceiling)", () => {
+    const { getByTestId } = render(<DepthChip depth={4} status="wired" maxDepth={5} />);
     const chip = getByTestId("depth-chip");
     expect(chip.className).toContain("amber");
   });
 
-  it("renders D2 with amber background class", () => {
-    const { getByTestId } = render(<DepthChip depth={2} status="wired" />);
+  it("renders D3 amber when maxDepth=5 (2 below ceiling)", () => {
+    const { getByTestId } = render(<DepthChip depth={3} status="wired" maxDepth={5} />);
     const chip = getByTestId("depth-chip");
     expect(chip.className).toContain("amber");
   });
 
-  it("renders D3 with blue/accent background class", () => {
-    const { getByTestId } = render(<DepthChip depth={3} status="wired" />);
+  it("renders D4 amber when maxDepth=6 (2 below ceiling)", () => {
+    const { getByTestId } = render(<DepthChip depth={4} status="wired" maxDepth={6} />);
     const chip = getByTestId("depth-chip");
-    expect(chip.className).toContain("accent");
+    expect(chip.className).toContain("amber");
   });
 
-  it("renders D4 with blue/accent background class", () => {
-    const { getByTestId } = render(<DepthChip depth={4} status="wired" />);
+  // ── Relative color: 3+ levels below maxDepth = red ──
+
+  it("renders D1 red when maxDepth=5 (4 below ceiling)", () => {
+    const { getByTestId } = render(<DepthChip depth={1} status="wired" maxDepth={5} />);
     const chip = getByTestId("depth-chip");
-    expect(chip.className).toContain("accent");
+    expect(chip.className).toContain("danger");
   });
 
-  it("renders D5 with emerald background class", () => {
+  it("renders D2 red when maxDepth=5 (3 below ceiling)", () => {
+    const { getByTestId } = render(<DepthChip depth={2} status="wired" maxDepth={5} />);
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("danger");
+  });
+
+  it("renders D1 red when maxDepth=6 (5 below ceiling)", () => {
+    const { getByTestId } = render(<DepthChip depth={1} status="wired" maxDepth={6} />);
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("danger");
+  });
+
+  // ── Fallback: no maxDepth uses heuristic (D4+ green, D2-D3 amber, D1 red) ──
+
+  it("renders D5 green when no maxDepth (fallback)", () => {
     const { getByTestId } = render(<DepthChip depth={5} status="wired" />);
     const chip = getByTestId("depth-chip");
     expect(chip.className).toContain("emerald");
   });
 
-  it("renders D6 with emerald background class", () => {
-    const { getByTestId } = render(<DepthChip depth={6} status="wired" />);
+  it("renders D4 green when no maxDepth (fallback)", () => {
+    const { getByTestId } = render(<DepthChip depth={4} status="wired" />);
     const chip = getByTestId("depth-chip");
     expect(chip.className).toContain("emerald");
   });
+
+  it("renders D3 amber when no maxDepth (fallback)", () => {
+    const { getByTestId } = render(<DepthChip depth={3} status="wired" />);
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("amber");
+  });
+
+  it("renders D2 amber when no maxDepth (fallback)", () => {
+    const { getByTestId } = render(<DepthChip depth={2} status="wired" />);
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("amber");
+  });
+
+  it("renders D1 red when no maxDepth (fallback)", () => {
+    const { getByTestId } = render(<DepthChip depth={1} status="wired" />);
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("danger");
+  });
+
+  // ── Unshipped / unsupported / stub / regression ──
 
   it("renders '--' for unshipped status with dashed border", () => {
     const { getByTestId } = render(<DepthChip depth={0} status="unshipped" />);
@@ -68,20 +134,18 @@ describe("DepthChip", () => {
     expect(chip.getAttribute("data-status")).toBe("unshipped");
   });
 
-  it("renders 🚫 emoji for unsupported with descriptive tooltip", () => {
+  it("renders prohibited emoji for unsupported with descriptive tooltip", () => {
     const { getByTestId } = render(
       <DepthChip depth={0} status="unsupported" />,
     );
     const chip = getByTestId("depth-chip");
-    expect(chip.textContent).toBe("🚫");
+    expect(chip.textContent).toBe("\u{1F6AB}");
     // Distinct attribute lets the matrix and tests differentiate from unshipped.
     expect(chip.getAttribute("data-status")).toBe("unsupported");
     expect(chip.getAttribute("title")).toBe("Not supported by this framework");
   });
 
   it("unsupported renders distinctly from unshipped (different glyph + status)", () => {
-    // Each render reuses the jsdom document, so we have to scope each query
-    // to its own container instead of relying on the global getByTestId.
     const { container: cU } = render(
       <DepthChip depth={0} status="unshipped" />,
     );
@@ -108,9 +172,9 @@ describe("DepthChip", () => {
     expect(chip.textContent).toBe("D0");
   });
 
-  it("renders regression with danger color", () => {
+  it("renders regression with danger color regardless of depth or maxDepth", () => {
     const { getByTestId } = render(
-      <DepthChip depth={2} status="wired" regression />,
+      <DepthChip depth={5} status="wired" regression maxDepth={5} />,
     );
     const chip = getByTestId("depth-chip");
     expect(chip.className).toContain("danger");

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -111,6 +111,7 @@ function DepthLayer({
           depth={depth.achieved}
           status={catalogCell.status}
           regression={depth.isRegression}
+          maxDepth={catalogCell.max_depth}
         />
       </button>
       {drilldownOpen && (

--- a/showcase/shell-dashboard/src/components/depth-chip.tsx
+++ b/showcase/shell-dashboard/src/components/depth-chip.tsx
@@ -1,16 +1,18 @@
 "use client";
 /**
- * DepthChip — colored chip showing achieved depth D0-D5.
+ * DepthChip — colored chip showing achieved depth D0-D6.
  *
- * Color mapping:
- *   D5    = emerald — deep multi-turn e2e coverage
- *   D3-D4 = amber/yellow — meaningful e2e but not yet D5
- *   D1-D2 = red — basic health only, needs work
- *   D0    = gray — exists but no live probe data
+ * Color mapping (relative to max achievable depth):
+ *   depth >= maxDepth = emerald (green) — at ceiling for this cell
+ *   1-2 below max     = amber — close but not at ceiling
+ *   3+ below max      = red — significantly below ceiling
+ *   D0                = gray — exists but no live probe data
  *   unshipped = transparent + dashed border, displays "--"
  *   unsupported = slate border + slate fill, displays "🚫"
  *                 (architectural limit — framework cannot support feature)
  *   regression = red (danger)
+ *
+ * Fallback (no maxDepth): D4+ green, D2-D3 amber, D0-D1 red.
  */
 
 export interface DepthChipProps {
@@ -18,29 +20,41 @@ export interface DepthChipProps {
   status: "wired" | "stub" | "unshipped" | "unsupported";
   /** When true, chip renders in red regardless of depth. */
   regression?: boolean;
+  /**
+   * Maximum achievable depth for this cell. When provided, the chip turns
+   * green when `depth >= maxDepth` (i.e. at ceiling), amber when 1-2 levels
+   * below, and red when 3+ levels below. This lets cells whose probes only
+   * go to D4 show green at D4 instead of the old hardcoded amber.
+   */
+  maxDepth?: number;
 }
 
-/** Background color class by depth tier. */
-function depthColorClass(depth: number, regression?: boolean): string {
+/**
+ * Background color class by depth tier.
+ *
+ * When `maxDepth` is supplied the color is relative: green at ceiling,
+ * amber within 2 levels, red otherwise. Without `maxDepth` the fallback
+ * heuristic is: D4+ green, D2-D3 amber, D0-D1 red.
+ */
+function depthColorClass(depth: number, regression?: boolean, maxDepth?: number): string {
   if (regression) {
     return "bg-[var(--danger)] text-white";
   }
-  switch (depth) {
-    case 5:
-      return "bg-emerald-600 text-white";
-    case 3:
-    case 4:
-      return "bg-[var(--amber)] text-white";
-    case 1:
-    case 2:
-      return "bg-[var(--danger)] text-white";
-    case 0:
-    default:
-      return "bg-[var(--text-muted)]/20 text-[var(--text-muted)]";
+  if (depth === 0) {
+    return "bg-[var(--text-muted)]/20 text-[var(--text-muted)]";
   }
+  if (maxDepth !== undefined) {
+    if (depth >= maxDepth) return "bg-emerald-600 text-white";
+    if (maxDepth - depth <= 2) return "bg-[var(--amber)] text-white";
+    return "bg-[var(--danger)] text-white";
+  }
+  // Fallback when maxDepth unknown
+  if (depth >= 4) return "bg-emerald-600 text-white";
+  if (depth >= 2) return "bg-[var(--amber)] text-white";
+  return "bg-[var(--danger)] text-white";
 }
 
-export function DepthChip({ depth, status, regression }: DepthChipProps) {
+export function DepthChip({ depth, status, regression, maxDepth }: DepthChipProps) {
   if (status === "unshipped") {
     return (
       <span
@@ -70,7 +84,7 @@ export function DepthChip({ depth, status, regression }: DepthChipProps) {
     );
   }
 
-  const colorClass = depthColorClass(depth, regression);
+  const colorClass = depthColorClass(depth, regression, maxDepth);
 
   return (
     <span

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -116,13 +116,9 @@ export function keyFor(
 export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   "agentic-chat": ["agentic-chat"],
   "tool-rendering": ["tool-rendering"],
-  "tool-rendering-default-catchall": ["tool-rendering"],
-  "tool-rendering-custom-catchall": ["tool-rendering"],
   "headless-simple": ["gen-ui-headless"],
-  "headless-complete": ["gen-ui-headless"],
   "gen-ui-tool-based": ["gen-ui-custom"],
   "hitl-in-chat": ["hitl-text-input"],
-  "hitl-in-chat-booking": ["hitl-text-input"],
   hitl: ["hitl-steps"],
   "hitl-in-app": ["hitl-approve-deny"],
   "shared-state-read-write": ["shared-state-read", "shared-state-write"],
@@ -130,7 +126,6 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   subagents: ["subagents"],
   // ── LGP D5 coverage wave (mirrors REGISTRY_TO_D5 in
   //    harness/src/probes/helpers/d5-feature-mapping.ts) ──
-  "beautiful-chat": ["agentic-chat"],
   "chat-slots": ["chat-slots"],
   "chat-customization-css": ["chat-css"],
   "prebuilt-sidebar": ["prebuilt-sidebar"],
@@ -141,7 +136,6 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   "frontend-tools": ["frontend-tools"],
   "frontend-tools-async": ["frontend-tools-async"],
   "agentic-chat-reasoning": ["reasoning-display"],
-  "reasoning-default-render": ["reasoning-display"],
   "tool-rendering-reasoning-chain": ["tool-rendering-reasoning-chain"],
   "shared-state-streaming": ["shared-state-streaming"],
   "readonly-state-agent-context": ["readonly-state-context"],
@@ -149,12 +143,10 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   "declarative-gen-ui": ["gen-ui-declarative"],
   "a2ui-fixed-schema": ["gen-ui-a2ui-fixed"],
   "open-gen-ui": ["gen-ui-open"],
-  "open-gen-ui-advanced": ["gen-ui-open"],
   "gen-ui-agent": ["gen-ui-agent"],
   "interrupt-headless": ["interrupt-headless"],
   "gen-ui-interrupt": ["gen-ui-interrupt"],
   "byoc-hashbrown": ["byoc"],
-  "byoc-json-render": ["byoc"],
 };
 
 function resolveD5Row(


### PR DESCRIPTION
Two fixes:
- **Depth chip colors**: green when at max achievable depth (D4 with no D5 probes = green), amber when 1-2 below max, red when 3+ below. Previously hardcoded D3/D4=amber regardless of max.
- **D5 false positives**: removed 8 secondary entries from CATALOG_TO_D5_KEY that shared D5 probe keys with sibling features. Cells without their own CV test no longer inherit D5 from siblings.