### PR TITLE
feat(angular): port CopilotChatReasoningMessage

### DIFF
--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat-reasoning-message.component.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat-reasoning-message.component.spec.ts
@@ -87,7 +87,10 @@ describe("CopilotChatReasoningMessage", () => {
 
   it("isStreaming is true only when running and latest", () => {
     const message = makeReasoning("hi");
-    const { component, bindings } = buildComponent({ message, isRunning: true });
+    const { component, bindings } = buildComponent({
+      message,
+      isRunning: true,
+    });
 
     expect(component.isStreaming()).toBe(true);
 

--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat-reasoning-message.component.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat-reasoning-message.component.spec.ts
@@ -1,0 +1,341 @@
+import {
+  EnvironmentInjector,
+  runInInjectionContext,
+  signal,
+} from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Message } from "@ag-ui/core";
+import {
+  CopilotChatReasoningMessage,
+  CopilotChatReasoningMessageHeader,
+  CopilotChatReasoningMessageContent,
+  formatReasoningDuration,
+} from "../copilot-chat-reasoning-message";
+import type { ReasoningMessage } from "../copilot-chat-reasoning-message.types";
+
+const reasoningId = "reasoning-1";
+
+function makeReasoning(content = ""): ReasoningMessage {
+  return {
+    id: reasoningId,
+    role: "reasoning",
+    content,
+  } as ReasoningMessage;
+}
+
+interface Bindings {
+  message: ReturnType<typeof signal<ReasoningMessage>>;
+  messages: ReturnType<typeof signal<Message[]>>;
+  isRunning: ReturnType<typeof signal<boolean>>;
+}
+
+function buildComponent(initial: {
+  message: ReasoningMessage;
+  messages?: Message[];
+  isRunning?: boolean;
+}): { component: CopilotChatReasoningMessage; bindings: Bindings } {
+  const injector = TestBed.inject(EnvironmentInjector);
+  const component = runInInjectionContext(
+    injector,
+    () => new CopilotChatReasoningMessage(),
+  );
+
+  const bindings: Bindings = {
+    message: signal(initial.message),
+    messages: signal(initial.messages ?? [initial.message]),
+    isRunning: signal(initial.isRunning ?? false),
+  };
+
+  (component as unknown as { message: () => ReasoningMessage }).message = () =>
+    bindings.message();
+  (component as unknown as { messages: () => Message[] }).messages = () =>
+    bindings.messages();
+  (component as unknown as { isRunning: () => boolean }).isRunning = () =>
+    bindings.isRunning();
+
+  return { component, bindings };
+}
+
+describe("formatReasoningDuration", () => {
+  it("formats sub-second durations as 'a few seconds'", () => {
+    expect(formatReasoningDuration(0)).toBe("a few seconds");
+    expect(formatReasoningDuration(0.5)).toBe("a few seconds");
+  });
+
+  it("formats sub-minute durations in seconds", () => {
+    expect(formatReasoningDuration(1)).toBe("1 seconds");
+    expect(formatReasoningDuration(45)).toBe("45 seconds");
+  });
+
+  it("formats whole-minute durations as N minute(s)", () => {
+    expect(formatReasoningDuration(60)).toBe("1 minute");
+    expect(formatReasoningDuration(120)).toBe("2 minutes");
+  });
+
+  it("formats mixed minute+second durations as Nm Ms", () => {
+    expect(formatReasoningDuration(75)).toBe("1m 15s");
+    expect(formatReasoningDuration(125)).toBe("2m 5s");
+  });
+});
+
+describe("CopilotChatReasoningMessage", () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+  });
+
+  it("isStreaming is true only when running and latest", () => {
+    const message = makeReasoning("hi");
+    const { component, bindings } = buildComponent({ message, isRunning: true });
+
+    expect(component.isStreaming()).toBe(true);
+
+    const later: Message = {
+      id: "assistant-2",
+      role: "assistant",
+      content: "answer",
+    } as Message;
+    bindings.messages.set([message, later]);
+    expect(component.isStreaming()).toBe(false);
+
+    bindings.messages.set([message]);
+    bindings.isRunning.set(false);
+    expect(component.isStreaming()).toBe(false);
+  });
+
+  it("shows 'Thinking…' label while streaming", () => {
+    const { component } = buildComponent({
+      message: makeReasoning(""),
+      isRunning: true,
+    });
+    expect(component.isStreaming()).toBe(true);
+    expect(component.label()).toBe("Thinking…");
+  });
+
+  it("shows 'Thought for X seconds' label after streaming ends", () => {
+    const message = makeReasoning("Some thought");
+    const { component, bindings } = buildComponent({
+      message,
+      isRunning: true,
+    });
+
+    bindings.isRunning.set(false);
+    component.onStreamingChange();
+
+    expect(component.isStreaming()).toBe(false);
+    expect(component.label()).toMatch(/^Thought for /);
+  });
+
+  it("auto-opens when streaming starts", () => {
+    const message = makeReasoning("partial...");
+    const { component, bindings } = buildComponent({
+      message,
+      isRunning: false,
+    });
+    expect(component.isOpen()).toBe(false);
+
+    bindings.isRunning.set(true);
+    component.onStreamingChange();
+    expect(component.isOpen()).toBe(true);
+  });
+
+  it("auto-collapses when streaming ends without manual interaction", () => {
+    const message = makeReasoning("done");
+    const { component, bindings } = buildComponent({
+      message,
+      isRunning: true,
+    });
+    component.onStreamingChange();
+    expect(component.isOpen()).toBe(true);
+
+    bindings.isRunning.set(false);
+    component.onStreamingChange();
+    expect(component.isOpen()).toBe(false);
+  });
+
+  it("manual toggle overrides auto-collapse when streaming ends", () => {
+    const message = makeReasoning("manual session");
+    const { component, bindings } = buildComponent({
+      message,
+      isRunning: true,
+    });
+    component.onStreamingChange();
+    expect(component.isOpen()).toBe(true);
+
+    component.toggle();
+    expect(component.isOpen()).toBe(false);
+    component.toggle();
+    expect(component.isOpen()).toBe(true);
+
+    bindings.isRunning.set(false);
+    component.onStreamingChange();
+    expect(component.isOpen()).toBe(true);
+  });
+
+  it("manual-toggle flag resets when streaming restarts", () => {
+    const message = makeReasoning("first session");
+    const { component, bindings } = buildComponent({
+      message,
+      isRunning: true,
+    });
+    component.onStreamingChange();
+    component.toggle();
+    bindings.isRunning.set(false);
+    component.onStreamingChange();
+    expect(component.isOpen()).toBe(false);
+
+    bindings.isRunning.set(true);
+    component.onStreamingChange();
+    expect(component.isOpen()).toBe(true);
+
+    bindings.isRunning.set(false);
+    component.onStreamingChange();
+    expect(component.isOpen()).toBe(false);
+  });
+
+  it("ignores toggle calls when there is no content", () => {
+    const { component } = buildComponent({
+      message: makeReasoning(""),
+      isRunning: false,
+    });
+    expect(component.handleToggle()).toBeUndefined();
+    component.toggle();
+    expect(component.isOpen()).toBe(false);
+  });
+
+  it("provides slot context computed values while streaming", () => {
+    const message = makeReasoning("hello");
+    const { component } = buildComponent({ message, isRunning: true });
+    component.onStreamingChange();
+
+    const headerCtx = component.headerContext();
+    expect(headerCtx.label).toBe("Thinking…");
+    expect(headerCtx.hasContent).toBe(true);
+    expect(headerCtx.isStreaming).toBe(true);
+    expect(typeof headerCtx.onClick).toBe("function");
+
+    const contentCtx = component.contentContext();
+    expect(contentCtx.content).toBe("hello");
+    expect(contentCtx.hasContent).toBe(true);
+    expect(contentCtx.isStreaming).toBe(true);
+
+    const toggleCtx = component.toggleContext();
+    expect(toggleCtx.isOpen).toBe(true);
+  });
+});
+
+describe("CopilotChatReasoningMessageHeader", () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+  });
+
+  function buildHeader(initial: {
+    isOpen?: boolean;
+    label?: string;
+    hasContent?: boolean;
+    isStreaming?: boolean;
+    clickHandler?: () => void;
+  }): CopilotChatReasoningMessageHeader {
+    const injector = TestBed.inject(EnvironmentInjector);
+    const header = runInInjectionContext(
+      injector,
+      () => new CopilotChatReasoningMessageHeader(),
+    );
+    (header as unknown as { isOpen: () => boolean }).isOpen = () =>
+      initial.isOpen ?? false;
+    (header as unknown as { label: () => string }).label = () =>
+      initial.label ?? "Thoughts";
+    (header as unknown as { hasContent: () => boolean }).hasContent = () =>
+      initial.hasContent ?? false;
+    (header as unknown as { isStreaming: () => boolean }).isStreaming = () =>
+      initial.isStreaming ?? false;
+    (
+      header as unknown as { clickHandler: () => (() => void) | undefined }
+    ).clickHandler = () => initial.clickHandler;
+    return header;
+  }
+
+  it("returns the provided label via signal", () => {
+    const header = buildHeader({ label: "Thinking…" });
+    expect(header.label()).toBe("Thinking…");
+  });
+
+  it("isExpandable matches hasContent", () => {
+    expect(buildHeader({ hasContent: false }).isExpandable()).toBe(false);
+    expect(buildHeader({ hasContent: true }).isExpandable()).toBe(true);
+  });
+
+  it("invokes provided clickHandler when handleClick is called", () => {
+    let count = 0;
+    const header = buildHeader({
+      hasContent: true,
+      clickHandler: () => {
+        count += 1;
+      },
+    });
+    header.handleClick();
+    expect(count).toBe(1);
+  });
+
+  it("does nothing when handleClick is called without a clickHandler", () => {
+    const header = buildHeader({ hasContent: false });
+    expect(() => header.handleClick()).not.toThrow();
+  });
+
+  it("computes chevronClass with rotate-90 when open", () => {
+    const open = buildHeader({ isOpen: true, hasContent: true });
+    expect(open.chevronClass()).toContain("rotate-90");
+    const closed = buildHeader({ isOpen: false, hasContent: true });
+    expect(closed.chevronClass()).not.toContain("rotate-90");
+  });
+});
+
+describe("CopilotChatReasoningMessageContent", () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+  });
+
+  function buildContent(initial: {
+    isStreaming?: boolean;
+    hasContent?: boolean;
+    content?: string;
+  }): CopilotChatReasoningMessageContent {
+    const injector = TestBed.inject(EnvironmentInjector);
+    const content = runInInjectionContext(
+      injector,
+      () => new CopilotChatReasoningMessageContent(),
+    );
+    (content as unknown as { isStreaming: () => boolean }).isStreaming = () =>
+      initial.isStreaming ?? false;
+    (content as unknown as { hasContent: () => boolean }).hasContent = () =>
+      initial.hasContent ?? false;
+    (content as unknown as { content: () => string }).content = () =>
+      initial.content ?? "";
+    return content;
+  }
+
+  it("shouldRender is false when no content and not streaming", () => {
+    expect(
+      buildContent({ hasContent: false, isStreaming: false }).shouldRender(),
+    ).toBe(false);
+  });
+
+  it("shouldRender is true when streaming even without content", () => {
+    expect(
+      buildContent({ hasContent: false, isStreaming: true }).shouldRender(),
+    ).toBe(true);
+  });
+
+  it("shouldRender is true when content exists even when not streaming", () => {
+    expect(
+      buildContent({
+        hasContent: true,
+        isStreaming: false,
+        content: "abc",
+      }).shouldRender(),
+    ).toBe(true);
+  });
+});

