### PR TITLE
feat(docs): scope sidebar to /learn with header + Overview landing

### DIFF
--- a/docs/components/layout/conditional-sidebar.tsx
+++ b/docs/components/layout/conditional-sidebar.tsx
@@ -12,6 +12,7 @@ import { useMemo } from "react";
 import VersionSelector, {
   getVersionFromPathname,
 } from "@/components/ui/reference-sidebar/version-selector";
+import LearnHeader from "@/components/ui/learn-sidebar/learn-header";
 
 interface ConditionalSidebarProps {
   pageTree: DocsLayoutProps["tree"];
@@ -114,7 +115,13 @@ export default function ConditionalSidebar({
   }
 
   if (isLearnRoute && learnPageTree) {
-    return <Sidebar pageTree={learnPageTree} showIntegrationSelector={false} />;
+    return (
+      <Sidebar
+        pageTree={learnPageTree}
+        showIntegrationSelector={false}
+        headerSlot={<LearnHeader />}
+      />
+    );
   }
 
   if (isReferenceRoute && referencePageTree) {

--- a/docs/components/layout/sidebar.tsx
+++ b/docs/components/layout/sidebar.tsx
@@ -74,9 +74,8 @@ const Sidebar = ({
         {headerSlot && <div className="pr-2">{headerSlot}</div>}
 
         <ul
-          className={`flex overflow-y-auto flex-col pr-1 max-h-full custom-scrollbar ${!showIntegrationSelector && !headerSlot ? "pt-6" : ""}`}
+          className={`flex overflow-y-auto flex-col pr-1 max-h-full custom-scrollbar`}
         >
-          <li className="w-full h-6" />
           {pages.map((page, index) => {
             const nodeType = isIntegrationFolder(page as Node)
               ? "integrationLink"

--- a/docs/components/ui/learn-sidebar/learn-header.tsx
+++ b/docs/components/ui/learn-sidebar/learn-header.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { BookOpenIcon } from "lucide-react";
+
+const LearnHeader = () => {
+  return (
+    <div className="flex justify-between items-center p-2 mt-3 mb-3 w-full h-12 rounded-lg border bg-[#BEC2FF33] dark:bg-[#7076D533] border-[#7076D5] dark:border-[#BEC2FF] [box-shadow:0px_17px_12px_-10px_rgba(112,118,213,0.3)]">
+      <div className="flex gap-2 items-center">
+        <div className="flex justify-center items-center w-8 h-8 shrink-0 rounded-md bg-[#BEC2FF] dark:bg-[#7076D5]">
+          <BookOpenIcon className="w-4 h-4 text-[#0C1112] dark:text-white" />
+        </div>
+        <span className="text-sm font-medium text-foreground">Learn</span>
+      </div>
+    </div>
+  );
+};
+
+export default LearnHeader;

--- a/docs/content/docs/learn/index.mdx
+++ b/docs/content/docs/learn/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Learn
+title: Overview
 description: "Understand how CopilotKit works — architecture, protocols, generative UI concepts, and the design decisions behind the platform."
 icon: "lucide/BookOpen"
 doc_type: explanation

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -4,6 +4,7 @@
   "pages": [
     "...(root)",
     "reference",
+    "learn",
     "---Integrations---",
     "...integrations",
     "a2a",


### PR DESCRIPTION
## What does this PR do?

Makes `/learn` behave like `/reference` in the docs site: when a user is under `/learn`, the framework picker disappears and the sidebar shows only learn content.

### Changes

- **Add `learn` to root `meta.json`** — the learn folder was missing from the root navigation, so `ConditionalSidebar` couldn't find it in the page tree and was falling through to the default sidebar (with the framework picker still visible). Adding it to the pages list mirrors how `reference` is wired up.
- **New `LearnHeader` component** — static header with a book icon and "Learn" label, styled to match the Reference version selector. Wired in via `Sidebar`'s existing `headerSlot` prop on `/learn` routes.
- **Rename learn index title to "Overview"** — the landing page that shows when you click the Learn tab now reads "Overview" in both the page heading and the sidebar.
- **Drop the redundant `h-6` spacer in `Sidebar`** — every header component (`IntegrationSelector`, `VersionSelector`, `LearnHeader`) already has its own `mb-3`. The extra spacer was producing a 24px phantom gap on `/learn` while collapsing to 0 on `/reference` under flex shrink, so the two sidebars looked inconsistent.

### Verification

Tested locally on the docs dev server:

| Route | Sidebar header | Sidebar contents | Framework picker |
|-------|---------------|------------------|------------------|
| `/`   | Integration selector | Full docs tree | shown |
| `/reference/v2` | API version selector | Reference v2 tree | hidden |
| `/learn` | New "Learn" header | Learn-only tree | hidden |
| `/learn/architecture` | New "Learn" header | Learn-only tree (Architecture active) | hidden |

Spacing between the header and first sidebar item is now equal across `/learn` and `/reference`.

## Related PRs and Issues

- N/A

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)