### PR TITLE
fix(docs): redirect active 404s and repair broken snippet links

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -546,6 +546,212 @@ const config = {
         destination: '/langgraph/prebuilt-components',
         permanent: true,
       },
+
+      // === 404 cleanup (2026-05) — see PostHog broken_link_accessed events ===
+
+      // Generative UI specs moved under /learn/
+      {
+        source: '/generative-ui/specs',
+        destination: '/learn/generative-ui/specs',
+        permanent: true,
+      },
+      {
+        source: '/generative-ui/specs/:path*',
+        destination: '/learn/generative-ui/specs/:path*',
+        permanent: true,
+      },
+
+      // /premium/threads and /premium/inspector are top-level pages, not under /premium
+      {
+        source: '/premium/threads',
+        destination: '/threads',
+        permanent: true,
+      },
+      {
+        source: '/premium/inspector',
+        destination: '/inspector',
+        permanent: true,
+      },
+      {
+        source: '/premium/premium/overview',
+        destination: '/premium/overview',
+        permanent: true,
+      },
+
+      // /built-in-agent/guides/* — guides/ prefix dropped in restructure
+      {
+        source: '/built-in-agent/guides/quickstart',
+        destination: '/built-in-agent/quickstart',
+        permanent: true,
+      },
+      {
+        source: '/built-in-agent/guides/use-agent-hook',
+        destination: '/built-in-agent/programmatic-control',
+        permanent: true,
+      },
+      {
+        source: '/built-in-agent/guides/self-hosting',
+        destination: '/built-in-agent/premium/self-hosting',
+        permanent: true,
+      },
+      {
+        source: '/built-in-agent/guides/:path*',
+        destination: '/built-in-agent',
+        permanent: true,
+      },
+
+      // /built-in-agent/* pages with no built-in-agent equivalent → root or closest concept
+      {
+        source: '/built-in-agent/human-in-the-loop',
+        destination: '/human-in-the-loop',
+        permanent: true,
+      },
+      {
+        source: '/built-in-agent/generative-ui/state-rendering',
+        destination: '/built-in-agent/generative-ui',
+        permanent: true,
+      },
+      {
+        source: '/built-in-agent/cookbook/state-machine',
+        destination: '/built-in-agent/programmatic-control',
+        permanent: true,
+      },
+
+      // /learn/direct-to-llm/* — direct-to-llm namespace removed in 2026-02 restructure
+      {
+        source: '/learn/direct-to-llm/tutorials/ai-todo-app/overview',
+        destination: '/built-in-agent/quickstart',
+        permanent: true,
+      },
+      {
+        source: '/learn/generative-ui/direct-to-llm/tutorials/ai-todo-app/overview',
+        destination: '/built-in-agent/quickstart',
+        permanent: true,
+      },
+      {
+        source: '/learn/direct-to-llm/cookbook/state-machine',
+        destination: '/built-in-agent',
+        permanent: true,
+      },
+      {
+        source: '/learn/direct-to-llm/:path*',
+        destination: '/built-in-agent',
+        permanent: true,
+      },
+
+      // /learn/langgraph/* — langgraph was never under /learn
+      {
+        source: '/learn/langgraph/:path*',
+        destination: '/langgraph/:path*',
+        permanent: true,
+      },
+
+      // Deepagents integration is missing pages other integrations have → root equivalents
+      {
+        source: '/deepagents/prebuilt-components',
+        destination: '/prebuilt-components',
+        permanent: true,
+      },
+      {
+        source: '/deepagents/custom-look-and-feel/headless-ui',
+        destination: '/custom-look-and-feel/headless-ui',
+        permanent: true,
+      },
+      {
+        source: '/deepagents/custom-look-and-feel/slots',
+        destination: '/custom-look-and-feel/slots',
+        permanent: true,
+      },
+
+      // /guides/* paths with no /built-in-agent/guides equivalent
+      {
+        source: '/guides/backend-actions/remote-backend-endpoint',
+        destination: '/built-in-agent/copilot-runtime',
+        permanent: true,
+      },
+      {
+        source: '/guides/model-context-protocol',
+        destination: '/built-in-agent/mcp-servers',
+        permanent: true,
+      },
+
+      // Reference v1 → v2 for hooks that only exist in v2
+      {
+        source: '/reference/v1/hooks/useRenderTool',
+        destination: '/reference/v2/hooks/useRenderTool',
+        permanent: true,
+      },
+      {
+        source: '/reference/v1/hooks/useComponent',
+        destination: '/reference/v2/hooks/useComponent',
+        permanent: true,
+      },
+      {
+        source: '/reference/v1/hooks/useThreads',
+        destination: '/reference/v2/hooks/useThreads',
+        permanent: true,
+      },
+      {
+        source: '/reference/v1/hooks/useInterrupt',
+        destination: '/reference/v2/hooks/useInterrupt',
+        permanent: true,
+      },
+      {
+        source: '/reference/v1/hooks/useCapabilities',
+        destination: '/reference/v2/hooks/useCapabilities',
+        permanent: true,
+      },
+      // useCopilotAction renamed to useFrontendTool in v2
+      {
+        source: '/reference/v2/hooks/useCopilotAction',
+        destination: '/reference/v2/hooks/useFrontendTool',
+        permanent: true,
+      },
+
+      // /whats-new/* moved under /learn/
+      {
+        source: '/whats-new',
+        destination: '/learn/whats-new',
+        permanent: true,
+      },
+      {
+        source: '/whats-new/a2ui-launch',
+        destination: '/learn/whats-new/a2ui-launch',
+        permanent: true,
+      },
+
+      // Doubled-prefix paths (broken outbound link generation)
+      {
+        source: '/agent-spec/agent-spec/wayflow',
+        destination: '/agent-spec/wayflow',
+        permanent: true,
+      },
+      {
+        source: '/langgraph/langgraph/overview',
+        destination: '/langgraph',
+        permanent: true,
+      },
+
+      // /langgraph/persistence/* moved under /langgraph/advanced/persistence/*
+      {
+        source: '/langgraph/persistence/message-persistence',
+        destination: '/langgraph/advanced/persistence/message-persistence',
+        permanent: true,
+      },
+
+      // Locale prefix not supported on this site
+      {
+        source: '/zh/langgraph/deep-agents',
+        destination: '/deepagents',
+        permanent: true,
+      },
+
+      // Old /langgraph/shared-guides/* paths
+      {
+        source: '/langgraph/shared-guides/langgraph-platform-authentication',
+        destination: '/langgraph',
+        permanent: true,
+      },
     ];
 
     // Combine auto-generated and manual redirects

