### PR TITLE
fix(showcase/beautiful-chat): render A2UI surfaces (fixed + dynamic schema)

### DIFF
--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -2,6 +2,44 @@
   "fixtures": [
     {
       "match": {
+        "toolCallId": "call_fp_generate_a2ui_sales_dashboard_001"
+      },
+      "response": {
+        "content": "Here's your sales dashboard \u2014 total revenue is $1.2M (+12% MoM), 342 new customers, and 4.2% conversion. The pie shows revenue split by category and the bar chart tracks monthly sales."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "with total revenue, new customers, and conversion rate metrics",
+        "toolName": "render_a2ui"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_render_a2ui_sales_dashboard_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"beautiful-chat-sales-dashboard\",\"catalogId\":\"copilotkit://app-dashboard-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"children\":[\"row-metrics\",\"row-charts\"],\"gap\":16},{\"id\":\"row-metrics\",\"component\":\"Row\",\"children\":[\"card-revenue\",\"card-customers\",\"card-conversion\"],\"gap\":16},{\"id\":\"card-revenue\",\"component\":\"DashboardCard\",\"title\":\"Total Revenue\",\"child\":\"metric-revenue\"},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Total Revenue\",\"value\":\"$1.2M\",\"trend\":\"up\",\"trendValue\":\"+12% MoM\"},{\"id\":\"card-customers\",\"component\":\"DashboardCard\",\"title\":\"New Customers\",\"child\":\"metric-customers\"},{\"id\":\"metric-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"342\",\"trend\":\"up\",\"trendValue\":\"+8% MoM\"},{\"id\":\"card-conversion\",\"component\":\"DashboardCard\",\"title\":\"Conversion Rate\",\"child\":\"metric-conversion\"},{\"id\":\"metric-conversion\",\"component\":\"Metric\",\"label\":\"Conversion Rate\",\"value\":\"4.2%\",\"trend\":\"neutral\"},{\"id\":\"row-charts\",\"component\":\"Row\",\"children\":[\"card-pie\",\"card-bar\"],\"gap\":16},{\"id\":\"card-pie\",\"component\":\"DashboardCard\",\"title\":\"Revenue by Category\",\"child\":\"pie-revenue\"},{\"id\":\"pie-revenue\",\"component\":\"PieChart\",\"data\":[{\"label\":\"Electronics\",\"value\":42000},{\"label\":\"Clothing\",\"value\":28000},{\"label\":\"Food\",\"value\":18000},{\"label\":\"Books\",\"value\":12000}]},{\"id\":\"card-bar\",\"component\":\"DashboardCard\",\"title\":\"Monthly Sales\",\"child\":\"bar-monthly\"},{\"id\":\"bar-monthly\",\"component\":\"BarChart\",\"data\":[{\"label\":\"Jan\",\"value\":50000},{\"label\":\"Feb\",\"value\":62000},{\"label\":\"Mar\",\"value\":58000},{\"label\":\"Apr\",\"value\":71000},{\"label\":\"May\",\"value\":80000},{\"label\":\"Jun\",\"value\":92000}]}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "with total revenue, new customers, and conversion rate metrics",
+        "toolName": "generate_a2ui"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_generate_a2ui_sales_dashboard_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
         "toolCallId": "call_fp_get_weather_001"
       },
       "response": {

--- a/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
+++ b/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
@@ -110,13 +110,16 @@ def query_data(query: str):
 
 CATALOG_ID = "copilotkit://app-dashboard-catalog"
 SURFACE_ID = "flight-search-results"
-FLIGHT_SCHEMA = a2ui.load_schema(
-    _DATA_DIR / "schemas" / "flight_schema.json"
-)
 
 
-class Flight(TypedDict):
-    id: str
+class Flight(TypedDict, total=False):
+    # Only `airline`-through-`price` are read by `_build_flight_components`.
+    # All fields marked optional (`total=False`) so the LLM (or aimock fixture)
+    # can omit auxiliary fields like `id` / `statusIcon` without tripping
+    # langchain's tool-arg validation. Previously these were required and any
+    # missing field surfaced as `Error invoking tool 'search_flights' with
+    # kwargs ... flights.N.id: Field required` — the agent treated the error
+    # string as the tool result and the surface never rendered.
     airline: str
     airlineLogo: str
     flightNumber: str
@@ -127,12 +130,48 @@ class Flight(TypedDict):
     arrivalTime: str
     duration: str
     status: str
-    statusIcon: str
     price: str
 
 
+def _build_flight_components(flights: list[dict]) -> list[dict]:
+    """Build a flat A2UI component tree with one literal FlightCard per flight.
+
+    Avoids the structural-children template form (Row.children = { componentId,
+    path }), which the GenericBinder only expands correctly for components whose
+    schema declares STRUCTURAL children — sibling demos work because their
+    schemas use literal-string-array children. Inlining the values per-flight
+    sidesteps the template path entirely and renders identically.
+    """
+    flight_card_ids: list[str] = []
+    components: list[dict] = []
+    for index, flight in enumerate(flights):
+        card_id = f"flight-card-{index}"
+        flight_card_ids.append(card_id)
+        components.append({
+            "id": card_id,
+            "component": "FlightCard",
+            "airline": flight["airline"],
+            "airlineLogo": flight["airlineLogo"],
+            "flightNumber": flight["flightNumber"],
+            "origin": flight["origin"],
+            "destination": flight["destination"],
+            "date": flight["date"],
+            "departureTime": flight["departureTime"],
+            "arrivalTime": flight["arrivalTime"],
+            "duration": flight["duration"],
+            "status": flight["status"],
+            "price": flight["price"],
+        })
+    root: dict = {
+        "id": "root",
+        "component": "Row",
+        "children": flight_card_ids,
+    }
+    return [root, *components]
+
+
 @tool
-def search_flights(flights: list[Flight]) -> str:
+def search_flights(flights: list[dict]) -> str:
     """Search for flights and display the results as rich cards. Return exactly 2 flights.
 
     Each flight must have: id, airline (e.g. "United Airlines"),
@@ -153,8 +192,7 @@ def search_flights(flights: list[Flight]) -> str:
     return a2ui.render(
         operations=[
             a2ui.create_surface(SURFACE_ID, catalog_id=CATALOG_ID),
-            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
+            a2ui.update_components(SURFACE_ID, _build_flight_components(flights)),
         ],
     )
 
@@ -267,10 +305,9 @@ agent = create_agent(
         - Flights: call search_flights to show flight cards with a pre-built schema.
         - Dashboards & rich UI: call generate_a2ui to create dashboard UIs with metrics,
           charts, tables, and cards. It handles rendering automatically.
-        - Charts: call query_data first, then render with the chart component.
-        - Todos: enable app mode first, then manage todos.
-        - A2UI actions: when you see a log_a2ui_event result (e.g. "view_details"),
-          respond with a brief confirmation. The UI already updated on the frontend.
+        - Charts: call query_data first, then render via pieChart or barChart (Controlled
+          Generative UI components registered on the frontend).
+        - Todos: call manage_todos to add, update, or remove todos.
     """,
 )
 

--- a/showcase/integrations/langgraph-python/src/app/demos/beautiful-chat/declarative-generative-ui/definitions.ts
+++ b/showcase/integrations/langgraph-python/src/app/demos/beautiful-chat/declarative-generative-ui/definitions.ts
@@ -27,35 +27,31 @@ export const demonstrationCatalogDefinitions = {
     }),
   },
 
