### PR TITLE
feat(showcase): D5 probe for beautiful-chat (langgraph-python)

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -525,6 +525,30 @@
           "text": "What is the weather in Tokyo?"
         }
       }
+    },
+    {
+      "match": {
+        "userMessage": "d5 beautiful-chat probe",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_search_flights_001",
+            "name": "search_flights",
+            "arguments": "{\"flights\":[{\"airline\":\"United Airlines\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=united.com&sz=128\",\"flightNumber\":\"UA123\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"08:00\",\"arrivalTime\":\"16:30\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"price\":\"$349\"},{\"airline\":\"Delta\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=delta.com&sz=128\",\"flightNumber\":\"DL456\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"10:15\",\"arrivalTime\":\"18:45\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"price\":\"$289\"}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "d5 beautiful-chat probe",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Two flights shown above — United at $349 (08:00) and Delta at $289 (10:15), both on time."
+      }
     }
   ]
 }

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -527,14 +527,80 @@
       }
     },
     {
+      "_comment": "Turn 1: Toggle Theme — single-shot frontend tool call.",
       "match": {
-        "userMessage": "d5 beautiful-chat probe",
+        "userMessage": "d5 beautiful-chat probe: toggle the theme"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_toggle_theme_001",
+            "name": "toggleTheme",
+            "arguments": "{}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Turn 2: Pie Chart — direct pieChart toolCall (skipping query_data — payload supplies inline data so the chart renders without a query_data round-trip, matching feature-parity's 'revenue distribution by category' pattern).",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: pie chart of revenue distribution by category",
         "hasToolResult": false
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d5_search_flights_001",
+            "id": "call_d5_bc_pie_chart_001",
+            "name": "pieChart",
+            "arguments": "{\"title\":\"Revenue by Category\",\"description\":\"Breakdown of revenue across product categories\",\"data\":[{\"label\":\"Electronics\",\"value\":42000},{\"label\":\"Clothing\",\"value\":28000},{\"label\":\"Food\",\"value\":18000},{\"label\":\"Books\",\"value\":12000}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: pie chart of revenue distribution by category",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Pie chart rendered above — Electronics leads at $42k, followed by Clothing, Food, and Books."
+      }
+    },
+    {
+      "_comment": "Turn 3: Bar Chart — direct barChart toolCall, mirrors feature-parity's 'expenses by category' fixture.",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: bar chart of expenses by category",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_bar_chart_001",
+            "name": "barChart",
+            "arguments": "{\"title\":\"Expenses by Category\",\"description\":\"Monthly expense breakdown\",\"data\":[{\"label\":\"Rent\",\"value\":15000},{\"label\":\"Salaries\",\"value\":80000},{\"label\":\"Marketing\",\"value\":12000},{\"label\":\"Travel\",\"value\":5000}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: bar chart of expenses by category",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Bar chart rendered above — Salaries dominate at $80k, with Rent at $15k as the next-largest category."
+      }
+    },
+    {
+      "_comment": "Turn 4: Search Flights — A2UI fixed-schema. Two-stage matcher (false→true). Payload byte-equal to feature-parity's call_fp_search_flights_001 so FlightCard literal fingerprints match across both runners.",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: search flights from SFO to JFK",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_search_flights_001",
             "name": "search_flights",
             "arguments": "{\"flights\":[{\"airline\":\"United Airlines\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=united.com&sz=128\",\"flightNumber\":\"UA123\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"08:00\",\"arrivalTime\":\"16:30\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"price\":\"$349\"},{\"airline\":\"Delta\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=delta.com&sz=128\",\"flightNumber\":\"DL456\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"10:15\",\"arrivalTime\":\"18:45\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"price\":\"$289\"}]}"
           }
