### PR TITLE
feat(angular): port Interrupt API (useInterrupt parity)

### DIFF
--- a/packages/angular/src/lib/interrupt.spec.ts
+++ b/packages/angular/src/lib/interrupt.spec.ts
@@ -385,6 +385,33 @@ describe("injectInterrupt", () => {
     expect(interrupt.result()).toBe("handled:second");
   });
 
+  it("discards async handler result when resolve was called before it settled", async () => {
+    let settleHandler: ((value: string) => void) | null = null;
+    const { interrupt } = setUp<string, string>({
+      handler: () =>
+        new Promise<string>((r) => {
+          settleHandler = r;
+        }),
+    });
+
+    agent.emitCustomEvent("on_interrupt", "pending");
+    agent.emitRunFinalized();
+    expect(interrupt.event()?.value).toBe("pending");
+    expect(interrupt.result()).toBeNull();
+
+    // User resolves before the handler promise settles.
+    interrupt.resolve("user-response");
+    expect(interrupt.event()).toBeNull();
+    expect(interrupt.result()).toBeNull();
+
+    // Now the handler's promise settles — its result should be discarded.
+    settleHandler?.("late-handler-result");
+    await flushMicrotasks();
+
+    expect(interrupt.result()).toBeNull();
+    expect(interrupt.event()).toBeNull();
+  });
+
   it("resolve passes the interrupt's value (not the response) as interruptEvent", () => {
     const payload = { question: "approve?", id: 42 };
     const { interrupt } = setUp<typeof payload>();

--- a/packages/angular/src/lib/interrupt.spec.ts
+++ b/packages/angular/src/lib/interrupt.spec.ts
@@ -1,0 +1,407 @@
+import { Component, signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AbstractAgent,
+  type AgentSubscriber,
+  type BaseEvent,
+  type RunAgentInput,
+} from "@ag-ui/client";
+import { Observable } from "rxjs";
+import {
+  CopilotKitCore,
+  CopilotKitCoreRuntimeConnectionStatus,
+} from "@copilotkit/core";
+import { CopilotKit } from "./copilotkit";
+import {
+  injectInterrupt,
+  type InterruptEvent,
+  type InterruptStoreSignal,
+} from "./interrupt";
+
+const DUMMY_RUN_INPUT: RunAgentInput = {
+  threadId: "",
+  runId: "",
+  state: {},
+  messages: [],
+  tools: [],
+  context: [],
+  forwardedProps: {},
+};
+
+class MockAgent extends AbstractAgent {
+  unsubscribeCount = 0;
+
+  constructor(id: string) {
+    super();
+    this.agentId = id;
+  }
+
+  run(_input: RunAgentInput): Observable<BaseEvent> {
+    return new Observable();
+  }
+
+  override subscribe(subscriber: AgentSubscriber) {
+    const sub = super.subscribe(subscriber);
+    return {
+      unsubscribe: () => {
+        sub.unsubscribe();
+        this.unsubscribeCount += 1;
+      },
+    };
+  }
+
+  emitCustomEvent(name: string, value: unknown) {
+    for (const s of this.subscribers) {
+      s.onCustomEvent?.({
+        // @ts-expect-error CustomEvent shape varies between versions
+        event: { name, value },
+        messages: this.messages,
+        state: this.state,
+        agent: this,
+      });
+    }
+  }
+
+  emitRunStartedEvent() {
+    for (const s of this.subscribers) {
+      s.onRunStartedEvent?.({
+        // @ts-expect-error event shape minimal
+        event: {},
+        messages: this.messages,
+        state: this.state,
+        agent: this,
+        input: DUMMY_RUN_INPUT,
+      });
+    }
+  }
+
+  emitRunFinalized() {
+    for (const s of this.subscribers) {
+      s.onRunFinalized?.({
+        messages: this.messages,
+        state: this.state,
+        agent: this,
+        input: DUMMY_RUN_INPUT,
+      });
+    }
+  }
+
+  emitRunFailed() {
+    for (const s of this.subscribers) {
+      s.onRunFailed?.({
+        messages: this.messages,
+        state: this.state,
+        agent: this,
+        input: DUMMY_RUN_INPUT,
+        error: new Error("run failed"),
+      });
+    }
+  }
+}
+
+class CopilotKitStub {
+  readonly #agents = signal<Record<string, AbstractAgent>>({});
+  readonly #runtimeConnectionStatus =
+    signal<CopilotKitCoreRuntimeConnectionStatus>(
+      CopilotKitCoreRuntimeConnectionStatus.Disconnected,
+    );
+  readonly #runtimeUrl = signal<string | undefined>(undefined);
+  readonly #runtimeTransport = signal<"rest" | "single" | "auto">("auto");
+  readonly #headers = signal<Record<string, string>>({});
+
+  getAgent = vi.fn((id: string) => this.#agents()[id]);
+  agents = this.#agents.asReadonly();
+  runtimeConnectionStatus = this.#runtimeConnectionStatus.asReadonly();
+  runtimeUrl = this.#runtimeUrl.asReadonly();
+  runtimeTransport = this.#runtimeTransport.asReadonly();
+  headers = this.#headers.asReadonly();
+
+  // Real CopilotKitCore so subscribeToAgentWithOptions works for AgentStore.
+  #coreInstance = new CopilotKitCore({});
+  runAgentMock = vi.fn(async () => {});
+  core = {
+    runtimeUrl: undefined as string | undefined,
+    runtimeTransport: "auto" as "rest" | "single" | "auto",
+    runtimeConnectionStatus:
+      CopilotKitCoreRuntimeConnectionStatus.Disconnected,
+    headers: {} as Record<string, string>,
+    subscribeToAgentWithOptions:
+      this.#coreInstance.subscribeToAgentWithOptions.bind(this.#coreInstance),
+    runAgent: this.runAgentMock,
+  };
+
+  setAgents(map: Record<string, AbstractAgent>) {
+    this.#agents.set(map);
+    this.core = { ...this.core, ...({ agents: map } as object) };
+  }
+}
+
+interface HarnessOpts<TValue = unknown, TResult = unknown> {
+  agentId?: string;
+  enabled?: (event: InterruptEvent<TValue>) => boolean;
+  handler?: (props: {
+    event: InterruptEvent<TValue>;
+    resolve: (response: unknown) => void;
+  }) => TResult | PromiseLike<TResult>;
+}
+
+function createHost<TValue = unknown, TResult = unknown>(
+  opts: HarnessOpts<TValue, TResult> = {},
+) {
+  @Component({ standalone: true, template: "" })
+  class Host {
+    interrupt = injectInterrupt<TValue, TResult>({
+      agentId: opts.agentId,
+      enabled: opts.enabled,
+      handler: opts.handler,
+    });
+  }
+  return Host;
+}
+
+function flushMicrotasks() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe("injectInterrupt", () => {
+  let copilotKitStub: CopilotKitStub;
+  let agent: MockAgent;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    copilotKitStub = new CopilotKitStub();
+    agent = new MockAgent("agent-1");
+    copilotKitStub.setAgents({ "agent-1": agent });
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: CopilotKit, useValue: copilotKitStub }],
+    });
+  });
+
+  function setUp<TValue = unknown, TResult = unknown>(
+    opts: HarnessOpts<TValue, TResult> = {},
+  ) {
+    const Host = createHost<TValue, TResult>({
+      agentId: "agent-1",
+      ...opts,
+    });
+    const fixture = TestBed.createComponent(Host);
+    fixture.detectChanges();
+    const interrupt = fixture.componentInstance
+      .interrupt as InterruptStoreSignal<TValue, TResult>;
+    return { fixture, interrupt };
+  }
+
+  it("subscribes to the agent and tears down on destroy", () => {
+    const { fixture } = setUp();
+    // injectInterrupt + the underlying AgentStore each add a subscriber.
+    const initial = agent.subscribers.length;
+    expect(initial).toBeGreaterThanOrEqual(1);
+    fixture.destroy();
+    // Both subscriptions should be released — the interrupt subscription
+    // contributes at least one to unsubscribeCount.
+    expect(agent.unsubscribeCount).toBeGreaterThanOrEqual(1);
+    expect(agent.subscribers.length).toBeLessThan(initial);
+  });
+
+  it("ignores non-interrupt custom events", () => {
+    const { interrupt } = setUp();
+    agent.emitCustomEvent("not_interrupt", "x");
+    agent.emitRunFinalized();
+    expect(interrupt.event()).toBeNull();
+    expect(interrupt.isPending()).toBe(false);
+  });
+
+  it("renders interrupt only after run finalized", () => {
+    const { interrupt } = setUp();
+    agent.emitCustomEvent("on_interrupt", "pending");
+    expect(interrupt.event()).toBeNull();
+    agent.emitRunFinalized();
+    expect(interrupt.event()).toEqual({
+      name: "on_interrupt",
+      value: "pending",
+    });
+    expect(interrupt.isPending()).toBe(true);
+  });
+
+  it("clears pending interrupt on run start", () => {
+    const { interrupt } = setUp();
+    agent.emitCustomEvent("on_interrupt", "first");
+    agent.emitRunFinalized();
+    expect(interrupt.event()).not.toBeNull();
+    agent.emitRunStartedEvent();
+    expect(interrupt.event()).toBeNull();
+  });
+
+  it("resolve clears state and resumes agent with response payload", () => {
+    const { interrupt } = setUp();
+    agent.emitCustomEvent("on_interrupt", "approve-me");
+    agent.emitRunFinalized();
+    expect(interrupt.event()).not.toBeNull();
+
+    interrupt.resolve({ approved: true, value: "approve-me" });
+
+    expect(interrupt.event()).toBeNull();
+    expect(copilotKitStub.runAgentMock).toHaveBeenCalledTimes(1);
+    expect(copilotKitStub.runAgentMock).toHaveBeenCalledWith({
+      agent,
+      forwardedProps: {
+        command: {
+          resume: { approved: true, value: "approve-me" },
+          interruptEvent: "approve-me",
+        },
+      },
+    });
+  });
+
+  it("resolve is a no-op when no interrupt is pending", () => {
+    const { interrupt } = setUp();
+    interrupt.resolve("noop");
+    expect(copilotKitStub.runAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("does not expose interrupt and does not run handler when enabled returns false", () => {
+    const handler = vi.fn(() => "should-not-run");
+    const { interrupt } = setUp({
+      enabled: () => false,
+      handler,
+    });
+
+    agent.emitCustomEvent("on_interrupt", "blocked");
+    agent.emitRunFinalized();
+
+    expect(interrupt.event()).toBeNull();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("exposes interrupt with null result when no handler is provided", () => {
+    const { interrupt } = setUp();
+    agent.emitCustomEvent("on_interrupt", "no-handler");
+    agent.emitRunFinalized();
+    expect(interrupt.event()).toEqual({
+      name: "on_interrupt",
+      value: "no-handler",
+    });
+    expect(interrupt.result()).toBeNull();
+  });
+
+  it("uses sync handler result", () => {
+    const { interrupt } = setUp({
+      handler: ({ event }) => `handled:${String(event.value)}`,
+    });
+    agent.emitCustomEvent("on_interrupt", "sync");
+    agent.emitRunFinalized();
+    expect(interrupt.result()).toBe("handled:sync");
+  });
+
+  it("uses async handler resolved value", async () => {
+    const { interrupt } = setUp({
+      handler: ({ event }) => Promise.resolve(`async:${String(event.value)}`),
+    });
+    agent.emitCustomEvent("on_interrupt", "value");
+    agent.emitRunFinalized();
+
+    // While pending, result should be null.
+    expect(interrupt.result()).toBeNull();
+
+    await flushMicrotasks();
+    expect(interrupt.result()).toBe("async:value");
+  });
+
+  it("falls back to null result when async handler rejects", async () => {
+    const { interrupt } = setUp({
+      handler: () => Promise.reject(new Error("boom")),
+    });
+    agent.emitCustomEvent("on_interrupt", "reject");
+    agent.emitRunFinalized();
+
+    await flushMicrotasks();
+    expect(interrupt.result()).toBeNull();
+    // Event is still pending; only result is null.
+    expect(interrupt.event()?.value).toBe("reject");
+  });
+
+  it("accepts thenable handler results (non-native Promise)", async () => {
+    const thenable = {
+      then(resolve: (value: string) => void) {
+        resolve("thenable-ok");
+        return { catch: () => undefined };
+      },
+    };
+    const { interrupt } = setUp({
+      handler: () => thenable as unknown as PromiseLike<string>,
+    });
+    agent.emitCustomEvent("on_interrupt", "thenable");
+    agent.emitRunFinalized();
+
+    await flushMicrotasks();
+    expect(interrupt.result()).toBe("thenable-ok");
+  });
+
+  it("discards local interrupt when run fails before finalize", () => {
+    const { interrupt } = setUp();
+    agent.emitCustomEvent("on_interrupt", "lost");
+    agent.emitRunFailed();
+    agent.emitRunFinalized();
+    expect(interrupt.event()).toBeNull();
+  });
+
+  it("keeps the latest interrupt when multiple arrive within one run", () => {
+    const { interrupt } = setUp();
+    agent.emitCustomEvent("on_interrupt", "first");
+    agent.emitCustomEvent("on_interrupt", "second");
+    agent.emitRunFinalized();
+    expect(interrupt.event()?.value).toBe("second");
+  });
+
+  it("ignores stale handler resolutions when a new interrupt arrives", async () => {
+    let resolveFirst: ((value: string) => void) | null = null;
+    const { interrupt } = setUp({
+      handler: ({ event }) => {
+        if (event.value === "first") {
+          return new Promise<string>((r) => {
+            resolveFirst = r;
+          });
+        }
+        return Promise.resolve(`handled:${String(event.value)}`);
+      },
+    });
+
+    agent.emitCustomEvent("on_interrupt", "first");
+    agent.emitRunFinalized();
+    // First handler is in-flight; result should be null.
+    expect(interrupt.result()).toBeNull();
+
+    // A new run starts and finalizes with a different interrupt.
+    agent.emitRunStartedEvent();
+    agent.emitCustomEvent("on_interrupt", "second");
+    agent.emitRunFinalized();
+
+    // Resolve the first handler late — should be ignored.
+    resolveFirst?.("late-first");
+    await flushMicrotasks();
+
+    expect(interrupt.event()?.value).toBe("second");
+    expect(interrupt.result()).toBe("handled:second");
+  });
+
+  it("resolve passes the interrupt's value (not the response) as interruptEvent", () => {
+    const payload = { question: "approve?", id: 42 };
+    const { interrupt } = setUp<typeof payload>();
+    agent.emitCustomEvent("on_interrupt", payload);
+    agent.emitRunFinalized();
+
+    interrupt.resolve("user-says-yes");
+
+    expect(copilotKitStub.runAgentMock).toHaveBeenCalledWith({
+      agent,
+      forwardedProps: {
+        command: {
+          resume: "user-says-yes",
+          interruptEvent: payload,
+        },
+      },
+    });
+  });
+});

--- a/packages/angular/src/lib/interrupt.spec.ts
+++ b/packages/angular/src/lib/interrupt.spec.ts
@@ -123,8 +123,7 @@ class CopilotKitStub {
   core = {
     runtimeUrl: undefined as string | undefined,
     runtimeTransport: "auto" as "rest" | "single" | "auto",
-    runtimeConnectionStatus:
-      CopilotKitCoreRuntimeConnectionStatus.Disconnected,
+    runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Disconnected,
     headers: {} as Record<string, string>,
     subscribeToAgentWithOptions:
       this.#coreInstance.subscribeToAgentWithOptions.bind(this.#coreInstance),

--- a/packages/angular/src/lib/interrupt.ts
+++ b/packages/angular/src/lib/interrupt.ts
@@ -126,9 +126,7 @@ export class CopilotkitInterruptFactory {
     const agentStoreSignal: Signal<AgentStore> = runInInjectionContext(
       injector,
       () =>
-        injectAgentStore(
-          computed(() => input.agentId() ?? DEFAULT_AGENT_ID),
-        ),
+        injectAgentStore(computed(() => input.agentId() ?? DEFAULT_AGENT_ID)),
     );
 
     // Local buffer that mirrors the React hook: a custom `on_interrupt`

--- a/packages/angular/src/lib/interrupt.ts
+++ b/packages/angular/src/lib/interrupt.ts
@@ -1,0 +1,338 @@
+import {
+  DestroyRef,
+  Injectable,
+  Injector,
+  Signal,
+  computed,
+  effect,
+  inject,
+  runInInjectionContext,
+  signal,
+} from "@angular/core";
+import type { AbstractAgent } from "@ag-ui/client";
+import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
+import { CopilotKit } from "./copilotkit";
+import { injectAgentStore, type AgentStore } from "./agent";
+
+/**
+ * Custom event name emitted by the agent runtime when an interrupt occurs.
+ * Mirrors `INTERRUPT_EVENT_NAME` in React's `useInterrupt`.
+ */
+const INTERRUPT_EVENT_NAME = "on_interrupt";
+
+/**
+ * Shape of an interrupt payload as exposed to consumer code.
+ *
+ * `value` is whatever the agent passed alongside `on_interrupt`. Type-narrow
+ * it in your `enabled`/`handler` callbacks based on your agent's contract.
+ */
+export interface InterruptEvent<TValue = unknown> {
+  name: string;
+  value: TValue;
+}
+
+/**
+ * Props passed to the optional `handler` function.
+ */
+export interface InterruptHandlerProps<TValue = unknown> {
+  event: InterruptEvent<TValue>;
+  resolve: (response: unknown) => void;
+}
+
+export type InterruptHandlerFn<TValue = unknown, TResult = unknown> = (
+  props: InterruptHandlerProps<TValue>,
+) => TResult | PromiseLike<TResult>;
+
+export type InterruptEnabledFn<TValue = unknown> = (
+  event: InterruptEvent<TValue>,
+) => boolean;
+
+/**
+ * Configuration for {@link injectInterrupt}.
+ */
+export interface InjectInterruptInput<TValue = unknown, TResult = unknown> {
+  /** Optional agent id. Defaults to the configured default agent. */
+  agentId?: string | Signal<string | undefined>;
+  /**
+   * Optional predicate to filter which interrupts should be handled by this
+   * store. Return `false` to ignore an interrupt — `event()` stays `null`.
+   */
+  enabled?: InterruptEnabledFn<TValue>;
+  /**
+   * Optional pre-render handler invoked when an interrupt is finalized. Its
+   * resolved value is exposed via `result()`. Sync, async, and thenable return
+   * values are all accepted; rejection / throw falls back to `null`.
+   */
+  handler?: InterruptHandlerFn<TValue, TResult>;
+}
+
+/**
+ * Signal-based store returned by {@link injectInterrupt}.
+ */
+export interface InterruptStoreSignal<TValue = unknown, TResult = unknown> {
+  /**
+   * The currently active interrupt, or `null` when there is no pending
+   * interrupt (also `null` while the run is still streaming and after the
+   * `enabled` predicate rejects an interrupt).
+   */
+  event: Signal<InterruptEvent<TValue> | null>;
+  /**
+   * Result of the optional `handler` function. `null` when no handler was
+   * provided, when the handler is still resolving an async value, or when
+   * the handler threw / rejected.
+   */
+  result: Signal<TResult | null>;
+  /** Convenience: `true` when `event()` is non-null (i.e. UI should render). */
+  isPending: Signal<boolean>;
+  /**
+   * Resume the agent run with the given response. Clears the local state and
+   * dispatches `core.runAgent({ agent, forwardedProps: { command: { resume,
+   * interruptEvent } } })` so the runtime can continue from the interrupt.
+   *
+   * Safe to call when no interrupt is pending — it becomes a no-op.
+   */
+  resolve: (response: unknown) => void;
+}
+
+function isPromiseLike<TValue>(
+  value: TValue | PromiseLike<TValue>,
+): value is PromiseLike<TValue> {
+  return (
+    (typeof value === "object" || typeof value === "function") &&
+    value !== null &&
+    typeof Reflect.get(value as object, "then") === "function"
+  );
+}
+
+@Injectable({ providedIn: "root" })
+export class CopilotkitInterruptFactory {
+  readonly #copilotkit = inject(CopilotKit);
+
+  createInterruptStoreSignal<TValue, TResult>(
+    input: {
+      agentId: Signal<string | undefined>;
+      enabled?: InterruptEnabledFn<TValue>;
+      handler?: InterruptHandlerFn<TValue, TResult>;
+    },
+    injector: Injector,
+    destroyRef: DestroyRef,
+  ): InterruptStoreSignal<TValue, TResult> {
+    const copilotkit = this.#copilotkit;
+
+    // Build (and tear down) the AgentStore inside an injection context so
+    // injectAgentStore can pick up DestroyRef / Injector. The reactive
+    // computed inside AgentStore reads the agentId signal, so re-rendering
+    // with a different agent id transparently re-targets subscriptions.
+    const agentStoreSignal: Signal<AgentStore> = runInInjectionContext(
+      injector,
+      () =>
+        injectAgentStore(
+          computed(() => input.agentId() ?? DEFAULT_AGENT_ID),
+        ),
+    );
+
+    // Local buffer that mirrors the React hook: a custom `on_interrupt`
+    // event is *staged* until the run finalizes — only then do we expose it.
+    type Buffer = InterruptEvent<TValue> | null;
+    let pendingBuffer: Buffer = null;
+
+    const eventState = signal<InterruptEvent<TValue> | null>(null);
+    // We reset per-event when the staged interrupt changes. Initialised to
+    // null so consumers see a stable shape until the first run finalizes.
+    const resultState = signal<TResult | null>(null);
+    let resultRunToken = 0;
+
+    let currentAgent: AbstractAgent | null = null;
+    let currentSubscription: { unsubscribe: () => void } | null = null;
+
+    const resolve = (response: unknown): void => {
+      const interruptEvent = eventState();
+      if (!interruptEvent) return;
+      eventState.set(null);
+      resultState.set(null);
+      pendingBuffer = null;
+      // We deliberately ignore the runAgent promise: callers that want to
+      // observe completion should subscribe to AgentStore.isRunning. This
+      // matches React's `useInterrupt` which fires-and-forgets.
+      const agent = currentAgent;
+      if (!agent) return;
+      void copilotkit.core.runAgent({
+        agent,
+        forwardedProps: {
+          command: {
+            resume: response,
+            interruptEvent: interruptEvent.value,
+          },
+        },
+      });
+    };
+
+    const subscribeAgent = (agent: AbstractAgent): void => {
+      currentAgent = agent;
+      currentSubscription = agent.subscribe({
+        onCustomEvent: ({ event }) => {
+          if (event.name === INTERRUPT_EVENT_NAME) {
+            pendingBuffer = {
+              name: event.name,
+              value: event.value as TValue,
+            };
+          }
+        },
+        onRunStartedEvent: () => {
+          pendingBuffer = null;
+          eventState.set(null);
+          resultState.set(null);
+        },
+        onRunFinalized: () => {
+          if (!pendingBuffer) return;
+          const candidate = pendingBuffer;
+          pendingBuffer = null;
+          if (input.enabled && !input.enabled(candidate)) {
+            // Filter rejected — discard. Do not expose; do not run handler.
+            eventState.set(null);
+            resultState.set(null);
+            return;
+          }
+          eventState.set(candidate);
+          runHandler(candidate);
+        },
+        onRunFailed: () => {
+          pendingBuffer = null;
+        },
+      });
+    };
+
+    const runHandler = (interruptEvent: InterruptEvent<TValue>): void => {
+      const handler = input.handler;
+      if (!handler) {
+        resultState.set(null);
+        return;
+      }
+      const token = ++resultRunToken;
+      const handlerResult = handler({
+        event: interruptEvent,
+        resolve,
+      });
+      if (isPromiseLike(handlerResult)) {
+        Promise.resolve(handlerResult)
+          .then((resolved) => {
+            // Discard if a newer interrupt has arrived OR the user resolved
+            // before the handler settled — token is bumped on each new run
+            // and the eventState is cleared on resolve.
+            if (token !== resultRunToken) return;
+            resultState.set((resolved ?? null) as TResult | null);
+          })
+          .catch(() => {
+            if (token !== resultRunToken) return;
+            resultState.set(null);
+          });
+        // While the handler is in-flight, expose null per the React
+        // contract. Consumers can `result() ?? fallback` if they prefer.
+        resultState.set(null);
+      } else {
+        resultState.set((handlerResult ?? null) as TResult | null);
+      }
+    };
+
+    const teardownSubscription = (): void => {
+      currentSubscription?.unsubscribe();
+      currentSubscription = null;
+      currentAgent = null;
+      pendingBuffer = null;
+    };
+
+    // Re-subscribe whenever the AgentStore signal changes (which happens when
+    // the agent id signal changes or the runtime resolves a real agent).
+    const agentEffect = runInInjectionContext(injector, () =>
+      effect(() => {
+        const agentStore = agentStoreSignal();
+        const nextAgent = agentStore.agent;
+        if (nextAgent === currentAgent) return;
+        teardownSubscription();
+        eventState.set(null);
+        resultState.set(null);
+        subscribeAgent(nextAgent);
+      }),
+    );
+
+    destroyRef.onDestroy(() => {
+      agentEffect.destroy();
+      teardownSubscription();
+    });
+
+    const isPending = computed(() => eventState() !== null);
+
+    return {
+      event: eventState.asReadonly(),
+      result: resultState.asReadonly(),
+      isPending,
+      resolve,
+    };
+  }
+}
+
+/**
+ * Angular equivalent of React's `useInterrupt`.
+ *
+ * Listens for `on_interrupt` custom events on the configured agent, buffers
+ * the latest payload until the run finalizes, optionally filters via
+ * `enabled`, optionally pre-processes via `handler`, and surfaces a
+ * signal-based store that consumers render from their own templates.
+ *
+ * Unlike the React variant, this does not auto-publish a rendered element
+ * into `<CopilotChat>` — Angular templates render reactively from the
+ * exposed signals, so consumers wire up their own UI with `@if` /
+ * structural directives. Call `resolve(response)` from your UI handlers
+ * to resume the agent run with the user's input.
+ *
+ * Must be invoked in an Angular DI / injection context.
+ *
+ * @example
+ * ```ts
+ * @Component({
+ *   template: `
+ *     @if (interrupt.event(); as event) {
+ *       <div>
+ *         <p>{{ event.value.question }}</p>
+ *         <button (click)="approve(event)">Approve</button>
+ *         <button (click)="reject(event)">Reject</button>
+ *       </div>
+ *     }
+ *   `,
+ * })
+ * export class InterruptUi {
+ *   readonly interrupt = injectInterrupt<{ question: string }>();
+ *
+ *   approve(event: InterruptEvent<{ question: string }>) {
+ *     this.interrupt.resolve({ approved: true });
+ *   }
+ *
+ *   reject(event: InterruptEvent<{ question: string }>) {
+ *     this.interrupt.resolve({ approved: false });
+ *   }
+ * }
+ * ```
+ */
+export function injectInterrupt<TValue = unknown, TResult = unknown>(
+  input: InjectInterruptInput<TValue, TResult> = {},
+): InterruptStoreSignal<TValue, TResult> {
+  const factory = inject(CopilotkitInterruptFactory);
+  const injector = inject(Injector);
+  const destroyRef = inject(DestroyRef);
+
+  const agentIdInput = input.agentId;
+  const agentIdSignal: Signal<string | undefined> =
+    typeof agentIdInput === "function"
+      ? (agentIdInput as Signal<string | undefined>)
+      : computed(() => agentIdInput);
+
+  return factory.createInterruptStoreSignal<TValue, TResult>(
+    {
+      agentId: agentIdSignal,
+      enabled: input.enabled,
+      handler: input.handler,
+    },
+    injector,
+    destroyRef,
+  );
+}

--- a/packages/angular/src/lib/interrupt.ts
+++ b/packages/angular/src/lib/interrupt.ts
@@ -146,6 +146,10 @@ export class CopilotkitInterruptFactory {
     const resolve = (response: unknown): void => {
       const interruptEvent = eventState();
       if (!interruptEvent) return;
+      // Bump the token so any in-flight handler promise that settles after
+      // this point is discarded — otherwise its `.then` callback would
+      // repopulate `resultState` with a stale value the user just cleared.
+      resultRunToken++;
       eventState.set(null);
       resultState.set(null);
       pendingBuffer = null;

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -9,6 +9,7 @@ export * from "./lib/scroll-position";
 export * from "./lib/resize-observer";
 export * from "./lib/utils";
 export * from "./lib/agent-context";
+export * from "./lib/interrupt";
 
 export * from "./lib/slots";
 


### PR DESCRIPTION
## Summary

Ports React's `useInterrupt` (`packages/react-core/src/v2/hooks/use-interrupt.tsx`) to Angular as `injectInterrupt()`.

## Contract

Listens for `on_interrupt` custom events on the active agent, buffers the latest payload until the run finalizes, optionally filters via `enabled`, optionally pre-processes via `handler`, and surfaces a signal-based store. Calling `resolve(response)` resumes the agent run via `core.runAgent({ agent, forwardedProps: { command: { resume, interruptEvent } } })`.

Lifecycle mirrors React 1:1:
- Custom `on_interrupt` events are buffered locally and only exposed on `onRunFinalized`.
- `onRunStartedEvent` clears state.
- `onRunFailed` discards the buffer (no exposure).
- Sync / async / thenable handlers all accepted; rejection or supersession by a newer interrupt falls back to `result=null` via a per-run token.
- `enabled()` predicate filters interrupts before exposure or handler invocation.
- The active agent is resolved through `injectAgentStore`, so the same runtime sync / `agentId` signal semantics apply.

## Signal + service shape

```ts
injectInterrupt<TValue, TResult>({
  agentId?: string | Signal<string | undefined>,
  enabled?: (event: InterruptEvent<TValue>) => boolean,
  handler?: (props) => TResult | PromiseLike<TResult>,
}): InterruptStoreSignal<TValue, TResult>

interface InterruptStoreSignal<TValue, TResult> {
  event: Signal<InterruptEvent<TValue> | null>;
  result: Signal<TResult | null>;
  isPending: Signal<boolean>;
  resolve: (response: unknown) => void;
}
```

Why no `render` / `setInterruptElement`?
- React's `renderInChat: true` mode publishes a `React.ReactElement` into core for `<CopilotChat>` to slot in. That depends on a React-only extension (`CopilotKitCoreReact.setInterruptElement`) that the Angular `CopilotKit` service does not have, and forcing it into Angular would require a template-form directive — explicitly forbidden by the dispatch.
- The idiomatic Angular alternative is to expose pure signals; consumers render via `@if (interrupt.event(); as event) { ... }` in their own templates and call `interrupt.resolve(...)` from `(click)` handlers. Auto-rendering in `<CopilotChat>` (if desired later) is a separate component-level concern.

## Test → contract mapping

`packages/angular/src/lib/interrupt.spec.ts` (16 behavioral tests, all pass):
- subscribe/teardown lifecycle (subscribers added on construction, released on destroy)
- ignores non-`on_interrupt` custom events
- gates exposure on `onRunFinalized`
- clears on `onRunStartedEvent`
- `resolve()` clears state and dispatches `core.runAgent` with the correct `forwardedProps.command.{resume, interruptEvent}` payload
- `resolve()` is a no-op when no interrupt is pending
- `enabled() === false` blocks exposure AND handler invocation
- `null` result when no handler provided
- sync handler result reflected in `result()`
- async handler resolved value reflected in `result()` after microtask flush; null while pending
- async rejection → `result()=null`, `event()` still pending
- thenable (non-Promise) handler return values supported
- run-failed before finalize discards buffered interrupt
- multiple interrupts in one run keep the latest
- stale handler resolution after a newer interrupt is ignored (per-run token)
- `interruptEvent` in resume payload is the original `event.value` (not the user's response)

## Test plan

- [x] `nx run @copilotkitnext/angular:test` — 63/63 passing (16 new)
- [x] `nx run @copilotkitnext/angular:check-types` — zero errors in the new files; only pre-existing `@copilotkit/core` failures remain (noted in dispatch as pre-existing on main)
- [x] `nx run @copilotkitnext/angular:build` — green

## Out of scope

- A UI component that auto-renders interrupts inside `<CopilotChat>` (separate work — would need a non-directive Angular slot mechanism).
- Refactoring existing services or any non-Angular packages.

https://claude.ai/code/session_01B1zJ4kMRgLuN1r5T3iiGbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1zJ4kMRgLuN1r5T3iiGbZ)_