--- a/docs/snippets/copilot-runtime.mdx
+++ b/docs/snippets/copilot-runtime.mdx
@@ -79,7 +79,7 @@ When you register multiple agents with the runtime, it handles discovery and rou
 
 ### Premium Features
 
-Features like [threads](/premium/threads), [observability](/premium/observability), and the [inspector](/premium/inspector) are provided through the runtime. These give you conversation persistence, monitoring, and debugging capabilities out of the box.
+Features like [threads](/threads), [observability](/premium/observability), and the [inspector](/inspector) are provided through the runtime. These give you conversation persistence, monitoring, and debugging capabilities out of the box.
 
 ## Built-in Middleware
 
@@ -151,7 +151,7 @@ There are important things to understand before going this route:
 
 1. **Authentication is your responsibility.** When you use the Copilot Runtime, safe defaults are put in place so that your agent endpoints are not exposed to unauthenticated access. When you connect directly, it is entirely up to you to secure your agent endpoint and manage authentication.
 
-2. **Many ecosystem features won't work.** The AG-UI protocol supports a middleware layer designed to run on the backend. Many features in the CopilotKit ecosystem depend on this server-side middleware. Without the runtime, these features — including [threads](/premium/threads), [observability](/premium/observability), and other capabilities — will not be available.
+2. **Many ecosystem features won't work.** The AG-UI protocol supports a middleware layer designed to run on the backend. Many features in the CopilotKit ecosystem depend on this server-side middleware. Without the runtime, these features — including [threads](/threads), [observability](/premium/observability), and other capabilities — will not be available.
 
 ### Comparison
 