@@ -543,11 +609,115 @@
     },
     {
       "match": {
-        "userMessage": "d5 beautiful-chat probe",
+        "userMessage": "d5 beautiful-chat probe: search flights from SFO to JFK",
         "hasToolResult": true
       },
       "response": {
         "content": "Two flights shown above — United at $349 (08:00) and Delta at $289 (10:15), both on time."
+      }
+    },
+    {
+      "_comment": "Turn 5: Schedule Meeting — single-shot scheduleTime call. The HITL pauses the agent until the picker UI is resolved by the user; the probe assertion CLICKS a slot to resume. After the slot click, MeetingTimePicker calls respond('Meeting scheduled for Tomorrow at 2:00 PM (30 min)') which the agent processes via the tool-result match below.",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: schedule a 30-minute meeting to learn about CopilotKit",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_schedule_time_001",
+            "name": "scheduleTime",
+            "arguments": "{\"reasonForScheduling\":\"Learn about CopilotKit\",\"meetingDuration\":30}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_bc_schedule_time_001"
+      },
+      "response": {
+        "content": "Meeting scheduled — calendar invite is on its way."
+      }
+    },
+    {
+      "_comment": "Turn 6a: Sales Dashboard primary call — generate_a2ui. The userMessage substring is unique to D5; toolName is omitted so this matches the agent's first turn, not the secondary render_a2ui call.",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: sales dashboard with metrics and charts",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_generate_a2ui_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Turn 6b: Sales Dashboard secondary LLM call. Inside generate_a2ui, the agent binds a fresh ChatOpenAI to render_a2ui and asks it to produce the actual UI tree. aimock disambiguates this from 6a via toolName=render_a2ui — the call is for render_a2ui specifically, not generate_a2ui. Catalog id matches feature-parity's copilotkit://app-dashboard-catalog. Tree: 'Total Revenue' Metric label + a Markdown header + Pie/Bar wrappers (each contains a recharts ResponsiveContainer).",
+      "match": {
+        "toolName": "render_a2ui"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_render_a2ui_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"d5-bc-sales-dashboard\",\"catalogId\":\"copilotkit://app-dashboard-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"children\":[\"header\",\"metrics\",\"charts\"]},{\"id\":\"header\",\"component\":\"Markdown\",\"children\":\"## Q4 Sales Summary\"},{\"id\":\"metrics\",\"component\":\"Row\",\"children\":[\"m1\",\"m2\",\"m3\"]},{\"id\":\"m1\",\"component\":\"Metric\",\"label\":\"Total Revenue\",\"value\":\"$1.2M\"},{\"id\":\"m2\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"248\"},{\"id\":\"m3\",\"component\":\"Metric\",\"label\":\"Conversion Rate\",\"value\":\"3.4%\"},{\"id\":\"charts\",\"component\":\"Row\",\"children\":[\"pie\",\"bar\"]},{\"id\":\"pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Segment\",\"data\":[{\"label\":\"Enterprise\",\"value\":600000},{\"label\":\"SMB\",\"value\":400000},{\"label\":\"Startup\",\"value\":200000}]},{\"id\":\"bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"data\":[{\"label\":\"Oct\",\"value\":350000},{\"label\":\"Nov\",\"value\":400000},{\"label\":\"Dec\",\"value\":450000}]}]}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Turn 6c: Sales Dashboard post-tool-result — closes the conversation so the runner's settle advances. toolCallId match disambiguates from 6a's userMessage match.",
+      "match": {
+        "toolCallId": "call_d5_bc_generate_a2ui_001"
+      },
+      "response": {
+        "content": "Sales dashboard rendered above — Total Revenue $1.2M, with breakdowns by segment and month."
+      }
+    },
+    {
+      "_comment": "Turn 7a: Task Manager — first call enableAppMode (frontend tool that flips the chat layout to expose the App pane). hasToolResult: false matches the user's initial turn before any tool has run. parallel_tool_calls is False on the agent, so this fires alone.",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: enable app mode and add three todos",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_enable_app_mode_001",
+            "name": "enableAppMode",
+            "arguments": "{}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Turn 7b: After enableAppMode resolves (frontend tool returns immediately), the agent's next turn calls manage_todos. toolCallId match disambiguates this post-enableAppMode turn from any subsequent post-manage_todos turn.",
+      "match": {
+        "toolCallId": "call_d5_bc_enable_app_mode_001"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_manage_todos_001",
+            "name": "manage_todos",
+            "arguments": "{\"todos\":[{\"id\":\"d5-todo-1\",\"title\":\"Read CopilotKit docs\",\"description\":\"Skim the quickstart and read the architecture guide.\",\"emoji\":\"📚\",\"status\":\"pending\"},{\"id\":\"d5-todo-2\",\"title\":\"Build a prototype\",\"description\":\"Stand up a minimal app with a CopilotKit chat surface.\",\"emoji\":\"🛠️\",\"status\":\"pending\"},{\"id\":\"d5-todo-3\",\"title\":\"Explore agent state\",\"description\":\"Wire shared state and inspect agent-driven updates.\",\"emoji\":\"🔍\",\"status\":\"pending\"}]}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Turn 7c: post-manage_todos closing message. Allows the runner's settle to advance after the App pane has fully rendered the 3 todos.",
+      "match": {
+        "toolCallId": "call_d5_bc_manage_todos_001"
+      },
+      "response": {
+        "content": "Three todos added — Read CopilotKit docs, Build a prototype, Explore agent state. App mode is on, so they're visible in the panel on the right."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/beautiful-chat.json
+++ b/showcase/harness/fixtures/d5/beautiful-chat.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "D5 fixture for /demos/beautiful-chat (langgraph-python). Triggers the search_flights tool which emits an a2ui_operations container with two literal-children FlightCards (United Airlines $349, Delta $289). Substring 'd5 beautiful-chat probe' is unique across d5-all and feature-parity. Uses hasToolResult matching to disambiguate the pre/post tool-call turns; mirrors the pattern in gen-ui-headless.json. Flight payload mirrors the call_fp_search_flights_001 entry in showcase/aimock/feature-parity.json so visual fingerprints match across both runners.",
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "d5 beautiful-chat probe",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_search_flights_001",
+            "name": "search_flights",
+            "arguments": "{\"flights\":[{\"airline\":\"United Airlines\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=united.com&sz=128\",\"flightNumber\":\"UA123\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"08:00\",\"arrivalTime\":\"16:30\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"price\":\"$349\"},{\"airline\":\"Delta\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=delta.com&sz=128\",\"flightNumber\":\"DL456\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"10:15\",\"arrivalTime\":\"18:45\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"price\":\"$289\"}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "d5 beautiful-chat probe",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Two flights shown above — United at $349 (08:00) and Delta at $289 (10:15), both on time."
+      }
+    }
+  ]
+}

