### PR TITLE
showcase/sync: detect re-introduction of previously-deleted shell-docs paths

### DIFF
--- a/showcase/scripts/sync-docs-from-main.ts
+++ b/showcase/scripts/sync-docs-from-main.ts
@@ -69,6 +69,80 @@ function isExcludedPath(relPath: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Re-introduction detector
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the set of paths that exist in showcase docs git history as
+ * deletions but are NOT currently present in the working tree.
+ *
+ * Background: PATH_EXCLUSIONS is the durable mechanism for keeping retired
+ * upstream paths out of shell-docs. But it requires whoever retires a page
+ * to also remember to add the regex — and historically that step has been
+ * missed (PR #4521 brought back /learn/* and the root ag-ui-middleware
+ * duplicate that earlier PRs had deliberately removed).
+ *
+ * This detector is the safety net: if a sync run is about to create a file
+ * at a path that previously existed and was deleted, surface it in the
+ * "needs review" PR body so a human can confirm the re-introduction is
+ * intentional. If it isn't, the fix is to add the upstream regex to
+ * PATH_EXCLUSIONS and delete the file again — at which point this detector
+ * picks it up on the next sync, the loop closes.
+ *
+ * Cached: `git log` over the docs tree is non-trivial; we run it once.
+ */
+let cachedHistoricallyDeleted: Set<string> | null = null;
+function getHistoricallyDeletedShowcasePaths(): Set<string> {
+  if (cachedHistoricallyDeleted !== null) return cachedHistoricallyDeleted;
+  const result = new Set<string>();
+  try {
+    const out = execFileSync(
+      "git",
+      [
+        "log",
+        "--all",
+        "--diff-filter=D",
+        "--pretty=format:",
+        "--name-only",
+        "--",
+        "showcase/shell-docs/src/content/docs/",
+        "showcase/shell-docs/src/content/snippets/",
+      ],
+      { encoding: "utf-8", cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    for (const line of out.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || !trimmed.endsWith(".mdx")) continue;
+      // Only flag paths the working tree no longer carries — files that were
+      // deleted and later re-created intentionally aren't re-introductions.
+      if (!fs.existsSync(path.join(ROOT, trimmed))) {
+        result.add(trimmed);
+      }
+    }
+  } catch (err: unknown) {
+    console.warn(
+      `[WARN] could not compute historical deletions; re-intro detector disabled: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+  cachedHistoricallyDeleted = result;
+  return result;
+}
+
+/**
+ * `true` when this sync would write to a showcase path that previously
+ * existed in shell-docs and was deleted. Caller flags for manual review.
+ *
+ * Returns `false` for files that currently exist in the worktree (those
+ * are updates, not re-introductions) and for any path that has no record
+ * of prior deletion in git history.
+ */
+function isReintroductionOfDeletedPath(showcaseAbsolutePath: string): boolean {
+  if (fs.existsSync(showcaseAbsolutePath)) return false;
+  const rel = path.relative(ROOT, showcaseAbsolutePath);
+  return getHistoricallyDeletedShowcasePaths().has(rel);
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -389,6 +463,7 @@ interface SyncResult {
   mergeConflict: string[];
   skipped: string[];
   deleted: string[];
+  reintroduced: string[];
   conflictManifest: ConflictEntry[];
 }
 
@@ -530,6 +605,7 @@ function main(): SyncResult {
     mergeConflict: [],
     skipped: [],
     deleted: [],
+    reintroduced: [],
     conflictManifest: [],
   };
 
@@ -637,6 +713,13 @@ function main(): SyncResult {
       }
     }
 
+    // Detect re-introduction of a previously-deleted showcase path BEFORE
+    // writing — fs.existsSync would flip to true after the write. The check
+    // is informational; we still write the file so the sync stays in flow,
+    // but we flag the path for manual review (and force the PR off the
+    // auto-merge path via exit 3).
+    const isReintro = isReintroductionOfDeletedPath(showcaseAbsolute);
+
     // Write
     if (!dryRun) {
       fs.mkdirSync(path.dirname(showcaseAbsolute), { recursive: true });
@@ -649,6 +732,13 @@ function main(): SyncResult {
     } else {
       result.transformed.push(relPath);
       console.log(`  [TRANSFORM] ${relPath}`);
+    }
+
+    if (isReintro) {
+      result.reintroduced.push(relPath);
+      console.log(
+        `  [REVIEW/REINTRODUCED] ${relPath} → ${path.relative(ROOT, showcaseAbsolute)} (previously deleted in shell-docs; verify intent)`,
+      );
     }
   }
 
@@ -681,6 +771,9 @@ function main(): SyncResult {
   console.log(`Needs review (total): ${result.needsReview.length}`);
   console.log(`Skipped (up to date): ${result.skipped.length}`);
   console.log(`Deleted on main: ${result.deleted.length}`);
+  console.log(
+    `Re-introduced from deletion history (review required): ${result.reintroduced.length}`,
+  );
 
   if (result.autoMerged.length > 0) {
     console.log("\nFiles auto-merged (3-way clean):");
@@ -696,6 +789,15 @@ function main(): SyncResult {
   if (result.deleted.length > 0) {
     console.log("\nFiles deleted on main (not auto-deleted in showcase):");
     for (const f of result.deleted) {
+      console.log(`  ${f}`);
+    }
+  }
+
+  if (result.reintroduced.length > 0) {
+    console.log(
+      "\nFiles re-introduced from shell-docs deletion history (verify intent before merging):",
+    );
+    for (const f of result.reintroduced) {
       console.log(`  ${f}`);
     }
   }
@@ -719,12 +821,17 @@ const hasAutoApplied =
 // - mergeConflict: 3-way merge failed, upstream-wins content staged to PR
 //   branch, human must reconcile
 // - deleted: files gone on main, not auto-deleted in showcase, human decides
+// - reintroduced: sync wrote to a path previously deleted in shell-docs;
+//   human confirms the re-introduction is intentional or adds the upstream
+//   regex to PATH_EXCLUSIONS
 // Auto-merged files (clean 3-way merge) are considered RESOLVED — they go
 // through the auto_push fast path and the marker advances. `needsReview`
 // is the superset tracker (local-mods detected pre-merge) and is NOT a
 // gating condition on its own.
 const hasReviewItems =
-  result.mergeConflict.length > 0 || result.deleted.length > 0;
+  result.mergeConflict.length > 0 ||
+  result.deleted.length > 0 ||
+  result.reintroduced.length > 0;
 
 if (!hasAutoApplied && !hasReviewItems) {
   process.exit(2);
@@ -752,6 +859,13 @@ if (!hasAutoApplied && !hasReviewItems) {
       "Files deleted on main (review whether to delete in showcase):",
     );
     for (const f of result.deleted) reviewLines.push(`  - ${f}`);
+  }
+  if (result.reintroduced.length > 0) {
+    reviewLines.push("");
+    reviewLines.push(
+      "Files re-introduced from shell-docs deletion history — these paths previously existed and were intentionally removed. Confirm the re-introduction is wanted; if not, add a PATH_EXCLUSIONS regex in showcase/scripts/sync-docs-from-main.ts and delete the file again:",
+    );
+    for (const f of result.reintroduced) reviewLines.push(`  - ${f}`);
   }
   // Write manifest + review items at the invocation cwd (the repo root
   // when run from CI, matching the workflow's `[ -f conflict-manifest.json ]`


### PR DESCRIPTION
## Summary

`PATH_EXCLUSIONS` keeps retired upstream paths out of shell-docs, but it requires whoever retires a page to also add the regex — and that step has been missed. PR #4521 brought back `/learn/*` and root `/ag-ui-middleware.mdx` after earlier PRs intentionally removed them; nothing in the sync flow caught it.

This PR adds a safety net to `sync-docs-from-main.ts`. Before writing each upstream file, it checks whether the target shell-docs path exists in git's deletion history and isn't currently on disk. If so, it surfaces the file in the auto-PR's `review-items.txt` under a new "Files re-introduced from shell-docs deletion history" section, and includes the count in `hasReviewItems` so the PR is flagged needs-review (exit 3) instead of going through the auto-merge path.

The detector is informational, not blocking — content still syncs as usual, only the flag is added. The fix loop is: human reviews, decides intent. If the re-introduction is unwanted, add a `PATH_EXCLUSIONS` regex and delete the file; the detector picks it up again on the next sync until the regex is in place.

## Verified locally

`tsx showcase/scripts/sync-docs-from-main.ts --dry-run` exits 3 and flags 3 real findings against current main:

```
docs/content/docs/(root)/index.mdx
docs/content/docs/integrations/langgraph/index.mdx
docs/content/docs/integrations/microsoft-agent-framework/index.mdx
```

All three were previously deleted in favor of meta.json folder pages — the detector correctly catches them as candidates for re-introduction the next time the sync runs.

## Test plan
- [ ] `tsx showcase/scripts/sync-docs-from-main.ts --dry-run` exits 3 against current main
- [ ] Output includes a `Files re-introduced from shell-docs deletion history` section in `review-items.txt`
- [ ] Files currently on disk are not flagged (only paths that exist in deletion history but aren't in the working tree)
- [ ] Future docs-sync(needs-review) PRs that bring back retired paths surface them in the same section