-  // Text: removed — the basic catalog's Text uses DynamicStringSchema
-  // which supports path bindings (e.g. { path: "flights[*].airline" }).
-  // Overriding it with z.string() breaks fixed-schema data binding.
-
+  // Custom Row/Column: override the basic catalog's versions so we can
+  // honour `gap` (basic Row/Column from web_core ignores it). We accept
+  // children as a literal-string array only — the agent
+  // (`src/agents/beautiful_chat.py` + the dashboard fixture) expands any
+  // per-item iteration server-side, so we don't need the binder's
+  // structural-children form here. `Text` is still provided by the basic
+  // catalog (path-binding support there is non-trivial to replicate).
   Row: {
-    description: "Horizontal layout container.",
+    description:
+      "Horizontal layout container. Children must be an array of component IDs.",
     props: z.object({
       gap: z.number().optional(),
       align: z.string().optional(),
       justify: z.string().optional(),
-      // Union with { componentId, path } so GenericBinder treats this as
-      // STRUCTURAL and resolves template children from the data model.
-      children: z.union([
-        z.array(z.string()),
-        z.object({ componentId: z.string(), path: z.string() }),
-      ]),
+      children: z.array(z.string()),
     }),
   },
 
   Column: {
-    description: "Vertical layout container.",
+    description:
+      "Vertical layout container. Children must be an array of component IDs.",
     props: z.object({
       gap: z.number().optional(),
       align: z.string().optional(),
-      // Same union as Row — required for template children support.
-      children: z.union([
-        z.array(z.string()),
-        z.object({ componentId: z.string(), path: z.string() }),
-      ]),
+      children: z.array(z.string()),
     }),
   },
 

