### PR TITLE
feat(angular): add CopilotKitConfigDirective (closes #3171)

### DIFF
--- a/packages/angular/src/lib/directives/__tests__/copilotkit-agent-directive.spec.ts
+++ b/packages/angular/src/lib/directives/__tests__/copilotkit-agent-directive.spec.ts
@@ -1,0 +1,156 @@
+import { Component } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CopilotKitAgentDirective } from "../copilotkit-agent";
+import { CopilotKit } from "../../copilotkit";
+
+function createFakeAgent(label: string): any {
+  return {
+    agentId: label,
+    messages: [],
+    threadId: `${label}-thread`,
+    state: {},
+    subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
+  };
+}
+
+class CopilotKitStub {
+  private _agents: Record<string, any> = {};
+  updateRuntime = vi.fn((options: { agents?: Record<string, any> }) => {
+    if (options.agents !== undefined) {
+      this._agents = options.agents;
+    }
+  });
+  agents = vi.fn(() => this._agents);
+}
+
+describe("CopilotKitAgentDirective", () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [{ provide: CopilotKit, useClass: CopilotKitStub }],
+    });
+  });
+
+  it("registers a single agent by id and unregisters on destroy", () => {
+    const planner = createFakeAgent("planner");
+
+    @Component({
+      standalone: true,
+      imports: [CopilotKitAgentDirective],
+      template: `<div [copilotkitAgent]="agent" agentId="planner"></div>`,
+    })
+    class HostComponent {
+      agent = planner;
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const copilotkit = TestBed.inject(CopilotKit) as unknown as CopilotKitStub;
+    expect(copilotkit.updateRuntime).toHaveBeenCalledWith({
+      agents: { planner },
+    });
+
+    fixture.destroy();
+    expect(copilotkit.updateRuntime).toHaveBeenLastCalledWith({ agents: {} });
+  });
+
+  it("registers a record of agents and unregisters on destroy", () => {
+    const planner = createFakeAgent("planner");
+    const writer = createFakeAgent("writer");
+
+    @Component({
+      standalone: true,
+      imports: [CopilotKitAgentDirective],
+      template: `<div [copilotkitAgent]="agents"></div>`,
+    })
+    class HostComponent {
+      agents = { planner, writer };
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const copilotkit = TestBed.inject(CopilotKit) as unknown as CopilotKitStub;
+    expect(copilotkit.updateRuntime).toHaveBeenCalledWith({
+      agents: { planner, writer },
+    });
+
+    fixture.destroy();
+    expect(copilotkit.updateRuntime).toHaveBeenLastCalledWith({ agents: {} });
+  });
+
+  it("does nothing when single agent is provided without an agentId", () => {
+    const orphan = createFakeAgent("orphan");
+
+    @Component({
+      standalone: true,
+      imports: [CopilotKitAgentDirective],
+      template: `<div [copilotkitAgent]="agent"></div>`,
+    })
+    class HostComponent {
+      agent = orphan;
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const copilotkit = TestBed.inject(CopilotKit) as unknown as CopilotKitStub;
+    expect(copilotkit.updateRuntime).not.toHaveBeenCalled();
+  });
+
+  it("re-registers when the agent input changes", () => {
+    const first = createFakeAgent("first");
+    const second = createFakeAgent("second");
+
+    @Component({
+      standalone: true,
+      imports: [CopilotKitAgentDirective],
+      template: `<div [copilotkitAgent]="agent" agentId="active"></div>`,
+    })
+    class HostComponent {
+      agent = first;
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const copilotkit = TestBed.inject(CopilotKit) as unknown as CopilotKitStub;
+    expect(copilotkit.updateRuntime).toHaveBeenLastCalledWith({
+      agents: { active: first },
+    });
+
+    fixture.componentInstance.agent = second;
+    fixture.detectChanges();
+
+    expect(copilotkit.updateRuntime).toHaveBeenLastCalledWith({
+      agents: { active: second },
+    });
+  });
+
+  it("preserves pre-existing agents on the CopilotKit service", () => {
+    const existing = createFakeAgent("existing");
+    const planner = createFakeAgent("planner");
+
+    @Component({
+      standalone: true,
+      imports: [CopilotKitAgentDirective],
+      template: `<div [copilotkitAgent]="agent" agentId="planner"></div>`,
+    })
+    class HostComponent {
+      agent = planner;
+    }
+
+    const copilotkit = TestBed.inject(CopilotKit) as unknown as CopilotKitStub;
+    // Seed an existing agent before directive registers.
+    (copilotkit as any)._agents = { existing };
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    expect(copilotkit.updateRuntime).toHaveBeenCalledWith({
+      agents: { existing, planner },
+    });
+  });
+});

--- a/packages/angular/src/lib/directives/__tests__/copilotkit-agent-directive.spec.ts
+++ b/packages/angular/src/lib/directives/__tests__/copilotkit-agent-directive.spec.ts
@@ -38,7 +38,9 @@ describe("CopilotKitAgentDirective", () => {
     @Component({
       standalone: true,
       imports: [CopilotKitAgentDirective],
-      template: `<div [copilotkitAgent]="agent" agentId="planner"></div>`,
+      template: `
+        <div [copilotkitAgent]="agent" agentId="planner"></div>
+      `,
     })
     class HostComponent {
       agent = planner;
@@ -63,7 +65,9 @@ describe("CopilotKitAgentDirective", () => {
     @Component({
       standalone: true,
       imports: [CopilotKitAgentDirective],
-      template: `<div [copilotkitAgent]="agents"></div>`,
+      template: `
+        <div [copilotkitAgent]="agents"></div>
+      `,
     })
     class HostComponent {
       agents = { planner, writer };
@@ -87,7 +91,9 @@ describe("CopilotKitAgentDirective", () => {
     @Component({
       standalone: true,
       imports: [CopilotKitAgentDirective],
-      template: `<div [copilotkitAgent]="agent"></div>`,
+      template: `
+        <div [copilotkitAgent]="agent"></div>
+      `,
     })
     class HostComponent {
       agent = orphan;
@@ -107,7 +113,9 @@ describe("CopilotKitAgentDirective", () => {
     @Component({
       standalone: true,
       imports: [CopilotKitAgentDirective],
-      template: `<div [copilotkitAgent]="agent" agentId="active"></div>`,
+      template: `
+        <div [copilotkitAgent]="agent" agentId="active"></div>
+      `,
     })
     class HostComponent {
       agent = first;
@@ -136,7 +144,9 @@ describe("CopilotKitAgentDirective", () => {
     @Component({
       standalone: true,
       imports: [CopilotKitAgentDirective],
-      template: `<div [copilotkitAgent]="agent" agentId="planner"></div>`,
+      template: `
+        <div [copilotkitAgent]="agent" agentId="planner"></div>
+      `,
     })
     class HostComponent {
       agent = planner;

--- a/packages/angular/src/lib/directives/__tests__/copilotkit-config-directive.spec.ts
+++ b/packages/angular/src/lib/directives/__tests__/copilotkit-config-directive.spec.ts
@@ -21,7 +21,9 @@ describe("CopilotKitConfigDirective", () => {
     @Component({
       standalone: true,
       imports: [CopilotKitConfigDirective],
-      template: `<div [copilotkitConfig]="config"></div>`,
+      template: `
+        <div [copilotkitConfig]="config"></div>
+      `,
     })
     class HostComponent {
       config = {
@@ -47,10 +49,12 @@ describe("CopilotKitConfigDirective", () => {
       standalone: true,
       imports: [CopilotKitConfigDirective],
       template: `
-        <div copilotkitConfig
-             [runtimeUrl]="runtimeUrl"
-             [headers]="headers"
-             [properties]="properties"></div>
+        <div
+          copilotkitConfig
+          [runtimeUrl]="runtimeUrl"
+          [headers]="headers"
+          [properties]="properties"
+        ></div>
       `,
     })
     class HostComponent {
@@ -76,7 +80,9 @@ describe("CopilotKitConfigDirective", () => {
     @Component({
       standalone: true,
       imports: [CopilotKitConfigDirective],
-      template: `<div copilotkitConfig [runtimeUrl]="runtimeUrl"></div>`,
+      template: `
+        <div copilotkitConfig [runtimeUrl]="runtimeUrl"></div>
+      `,
     })
     class HostComponent {
       runtimeUrl = "https://first.example.com";
@@ -102,7 +108,9 @@ describe("CopilotKitConfigDirective", () => {
     @Component({
       standalone: true,
       imports: [CopilotKitConfigDirective],
-      template: `<div copilotkitConfig></div>`,
+      template: `
+        <div copilotkitConfig></div>
+      `,
     })
     class HostComponent {}
 
@@ -118,9 +126,11 @@ describe("CopilotKitConfigDirective", () => {
       standalone: true,
       imports: [CopilotKitConfigDirective],
       template: `
-        <div [copilotkitConfig]="config"
-             [runtimeUrl]="ignored"
-             [headers]="ignoredHeaders"></div>
+        <div
+          [copilotkitConfig]="config"
+          [runtimeUrl]="ignored"
+          [headers]="ignoredHeaders"
+        ></div>
       `,
     })
     class HostComponent {

--- a/packages/angular/src/lib/directives/__tests__/copilotkit-config-directive.spec.ts
+++ b/packages/angular/src/lib/directives/__tests__/copilotkit-config-directive.spec.ts
@@ -1,0 +1,146 @@
+import { Component } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CopilotKitConfigDirective } from "../copilotkit-config";
+import { CopilotKit } from "../../copilotkit";
+
+class CopilotKitStub {
+  updateRuntime = vi.fn();
+  agents = vi.fn(() => ({}));
+}
+
+describe("CopilotKitConfigDirective", () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [{ provide: CopilotKit, useClass: CopilotKitStub }],
+    });
+  });
+
+  it("forwards a config object to CopilotKit.updateRuntime on init", () => {
+    @Component({
+      standalone: true,
+      imports: [CopilotKitConfigDirective],
+      template: `<div [copilotkitConfig]="config"></div>`,
+    })
+    class HostComponent {
+      config = {
+        runtimeUrl: "https://example.com",
+        headers: { Authorization: "token" },
+      };
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const copilotkit = TestBed.inject(CopilotKit) as unknown as CopilotKitStub;
+    expect(copilotkit.updateRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeUrl: "https://example.com",
+        headers: { Authorization: "token" },
+      }),
+    );
+  });
+
+  it("forwards individual inputs to CopilotKit.updateRuntime", () => {
+    @Component({
+      standalone: true,
+      imports: [CopilotKitConfigDirective],
+      template: `
+        <div copilotkitConfig
+             [runtimeUrl]="runtimeUrl"
+             [headers]="headers"
+             [properties]="properties"></div>
+      `,
+    })
+    class HostComponent {
+      runtimeUrl = "https://api.example.com";
+      headers = { "X-Custom": "yes" };
+      properties = { tenant: "acme" };
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const copilotkit = TestBed.inject(CopilotKit) as unknown as CopilotKitStub;
+    expect(copilotkit.updateRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeUrl: "https://api.example.com",
+        headers: { "X-Custom": "yes" },
+        properties: { tenant: "acme" },
+      }),
+    );
+  });
+
+  it("re-applies config when inputs change", () => {
+    @Component({
+      standalone: true,
+      imports: [CopilotKitConfigDirective],
+      template: `<div copilotkitConfig [runtimeUrl]="runtimeUrl"></div>`,
+    })
+    class HostComponent {
+      runtimeUrl = "https://first.example.com";
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const copilotkit = TestBed.inject(CopilotKit) as unknown as CopilotKitStub;
+    expect(copilotkit.updateRuntime).toHaveBeenLastCalledWith(
+      expect.objectContaining({ runtimeUrl: "https://first.example.com" }),
+    );
+
+    fixture.componentInstance.runtimeUrl = "https://second.example.com";
+    fixture.detectChanges();
+
+    expect(copilotkit.updateRuntime).toHaveBeenLastCalledWith(
+      expect.objectContaining({ runtimeUrl: "https://second.example.com" }),
+    );
+  });
+
+  it("does not call updateRuntime when no inputs are set", () => {
+    @Component({
+      standalone: true,
+      imports: [CopilotKitConfigDirective],
+      template: `<div copilotkitConfig></div>`,
+    })
+    class HostComponent {}
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const copilotkit = TestBed.inject(CopilotKit) as unknown as CopilotKitStub;
+    expect(copilotkit.updateRuntime).not.toHaveBeenCalled();
+  });
+
+  it("config object overrides individual inputs", () => {
+    @Component({
+      standalone: true,
+      imports: [CopilotKitConfigDirective],
+      template: `
+        <div [copilotkitConfig]="config"
+             [runtimeUrl]="ignored"
+             [headers]="ignoredHeaders"></div>
+      `,
+    })
+    class HostComponent {
+      config = {
+        runtimeUrl: "https://from-object.example.com",
+        headers: { From: "object" },
+      };
+      ignored = "https://from-input.example.com";
+      ignoredHeaders = { From: "input" };
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const copilotkit = TestBed.inject(CopilotKit) as unknown as CopilotKitStub;
+    expect(copilotkit.updateRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeUrl: "https://from-object.example.com",
+        headers: { From: "object" },
+      }),
+    );
+  });
+});

--- a/packages/angular/src/lib/directives/copilotkit-agent.ts
+++ b/packages/angular/src/lib/directives/copilotkit-agent.ts
@@ -35,9 +35,7 @@ import { CopilotKit } from "../copilotkit";
   selector: "[copilotkitAgent]",
   standalone: true,
 })
-export class CopilotKitAgentDirective
-  implements OnInit, OnChanges, OnDestroy
-{
+export class CopilotKitAgentDirective implements OnInit, OnChanges, OnDestroy {
   constructor(@Inject(CopilotKit) private readonly copilotkit: CopilotKit) {}
 
   /**

--- a/packages/angular/src/lib/directives/copilotkit-agent.ts
+++ b/packages/angular/src/lib/directives/copilotkit-agent.ts
@@ -1,0 +1,126 @@
+import {
+  Directive,
+  Inject,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+} from "@angular/core";
+import { AbstractAgent } from "@ag-ui/client";
+import { CopilotKit } from "../copilotkit";
+
+/**
+ * Template-form directive for registering an agent with CopilotKit at runtime.
+ *
+ * Useful when an agent instance is owned by a component (e.g. constructed
+ * from props) and should be made available to descendants via the standard
+ * `injectAgent` / `<copilot-chat>` machinery. The directive registers the
+ * agent on init, updates it on input changes, and removes it on destroy.
+ *
+ * @example
+ * ```html
+ * <!-- Register a single agent under an explicit id -->
+ * <div [copilotkitAgent]="agent" agentId="my-agent">
+ *   <copilot-chat agentId="my-agent"></copilot-chat>
+ * </div>
+ *
+ * <!-- Register multiple agents at once -->
+ * <div [copilotkitAgent]="{ planner: plannerAgent, writer: writerAgent }">
+ *   <copilot-chat agentId="writer"></copilot-chat>
+ * </div>
+ * ```
+ */
+@Directive({
+  selector: "[copilotkitAgent]",
+  standalone: true,
+})
+export class CopilotKitAgentDirective
+  implements OnInit, OnChanges, OnDestroy
+{
+  constructor(@Inject(CopilotKit) private readonly copilotkit: CopilotKit) {}
+
+  /**
+   * Either a single agent (paired with `agentId`) or a record of
+   * `{ id: agent }` to register multiple agents at once.
+   */
+  @Input("copilotkitAgent") agent?:
+    | AbstractAgent
+    | Record<string, AbstractAgent>;
+
+  /**
+   * Required when `agent` is a single `AbstractAgent` instance.
+   * Ignored when `agent` is a `Record<string, AbstractAgent>`.
+   */
+  @Input() agentId?: string;
+
+  private registeredIds: string[] = [];
+
+  ngOnInit(): void {
+    this.registerAgents();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!("agent" in changes) && !("agentId" in changes)) {
+      return;
+    }
+    if (
+      changes["agent"]?.firstChange === true &&
+      changes["agentId"]?.firstChange !== false
+    ) {
+      // ngOnInit will handle the first call.
+      return;
+    }
+    this.unregisterAgents();
+    this.registerAgents();
+  }
+
+  ngOnDestroy(): void {
+    this.unregisterAgents();
+  }
+
+  private registerAgents(): void {
+    const map = this.resolveAgentMap();
+    if (!map) {
+      return;
+    }
+    const existing = this.copilotkit.agents();
+    const merged: Record<string, AbstractAgent> = { ...existing, ...map };
+    this.copilotkit.updateRuntime({ agents: merged });
+    this.registeredIds = Object.keys(map);
+  }
+
+  private unregisterAgents(): void {
+    if (this.registeredIds.length === 0) {
+      return;
+    }
+    const remaining = { ...this.copilotkit.agents() };
+    for (const id of this.registeredIds) {
+      delete remaining[id];
+    }
+    this.copilotkit.updateRuntime({ agents: remaining });
+    this.registeredIds = [];
+  }
+
+  private resolveAgentMap(): Record<string, AbstractAgent> | null {
+    if (!this.agent) {
+      return null;
+    }
+    if (this.isAgentMap(this.agent)) {
+      return this.agent;
+    }
+    if (!this.agentId) {
+      return null;
+    }
+    return { [this.agentId]: this.agent };
+  }
+
+  private isAgentMap(
+    value: AbstractAgent | Record<string, AbstractAgent>,
+  ): value is Record<string, AbstractAgent> {
+    if (typeof value !== "object" || value === null) {
+      return false;
+    }
+    return typeof (value as { subscribe?: unknown }).subscribe !== "function";
+  }
+}

--- a/packages/angular/src/lib/directives/copilotkit-config.ts
+++ b/packages/angular/src/lib/directives/copilotkit-config.ts
@@ -1,0 +1,92 @@
+import {
+  Directive,
+  Inject,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from "@angular/core";
+import { AbstractAgent } from "@ag-ui/client";
+import { CopilotKit } from "../copilotkit";
+import { CopilotKitConfig } from "../config";
+
+/**
+ * Template-form directive for configuring CopilotKit at runtime.
+ *
+ * `provideCopilotKit({...})` must already be present in the injector tree
+ * (typically at app bootstrap). This directive forwards inputs to
+ * `CopilotKit.updateRuntime(...)` so config can be driven from a template
+ * the way React's `<CopilotKit runtimeUrl=... headers=...>` works.
+ *
+ * @example
+ * ```html
+ * <!-- With a single config object -->
+ * <div [copilotkitConfig]="{ runtimeUrl: 'https://api.example.com' }">
+ *   <copilot-chat></copilot-chat>
+ * </div>
+ *
+ * <!-- With individual inputs -->
+ * <div copilotkitConfig
+ *      [runtimeUrl]="runtimeUrl"
+ *      [headers]="headers"
+ *      [properties]="properties">
+ *   <copilot-chat></copilot-chat>
+ * </div>
+ * ```
+ */
+@Directive({
+  selector: "[copilotkitConfig]",
+  standalone: true,
+})
+export class CopilotKitConfigDirective implements OnInit, OnChanges {
+  constructor(@Inject(CopilotKit) private readonly copilotkit: CopilotKit) {}
+
+  /**
+   * Optional config object. When provided, fields here override individual
+   * inputs of the same name.
+   */
+  @Input("copilotkitConfig") config?: Partial<CopilotKitConfig>;
+
+  @Input() runtimeUrl?: string;
+  @Input() headers?: Record<string, string>;
+  @Input() properties?: Record<string, unknown>;
+  @Input() agents?: Record<string, AbstractAgent>;
+  @Input() selfManagedAgents?: Record<string, AbstractAgent>;
+
+  ngOnInit(): void {
+    this.applyConfig();
+  }
+
+  ngOnChanges(_changes: SimpleChanges): void {
+    this.applyConfig();
+  }
+
+  private applyConfig(): void {
+    const merged = this.resolveConfig();
+    if (this.isEmpty(merged)) {
+      return;
+    }
+    this.copilotkit.updateRuntime(merged);
+  }
+
+  private resolveConfig(): {
+    runtimeUrl?: string;
+    headers?: Record<string, string>;
+    properties?: Record<string, unknown>;
+    agents?: Record<string, AbstractAgent>;
+    selfManagedAgents?: Record<string, AbstractAgent>;
+  } {
+    return {
+      runtimeUrl: this.config?.runtimeUrl ?? this.runtimeUrl,
+      headers: this.config?.headers ?? this.headers,
+      properties: this.config?.properties ?? this.properties,
+      agents: this.config?.agents ?? this.agents,
+      selfManagedAgents:
+        this.config?.selfManagedAgents ?? this.selfManagedAgents,
+    };
+  }
+
+  private isEmpty(value: Record<string, unknown>): boolean {
+    return Object.values(value).every((v) => v === undefined);
+  }
+}

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -13,6 +13,8 @@ export * from "./lib/agent-context";
 export * from "./lib/slots";
 
 export * from "./lib/directives/copilotkit-agent-context";
+export * from "./lib/directives/copilotkit-agent";
+export * from "./lib/directives/copilotkit-config";
 export * from "./lib/directives/stick-to-bottom";
 export * from "./lib/directives/tooltip";
 


### PR DESCRIPTION
## Issue #3171 summary

The issue reports that `CopilotKitConfigDirective` and `CopilotKitAgentDirective` are documented as imports from `@copilotkitnext/angular` but don't exist. Today, configuration is provided via `provideCopilotKit({...})` at the DI level, and there is no template-form directive equivalent — so the imports fail at compile time.

## Decision + reasoning

**Decision tree branch picked: implement new template-form directives** (not aliases / re-exports) — because the missing exports are *directives*, and there are no existing directives whose behavior matches what users expect from a `<CopilotKit runtimeUrl=... headers=...>`-style template form. A pure rename/alias wouldn't satisfy the use case.

The directives are intentionally thin: they don't replace `provideCopilotKit` (which still must be present at app bootstrap so the `CopilotKit` service can be instantiated). Instead, they bridge templates to the already-existing `CopilotKit.updateRuntime(...)` mutation surface — mirroring how React's `<CopilotKit>` provider re-evaluates props on render.

This satisfies #3171 without:
- Refactoring `provideCopilotKit` semantics
- Changing `CopilotKitAgentContext`'s behavior
- Touching any non-Angular package

## Chosen API shape

```html
<!-- Configuration directive -->
<div [copilotkitConfig]="{ runtimeUrl: 'https://api.example.com', headers: { Authorization: 'Bearer ...' } }">
  <copilot-chat></copilot-chat>
</div>

<!-- Or with individual inputs -->
<div copilotkitConfig
     [runtimeUrl]="runtimeUrl"
     [headers]="headers"
     [properties]="properties">
  <copilot-chat></copilot-chat>
</div>

<!-- Agent directive: single agent with id -->
<div [copilotkitAgent]="myAgent" agentId="planner">
  <copilot-chat agentId="planner"></copilot-chat>
</div>

<!-- Agent directive: record of agents -->
<div [copilotkitAgent]="{ planner: plannerAgent, writer: writerAgent }">
  <copilot-chat agentId="writer"></copilot-chat>
</div>
```

Both are `standalone: true` directives, exported from `public-api.ts`. `provideCopilotKit({})` must still be present for the `CopilotKit` service to be available — the directives mutate runtime state, they do not bootstrap it.

## Test → behavior mapping

`copilotkit-config-directive.spec.ts` (5 tests):
- forwards a config object to `CopilotKit.updateRuntime` on init
- forwards individual inputs to `CopilotKit.updateRuntime`
- re-applies config when inputs change
- does not call `updateRuntime` when no inputs are set
- config object overrides individual inputs

`copilotkit-agent-directive.spec.ts` (5 tests):
- registers a single agent by id and unregisters on destroy
- registers a record of agents and unregisters on destroy
- does nothing when single agent is provided without an `agentId`
- re-registers when the agent input changes
- preserves pre-existing agents on the `CopilotKit` service when adding new ones

## Verification

- `nx run @copilotkitnext/angular:test` — 57 passed (10 new)
- `nx run @copilotkitnext/angular:check-types` — zero errors in Angular `src/`. Pre-existing failures in `@copilotkit/core` are unchanged from main (per task spec).
- `nx run @copilotkitnext/angular:build` — passed.

## Test plan

- [ ] CI passes
- [ ] Manual smoke: import `CopilotKitConfigDirective` from `@copilotkitnext/angular` and bind to a host element with `[copilotkitConfig]="{ runtimeUrl: '...' }"`; confirm runtime URL reflected in `CopilotKit` service
- [ ] Manual smoke: import `CopilotKitAgentDirective` and confirm an agent registered via the directive is reachable through `injectAgent(...)` in descendants

https://claude.ai/code/session_01B1zJ4kMRgLuN1r5T3iiGbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1zJ4kMRgLuN1r5T3iiGbZ)_