### PR TITLE
Security: fix template injection in CI workflow shell commands

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,8 +26,10 @@ jobs:
     steps:
       - name: Extract scope from branch
         id: meta
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
+          BRANCH="${PR_HEAD_REF}"
           # Branch format: release/publish/<scope>/v<version>
           SCOPE=$(echo "$BRANCH" | sed 's|release/publish/\([^/]*\)/v.*|\1|')
           echo "scope=$SCOPE" >> $GITHUB_OUTPUT

--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -59,8 +59,10 @@ jobs:
       - name: Collect PR-changed files for formatting
         if: github.event_name == 'pull_request'
         id: changed
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          base_ref="${{ github.event.pull_request.base.ref }}"
+          base_ref="${PR_BASE_REF}"
           # Fetch the current tip of the base branch so the merge-base tracks
           # main as it advances (using the PR's stored base.sha would pull in
           # every file main has touched since the PR opened).
@@ -228,7 +230,10 @@ jobs:
         id: commitlint
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose 2>&1 | tee /tmp/commitlint-output.txt
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: npx commitlint --from "${PR_BASE_SHA}" --to "${PR_HEAD_SHA}" --verbose 2>&1 | tee /tmp/commitlint-output.txt
 
       - name: Post fix suggestion on failure
         if: github.event_name == 'pull_request' && steps.commitlint.outcome == 'failure'

--- a/.github/workflows/test_smoke-starter.yml
+++ b/.github/workflows/test_smoke-starter.yml
@@ -61,6 +61,12 @@ jobs:
         if: failure()
         id: failure-cause
         working-directory: examples/integrations/${{ matrix.starter }}
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_USER_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           {
             echo "summary<<CAUSE_EOF"
@@ -86,10 +92,10 @@ jobs:
             echo ""
 
             # Identify recent changes that may have caused the failure
-            if [ "${{ github.event_name }}" = "pull_request" ]; then
-              echo "Triggered by PR #${{ github.event.pull_request.number }} (${{ github.event.pull_request.user.login }}): ${{ github.event.pull_request.title }}"
-              echo "Head: ${{ github.event.pull_request.head.sha }}"
-            elif [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_run" ]; then
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              echo "Triggered by PR #${PR_NUMBER} (${PR_USER_LOGIN}): ${PR_TITLE}"
+              echo "Head: ${PR_HEAD_SHA}"
+            elif [ "$EVENT_NAME" = "schedule" ] || [ "$EVENT_NAME" = "workflow_run" ]; then
               # Use GitHub API instead of git log (avoids needing deep clone)
               echo "Recent commits touching this starter (last 12h):"
               gh api "repos/${{ github.repository }}/commits?path=examples/integrations/${{ matrix.starter }}&since=$(date -u -d '12 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-12H +%Y-%m-%dT%H:%M:%SZ)&per_page=5" \


### PR DESCRIPTION
## Summary

Fixes GitHub Actions template injection (CWE-78) across three workflow files. Untrusted PR event data (`title`, `head.ref`, `base.ref`, SHAs, `user.login`) was interpolated directly into shell `run:` blocks via `${{ }}`, allowing arbitrary code execution on the runner via a crafted PR title or branch name.

**Fix:** Move all untrusted expressions to `env:` blocks and reference them as shell variables (`${VAR}`) instead. This is the standard mitigation recommended by GitHub's security hardening guide.

### Affected files

- **test_smoke-starter.yml** — PR title, user login, head SHA in the "Capture failure cause" step
- **publish-release.yml** — PR head ref (branch name) in the "Extract scope from branch" step  
- **static_quality.yml** — PR base ref in the "Collect PR-changed files" step; base/head SHAs in the "Validate PR commits with commitlint" step

All other workflow files were audited and already use safe patterns (`env:`, `with:`, or `concurrency:` blocks).

## Test plan

- [ ] CI passes on this PR (the workflows themselves are exercised by PR events)
- [ ] Grep confirms no remaining `${{ github.event.pull_request.*` inside `run:` blocks