--- a/showcase/integrations/langgraph-python/src/app/demos/beautiful-chat/declarative-generative-ui/renderers.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/beautiful-chat/declarative-generative-ui/renderers.tsx
@@ -132,9 +132,6 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
       );
     },
 
-    // Text: removed — use the basic catalog's Text (supports DynamicStringSchema
-    // for path bindings in fixed-schema templates).
-
     Row: ({ props, children }) => {
       const justifyMap: Record<string, string> = {
         start: "flex-start",
@@ -156,27 +153,14 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             width: "100%",
           }}
         >
-          {items.map((item: any, i: number) => {
-            if (typeof item === "string")
-              return (
-                <div
-                  key={`${item}-${i}`}
-                  style={{ flex: "1 1 0", minWidth: 0 }}
-                >
-                  {children(item)}
-                </div>
-              );
-            if (item && typeof item === "object" && "id" in item)
-              return (
-                <div
-                  key={`${item.id}-${i}`}
-                  style={{ flex: "1 1 0", minWidth: 0 }}
-                >
-                  {(children as any)(item.id, item.basePath)}
-                </div>
-              );
-            return null;
-          })}
+          {items.map((id: string, i: number) => (
+            <div
+              key={`${id}-${i}`}
+              style={{ flex: "1 1 0", minWidth: 0 }}
+            >
+              {children(id)}
+            </div>
+          ))}
         </div>
       );
     },
@@ -192,21 +176,9 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             width: "100%",
           }}
         >
-          {items.map((item: any, i: number) => {
-            if (typeof item === "string")
-              return (
-                <React.Fragment key={`${item}-${i}`}>
-                  {children(item)}
-                </React.Fragment>
-              );
-            if (item && typeof item === "object" && "id" in item)
-              return (
-                <React.Fragment key={`${item.id}-${i}`}>
-                  {(children as any)(item.id, item.basePath)}
-                </React.Fragment>
-              );
-            return null;
-          })}
+          {items.map((id: string, i: number) => (
+            <React.Fragment key={`${id}-${i}`}>{children(id)}</React.Fragment>
+          ))}
         </div>
       );
     },
