### PR TITLE
fix(react-core): IntelligenceIndicator stays visible through real MCP recall flows

### DIFF
--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
@@ -78,15 +78,21 @@ export interface IntelligenceIndicatorProps {
  *      again here as a defence)
  *   2. The message is an assistant message with at least one tool call
  *      whose name matches {@link DEFAULT_TOOL_PATTERNS}
- *   3. The message's run is the latest run on the thread
- *   4. The message is the *latest* such matching-assistant message in
- *      its run — i.e. no later assistant-with-matching-tool-call
- *      message exists in the same run. Tool result messages
+ *   3. The message is the *latest* such matching-assistant message
+ *      anywhere in `agent.messages` — i.e. no later assistant-with-
+ *      matching-tool-call message exists. Tool result messages
  *      (`role: "tool"`) and prose-only assistant messages do NOT
  *      invalidate this slot, so the pill stays continuously through a
- *      multi-step bash chain instead of flickering off every time a
- *      tool result arrives.
- *   5. The phase machine is not yet `hidden`
+ *      multi-step tool chain instead of flickering off every time a
+ *      tool reply arrives.
+ *   4. The phase machine is not yet `hidden` — once a pill has faded
+ *      out it stays gone; a subsequent run on the same chat mounts a
+ *      fresh pill on its own assistant message rather than resurrecting
+ *      this one.
+ *   5. (Run scoping comes for free from `phase === "hidden"` being
+ *      sticky after the previous run's fade-out — no `getRunIdForMessage`
+ *      lookup is needed, and the indicator stays robust against gaps
+ *      in the SDK's run-tracking map.)
  *
  * Phase machine (per-instance, all timers local):
  *   - `spinner` while `agent.isRunning`
@@ -145,14 +151,20 @@ export function IntelligenceIndicator(
   // (isRunning → true) snap to spinner immediately; falling edges
   // schedule a transition to check after RUN_IDLE_DEBOUNCE_MS, which
   // can be cancelled by another rising edge inside the window.
+  //
+  // Once `phase` reaches `"hidden"` it stays there: a subsequent run on
+  // the same chat must NOT resurrect a finished pill. New pills mount
+  // on new assistant messages emitted by the new run; this instance's
+  // job is done.
   useEffect(() => {
+    if (phase === "hidden") return undefined;
     if (agent.isRunning) {
       setPhase("spinner");
       return undefined;
     }
     const t = setTimeout(() => setPhase("check"), RUN_IDLE_DEBOUNCE_MS);
     return () => clearTimeout(t);
-  }, [agent.isRunning]);
+  }, [agent.isRunning, phase]);
 
   // check → fading after the hold.
   useEffect(() => {
@@ -190,55 +202,43 @@ export function IntelligenceIndicator(
   });
   if (!hasMatch) return null;
 
-  // The message must belong to the latest run on the thread, AND must
-  // be the latest assistant-with-matching-tool-call message in its
-  // run. We derive both by walking `agent.messages` from the end:
-  //   - the most recent run-associated message defines the latest run
-  //   - the first match-eligible assistant message we hit (walking
-  //     backwards) within `messageRunId` is the canonical pill slot
+  // Walk `agent.messages` from the end and find the latest assistant
+  // message that itself has a matching tool call. If that's not us,
+  // we're not the canonical slot — return `null`.
   //
-  // Tool result messages (`role: "tool"`) and prose-only assistant
-  // messages are skipped during the walk: they don't invalidate an
-  // earlier matching-assistant message's claim on the slot. This is
-  // what keeps the pill continuously visible through a multi-step
-  // tool chain (each MCP tool reply is a `role: "tool"` message that
-  // would otherwise become "the last message in the run" and suppress
-  // the pill on every cycle).
-  const messageRunId = copilotkit.getRunIdForMessage(
-    agentId,
-    config.threadId,
-    message.id,
-  );
-  if (!messageRunId) return null;
-  let latestRunId: string | undefined;
-  let latestMatchingAssistantIdInRun: string | undefined;
+  // Earlier revisions also asked `copilotkit.getRunIdForMessage(...)`
+  // to scope the walk to the current run, but the SDK's run-tracking
+  // map doesn't reliably contain every assistant-with-tool-call
+  // message (the bash-issuing assistant in a real MCP recall flow is
+  // commonly missing) and its threadId key can drift out of sync with
+  // the chat configuration. Both gaps would suppress the pill before
+  // any of the slot logic ran. The walk below stays at the message
+  // layer — it only needs `agent.messages` and `message.role` /
+  // `message.toolCalls`, both of which the runtime always populates
+  // correctly.
+  //
+  // Cross-run isolation: once a pill enters `phase === "hidden"` it
+  // stays there (see the run-state effect above), so a finished pill
+  // can't re-spawn when a later run emits new messages — the new run
+  // mounts new indicator instances on its own assistant messages.
+  let latestMatchingAssistantId: string | undefined;
   for (let i = agent.messages.length - 1; i >= 0; i -= 1) {
     const m = agent.messages[i]!;
-    const r = copilotkit.getRunIdForMessage(agentId, config.threadId, m.id);
-    if (latestRunId === undefined && r) latestRunId = r;
-    if (
-      latestMatchingAssistantIdInRun === undefined &&
-      r === messageRunId &&
-      m.role === "assistant"
-    ) {
-      const tcs = Array.isArray(m.toolCalls) ? m.toolCalls : [];
-      const isMatch = tcs.some((tc) => {
-        const name = tc?.function?.name;
-        return (
-          typeof name === "string" &&
-          DEFAULT_TOOL_PATTERNS.some((p) => p.test(name))
-        );
-      });
-      if (isMatch) latestMatchingAssistantIdInRun = m.id;
-    }
-    if (
-      latestRunId !== undefined &&
-      latestMatchingAssistantIdInRun !== undefined
-    )
+    if (m.role !== "assistant") continue;
+    const tcs = Array.isArray(m.toolCalls) ? m.toolCalls : [];
+    const isMatch = tcs.some((tc) => {
+      const name = tc?.function?.name;
+      return (
+        typeof name === "string" &&
+        DEFAULT_TOOL_PATTERNS.some((p) => p.test(name))
+      );
+    });
+    if (isMatch) {
+      latestMatchingAssistantId = m.id;
       break;
+    }
   }
-  if (latestRunId !== messageRunId) return null;
-  if (latestMatchingAssistantIdInRun !== message.id) return null;
+  if (latestMatchingAssistantId !== message.id) return null;
 
   // ─── Visual ──────────────────────────────────────────────────────────
 

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
@@ -76,10 +76,16 @@ export interface IntelligenceIndicatorProps {
  *   1. `copilotkit.intelligence !== undefined` (Intelligence runtime
  *      is configured; checked by the parent before mounting, and
  *      again here as a defence)
- *   2. The message is the last message of its run
+ *   2. The message is an assistant message with at least one tool call
+ *      whose name matches {@link DEFAULT_TOOL_PATTERNS}
  *   3. The message's run is the latest run on the thread
- *   4. The message has at least one tool call whose name matches
- *      {@link DEFAULT_TOOL_PATTERNS}
+ *   4. The message is the *latest* such matching-assistant message in
+ *      its run — i.e. no later assistant-with-matching-tool-call
+ *      message exists in the same run. Tool result messages
+ *      (`role: "tool"`) and prose-only assistant messages do NOT
+ *      invalidate this slot, so the pill stays continuously through a
+ *      multi-step bash chain instead of flickering off every time a
+ *      tool result arrives.
  *   5. The phase machine is not yet `hidden`
  *
  * Phase machine (per-instance, all timers local):
@@ -185,11 +191,19 @@ export function IntelligenceIndicator(
   if (!hasMatch) return null;
 
   // The message must belong to the latest run on the thread, AND must
-  // be the LAST message in its run. We derive both by walking
-  // `agent.messages` from the end:
+  // be the latest assistant-with-matching-tool-call message in its
+  // run. We derive both by walking `agent.messages` from the end:
   //   - the most recent run-associated message defines the latest run
-  //   - if `message` is the last message in `agent.messages` whose
-  //     runId matches `messageRunId`, it's the last in its run
+  //   - the first match-eligible assistant message we hit (walking
+  //     backwards) within `messageRunId` is the canonical pill slot
+  //
+  // Tool result messages (`role: "tool"`) and prose-only assistant
+  // messages are skipped during the walk: they don't invalidate an
+  // earlier matching-assistant message's claim on the slot. This is
+  // what keeps the pill continuously visible through a multi-step
+  // tool chain (each MCP tool reply is a `role: "tool"` message that
+  // would otherwise become "the last message in the run" and suppress
+  // the pill on every cycle).
   const messageRunId = copilotkit.getRunIdForMessage(
     agentId,
     config.threadId,
@@ -197,19 +211,34 @@ export function IntelligenceIndicator(
   );
   if (!messageRunId) return null;
   let latestRunId: string | undefined;
-  let lastMessageIdInThisRun: string | undefined;
+  let latestMatchingAssistantIdInRun: string | undefined;
   for (let i = agent.messages.length - 1; i >= 0; i -= 1) {
     const m = agent.messages[i]!;
     const r = copilotkit.getRunIdForMessage(agentId, config.threadId, m.id);
     if (latestRunId === undefined && r) latestRunId = r;
-    if (lastMessageIdInThisRun === undefined && r === messageRunId) {
-      lastMessageIdInThisRun = m.id;
+    if (
+      latestMatchingAssistantIdInRun === undefined &&
+      r === messageRunId &&
+      m.role === "assistant"
+    ) {
+      const tcs = Array.isArray(m.toolCalls) ? m.toolCalls : [];
+      const isMatch = tcs.some((tc) => {
+        const name = tc?.function?.name;
+        return (
+          typeof name === "string" &&
+          DEFAULT_TOOL_PATTERNS.some((p) => p.test(name))
+        );
+      });
+      if (isMatch) latestMatchingAssistantIdInRun = m.id;
     }
-    if (latestRunId !== undefined && lastMessageIdInThisRun !== undefined)
+    if (
+      latestRunId !== undefined &&
+      latestMatchingAssistantIdInRun !== undefined
+    )
       break;
   }
   if (latestRunId !== messageRunId) return null;
-  if (lastMessageIdInThisRun !== message.id) return null;
+  if (latestMatchingAssistantIdInRun !== message.id) return null;
 
   // ─── Visual ──────────────────────────────────────────────────────────
 

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -238,6 +238,12 @@
  */
 .cpk-intelligence-pill {
   display: inline-flex;
+  /* Opt out of the parent flex-column's default `align-items: stretch`
+     (the auto-mount lives inside `CopilotChatMessageView`'s
+     `cpk:flex cpk:flex-col` container). Without this the pill would
+     stretch to the full chat width even though `inline-flex` is
+     supposed to shrink to its content. */
+  align-self: flex-start;
   align-items: center;
   gap: 0.55rem;
   margin: 0.4rem 0;


### PR DESCRIPTION
## What does this PR do?

Fixes the auto-mounted `<IntelligenceIndicator>` (added by [`mme/integration-4629-4632-4420`](https://github.com/CopilotKit/CopilotKit/tree/mme/integration-4629-4632-4420)) so it actually renders during real MCP-driven memory-recall flows in the Intelligence simple-agent demo. As shipped on the base branch the pill never appeared; this PR fixes that.

### Problem

Two issues compounded:

1. **Tool-result interleaving suppressed the pill.** The original gate required the indicator's message to be `the last message of its run`. In real MCP flows every assistant-with-tool-call message is immediately followed by `role: "tool"` result messages, so the bash-issuing assistant message lost its "last in run" claim within microseconds. The pill flashed off as soon as the first tool result arrived. By the time the run finished, the final prose-only assistant became the last message in the run, so its own indicator returned `null` (no matching tool calls) and the pill never came back.

2. **The runtime's `getRunIdForMessage` map has gaps.** Empirical inspection of the live SDK state in the browser found:
   - The bash-issuing assistant message is consistently missing from `stateManager.messageToRun` even though it is the message the indicator needs to attach to. The first gate `if (!messageRunId) return null;` short-circuited every render.
   - The threadId key in `messageToRun` can drift out of sync with the chat configuration's threadId, so `getRunIdForMessage(currentThreadId, msgId)` returns `undefined` for every message in the current chat.

### Fix

- Change the `agent.messages` walk to find the **latest assistant message that itself has a matching tool call**. Tool result messages and prose-only assistant messages are skipped during the walk and don't invalidate the slot, so the pill stays continuously through a multi-step tool chain.
- Drop the `copilotkit.getRunIdForMessage(...)` lookup entirely. The walk only needs `agent.messages` and `message.role` / `message.toolCalls`, which the runtime always populates correctly.
- Make `phase === "hidden"` sticky in the run-state effect so that a finished pill cannot resurrect when a later run flips `agent.isRunning` back to `true`. New runs mount fresh indicator instances on their own assistant messages — old ones stay hidden.

### Test-coverage gap

The existing `IntelligenceIndicator.e2e.test.tsx` walkthrough emits assistant-with-toolCalls messages back-to-back without ever emitting `role: "tool"` events between them, so it doesn't exercise the interleaving case real MCP flows always produce. Worth adding a regression test that interleaves a tool result message between two successive assistants — happy to add this in a follow-up if the team wants it in the same PR.

### Verification

End-to-end in the simple-agent demo (Intelligence repo, `lukas/cpk-7527-...` branch) using the canary cut from this branch:

| Scenario | Result |
|---|---|
| Single bash recall | Pill fades in on assistant-with-bash, stays through tool result + final prose, then `isRunning` falls → 500 ms debounce → checkmark (800 ms hold) → fade (480 ms) → DOM-removed |
| Multi-bash recall (8 calls in one assistant message) | Exactly 1 pill on screen the entire run, no flicker |

Browser inspection of `agent.messages` confirms the sequence `user → assistant[bash] → tool → tool → assistant(prose)` with the pill's `data-testid` present continuously from `assistant[bash]` arrival through fade-out.

## Related PRs and Issues

- Consumed by: CopilotKit/Intelligence#155 (simple-agent demo refactor — replaces 414 lines of demo-side pill scaffolding with this auto-mounted indicator)
- Forked from: `mme/integration-4629-4632-4420` (the indicator's introduction commit, 678d143b2)

## Commits

- `92ae94f74` — first iteration: gate change to "latest matching assistant in run" (still scoped via `getRunIdForMessage`). Superseded by the next commit but kept for history; happy to squash on merge.
- `9641a2c11` — final fix: drop `getRunIdForMessage` dependency, sticky `phase === "hidden"`.

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked