### PR TITLE
fix(showcase/dashboard): pass maxDepth to DepthChip so D5 cells aren't all red

### DIFF
--- a/showcase/shell-dashboard/src/components/cell-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/cell-matrix.tsx
@@ -182,7 +182,7 @@ function CategorySection({
                     <DepthChip
                       depth={depth.achieved}
                       status={cellStatus}
-                      regression={depth.isRegression}
+                      maxDepth={depth.maxPossible}
                     />
                   </button>
                   {isSelected && (

--- a/showcase/shell-dashboard/src/components/parity-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/parity-matrix.tsx
@@ -139,7 +139,7 @@ function ParityCategorySection({
                 <DepthChip
                   depth={refDepth.achieved}
                   status={refStatus}
-                  regression={refDepth.isRegression}
+                  maxDepth={refDepth.maxPossible}
                 />
               </td>
               {nonRefIntegrations.map((int) => {
@@ -164,7 +164,7 @@ function ParityCategorySection({
                     <DepthChip
                       depth={depth.achieved}
                       status={cellStatus}
-                      regression={depth.isRegression}
+                      maxDepth={depth.maxPossible}
                     />
                   </td>
                 );


### PR DESCRIPTION
## Summary

The parity-matrix and cell-matrix views were rendering virtually every D5 cell as red. Root cause is a collision between two definitions of "regression":

- `depth-utils.ts` redefines `isRegression` as `achieved < maxPossible` ("below structural ceiling"), not "below historical max_depth".
- `computeMaxPossible()` returns **6** whenever a D5 mapping exists, on the assumption D6 is also reachable. In practice D6 probes are rare (commit `eda75a512` even said *"D5 mapping means max=5 not 6 (D6 probes are rare)"* — that cap is no longer in the file).
- `parity-matrix.tsx` and `cell-matrix.tsx` passed `regression={depth.isRegression}` to `DepthChip` but **never** `maxDepth`.
- `DepthChip` short-circuits to red when `regression` is true, regardless of depth.

Net: any wired cell that hit D5 without a green D6 probe → `isRegression=true` → red.

## Fix

Pass `maxDepth={depth.maxPossible}` and drop `regression` for the not-at-ceiling case. This re-engages `DepthChip`'s intended graduated coloring:

- green at ceiling (`achieved >= maxDepth`)
- amber 1–2 below
- red 3+ below

The `isRegression` field is still consumed by `cell-matrix`'s `filter="regressions"` row filter — that's unchanged.

## Test plan

- [x] `parity-matrix`, `cell-matrix`, `depth-utils`, `depth-chip` unit tests — 93/93 passing
- [ ] Visual check on dashboard: D5 cells with `maxPossible=6` should now show amber, not red
- [ ] Cells whose probes only reach D4 should still show green at D4 (already covered by chip's graduated logic)
- [ ] Cells with achieved < maxPossible by 3+ should still show red