### PR TITLE
Revert to LangGraph naming (orchestration layer, not model router)

### DIFF
--- a/showcase/integrations/langgraph-fastapi/manifest.yaml
+++ b/showcase/integrations/langgraph-fastapi/manifest.yaml
@@ -1,9 +1,9 @@
-name: LangChain (FastAPI)
+name: LangGraph (FastAPI)
 slug: langgraph-fastapi
 category: emerging
 language: python
 logo: /logos/langgraph-fastapi.svg
-description: CopilotKit integration with LangChain (FastAPI)
+description: CopilotKit integration with LangGraph (FastAPI)
 partner_docs: null
 repo: https://github.com/CopilotKit/CopilotKit/tree/main/showcase/integrations/langgraph-fastapi
 copilotkit_version: 2.0.0

--- a/showcase/integrations/langgraph-fastapi/src/app/page.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/page.tsx
@@ -1,7 +1,7 @@
 export default function Home() {
   return (
     <main style={{ padding: "2rem", maxWidth: "800px", margin: "0 auto" }}>
-      <h1>LangChain (FastAPI)</h1>
+      <h1>LangGraph (FastAPI)</h1>
       <p>Integration ID: langgraph-fastapi</p>
       <h2 style={{ marginTop: "2rem" }}>Demos</h2>
       <div style={{ display: "grid", gap: "1rem", marginTop: "1rem" }}>

--- a/showcase/integrations/langgraph-python/manifest.yaml
+++ b/showcase/integrations/langgraph-python/manifest.yaml
@@ -1,4 +1,4 @@
-name: LangChain (Python)
+name: LangGraph (Python)
 slug: langgraph-python
 category: popular
 language: python

--- a/showcase/integrations/langgraph-python/src/app/layout.tsx
+++ b/showcase/integrations/langgraph-python/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import "./copilotkit-overrides.css";
 
 export const metadata: Metadata = {
-  title: "CopilotKit Showcase — LangChain (Python)",
+  title: "CopilotKit Showcase — LangGraph (Python)",
 };
 
 export default function RootLayout({

--- a/showcase/integrations/langgraph-python/src/app/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/page.tsx
@@ -1,7 +1,7 @@
 export default function Home() {
   return (
     <main style={{ padding: "2rem", maxWidth: "800px", margin: "0 auto" }}>
-      <h1>LangChain (Python)</h1>
+      <h1>LangGraph (Python)</h1>
       <p>Integration ID: langgraph-python</p>
       <h2 style={{ marginTop: "2rem" }}>Demos</h2>
       <div style={{ display: "grid", gap: "1rem", marginTop: "1rem" }}>

--- a/showcase/integrations/langgraph-typescript/manifest.yaml
+++ b/showcase/integrations/langgraph-typescript/manifest.yaml
@@ -1,4 +1,4 @@
-name: LangChain (TypeScript)
+name: LangGraph (TypeScript)
 slug: langgraph-typescript
 category: popular
 language: typescript

--- a/showcase/integrations/langgraph-typescript/src/app/layout.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import "./copilotkit-overrides.css";
 
 export const metadata: Metadata = {
-  title: "CopilotKit Showcase — LangChain (TypeScript)",
+  title: "CopilotKit Showcase — LangGraph (TypeScript)",
 };
 
 export default function RootLayout({

--- a/showcase/integrations/langgraph-typescript/src/app/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/page.tsx
@@ -1,7 +1,7 @@
 export default function Home() {
   return (
     <main style={{ padding: "2rem", maxWidth: "800px", margin: "0 auto" }}>
-      <h1>LangChain (TypeScript)</h1>
+      <h1>LangGraph (TypeScript)</h1>
       <p>Integration ID: langgraph-typescript</p>
       <h2 style={{ marginTop: "2rem" }}>Demos</h2>
       <div style={{ display: "grid", gap: "1rem", marginTop: "1rem" }}>

--- a/showcase/scripts/__tests__/generate-catalog.test.ts
+++ b/showcase/scripts/__tests__/generate-catalog.test.ts
@@ -297,7 +297,7 @@ describe("Catalog Generator", () => {
       (c: any) => c.id === "langgraph-python/agentic-chat",
     );
     expect(lgpAgenticChat).toBeDefined();
-    expect(lgpAgenticChat.integration_name).toBe("LangChain (Python)");
+    expect(lgpAgenticChat.integration_name).toBe("LangGraph (Python)");
     expect(lgpAgenticChat.feature_name).toBe("Pre-Built CopilotChat");
     expect(lgpAgenticChat.category_name).toBe("Chat & UI");
 

--- a/showcase/scripts/__tests__/generate-registry.test.ts
+++ b/showcase/scripts/__tests__/generate-registry.test.ts
@@ -51,7 +51,7 @@ describe("Registry Generator", () => {
     const stdout = runGenerator();
 
     expect(stdout).toContain("Generating integration registry");
-    expect(stdout).toContain("LangChain (Python)");
+    expect(stdout).toContain("LangGraph (Python)");
 
     const registryPath = path.join(SHELL_DATA_DIR, "registry.json");
     expect(fs.existsSync(registryPath)).toBe(true);
@@ -65,7 +65,7 @@ describe("Registry Generator", () => {
       (i: any) => i.slug === "langgraph-python",
     );
     expect(langgraph).toBeDefined();
-    expect(langgraph.name).toBe("LangChain (Python)");
+    expect(langgraph.name).toBe("LangGraph (Python)");
     expect(langgraph.category).toBe("popular");
     expect(langgraph.language).toBe("python");
     expect(langgraph.features.length).toBe(40);

--- a/showcase/shell-dashboard/src/lib/baseline-types.ts
+++ b/showcase/shell-dashboard/src/lib/baseline-types.ts
@@ -226,9 +226,9 @@ export const FEATURE_CATEGORIES: Record<string, string[]> = {
 /* ------------------------------------------------------------------ */
 
 export const BASELINE_PARTNERS: readonly { name: string; slug: string }[] = [
-  { name: "LangChain (Python)", slug: "langgraph-python" },
-  { name: "LangChain (TypeScript)", slug: "langgraph-typescript" },
-  { name: "LangChain (FastAPI)", slug: "langgraph-fastapi" },
+  { name: "LangGraph (Python)", slug: "langgraph-python" },
+  { name: "LangGraph (TypeScript)", slug: "langgraph-typescript" },
+  { name: "LangGraph (FastAPI)", slug: "langgraph-fastapi" },
   { name: "Google ADK", slug: "google-adk" },
   { name: "MS Agent Framework (Python)", slug: "ms-agent-python" },
   { name: "MS Agent Framework (.NET)", slug: "ms-agent-dotnet" },

--- a/showcase/shell/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/showcase/shell/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -17,7 +17,7 @@ You should:
 - Be concise and helpful — 1-3 sentences unless they ask for detail
 
 When suggesting demos, provide links like /integrations/{slug}/{demoId}.
-Available integrations: LangChain (Python) at /integrations/langgraph-python, Mastra at /integrations/mastra.
+Available integrations: LangGraph (Python) at /integrations/langgraph-python, Mastra at /integrations/mastra.
 Available features: agentic-chat, human-in-the-loop, tool-rendering, gen-ui-tool-based.`,
   maxSteps: 3,
 });


### PR DESCRIPTION
LangGraph = orchestration runtime (StateGraph, Command, interrupt). LangChain = model router underneath. Our integrations are LangGraph agents. Reverts #4616.