### PR TITLE
chore(shell-docs): exclude mcp-server-setup snippet from upstream sync

### DIFF
--- a/showcase/scripts/sync-docs-from-main.ts
+++ b/showcase/scripts/sync-docs-from-main.ts
@@ -65,6 +65,13 @@ const LANGCHAIN_EXCLUSIONS = [
  * redirect). The root path stays excluded so future syncs don't restore
  * the duplicate.
  *
+ * The shared `mcp-server-setup.mdx` snippet is also excluded
+ * (PDX-117 — https://linear.app/copilotkit/issue/PDX-117). Shell-docs
+ * ships an enhanced version with HTTP/SSE transport Tabs, the
+ * `mcp-remote` bridge, and a Tadata Callout; upstream still carries
+ * the older single-`url` JSON shape, so syncing would regress the
+ * shell-docs experience.
+ *
  * Upstream keeps all of these copies — removing them there means touching
  * every parallel framework tree, which is upstream-IA work outside this
  * branch's scope. The exclusion is the durable shell-docs-only fix.
@@ -75,6 +82,7 @@ const PATH_EXCLUSIONS: RegExp[] = [
   /^docs\/content\/docs\/integrations\/[^/]+\/premium\/self-hosting\.mdx$/,
   /^docs\/content\/docs\/learn\//,
   /^docs\/content\/docs\/\(root\)\/ag-ui-middleware\.mdx$/,
+  /^docs\/snippets\/shared\/guides\/mcp-server-setup\.mdx$/,
   // PR #4494 dropped these stale workflow-execution / state-inputs-outputs
   // duplicates from shell-docs. Each shared-state meta.json wires only one
   // of the two files; the other was an orphan. Block the sync from


### PR DESCRIPTION
## Summary
- Adds an exclusion regex for `mcp-server-setup.mdx` to the `PATH_EXCLUSIONS` array in `showcase/scripts/sync-docs-from-main.ts`, mirroring the existing `ag-ui-middleware.mdx` exclusion.
- The shell-docs version is intentionally ahead of upstream — it ships HTTP/SSE Tabs, an `mcp-remote` bridge as a default-shown option, and a Tadata callout. Upstream lacks all three; without this exclusion the next sync would clobber the richer shell-docs version.
- JSDoc comment block updated to document the new exclusion alongside `ag-ui-middleware`.

## Test plan
- [ ] Inspect the regex location in `sync-docs-from-main.ts` — should sit immediately after the existing `ag-ui-middleware` regex.
- [ ] Dry-run the sync script (or simulate via the existing test harness if any) and confirm `docs/snippets/shared/guides/mcp-server-setup.mdx` is now reported as skipped.
- [ ] Confirm `showcase/shell-docs/src/content/snippets/shared/guides/mcp-server-setup.mdx` still renders with the HTTP/SSE Tabs + Tadata callout intact.