### PR TITLE
fix(showcase/dashboard): cap maxPossible at D5 and align live-cell + RefDepth chips

### DIFF
--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -94,11 +94,9 @@ export default function Page() {
       if (cell.status !== "wired" || cell.feature === null) continue;
       const result = deriveDepth(cell as CatalogCell, liveStatus);
       if (result.unsupported) continue;
-      const { achieved, maxPossible, isRegression } = result;
+      const { achieved, maxPossible } = result;
       if (achieved === 0) {
         green++; // D0 = no probe data yet, not a failure
-      } else if (isRegression) {
-        red++;
       } else if (achieved >= maxPossible) {
         green++; // At ceiling — same as green chip
       } else if (maxPossible - achieved <= 2) {

--- a/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
@@ -286,7 +286,7 @@ describe("CellMatrix", () => {
   });
 
   it("filters to rows with regressions when filter=regressions", () => {
-    // lgp/agentic-chat has D5 mapping → maxPossible=6, achieved=2 → regression
+    // lgp/agentic-chat has D5 mapping → maxPossible=5, achieved=2 → regression
     // lgp/no-d5-feature has NO D5 mapping → maxPossible=4, achieved=4 → no regression
     const regressCells: CatalogCell[] = [
       {
@@ -333,7 +333,7 @@ describe("CellMatrix", () => {
         referenceSlug="lgp"
       />,
     );
-    // agentic-chat has regression (achieved=2 < maxPossible=6) → visible
+    // agentic-chat has regression (achieved=2 < maxPossible=5) → visible
     expect(queryByText("Agentic Chat")).not.toBeNull();
     // no-d5-feature at ceiling (achieved=4 === maxPossible=4) → hidden
     expect(queryByText("No D5 Feature")).toBeNull();

--- a/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
@@ -204,7 +204,7 @@ describe("deriveDepth", () => {
   // ── isRegression now compares against maxPossible, not historical max_depth ──
 
   it("isRegression is true when achieved < maxPossible (D5 mapping exists, CV red)", () => {
-    // "agentic-chat" has D5 mapping → maxPossible=6, achieved=4 → regression
+    // "agentic-chat" has D5 mapping → maxPossible=5, achieved=4 → regression
     const c = cell("lgp", "agentic-chat", "wired", 4);
     const live = mapOf([
       row("health:lgp", "health", "green"),
@@ -215,7 +215,7 @@ describe("deriveDepth", () => {
     ]);
     const result = deriveDepth(c, live);
     expect(result.achieved).toBe(4);
-    expect(result.maxPossible).toBe(6);
+    expect(result.maxPossible).toBe(5);
     expect(result.isRegression).toBe(true);
   });
 
@@ -235,12 +235,12 @@ describe("deriveDepth", () => {
   });
 
   it("isRegression is true when health drops (maxPossible > 0)", () => {
-    // "agentic-chat" has D5 mapping → maxPossible=6, health red → achieved=0
+    // "agentic-chat" has D5 mapping → maxPossible=5, health red → achieved=0
     const c = cell("lgp", "agentic-chat", "wired", 1);
     const live = mapOf([row("health:lgp", "health", "red")]);
     const result = deriveDepth(c, live);
     expect(result.achieved).toBe(0);
-    expect(result.maxPossible).toBe(6);
+    expect(result.maxPossible).toBe(5);
     expect(result.isRegression).toBe(true);
   });
 
@@ -339,7 +339,7 @@ describe("deriveDepth", () => {
   // ── maxPossible computation ──
 
   describe("maxPossible", () => {
-    it("(a) D5 mapping exists, all green → achieved=5, maxPossible=6, chip=GREEN territory", () => {
+    it("(a) D5 mapping exists, all green → achieved=5, maxPossible=5, chip=GREEN territory", () => {
       const c = cell("lgp", "agentic-chat");
       const live = mapOf([
         row("health:lgp", "health", "green"),
@@ -350,12 +350,12 @@ describe("deriveDepth", () => {
       ]);
       const result = deriveDepth(c, live);
       expect(result.achieved).toBe(5);
-      expect(result.maxPossible).toBe(6);
-      // achieved < maxPossible → regression (D6 is possible but not achieved)
-      expect(result.isRegression).toBe(true);
+      expect(result.maxPossible).toBe(5);
+      // achieved === maxPossible → at ceiling, no regression
+      expect(result.isRegression).toBe(false);
     });
 
-    it("(a-full) D5+D6 mapping exists, all green → achieved=6, maxPossible=6", () => {
+    it("(a-full) D5+D6 green → achieved=6, maxPossible=5 (D6 is stretch, still at-ceiling)", () => {
       const c = cell("lgp", "agentic-chat");
       const live = mapOf([
         row("health:lgp", "health", "green"),
@@ -367,11 +367,13 @@ describe("deriveDepth", () => {
       ]);
       const result = deriveDepth(c, live);
       expect(result.achieved).toBe(6);
-      expect(result.maxPossible).toBe(6);
+      expect(result.maxPossible).toBe(5);
+      // depthColorClass treats `depth >= maxDepth` as at-ceiling, so D6
+      // still renders green even though it exceeds the structural cap.
       expect(result.isRegression).toBe(false);
     });
 
-    it("(b) D5 mapping exists, CV red → achieved=4, maxPossible=6, chip=AMBER territory", () => {
+    it("(b) D5 mapping exists, CV red → achieved=4, maxPossible=5, chip=AMBER territory", () => {
       const c = cell("lgp", "agentic-chat");
       const live = mapOf([
         row("health:lgp", "health", "green"),
@@ -382,11 +384,11 @@ describe("deriveDepth", () => {
       ]);
       const result = deriveDepth(c, live);
       expect(result.achieved).toBe(4);
-      expect(result.maxPossible).toBe(6);
+      expect(result.maxPossible).toBe(5);
       expect(result.isRegression).toBe(true);
     });
 
-    it("(c) D5 mapping exists, CV no data → achieved=4, maxPossible=6, chip=AMBER territory", () => {
+    it("(c) D5 mapping exists, CV no data → achieved=4, maxPossible=5, chip=AMBER territory", () => {
       const c = cell("lgp", "agentic-chat");
       const live = mapOf([
         row("health:lgp", "health", "green"),
@@ -397,7 +399,7 @@ describe("deriveDepth", () => {
       ]);
       const result = deriveDepth(c, live);
       expect(result.achieved).toBe(4);
-      expect(result.maxPossible).toBe(6);
+      expect(result.maxPossible).toBe(5);
       expect(result.isRegression).toBe(true);
     });
 
@@ -429,7 +431,7 @@ describe("deriveDepth", () => {
       expect(result.isRegression).toBe(true);
     });
 
-    it("(f) D2 with maxPossible=6 → chip=RED territory (4 levels below)", () => {
+    it("(f) D2 with maxPossible=5 → chip=RED territory (3 levels below)", () => {
       const c = cell("lgp", "agentic-chat");
       const live = mapOf([
         row("health:lgp", "health", "green"),
@@ -438,8 +440,8 @@ describe("deriveDepth", () => {
       ]);
       const result = deriveDepth(c, live);
       expect(result.achieved).toBe(2);
-      expect(result.maxPossible).toBe(6);
-      // 6 - 2 = 4, which is > 2 → RED territory
+      expect(result.maxPossible).toBe(5);
+      // 5 - 2 = 3, which is > 2 → RED territory
       expect(result.isRegression).toBe(true);
     });
 
@@ -448,7 +450,7 @@ describe("deriveDepth", () => {
       const live = mapOf([]); // no live data
       const result = deriveDepth(c, live);
       expect(result.achieved).toBe(0);
-      expect(result.maxPossible).toBe(6); // D5 mapping exists
+      expect(result.maxPossible).toBe(5); // D5 mapping exists
       expect(result.isRegression).toBe(true);
     });
 

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -110,7 +110,6 @@ function DepthLayer({
         <DepthChip
           depth={depth.achieved}
           status={catalogCell.status}
-          regression={depth.isRegression}
           maxDepth={depth.maxPossible}
         />
       </button>

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -90,7 +90,12 @@ function isD5Green(
  * - D0: always possible for wired/stub cells
  * - D1-D4: always possible if the cell has a feature ID
  * - D5: possible only if CATALOG_TO_D5_KEY[featureId] exists and has entries
- * - D6: always possible if D5 is possible (d6 keys are per-feature)
+ * - D6: a stretch goal, not a structural ceiling — D6 probes are rare and
+ *   not registered per-feature, so we treat D5 as the ceiling. A cell that
+ *   actually reaches D6 still renders green (depthColorClass treats
+ *   `depth >= maxDepth` as at-ceiling), so capping at 5 doesn't penalize
+ *   the rare D6 achievers — it just stops penalizing every D5 cell as
+ *   "below ceiling" when D6 was never wired.
  */
 function computeMaxPossible(cell: CatalogCell): AchievedDepth {
   // Unsupported/unshipped: max possible is 0.
@@ -110,9 +115,8 @@ function computeMaxPossible(cell: CatalogCell): AchievedDepth {
     return 4;
   }
 
-  // D5 mapping exists: D6 is always structurally possible too
-  // (d6 keys are per-feature, no separate mapping needed).
-  return 6;
+  // D5 mapping exists. D6 is a stretch goal — see fn doc above.
+  return 5;
 }
 
 /**

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -312,7 +312,7 @@ const CategorySection = React.memo(
                       status={
                         refDepth.unsupported ? "unsupported" : refCell.status
                       }
-                      regression={refDepth.isRegression}
+                      maxDepth={refDepth.maxPossible}
                     />
                   ) : (
                     <td

--- a/showcase/shell-dashboard/src/components/ref-depth-column.tsx
+++ b/showcase/shell-dashboard/src/components/ref-depth-column.tsx
@@ -31,17 +31,17 @@ export function RefDepthHeader() {
 export interface RefDepthCellProps {
   depth: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   status: "wired" | "stub" | "unshipped" | "unsupported";
-  /** When true, chip renders in red regardless of depth. */
-  regression?: boolean;
+  /** Structural ceiling for this cell — drives graduated chip coloring. */
+  maxDepth?: number;
 }
 
-export function RefDepthCell({ depth, status, regression }: RefDepthCellProps) {
+export function RefDepthCell({ depth, status, maxDepth }: RefDepthCellProps) {
   return (
     <td
       className="sticky left-[160px] z-10 px-1.5 py-1 border-r-2 border-r-[#c4b5fd] border-l border-[var(--border)] align-top"
       style={{ backgroundColor: "#f5f0ff" }}
     >
-      <DepthChip depth={depth} status={status} regression={regression} />
+      <DepthChip depth={depth} status={status} maxDepth={maxDepth} />
     </td>
   );
 }


### PR DESCRIPTION
Follow-up to #4664 — same root cause, two more callsites and one inflation.

## Two issues

### 1. Live cell + Ref Depth column still rendered red
`composed-cell.tsx`, `feature-grid.tsx` (via `ref-depth-column.tsx`) had the same regression-vs-ceiling collision the matrix views did: they passed `regression={depth.isRegression}` to `DepthChip`, and `regression` short-circuits the chip to red regardless of `maxDepth`. Switched them to pass `maxDepth={depth.maxPossible}` only. `RefDepthCellProps.regression?` flips to `maxDepth?` to stop propagating the dead prop.

### 2. `maxPossible` was inflated to 6
`computeMaxPossible` returned **6** whenever a D5 mapping existed, on the assumption D6 was structurally reachable. There is no per-feature D6 registry, so D6 is a stretch goal in practice — every D5 cell rendered amber as "1 below ceiling," even when it was the realistic ceiling. Cap at 5; D6-green cells still render green because `depthColorClass` treats `depth >= maxDepth` as at-ceiling.

This restores the cap from commit `eda75a512` (*"D5 mapping means max=5 not 6 (D6 probes are rare)"*) which was lost in the subsequent depth thrash.

`page.tsx` `healthStats` also dropped its `isRegression` short-circuit so the stats bar mirrors the chip's graduated logic instead of double-counting non-ceiling cells as red.

## Verified locally

Pointed dev dashboard at production PocketBase + harness:
- Before: 539 D5 cells **amber**, 162 D4 green
- After: **701 green**, 0 amber, 0 red

## Test plan

- [x] `depth-utils`, `depth-chip`, `parity-matrix`, `cell-matrix`, `composed-cell`, `feature-grid` test files — 115/115 passing
- [x] Visual check on local dashboard against prod data — all wired cells now render green
- [ ] On deploy, confirm matrix view at `dashboard.showcase.copilotkit.ai/#matrix:depth,health` matches local