--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat-reasoning-message.component.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat-reasoning-message.component.spec.ts
@@ -1,10 +1,11 @@
 import {
   EnvironmentInjector,
+  createEnvironmentInjector,
   runInInjectionContext,
   signal,
 } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Message } from "@ag-ui/core";
 import {
   CopilotChatReasoningMessage,
@@ -225,6 +226,40 @@ describe("CopilotChatReasoningMessage", () => {
 
     const toggleCtx = component.toggleContext();
     expect(toggleCtx.isOpen).toBe(true);
+  });
+
+  it("clears the elapsed-time interval when destroyed mid-stream", () => {
+    const message = makeReasoning("streaming...");
+    const parentInjector = TestBed.inject(EnvironmentInjector);
+    const childInjector = createEnvironmentInjector([], parentInjector);
+
+    const component = runInInjectionContext(
+      childInjector,
+      () => new CopilotChatReasoningMessage(),
+    );
+    (component as unknown as { message: () => ReasoningMessage }).message =
+      () => message;
+    (component as unknown as { messages: () => Message[] }).messages = () => [
+      message,
+    ];
+    (component as unknown as { isRunning: () => boolean }).isRunning = () =>
+      true;
+
+    component.onStreamingChange();
+    expect(component.isStreaming()).toBe(true);
+    expect(
+      (component as unknown as { tickInterval: unknown }).tickInterval,
+    ).not.toBeNull();
+
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+
+    childInjector.destroy();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(
+      (component as unknown as { tickInterval: unknown }).tickInterval,
+    ).toBeNull();
+    clearIntervalSpy.mockRestore();
   });
 });
 

--- a/packages/angular/src/lib/components/chat/copilot-chat-reasoning-message.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-reasoning-message.ts
@@ -1,12 +1,14 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  DestroyRef,
   ViewEncapsulation,
   ContentChild,
   TemplateRef,
   Type,
   computed,
   effect,
+  inject,
   input,
   signal,
 } from "@angular/core";
@@ -305,6 +307,8 @@ export class CopilotChatReasoningMessage {
   }));
 
   constructor() {
+    const destroyRef = inject(DestroyRef);
+    destroyRef.onDestroy(() => this.stopTick());
     effect(() => this.onStreamingChange(), { allowSignalWrites: true });
   }
 

--- a/packages/angular/src/lib/components/chat/copilot-chat-reasoning-message.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-reasoning-message.ts
@@ -1,0 +1,366 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ViewEncapsulation,
+  ContentChild,
+  TemplateRef,
+  Type,
+  computed,
+  effect,
+  input,
+  signal,
+} from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { LucideAngularModule, ChevronRight } from "lucide-angular";
+import type { Message } from "@ag-ui/core";
+import { CopilotSlot } from "../../slots/copilot-slot";
+import { CopilotChatAssistantMessageRenderer } from "./copilot-chat-assistant-message-renderer";
+import { cn } from "../../utils";
+import {
+  type ReasoningMessage,
+  type ReasoningMessageHeaderContext,
+  type ReasoningMessageContentContext,
+  type ReasoningMessageToggleContext,
+} from "./copilot-chat-reasoning-message.types";
+
+export function formatReasoningDuration(seconds: number): string {
+  if (seconds < 1) return "a few seconds";
+  if (seconds < 60) return `${Math.round(seconds)} seconds`;
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.round(seconds % 60);
+  if (secs === 0) return `${mins} minute${mins > 1 ? "s" : ""}`;
+  return `${mins}m ${secs}s`;
+}
+
+@Component({
+  standalone: true,
+  selector: "copilot-chat-reasoning-message-header",
+  imports: [CommonModule, LucideAngularModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <button
+      type="button"
+      [class]="computedClass()"
+      [attr.aria-expanded]="isExpandable() ? isOpen() : null"
+      [disabled]="!isExpandable()"
+      (click)="handleClick()"
+    >
+      <span class="font-medium">{{ label() || "Thoughts" }}</span>
+      @if (isStreaming() && !hasContent()) {
+        <span class="inline-flex items-center ml-1">
+          <span
+            class="w-1.5 h-1.5 rounded-full bg-muted-foreground animate-pulse"
+            data-testid="reasoning-pulse-dot"
+          ></span>
+        </span>
+      }
+      @if (isExpandable()) {
+        <lucide-angular
+          [img]="ChevronRightIcon"
+          [class]="chevronClass()"
+        ></lucide-angular>
+      }
+    </button>
+  `,
+})
+export class CopilotChatReasoningMessageHeader {
+  readonly isOpen = input<boolean>(false);
+  readonly label = input<string>("Thoughts");
+  readonly hasContent = input<boolean>(false);
+  readonly isStreaming = input<boolean>(false);
+  readonly clickHandler = input<(() => void) | undefined>(undefined);
+  readonly inputClass = input<string | undefined>();
+
+  protected readonly ChevronRightIcon = ChevronRight;
+
+  readonly isExpandable = computed(() => this.hasContent());
+
+  readonly computedClass = computed(() =>
+    cn(
+      "inline-flex items-center gap-1 py-1 text-sm text-muted-foreground transition-colors select-none",
+      this.isExpandable()
+        ? "hover:text-foreground cursor-pointer"
+        : "cursor-default",
+      this.inputClass(),
+    ),
+  );
+
+  readonly chevronClass = computed(() =>
+    cn(
+      "size-3.5 shrink-0 transition-transform duration-200",
+      this.isOpen() && "rotate-90",
+    ),
+  );
+
+  handleClick(): void {
+    const fn = this.clickHandler();
+    if (fn) fn();
+  }
+}
+
+@Component({
+  standalone: true,
+  selector: "copilot-chat-reasoning-message-content",
+  imports: [CommonModule, CopilotChatAssistantMessageRenderer],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    @if (shouldRender()) {
+      <div [class]="computedClass()">
+        <div class="text-sm text-muted-foreground">
+          <copilot-chat-assistant-message-renderer
+            [content]="content()"
+          ></copilot-chat-assistant-message-renderer>
+          @if (isStreaming() && hasContent()) {
+            <span
+              class="inline-flex items-center ml-1 align-middle"
+              data-testid="reasoning-streaming-cursor"
+            >
+              <span
+                class="w-2 h-2 rounded-full bg-muted-foreground animate-pulse-cursor"
+              ></span>
+            </span>
+          }
+        </div>
+      </div>
+    }
+  `,
+})
+export class CopilotChatReasoningMessageContent {
+  readonly isStreaming = input<boolean>(false);
+  readonly hasContent = input<boolean>(false);
+  readonly content = input<string>("");
+  readonly inputClass = input<string | undefined>();
+
+  readonly shouldRender = computed(
+    () => this.hasContent() || this.isStreaming(),
+  );
+
+  readonly computedClass = computed(() =>
+    cn("pb-2 pt-1", this.inputClass()),
+  );
+}
+
+@Component({
+  standalone: true,
+  selector: "copilot-chat-reasoning-message-toggle",
+  imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div [class]="computedClass()" [style.gridTemplateRows]="gridRows()">
+      <div class="overflow-hidden">
+        <ng-content></ng-content>
+      </div>
+    </div>
+  `,
+})
+export class CopilotChatReasoningMessageToggle {
+  readonly isOpen = input<boolean>(false);
+  readonly inputClass = input<string | undefined>();
+
+  readonly gridRows = computed(() => (this.isOpen() ? "1fr" : "0fr"));
+
+  readonly computedClass = computed(() =>
+    cn(
+      "grid transition-[grid-template-rows] duration-200 ease-in-out",
+      this.inputClass(),
+    ),
+  );
+}
+
+@Component({
+  standalone: true,
+  selector: "copilot-chat-reasoning-message",
+  host: { "data-copilotkit": "" },
+  imports: [
+    CommonModule,
+    CopilotSlot,
+    CopilotChatReasoningMessageHeader,
+    CopilotChatReasoningMessageContent,
+    CopilotChatReasoningMessageToggle,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div [class]="computedClass()" [attr.data-message-id]="messageId()">
+      @if (headerTemplate || headerComponent()) {
+        <copilot-slot
+          [slot]="headerTemplate || headerComponent()"
+          [context]="headerContext()"
+          [defaultComponent]="HeaderComponent"
+        ></copilot-slot>
+      } @else {
+        <copilot-chat-reasoning-message-header
+          [isOpen]="isOpen()"
+          [label]="label()"
+          [hasContent]="hasContent()"
+          [isStreaming]="isStreaming()"
+          [clickHandler]="handleToggle()"
+        ></copilot-chat-reasoning-message-header>
+      }
+
+      @if (toggleTemplate || toggleComponent()) {
+        <copilot-slot
+          [slot]="toggleTemplate || toggleComponent()"
+          [context]="toggleContext()"
+          [defaultComponent]="ToggleComponent"
+        ></copilot-slot>
+      } @else {
+        <copilot-chat-reasoning-message-toggle [isOpen]="isOpen()">
+          @if (contentTemplate || contentComponent()) {
+            <copilot-slot
+              [slot]="contentTemplate || contentComponent()"
+              [context]="contentContext()"
+              [defaultComponent]="ContentComponent"
+            ></copilot-slot>
+          } @else {
+            <copilot-chat-reasoning-message-content
+              [isStreaming]="isStreaming()"
+              [hasContent]="hasContent()"
+              [content]="messageContent()"
+            ></copilot-chat-reasoning-message-content>
+          }
+        </copilot-chat-reasoning-message-toggle>
+      }
+    </div>
+  `,
+})
+export class CopilotChatReasoningMessage {
+  @ContentChild("header", { read: TemplateRef })
+  headerTemplate?: TemplateRef<ReasoningMessageHeaderContext>;
+  @ContentChild("contentView", { read: TemplateRef })
+  contentTemplate?: TemplateRef<ReasoningMessageContentContext>;
+  @ContentChild("toggle", { read: TemplateRef })
+  toggleTemplate?: TemplateRef<ReasoningMessageToggleContext>;
+
+  readonly message = input.required<ReasoningMessage>();
+  readonly messages = input<Message[]>([]);
+  readonly isRunning = input<boolean>(false);
+  readonly inputClass = input<string | undefined>();
+
+  readonly headerComponent = input<Type<unknown> | undefined>(undefined);
+  readonly contentComponent = input<Type<unknown> | undefined>(undefined);
+  readonly toggleComponent = input<Type<unknown> | undefined>(undefined);
+
+  protected readonly HeaderComponent = CopilotChatReasoningMessageHeader;
+  protected readonly ContentComponent = CopilotChatReasoningMessageContent;
+  protected readonly ToggleComponent = CopilotChatReasoningMessageToggle;
+
+  private readonly elapsedSignal = signal(0);
+  private readonly isOpenSignal = signal(false);
+  private startTime: number | null = null;
+  private userToggled = false;
+  private tickInterval: ReturnType<typeof setInterval> | null = null;
+  private wasStreaming = false;
+
+  readonly isLatest = computed(() => {
+    const msgs = this.messages();
+    if (!msgs || msgs.length === 0) return false;
+    return msgs[msgs.length - 1]?.id === this.message().id;
+  });
+
+  readonly isStreaming = computed(() => !!(this.isRunning() && this.isLatest()));
+
+  readonly messageContent = computed(() => this.message().content ?? "");
+
+  readonly messageId = computed(() => this.message().id);
+
+  readonly hasContent = computed(() => this.messageContent().length > 0);
+
+  readonly elapsed = computed(() => this.elapsedSignal());
+
+  readonly isOpen = computed(() => this.isOpenSignal());
+
+  readonly label = computed(() =>
+    this.isStreaming()
+      ? "Thinking…"
+      : `Thought for ${formatReasoningDuration(this.elapsed())}`,
+  );
+
+  readonly computedClass = computed(() => cn("my-1", this.inputClass()));
+
+  readonly handleToggle = computed<(() => void) | undefined>(() => {
+    if (!this.hasContent()) return undefined;
+    return () => this.toggle();
+  });
+
+  readonly headerContext = computed<ReasoningMessageHeaderContext>(() => ({
+    isOpen: this.isOpen(),
+    label: this.label(),
+    hasContent: this.hasContent(),
+    isStreaming: this.isStreaming(),
+    onClick: this.handleToggle(),
+  }));
+
+  readonly contentContext = computed<ReasoningMessageContentContext>(() => ({
+    isStreaming: this.isStreaming(),
+    hasContent: this.hasContent(),
+    content: this.messageContent(),
+  }));
+
+  readonly toggleContext = computed<ReasoningMessageToggleContext>(() => ({
+    isOpen: this.isOpen(),
+  }));
+
+  constructor() {
+    effect(() => this.onStreamingChange(), { allowSignalWrites: true });
+  }
+
+  /**
+   * Reconciles internal open/elapsed state with the current isStreaming value.
+   * Idempotent on the same streaming state, so safe to call from effect or tests.
+   */
+  onStreamingChange(): void {
+    const streaming = this.isStreaming();
+    if (streaming === this.wasStreaming) {
+      // First-time entry into streaming still needs initialization
+      if (streaming && this.startTime === null) {
+        this.startTime = Date.now();
+        this.userToggled = false;
+        this.isOpenSignal.set(true);
+        this.startTick();
+      }
+      return;
+    }
+    this.wasStreaming = streaming;
+
+    if (streaming) {
+      this.startTime = Date.now();
+      this.userToggled = false;
+      this.isOpenSignal.set(true);
+      this.startTick();
+    } else {
+      if (this.startTime !== null) {
+        this.elapsedSignal.set((Date.now() - this.startTime) / 1000);
+      }
+      this.stopTick();
+      if (!this.userToggled) {
+        this.isOpenSignal.set(false);
+      }
+    }
+  }
+
+  toggle(): void {
+    if (!this.hasContent()) return;
+    this.userToggled = true;
+    this.isOpenSignal.update((value) => !value);
+  }
+
+  private startTick(): void {
+    this.stopTick();
+    this.tickInterval = setInterval(() => {
+      if (this.startTime !== null) {
+        this.elapsedSignal.set((Date.now() - this.startTime) / 1000);
+      }
+    }, 1000);
+  }
+
+  private stopTick(): void {
+    if (this.tickInterval !== null) {
+      clearInterval(this.tickInterval);
+      this.tickInterval = null;
+    }
+  }
+}

--- a/packages/angular/src/lib/components/chat/copilot-chat-reasoning-message.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-reasoning-message.ts
@@ -137,9 +137,7 @@ export class CopilotChatReasoningMessageContent {
     () => this.hasContent() || this.isStreaming(),
   );
 
-  readonly computedClass = computed(() =>
-    cn("pb-2 pt-1", this.inputClass()),
-  );
+  readonly computedClass = computed(() => cn("pb-2 pt-1", this.inputClass()));
 }
 
 @Component({
@@ -261,7 +259,9 @@ export class CopilotChatReasoningMessage {
     return msgs[msgs.length - 1]?.id === this.message().id;
   });
 
-  readonly isStreaming = computed(() => !!(this.isRunning() && this.isLatest()));
+  readonly isStreaming = computed(
+    () => !!(this.isRunning() && this.isLatest()),
+  );
 
   readonly messageContent = computed(() => this.message().content ?? "");
 

--- a/packages/angular/src/lib/components/chat/copilot-chat-reasoning-message.types.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-reasoning-message.types.ts
@@ -1,0 +1,21 @@
+import type { ReasoningMessage } from "@ag-ui/core";
+
+export interface ReasoningMessageHeaderContext {
+  isOpen: boolean;
+  label: string;
+  hasContent: boolean;
+  isStreaming: boolean;
+  onClick?: () => void;
+}
+
+export interface ReasoningMessageContentContext {
+  isStreaming: boolean;
+  hasContent: boolean;
+  content: string;
+}
+
+export interface ReasoningMessageToggleContext {
+  isOpen: boolean;
+}
+
+export type { ReasoningMessage };

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -30,6 +30,8 @@ export * from "./lib/components/chat/copilot-chat-input.types";
 export * from "./lib/components/chat/copilot-chat-message-view";
 export * from "./lib/components/chat/copilot-chat-message-view-cursor";
 export * from "./lib/components/chat/copilot-chat-message-view.types";
+export * from "./lib/components/chat/copilot-chat-reasoning-message";
+export * from "./lib/components/chat/copilot-chat-reasoning-message.types";
 export * from "./lib/components/chat/copilot-chat-textarea";
 export * from "./lib/components/chat/copilot-chat-tool-calls-view";
 export * from "./lib/components/chat/copilot-chat-toolbar";


### PR DESCRIPTION
## Summary

Ports `CopilotChatReasoningMessage` from `@copilotkitnext/react-core` to `@copilotkitnext/angular`. Net new component (plus three slot-overridable sub-components), behavioral spec, and public API surface — no other packages touched. The Angular implementation expresses the same behavioral contract as the React source while idiomatic-converting hooks → signals/effects.

## Behavioral contract (preserved from React)

- `isStreaming` is true iff `isRunning && message.id === messages[messages.length - 1].id`.
- While streaming: header label is `"Thinking…"`, with a small pulsing dot when there is no content yet.
- After streaming ends: header label is `"Thought for X seconds"` using a ported `formatDuration` helper (`< 1s` → `"a few seconds"`, `< 60s` → `"N seconds"`, whole minutes → `"N minute(s)"`, otherwise `"Nm Ms"`). Elapsed time is captured at the moment streaming flips off.
- Auto-collapse: opens automatically when streaming starts, auto-collapses when streaming ends — UNLESS the user has manually clicked the header during this streaming session. Manual flag resets each time streaming restarts.
- Header click toggles open/closed only when `hasContent`. When no content, click is a no-op (and the rendered `<button>` is `disabled`).
- When `hasContent` is false AND not streaming, the Content area renders nothing.
- Header has `aria-expanded` only when expandable (i.e. content exists).
- Three slot-overridable sub-components: Header, Content, Toggle.
- Content rendering uses the existing Angular markdown renderer (`CopilotChatAssistantMessageRenderer`), mirroring how React uses Streamdown.
- While streaming AND content exists, a small pulsing cursor renders at the end of the content.

## What differs from React (and why)

- **Hooks → signals/effects.** React's `useState` + `useRef` + `useEffect` map to Angular `signal()` + private fields + a single `effect()` that calls `onStreamingChange()`. The state-transition logic was extracted into a method (`onStreamingChange`) so it can be exercised deterministically from tests without relying on the effect/zone tick.
- **`renderSlot` + namespace → standalone components + `<copilot-slot>`.** Mirrors the existing `copilot-chat-assistant-message` pattern. Sub-components are exported as `CopilotChatReasoningMessageHeader`, `CopilotChatReasoningMessageContent`, `CopilotChatReasoningMessageToggle`.
- **`onClick` slot prop → `clickHandler`.** Angular treats `[onClick]` as a DOM event property (NG0306), so the input is renamed `clickHandler`. The slot context object still uses `onClick` to match React's React-friendly shape.
- **`tw-merge` (`twMerge`) → existing `cn` util** (clsx + tailwind-merge wrapper already used across this package). Tailwind classes drop the React project's `cpk:` variant prefix because the Angular package's stylesheet pipeline does not use that prefix (matches sibling components like `copilot-chat-assistant-message-renderer`).
- **No top-level `children` render-prop.** Angular's content-projection API differs from React render-props; consumers override pieces via slot inputs (`headerComponent` / `contentComponent` / `toggleComponent`) or `<ng-template #header>` / `#contentView` / `#toggle`.

## Test coverage → contract bullet mapping

`packages/angular/src/lib/components/chat/__tests__/copilot-chat-reasoning-message.component.spec.ts`

- `formatReasoningDuration` (4 tests) → duration helper exact branches (sub-second / sub-minute / whole minutes / mixed).
- `isStreaming is true only when running and latest` → contract bullet 2.
- `shows 'Thinking…' label while streaming` → contract bullet 3.
- `shows 'Thought for X seconds' label after streaming ends` → contract bullet 4.
- `auto-opens when streaming starts` → contract bullet 5 (open-on-start).
- `auto-collapses when streaming ends without manual interaction` → contract bullet 5 (auto-collapse).
- `manual toggle overrides auto-collapse when streaming ends` → contract bullet 5 (manual override).
- `manual-toggle flag resets when streaming restarts` → contract bullet 5 (flag reset).
- `ignores toggle calls when there is no content` → contract bullet 6.
- `provides slot context computed values while streaming` → contract bullet 9 (slot wiring).
- Header sub-component tests (`label`, `isExpandable`, `handleClick`, `chevronClass`) → contract bullets 3/6/8/9.
- Content sub-component tests (`shouldRender` matrix) → contract bullet 7.

## Test plan

- [x] `nx run @copilotkitnext/angular:test` — 14 files / 68 tests passing (21 new).
- [x] `nx run @copilotkitnext/angular:build` — green.
- [ ] `nx run @copilotkitnext/angular:check-types` — Angular task itself green; the nx target run is blocked by a **pre-existing** failure in `@copilotkit/core:check-types` (`packages/core/src/threads.ts` + `phoenix-observable.ts` errors reproduce on a clean `main` checkout, no Angular sources involved). Reported but not fixed here (out of scope for an Angular-only capability).

## Notes / observations for the worker template

- `ComponentFixture#componentRef.setInput(...)` does **not** propagate to signal-based `input()` declarations in this Angular 19.2 + AnalogJS + vitest jsdom setup. Tests therefore follow the existing assistant-message idiom: `runInInjectionContext` + overwrite the input function with a plain `() => value` closure for unit assertions, with sub-component-level structural assertions split out where DOM coverage was important.
- `[onClick]` cannot be used as a custom-component input name — Angular blocks it as a DOM event property. Worker template should call out: avoid input names matching DOM event handlers.
- Angular's pre-existing repo-wide `nx check-types` is blocked by `@copilotkit/core` failures unrelated to Angular. Workers should treat "Angular task itself green" as the relevant signal until that upstream failure is fixed.

https://claude.ai/code/session_01B1zJ4kMRgLuN1r5T3iiGbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1zJ4kMRgLuN1r5T3iiGbZ)_