### PR TITLE
fix(shell-docs): retarget /migrate/1.10.X redirect to /migrate/v2

### DIFF
--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -351,7 +351,7 @@ const nextConfig: NextConfig = {
       // point.
       {
         source: "/migrate/1.10.X",
-        destination: "/migrate",
+        destination: "/migrate/v2",
         permanent: false,
       },
 


### PR DESCRIPTION
## Summary
- Changes the `/migrate/1.10.X` redirect destination in `showcase/shell-docs/next.config.ts` from `/migrate` (which 404s — `migrate/meta.json` lists only `["v2", "1.8.2"]`, no index page) to `/migrate/v2`, the canonical V2 migration page.
- `permanent: false` preserved (302) so the slot remains reclaimable post-launch.

## Test plan
- [ ] Run `nx run shell-docs:dev` and visit `http://localhost:3003/migrate/1.10.X` — should redirect to `/migrate/v2` and render the V2 migration page.
- [ ] Confirm `/migrate/v2` and `/migrate/1.8.2` still resolve directly.

## Notes
- Sibling redirects `/troubleshooting/migrate-to-1.10.X` (line 64) and `/unselected/troubleshooting/migrate-to-1.10.X` (line 147) now produce a two-hop chain through `/migrate/1.10.X` → `/migrate/v2`. Functionally fine; cleanup is a minor follow-up if needed.