### PR TITLE
feat(showcase): D5 probes for headless-simple + headless-complete (langgraph-python)

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -525,6 +525,60 @@
           "text": "What is the weather in Tokyo?"
         }
       }
+    },
+    {
+      "match": {
+        "userMessage": "AAPL trading",
+        "toolCallId": "call_d5_get_stock_price_001"
+      },
+      "response": {
+        "content": "AAPL is trading at $189.42, up 1.27% on the day. The card above shows the live ticker and the percentage change."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "AAPL trading"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_get_stock_price_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Highlight 'meeting at 3pm'",
+        "toolCallId": "call_d5_highlight_note_001"
+      },
+      "response": {
+        "content": "Highlighted 'meeting at 3pm' in yellow above. Let me know if you want a different color or a longer note."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Highlight 'meeting at 3pm'"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_highlight_note_001",
+            "name": "highlight_note",
+            "arguments": "{\"text\":\"meeting at 3pm\",\"color\":\"yellow\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Use Excalidraw to sketch"
+      },
+      "response": {
+        "content": "Sketched a simple system diagram for you above — three boxes (frontend, runtime, agent) connected by arrows showing the request flow. Ask if you'd like a different shape or more detail."
+      }
     }
   ]
 }

--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -98,6 +98,17 @@ services:
       context: ../
       dockerfile: showcase/shell-dashboard/Dockerfile
       args:
+        # PocketBase URL the browser hits at runtime — pinned to the host
+        # binding so the user's browser (not the container) can resolve it.
+        NEXT_PUBLIC_POCKETBASE_URL: http://localhost:8090
+        # Showcase shell URL the dashboard links to for Demo / Code /
+        # docs-shell jumps. Points at the langgraph-python integration's
+        # host port for now (no shared "shell" service in the local stack).
+        NEXT_PUBLIC_SHELL_URL: http://localhost:3100
+        # /api/ops/* rewrites here. There's no harness HTTP server in the
+        # local stack, so this points back at the dashboard itself; the
+        # rewrites will 404 but the matrix view reads from PocketBase
+        # directly and doesn't depend on /api/ops.
         OPS_BASE_URL: http://localhost:3200
     image: showcase-dashboard:local
     container_name: showcase-dashboard

--- a/showcase/harness/fixtures/d5/gen-ui-headless-complete.json
+++ b/showcase/harness/fixtures/d5/gen-ui-headless-complete.json
@@ -1,0 +1,59 @@
+{
+  "_comment": "D5 fixture for /demos/headless-complete. Five chips: weather (already covered by feature-parity weather fixture), AAPL stock (new — get_stock_price tool), highlight note (new — frontend useComponent), Excalidraw (text fallback so probe stays deterministic without depending on the MCP server), and largest continent (already covered by feature-parity continent fixture). Two-leg fixtures pin BOTH userMessage AND toolCallId on the narration leg, with the more-specific narration fixture placed BEFORE the bare userMessage toolCall fixture in this array. Reason: aimock matches in array order with first-match-wins, and its toolCallId match looks at the LAST tool message in the request — across multi-turn probes that 'last tool' can be a stale id from a previous turn. Pinning narration fixtures with userMessage too prevents one turn's narration from firing for another turn's prompt.",
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "AAPL trading",
+        "toolCallId": "call_d5_get_stock_price_001"
+      },
+      "response": {
+        "content": "AAPL is trading at $189.42, up 1.27% on the day. The card above shows the live ticker and the percentage change."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "AAPL trading"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_get_stock_price_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Highlight 'meeting at 3pm'",
+        "toolCallId": "call_d5_highlight_note_001"
+      },
+      "response": {
+        "content": "Highlighted 'meeting at 3pm' in yellow above. Let me know if you want a different color or a longer note."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Highlight 'meeting at 3pm'"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_highlight_note_001",
+            "name": "highlight_note",
+            "arguments": "{\"text\":\"meeting at 3pm\",\"color\":\"yellow\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Use Excalidraw to sketch"
+      },
+      "response": {
+        "content": "Sketched a simple system diagram for you above — three boxes (frontend, runtime, agent) connected by arrows showing the request flow. Ask if you'd like a different shape or more detail."
+      }
+    }
+  ]
+}

