### PR TITLE
fix(react-ui): allow sidebar children to use height 100%%

### DIFF
--- a/packages/react-ui/src/css/sidebar.css
+++ b/packages/react-ui/src/css/sidebar.css
@@ -37,6 +37,14 @@
   overflow: visible;
   margin-right: 0px;
   transition: margin-right 0.3s ease;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.copilotKitSidebarContentWrapper > .copilotKitModalChildrenWrapper {
+  flex: 1;
+  height: 100%;
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Summary
Fixes #261

When child nodes are placed under <CopilotSidebar>, they can't use height: 100%% because the wrapper DOM elements don't propagate height properly. This doesn't happen on Safari but occurs on Chrome.

## Problem
The .copilotKitSidebarContentWrapper and .copilotKitModalChildrenWrapper divs don't have height/flex properties, so children can't inherit height: 100%%.

## Changes
- Added height: 100%%, display: flex, and lex-direction: column to .copilotKitSidebarContentWrapper
- Added lex: 1 and height: 100%% to .copilotKitModalChildrenWrapper (child selector scoped)

## How to Test
1. Wrap content inside <CopilotSidebar>
2. Set a child element to height: 100%%
3. Verify the child fills full height in Chrome (previously failed)