### PR TITLE
feat(angular): port custom + activity message renderer registry

### DIFF
--- a/packages/angular/src/lib/config.ts
+++ b/packages/angular/src/lib/config.ts
@@ -6,6 +6,10 @@ import {
   HumanInTheLoopConfig,
   RenderToolCallConfig,
 } from "./tools";
+import type {
+  ActivityMessageRendererConfig,
+  CustomMessageRendererConfig,
+} from "./render-messages";
 
 export interface CopilotKitConfig {
   runtimeUrl?: string;
@@ -18,6 +22,8 @@ export interface CopilotKitConfig {
   renderToolCalls?: RenderToolCallConfig[];
   frontendTools?: FrontendToolConfig[];
   humanInTheLoop?: HumanInTheLoopConfig[];
+  renderActivityMessages?: ActivityMessageRendererConfig[];
+  renderCustomMessages?: CustomMessageRendererConfig[];
 }
 
 const COPILOT_CLOUD_PUBLIC_API_KEY_HEADER = "X-CopilotCloud-Public-Api-Key";

--- a/packages/angular/src/lib/copilotkit.ts
+++ b/packages/angular/src/lib/copilotkit.ts
@@ -265,10 +265,7 @@ export class CopilotKit {
   }
 
   /** Remove a previously-associated thread clone, if any. */
-  clearThreadClone(
-    registryAgent: AbstractAgent,
-    threadId: string,
-  ): void {
+  clearThreadClone(registryAgent: AbstractAgent, threadId: string): void {
     this.#threadClones.get(registryAgent)?.delete(threadId);
   }
 

--- a/packages/angular/src/lib/copilotkit.ts
+++ b/packages/angular/src/lib/copilotkit.ts
@@ -22,6 +22,10 @@ import {
 import { injectCopilotKitConfig } from "./config";
 import { HumanInTheLoop } from "./human-in-the-loop";
 import { ensureLicenseWatermark } from "./license-watermark";
+import type {
+  ActivityMessageRendererConfig,
+  CustomMessageRendererConfig,
+} from "./render-messages";
 
 @Injectable({ providedIn: "root" })
 export class CopilotKit {
@@ -69,6 +73,38 @@ export class CopilotKit {
     this.#clientToolCallRenderConfigs.asReadonly();
   readonly humanInTheLoopToolRenderConfigs: Signal<HumanInTheLoopConfig[]> =
     this.#humanInTheLoopToolRenderConfigs.asReadonly();
+
+  readonly #renderActivityMessageConfigs: WritableSignal<
+    ActivityMessageRendererConfig[]
+  > = signal([]);
+  readonly #renderCustomMessageConfigs: WritableSignal<
+    CustomMessageRendererConfig[]
+  > = signal([]);
+
+  /**
+   * Activity message renderers registered with the registry. Mirrors React's
+   * `copilotkit.renderActivityMessages`.
+   */
+  readonly renderActivityMessageConfigs: Signal<
+    ActivityMessageRendererConfig[]
+  > = this.#renderActivityMessageConfigs.asReadonly();
+
+  /**
+   * Custom message renderers registered with the registry. Mirrors React's
+   * `copilotkit.renderCustomMessages`.
+   */
+  readonly renderCustomMessageConfigs: Signal<CustomMessageRendererConfig[]> =
+    this.#renderCustomMessageConfigs.asReadonly();
+
+  /**
+   * Per-(registry-agent, threadId) clones used by the chat view. Activity and
+   * custom-message renderers prefer the clone over the registry agent so
+   * `runAgent`/`messages` reads stay consistent with the visible chat.
+   */
+  readonly #threadClones = new WeakMap<
+    AbstractAgent,
+    Map<string, AbstractAgent>
+  >();
 
   constructor() {
     ensureLicenseWatermark(this.#config.headers);
@@ -195,6 +231,72 @@ export class CopilotKit {
 
   getAgent(agentId: string): AbstractAgent | undefined {
     return this.core.getAgent(agentId);
+  }
+
+  /**
+   * Look up an existing per-thread agent clone, when one has been associated
+   * with this registry agent + thread. Returns `undefined` when no clone has
+   * been registered. Mirrors `getThreadClone` from React's `use-agent`.
+   */
+  getThreadClone(
+    registryAgent: AbstractAgent | undefined | null,
+    threadId: string | undefined | null,
+  ): AbstractAgent | undefined {
+    if (!registryAgent || !threadId) return undefined;
+    return this.#threadClones.get(registryAgent)?.get(threadId);
+  }
+
+  /**
+   * Associate a per-thread clone with the given registry agent + thread.
+   * Used by chat views that maintain their own per-thread agent so renderer
+   * resolution can hand the matching clone to user components.
+   */
+  setThreadClone(
+    registryAgent: AbstractAgent,
+    threadId: string,
+    clone: AbstractAgent,
+  ): void {
+    let byThread = this.#threadClones.get(registryAgent);
+    if (!byThread) {
+      byThread = new Map();
+      this.#threadClones.set(registryAgent, byThread);
+    }
+    byThread.set(threadId, clone);
+  }
+
+  /** Remove a previously-associated thread clone, if any. */
+  clearThreadClone(
+    registryAgent: AbstractAgent,
+    threadId: string,
+  ): void {
+    this.#threadClones.get(registryAgent)?.delete(threadId);
+  }
+
+  addRenderActivityMessage(
+    config: ActivityMessageRendererConfig<unknown>,
+  ): void {
+    this.#renderActivityMessageConfigs.update((current) => [
+      ...current,
+      config,
+    ]);
+  }
+
+  removeRenderActivityMessage(
+    config: ActivityMessageRendererConfig<unknown>,
+  ): void {
+    this.#renderActivityMessageConfigs.update((current) =>
+      current.filter((c) => c !== config),
+    );
+  }
+
+  addRenderCustomMessage(config: CustomMessageRendererConfig): void {
+    this.#renderCustomMessageConfigs.update((current) => [...current, config]);
+  }
+
+  removeRenderCustomMessage(config: CustomMessageRendererConfig): void {
+    this.#renderCustomMessageConfigs.update((current) =>
+      current.filter((c) => c !== config),
+    );
   }
 
   updateRuntime(options: {

--- a/packages/angular/src/lib/copilotkit.ts
+++ b/packages/angular/src/lib/copilotkit.ts
@@ -136,6 +136,14 @@ export class CopilotKit {
       this.addHumanInTheLoop(humanInTheLoopTool);
     });
 
+    this.#config.renderActivityMessages?.forEach((renderConfig) => {
+      this.addRenderActivityMessage(renderConfig);
+    });
+
+    this.#config.renderCustomMessages?.forEach((renderConfig) => {
+      this.addRenderCustomMessage(renderConfig);
+    });
+
     this.core.subscribe({
       onAgentsChanged: () => {
         this.#agents.set(this.core.agents);

--- a/packages/angular/src/lib/render-messages.spec.ts
+++ b/packages/angular/src/lib/render-messages.spec.ts
@@ -1,0 +1,476 @@
+import { Component, signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+  AbstractAgent,
+  type AgentSubscriber,
+  type BaseEvent,
+  type Message,
+  type RunAgentInput,
+} from "@ag-ui/client";
+import { Observable } from "rxjs";
+import { CopilotKit } from "./copilotkit";
+import {
+  injectRenderActivityMessage,
+  injectRenderCustomMessages,
+  registerRenderActivityMessage,
+  registerRenderCustomMessage,
+  type ActivityMessageRendererConfig,
+  type CustomMessageRendererConfig,
+} from "./render-messages";
+import { provideCopilotKit } from "./config";
+
+const licenseKey = "ck_pub_" + "a".repeat(32);
+
+class MockAgent extends AbstractAgent {
+  constructor(id: string) {
+    super();
+    this.agentId = id;
+  }
+
+  run(_input: RunAgentInput): Observable<BaseEvent> {
+    return new Observable();
+  }
+
+  override subscribe(subscriber: AgentSubscriber) {
+    return super.subscribe(subscriber);
+  }
+
+  setMessages(messages: Message[]) {
+    this.messages = messages;
+  }
+}
+
+@Component({ standalone: true, selector: "test-renderer", template: "" })
+class TestRenderer {}
+
+@Component({ standalone: true, selector: "other-renderer", template: "" })
+class OtherRenderer {}
+
+@Component({ standalone: true, selector: "wildcard-renderer", template: "" })
+class WildcardRenderer {}
+
+describe("render-messages registry", () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it("addRenderActivityMessage / addRenderCustomMessage update CopilotKit signals", () => {
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({ licenseKey })],
+    });
+    const copilotkit = TestBed.inject(CopilotKit);
+
+    const a: ActivityMessageRendererConfig = {
+      activityType: "search",
+      content: z.object({}),
+      component: TestRenderer,
+    };
+    const c: CustomMessageRendererConfig = { component: TestRenderer };
+
+    expect(copilotkit.renderActivityMessageConfigs()).toEqual([]);
+    expect(copilotkit.renderCustomMessageConfigs()).toEqual([]);
+
+    copilotkit.addRenderActivityMessage(a);
+    copilotkit.addRenderCustomMessage(c);
+
+    expect(copilotkit.renderActivityMessageConfigs()).toEqual([a]);
+    expect(copilotkit.renderCustomMessageConfigs()).toEqual([c]);
+
+    copilotkit.removeRenderActivityMessage(a);
+    copilotkit.removeRenderCustomMessage(c);
+
+    expect(copilotkit.renderActivityMessageConfigs()).toEqual([]);
+    expect(copilotkit.renderCustomMessageConfigs()).toEqual([]);
+  });
+
+  it("registerRenderActivityMessage adds the renderer for the host's lifetime", () => {
+    @Component({ standalone: true, template: "" })
+    class Host {
+      constructor() {
+        registerRenderActivityMessage({
+          activityType: "search",
+          content: z.object({}),
+          component: TestRenderer,
+        });
+      }
+    }
+
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({ licenseKey })],
+    });
+
+    const copilotkit = TestBed.inject(CopilotKit);
+    const fixture = TestBed.createComponent(Host);
+    fixture.detectChanges();
+    expect(copilotkit.renderActivityMessageConfigs().length).toBe(1);
+
+    fixture.destroy();
+    expect(copilotkit.renderActivityMessageConfigs().length).toBe(0);
+  });
+
+  it("registerRenderCustomMessage adds the renderer for the host's lifetime", () => {
+    @Component({ standalone: true, template: "" })
+    class Host {
+      constructor() {
+        registerRenderCustomMessage({ component: TestRenderer });
+      }
+    }
+
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({ licenseKey })],
+    });
+
+    const copilotkit = TestBed.inject(CopilotKit);
+    const fixture = TestBed.createComponent(Host);
+    fixture.detectChanges();
+    expect(copilotkit.renderCustomMessageConfigs().length).toBe(1);
+
+    fixture.destroy();
+    expect(copilotkit.renderCustomMessageConfigs().length).toBe(0);
+  });
+});
+
+describe("injectRenderActivityMessage", () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it("returns null when no renderer is registered", () => {
+    @Component({ standalone: true, template: "" })
+    class Host {
+      api = injectRenderActivityMessage();
+    }
+
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({ licenseKey })],
+    });
+    const fixture = TestBed.createComponent(Host);
+    const { renderActivityMessage, findRenderer } =
+      fixture.componentInstance.api;
+
+    expect(findRenderer("search")).toBeNull();
+    expect(
+      renderActivityMessage({
+        id: "m1",
+        activityType: "search",
+        content: {},
+      } as never),
+    ).toBeNull();
+  });
+
+  it("renders content and validates via Standard Schema", () => {
+    @Component({ standalone: true, template: "" })
+    class Host {
+      api = injectRenderActivityMessage();
+    }
+
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({ licenseKey })],
+    });
+    const copilotkit = TestBed.inject(CopilotKit);
+    copilotkit.addRenderActivityMessage({
+      activityType: "search",
+      content: z.object({ status: z.string(), percent: z.number() }),
+      component: TestRenderer,
+    });
+
+    const fixture = TestBed.createComponent(Host);
+    const { renderActivityMessage } = fixture.componentInstance.api;
+
+    const valid = renderActivityMessage({
+      id: "m1",
+      activityType: "search",
+      content: { status: "ok", percent: 30 },
+    } as never);
+
+    expect(valid?.component).toBe(TestRenderer);
+    expect(valid?.inputs.content).toEqual({ status: "ok", percent: 30 });
+    expect(valid?.inputs.activityType).toBe("search");
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const invalid = renderActivityMessage({
+      id: "m2",
+      activityType: "search",
+      content: { status: 1 },
+    } as never);
+    expect(invalid).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("prefers agent-scoped renderer, then global, then wildcard", () => {
+    const agentId = signal<string | undefined>("agent-a");
+
+    @Component({ standalone: true, template: "" })
+    class Host {
+      api = injectRenderActivityMessage({ agentId });
+    }
+
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({ licenseKey })],
+    });
+    const copilotkit = TestBed.inject(CopilotKit);
+
+    copilotkit.addRenderActivityMessage({
+      activityType: "search",
+      content: z.any(),
+      component: OtherRenderer,
+    });
+    copilotkit.addRenderActivityMessage({
+      activityType: "search",
+      agentId: "agent-a",
+      content: z.any(),
+      component: TestRenderer,
+    });
+    copilotkit.addRenderActivityMessage({
+      activityType: "*",
+      content: z.any(),
+      component: WildcardRenderer,
+    });
+
+    const fixture = TestBed.createComponent(Host);
+    const { findRenderer } = fixture.componentInstance.api;
+
+    // 1. Agent-scoped wins
+    expect(findRenderer("search")?.component).toBe(TestRenderer);
+
+    // 2. Different agent — should fall back to global match (no agentId)
+    agentId.set("agent-b");
+    expect(findRenderer("search")?.component).toBe(OtherRenderer);
+
+    // 3. Activity type with no specific match — wildcard fallback
+    expect(findRenderer("unknown")?.component).toBe(WildcardRenderer);
+  });
+
+  it("passes the per-thread clone as `agent` when one is registered", () => {
+    const registryAgent = new MockAgent("agent-a");
+    const cloneAgent = new MockAgent("agent-a");
+
+    @Component({ standalone: true, template: "" })
+    class Host {
+      api = injectRenderActivityMessage({
+        agentId: "agent-a",
+        threadId: "thread-1",
+      });
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({
+          licenseKey,
+          agents: { "agent-a": registryAgent },
+        }),
+      ],
+    });
+    const copilotkit = TestBed.inject(CopilotKit);
+    copilotkit.setThreadClone(registryAgent, "thread-1", cloneAgent);
+    copilotkit.addRenderActivityMessage({
+      activityType: "search",
+      content: z.any(),
+      component: TestRenderer,
+    });
+
+    const fixture = TestBed.createComponent(Host);
+    const result = fixture.componentInstance.api.renderActivityMessage({
+      id: "m1",
+      activityType: "search",
+      content: {},
+    } as never);
+
+    expect(result?.inputs.agent).toBe(cloneAgent);
+  });
+});
+
+describe("injectRenderCustomMessages", () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it("returns null when no renderers are registered", () => {
+    @Component({ standalone: true, template: "" })
+    class Host {
+      api = injectRenderCustomMessages({ agentId: "agent-a" });
+    }
+
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({ licenseKey })],
+    });
+    const fixture = TestBed.createComponent(Host);
+    expect(
+      fixture.componentInstance.api({
+        message: { id: "m", role: "assistant", content: "" } as never,
+        position: "after",
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores renderers whose component is null and falls through to next", () => {
+    const agent = new MockAgent("agent-a");
+    agent.setMessages([{ id: "m1", role: "assistant", content: "Hi" } as Message]);
+
+    @Component({ standalone: true, template: "" })
+    class Host {
+      api = injectRenderCustomMessages({ agentId: "agent-a" });
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({ licenseKey, agents: { "agent-a": agent } }),
+      ],
+    });
+    const copilotkit = TestBed.inject(CopilotKit);
+    copilotkit.addRenderCustomMessage({ component: null });
+    copilotkit.addRenderCustomMessage({ component: TestRenderer });
+
+    const fixture = TestBed.createComponent(Host);
+    const result = fixture.componentInstance.api({
+      message: { id: "m1", role: "assistant", content: "Hi" } as never,
+      position: "after",
+    });
+    expect(result?.component).toBe(TestRenderer);
+  });
+
+  it("prioritises agent-scoped renderer over a global one", () => {
+    const agent = new MockAgent("agent-a");
+    agent.setMessages([{ id: "m1", role: "assistant", content: "Hi" } as Message]);
+
+    @Component({ standalone: true, template: "" })
+    class Host {
+      api = injectRenderCustomMessages({ agentId: "agent-a" });
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({ licenseKey, agents: { "agent-a": agent } }),
+      ],
+    });
+    const copilotkit = TestBed.inject(CopilotKit);
+    copilotkit.addRenderCustomMessage({ component: OtherRenderer });
+    copilotkit.addRenderCustomMessage({
+      agentId: "agent-a",
+      component: TestRenderer,
+    });
+
+    const fixture = TestBed.createComponent(Host);
+    const result = fixture.componentInstance.api({
+      message: { id: "m1", role: "assistant", content: "Hi" } as never,
+      position: "after",
+    });
+    expect(result?.component).toBe(TestRenderer);
+  });
+
+  it("filters out renderers whose agentId does not match the active agent", () => {
+    const agent = new MockAgent("agent-a");
+    agent.setMessages([{ id: "m1", role: "assistant", content: "Hi" } as Message]);
+
+    @Component({ standalone: true, template: "" })
+    class Host {
+      api = injectRenderCustomMessages({ agentId: "agent-a" });
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({ licenseKey, agents: { "agent-a": agent } }),
+      ],
+    });
+    const copilotkit = TestBed.inject(CopilotKit);
+    copilotkit.addRenderCustomMessage({
+      agentId: "agent-b",
+      component: TestRenderer,
+    });
+
+    const fixture = TestBed.createComponent(Host);
+    expect(
+      fixture.componentInstance.api({
+        message: { id: "m1", role: "assistant", content: "Hi" } as never,
+        position: "after",
+      }),
+    ).toBeNull();
+  });
+
+  it("computes message-index inputs (messageIndex / messageIndexInRun / numberOfMessagesInRun)", () => {
+    const agent = new MockAgent("agent-a");
+    agent.setMessages([
+      { id: "u1", role: "user", content: "hi" } as Message,
+      { id: "a1", role: "assistant", content: "hello" } as Message,
+    ]);
+
+    @Component({ standalone: true, template: "" })
+    class Host {
+      api = injectRenderCustomMessages({ agentId: "agent-a" });
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({ licenseKey, agents: { "agent-a": agent } }),
+      ],
+    });
+    const copilotkit = TestBed.inject(CopilotKit);
+    copilotkit.addRenderCustomMessage({ component: TestRenderer });
+
+    const fixture = TestBed.createComponent(Host);
+    const result = fixture.componentInstance.api({
+      message: { id: "a1", role: "assistant", content: "hello" } as never,
+      position: "before",
+    });
+
+    expect(result?.inputs.messageIndex).toBe(1);
+    expect(result?.inputs.numberOfMessagesInRun).toBe(1);
+    expect(result?.inputs.messageIndexInRun).toBe(0);
+    expect(result?.inputs.position).toBe("before");
+    expect(result?.inputs.agentId).toBe("agent-a");
+    // No registered run for the message, so runId is the missing-id placeholder.
+    expect(result?.inputs.runId.startsWith("missing-run-id:")).toBe(true);
+  });
+
+  it("returns null when no agent is registered for the requested agentId", () => {
+    @Component({ standalone: true, template: "" })
+    class Host {
+      api = injectRenderCustomMessages({ agentId: "missing" });
+    }
+
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({ licenseKey })],
+    });
+    const copilotkit = TestBed.inject(CopilotKit);
+    copilotkit.addRenderCustomMessage({ component: TestRenderer });
+
+    const fixture = TestBed.createComponent(Host);
+    expect(
+      fixture.componentInstance.api({
+        message: { id: "m1", role: "assistant", content: "" } as never,
+        position: "after",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("CopilotKit.getThreadClone", () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it("returns undefined until a clone is registered, then returns it", () => {
+    const registry = new MockAgent("a");
+    const clone = new MockAgent("a");
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({ licenseKey, agents: { a: registry } }),
+      ],
+    });
+    const copilotkit = TestBed.inject(CopilotKit);
+    expect(copilotkit.getThreadClone(registry, "t")).toBeUndefined();
+
+    copilotkit.setThreadClone(registry, "t", clone);
+    expect(copilotkit.getThreadClone(registry, "t")).toBe(clone);
+
+    copilotkit.clearThreadClone(registry, "t");
+    expect(copilotkit.getThreadClone(registry, "t")).toBeUndefined();
+
+    expect(copilotkit.getThreadClone(undefined, "t")).toBeUndefined();
+    expect(copilotkit.getThreadClone(registry, undefined)).toBeUndefined();
+  });
+});