--- a/showcase/harness/src/cli/config.ts
+++ b/showcase/harness/src/cli/config.ts
@@ -36,7 +36,12 @@ export function loadConfig(): LocalConfig {
     localPorts,
     pocketbase: {
       url: "http://localhost:8090",
-      email: "admin@localhost",
+      // PB 0.22+ rejects `admin@localhost` (single-label TLD) as an invalid
+      // email. Use a valid format that the PB validator accepts. The
+      // matching admin account is created in the entrypoint / migrations
+      // path; the docker-compose env vars and `bin/showcase` superuser
+      // bootstrap must agree on this value.
+      email: "admin@localhost.dev",
       password: "showcase-local-dev",
     },
     aimockUrl: "http://localhost:4010",

--- a/showcase/harness/src/cli/runner.ts
+++ b/showcase/harness/src/cli/runner.ts
@@ -30,13 +30,12 @@ import {
 import { up, down, rebuild, isRunning } from "./lifecycle.js";
 
 import {
-  type TerminalResult,
-  type PbWriteConfig,
   printResult,
   printSummary,
   probeResultToTerminal,
   createPbWriter,
 } from "./results.js";
+import type { TerminalResult, PbWriteConfig } from "./results.js";
 
 import { livenessDriver } from "../probes/drivers/liveness.js";
 import { e2eChatToolsDriver } from "../probes/drivers/e2e-chat-tools.js";
@@ -201,6 +200,13 @@ export async function run(
     logger,
     env: { ...process.env, SHOWCASE_LOCAL: "1" },
     abortSignal: abortController.signal,
+    // Wire the PB writer into the probe context so drivers that emit
+    // per-feature side rows (e2e-deep emits `d5:<slug>/<featureType>`)
+    // actually land in PocketBase. Without this the runner only wrote
+    // the aggregate `e2e-deep:<slug>` row and every D5 cell stayed gray
+    // on the dashboard. `pbWriter` is null when --live wasn't passed,
+    // matching the legacy behaviour of skipping side emission.
+    ...(pbWriter !== null && { writer: pbWriter }),
   };
 
   // -- 6. Create headed-mode deep driver if needed --------------------------

--- a/showcase/harness/src/cli/targets.ts
+++ b/showcase/harness/src/cli/targets.ts
@@ -192,10 +192,20 @@ export function buildSmokeInputs(
   const slugs = [target.slug];
 
   return slugs.map((slug) => {
-    const manifest = loadManifest(slug, config);
+    void loadManifest(slug, config); // ensures the slug is real
+    // The driver's `deriveSlug` for discovery-mode inputs takes
+    // `input.name` and strips a leading `showcase-` prefix. In production
+    // discovery `name` is the Railway service name (`showcase-<slug>`),
+    // so the derived slug matches the rest of the row keyspace
+    // (`smoke:<slug>`, `health:<slug>`, etc.). The CLI was previously
+    // passing `manifest.name` (the display name like "LangGraph (Python)")
+    // which stripped to itself, producing rows like
+    // `health:LangGraph (Python)` that didn't join with anything else
+    // on the dashboard. Use the showcase-prefixed slug shape to mirror
+    // production.
     return {
       key: `smoke:${slug}`,
-      name: manifest.name,
+      name: `showcase-${slug}`,
       publicUrl: getPackageUrl(slug, config),
       shape: "package" as const,
     };

--- a/showcase/harness/src/probes/helpers/d5-feature-mapping.ts
+++ b/showcase/harness/src/probes/helpers/d5-feature-mapping.ts
@@ -64,11 +64,14 @@ const REGISTRY_TO_D5: Readonly<Record<string, readonly D5FeatureType[]>> = {
   "tool-rendering-default-catchall": ["tool-rendering"],
   "tool-rendering-custom-catchall": ["tool-rendering"],
 
-  // gen-ui (headless tier) — D5 script `d5-gen-ui-headless.ts` drives
-  // /demos/headless-simple, but the registry also exposes a fuller
-  // /demos/headless-complete demo on the same surface.
+  // gen-ui (headless tier) — `headless-simple` and `headless-complete`
+  // each have their own D5 script and fixture. They live on different
+  // routes (`/demos/headless-simple` vs `/demos/headless-complete`) and
+  // exercise different rendering surfaces (show_card via useComponent
+  // vs WeatherCard/StockCard/HighlightNote via useRenderTool +
+  // useComponent + MCP), so the mapping is one-to-one.
   "headless-simple": ["gen-ui-headless"],
-  "headless-complete": ["gen-ui-headless"],
+  "headless-complete": ["gen-ui-headless-complete"],
 
   // gen-ui (custom tier)
   "gen-ui-tool-based": ["gen-ui-custom"],

--- a/showcase/harness/src/probes/helpers/d5-registry.ts
+++ b/showcase/harness/src/probes/helpers/d5-registry.ts
@@ -40,6 +40,7 @@ export type D5FeatureType =
   | "hitl-steps"
   | "hitl-text-input"
   | "gen-ui-headless"
+  | "gen-ui-headless-complete"
   | "gen-ui-custom"
   | "mcp-apps"
   | "subagents"
@@ -91,6 +92,7 @@ const D5_FEATURE_TYPES: readonly D5FeatureType[] = [
   "hitl-steps",
   "hitl-text-input",
   "gen-ui-headless",
+  "gen-ui-headless-complete",
   "gen-ui-custom",
   "mcp-apps",
   "subagents",

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-headless-complete.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-headless-complete.ts
@@ -1,0 +1,273 @@
+/**
+ * D5 — gen-UI (headless-complete) script.
+ *
+ * Probes the showcase's `/demos/headless-complete` page — a hand-rolled
+ * chat surface (no `<CopilotChat />`) that exercises the full
+ * generative-UI composition: per-tool renderers (WeatherCard,
+ * StockCard), a frontend-only `useComponent` (HighlightNote), an MCP
+ * server (Excalidraw), and a plain-text fallback path.
+ *
+ * The page exposes 5 suggestion chips (`[data-testid="headless-suggestions"]`)
+ * with deterministic prompts. This probe clicks each chip in turn and
+ * asserts the right rendering surface fires for each:
+ *
+ *   1. "Weather in Tokyo" → backend `get_weather` tool → WeatherCard
+ *      (per-tool `useRenderTool`). Asserts the messages container shows
+ *      "Weather" + "Tokyo".
+ *   2. "AAPL stock price" → backend `get_stock_price` tool → StockCard
+ *      (per-tool `useRenderTool`). Asserts the container shows "AAPL"
+ *      and a `$` price marker.
+ *   3. "Highlight a note" → frontend `highlight_note` tool → HighlightNote
+ *      (frontend `useComponent`). Asserts the container shows the
+ *      "Note" eyebrow and the highlighted text "meeting at 3pm".
+ *   4. "Sketch a diagram" → Excalidraw MCP tool. The MCP path is more
+ *      involved (server-side tool-call execution) so this turn
+ *      asserts only that the assistant responded with a non-empty
+ *      message — the conversation-runner's settle detection already
+ *      pins the message arrival, this just confirms the MCP path
+ *      didn't error out.
+ *   5. "Largest continent" → plain-text reply. Asserts "asia" in the
+ *      assistant text. Same fixture used by the headless-simple probe.
+ *
+ * All five turns use `preFill` to click the chip — the runner's normal
+ * fill+press is a no-op because the chip dispatch already submitted
+ * the message and the demo's `handleSubmit` guards empty input.
+ */
+
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
+import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
+
+/**
+ * Click a suggestion chip by its visible label, scoped to the
+ * `[data-testid="headless-suggestions"]` row. Mirrors the helper in
+ * `d5-gen-ui-headless.ts`; duplicated here to avoid a cross-script
+ * import (each `d5-*.ts` is a self-contained loader entry).
+ */
+async function clickChip(page: Page, label: string): Promise<void> {
+  const pageWithClick = page as Page & {
+    click(selector: string, opts?: { timeout?: number }): Promise<void>;
+  };
+  if (typeof pageWithClick.click !== "function") {
+    throw new Error(
+      "headless-complete probe: page.click is not available — the " +
+        "runner's Page shim must expose click() for chip-driven turns",
+    );
+  }
+  const selector = `[data-testid="headless-suggestions"] >> text="${label}"`;
+  await pageWithClick.click(selector, { timeout: 10_000 });
+}
+
+/**
+ * Read the lowercase textContent of the messages container
+ * (`[data-testid="headless-complete-messages"]`). Captures BOTH the
+ * assistant's prose AND the rendered tool components (WeatherCard,
+ * StockCard, HighlightNote) — unlike `readLastAssistantText` which
+ * scopes to the prose child only.
+ *
+ * Returns the empty string when the container is missing or empty.
+ */
+async function readMessagesText(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const win = globalThis as unknown as {
+      document: {
+        querySelector(sel: string): { textContent: string | null } | null;
+      };
+    };
+    const el = win.document.querySelector(
+      '[data-testid="headless-complete-messages"]',
+    );
+    if (!el) return "";
+    return (el.textContent || "").toLowerCase();
+  });
+}
+
+/**
+ * Count assistant message elements in the messages container. Used by
+ * the Excalidraw best-effort assertion to confirm the MCP path
+ * produced AT LEAST one assistant response (the runner's settle
+ * detection already gated on this count growing, but we re-read here
+ * to surface a clearer error if the response was an empty bubble).
+ */
+async function countAssistantMessages(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const win = globalThis as unknown as {
+      document: {
+        querySelectorAll(sel: string): { length: number };
+      };
+    };
+    return win.document.querySelectorAll(
+      '[data-testid="headless-complete-messages"] [data-message-role="assistant"]',
+    ).length;
+  });
+}
+
+function assertContainsAll(
+  text: string,
+  tokens: readonly string[],
+  context: string,
+): void {
+  const missing = tokens.filter((t) => !text.includes(t.toLowerCase()));
+  if (missing.length > 0) {
+    throw new Error(
+      `${context}: messages container missing tokens [${missing.join(
+        ", ",
+      )}]; container text (truncated): ${text.slice(0, 300)}`,
+    );
+  }
+}
+
+export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
+  return [
+    {
+      input: "",
+      preFill: async (page) => {
+        console.debug(
+          "[d5-gen-ui-headless-complete] turn 1: clicking 'Weather in Tokyo'",
+        );
+        await clickChip(page, "Weather in Tokyo");
+      },
+      // The WeatherCard renders eyebrow "Fetching weather" → "Weather"
+      // once the tool result lands; the second leg can take a moment
+      // because the agent narrates afterward. 60 s is generous but
+      // matches the upper bound on slow CI shards.
+      responseTimeoutMs: 60_000,
+      assertions: async (page) => {
+        const text = await readMessagesText(page);
+        console.debug("[d5-gen-ui-headless-complete] weather text", {
+          text: text.slice(0, 300),
+        });
+        assertContainsAll(
+          text,
+          ["weather", "tokyo"],
+          "gen-ui-headless-complete weather",
+        );
+      },
+    },
+    {
+      input: "",
+      preFill: async (page) => {
+        console.debug(
+          "[d5-gen-ui-headless-complete] turn 2: clicking 'AAPL stock price'",
+        );
+        await clickChip(page, "AAPL stock price");
+      },
+      responseTimeoutMs: 60_000,
+      assertions: async (page) => {
+        const text = await readMessagesText(page);
+        console.debug("[d5-gen-ui-headless-complete] stock text", {
+          text: text.slice(0, 300),
+        });
+        // StockCard renders ticker uppercase ("AAPL") and price as
+        // "$189.42". `aapl` + `$` is enough to distinguish a
+        // rendered card from a plain-text fallback or a wrong tool.
+        assertContainsAll(
+          text,
+          ["aapl", "$"],
+          "gen-ui-headless-complete stock",
+        );
+      },
+    },
+    {
+      input: "",
+      preFill: async (page) => {
+        console.debug(
+          "[d5-gen-ui-headless-complete] turn 3: clicking 'Highlight a note'",
+        );
+        await clickChip(page, "Highlight a note");
+      },
+      responseTimeoutMs: 60_000,
+      assertions: async (page) => {
+        const text = await readMessagesText(page);
+        console.debug("[d5-gen-ui-headless-complete] highlight text", {
+          text: text.slice(0, 300),
+        });
+        // HighlightNote renders the eyebrow "Note" and the highlighted
+        // text from the chip prompt ("meeting at 3pm").
+        assertContainsAll(
+          text,
+          ["note", "meeting at 3pm"],
+          "gen-ui-headless-complete highlight",
+        );
+      },
+    },
+    {
+      input: "",
+      preFill: async (page) => {
+        console.debug(
+          "[d5-gen-ui-headless-complete] turn 4: clicking 'Sketch a diagram'",
+        );
+        await clickChip(page, "Sketch a diagram");
+      },
+      // Excalidraw goes through MCP — the round-trip can be slower
+      // than the in-runtime tool path. Bump the budget.
+      responseTimeoutMs: 90_000,
+      assertions: async (page) => {
+        // Best-effort: the MCP path is server-side and the surface
+        // depends on the Excalidraw MCP server actually responding.
+        // We can't pin a specific render shape across integrations
+        // here, so we assert that the messages container has at least
+        // one assistant message and is non-empty. The runner's settle
+        // detection already gated on assistant-count growth, this
+        // re-check guards against the edge case of an empty assistant
+        // bubble (which the AssistantBubble would null out anyway).
+        const count = await countAssistantMessages(page);
+        const text = await readMessagesText(page);
+        console.debug("[d5-gen-ui-headless-complete] excalidraw signal", {
+          assistantCount: count,
+          textPreview: text.slice(0, 200),
+        });
+        if (count === 0) {
+          throw new Error(
+            "gen-ui-headless-complete excalidraw: no assistant messages in container",
+          );
+        }
+        if (text.trim().length === 0) {
+          throw new Error(
+            "gen-ui-headless-complete excalidraw: messages container empty",
+          );
+        }
+      },
+    },
+    {
+      input: "",
+      preFill: async (page) => {
+        console.debug(
+          "[d5-gen-ui-headless-complete] turn 5: clicking 'Largest continent'",
+        );
+        await clickChip(page, "Largest continent");
+      },
+      assertions: async (page) => {
+        const text = await readMessagesText(page);
+        console.debug("[d5-gen-ui-headless-complete] continent text", {
+          text: text.slice(0, 300),
+        });
+        if (!text.includes("asia")) {
+          throw new Error(
+            `gen-ui-headless-complete continent: missing "asia"; container text: ${text.slice(
+              0,
+              200,
+            )}`,
+          );
+        }
+      },
+    },
+  ];
+}
+
+/**
+ * Override the default `/demos/<featureType>` route. The hyphenated
+ * feature type would resolve to `/demos/gen-ui-headless-complete`,
+ * which doesn't exist — the actual showcase route is
+ * `/demos/headless-complete`.
+ */
+function preNavigateRoute(): string {
+  return "/demos/headless-complete";
+}
+
+registerD5Script({
+  featureTypes: ["gen-ui-headless-complete"],
+  fixtureFile: "gen-ui-headless-complete.json",
+  buildTurns,
+  preNavigateRoute,
+});

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-headless.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-headless.ts
@@ -1,27 +1,36 @@
 /**
  * D5 — gen-UI (headless) script.
  *
- * Probes the showcase's `/demos/headless-simple` page against the
- * frontend-defined `show_card` tool (registered via `useComponent` in
- * `headless-simple/page.tsx`). The fixture
- * (`fixtures/d5/gen-ui-headless.json`) makes the agent emit a
- * `show_card` tool call which the headless chat surface materialises
- * into a `ShowCard` React component (titled card with a body
- * paragraph).
+ * Probes the showcase's `/demos/headless-simple` page. The page exposes
+ * a row of suggestion chips (`[data-testid="headless-suggestions"]`)
+ * whose buttons dispatch deterministic prompts directly to the agent's
+ * `send()` handler — the same code path the textarea+Enter flow uses,
+ * just without the typing.
  *
- * Two-turn shape (mirrors the recorded fixture):
- *   1. User: "Show me a profile card for Ada Lovelace"
- *      -> Agent calls `show_card({ title, body })` -> frontend renders
- *      `ShowCard` -> second-leg LLM round narrates the rendered card.
+ * Two turns (both chip-driven):
+ *   1. Click "Profile card" → agent emits `show_card({title, body})` →
+ *      frontend `useComponent` materialises a `ShowCard` React component
+ *      (titled card with body paragraph). Asserts the gen-UI cascade
+ *      finds the rendered component AND the assistant narration
+ *      mentions "card" or "ada".
+ *   2. Click "Largest continent" → agent returns plain text "Asia is
+ *      the largest continent…". Asserts the assistant text contains
+ *      "asia".
+ *
+ * Both turns use `preFill` to click the chip — the runner's normal
+ * fill+press is a guarded no-op because the chip click already
+ * submitted the message and the demo's `send()` rejects empty input.
  *
  * Acceptance for the headless tier (NOT the custom tier):
- *   - The custom-rendered component must be present in the DOM (NOT
- *     just text). Empty wrappers are explicitly rejected by the
- *     selector cascade in `_gen-ui-shared.ts`.
- *   - Component must have at least one child element (the headless
- *     `ShowCard` has two: the title `<div>` and the body `<div>`).
- *   - The assistant's follow-up narration must reference the rendered
- *     content (the fixture narrates "card above" / Ada's biography).
+ *   - Turn 1: the custom-rendered ShowCard must be present in the DOM
+ *     with at least one child element (NOT just text). Empty wrappers
+ *     are explicitly rejected by the selector cascade in
+ *     `_gen-ui-shared.ts`.
+ *   - Turn 2: the deterministic continent fixture lives in
+ *     `aimock/feature-parity.json` ("What is the largest continent?" →
+ *     "Asia is the largest continent — about 30% of Earth's land area,
+ *     home to over 4.6 billion people.") so the substring `asia` is
+ *     reliable across integrations.
  *
  * The custom-tier script (`d5-gen-ui-custom.ts`) layers a STRUCTURAL
  * match on top -- for `render_pie_chart` it asserts an SVG with
@@ -31,11 +40,35 @@
 
 import { registerD5Script } from "../helpers/d5-registry.js";
 import type { D5BuildContext } from "../helpers/d5-registry.js";
-import type { ConversationTurn } from "../helpers/conversation-runner.js";
+import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 import {
   readLastAssistantText,
   waitForGenUiComponent,
 } from "./_gen-ui-shared.js";
+
+/**
+ * Click a suggestion chip by its visible label, scoped to the
+ * `[data-testid="headless-suggestions"]` row so the click can't pick
+ * up an unrelated button on the page. The runner's structural Page
+ * shim doesn't expose `click()` (Playwright's real Page does); the
+ * driver's wrapper passes it through, so we narrow at call time.
+ */
+async function clickChip(page: Page, label: string): Promise<void> {
+  const pageWithClick = page as Page & {
+    click(selector: string, opts?: { timeout?: number }): Promise<void>;
+  };
+  if (typeof pageWithClick.click !== "function") {
+    throw new Error(
+      "headless probe: page.click is not available — the runner's Page " +
+        "shim must expose click() for chip-driven turns",
+    );
+  }
+  // Playwright's `text=` engine matches button text. The visible
+  // label on the chip is the suggestion's `title` field
+  // (e.g. "Profile card", "Largest continent").
+  const selector = `[data-testid="headless-suggestions"] >> text="${label}"`;
+  await pageWithClick.click(selector, { timeout: 10_000 });
+}
 
 /**
  * Minimum childElementCount required after the cascade resolves. The
@@ -46,40 +79,38 @@ import {
 const MIN_CHILDREN = 1;
 
 /**
- * Lower-case tokens we expect to find in the assistant's follow-up
- * text (post-tool-call narration). The fixture writes a short
- * paragraph that mentions "card" and "Ada".
- *
- * We accept EITHER "card" OR "ada" (not both) because the headless
- * surface may combine the tool-call message and narration into a
- * single `[data-message-role="assistant"]` element. When that
- * happens, `readLastAssistantText` captures the full text including
- * the ShowCard's content ("Ada Lovelace", "English mathematician...")
- * which guarantees "ada" is present. Requiring both tokens would
- * be fragile if the narration message arrives as a separate element
- * that only mentions "card" or only mentions "Ada".
+ * Lower-case tokens we expect to find in the assistant's text after
+ * the ShowCard render. Accept EITHER "card" OR "ada" — see the file
+ * header for the rationale (combined-message edge case in headless).
  */
-const FOLLOWUP_TOKENS_PRIMARY = ["card"] as const;
-const FOLLOWUP_TOKENS_SECONDARY = ["ada"] as const;
+const PROFILE_FOLLOWUP_TOKENS_PRIMARY = ["card"] as const;
+const PROFILE_FOLLOWUP_TOKENS_SECONDARY = ["ada"] as const;
 
 export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
   return [
     {
-      input: "Show me a profile card for Ada Lovelace",
+      // Empty input + chip click via preFill. The chip's onClick
+      // submits the message directly; the runner's fill+press is a
+      // no-op because the demo's `send()` guards empty input.
+      input: "",
+      preFill: async (page) => {
+        console.debug(
+          "[d5-gen-ui-headless] turn 1: clicking 'Profile card' chip",
+        );
+        await clickChip(page, "Profile card");
+      },
       assertions: async (page) => {
-        // 1. Cascade-find the rendered component. Throws on timeout
-        //    with a descriptive error so the conversation-runner
-        //    surfaces it as the turn's failure_turn.
+        // 1. Cascade-find the rendered ShowCard component. Throws on
+        //    timeout with a descriptive error.
         console.debug("[d5-gen-ui-headless] waiting for gen-UI component");
         const matchedSelector = await waitForGenUiComponent(page);
         console.debug("[d5-gen-ui-headless] gen-UI component found", {
           matchedSelector,
         });
 
-        // 2. Read the matched node's child count via page.evaluate.
-        //    Ensures the component is structurally non-trivial. The
-        //    selector cascade already filtered empty wrappers, but
-        //    the chat surface may grow content asynchronously.
+        // 2. Structural check: the matched node has children (i.e. the
+        //    ShowCard's title + body actually rendered, not just an
+        //    empty wrapper).
         const childCount = await readChildCountForSelector(
           page,
           matchedSelector,
@@ -95,29 +126,56 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
           );
         }
 
-        // 3. Confirm the assistant followed up with narration that
-        //    references the rendered card. Token-level check (NOT a
-        //    string-equality assertion) so wording drift across
-        //    integrations doesn't fail the probe. We require at
-        //    least one primary token OR one secondary token.
+        // 3. Token-level narration check. Require at least one
+        //    primary OR one secondary token.
         const text = (await readLastAssistantText(page)).toLowerCase();
         console.debug("[d5-gen-ui-headless] follow-up text check", {
-          primaryTokens: [...FOLLOWUP_TOKENS_PRIMARY],
-          secondaryTokens: [...FOLLOWUP_TOKENS_SECONDARY],
+          primaryTokens: [...PROFILE_FOLLOWUP_TOKENS_PRIMARY],
+          secondaryTokens: [...PROFILE_FOLLOWUP_TOKENS_SECONDARY],
           assistantText: text.slice(0, 300),
         });
-        const primaryMissing = FOLLOWUP_TOKENS_PRIMARY.filter(
+        const primaryMissing = PROFILE_FOLLOWUP_TOKENS_PRIMARY.filter(
           (tok) => !text.includes(tok),
         );
-        const secondaryMissing = FOLLOWUP_TOKENS_SECONDARY.filter(
+        const secondaryMissing = PROFILE_FOLLOWUP_TOKENS_SECONDARY.filter(
           (tok) => !text.includes(tok),
         );
         if (primaryMissing.length > 0 && secondaryMissing.length > 0) {
           throw new Error(
-            `gen-ui-headless: assistant follow-up missing tokens (need at least one of [${[...FOLLOWUP_TOKENS_PRIMARY, ...FOLLOWUP_TOKENS_SECONDARY].join(", ")}]); last assistant text: ${text.slice(0, 200)}`,
+            `gen-ui-headless: assistant follow-up missing tokens (need at least one of [${[
+              ...PROFILE_FOLLOWUP_TOKENS_PRIMARY,
+              ...PROFILE_FOLLOWUP_TOKENS_SECONDARY,
+            ].join(", ")}]); last assistant text: ${text.slice(0, 200)}`,
           );
         }
-        console.debug("[d5-gen-ui-headless] all assertions passed");
+        console.debug("[d5-gen-ui-headless] turn 1 assertions passed");
+      },
+    },
+    {
+      input: "",
+      preFill: async (page) => {
+        console.debug(
+          "[d5-gen-ui-headless] turn 2: clicking 'Largest continent' chip",
+        );
+        await clickChip(page, "Largest continent");
+      },
+      assertions: async (page) => {
+        // The aimock fixture returns "Asia is the largest continent…".
+        // Asserting on the lowercase token "asia" is robust to wording
+        // drift while still pinning the deterministic answer.
+        const text = (await readLastAssistantText(page)).toLowerCase();
+        console.debug("[d5-gen-ui-headless] continent text check", {
+          assistantText: text.slice(0, 300),
+        });
+        if (!text.includes("asia")) {
+          throw new Error(
+            `gen-ui-headless: continent reply missing "asia"; last assistant text: ${text.slice(
+              0,
+              200,
+            )}`,
+          );
+        }
+        console.debug("[d5-gen-ui-headless] turn 2 assertions passed");
       },
     },
   ];

--- a/showcase/integrations/langgraph-python/src/app/demos/headless-complete/assistant-bubble.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/headless-complete/assistant-bubble.tsx
@@ -20,7 +20,7 @@ export function AssistantBubble({ children }: { children: React.ReactNode }) {
   if (isEmpty(children)) return null;
 
   return (
-    <div className="flex justify-start">
+    <div data-message-role="assistant" className="flex justify-start">
       <div className="max-w-[85%] flex flex-col gap-2">
         <div className="rounded-2xl rounded-bl-sm bg-[#F0F0F4] text-[#010507] px-4 py-2 text-sm">
           {children}

--- a/showcase/integrations/langgraph-python/src/app/demos/headless-complete/user-bubble.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/headless-complete/user-bubble.tsx
@@ -12,7 +12,7 @@ import React from "react";
 // @region[custom-bubbles]
 export function UserBubble({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex justify-end">
+    <div data-message-role="user" className="flex justify-end">
       <div className="max-w-[75%] rounded-2xl rounded-br-sm bg-[#010507] text-white px-4 py-2 text-sm whitespace-pre-wrap break-words">
         {children}
       </div>

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -117,6 +117,7 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   "agentic-chat": ["agentic-chat"],
   "tool-rendering": ["tool-rendering"],
   "headless-simple": ["gen-ui-headless"],
+  "headless-complete": ["gen-ui-headless-complete"],
   "gen-ui-tool-based": ["gen-ui-custom"],
   "hitl-in-chat": ["hitl-text-input"],
   hitl: ["hitl-steps"],


### PR DESCRIPTION
## Summary

- **Promotes `/demos/headless-complete` to its own D5 feature type** (`gen-ui-headless-complete`) so the dashboard cell can reach D5. Previously `headless-complete` aliased onto `gen-ui-headless`, which navigated to `/demos/headless-simple` and asserted on a `show_card` tool the headless-complete page doesn't even register — i.e. the cell was never actually being probed.
- **Extends `gen-ui-headless`** (the simple probe) to also click the "Largest continent" chip and assert the canonical Asia text reply.
- **Both probes now click chips via `preFill`** instead of typing the prompt — same handler the user clicks, no input drift.
- **Bug fixes uncovered while wiring this up locally** that explain why the dashboard matrix had been showing every cell as D0 — see "What was actually broken" below.

## What was added (the feature work)

- New `gen-ui-headless-complete` D5 feature type + script that exercises **all 5 chips** on `/demos/headless-complete`:
  - `Weather in Tokyo` → `WeatherCard` (per-tool `useRenderTool`)
  - `AAPL stock price` → `StockCard` (per-tool `useRenderTool`)
  - `Highlight a note` → `HighlightNote` (frontend `useComponent`)
  - `Sketch a diagram` → best-effort assistant response (Excalidraw MCP path)
  - `Largest continent` → "Asia is the largest continent…" text reply
- New fixture `harness/fixtures/d5/gen-ui-headless-complete.json` (also bundled into `aimock/d5-all.json`) for AAPL + highlight + Excalidraw prompts.
- `headless-complete` `UserBubble` + `AssistantBubble` now carry `data-message-role` so the harness conversation runner can detect message arrivals (mirrors the headless-simple convention; required to probe the page at all).
- Mappings updated in lockstep: `REGISTRY_TO_D5` (harness) and `CATALOG_TO_D5_KEY` (dashboard) both map `headless-complete → ["gen-ui-headless-complete"]`.

### Non-obvious fixture detail worth flagging

Aimock's `toolCallId` matcher reads only the **last** tool message in the request, but in a multi-turn probe the "last tool" stays on a previous turn's id until a new tool runs. A bare `toolCallId` narration fixture will therefore fire for the *next* turn's prompt and hijack it with a stale narration. The fix is to pin each narration fixture with both `userMessage` AND `toolCallId`, and order them BEFORE the bare `userMessage` toolCall fixture in the array — that way the more-specific narration only fires on the matching turn's second leg, and the bare userMessage fixture covers the first leg.

## What was actually broken (incidental bugs fixed)

These were uncovered while running the new probe locally — none of them were caused by this PR, all of them prevented the dashboard from working at all in `--live` mode. Each is a separate commit so they can be reviewed / cherry-picked independently:

1. **`fix(showcase/harness): wire pbWriter into ProbeContext for live writes`** — `runner.ts` constructed `ctx` without `writer`, so every per-feature side row from every driver (e2e-deep's `d5:<slug>/<featureType>`, liveness's `health:<slug>` / `agent:<slug>`, etc.) was silently dropped on `--live` runs. Only aggregate primary results made it to PB. This is why the dashboard matrix showed every cell as D0 even after a successful `--live` probe.
2. **`fix(showcase/harness): align CLI smoke input slug shape with discovery`** — `buildSmokeInputs` passed `name: manifest.name` (display name like "LangGraph (Python)") which the liveness driver's `deriveSlug` used as the slug, producing rows like `health:LangGraph (Python)` that didn't join with anything else. Matches production discovery shape (`name = showcase-<slug>`) now.
3. **`fix(showcase/harness): use PB-validator-compliant email for local superuser`** — PocketBase 0.22 rejects `admin@localhost` (single-label TLD). Switched the hardcoded local creds to `admin@localhost.dev`.
4. **`chore(showcase/dashboard): plumb NEXT_PUBLIC_* build args in local compose`** — `NEXT_PUBLIC_POCKETBASE_URL` and `NEXT_PUBLIC_SHELL_URL` were unset at build time, so the dashboard JS couldn't reach PB from the browser at all (FATAL-CONFIG banner) and every Demo/Code link in the matrix rendered as `about:blank#shell-url-missing`.

## Verification

Run locally against the langgraph-python integration:

```sh
docker compose -f showcase/docker-compose.local.yml up -d aimock pocketbase
docker exec showcase-pocketbase /usr/local/bin/pocketbase migrate up --dir=/pb_data
docker exec showcase-pocketbase /usr/local/bin/pocketbase admin create admin@localhost.dev showcase-local-dev --dir=/pb_data
docker compose -f showcase/docker-compose.local.yml up -d --build dashboard langgraph-python

npx tsx showcase/harness/src/cli.ts test langgraph-python --d5 --verbose
# 33/33 passed, including gen-ui-headless and gen-ui-headless-complete

npx tsx showcase/harness/src/cli.ts test langgraph-python --level all --live
# Writes the full ladder to PB
```

Open http://localhost:3200 — the langgraph-python `headless-simple` and `headless-complete` cells both show **D5** with API ✓ / RT ✓ / CV ✓.

## Test plan

- [ ] Run `npx tsx showcase/harness/src/cli.ts test langgraph-python --d5 --verbose` and confirm `gen-ui-headless` and `gen-ui-headless-complete` both green.
- [ ] Run with `--live` and confirm `d5:langgraph-python/gen-ui-headless-complete` appears in PocketBase as `green`.
- [ ] Open the dashboard matrix and confirm the langgraph-python `headless-complete` cell shows D5/D5.
- [ ] Visually click each chip on `/demos/headless-complete` and confirm the right surface renders (WeatherCard / StockCard / HighlightNote / Excalidraw / Asia text).
- [ ] D5 probe still passes for every other langgraph-python feature (no regressions in the existing 32 features).

## What was NOT done

- The `data-message-role` bubble tags are only on the **langgraph-python** copy of `headless-complete/{user,assistant}-bubble.tsx`. The other 16 integrations' headless-complete demos still lack the attribute. They aren't probed at D5 today, so this is fine — but propagate before bumping any of them to D5.
- The local CLI's `--smoke / --d4 / --d5 / --level all` flag set does not run the `e2e-demos` driver that emits `e2e:<slug>/<featureId>` rows, so the depth ladder caps at D2 from those flags alone. Dashboard verification in this PR populated D3 rows manually. Wiring `e2e-demos` (or an equivalent D3 generator) into the local CLI is a separate follow-up.