--- a/docs/snippets/shared/backend/ag-ui.mdx
+++ b/docs/snippets/shared/backend/ag-ui.mdx
@@ -104,7 +104,7 @@ agent.subscribe({ ... });     // Subscribe to events
 // agent.runAgent() → HTTP POST to runtime → runtime routes to your agent → SSE stream back
 ```
 
-This indirection is what enables the runtime to provide authentication, middleware, agent routing, and ecosystem features like [threads](/premium/threads) and [observability](/premium/observability) — without changing how you interact with agents on the frontend.
+This indirection is what enables the runtime to provide authentication, middleware, agent routing, and ecosystem features like [threads](/threads) and [observability](/premium/observability) — without changing how you interact with agents on the frontend.
 
 ## How Agents Slot into the Runtime
 

--- a/docs/snippets/shared/generative-ui-specs-overview.mdx
+++ b/docs/snippets/shared/generative-ui-specs-overview.mdx
@@ -38,9 +38,9 @@ AG-UI natively supports all of the above generative UI specs and allows develope
 
 Explore each specification in detail:
 
-- [A2UI](/generative-ui/specs/a2ui) - Google's declarative Generative UI spec
-- [Open-JSON-UI](/generative-ui/specs/open-json-ui) - OpenAI's open Generative UI standard
-- [MCP Apps](/generative-ui/specs/mcp-apps) - Iframe-based Generative UI extending MCP
+- [A2UI](/learn/generative-ui/specs/a2ui) - Google's declarative Generative UI spec
+- [Open-JSON-UI](/learn/generative-ui/specs/open-json-ui) - OpenAI's open Generative UI standard
+- [MCP Apps](/learn/generative-ui/specs/mcp-apps) - Iframe-based Generative UI extending MCP
 
 Or learn about related protocols:
 

--- a/docs/snippets/shared/generative-ui/a2ui.mdx
+++ b/docs/snippets/shared/generative-ui/a2ui.mdx
@@ -178,9 +178,9 @@ Check out the [A2UI Composer](https://a2ui-editor.ag-ui.com/gallery) to create a
 
 ## Learn More
 
-- [Generative UI Specs Overview](/generative-ui/specs) - Compare all supported specifications
+- [Generative UI Specs Overview](/learn/generative-ui/specs) - Compare all supported specifications
 - [Generative UI Guide](/generative-ui) - Build with Generative UI in CopilotKit
 - [A2UI Site](https://a2ui.org/) - Visit the A2UI site
 - [AG-UI Protocol](/ag-ui-protocol) - Learn about the protocol that supports A2UI
-- [Open-JSON-UI](/generative-ui/specs/open-json-ui) - OpenAI's alternative approach
-- [MCP Apps](/generative-ui/specs/mcp-apps) - Iframe-based Generative UI extending MCP
+- [Open-JSON-UI](/learn/generative-ui/specs/open-json-ui) - OpenAI's alternative approach
+- [MCP Apps](/learn/generative-ui/specs/mcp-apps) - Iframe-based Generative UI extending MCP


### PR DESCRIPTION
## Summary

- Repairs broken links in 4 shared snippets that were the root cause of most internal-referrer 404s on docs.copilotkit.ai
- Adds 35 redirects in \`next.config.mjs\` covering every URL with \`broken_link_accessed\` events from the last 30 days of PostHog data

## Approach

PostHog tracks 404s via the \`broken_link_accessed\` event (see \`docs/POSTHOG_BROKEN_LINKS.md\`). I queried the last 30 days, grouped by \`broken_url\`, and split the results into two buckets:

1. **Source-side bugs** — broken links coming from our own MDX. The biggest offenders were shared snippets (\`copilot-runtime.mdx\`, \`generative-ui/a2ui.mdx\`, \`generative-ui-specs-overview.mdx\`, \`backend/ag-ui.mdx\`) that get inlined into many integration pages, multiplying each broken link across the site. Fixed at source.

2. **External / legacy traffic** — search results, marketing site links, partner sites. Added redirects.

For URLs without a clean 1:1 destination, every broken path now redirects to the closest matching concept page (no hard 404s left). Each ambiguous mapping was validated by reading the candidate destination's content.

## Categories of redirects added

- \`/generative-ui/specs/*\` → \`/learn/generative-ui/specs/*\` (section moved)
- \`/premium/{threads,inspector}\` → root equivalents (those pages are at root, not under \`/premium\`)
- \`/built-in-agent/guides/*\` → renamed pages or section index (the \`guides/\` prefix was dropped in the 2026-02 restructure)
- \`/learn/direct-to-llm/*\` → \`/built-in-agent\` (namespace removed)
- \`/learn/langgraph/*\` → \`/langgraph/*\` (was never under \`/learn\`)
- \`/deepagents/{prebuilt-components,custom-look-and-feel/*}\` → root equivalents (deepagents integration is missing these pages — see follow-up note below)
- \`/reference/v1/hooks/{useRenderTool,useComponent,useThreads,useInterrupt,useCapabilities}\` → \`/reference/v2/hooks/<same>\` (these hooks are new in v2)
- \`/reference/v2/hooks/useCopilotAction\` → \`/reference/v2/hooks/useFrontendTool\` (renamed)
- \`/whats-new/*\` → \`/learn/whats-new/*\`
- Doubled-prefix paths (\`/agent-spec/agent-spec/wayflow\`, etc.) — straightforward un-double
- \`/zh/langgraph/deep-agents\` → \`/deepagents\` (no i18n on this site)

## Follow-up worth tracking separately

The \`integrations/deepagents/\` directory is missing several pages that other integrations have (\`prebuilt-components.mdx\`, \`custom-look-and-feel/\`, \`premium/\`, etc.). The redirects in this PR band-aid the symptom; the integration page itself is incomplete vs siblings.

## Test plan

- [x] Verified each of the 35 former-404 paths returns 308 → final 200 on local \`next dev\`
- [x] Verified rendered HTML on pages that include the fixed snippets now emits the new link targets
- [x] Confirmed the failing pre-commit test (\`@copilotkit/sqlite-runner:test\`) is pre-existing on \`main\` and unrelated to this docs-only change