--- a/packages/angular/src/lib/render-messages.spec.ts
+++ b/packages/angular/src/lib/render-messages.spec.ts
@@ -308,7 +308,9 @@ describe("injectRenderCustomMessages", () => {
 
   it("ignores renderers whose component is null and falls through to next", () => {
     const agent = new MockAgent("agent-a");
-    agent.setMessages([{ id: "m1", role: "assistant", content: "Hi" } as Message]);
+    agent.setMessages([
+      { id: "m1", role: "assistant", content: "Hi" } as Message,
+    ]);
 
     @Component({ standalone: true, template: "" })
     class Host {
@@ -334,7 +336,9 @@ describe("injectRenderCustomMessages", () => {
 
   it("prioritises agent-scoped renderer over a global one", () => {
     const agent = new MockAgent("agent-a");
-    agent.setMessages([{ id: "m1", role: "assistant", content: "Hi" } as Message]);
+    agent.setMessages([
+      { id: "m1", role: "assistant", content: "Hi" } as Message,
+    ]);
 
     @Component({ standalone: true, template: "" })
     class Host {
@@ -363,7 +367,9 @@ describe("injectRenderCustomMessages", () => {
 
   it("filters out renderers whose agentId does not match the active agent", () => {
     const agent = new MockAgent("agent-a");
-    agent.setMessages([{ id: "m1", role: "assistant", content: "Hi" } as Message]);
+    agent.setMessages([
+      { id: "m1", role: "assistant", content: "Hi" } as Message,
+    ]);
 
     @Component({ standalone: true, template: "" })
     class Host {
@@ -457,9 +463,7 @@ describe("CopilotKit.getThreadClone", () => {
     const clone = new MockAgent("a");
 
     TestBed.configureTestingModule({
-      providers: [
-        provideCopilotKit({ licenseKey, agents: { a: registry } }),
-      ],
+      providers: [provideCopilotKit({ licenseKey, agents: { a: registry } })],
     });
     const copilotkit = TestBed.inject(CopilotKit);
     expect(copilotkit.getThreadClone(registry, "t")).toBeUndefined();

--- a/packages/angular/src/lib/render-messages.spec.ts
+++ b/packages/angular/src/lib/render-messages.spec.ts
@@ -130,6 +130,99 @@ describe("render-messages registry", () => {
     fixture.destroy();
     expect(copilotkit.renderCustomMessageConfigs().length).toBe(0);
   });
+
+  it("provideCopilotKit({ renderActivityMessages }) seeds the registry signal", () => {
+    const a: ActivityMessageRendererConfig = {
+      activityType: "search",
+      content: z.object({}),
+      component: TestRenderer,
+    };
+    const b: ActivityMessageRendererConfig = {
+      activityType: "*",
+      content: z.any(),
+      component: WildcardRenderer,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({ licenseKey, renderActivityMessages: [a, b] }),
+      ],
+    });
+
+    const copilotkit = TestBed.inject(CopilotKit);
+    expect(copilotkit.renderActivityMessageConfigs()).toEqual([a, b]);
+  });
+
+  it("provideCopilotKit({ renderCustomMessages }) seeds the registry signal", () => {
+    const c1: CustomMessageRendererConfig = { component: TestRenderer };
+    const c2: CustomMessageRendererConfig = {
+      agentId: "agent-a",
+      component: OtherRenderer,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({ licenseKey, renderCustomMessages: [c1, c2] }),
+      ],
+    });
+
+    const copilotkit = TestBed.inject(CopilotKit);
+    expect(copilotkit.renderCustomMessageConfigs()).toEqual([c1, c2]);
+  });
+
+  it("imperative add* coexists with declarative provider config without clobbering", () => {
+    const seededActivity: ActivityMessageRendererConfig = {
+      activityType: "search",
+      content: z.object({}),
+      component: TestRenderer,
+    };
+    const seededCustom: CustomMessageRendererConfig = {
+      component: TestRenderer,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({
+          licenseKey,
+          renderActivityMessages: [seededActivity],
+          renderCustomMessages: [seededCustom],
+        }),
+      ],
+    });
+
+    const copilotkit = TestBed.inject(CopilotKit);
+    expect(copilotkit.renderActivityMessageConfigs()).toEqual([seededActivity]);
+    expect(copilotkit.renderCustomMessageConfigs()).toEqual([seededCustom]);
+
+    const addedActivity: ActivityMessageRendererConfig = {
+      activityType: "*",
+      content: z.any(),
+      component: WildcardRenderer,
+    };
+    const addedCustom: CustomMessageRendererConfig = {
+      agentId: "agent-a",
+      component: OtherRenderer,
+    };
+    copilotkit.addRenderActivityMessage(addedActivity);
+    copilotkit.addRenderCustomMessage(addedCustom);
+
+    expect(copilotkit.renderActivityMessageConfigs()).toEqual([
+      seededActivity,
+      addedActivity,
+    ]);
+    expect(copilotkit.renderCustomMessageConfigs()).toEqual([
+      seededCustom,
+      addedCustom,
+    ]);
+
+    copilotkit.removeRenderActivityMessage(addedActivity);
+    copilotkit.removeRenderCustomMessage(addedCustom);
+
+    // The seeded entries from provideCopilotKit must remain after the
+    // imperatively-added ones are removed.
+    expect(copilotkit.renderActivityMessageConfigs()).toEqual([seededActivity]);
+    expect(copilotkit.renderCustomMessageConfigs()).toEqual([seededCustom]);
+  });
 });
 
 describe("injectRenderActivityMessage", () => {

--- a/packages/angular/src/lib/render-messages.ts
+++ b/packages/angular/src/lib/render-messages.ts
@@ -143,9 +143,7 @@ export function injectRenderActivityMessage(input?: {
     message: ActivityMessage,
   ) => ResolvedActivityMessageRender | null;
   /** Find the registered renderer config for an activity type. */
-  findRenderer: (
-    activityType: string,
-  ) => ActivityMessageRendererConfig | null;
+  findRenderer: (activityType: string) => ActivityMessageRendererConfig | null;
 } {
   const copilotkit = inject(CopilotKit);
   const agentIdSignal = toSignal(input?.agentId);
@@ -276,7 +274,9 @@ export function injectRenderCustomMessages(input?: {
           .map((m) => m.id)
       : [message.id];
 
-    const rawMessageIndex = agent.messages.findIndex((m) => m.id === message.id);
+    const rawMessageIndex = agent.messages.findIndex(
+      (m) => m.id === message.id,
+    );
     const messageIndex = rawMessageIndex >= 0 ? rawMessageIndex : 0;
     const messageIndexInRun = resolvedRunId
       ? Math.max(messageIdsInRun.indexOf(message.id), 0)
@@ -351,9 +351,7 @@ export function registerRenderCustomMessage(
   });
 }
 
-function toSignal<T>(
-  value: T | Signal<T> | undefined,
-): Signal<T | undefined> {
+function toSignal<T>(value: T | Signal<T> | undefined): Signal<T | undefined> {
   if (value === undefined) {
     return computed(() => undefined);
   }
@@ -362,4 +360,3 @@ function toSignal<T>(
   }
   return computed(() => value);
 }
-

--- a/packages/angular/src/lib/render-messages.ts
+++ b/packages/angular/src/lib/render-messages.ts
@@ -1,0 +1,365 @@
+import {
+  computed,
+  DestroyRef,
+  inject,
+  type Signal,
+  type Type,
+} from "@angular/core";
+import type { AbstractAgent, ActivityMessage, Message } from "@ag-ui/client";
+import type { StandardSchemaV1 } from "@copilotkit/shared";
+import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
+import { CopilotKit } from "./copilotkit";
+
+/**
+ * Inputs delivered to a custom message renderer component.
+ *
+ * Mirrors the prop shape of React's `ReactCustomMessageRenderer`. Each
+ * field corresponds to an `@Input()` (or signal `input()`) the rendering
+ * component must accept.
+ */
+export interface CustomMessageRendererInputs {
+  message: Message;
+  position: CustomMessageRendererPosition;
+  runId: string;
+  messageIndex: number;
+  messageIndexInRun: number;
+  numberOfMessagesInRun: number;
+  agentId: string;
+  stateSnapshot: unknown;
+}
+
+export type CustomMessageRendererPosition = "before" | "after";
+
+/**
+ * Configuration for an Angular custom message renderer.
+ *
+ * Equivalent to React's `ReactCustomMessageRenderer`.
+ */
+export interface CustomMessageRendererConfig {
+  /**
+   * Optional agent id to scope this renderer to a particular agent.
+   * Renderers without `agentId` apply to every agent.
+   */
+  agentId?: string;
+  /**
+   * Component rendered for each message; receives all
+   * {@link CustomMessageRendererInputs} as inputs.
+   *
+   * `null` means "no rendering" — useful for conditionally disabling a
+   * registered renderer without removing it.
+   */
+  component: Type<unknown> | null;
+}
+
+/**
+ * Inputs delivered to an activity message renderer component.
+ *
+ * Mirrors `ReactActivityMessageRenderer`'s render prop shape.
+ */
+export interface ActivityMessageRendererInputs<TActivityContent = unknown> {
+  activityType: string;
+  content: TActivityContent;
+  message: ActivityMessage;
+  agent: AbstractAgent | undefined;
+}
+
+/**
+ * Configuration for an Angular activity message renderer.
+ *
+ * Equivalent to React's `ReactActivityMessageRenderer`.
+ */
+export interface ActivityMessageRendererConfig<TActivityContent = unknown> {
+  /**
+   * Activity type to match. Use `"*"` as a wildcard renderer.
+   */
+  activityType: string;
+  /**
+   * Optional agent id to scope this renderer to a particular agent.
+   */
+  agentId?: string;
+  /**
+   * Standard Schema describing the expected `content` payload. Failed parses
+   * fall through and the activity is not rendered.
+   */
+  content: StandardSchemaV1<unknown, TActivityContent>;
+  /**
+   * Component rendered for matching activities; receives all
+   * {@link ActivityMessageRendererInputs} as inputs.
+   */
+  component: Type<unknown>;
+}
+
+/**
+ * Resolved match returned by {@link injectRenderActivityMessage} when a
+ * registered renderer applies to a given message.
+ */
+export interface ResolvedActivityMessageRender {
+  component: Type<unknown>;
+  inputs: ActivityMessageRendererInputs;
+}
+
+/**
+ * Resolved match returned by {@link injectRenderCustomMessages} when a
+ * registered renderer applies to a given (message, position) pair.
+ */
+export interface ResolvedCustomMessageRender {
+  component: Type<unknown>;
+  inputs: CustomMessageRendererInputs;
+}
+
+/**
+ * Parameters passed to {@link InjectRenderCustomMessagesFn} when computing the
+ * renderer + props for a particular message + position.
+ */
+export interface InjectRenderCustomMessagesParams {
+  message: Message;
+  position: CustomMessageRendererPosition;
+}
+
+export type InjectRenderCustomMessagesFn = (
+  params: InjectRenderCustomMessagesParams,
+) => ResolvedCustomMessageRender | null;
+
+/**
+ * Look up an activity-message renderer for a given {@link ActivityMessage}.
+ *
+ * Mirrors React's `useRenderActivityMessage`: the registered renderers are
+ * filtered by `activityType` and resolved with the precedence
+ *
+ * 1. Renderer matching the active `agentId`,
+ * 2. Renderer with no `agentId` set (global),
+ * 3. Wildcard renderer (`activityType === "*"`).
+ *
+ * Failed schema parses are reported via `console.warn` and produce `null`.
+ *
+ * Must be invoked in an Angular DI context.
+ */
+export function injectRenderActivityMessage(input?: {
+  agentId?: string | Signal<string | undefined>;
+  threadId?: string | Signal<string | undefined>;
+}): {
+  /** Resolve a renderer for the message, or `null` if no match. */
+  renderActivityMessage: (
+    message: ActivityMessage,
+  ) => ResolvedActivityMessageRender | null;
+  /** Find the registered renderer config for an activity type. */
+  findRenderer: (
+    activityType: string,
+  ) => ActivityMessageRendererConfig | null;
+} {
+  const copilotkit = inject(CopilotKit);
+  const agentIdSignal = toSignal(input?.agentId);
+  const threadIdSignal = toSignal(input?.threadId);
+
+  const findRenderer = (
+    activityType: string,
+  ): ActivityMessageRendererConfig | null => {
+    const renderers = copilotkit.renderActivityMessageConfigs();
+    if (!renderers.length) return null;
+    const agentId = agentIdSignal() ?? DEFAULT_AGENT_ID;
+
+    const matches = renderers.filter((r) => r.activityType === activityType);
+
+    return (
+      matches.find((c) => c.agentId === agentId) ??
+      matches.find((c) => c.agentId === undefined) ??
+      renderers.find((c) => c.activityType === "*") ??
+      null
+    );
+  };
+
+  const renderActivityMessage = (
+    message: ActivityMessage,
+  ): ResolvedActivityMessageRender | null => {
+    const renderer = findRenderer(message.activityType);
+    if (!renderer) return null;
+
+    const parseResult = renderer.content["~standard"].validate(message.content);
+    // StandardSchema.validate() may return a Promise; for synchronous schemas
+    // (the common case) the result is a `{ value }` or `{ issues }` record.
+    if (parseResult instanceof Promise) {
+      console.warn(
+        `Activity renderer for '${message.activityType}' uses an async schema; async validation is not supported.`,
+      );
+      return null;
+    }
+    if ("issues" in parseResult && parseResult.issues) {
+      console.warn(
+        `Failed to parse content for activity message '${message.activityType}':`,
+        parseResult.issues,
+      );
+      return null;
+    }
+
+    const value = (parseResult as { value: unknown }).value;
+    const agentId = agentIdSignal() ?? DEFAULT_AGENT_ID;
+    const threadId = threadIdSignal();
+    const registryAgent = copilotkit.getAgent(agentId);
+    // Prefer the per-thread clone so action handlers in the renderer call
+    // runAgent on the same instance the chat view renders from.
+    const agent =
+      copilotkit.getThreadClone(registryAgent, threadId) ?? registryAgent;
+
+    return {
+      component: renderer.component,
+      inputs: {
+        activityType: message.activityType,
+        content: value,
+        message,
+        agent,
+      },
+    };
+  };
+
+  return { renderActivityMessage, findRenderer };
+}
+
+/**
+ * Build a custom-message renderer resolver. The returned function, when
+ * called with a (`message`, `position`) pair, returns the matching renderer
+ * config and props or `null`.
+ *
+ * Mirrors React's `useRenderCustomMessages`: agent-scoped renderers are
+ * preferred over global ones, the per-thread clone (if any) is used to read
+ * messages, and renderers whose `component` field is `null` are skipped (the
+ * search continues with the next renderer until a non-null component is
+ * found).
+ *
+ * Must be invoked in an Angular DI context.
+ */
+export function injectRenderCustomMessages(input?: {
+  agentId?: string | Signal<string | undefined>;
+  threadId?: string | Signal<string | undefined>;
+}): InjectRenderCustomMessagesFn {
+  const copilotkit = inject(CopilotKit);
+  const agentIdSignal = toSignal(input?.agentId);
+  const threadIdSignal = toSignal(input?.threadId);
+
+  return ({ message, position }) => {
+    const agentId = agentIdSignal() ?? DEFAULT_AGENT_ID;
+    const threadId = threadIdSignal();
+
+    const all = copilotkit.renderCustomMessageConfigs();
+    if (!all.length) return null;
+
+    const candidates = all
+      .filter((r) => r.agentId === undefined || r.agentId === agentId)
+      .sort((a, b) => {
+        const aHasAgent = a.agentId !== undefined;
+        const bHasAgent = b.agentId !== undefined;
+        if (aHasAgent === bHasAgent) return 0;
+        return aHasAgent ? -1 : 1;
+      });
+
+    if (!candidates.length) return null;
+
+    const resolvedRunId =
+      copilotkit.core.getRunIdForMessage(agentId, threadId ?? "", message.id) ??
+      copilotkit.core.getRunIdsForThread(agentId, threadId ?? "").slice(-1)[0];
+    const runId = resolvedRunId ?? `missing-run-id:${message.id}`;
+
+    const registryAgent = copilotkit.getAgent(agentId);
+    const agent =
+      copilotkit.getThreadClone(registryAgent, threadId) ?? registryAgent;
+    if (!agent) return null;
+
+    const messageIdsInRun = resolvedRunId
+      ? agent.messages
+          .filter(
+            (m) =>
+              copilotkit.core.getRunIdForMessage(
+                agentId,
+                threadId ?? "",
+                m.id,
+              ) === resolvedRunId,
+          )
+          .map((m) => m.id)
+      : [message.id];
+
+    const rawMessageIndex = agent.messages.findIndex((m) => m.id === message.id);
+    const messageIndex = rawMessageIndex >= 0 ? rawMessageIndex : 0;
+    const messageIndexInRun = resolvedRunId
+      ? Math.max(messageIdsInRun.indexOf(message.id), 0)
+      : 0;
+    const numberOfMessagesInRun = resolvedRunId ? messageIdsInRun.length : 1;
+    const stateSnapshot = resolvedRunId
+      ? copilotkit.core.getStateByRun(agentId, threadId ?? "", resolvedRunId)
+      : undefined;
+
+    for (const renderer of candidates) {
+      if (!renderer.component) continue;
+      return {
+        component: renderer.component,
+        inputs: {
+          message,
+          position,
+          runId,
+          messageIndex,
+          messageIndexInRun,
+          numberOfMessagesInRun,
+          agentId,
+          stateSnapshot,
+        },
+      };
+    }
+    return null;
+  };
+}
+
+/**
+ * Register an activity-message renderer for the lifetime of the calling
+ * Angular DI context (cleared automatically on `DestroyRef` teardown).
+ *
+ * Equivalent in spirit to passing a renderer via React's
+ * `<CopilotKitProvider renderActivityMessages={...}>` prop, but scoped to an
+ * Angular component or directive instead of a provider.
+ *
+ * Must be called inside an Angular DI / injection context.
+ */
+export function registerRenderActivityMessage<TActivityContent = unknown>(
+  config: ActivityMessageRendererConfig<TActivityContent>,
+): void {
+  const copilotkit = inject(CopilotKit);
+  const destroyRef = inject(DestroyRef);
+  copilotkit.addRenderActivityMessage(
+    config as ActivityMessageRendererConfig<unknown>,
+  );
+  destroyRef.onDestroy(() => {
+    copilotkit.removeRenderActivityMessage(
+      config as ActivityMessageRendererConfig<unknown>,
+    );
+  });
+}
+
+/**
+ * Register a custom-message renderer for the lifetime of the calling
+ * Angular DI context (cleared automatically on `DestroyRef` teardown).
+ *
+ * Equivalent in spirit to passing a renderer via React's
+ * `<CopilotKitProvider renderCustomMessages={...}>` prop.
+ *
+ * Must be called inside an Angular DI / injection context.
+ */
+export function registerRenderCustomMessage(
+  config: CustomMessageRendererConfig,
+): void {
+  const copilotkit = inject(CopilotKit);
+  const destroyRef = inject(DestroyRef);
+  copilotkit.addRenderCustomMessage(config);
+  destroyRef.onDestroy(() => {
+    copilotkit.removeRenderCustomMessage(config);
+  });
+}
+
+function toSignal<T>(
+  value: T | Signal<T> | undefined,
+): Signal<T | undefined> {
+  if (value === undefined) {
+    return computed(() => undefined);
+  }
+  if (typeof value === "function") {
+    return value as Signal<T>;
+  }
+  return computed(() => value);
+}
+

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -2,6 +2,7 @@ export * from "./lib/config";
 export * from "./lib/copilotkit";
 export * from "./lib/tools";
 export * from "./lib/render-tool-calls";
+export * from "./lib/render-messages";
 export * from "./lib/agent";
 export * from "./lib/chat-config";
 export * from "./lib/chat-state";


### PR DESCRIPTION
## Summary

Ports the React hooks `useRenderActivityMessage` and `useRenderCustomMessages` to Angular as DI-factory functions, plus `registerXxx` helpers that scope a registration to the calling host's `DestroyRef`. Out of scope: wiring the registry into `<copilot-chat-view>` rendering — handled in a follow-up.

## Behavioral contract

Mirrors React's behaviour exactly.

**Activity message renderer** (`injectRenderActivityMessage`)
- Match precedence: `agentId`-scoped match  →  global match (no `agentId`)  →  wildcard (`activityType === "*"`).
- Standard Schema validation on `content`; failures `console.warn` and resolve to `null`.
- Per-thread clone (when registered via `setThreadClone`) is preferred over the registry agent so action handlers in the renderer call `runAgent` on the visible chat instance.

**Custom message renderer** (`injectRenderCustomMessages`)
- Agent-scoped renderers sort ahead of global renderers; the first match with a non-`null` `component` wins.
- Run id is resolved via `core.getRunIdForMessage` → falls back to most recent run for the thread → falls back to `missing-run-id:<id>`.
- `messageIndex`, `messageIndexInRun`, `numberOfMessagesInRun`, `stateSnapshot` computed identically to React.
- Returns `null` when no matching renderer exists or no agent is found (#3497-style graceful handling).

## Signal + service shape

- `CopilotKit` service gains:
  - `renderActivityMessageConfigs: Signal<ActivityMessageRendererConfig[]>`
  - `renderCustomMessageConfigs: Signal<CustomMessageRendererConfig[]>`
  - `addRenderActivityMessage` / `removeRenderActivityMessage`
  - `addRenderCustomMessage` / `removeRenderCustomMessage`
  - `getThreadClone` / `setThreadClone` / `clearThreadClone` (mirror of React's `globalThreadCloneMap`)
- New module `render-messages.ts` exposes:
  - Types: `CustomMessageRendererConfig`, `CustomMessageRendererInputs`, `CustomMessageRendererPosition`, `ActivityMessageRendererConfig`, `ActivityMessageRendererInputs`, `ResolvedActivityMessageRender`, `ResolvedCustomMessageRender`, `InjectRenderCustomMessagesFn`.
  - Factories: `injectRenderActivityMessage(input?)` and `injectRenderCustomMessages(input?)` that accept `agentId` / `threadId` as raw values or signals, in the spirit of `injectAgentStore`.
  - Lifecycle helpers: `registerRenderActivityMessage`, `registerRenderCustomMessage` — auto-cleared on `DestroyRef` teardown.
- Resolved match is a plain `{ component, inputs }` record; consumers (chat-view, follow-up PR) drive `NgComponentOutlet` with it. No template directives are added.

## Test → contract mapping

`packages/angular/src/lib/render-messages.spec.ts` (14 tests, all passing):

| Test | Contract |
| --- | --- |
| `addRender*Message` updates signals | basic registry mutation |
| `registerRenderActivityMessage` host-scoped | DestroyRef teardown removes registration |
| `registerRenderCustomMessage` host-scoped | DestroyRef teardown removes registration |
| `injectRenderActivityMessage` returns null | empty registry contract |
| validates content via Standard Schema | parse-failure path emits `console.warn` and returns null |
| precedence: agent-scoped → global → wildcard | match resolution order |
| per-thread clone passed as `agent` | thread-clone preference |
| `injectRenderCustomMessages` empty | empty registry contract |
| skips renderers whose component is null | falls through to next candidate |
| prioritises agent-scoped over global | ordering/prioritisation |
| filters mismatched agentId | scoping |
| messageIndex / messageIndexInRun / numberOfMessagesInRun computed | index props contract |
| missing agent → null | regression guard (#3497-style) |
| `getThreadClone` / `setThreadClone` / `clearThreadClone` | thread-clone primitive |

## Test plan

- [x] `pnpm exec vitest run` in `packages/angular` — 61/61 tests passing
- [x] `pnpm exec ng-packagr -p ng-package.json` — build succeeds
- [x] `tsc --noEmit` — no errors in `packages/angular/*` (pre-existing failures in `@copilotkit/core` are unrelated)

https://claude.ai/code/session_01B1zJ4kMRgLuN1r5T3iiGbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1zJ4kMRgLuN1r5T3iiGbZ)_