### PR TITLE
fix(showcase/dashboard): add maxPossible to parity-matrix DepthResult literals

### DIFF
--- a/showcase/shell-dashboard/src/components/parity-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/parity-matrix.tsx
@@ -115,7 +115,12 @@ function ParityCategorySection({
           const refCell = cellIndex.get(`${referenceSlug}/${feature.id}`);
           const refDepth: DepthResult = refCell
             ? deriveDepth(refCell, liveStatus)
-            : { achieved: 0, isRegression: false, unsupported: false };
+            : {
+                achieved: 0,
+                maxPossible: 0,
+                isRegression: false,
+                unsupported: false,
+              };
           const refStatus = refDepth.unsupported
             ? "unsupported"
             : (refCell?.status ?? "unshipped");
@@ -141,7 +146,12 @@ function ParityCategorySection({
                 const cell = cellIndex.get(`${int.slug}/${feature.id}`);
                 const depth: DepthResult = cell
                   ? deriveDepth(cell, liveStatus)
-                  : { achieved: 0, isRegression: false, unsupported: false };
+                  : {
+                      achieved: 0,
+                      maxPossible: 0,
+                      isRegression: false,
+                      unsupported: false,
+                    };
                 const cellStatus = depth.unsupported
                   ? "unsupported"
                   : (cell?.status ?? "unshipped");


### PR DESCRIPTION
## Summary

- Two object literals in `showcase/shell-dashboard/src/components/parity-matrix.tsx` (`ParityCategorySection`) were missing the required `maxPossible` field on `DepthResult`, causing `next build` to fail with TS2322 on every shell-dashboard production build.
- This blocked rebuilding the deployed showcase shell-dashboard, which currently ships with `NEXT_PUBLIC_SHELL_URL` unset — every Demo button on the dashboard renders as `about:blank#shell-url-missing/integrations/<slug>/<feature>/preview` instead of the actual preview URL.
- Setting `maxPossible: 0` alongside `achieved: 0` for unwired cells is the natural fallback (no probe → no ceiling) and matches how `DepthChip` already renders an unshipped cell.

## Background

The fix is cherry-picked from commit `1db2fbc7b` on the `fix/dashboard-polish` branch (Jordan Ritter) — that branch also has 8 other commits (D5 depth model rework, ops→harness rename) which together form a larger polish pass that hasn't been opened as a PR yet. Landing this 2-line slice standalone unblocks the showcase deploy without waiting on review of the larger branch.

Once this lands, re-running `gh workflow run showcase_build.yml --ref main -f service=shell-dashboard` will produce a working production image with `NEXT_PUBLIC_SHELL_URL=https://showcase.copilotkit.ai` baked in.

## Test plan

- [ ] CI typecheck passes (was previously failing here)
- [ ] CI build of showcase-shell-dashboard image succeeds
- [ ] After merge: trigger \`showcase_build.yml\` for \`shell-dashboard\` and verify deployed dashboard's Demo links resolve to \`https://showcase.copilotkit.ai/integrations/...\` instead of the \`about:blank#shell-url-missing\` sentinel