### PR TITLE
fix(langgraph-python-threads): pin to stable @copilotkit/* 1.57.0 and intelligence 0.1.0

### DIFF
--- a/examples/integrations/langgraph-python-threads/Dockerfile
+++ b/examples/integrations/langgraph-python-threads/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /app
 COPY apps/agent/ ./apps/agent/
 # Install ag-ui-langgraph FIRST at pinned version (before copilotkit can override it)
 RUN uv pip install --system "ag-ui-langgraph[fastapi]==0.0.22" && \
-    uv pip install --system --no-deps "copilotkit==0.1.78" && \
+    uv pip install --system --no-deps "copilotkit==0.1.86" && \
     uv pip install --system "partialjson>=0.0.8,<0.0.9" "toml>=0.10.2,<0.11.0" && \
     uv pip install --system \
     "langchain==1.0.1" \

--- a/examples/integrations/langgraph-python-threads/apps/app/package.json
+++ b/examples/integrations/langgraph-python-threads/apps/app/package.json
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "@ag-ui/client": "0.0.52",
-    "@copilotkit/a2ui-renderer": "1.56.5-canary.1777671752",
-    "@copilotkit/react-core": "1.56.5-canary.1777671752",
-    "@copilotkit/react-ui": "1.56.5-canary.1777671752",
+    "@copilotkit/a2ui-renderer": "1.57.0",
+    "@copilotkit/react-core": "1.57.0",
+    "@copilotkit/react-ui": "1.57.0",
     "@hono/node-server": "^1.19.14",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-label": "^2.1.8",

--- a/examples/integrations/langgraph-python-threads/apps/bff/package.json
+++ b/examples/integrations/langgraph-python-threads/apps/bff/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/server.js"
   },
   "dependencies": {
-    "@copilotkit/runtime": "1.56.5-canary.1777671752",
+    "@copilotkit/runtime": "1.57.0",
     "@hono/node-server": "^1.13.6",
     "express": "5.2.1",
     "hono": "^4.7.11",

--- a/examples/integrations/langgraph-python-threads/docker-compose.yml
+++ b/examples/integrations/langgraph-python-threads/docker-compose.yml
@@ -58,7 +58,7 @@ services:
   # ---------------------------------------------------------------------------
 
   intelligence:
-    image: ghcr.io/copilotkit/intelligence/composite:0.1.0-rc.16
+    image: ghcr.io/copilotkit/intelligence/composite:0.1.0
     ports:
       - "${APP_API_HOST_PORT:-4201}:4201"
       - "${REALTIME_GATEWAY_HOST_PORT:-4401}:4401"

--- a/examples/integrations/langgraph-python-threads/package-lock.json
+++ b/examples/integrations/langgraph-python-threads/package-lock.json
@@ -25,9 +25,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@ag-ui/client": "0.0.52",
-        "@copilotkit/a2ui-renderer": "1.56.5-canary.1777671752",
-        "@copilotkit/react-core": "1.56.5-canary.1777671752",
-        "@copilotkit/react-ui": "1.56.5-canary.1777671752",
+        "@copilotkit/a2ui-renderer": "1.57.0",
+        "@copilotkit/react-core": "1.57.0",
+        "@copilotkit/react-ui": "1.57.0",
         "@hono/node-server": "^1.19.14",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-label": "^2.1.8",
@@ -56,11 +56,416 @@
         "vite": "^7.1.12"
       }
     },
+    "apps/app/node_modules/@ag-ui/core": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.53.tgz",
+      "integrity": "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
+    },
+    "apps/app/node_modules/@ag-ui/encoder": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.53.tgz",
+      "integrity": "sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.53",
+        "@ag-ui/proto": "0.0.53"
+      }
+    },
+    "apps/app/node_modules/@ag-ui/proto": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.53.tgz",
+      "integrity": "sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.53",
+        "@bufbuild/protobuf": "^2.2.5",
+        "@protobuf-ts/protoc": "^2.11.1"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/a2ui-renderer": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.57.0.tgz",
+      "integrity": "sha512-5Fn48h02oj1e0gGHc+lSnKvh4yrP4MPS4lpnBMSnif/kUzuNcyxGblnBRdxfjZo8gWj9Un8Who5Wy513CdToMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@a2ui/web_core": "0.9.0",
+        "clsx": "^2.1.1",
+        "zod": "^3.25.75",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.57.0.tgz",
+      "integrity": "sha512-fCh9/71uJO0yT2b/0o/Rf4moDEYP8nfpJZxy6/xfEJxUsz0NIb8vnQgGO1iE2l2BWTVP2Gg2iGn/Pe9K0YfF1g==",
+      "dependencies": {
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/shared": "1.57.0",
+        "@tanstack/pacer": "^0.20.1",
+        "phoenix": "^1.8.4",
+        "rxjs": "7.8.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/core/node_modules/@ag-ui/client": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
+      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.53",
+        "@ag-ui/encoder": "0.0.53",
+        "@ag-ui/proto": "0.0.53",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/core/node_modules/@tanstack/pacer": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/pacer/-/pacer-0.20.1.tgz",
+      "integrity": "sha512-ZNQ1bIL6eUXVKdic0tiImvBVkWrg/IoSK6VIacTrO3d3HAGnd70qFJNJagR/YOJIOw4EKGWnodwpYZkN1pWuVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/devtools-event-client": "^0.4.3",
+        "@tanstack/store": "^0.9.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/react-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.57.0.tgz",
+      "integrity": "sha512-q+Vs+Dyu+ng1/JziWurTLMjev/f0FOz3NCGXT/aSQ2/Xm0ZLF6WzUbJnTRd2R7xdyY8y8UAez0cgnuxbFbXVDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/client": "0.0.53",
+        "@ag-ui/core": "0.0.53",
+        "@copilotkit/a2ui-renderer": "1.57.0",
+        "@copilotkit/core": "1.57.0",
+        "@copilotkit/runtime-client-gql": "1.57.0",
+        "@copilotkit/shared": "1.57.0",
+        "@copilotkit/web-inspector": "1.57.0",
+        "@jetbrains/websandbox": "^1.1.3",
+        "@lit-labs/react": "^2.0.2",
+        "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tooltip": "^1.2.7",
+        "@scarf/scarf": "^1.3.0",
+        "@tanstack/react-virtual": "^3.13.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "katex": "^0.16.22",
+        "lucide-react": "^0.525.0",
+        "react-markdown": "^8.0.7",
+        "rxjs": "7.8.1",
+        "streamdown": "^1.3.0",
+        "tailwind-merge": "^3.3.1",
+        "tw-animate-css": "^1.3.5",
+        "untruncate-json": "^0.0.1",
+        "use-stick-to-bottom": "^1.1.1",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc",
+        "zod": ">=3.0.0"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/react-core/node_modules/@ag-ui/client": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
+      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.53",
+        "@ag-ui/encoder": "0.0.53",
+        "@ag-ui/proto": "0.0.53",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/react-core/node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/react-ui": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/react-ui/-/react-ui-1.57.0.tgz",
+      "integrity": "sha512-a7YvBi3d7LuHownG0xMRIgVfgGA62hqiQQ3pPvFwTEamCmmc9qDZIzo589KTRDBYLsWFnvb25v3jEQz1KWWUXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@copilotkit/react-core": "1.57.0",
+        "@copilotkit/runtime-client-gql": "1.57.0",
+        "@copilotkit/shared": "1.57.0",
+        "@headlessui/react": "^2.2.9",
+        "react-markdown": "^10.1.0",
+        "react-syntax-highlighter": "^15.6.1",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/react-ui/node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/runtime-client-gql": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.57.0.tgz",
+      "integrity": "sha512-gQebShiQ2ywjKstC+AwK8W91n49YtqxbhNIfpUFCg6uzlK++CQ2ma9u6tsvJphitsaLfBrhJDJto4BzXzg1wPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@copilotkit/shared": "1.57.0",
+        "@urql/core": "^5.0.3",
+        "untruncate-json": "^0.0.1",
+        "urql": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/shared": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.57.0.tgz",
+      "integrity": "sha512-X6uqeAWLDh08LUj4a0gpC9mrlmlyaviuybsnGJQPzAJonYIehYH63bEksj6xFgIA1FfkmEzK2XTxUnbrtpMd3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/license-verifier": "0.2.0",
+        "@segment/analytics-node": "^2.1.2",
+        "@standard-schema/spec": "^1.0.0",
+        "chalk": "4.1.2",
+        "graphql": "^16.8.1",
+        "partial-json": "^0.1.7",
+        "uuid": "^11.1.0",
+        "zod": "^3.23.3",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "peerDependencies": {
+        "@ag-ui/core": ">=0.0.48"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/shared/node_modules/@ag-ui/client": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
+      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.53",
+        "@ag-ui/encoder": "0.0.53",
+        "@ag-ui/proto": "0.0.53",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/web-inspector": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.57.0.tgz",
+      "integrity": "sha512-V05eKxqWNFnyhoNct7qc21AjFipxzK8RQNA72tRgnug38hodSNr6haqQGOcacjLD+tpe17KDEMO45QYm9YuExQ==",
+      "dependencies": {
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/core": "1.57.0",
+        "lit": "^3.2.0",
+        "lucide": "^0.525.0",
+        "marked": "^12.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/app/node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/client": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
+      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.53",
+        "@ag-ui/encoder": "0.0.53",
+        "@ag-ui/proto": "0.0.53",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "apps/app/node_modules/@tanstack/store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
+      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "apps/app/node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "apps/app/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "apps/app/node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "apps/app/node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "apps/app/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "apps/app/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "apps/app/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "apps/app/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "apps/bff": {
       "name": "@repo/bff",
       "version": "0.1.0",
       "dependencies": {
-        "@copilotkit/runtime": "1.56.5-canary.1777671752",
+        "@copilotkit/runtime": "1.57.0",
         "@hono/node-server": "^1.13.6",
         "express": "5.2.1",
         "hono": "^4.7.11",
@@ -120,7 +525,9 @@
       }
     },
     "apps/bff/node_modules/@copilotkit/runtime": {
-      "version": "1.56.5-canary.1777671752",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.57.0.tgz",
+      "integrity": "sha512-rvFXgQZkFcojdGubmS51OUYnrXQ/MLFj8TrhEgEKRwHT2wqB7OuA1DAPn1d2bip6LqUOPYsFOFGt9Qhy19narw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/a2ui-middleware": "0.0.5",
@@ -135,7 +542,7 @@
         "@ai-sdk/mcp": "^1.0.21",
         "@ai-sdk/openai": "^3.0.36",
         "@copilotkit/license-verifier": "0.2.0",
-        "@copilotkit/shared": "1.56.5-canary.1777671752",
+        "@copilotkit/shared": "1.57.0",
         "@graphql-yoga/plugin-defer-stream": "^3.3.1",
         "@hono/node-server": "^1.13.5",
         "@modelcontextprotocol/sdk": "^1.18.2",
@@ -272,6 +679,27 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "apps/bff/node_modules/@copilotkit/shared": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.57.0.tgz",
+      "integrity": "sha512-X6uqeAWLDh08LUj4a0gpC9mrlmlyaviuybsnGJQPzAJonYIehYH63bEksj6xFgIA1FfkmEzK2XTxUnbrtpMd3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/license-verifier": "0.2.0",
+        "@segment/analytics-node": "^2.1.2",
+        "@standard-schema/spec": "^1.0.0",
+        "chalk": "4.1.2",
+        "graphql": "^16.8.1",
+        "partial-json": "^0.1.7",
+        "uuid": "^11.1.0",
+        "zod": "^3.23.3",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "peerDependencies": {
+        "@ag-ui/core": ">=0.0.48"
       }
     },
     "apps/bff/node_modules/@types/node": {
@@ -1154,521 +1582,8 @@
         "commander": "~13.1.0"
       }
     },
-    "node_modules/@copilotkit/a2ui-renderer": {
-      "version": "1.56.5-canary.1777671752",
-      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.56.5-canary.1777671752.tgz",
-      "integrity": "sha512-9BUgF8QzHduZVH0mCx938MybyMElSI3XVeJ4Gy9wKQSY9I+YdgXRaNyVqJLGmDKdlZMGG80f1wu9iD7xaEiYhg==",
-      "license": "MIT",
-      "dependencies": {
-        "@a2ui/web_core": "0.9.0",
-        "clsx": "^2.1.1",
-        "zod": "^3.25.75",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/@copilotkit/core": {
-      "version": "1.56.5-canary.1777671752",
-      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.56.5-canary.1777671752.tgz",
-      "integrity": "sha512-5XAdoV875qGVwvHQYWNfKFQ1yFNsVXHgJWtn05ByIwMs3xWzY076hClOr0DrfiX+QSkwevoNldmNPNDGQmPWfA==",
-      "dependencies": {
-        "@ag-ui/client": "0.0.53",
-        "@copilotkit/shared": "1.56.5-canary.1777671752",
-        "@tanstack/pacer": "^0.20.1",
-        "phoenix": "^1.8.4",
-        "rxjs": "7.8.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/@ag-ui/client": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
-      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/proto": "0.0.53",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/@ag-ui/core": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.53.tgz",
-      "integrity": "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/@ag-ui/encoder": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.53.tgz",
-      "integrity": "sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/proto": "0.0.53"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/@ag-ui/proto": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.53.tgz",
-      "integrity": "sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/@tanstack/pacer": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/pacer/-/pacer-0.20.1.tgz",
-      "integrity": "sha512-ZNQ1bIL6eUXVKdic0tiImvBVkWrg/IoSK6VIacTrO3d3HAGnd70qFJNJagR/YOJIOw4EKGWnodwpYZkN1pWuVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/devtools-event-client": "^0.4.3",
-        "@tanstack/store": "^0.9.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/@tanstack/store": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
-      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@copilotkit/license-verifier": {
       "version": "0.2.0"
-    },
-    "node_modules/@copilotkit/react-core": {
-      "version": "1.56.5-canary.1777671752",
-      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.56.5-canary.1777671752.tgz",
-      "integrity": "sha512-TpBr5ixGmYjWCSje7jCTLOsMhy37rvT+tHo7fNupa87+6WBJ6Nbao9J41ojSE7q2VQlPD33gKlok5xYQlyslEw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ag-ui/client": "0.0.53",
-        "@ag-ui/core": "0.0.53",
-        "@copilotkit/a2ui-renderer": "1.56.5-canary.1777671752",
-        "@copilotkit/core": "1.56.5-canary.1777671752",
-        "@copilotkit/runtime-client-gql": "1.56.5-canary.1777671752",
-        "@copilotkit/shared": "1.56.5-canary.1777671752",
-        "@copilotkit/web-inspector": "1.56.5-canary.1777671752",
-        "@jetbrains/websandbox": "^1.1.3",
-        "@lit-labs/react": "^2.0.2",
-        "@radix-ui/react-dropdown-menu": "^2.1.15",
-        "@radix-ui/react-slot": "^1.2.3",
-        "@radix-ui/react-tooltip": "^1.2.7",
-        "@scarf/scarf": "^1.3.0",
-        "@tanstack/react-virtual": "^3.13.0",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "katex": "^0.16.22",
-        "lucide-react": "^0.525.0",
-        "react-markdown": "^8.0.7",
-        "rxjs": "7.8.1",
-        "streamdown": "^1.3.0",
-        "tailwind-merge": "^3.3.1",
-        "tw-animate-css": "^1.3.5",
-        "untruncate-json": "^0.0.1",
-        "use-stick-to-bottom": "^1.1.1",
-        "zod-to-json-schema": "^3.24.5"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^18 || ^19 || ^19.0.0-rc",
-        "zod": ">=3.0.0"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/@ag-ui/client": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
-      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/proto": "0.0.53",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/@ag-ui/core": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.53.tgz",
-      "integrity": "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/@ag-ui/encoder": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.53.tgz",
-      "integrity": "sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/proto": "0.0.53"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/@ag-ui/proto": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.53.tgz",
-      "integrity": "sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/lucide-react": {
-      "version": "0.525.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
-      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@copilotkit/react-ui": {
-      "version": "1.56.5-canary.1777671752",
-      "resolved": "https://registry.npmjs.org/@copilotkit/react-ui/-/react-ui-1.56.5-canary.1777671752.tgz",
-      "integrity": "sha512-VfxlUfw/6yQC3lP9BtOfQzK9nkK5/7TU/hLnbbVgWsvSd21VgQIqqt+I3APZPPxsVpQQkdD17VpVoQXW5Hetzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@copilotkit/react-core": "1.56.5-canary.1777671752",
-        "@copilotkit/runtime-client-gql": "1.56.5-canary.1777671752",
-        "@copilotkit/shared": "1.56.5-canary.1777671752",
-        "@headlessui/react": "^2.2.9",
-        "react-markdown": "^10.1.0",
-        "react-syntax-highlighter": "^15.6.1",
-        "rehype-raw": "^7.0.0",
-        "remark-gfm": "^4.0.1",
-        "remark-math": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/@copilotkit/react-ui/node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@copilotkit/react-ui/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@copilotkit/react-ui/node_modules/react-markdown": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
-      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "hast-util-to-jsx-runtime": "^2.0.0",
-        "html-url-attributes": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.0.0",
-        "unified": "^11.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18",
-        "react": ">=18"
-      }
-    },
-    "node_modules/@copilotkit/react-ui/node_modules/remark-parse": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
-      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@copilotkit/react-ui/node_modules/remark-rehype": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
-      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "unified": "^11.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@copilotkit/react-ui/node_modules/unified": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
-      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "bail": "^2.0.0",
-        "devlop": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^4.0.0",
-        "trough": "^2.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@copilotkit/react-ui/node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@copilotkit/react-ui/node_modules/vfile": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/@copilotkit/runtime-client-gql": {
-      "version": "1.56.5-canary.1777671752",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.56.5-canary.1777671752.tgz",
-      "integrity": "sha512-DRi5nE6wzEb2g6KQXDSZAoYwpHEFUY0KMfnxRuZeojD1FLX/9FPIZlBADoXezWXT6LR9Fer63/Iy34/YuKDU1A==",
-      "license": "MIT",
-      "dependencies": {
-        "@copilotkit/shared": "1.56.5-canary.1777671752",
-        "@urql/core": "^5.0.3",
-        "untruncate-json": "^0.0.1",
-        "urql": "^4.1.0"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/@copilotkit/shared": {
-      "version": "1.56.5-canary.1777671752",
-      "license": "MIT",
-      "dependencies": {
-        "@ag-ui/client": "0.0.53",
-        "@copilotkit/license-verifier": "0.2.0",
-        "@segment/analytics-node": "^2.1.2",
-        "@standard-schema/spec": "^1.0.0",
-        "chalk": "4.1.2",
-        "graphql": "^16.8.1",
-        "partial-json": "^0.1.7",
-        "uuid": "^11.1.0",
-        "zod": "^3.23.3",
-        "zod-to-json-schema": "^3.23.5"
-      },
-      "peerDependencies": {
-        "@ag-ui/core": ">=0.0.48"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/client": {
-      "version": "0.0.53",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/proto": "0.0.53",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/client/node_modules/@ag-ui/core": {
-      "version": "0.0.53",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/encoder": {
-      "version": "0.0.53",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/proto": "0.0.53"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/encoder/node_modules/@ag-ui/core": {
-      "version": "0.0.53",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/proto": {
-      "version": "0.0.53",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/proto/node_modules/@ag-ui/core": {
-      "version": "0.0.53",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/rxjs": {
-      "version": "7.8.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector": {
-      "version": "1.56.5-canary.1777671752",
-      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.56.5-canary.1777671752.tgz",
-      "integrity": "sha512-OItckQV3AKSWyzwdI3cZ+grhZ0xHTfH+bzD6rkJKwAF8Uj6yE+SB4sGhe0hIi97ckWL8hps65X8QUeCgy2qYKQ==",
-      "dependencies": {
-        "@ag-ui/client": "0.0.53",
-        "@copilotkit/core": "1.56.5-canary.1777671752",
-        "lit": "^3.2.0",
-        "lucide": "^0.525.0",
-        "marked": "^12.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/client": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
-      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/proto": "0.0.53",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/core": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.53.tgz",
-      "integrity": "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/encoder": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.53.tgz",
-      "integrity": "sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/proto": "0.0.53"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/proto": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.53.tgz",
-      "integrity": "sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
     },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.8",


### PR DESCRIPTION
## Summary
- Bump `@copilotkit/{a2ui-renderer,react-core,react-ui,runtime}` from `1.56.5-canary.1777671752` to `1.57.0` in `apps/app/package.json` and `apps/bff/package.json`
- Bump `ghcr.io/copilotkit/intelligence/composite` from `0.1.0-rc.16` to `0.1.0` in `docker-compose.yml`
- Align the Dockerfile python pin (`copilotkit==0.1.78`) with `apps/agent/pyproject.toml` (`copilotkit==0.1.86`)
- Regenerate `package-lock.json` against the new stable npm pins

## Test plan
- [ ] CI's `showcase_validate.yml` passes (or reports an expected ratchet drop in `validate-pins` baseline that a maintainer can reset)
- [ ] `docker pull ghcr.io/copilotkit/intelligence/composite:0.1.0` succeeds (verify the literal tag string matches what is published)
- [ ] From `examples/integrations/langgraph-python-threads/`: `npm install && docker compose up` boots cleanly with the new pins
- [ ] BFF connects to the intelligence composite at `0.1.0` without API surface drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)