@@ -601,5 +573,12 @@ export const demonstrationCatalog = createCatalog(
   demonstrationCatalogRenderers,
   {
     catalogId: "copilotkit://app-dashboard-catalog",
+    // Required: merges the basic A2UI primitives (Row, Column, Text, Card,
+    // Button, …) into this catalog so structural-children expansion works
+    // for templates like flight_schema.json's
+    // `Row { children: { componentId: "flight-card", path: "/flights" } }`.
+    // Both sibling working demos (a2ui-fixed-schema, declarative-gen-ui)
+    // already set this — beautiful-chat was the outlier.
+    includeBasicCatalog: true,
   },
 );

--- a/showcase/integrations/langgraph-python/src/app/demos/beautiful-chat/declarative-generative-ui/renderers.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/beautiful-chat/declarative-generative-ui/renderers.tsx
@@ -12,7 +12,8 @@
  */
 "use client";
 
-import React, { useState, type JSX } from "react";
+import React, { useState } from "react";
+import type { JSX } from "react";
 import {
   PieChart as RechartsPie,
   Pie,
@@ -25,14 +26,10 @@ import {
   Tooltip,
   CartesianGrid,
 } from "recharts";
-import {
-  createCatalog,
-  type CatalogRenderers,
-} from "@copilotkit/a2ui-renderer";
-import {
-  demonstrationCatalogDefinitions,
-  type DemonstrationCatalogDefinitions,
-} from "./definitions";
+import { createCatalog } from "@copilotkit/a2ui-renderer";
+import type { CatalogRenderers } from "@copilotkit/a2ui-renderer";
+import { demonstrationCatalogDefinitions } from "./definitions";
+import type { DemonstrationCatalogDefinitions } from "./definitions";
 
 // ─── Theme-aware colors ─────────────────────────────────────────────
 
@@ -154,10 +151,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
           }}
         >
           {items.map((id: string, i: number) => (
-            <div
-              key={`${id}-${i}`}
-              style={{ flex: "1 1 0", minWidth: 0 }}
-            >
+            <div key={`${id}-${i}`} style={{ flex: "1 1 0", minWidth: 0 }}>
               {children(id)}
             </div>
           ))}

--- a/showcase/integrations/langgraph-python/tests/e2e/beautiful-chat.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/beautiful-chat.spec.ts
@@ -3,6 +3,11 @@ import { test, expect } from "@playwright/test";
 test.describe("Beautiful Chat", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/demos/beautiful-chat");
+    // The chat client (CopilotKit v2) needs a moment to attach its provider
+    // before suggestion clicks dispatch reliably. Without this the click can
+    // race the hydration and silently no-op. Existing pill tests above were
+    // tolerant of this — the A2UI tests need the round-trip to succeed.
+    await page.waitForTimeout(3000);
   });
 
   test("page loads with logo, mode toggle, and chat input", async ({
@@ -116,5 +121,71 @@ test.describe("Beautiful Chat", () => {
     await expect
       .poll(async () => await bars.count(), { timeout: 15000 })
       .toBeGreaterThanOrEqual(2);
+  });
+
+  test("Search Flights pill renders FlightCard surface from A2UI fixed schema", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    // Backend: search_flights tool emits an a2ui_operations container with one
+    // FlightCard component per flight. The agent (`src/agents/beautiful_chat.py`
+    // `_build_flight_components`) emits literal-children components rather than
+    // the structural-children template form, because the binder's structural
+    // expansion isn't reliably exercised by sibling demos. Aimock returns 2
+    // flights — United at $349 and Delta at $289.
+    //
+    // Visual fingerprint: the airline names and prices are inlined into each
+    // FlightCard so they appear as literal text.
+    const pill = page.getByRole("button", {
+      name: "Search Flights (A2UI Fixed Schema)",
+    });
+    await expect(pill).toBeVisible({ timeout: 15_000 });
+    await pill.click();
+
+    // 60s budget: tool call + a2ui_operations round-trip can be slow on cold
+    // starts. Assertion targets are aimock-fixture text, not LLM output, so
+    // they're stable across runs.
+    await expect(page.getByText("United Airlines").first()).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(page.getByText("Delta").first()).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByText("$349").first()).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByText("$289").first()).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("Sales Dashboard pill renders A2UI dashboard surface", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    // Backend: generate_a2ui tool calls a secondary LLM bound to render_a2ui;
+    // both calls hit aimock fixtures
+    // (showcase/aimock/feature-parity.json — userMessage + toolName matchers
+    // differentiate primary vs secondary calls; a toolCallId match breaks the
+    // post-tool loop). The render_a2ui fixture ships a 3-metric + 2-chart
+    // dashboard tree against `copilotkit://app-dashboard-catalog`.
+    //
+    // Visual fingerprint: a Metric label "Total Revenue", plus a recharts
+    // ResponsiveContainer (the Pie/BarChart custom renderers wrap their
+    // recharts content in one).
+    const pill = page.getByRole("button", {
+      name: "Sales Dashboard (A2UI Dynamic)",
+    });
+    await expect(pill).toBeVisible({ timeout: 15_000 });
+    await pill.click();
+
+    // 90s budget: secondary-LLM stage inside generate_a2ui can stall on cold
+    // starts.
+    await expect(page.getByText(/Total Revenue/i).first()).toBeVisible({
+      timeout: 90_000,
+    });
+
+    const chartRoot = page.locator(".recharts-responsive-container").first();
+    await expect(chartRoot).toBeVisible({ timeout: 15_000 });
   });
 });


