### PR TITLE
fix(shell-docs): add programmatic-control fallback for non-native frameworks

### DIFF
--- a/showcase/shell-docs/src/content/docs/programmatic-control.mdx
+++ b/showcase/shell-docs/src/content/docs/programmatic-control.mdx
@@ -99,6 +99,23 @@ UI.
 
 </WhenFrameworkHas>
 
+<WhenFrameworkHas flag="interrupt_pattern" absent>
+
+## Resolving a pause from a button
+
+> **Interrupt-style pause/resume isn't available on this framework.**
+> The headless interrupt pattern shown above requires the underlying
+> runtime to expose either a native `interrupt(...)` primitive
+> (LangGraph) or a Promise-resolving frontend-tool path (Microsoft
+> Agent Framework). For all other integrations, drive pauses through
+> [`useHumanInTheLoop`](./human-in-the-loop) instead — it's the
+> standard hook for tool-call-based pause/resume flows and works on
+> every framework that supports tool calls. The `agent.addMessage`,
+> `copilotkit.runAgent`, and `agent.subscribe` primitives above still
+> apply — only the interrupt-resolution path is framework-specific.
+
+</WhenFrameworkHas>
+
 ## See also
 
 - [Headless UI](./headless) — the full `useRenderedMessages` composition


### PR DESCRIPTION
## Summary
- Adds a `<WhenFrameworkHas flag="interrupt_pattern" absent>` fallback block to `programmatic-control.mdx` so the 7 frameworks without `interrupt_pattern` (ag2, agno, built-in-agent, crewai-crews, google-adk, mastra, spring-ai) see a useful callout pointing readers at `useHumanInTheLoop` instead of an empty section.
- Mirrors the canonical pattern shipped on `useInterrupt.mdx` and `headless.mdx` in PR #4496.

## Test plan
- [ ] Run `nx run shell-docs:dev` and visit `/programmatic-control`. Switch the framework selector through ag2, agno, built-in-agent, crewai-crews, google-adk, mastra, spring-ai — the new fallback callout should render and link to `/human-in-the-loop`.
- [ ] Switch to langgraph-python (native) — the existing native-flow section should still render.
- [ ] Switch to claude-sdk-python (promise-based) — the existing promise-based section should still render.