### PR TITLE
feat(showcase/voice): D5 mapping + sample-button bypasses /transcribe

### DIFF
--- a/showcase/harness/src/probes/scripts/d5-voice.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-voice.test.ts
@@ -1,15 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { getD5Script, type D5BuildContext } from "../helpers/d5-registry.js";
+import { getD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { Page } from "../helpers/conversation-runner.js";
 // Top-level import triggers the script's `registerD5Script` side effect
 // against the singleton registry. Mirrors the pattern in
 // `d5-tool-rendering.test.ts` — the registry is process-wide, modules
 // are cached, so we register once at import time and read it back via
 // `getD5Script` per assertion.
-import {
-  buildTurns,
-  SAMPLE_AUDIO_BUTTON_SELECTOR,
-} from "./d5-voice.js";
+import { buildTurns, SAMPLE_AUDIO_BUTTON_SELECTOR } from "./d5-voice.js";
 
 /**
  * Tests for the D5 voice script. Three concerns:
@@ -200,27 +198,23 @@ describe("d5-voice script", () => {
       await expect(turn.assertions!(page)).resolves.toBeUndefined();
     });
 
-    it(
-      "throws when the assistant transcript is unrelated to weather",
-      async () => {
-        const turns = buildTurns({
-          integrationSlug: "langgraph-python",
-          featureType: "voice",
-          baseUrl: "https://example.test",
-        });
-        const turn = turns[0]!;
-        const page = makePage({
-          evaluateValues: ["i don't know how to answer that question"],
-        });
+    it("throws when the assistant transcript is unrelated to weather", async () => {
+      const turns = buildTurns({
+        integrationSlug: "langgraph-python",
+        featureType: "voice",
+        baseUrl: "https://example.test",
+      });
+      const turn = turns[0]!;
+      const page = makePage({
+        evaluateValues: ["i don't know how to answer that question"],
+      });
 
-        // The assertion polls for up to 5s before giving up — give the
-        // test enough headroom to observe the rejection rather than
-        // racing it against vitest's default 5000ms timeout.
-        await expect(turn.assertions!(page)).rejects.toThrow(
-          /assistant transcript missing weather\/Tokyo content/,
-        );
-      },
-      10_000,
-    );
+      // The assertion polls for up to 5s before giving up — give the
+      // test enough headroom to observe the rejection rather than
+      // racing it against vitest's default 5000ms timeout.
+      await expect(turn.assertions!(page)).rejects.toThrow(
+        /assistant transcript missing weather\/Tokyo content/,
+      );
+    }, 10_000);
   });
 });

--- a/showcase/harness/src/probes/scripts/d5-voice.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-voice.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import { getD5Script, type D5BuildContext } from "../helpers/d5-registry.js";
+import type { Page } from "../helpers/conversation-runner.js";
+// Top-level import triggers the script's `registerD5Script` side effect
+// against the singleton registry. Mirrors the pattern in
+// `d5-tool-rendering.test.ts` — the registry is process-wide, modules
+// are cached, so we register once at import time and read it back via
+// `getD5Script` per assertion.
+import {
+  buildTurns,
+  SAMPLE_AUDIO_BUTTON_SELECTOR,
+} from "./d5-voice.js";
+
+/**
+ * Tests for the D5 voice script. Three concerns:
+ *
+ *   1. Side-effect registration — the import wires up `voice` in the
+ *      registry pointing at the bundled `d5-all.json` fixture (the
+ *      script reuses the canned transcription + weather fixtures that
+ *      already live there).
+ *   2. `buildTurns` produces a single `skipFill` turn whose `preFill`
+ *      drives the sample-audio button click + textarea-poll path.
+ *   3. The `assertions` callback fires (throws) when the assistant
+ *      transcript is empty/missing the weather/Tokyo content, and
+ *      passes through when the transcript contains the expected
+ *      keywords.
+ */
+
+interface FakePageScript {
+  /** Sequence of textContent values returned by readAssistantTranscript. */
+  evaluateValues?: unknown[];
+  /** Whether `waitForSelector` should throw (button not visible). */
+  throwOnWaitForSelector?: boolean;
+  /** Whether the click should throw. */
+  throwOnClick?: boolean;
+  /** Sequence of textarea values returned to the textarea poll. */
+  textareaValues?: string[];
+  /** Tracks how many times the click was invoked. */
+  clickCalls?: { count: number };
+}
+
+/**
+ * Build a fake Page that satisfies the runner's `Page` interface plus the
+ * additional `click` method d5-voice's preFill uses. The fake interleaves
+ * two `evaluate` consumers: the textarea-value poll inside preFill, and
+ * the assistant-transcript read inside the assertion. We split them by
+ * tagging `evaluateValues` (used after preFill returns) and
+ * `textareaValues` (consumed by the textarea poll). The fake hands out
+ * textareaValues first, then falls through to evaluateValues.
+ */
+function makePage(script: FakePageScript = {}): Page & {
+  click: (sel: string, opts?: { timeout?: number }) => Promise<void>;
+} {
+  const transcripts = [...(script.evaluateValues ?? [])];
+  const textareaQueue = [...(script.textareaValues ?? [])];
+  return {
+    async waitForSelector() {
+      if (script.throwOnWaitForSelector) {
+        throw new Error("waitForSelector timeout (test fake)");
+      }
+    },
+    async fill() {
+      // Unused — voice script uses skipFill: true.
+    },
+    async press() {
+      // Unused — these tests assert on preFill + assertion, not the
+      // runner's press step.
+    },
+    async click() {
+      if (script.clickCalls) script.clickCalls.count += 1;
+      if (script.throwOnClick) {
+        throw new Error("click failed (test fake)");
+      }
+    },
+    async evaluate<R>(): Promise<R> {
+      // The textarea-value poll runs first (during preFill); after it
+      // resolves, evaluateValues feeds the assistant-transcript reader.
+      if (textareaQueue.length > 0) {
+        const next = textareaQueue.shift();
+        // The textarea poll evaluator returns a string. Wrap as the
+        // generic R the caller asked for — the runner doesn't introspect.
+        return next as unknown as R;
+      }
+      if (transcripts.length === 0) return undefined as R;
+      if (transcripts.length === 1) return transcripts[0] as R;
+      return transcripts.shift() as R;
+    },
+  };
+}
+
+describe("d5-voice script", () => {
+  describe("registration", () => {
+    it("registers under featureType 'voice' with the bundled d5-all.json fixture", () => {
+      const script = getD5Script("voice");
+      expect(script).toBeDefined();
+      expect(script?.featureTypes).toEqual(["voice"]);
+      // Voice piggybacks on the bundled d5-all.json fixture because the
+      // canned transcription + weather get_weather entries already live
+      // there. No per-feature fixture file is needed.
+      expect(script?.fixtureFile).toBe("d5-all.json");
+    });
+
+    it("registers a buildTurns function that round-trips through the registry", () => {
+      const script = getD5Script("voice");
+      expect(script?.buildTurns).toBe(buildTurns);
+    });
+  });
+
+  describe("buildTurns", () => {
+    const ctx: D5BuildContext = {
+      integrationSlug: "langgraph-python",
+      featureType: "voice",
+      baseUrl: "https://example.test",
+    };
+
+    it("produces a single turn with skipFill=true and an empty input", () => {
+      const turns = buildTurns(ctx);
+      expect(turns).toHaveLength(1);
+      const turn = turns[0]!;
+      expect(turn.skipFill).toBe(true);
+      // input is empty because preFill + the synchronous text injection
+      // populate the textarea — `page.fill()` would overwrite it.
+      expect(turn.input).toBe("");
+      expect(typeof turn.preFill).toBe("function");
+      expect(typeof turn.assertions).toBe("function");
+    });
+
+    it("uses the canonical sample-audio-button testid", () => {
+      // Pinning the selector here so a refactor that breaks the testid
+      // surfaces as a test failure rather than a silent probe miss.
+      expect(SAMPLE_AUDIO_BUTTON_SELECTOR).toBe(
+        '[data-testid="voice-sample-audio-button"]',
+      );
+    });
+  });
+
+  describe("preFill", () => {
+    it("clicks the sample audio button and resolves once the textarea is populated", async () => {
+      const turns = buildTurns({
+        integrationSlug: "langgraph-python",
+        featureType: "voice",
+        baseUrl: "https://example.test",
+      });
+      const turn = turns[0]!;
+      const clickCalls = { count: 0 };
+      const page = makePage({
+        clickCalls,
+        // First poll returns "" (still empty), second returns the canned
+        // phrase — the script must keep polling until non-empty rather
+        // than returning on first read.
+        textareaValues: ["", "What is the weather in Tokyo?"],
+      });
+
+      await turn.preFill!(page);
+
+      expect(clickCalls.count).toBe(1);
+    });
+
+    it("throws when the sample-audio button never becomes visible", async () => {
+      const turns = buildTurns({
+        integrationSlug: "langgraph-python",
+        featureType: "voice",
+        baseUrl: "https://example.test",
+      });
+      const turn = turns[0]!;
+      const page = makePage({ throwOnWaitForSelector: true });
+
+      await expect(turn.preFill!(page)).rejects.toThrow(
+        /sample audio button.*not visible/,
+      );
+    });
+  });
+
+  describe("assertion", () => {
+    it("passes when the assistant transcript mentions weather", async () => {
+      const turns = buildTurns({
+        integrationSlug: "langgraph-python",
+        featureType: "voice",
+        baseUrl: "https://example.test",
+      });
+      const turn = turns[0]!;
+      const page = makePage({
+        evaluateValues: ["the weather in tokyo is 22°c and partly cloudy"],
+      });
+
+      await expect(turn.assertions!(page)).resolves.toBeUndefined();
+    });
+
+    it("passes on temperature-only mention (matches the weather/tokyo/temperature OR cascade)", async () => {
+      const turns = buildTurns({
+        integrationSlug: "langgraph-python",
+        featureType: "voice",
+        baseUrl: "https://example.test",
+      });
+      const turn = turns[0]!;
+      const page = makePage({
+        evaluateValues: ["current temperature: 22 degrees"],
+      });
+
+      await expect(turn.assertions!(page)).resolves.toBeUndefined();
+    });
+
+    it(
+      "throws when the assistant transcript is unrelated to weather",
+      async () => {
+        const turns = buildTurns({
+          integrationSlug: "langgraph-python",
+          featureType: "voice",
+          baseUrl: "https://example.test",
+        });
+        const turn = turns[0]!;
+        const page = makePage({
+          evaluateValues: ["i don't know how to answer that question"],
+        });
+
+        // The assertion polls for up to 5s before giving up — give the
+        // test enough headroom to observe the rejection rather than
+        // racing it against vitest's default 5000ms timeout.
+        await expect(turn.assertions!(page)).rejects.toThrow(
+          /assistant transcript missing weather\/Tokyo content/,
+        );
+      },
+      10_000,
+    );
+  });
+});

--- a/showcase/integrations/ag2/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/voice/page.tsx
@@ -7,16 +7,16 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo (AG2). Two affordances on this page:
 //
 // 1. The default mic button rendered by <CopilotChat /> when the runtime at
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`.
-// 2. A "Play sample" button that POSTs a bundled clip to /transcribe and
-//    injects the transcript into the chat composer (bypasses mic perms so
-//    Playwright + screenshot flows work too).
+// 2. A "Play sample" button that synchronously injects a canned phrase into
+//    the composer (bypasses mic perms and the runtime entirely so Playwright
+//    + screenshot flows work too). Real transcription only happens through
+//    the mic path.
 // @region[voice-page]
 export default function VoiceDemoPage() {
   const handleTranscribed = useCallback((text: string) => {
@@ -59,9 +59,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/ag2/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/ag2/src/app/demos/voice/sample-audio-button.tsx
@@ -1,61 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
- * Sample-audio button for the voice demo (AG2).
+ * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  runtimeUrl: string;
-  audioSrc: string;
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -64,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing..." : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/agno/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/voice/page.tsx
@@ -6,16 +6,15 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo (Agno).
 //
 // The mic button on <CopilotChat /> appears when the runtime advertises
 // `audioFileTranscriptionEnabled: true`. Click it, speak, click again — text
 // is transcribed into the composer. The <SampleAudioButton /> below the
-// chat fetches a bundled wav and POSTs it to /transcribe so screenshot &
-// playwright runs work without mic permissions.
+// chat synchronously injects a canned phrase so screenshot & playwright runs
+// work without mic permissions; the runtime is not involved on that path.
 // @region[voice-page]
 export default function VoiceDemoPage() {
   const handleTranscribed = useCallback((text: string) => {
@@ -58,9 +57,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/agno/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/agno/src/app/demos/voice/sample-audio-button.tsx
@@ -1,61 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * `/public` and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  runtimeUrl: string;
-  audioSrc: string;
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -64,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/built-in-agent/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/voice/page.tsx
@@ -5,17 +5,17 @@
 // 1. The default mic button rendered by <CopilotChat /> when the runtime at
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click,
 //    speak, click again — text is transcribed into the composer.
-// 2. <SampleAudioButton /> fetches a bundled sample.wav and POSTs it to the
-//    same /transcribe endpoint, then writes the result into the composer
-//    textarea (bypassing mic permissions for screenshots/Playwright).
+// 2. <SampleAudioButton /> synchronously injects a canned phrase into the
+//    composer (bypassing mic permissions and the runtime entirely so
+//    screenshots/Playwright work too). Real transcription only flows through
+//    the mic path.
 
 import { useCallback } from "react";
 import { CopilotKitProvider, CopilotChat } from "@copilotkit/react-core/v2";
 import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // @region[voice-page]
 export default function VoiceDemoPage() {
@@ -55,9 +55,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10">
           <CopilotChat className="h-full" />

--- a/showcase/integrations/built-in-agent/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/voice/sample-audio-button.tsx
@@ -1,60 +1,27 @@
 "use client";
 
-import { useState } from "react";
-
 /**
- * Sample-audio button for the voice demo. Bypasses the microphone entirely:
- * fetches a bundled audio clip from /public and POSTs it as multipart/form-data
- * to the runtime's `/transcribe` endpoint. Matches the REST-mode payload shape
- * used by `transcribeAudio()` in `@copilotkit/react-core`'s
- * transcription-client.ts when the provider runs with `useSingleEndpoint={false}`.
+ * Sample-audio button for the voice demo.
+ *
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
  */
 export interface SampleAudioButtonProps {
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  runtimeUrl: string;
-  audioSrc: string;
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
-// @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -63,22 +30,12 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
-      <span className="text-black/60">Sample: &ldquo;{sampleLabel}&rdquo;</span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600"
-        >
-          Error — see console
-        </span>
-      )}
+      <span className="text-black/60">Sample: &ldquo;{sampleText}&rdquo;</span>
     </div>
   );
 }
-// @endregion[sample-audio-button]

--- a/showcase/integrations/claude-sdk-python/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,12 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime's transcription endpoint so Playwright and screenshot flows
+//    work too). The mic path is the only affordance that exercises real
+//    transcription; the sample button is a deterministic test/demo
+//    affordance.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -73,9 +74,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/claude-sdk-python/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,12 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime's transcription endpoint so Playwright and screenshot flows
+//    work too). The mic path is the only affordance that exercises real
+//    transcription; the sample button is a deterministic test/demo
+//    affordance.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -73,9 +74,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/crewai-crews/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,10 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime so Playwright and screenshot flows work too). Real
+//    transcription only happens on the mic path.
 //
 // Backend: the agent is the shared CrewAI crew — voice is an input-modality
 // concern implemented entirely in the Next.js runtime via TranscriptionService.
@@ -76,9 +75,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/crewai-crews/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/google-adk/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/voice/page.tsx
@@ -7,16 +7,16 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo (Google ADK). Two affordances on this page:
 //
 // 1. The default mic button rendered by <CopilotChat /> when the runtime at
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`.
-// 2. A "Play sample" button that POSTs a bundled clip to /transcribe and
-//    injects the transcript into the chat composer (bypasses mic perms so
-//    Playwright + screenshot flows work too).
+// 2. A "Play sample" button that synchronously injects a canned phrase into
+//    the composer (bypasses mic perms and the runtime entirely so Playwright
+//    + screenshot flows work too). Real transcription only flows through the
+//    mic path.
 export default function VoiceDemoPage() {
   const handleTranscribed = useCallback((text: string) => {
     if (typeof document === "undefined") return;
@@ -58,9 +58,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/google-adk/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/voice/sample-audio-button.tsx
@@ -1,60 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
- * Sample-audio button for the voice demo (Google ADK).
+ * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  runtimeUrl: string;
-  audioSrc: string;
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
+// @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -63,23 +35,15 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing..." : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }
+// @endregion[sample-audio-button]

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,12 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime's transcription endpoint so Playwright and screenshot flows
+//    work too). The mic path is the only affordance that exercises real
+//    transcription; the sample button is a deterministic test/demo
+//    affordance.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -73,9 +74,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/langgraph-python/qa/voice.md
+++ b/showcase/integrations/langgraph-python/qa/voice.md
@@ -7,7 +7,7 @@
 - `OPENAI_API_KEY` is set on the Railway service (shared with other demos)
 - A modern browser that supports `MediaRecorder` (Chromium, Firefox, Safari 14+)
 - Microphone hardware available (required only for the mic path in section 3)
-- A bundled `public/demo-audio/sample.wav` saying "What is the weather in Tokyo?" is present
+- A bundled `public/demo-audio/sample.wav` is present (used for screenshot/preview generation; the in-app sample button no longer fetches it)
 
 ## Test Steps
 
@@ -24,9 +24,8 @@
 ### 2. Sample-audio path (no mic permission required)
 
 - [ ] Click the "Play sample" button
-- [ ] Verify the button label flips to "Transcribing…" and the button is disabled
-- [ ] Within 5 seconds, the chat textarea (`data-testid="copilot-chat-textarea"`) contains text that includes "weather" (case-insensitive) AND/OR "Tokyo" (case-insensitive)
-- [ ] The button label returns to "Play sample" and the button is re-enabled
+- [ ] Immediately, the chat textarea (`data-testid="copilot-chat-textarea"`) contains the canned phrase "What is the weather in Tokyo?" (no async round-trip; no "Transcribing…" state)
+- [ ] The button stays enabled
 - [ ] Click send (`data-testid="copilot-send-button"`)
 - [ ] Within 10 seconds, the agent responds with a weather-related tool render (WeatherCard, custom-catchall card, or default tool card — depending on which tool-rendering mode is active on this page)
 
@@ -41,19 +40,12 @@
 
 ### 4. Error Handling
 
-- [ ] In DevTools → Network, block requests to `/demo-audio/sample.wav`
-- [ ] Click "Play sample"
-- [ ] Verify the row shows the error state (`data-testid="voice-sample-audio-error"`) reading "Error — see console"
-- [ ] Verify no page crash; composer remains interactive
-- [ ] Remove the block and click "Play sample" again — verify the button recovers and completes the round-trip
-
 - [ ] Deny microphone permission, click the mic button
 - [ ] Verify the UI handles permission denial gracefully (no crash, mic button remains visible)
 
 ## Expected Results
 
-- Sample-audio transcription completes within 5 seconds for the 3-5s clip
+- Sample button click populates the textarea synchronously (no perceptible delay)
 - Weather-related tool response renders within 10 seconds of send
 - No console errors during the successful paths
-- Error states are visible and recoverable (re-clicking after a block removal should succeed)
-- Whisper transcription is stable enough that "weather" OR "Tokyo" keywords appear in the transcribed text across runs
+- Whisper transcription via the mic path returns text resembling what was spoken (deployment must have `OPENAI_API_KEY` configured)

--- a/showcase/integrations/langgraph-python/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,12 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime's transcription endpoint so Playwright and screenshot flows
+//    work too). The mic path is the only affordance that exercises real
+//    transcription; the sample button is a deterministic test/demo
+//    affordance.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -73,9 +74,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/langgraph-python/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/langgraph-python/tests/e2e/voice.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/voice.spec.ts
@@ -2,10 +2,16 @@ import { test, expect } from "@playwright/test";
 
 // E2E for the voice demo — sample-audio path only.
 //
+// The "Play sample" button is a deterministic test/demo affordance: it
+// synchronously injects the canned phrase ("What is the weather in Tokyo?")
+// into the chat composer without touching the runtime's `/transcribe`
+// endpoint. That keeps this suite stable across environments where Whisper
+// or aimock might be unavailable.
+//
 // The microphone path is intentionally out of scope: MediaRecorder is hard
-// to exercise headlessly without mocking, and the Wave 2a plan constrains
-// E2E to the sample-audio round-trip for stability. The mic path is
-// covered by the manual QA checklist at qa/voice.md.
+// to exercise headlessly without mocking, and the mic is the only path that
+// actually exercises real transcription. It's covered by the manual QA
+// checklist at qa/voice.md.
 //
 // Stability expectation: 3 consecutive runs against Railway must pass.
 
@@ -40,7 +46,7 @@ test.describe("Voice Input", () => {
     ).toBeVisible();
   });
 
-  test("sample audio button transcribes and populates the input", async ({
+  test("sample audio button injects the canned phrase into the input", async ({
     page,
   }) => {
     const sampleButton = page.locator(
@@ -49,16 +55,14 @@ test.describe("Voice Input", () => {
     const textarea = page.locator('[data-testid="copilot-chat-textarea"]');
 
     await expect(sampleButton).toBeEnabled();
+    await expect(textarea).toHaveValue("");
     await sampleButton.click();
 
-    // Button flips to "Transcribing…" while the round-trip is in flight.
-    await expect(sampleButton).toHaveText(/transcribing/i, { timeout: 2000 });
-
-    // Within 15s the textarea should contain the transcribed sample. Whisper
-    // is deterministic enough for a fixed clip that weather/tokyo keywords
-    // are stable across runs, though punctuation may vary.
-    await expect(textarea).toHaveValue(/weather|tokyo/i, { timeout: 15000 });
-    await expect(sampleButton).toBeEnabled({ timeout: 2000 });
+    // The button is synchronous — clicking immediately populates the
+    // textarea with the canned sample text. No transient "Transcribing…"
+    // state, no /transcribe round trip.
+    await expect(textarea).toHaveValue(/weather|tokyo/i, { timeout: 1000 });
+    await expect(sampleButton).toBeEnabled();
   });
 
   test("sending the transcribed text produces a weather tool render", async ({
@@ -71,7 +75,7 @@ test.describe("Voice Input", () => {
     const sendButton = page.locator('[data-testid="copilot-send-button"]');
 
     await sampleButton.click();
-    await expect(textarea).toHaveValue(/weather|tokyo/i, { timeout: 15000 });
+    await expect(textarea).toHaveValue(/weather|tokyo/i, { timeout: 1000 });
     await sendButton.click();
 
     // The voice-demo route reuses the neutral sample_agent graph, which

--- a/showcase/integrations/langgraph-typescript/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,12 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime's transcription endpoint so Playwright and screenshot flows
+//    work too). The mic path is the only affordance that exercises real
+//    transcription; the sample button is a deterministic test/demo
+//    affordance.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -73,9 +74,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/langgraph-typescript/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/langroid/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo for the Langroid integration.
 //
@@ -17,10 +16,10 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime so Playwright and screenshot flows work too). Real
+//    transcription only flows through the mic path.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -70,9 +69,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/langroid/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/langroid/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/llamaindex/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,12 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime's transcription endpoint so Playwright and screenshot flows
+//    work too). The mic path is the only affordance that exercises real
+//    transcription; the sample button is a deterministic test/demo
+//    affordance.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -73,9 +74,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/llamaindex/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/mastra/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/mastra/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,12 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime's transcription endpoint so Playwright and screenshot flows
+//    work too). The mic path is the only affordance that exercises real
+//    transcription; the sample button is a deterministic test/demo
+//    affordance.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -73,9 +74,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/mastra/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/mastra/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/voice/page.tsx
@@ -7,8 +7,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -18,10 +17,10 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime so Playwright and screenshot flows work too). Real
+//    transcription only flows through the mic path.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns
 // its input state internally (no external controlled-input API on v2 today),
@@ -74,9 +73,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/ms-agent-python/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,12 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime's transcription endpoint so Playwright and screenshot flows
+//    work too). The mic path is the only affordance that exercises real
+//    transcription; the sample button is a deterministic test/demo
+//    affordance.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -73,9 +74,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/ms-agent-python/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/pydantic-ai/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,12 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime's transcription endpoint so Playwright and screenshot flows
+//    work too). The mic path is the only affordance that exercises real
+//    transcription; the sample button is a deterministic test/demo
+//    affordance.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -73,9 +74,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/pydantic-ai/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/spring-ai/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 /**
  * Voice demo (Spring AI port).
@@ -61,9 +60,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/spring-ai/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/integrations/strands/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/strands/src/app/demos/voice/page.tsx
@@ -6,8 +6,7 @@ import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";
 const AGENT_ID = "voice-demo";
-const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
-const SAMPLE_LABEL = "What is the weather in Tokyo?";
+const SAMPLE_TEXT = "What is the weather in Tokyo?";
 
 // Voice demo.
 //
@@ -17,10 +16,12 @@ const SAMPLE_LABEL = "What is the weather in Tokyo?";
 //    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
 //    speak, click again — text is transcribed into the composer.
 //
-// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
-//    sample.wav, POSTs it to the same transcription endpoint, and writes the
-//    result into the chat's textarea (bypassing mic permissions so Playwright
-//    and screenshot flows work too).
+// 2. The <SampleAudioButton /> below the chat, which synchronously injects a
+//    canned phrase into the chat's textarea (bypassing mic permissions and
+//    the runtime's transcription endpoint so Playwright and screenshot flows
+//    work too). The mic path is the only affordance that exercises real
+//    transcription; the sample button is a deterministic test/demo
+//    affordance.
 //
 // Injecting text into the composer goes through the DOM: CopilotChat owns its
 // input state internally (no external controlled-input API on v2 today), but
@@ -73,9 +74,7 @@ export default function VoiceDemoPage() {
         </header>
         <SampleAudioButton
           onTranscribed={handleTranscribed}
-          runtimeUrl={RUNTIME_URL}
-          audioSrc={SAMPLE_AUDIO_PATH}
-          sampleLabel={SAMPLE_LABEL}
+          sampleText={SAMPLE_TEXT}
         />
         <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
           <CopilotChat agentId={AGENT_ID} className="h-full" />

--- a/showcase/integrations/strands/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/strands/src/app/demos/voice/sample-audio-button.tsx
@@ -1,69 +1,32 @@
 "use client";
 
-import { useState } from "react";
-
 /**
  * Sample-audio button for the voice demo.
  *
- * Bypasses the microphone entirely: fetches a bundled audio clip from
- * /public and POSTs it as multipart/form-data to the runtime's
- * `/transcribe` endpoint. On success, invokes `onTranscribed(text)` so the
- * caller can populate the chat composer.
- *
- * Matches the REST-mode payload shape used by `transcribeAudio()` in
- * `@copilotkit/react-core`'s transcription-client.ts when the provider runs
- * with `useSingleEndpoint={false}`.
+ * Pure test/demo affordance: clicking the button synchronously injects a
+ * canned phrase into the chat composer via `onTranscribed(sampleText)`.
+ * No microphone permission, no audio fetch, no `/transcribe` round trip
+ * — those concerns belong to the mic button rendered by `<CopilotChat />`.
+ * Keeping this affordance deterministic means the d5-voice probe and the
+ * Playwright e2e never depend on the runtime's transcription endpoint
+ * being healthy or on any specific aimock fixture surviving across
+ * environments.
  */
 export interface SampleAudioButtonProps {
-  /** Called with the transcribed text on success. */
+  /** Called with the canned sample text when the button is clicked. */
   onTranscribed: (text: string) => void;
-  /** Runtime URL whose `/transcribe` sub-path receives the upload. */
-  runtimeUrl: string;
-  /** Public path of the sample audio clip. */
-  audioSrc: string;
-  /** Caption shown next to the button — what the user should expect. */
-  sampleLabel: string;
+  /**
+   * Phrase that doubles as the visible caption AND the text injected
+   * into the composer when the button is clicked.
+   */
+  sampleText: string;
 }
 
 // @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
-  runtimeUrl,
-  audioSrc,
-  sampleLabel,
+  sampleText,
 }: SampleAudioButtonProps) {
-  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
-
-  async function handleClick() {
-    setStatus("loading");
-    try {
-      const audioRes = await fetch(audioSrc);
-      if (!audioRes.ok) {
-        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
-      }
-      const blob = await audioRes.blob();
-      const formData = new FormData();
-      formData.append("audio", blob, "sample.wav");
-      const base = runtimeUrl.replace(/\/$/, "");
-      const transcribeRes = await fetch(`${base}/transcribe`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!transcribeRes.ok) {
-        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
-      }
-      const json = (await transcribeRes.json()) as { text?: string };
-      if (!json.text) {
-        throw new Error("Transcribe returned no text");
-      }
-      onTranscribed(json.text);
-      setStatus("idle");
-    } catch (err) {
-      console.error("[voice-demo] sample transcription failed", err);
-      setStatus("error");
-    }
-  }
-
   return (
     <div
       data-testid="voice-sample-audio"
@@ -72,23 +35,14 @@ export function SampleAudioButton({
       <button
         type="button"
         data-testid="voice-sample-audio-button"
-        onClick={handleClick}
-        disabled={status === "loading"}
-        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+        onClick={() => onTranscribed(sampleText)}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
       >
-        {status === "loading" ? "Transcribing…" : "Play sample"}
+        Play sample
       </button>
       <span className="text-black/60 dark:text-white/60">
-        Sample: &ldquo;{sampleLabel}&rdquo;
+        Sample: &ldquo;{sampleText}&rdquo;
       </span>
-      {status === "error" && (
-        <span
-          data-testid="voice-sample-audio-error"
-          className="ml-auto text-red-600 dark:text-red-400"
-        >
-          Error — see console
-        </span>
-      )}
     </div>
   );
 }

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -147,6 +147,7 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   "interrupt-headless": ["interrupt-headless"],
   "gen-ui-interrupt": ["gen-ui-interrupt"],
   "byoc-hashbrown": ["byoc"],
+  voice: ["voice"],
 };
 
 function resolveD5Row(


### PR DESCRIPTION
## Summary

- **Dashboard mapping fix.** `CATALOG_TO_D5_KEY` in `showcase/shell-dashboard/src/lib/live-status.ts` was missing `voice → ["voice"]`, so `computeMaxPossible` capped the langgraph-python voice cell at D4 even when the d5-voice probe row was green. The harness `REGISTRY_TO_D5` already had the entry; only the dashboard mirror was out of sync.
- **Sample-button decoupled from `/transcribe`.** The "Play sample" button used to fetch `sample.wav` and POST it to the runtime's transcription endpoint, which made the sample button and the mic indistinguishable under aimock (both returned the canned transcription). Reworked it into a synchronous static-text injector — sample button is now a deterministic test/demo affordance, and the mic is the only path that exercises real Whisper transcription. Synced across all 18 voice-enabled integrations. Phrase stays `"What is the weather in Tokyo?"` so aimock's `weather in Tokyo` substring fixture still matches.
- **Probe-test parity.** Added the missing `d5-voice.test.ts` companion (every other `d5-*.ts` script has one) — 9 tests covering registration, `buildTurns`, `preFill` (sample-button click + textarea-poll path), and the weather/Tokyo assertion.
- **QA + e2e cleanup** for langgraph-python: dropped the no-longer-applicable "Transcribing…" mid-flight assertion and the `block /demo-audio/sample.wav` error-state subsection. Other 16 integrations' qa/e2e files follow in a parity sync PR.

## Test plan

- [x] `nx test @copilotkit/showcase-harness -- --run d5-voice` → 9/9 pass
- [x] `npm test` in `showcase/shell-dashboard` → 509/510 pass (1 skipped, 0 failed)
- [x] `nx build @copilotkit/showcase-harness` → clean
- [x] Local boot: `langgraph-cli dev` (port 8123) + `next dev` (port 3000) + dashboard (port 3002) — voice page at `/demos/voice` renders, "Play sample" injects the canned phrase instantly, send → agent returns weather, mic → real Whisper transcription with `OPENAI_API_KEY` set
- [ ] Reviewer: confirm the langgraph-python voice cell on the live dashboard advances to D5 once the next d5-voice probe tick lands a green row