### PR DESCRIPTION
## Summary

Search Flights and Sales Dashboard pills on the langgraph-python beautiful-chat demo now produce visible A2UI surfaces. Three independent bugs were masking each other:

- **Tool args were silently rejected.** `Flight` TypedDict required `id` + `statusIcon`, which the aimock fixture doesn't supply. langchain bounced the call with `flights.0.id: Field required` and the agent surfaced the validation error string as the "tool result" — so the LLM summarized "Two flights shown above" without any cards ever rendering. Made `Flight` permissive (`total=False` then `list[dict]`); only the fields `_build_flight_components` reads need to be there.
- **`search_flights` now expands flights into literal-children FlightCards server-side.** The structural-children template form (`Row.children = { componentId, path }`) doesn't reliably expand for our custom catalog — the working sibling demo (`a2ui-fixed-schema`) avoids the form for the same reason.
- **Sales Dashboard pill went into a tool-call loop** because the `userMessage + toolName` fixtures matched both the initial call and the post-tool turn. Hoisted the `toolCallId` fixture above them so the follow-up turn returns content and breaks the loop. Three new fixtures at the top of `feature-parity.json`: a follow-up content match, the secondary-LLM `render_a2ui` call, and the primary `generate_a2ui` call.

Reintroduced custom `Row`/`Column` renderers with `gap` support — the basic catalog versions ignore it and the dashboard cards were squished. Children are array-of-strings only (matches what the agent and fixture emit).

## Test plan

- [x] All 7 tests in `showcase/integrations/langgraph-python/tests/e2e/beautiful-chat.spec.ts` pass (45s). Two new ones cover both pills end-to-end: `Search Flights pill renders FlightCard surface from A2UI fixed schema` and `Sales Dashboard pill renders A2UI dashboard surface`.
- [x] `pnpm test aimock-fixtures` passes (18/18) — fixture schema validator is happy with the 3 new entries.
- [x] Manual visual confirmation: both pills render full surfaces with proper card spacing.
- [x] No regression on existing `Toggle Theme` / `Pie Chart` / `Bar Chart` pills.

## Notes

- Added a 3-second `waitForTimeout` to the spec's `beforeEach` so the v2 chat provider hydrates before suggestion clicks dispatch. Without it, the click can race past hydration and silently no-op (the existing pre-existing tests happened to be tolerant of this; the A2UI ones aren't).
- System prompt cleaned up: dropped references to tools that don't exist (`log_a2ui_event`, "enable app mode") and named `pieChart`/`barChart` explicitly.