--- a/showcase/harness/fixtures/d5/beautiful-chat.json
+++ b/showcase/harness/fixtures/d5/beautiful-chat.json
@@ -1,15 +1,81 @@
 {
-  "_comment": "D5 fixture for /demos/beautiful-chat (langgraph-python). Triggers the search_flights tool which emits an a2ui_operations container with two literal-children FlightCards (United Airlines $349, Delta $289). Substring 'd5 beautiful-chat probe' is unique across d5-all and feature-parity. Uses hasToolResult matching to disambiguate the pre/post tool-call turns; mirrors the pattern in gen-ui-headless.json. Flight payload mirrors the call_fp_search_flights_001 entry in showcase/aimock/feature-parity.json so visual fingerprints match across both runners.",
+  "_comment": "D5 fixture for /demos/beautiful-chat (langgraph-python). Drives 7 of the 9 suggestion pills (Excalidraw + Calculator skipped — see d5-beautiful-chat.ts for rationale). Each turn dispatches a unique 'd5 beautiful-chat probe: ...' substring so aimock matches these entries first (loaded before feature-parity.json) without colliding with the live pill messages. Uses hasToolResult and toolName matchers to disambiguate multi-stage flows (Sales Dashboard secondary-LLM call, Task Manager enableAppMode → manage_todos chain). Tool payloads mirror feature-parity.json so visual fingerprints match across both runners.",
   "fixtures": [
     {
+      "_comment": "Turn 1: Toggle Theme — single-shot frontend tool call.",
       "match": {
-        "userMessage": "d5 beautiful-chat probe",
+        "userMessage": "d5 beautiful-chat probe: toggle the theme"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_toggle_theme_001",
+            "name": "toggleTheme",
+            "arguments": "{}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Turn 2: Pie Chart — direct pieChart toolCall (skipping query_data — payload supplies inline data so the chart renders without a query_data round-trip, matching feature-parity's 'revenue distribution by category' pattern).",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: pie chart of revenue distribution by category",
         "hasToolResult": false
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_d5_search_flights_001",
+            "id": "call_d5_bc_pie_chart_001",
+            "name": "pieChart",
+            "arguments": "{\"title\":\"Revenue by Category\",\"description\":\"Breakdown of revenue across product categories\",\"data\":[{\"label\":\"Electronics\",\"value\":42000},{\"label\":\"Clothing\",\"value\":28000},{\"label\":\"Food\",\"value\":18000},{\"label\":\"Books\",\"value\":12000}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: pie chart of revenue distribution by category",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Pie chart rendered above — Electronics leads at $42k, followed by Clothing, Food, and Books."
+      }
+    },
+    {
+      "_comment": "Turn 3: Bar Chart — direct barChart toolCall, mirrors feature-parity's 'expenses by category' fixture.",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: bar chart of expenses by category",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_bar_chart_001",
+            "name": "barChart",
+            "arguments": "{\"title\":\"Expenses by Category\",\"description\":\"Monthly expense breakdown\",\"data\":[{\"label\":\"Rent\",\"value\":15000},{\"label\":\"Salaries\",\"value\":80000},{\"label\":\"Marketing\",\"value\":12000},{\"label\":\"Travel\",\"value\":5000}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: bar chart of expenses by category",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Bar chart rendered above — Salaries dominate at $80k, with Rent at $15k as the next-largest category."
+      }
+    },
+    {
+      "_comment": "Turn 4: Search Flights — A2UI fixed-schema. Two-stage matcher (false→true). Payload byte-equal to feature-parity's call_fp_search_flights_001 so FlightCard literal fingerprints match across both runners.",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: search flights from SFO to JFK",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_search_flights_001",
             "name": "search_flights",
             "arguments": "{\"flights\":[{\"airline\":\"United Airlines\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=united.com&sz=128\",\"flightNumber\":\"UA123\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"08:00\",\"arrivalTime\":\"16:30\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"price\":\"$349\"},{\"airline\":\"Delta\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=delta.com&sz=128\",\"flightNumber\":\"DL456\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"10:15\",\"arrivalTime\":\"18:45\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"price\":\"$289\"}]}"
           }
@@ -18,11 +84,115 @@
     },
     {
       "match": {
-        "userMessage": "d5 beautiful-chat probe",
+        "userMessage": "d5 beautiful-chat probe: search flights from SFO to JFK",
         "hasToolResult": true
       },
       "response": {
         "content": "Two flights shown above — United at $349 (08:00) and Delta at $289 (10:15), both on time."
+      }
+    },
+    {
+      "_comment": "Turn 5: Schedule Meeting — single-shot scheduleTime call. The HITL pauses the agent until the picker UI is resolved by the user; the probe assertion CLICKS a slot to resume. After the slot click, MeetingTimePicker calls respond('Meeting scheduled for Tomorrow at 2:00 PM (30 min)') which the agent processes via the tool-result match below.",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: schedule a 30-minute meeting to learn about CopilotKit",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_schedule_time_001",
+            "name": "scheduleTime",
+            "arguments": "{\"reasonForScheduling\":\"Learn about CopilotKit\",\"meetingDuration\":30}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_bc_schedule_time_001"
+      },
+      "response": {
+        "content": "Meeting scheduled — calendar invite is on its way."
+      }
+    },
+    {
+      "_comment": "Turn 6a: Sales Dashboard primary call — generate_a2ui. The userMessage substring is unique to D5; toolName is omitted so this matches the agent's first turn, not the secondary render_a2ui call.",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: sales dashboard with metrics and charts",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_generate_a2ui_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Turn 6b: Sales Dashboard secondary LLM call. Inside generate_a2ui, the agent binds a fresh ChatOpenAI to render_a2ui and asks it to produce the actual UI tree. aimock disambiguates this from 6a via toolName=render_a2ui — the call is for render_a2ui specifically, not generate_a2ui. Catalog id matches feature-parity's copilotkit://app-dashboard-catalog. Tree: 'Total Revenue' Metric label + a Markdown header + Pie/Bar wrappers (each contains a recharts ResponsiveContainer).",
+      "match": {
+        "toolName": "render_a2ui"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_render_a2ui_001",
+            "name": "render_a2ui",
+            "arguments": "{\"surfaceId\":\"d5-bc-sales-dashboard\",\"catalogId\":\"copilotkit://app-dashboard-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"children\":[\"header\",\"metrics\",\"charts\"]},{\"id\":\"header\",\"component\":\"Markdown\",\"children\":\"## Q4 Sales Summary\"},{\"id\":\"metrics\",\"component\":\"Row\",\"children\":[\"m1\",\"m2\",\"m3\"]},{\"id\":\"m1\",\"component\":\"Metric\",\"label\":\"Total Revenue\",\"value\":\"$1.2M\"},{\"id\":\"m2\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"248\"},{\"id\":\"m3\",\"component\":\"Metric\",\"label\":\"Conversion Rate\",\"value\":\"3.4%\"},{\"id\":\"charts\",\"component\":\"Row\",\"children\":[\"pie\",\"bar\"]},{\"id\":\"pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Segment\",\"data\":[{\"label\":\"Enterprise\",\"value\":600000},{\"label\":\"SMB\",\"value\":400000},{\"label\":\"Startup\",\"value\":200000}]},{\"id\":\"bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"data\":[{\"label\":\"Oct\",\"value\":350000},{\"label\":\"Nov\",\"value\":400000},{\"label\":\"Dec\",\"value\":450000}]}]}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Turn 6c: Sales Dashboard post-tool-result — closes the conversation so the runner's settle advances. toolCallId match disambiguates from 6a's userMessage match.",
+      "match": {
+        "toolCallId": "call_d5_bc_generate_a2ui_001"
+      },
+      "response": {
+        "content": "Sales dashboard rendered above — Total Revenue $1.2M, with breakdowns by segment and month."
+      }
+    },
+    {
+      "_comment": "Turn 7a: Task Manager — first call enableAppMode (frontend tool that flips the chat layout to expose the App pane). hasToolResult: false matches the user's initial turn before any tool has run. parallel_tool_calls is False on the agent, so this fires alone.",
+      "match": {
+        "userMessage": "d5 beautiful-chat probe: enable app mode and add three todos",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_enable_app_mode_001",
+            "name": "enableAppMode",
+            "arguments": "{}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Turn 7b: After enableAppMode resolves (frontend tool returns immediately), the agent's next turn calls manage_todos. toolCallId match disambiguates this post-enableAppMode turn from any subsequent post-manage_todos turn.",
+      "match": {
+        "toolCallId": "call_d5_bc_enable_app_mode_001"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_bc_manage_todos_001",
+            "name": "manage_todos",
+            "arguments": "{\"todos\":[{\"id\":\"d5-todo-1\",\"title\":\"Read CopilotKit docs\",\"description\":\"Skim the quickstart and read the architecture guide.\",\"emoji\":\"📚\",\"status\":\"pending\"},{\"id\":\"d5-todo-2\",\"title\":\"Build a prototype\",\"description\":\"Stand up a minimal app with a CopilotKit chat surface.\",\"emoji\":\"🛠️\",\"status\":\"pending\"},{\"id\":\"d5-todo-3\",\"title\":\"Explore agent state\",\"description\":\"Wire shared state and inspect agent-driven updates.\",\"emoji\":\"🔍\",\"status\":\"pending\"}]}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Turn 7c: post-manage_todos closing message. Allows the runner's settle to advance after the App pane has fully rendered the 3 todos.",
+      "match": {
+        "toolCallId": "call_d5_bc_manage_todos_001"
+      },
+      "response": {
+        "content": "Three todos added — Read CopilotKit docs, Build a prototype, Explore agent state. App mode is on, so they're visible in the panel on the right."
       }
     }
   ]

--- a/showcase/harness/src/probes/helpers/d5-feature-mapping.ts
+++ b/showcase/harness/src/probes/helpers/d5-feature-mapping.ts
@@ -108,7 +108,11 @@ const REGISTRY_TO_D5: Readonly<Record<string, readonly D5FeatureType[]>> = {
   // Chat-surface family: each surface gets its own D5 literal because
   // assertions are surface-specific (custom slot rendered, computed
   // theme colors, sidebar/popup root scoping).
-  "beautiful-chat": ["agentic-chat"], // reuses agentic-chat conversation
+  // Beautiful Chat owns a dedicated D5 probe (`d5-beautiful-chat.ts`) that
+  // asserts the A2UI fixed-schema FlightCard surface — the previous
+  // `["agentic-chat"]` alias would freeload agentic-chat's green status
+  // without exercising any of the A2UI render path the surface depends on.
+  "beautiful-chat": ["beautiful-chat"],
   "chat-slots": ["chat-slots"],
   "chat-customization-css": ["chat-css"],
   "prebuilt-sidebar": ["prebuilt-sidebar"],

--- a/showcase/harness/src/probes/helpers/d5-registry.ts
+++ b/showcase/harness/src/probes/helpers/d5-registry.ts
@@ -75,7 +75,13 @@ export type D5FeatureType =
   // (one literal covers hashbrown + json-render via preNavigateRoute).
   | "byoc"
   // Voice family — voice input/output.
-  | "voice";
+  | "voice"
+  // Beautiful Chat surface — exercises the A2UI fixed-schema render path
+  // by asserting FlightCard surfaces from `search_flights` are visible
+  // in the rendered DOM. Owns its own literal (rather than reusing
+  // `agentic-chat`) so the probe can target surface-specific text rather
+  // than the generic conversation reply.
+  | "beautiful-chat";
 
 /**
  * Closed-set runtime mirror of `D5FeatureType`. Kept in lock-step with
@@ -115,6 +121,7 @@ const D5_FEATURE_TYPES: readonly D5FeatureType[] = [
   "gen-ui-interrupt",
   "byoc",
   "voice",
+  "beautiful-chat",
 ] as const satisfies readonly D5FeatureType[];
 
 /**

--- a/showcase/harness/src/probes/scripts/d5-beautiful-chat.ts
+++ b/showcase/harness/src/probes/scripts/d5-beautiful-chat.ts
@@ -1,112 +1,404 @@
 /**
  * D5 — beautiful-chat script.
  *
- * Drives `/demos/beautiful-chat` through one user turn that triggers the
- * `search_flights` tool against the LangGraph backend at
- * `showcase/integrations/langgraph-python/src/agents/beautiful_chat.py`.
- * The tool emits an `a2ui_operations` container with one literal-children
- * `FlightCard` per flight (see `_build_flight_components` in that module),
- * and the renderer registered in
- * `showcase/integrations/langgraph-python/src/app/demos/declarative-generative-ui/renderers.tsx`
- * paints each card inline.
+ * Drives `/demos/beautiful-chat` (langgraph-python) through 7 of the 9
+ * suggestion pills, asserting per-pill render fingerprints in the live
+ * DOM. Each `ConversationTurn` corresponds to one pill, dispatched as a
+ * unique D5-prefixed user message that aimock matches via the
+ * `harness/fixtures/d5/beautiful-chat.json` fixture (bundled into
+ * `showcase/aimock/d5-all.json`).
  *
- * Why this surface (vs Sales Dashboard, Pie Chart, Toggle Theme):
- *   - `search_flights` is a single-turn tool call. The Sales Dashboard pill
- *     is a two-stage flow (`generate_a2ui` → secondary LLM bound to
- *     `render_a2ui`) that takes 90s+ on cold starts and depends on a
- *     second fixture matching the sub-call — too much surface area for a
- *     first probe.
- *   - Pie/Bar Chart depend on Controlled Generative UI components
- *     registered via `useComponent`, which is a different code path than
- *     A2UI fixed-schema (covered by `d5-gen-ui-a2ui-fixed`).
- *   - Toggle Theme exercises only frontend tools, already covered by
- *     `d5-frontend-tools` against a different demo.
+ * Out-of-scope by design (track in a follow-up):
+ *   - Excalidraw Diagram (MCP App): depends on `mcp.excalidraw.com`
+ *     reachability — turning D5 reliability into a third-party uptime
+ *     bet is the wrong tradeoff for a scheduled probe.
+ *   - Calculator App (Open Generative UI): renders inside a sandboxed
+ *     iframe, which makes Playwright assertions cross-frame-fragile.
+ *     The `generateSandboxedUi` render path is already covered by
+ *     `d5-gen-ui-open` on a different demo route, so this surface
+ *     duplicates coverage rather than catching new regressions.
  *
- * Acceptance:
- *   - `United Airlines` literal text is visible (canonical fixture flight 1)
- *   - `Delta` literal text is visible (canonical fixture flight 2)
- *   - `$349` and `$289` price literals are visible
+ * Turn ordering is load-bearing for state safety:
+ *   1. Toggle Theme — cheap warm-up; flips `html.dark`. No assertion
+ *      depends on theme color, so the flip doesn't pollute later turns.
+ *   2. Pie Chart — controlled-gen-UI `pieChart` component (frontend
+ *      `useComponent`). Asserts inline SVG slices.
+ *   3. Bar Chart — controlled-gen-UI `barChart`. Asserts recharts
+ *      bar rectangles.
+ *   4. Search Flights — A2UI fixed-schema `search_flights` →
+ *      FlightCard surface (the #4668 fix path).
+ *   5. Schedule Meeting — HITL `scheduleTime` → MeetingTimePicker. The
+ *      assertion CLICKS a slot button to resolve the HITL pause —
+ *      otherwise the agent stays paused and turn 6's chat input is
+ *      ambiguous (resume vs new-message).
+ *   6. Sales Dashboard — A2UI dynamic `generate_a2ui` → secondary LLM
+ *      `render_a2ui` → dashboard tree. Heaviest turn (~90s cold-start
+ *      budget). Placed after Schedule Meeting so its DOM additions
+ *      don't fight earlier text-fingerprint assertions.
+ *   7. Task Manager — `enableAppMode` + `manage_todos`. MUST be last:
+ *      flips the layout to App pane, which collapses the chat surface
+ *      to `w-1/3` and could break subsequent input dispatch on small
+ *      viewports.
  *
- * Assertion text targets aimock-fixture content directly (not LLM output)
- * so it's stable across runs. The assertion uses a generous timeout for
- * the first selector — the A2UI tool round-trip can take ~30-60s on a
- * cold start when langgraph rehydrates the agent module.
- *
- * Fixture (`showcase/harness/fixtures/d5/beautiful-chat.json`) uses the
- * `hasToolResult` matcher to disambiguate the pre-tool-call turn (returns
- * the `search_flights` toolCall) from the post-tool-call turn (returns
- * narration that lets the agent close the conversation). Mirrors the
- * pattern in `showcase/harness/fixtures/d5/gen-ui-headless.json`.
+ * On any turn failure the conversation runner records the 1-based
+ * `failure_turn` and short-circuits the rest — failure messages call
+ * out the failing pill so the dashboard's drilldown points right at
+ * the regressed surface. Settle behaviour: the runner waits on
+ * assistant-message DOM count plateau, which works correctly even when
+ * a turn's primary signal is a tool-driven render rather than a chat
+ * bubble (turns 1, 5, 7 in particular).
  */
 
-import {
-  registerD5Script,
-  type D5BuildContext,
-} from "../helpers/d5-registry.js";
-import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
+import type {
+  ConversationTurn,
+  Page as ConversationPage,
+} from "../helpers/conversation-runner.js";
 
-/** Seconds budget for the A2UI tool round-trip on cold-start integrations. */
-const FLIGHT_SURFACE_TIMEOUT_MS = 60_000;
-/** Tighter budget for sibling assertions once the first card has rendered. */
-const SIBLING_ASSERTION_TIMEOUT_MS = 5_000;
+/**
+ * Extension of the runner's structural Page type with the methods this
+ * probe needs beyond the runner's minimal surface — same pattern as
+ * `_hitl-shared.ts`. Real Playwright Page exposes both natively; the
+ * runner's minimal type intentionally excludes them so unit tests can
+ * pass scripted fakes without spinning up chromium. The Schedule
+ * Meeting turn needs `.click()` to resolve the HITL pause.
+ */
+interface Page extends ConversationPage {
+  click(selector: string, opts?: { timeout?: number }): Promise<void>;
+}
 
-/** Canonical user prompt used by both the dispatched chat-input message and
- *  the aimock fixture's substring matcher. Unique enough to avoid colliding
- *  with the `flights from SFO to JFK` entry in `feature-parity.json`. */
-const PROMPT = "d5 beautiful-chat probe: search flights from SFO to JFK";
+/** Long budget for the FIRST visible signal in a tool-driven render —
+ *  covers cold-start tax (Playwright launch, Next.js hydrate, agent
+ *  rehydrate). Sales Dashboard's secondary-LLM stage gets its own
+ *  longer budget below. */
+const FIRST_SIGNAL_TIMEOUT_MS = 60_000;
+/** Tighter budget once the surface is mounted — sibling assertions
+ *  should land within a few hundred ms. 5s leaves headroom for slow
+ *  Windows CI agents. */
+const SIBLING_TIMEOUT_MS = 5_000;
+/** Sales Dashboard's first signal — `generate_a2ui` invokes a
+ *  secondary LLM bound to `render_a2ui`, doubling the round-trip cost.
+ *  The e2e equivalent uses 90s; we match. */
+const DASHBOARD_FIRST_SIGNAL_TIMEOUT_MS = 90_000;
 
-export function buildAssertions(opts?: {
-  flightSurfaceTimeoutMs?: number;
-  siblingTimeoutMs?: number;
-}): (page: Page) => Promise<void> {
-  const flightTimeout =
-    opts?.flightSurfaceTimeoutMs ?? FLIGHT_SURFACE_TIMEOUT_MS;
-  const siblingTimeout = opts?.siblingTimeoutMs ?? SIBLING_ASSERTION_TIMEOUT_MS;
-  return async (page: Page): Promise<void> => {
-    // United is the first flight in the fixture; wait for it to land. If
-    // the A2UI surface never renders, this is the assertion that fires.
-    try {
-      await page.waitForSelector("text=United Airlines", {
-        state: "visible",
-        timeout: flightTimeout,
-      });
-    } catch {
-      throw new Error(
-        `beautiful-chat: expected FlightCard for "United Airlines" to render within ${flightTimeout}ms — A2UI surface did not paint`,
-      );
+/**
+ * Turn 1 — Toggle Theme.
+ *
+ * The `toggleTheme` frontend tool flips `document.documentElement.class`
+ * between "dark" / "light". The runner has no assistant-message growth
+ * to settle on (frontend-tool calls render as in-transcript tool cards
+ * without a text bubble), so the runner's settle plateaus quickly and
+ * the assertion runs.
+ *
+ * Mirrors the e2e signal (`html.dark` class flip) — strictly stronger
+ * than asserting on a chat-bubble selector that `beautiful-chat`'s
+ * tool-call transcripts don't emit.
+ */
+/**
+ * DOM-side helpers — inline `page.evaluate` closures that read a
+ * single piece of state from the browser context. We use the same
+ * `globalThis as unknown as { document: ... }` pattern as
+ * `d5-chat-css.ts` so the harness's Node-only tsconfig (no DOM lib)
+ * still typechecks. Each helper is a fresh arrow per call so esbuild
+ * doesn't emit a named `__name(fn, "...")` wrapper that would fail in
+ * the browser context — see the inline-only-style note in
+ * `d5-chat-css.ts`'s `probeChatCss` body.
+ */
+async function readIsHtmlDark(page: ConversationPage): Promise<boolean> {
+  return await page.evaluate(() => {
+    const win = globalThis as unknown as {
+      document: {
+        documentElement: { classList: { contains(s: string): boolean } };
+      };
+    };
+    return win.document.documentElement.classList.contains("dark");
+  });
+}
+async function readSvgCircleCount(page: ConversationPage): Promise<number> {
+  return await page.evaluate(() => {
+    const win = globalThis as unknown as {
+      document: { querySelectorAll(sel: string): { length: number } };
+    };
+    return win.document.querySelectorAll("svg circle").length;
+  });
+}
+async function readRechartsContainerCount(
+  page: ConversationPage,
+): Promise<number> {
+  return await page.evaluate(() => {
+    const win = globalThis as unknown as {
+      document: { querySelectorAll(sel: string): { length: number } };
+    };
+    return win.document.querySelectorAll(".recharts-responsive-container")
+      .length;
+  });
+}
+async function readRechartsBarCount(page: ConversationPage): Promise<number> {
+  return await page.evaluate(() => {
+    const win = globalThis as unknown as {
+      document: { querySelectorAll(sel: string): { length: number } };
+    };
+    return win.document.querySelectorAll(".recharts-bar-rectangle").length;
+  });
+}
+
+async function assertToggleTheme(page: ConversationPage): Promise<void> {
+  const initiallyDark = await readIsHtmlDark(page);
+
+  // Poll until the class flips. The runner has already waited for the
+  // assistant-message settle, so the tool call has fired — we just
+  // need to observe the side effect. Read via `evaluate` so the DOM
+  // check is synchronous on the browser side without invoking
+  // Playwright's auto-wait machinery.
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const isDark = await readIsHtmlDark(page);
+    if (isDark !== initiallyDark) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(
+    `beautiful-chat/toggle-theme: html.dark class did not flip from ${initiallyDark ? "dark" : "light"} within 30s — toggleTheme tool did not fire`,
+  );
+}
+
+/**
+ * Turn 2 — Pie Chart (controlled gen-UI).
+ *
+ * Frontend `useComponent` registered as `pieChart` renders an inline
+ * SVG with one background `<circle>` plus one per data slice. The
+ * fixture supplies 4 slices, so >= 3 circles confirms the component
+ * mounted and at least some slices rendered (>= 3 instead of 5
+ * accommodates partial-render races without sacrificing the signal).
+ */
+async function assertPieChart(page: ConversationPage): Promise<void> {
+  const deadline = Date.now() + FIRST_SIGNAL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if ((await readSvgCircleCount(page)) >= 3) return;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(
+    `beautiful-chat/pie-chart: expected >= 3 svg circles within ${FIRST_SIGNAL_TIMEOUT_MS}ms (pieChart component did not render)`,
+  );
+}
+
+/**
+ * Turn 3 — Bar Chart (controlled gen-UI).
+ *
+ * `BarChart` wraps recharts' `<ResponsiveContainer>`. Asserts both the
+ * container mounted AND >= 2 bar rectangles rendered. The container
+ * alone could be a stub; the bars confirm data flowed through.
+ */
+async function assertBarChart(page: ConversationPage): Promise<void> {
+  // First: the recharts container must mount. This is the heavy step.
+  const containerDeadline = Date.now() + FIRST_SIGNAL_TIMEOUT_MS;
+  let containerSeen = false;
+  while (Date.now() < containerDeadline) {
+    if ((await readRechartsContainerCount(page)) > 0) {
+      containerSeen = true;
+      break;
     }
-    // Once the surface is mounted, the rest of the literals are siblings
-    // in the same render — short timeout is fine. Each is asserted
-    // separately so a regression that loses (e.g.) only the price text
-    // points at the right field rather than failing the whole probe on
-    // a single combined selector.
-    for (const literal of ["Delta", "$349", "$289"]) {
-      try {
-        await page.waitForSelector(`text=${literal}`, {
-          state: "visible",
-          timeout: siblingTimeout,
-        });
-      } catch {
-        throw new Error(
-          `beautiful-chat: FlightCard rendered "United Airlines" but "${literal}" was not found within ${siblingTimeout}ms — surface partially painted`,
-        );
-      }
-    }
-  };
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  if (!containerSeen) {
+    throw new Error(
+      `beautiful-chat/bar-chart: .recharts-responsive-container did not mount within ${FIRST_SIGNAL_TIMEOUT_MS}ms`,
+    );
+  }
+  // Then: bar rectangles within sibling timeout (recharts paints them
+  // synchronously after layout).
+  const barsDeadline = Date.now() + 15_000;
+  while (Date.now() < barsDeadline) {
+    if ((await readRechartsBarCount(page)) >= 2) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(
+    `beautiful-chat/bar-chart: container mounted but < 2 bar rectangles within 15s (data wiring broken)`,
+  );
+}
+
+/**
+ * Turn 4 — Search Flights (A2UI fixed-schema).
+ *
+ * The `search_flights` tool emits an `a2ui_operations` container with
+ * literal-children FlightCards. The fixture is byte-equal to PR #4668's
+ * canonical 2-flight payload, so the literals (United/$349, Delta/$289)
+ * are stable visual fingerprints unaffected by LLM wording drift.
+ */
+async function assertSearchFlights(page: ConversationPage): Promise<void> {
+  // Wait for the FIRST flight card to mount — this is the surface-
+  // mounted signal. After that, sibling literals should follow within
+  // sibling timeout.
+  await waitForText(page, "United Airlines", FIRST_SIGNAL_TIMEOUT_MS);
+  for (const literal of ["Delta", "$349", "$289"]) {
+    await waitForText(page, literal, SIBLING_TIMEOUT_MS);
+  }
+}
+
+/**
+ * Turn 5 — Schedule Meeting (HITL).
+ *
+ * `scheduleTime` is registered via `useHumanInTheLoop`, which renders
+ * `MeetingTimePicker` and pauses the agent until the user clicks a
+ * slot OR declines. We assert the picker mounted (selection-state
+ * heading text), then CLICK a slot to resolve the HITL — without that,
+ * subsequent turns would type into a chat input while the agent is
+ * paused, which CopilotKit's runtime treats ambiguously.
+ *
+ * After click, `respond("Meeting scheduled for ...")` fires; the agent
+ * resumes and emits a closing assistant message, which causes the
+ * runner's settle to advance.
+ */
+async function assertScheduleMeeting(page: ConversationPage): Promise<void> {
+  // Selection-state heading — picker is mounted and showing slots.
+  await waitForText(
+    page,
+    "Pick a time that works for you",
+    FIRST_SIGNAL_TIMEOUT_MS,
+  );
+
+  // Narrow to the click-capable Page shape. Real Playwright Page
+  // exposes click() natively; the runner's minimal type omits it so
+  // unit tests can pass scripted fakes. Mirrors the runtime guard in
+  // d5-hitl-text-input — fail loudly here rather than letting the
+  // cast hide a missing method when something hands us a different
+  // page implementation.
+  const pageWithClick = page as unknown as Page;
+  if (typeof (pageWithClick as { click?: unknown }).click !== "function") {
+    throw new Error(
+      "beautiful-chat/schedule-meeting: page is missing click() — cannot resolve HITL slot",
+    );
+  }
+
+  // Click the first default slot ("Tomorrow"). The picker's default
+  // timeSlots array (meeting-time-picker.tsx) starts with
+  // `{ date: "Tomorrow", time: "2:00 PM", duration: "30 min" }`.
+  // Playwright's `:has-text()` pseudo-selector finds the slot button
+  // by visible text without needing role-based queries.
+  const tomorrowSelector = 'button:has-text("Tomorrow")';
+  await page.waitForSelector(tomorrowSelector, {
+    state: "visible",
+    timeout: SIBLING_TIMEOUT_MS,
+  });
+  await pageWithClick.click(tomorrowSelector, {
+    timeout: SIBLING_TIMEOUT_MS,
+  });
+
+  // Confirmed-state heading appears after `respond(...)` fires and the
+  // selectedSlot state propagates — typically synchronous in React.
+  await waitForText(page, "Meeting Scheduled", SIBLING_TIMEOUT_MS);
+}
+
+/**
+ * Turn 6 — Sales Dashboard (A2UI dynamic).
+ *
+ * `generate_a2ui` invokes a secondary LLM bound to `render_a2ui`. The
+ * fixture covers BOTH legs:
+ *   - Primary: `userMessage` substring match → `generate_a2ui` toolCall
+ *   - Secondary: `toolName: "render_a2ui"` match → `render_a2ui` with
+ *     a 3-metric + 2-chart dashboard tree against the
+ *     `copilotkit://app-dashboard-catalog` catalog.
+ *
+ * Visual fingerprint: a Metric label "Total Revenue" + a recharts
+ * container (the embedded Pie/Bar wrappers). Cold-start budget is
+ * 90s — both LLM calls are sequential.
+ */
+async function assertSalesDashboard(page: ConversationPage): Promise<void> {
+  await waitForText(page, "Total Revenue", DASHBOARD_FIRST_SIGNAL_TIMEOUT_MS);
+  // Recharts container check — the dashboard's pie + bar are both
+  // wrapped in a ResponsiveContainer. Earlier turns also painted
+  // recharts content (Bar Chart, possibly Pie Chart embedded in
+  // dashboard) — count is cumulative, so >= 1 is enough to confirm
+  // dashboard's chart wrapping rendered.
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if ((await readRechartsContainerCount(page)) > 0) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(
+    `beautiful-chat/sales-dashboard: "Total Revenue" appeared but recharts container missing — dashboard tree partial`,
+  );
+}
+
+/**
+ * Turn 7 — Task Manager (shared state).
+ *
+ * `enableAppMode` flips the layout (chat shrinks to w-1/3, App pane
+ * unhides). `manage_todos` populates state.todos which the App-pane
+ * `TodoList` renders. The fixture supplies 3 specific todos; we assert
+ * the "To Do" column heading + at least one of the canonical titles.
+ *
+ * Must be last: the App-pane layout breaks chat-input dispatch on
+ * narrow viewports (max-lg:hidden). Subsequent turns would silently
+ * fail to fill the input.
+ */
+async function assertTaskManager(page: ConversationPage): Promise<void> {
+  // "To Do" column heading is the App-pane mount signal.
+  await waitForText(page, "To Do", FIRST_SIGNAL_TIMEOUT_MS);
+  // Canonical todo title from the fixture. Asserting one is enough —
+  // the runtime renders all-or-none from a single state update.
+  await waitForText(page, "Read CopilotKit docs", SIBLING_TIMEOUT_MS);
+}
+
+/**
+ * Wait for a literal text node to be visible. Wraps Playwright's
+ * `waitForSelector` with a friendlier error so the failure_turn entry
+ * carries a descriptive message — the conversation runner surfaces
+ * the thrown message verbatim into the probe's signal blob, which is
+ * what the dashboard's drilldown displays.
+ */
+async function waitForText(
+  page: ConversationPage,
+  text: string,
+  timeoutMs: number,
+): Promise<void> {
+  try {
+    await page.waitForSelector(`text=${text}`, {
+      state: "visible",
+      timeout: timeoutMs,
+    });
+  } catch {
+    throw new Error(
+      `beautiful-chat: expected text "${text}" to appear within ${timeoutMs}ms`,
+    );
+  }
 }
 
 export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
   return [
     {
-      input: PROMPT,
-      assertions: buildAssertions(),
+      input: "d5 beautiful-chat probe: toggle the theme",
+      assertions: assertToggleTheme,
+    },
+    {
+      input:
+        "d5 beautiful-chat probe: pie chart of revenue distribution by category",
+      assertions: assertPieChart,
+    },
+    {
+      input: "d5 beautiful-chat probe: bar chart of expenses by category",
+      assertions: assertBarChart,
+    },
+    {
+      input: "d5 beautiful-chat probe: search flights from SFO to JFK",
+      assertions: assertSearchFlights,
+    },
+    {
+      input:
+        "d5 beautiful-chat probe: schedule a 30-minute meeting to learn about CopilotKit",
+      assertions: assertScheduleMeeting,
+    },
+    {
+      input: "d5 beautiful-chat probe: sales dashboard with metrics and charts",
+      assertions: assertSalesDashboard,
+    },
+    {
+      input: "d5 beautiful-chat probe: enable app mode and add three todos",
+      assertions: assertTaskManager,
     },
   ];
 }
 
-/** Override the default `/demos/<featureType>` route. The literal feature
- *  type matches the catalog ID, so the route is unambiguous, but kept
- *  explicit for parity with the chat-css/chat-slots overrides. */
 function preNavigateRoute(): string {
   return "/demos/beautiful-chat";
 }

--- a/showcase/harness/src/probes/scripts/d5-beautiful-chat.ts
+++ b/showcase/harness/src/probes/scripts/d5-beautiful-chat.ts
@@ -1,0 +1,119 @@
+/**
+ * D5 — beautiful-chat script.
+ *
+ * Drives `/demos/beautiful-chat` through one user turn that triggers the
+ * `search_flights` tool against the LangGraph backend at
+ * `showcase/integrations/langgraph-python/src/agents/beautiful_chat.py`.
+ * The tool emits an `a2ui_operations` container with one literal-children
+ * `FlightCard` per flight (see `_build_flight_components` in that module),
+ * and the renderer registered in
+ * `showcase/integrations/langgraph-python/src/app/demos/declarative-generative-ui/renderers.tsx`
+ * paints each card inline.
+ *
+ * Why this surface (vs Sales Dashboard, Pie Chart, Toggle Theme):
+ *   - `search_flights` is a single-turn tool call. The Sales Dashboard pill
+ *     is a two-stage flow (`generate_a2ui` → secondary LLM bound to
+ *     `render_a2ui`) that takes 90s+ on cold starts and depends on a
+ *     second fixture matching the sub-call — too much surface area for a
+ *     first probe.
+ *   - Pie/Bar Chart depend on Controlled Generative UI components
+ *     registered via `useComponent`, which is a different code path than
+ *     A2UI fixed-schema (covered by `d5-gen-ui-a2ui-fixed`).
+ *   - Toggle Theme exercises only frontend tools, already covered by
+ *     `d5-frontend-tools` against a different demo.
+ *
+ * Acceptance:
+ *   - `United Airlines` literal text is visible (canonical fixture flight 1)
+ *   - `Delta` literal text is visible (canonical fixture flight 2)
+ *   - `$349` and `$289` price literals are visible
+ *
+ * Assertion text targets aimock-fixture content directly (not LLM output)
+ * so it's stable across runs. The assertion uses a generous timeout for
+ * the first selector — the A2UI tool round-trip can take ~30-60s on a
+ * cold start when langgraph rehydrates the agent module.
+ *
+ * Fixture (`showcase/harness/fixtures/d5/beautiful-chat.json`) uses the
+ * `hasToolResult` matcher to disambiguate the pre-tool-call turn (returns
+ * the `search_flights` toolCall) from the post-tool-call turn (returns
+ * narration that lets the agent close the conversation). Mirrors the
+ * pattern in `showcase/harness/fixtures/d5/gen-ui-headless.json`.
+ */
+
+import {
+  registerD5Script,
+  type D5BuildContext,
+} from "../helpers/d5-registry.js";
+import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
+
+/** Seconds budget for the A2UI tool round-trip on cold-start integrations. */
+const FLIGHT_SURFACE_TIMEOUT_MS = 60_000;
+/** Tighter budget for sibling assertions once the first card has rendered. */
+const SIBLING_ASSERTION_TIMEOUT_MS = 5_000;
+
+/** Canonical user prompt used by both the dispatched chat-input message and
+ *  the aimock fixture's substring matcher. Unique enough to avoid colliding
+ *  with the `flights from SFO to JFK` entry in `feature-parity.json`. */
+const PROMPT = "d5 beautiful-chat probe: search flights from SFO to JFK";
+
+export function buildAssertions(opts?: {
+  flightSurfaceTimeoutMs?: number;
+  siblingTimeoutMs?: number;
+}): (page: Page) => Promise<void> {
+  const flightTimeout =
+    opts?.flightSurfaceTimeoutMs ?? FLIGHT_SURFACE_TIMEOUT_MS;
+  const siblingTimeout = opts?.siblingTimeoutMs ?? SIBLING_ASSERTION_TIMEOUT_MS;
+  return async (page: Page): Promise<void> => {
+    // United is the first flight in the fixture; wait for it to land. If
+    // the A2UI surface never renders, this is the assertion that fires.
+    try {
+      await page.waitForSelector("text=United Airlines", {
+        state: "visible",
+        timeout: flightTimeout,
+      });
+    } catch {
+      throw new Error(
+        `beautiful-chat: expected FlightCard for "United Airlines" to render within ${flightTimeout}ms — A2UI surface did not paint`,
+      );
+    }
+    // Once the surface is mounted, the rest of the literals are siblings
+    // in the same render — short timeout is fine. Each is asserted
+    // separately so a regression that loses (e.g.) only the price text
+    // points at the right field rather than failing the whole probe on
+    // a single combined selector.
+    for (const literal of ["Delta", "$349", "$289"]) {
+      try {
+        await page.waitForSelector(`text=${literal}`, {
+          state: "visible",
+          timeout: siblingTimeout,
+        });
+      } catch {
+        throw new Error(
+          `beautiful-chat: FlightCard rendered "United Airlines" but "${literal}" was not found within ${siblingTimeout}ms — surface partially painted`,
+        );
+      }
+    }
+  };
+}
+
+export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
+  return [
+    {
+      input: PROMPT,
+      assertions: buildAssertions(),
+    },
+  ];
+}
+
+/** Override the default `/demos/<featureType>` route. The literal feature
+ *  type matches the catalog ID, so the route is unambiguous, but kept
+ *  explicit for parity with the chat-css/chat-slots overrides. */
+function preNavigateRoute(): string {
+  return "/demos/beautiful-chat";
+}
+
+registerD5Script({
+  featureTypes: ["beautiful-chat"],
+  fixtureFile: "beautiful-chat.json",
+  buildTurns,
+  preNavigateRoute,
+});

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -126,6 +126,7 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   subagents: ["subagents"],
   // ── LGP D5 coverage wave (mirrors REGISTRY_TO_D5 in
   //    harness/src/probes/helpers/d5-feature-mapping.ts) ──
+  "beautiful-chat": ["beautiful-chat"],
   "chat-slots": ["chat-slots"],
   "chat-customization-css": ["chat-css"],
   "prebuilt-sidebar": ["prebuilt-sidebar"],


### PR DESCRIPTION
## Summary

- Add a dedicated D5 conversation probe for `beautiful-chat` so the cell can advance past D4 in the dashboard. Asserts the A2UI fixed-schema FlightCard surface renders with stable text fingerprints (`United Airlines`, `Delta`, `$349`, `$289`) from the `search_flights` tool round-trip — the same render path that PR #4668 fixed.
- Replace the freeloading `["agentic-chat"]` alias in `REGISTRY_TO_D5` with a dedicated `["beautiful-chat"]` key, and re-add the matching `CATALOG_TO_D5_KEY` entry so `computeMaxPossible` lifts the D4 cap to D5. Commit `974494ecb` had stripped the alias because it would inherit agentic-chat's green status without exercising any A2UI assertion; this PR replaces it with a real probe instead of restoring the alias.
- Splice the new fixture (two entries, `hasToolResult` false→true mirroring the `gen-ui-headless` pattern) into `showcase/aimock/d5-all.json`.

## What changed

- `showcase/harness/src/probes/scripts/d5-beautiful-chat.ts` — new probe. Single turn: navigates `/demos/beautiful-chat`, sends the unique substring `d5 beautiful-chat probe: search flights from SFO to JFK`, asserts FlightCard literals appear (60s budget on first card, 5s on siblings).
- `showcase/harness/fixtures/d5/beautiful-chat.json` — new fixture. Payload mirrors `call_fp_search_flights_001` from `feature-parity.json` so visual fingerprints match across both runners.
- `showcase/harness/src/probes/helpers/d5-registry.ts` — add `"beautiful-chat"` to the `D5FeatureType` union + runtime mirror.
- `showcase/harness/src/probes/helpers/d5-feature-mapping.ts:111` — point at the new probe key, not the agentic-chat alias.
- `showcase/shell-dashboard/src/lib/live-status.ts` — re-add `"beautiful-chat": ["beautiful-chat"]` to `CATALOG_TO_D5_KEY`.
- `showcase/aimock/d5-all.json` — splice the two new fixture entries (additions only).

## Why one surface, not all 5 pills

The probe asserts only the Search Flights pill. Lowest-risk surface to start with: literal-text fingerprints (no LLM-output dependency), single-turn `search_flights` call, fastest round-trip among the A2UI pills. Sales Dashboard's `generate_a2ui` is a two-stage flow (secondary LLM bound to `render_a2ui`) that takes 90s+ on cold starts and would balloon the probe budget. Once this lands and runs green, it's straightforward to add surface-specific D5 literals (`beautiful-chat-flights`, `beautiful-chat-dashboard`, etc.) — the registry is set up for it and `isD5Green` uses `every` so multi-key gating just works.

## Test plan

- [x] `npx nx run @copilotkit/showcase-harness:typecheck` — clean
- [x] `npx nx run @copilotkit/showcase-shell-dashboard:typecheck` — no new errors (5 pre-existing test-file errors unchanged)
- [x] `npm test -- --run d5-registry` (harness) — 12/12 pass with the new literal
- [x] `npm test -- --run depth-utils` (shell-dashboard) — 35/35 pass
- [x] `npm run build` (harness) — clean
- [x] `OPS_BASE_URL=stub npm run build` (shell-dashboard) — clean
- [x] Local end-to-end: aimock + pocketbase + dashboard up, full D1–D5 ladder seeded into PB, dashboard renders `beautiful-chat × langgraph-python` cell as **D5**. Beautiful Chat demo at `localhost:3100/demos/beautiful-chat` round-trips the new fixture.

## Follow-up (not in this PR)

- The full harness orchestrator running this probe end-to-end was not exercised locally — verifying it in the Railway deploy is the proper end-to-end test. The static side (mapping + registry + chip render) is verified locally via the seeded PB row.
- A vitest unit test for `d5-beautiful-chat.ts` (similar shape to `d5-chat-slots.test.ts`) is a reasonable next addition. The other LGP-wave probes in `harness/src/probes/scripts/` mostly don't ship paired tests, so this PR follows the existing pattern.