### PR TITLE
chore(cutover): Phase 1 redirect inventory (3 of 4 sources; GSC deferred)

### DIFF
--- a/redirect-inventory.json
+++ b/redirect-inventory.json
@@ -1,0 +1,7178 @@
+{
+  "refreshed_at": "2026-05-06T22:06:22.267Z",
+  "sources_completed": [
+    "sitemap",
+    "monorepo_grep"
+  ],
+  "sources_failed": [
+    {
+      "source": "wget_orphans",
+      "reason": "wget --spider --recursive --level=4 against https://docs.copilotkit.ai/ returned only 29 URLs, all of which were _next/static/* assets, fonts, and robots.txt — no HTML page links. The docs site is a Next.js client-rendered SPA whose nav menu is hydrated in JavaScript, so wget has no anchor hrefs to follow. The sitemap is the canonical source of doc URLs and supersedes the wget crawl. Source documented as failed but not blocking."
+    }
+  ],
+  "sources_deferred": [
+    "gsc_export"
+  ],
+  "urls": [
+    {
+      "url": "https://docs.copilotkit.ai/",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/?ref=github_readme",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "README.md:171",
+        "README.md:9",
+        "community/content/README.md:34"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/a2a",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/a2a-a2ui/README.md:90"
+      ],
+      "redirect_destination": "/docs/integrations/a2a"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/a2a-protocol",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:533"
+      ],
+      "redirect_destination": "/docs/learn/a2a-protocol"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:17",
+        "showcase/integrations/google-adk/docs-links.json:21",
+        "showcase/integrations/google-adk/docs-links.json:25",
+        "showcase/integrations/google-adk/docs-links.json:29",
+        "showcase/integrations/google-adk/docs-links.json:33",
+        "showcase/integrations/google-adk/docs-links.json:5",
+        "showcase/integrations/google-adk/docs-links.json:9",
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:512"
+      ],
+      "redirect_destination": "/docs/integrations/adk"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/frontend-actions",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/adk/src/app/page.tsx:19"
+      ],
+      "redirect_destination": "/docs/integrations/adk/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/frontend-tools",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:45",
+        "showcase/integrations/google-adk/docs-links.json:49",
+        "showcase/integrations/google-adk/docs-links.json:61"
+      ],
+      "redirect_destination": "/docs/integrations/adk/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/generative-ui",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/adk/src/app/page.tsx:89"
+      ],
+      "redirect_destination": "/docs/integrations/adk/generative-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/generative-ui/a2ui",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:65",
+        "showcase/integrations/google-adk/docs-links.json:69"
+      ],
+      "redirect_destination": "/docs/integrations/adk/generative-ui/a2ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:81"
+      ],
+      "redirect_destination": "/docs/integrations/adk/generative-ui/state-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:85",
+        "showcase/integrations/google-adk/docs-links.json:89",
+        "showcase/integrations/google-adk/docs-links.json:93",
+        "showcase/integrations/google-adk/docs-links.json:97"
+      ],
+      "redirect_destination": "/docs/integrations/adk/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:53"
+      ],
+      "redirect_destination": "/docs/integrations/adk/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/human-in-the-loop",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:57"
+      ],
+      "redirect_destination": "/docs/integrations/adk/human-in-the-loop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/quickstart",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:13"
+      ],
+      "redirect_destination": "/docs/integrations/adk/quickstart"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/shared-state",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/adk/src/app/page.tsx:79"
+      ],
+      "redirect_destination": "/docs/integrations/adk/shared-state"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/shared-state/in-app-agent-read",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:109"
+      ],
+      "redirect_destination": "/docs/integrations/adk/shared-state/in-app-agent-read"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/shared-state/in-app-agent-write",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:101"
+      ],
+      "redirect_destination": "/docs/integrations/adk/shared-state/in-app-agent-write"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/adk/shared-state/predictive-state-updates",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:105"
+      ],
+      "redirect_destination": "/docs/integrations/adk/shared-state/predictive-state-updates"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag-ui-middleware",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag-ui-protocol",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "README.md:142"
+      ],
+      "redirect_destination": "/docs/learn/ag-ui-protocol"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag2",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/docs-links.json:33"
+      ],
+      "redirect_destination": "/docs/integrations/ag2"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag2/",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:519"
+      ],
+      "redirect_destination": "/docs/integrations/ag2/"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag2/auth",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/docs-links.json:37"
+      ],
+      "redirect_destination": "/docs/integrations/ag2/auth"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag2/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/docs-links.json:21"
+      ],
+      "redirect_destination": "/docs/integrations/ag2/generative-ui/state-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag2/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/docs-links.json:13"
+      ],
+      "redirect_destination": "/docs/integrations/ag2/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag2/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/docs-links.json:17"
+      ],
+      "redirect_destination": "/docs/integrations/ag2/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag2/human-in-the-loop",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/docs-links.json:9"
+      ],
+      "redirect_destination": "/docs/integrations/ag2/human-in-the-loop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag2/prebuilt-components",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/docs-links.json:5"
+      ],
+      "redirect_destination": "/docs/integrations/ag2/prebuilt-components"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag2/shared-state",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/docs-links.json:25"
+      ],
+      "redirect_destination": "/docs/integrations/ag2/shared-state"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/ag2/shared-state/write",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/docs-links.json:29"
+      ],
+      "redirect_destination": "/docs/integrations/ag2/shared-state/write"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/agentic-chat-ui",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/claude-sdk-python/docs-links.json:5",
+        "showcase/integrations/claude-sdk-typescript/docs-links.json:5",
+        "showcase/integrations/spring-ai/docs-links.json:5",
+        "showcase/shared/feature-registry.json:65",
+        "showcase/shared/feature-registry.json:74"
+      ],
+      "redirect_destination": "/docs/prebuilt-components"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/agno",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/agno/docs-links.json:33"
+      ],
+      "redirect_destination": "/docs/integrations/agno"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/agno/",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:517"
+      ],
+      "redirect_destination": "/docs/integrations/agno/"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/agno/frontend-tools",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/agno/src/app/page.tsx:79",
+        "showcase/integrations/agno/docs-links.json:5"
+      ],
+      "redirect_destination": "/docs/integrations/agno/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/agno/generative-ui/backend-tools",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/agno/src/app/page.tsx:113",
+        "examples/integrations/agno/src/app/page.tsx:97"
+      ],
+      "redirect_destination": "/docs/integrations/agno/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/agno/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/agno/docs-links.json:13"
+      ],
+      "redirect_destination": "/docs/integrations/agno/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/agno/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/agno/docs-links.json:17"
+      ],
+      "redirect_destination": "/docs/integrations/agno/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/agno/human-in-the-loop",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/agno/docs-links.json:9"
+      ],
+      "redirect_destination": "/docs/integrations/agno/human-in-the-loop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/aws-strands",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/strands/docs-links.json:33",
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:513"
+      ],
+      "redirect_destination": "/docs/integrations/aws-strands"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/aws-strands/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/strands/docs-links.json:21"
+      ],
+      "redirect_destination": "/docs/integrations/aws-strands/generative-ui/state-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/aws-strands/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/strands/docs-links.json:13"
+      ],
+      "redirect_destination": "/docs/integrations/aws-strands/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/aws-strands/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/strands/docs-links.json:17"
+      ],
+      "redirect_destination": "/docs/integrations/aws-strands/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/aws-strands/prebuilt-components",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/strands/docs-links.json:5"
+      ],
+      "redirect_destination": "/docs/integrations/aws-strands/prebuilt-components"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/aws-strands/shared-state/in-app-agent-write",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/strands/docs-links.json:25"
+      ],
+      "redirect_destination": "/docs/integrations/aws-strands/shared-state/in-app-agent-write"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/backend/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/backend/ag-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/backend/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/backend/copilot-runtime"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/backend/custom-agent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/backend/custom-agent"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/built-in-agent/quickstart",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/built-in-agent/docs-links.json:4"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/built-in-agent/shared-state",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/built-in-agent/docs-links.json:8"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/showcases/multi-agent-canvas/README.md:102",
+        "examples/showcases/research-canvas/README.md:8",
+        "examples/showcases/research-canvas/README.md:83",
+        "examples/showcases/research-canvas/final/README.md:8",
+        "examples/showcases/research-canvas/final/README.md:83",
+        "examples/showcases/research-canvas/start/README.md:8",
+        "examples/showcases/research-canvas/start/README.md:83"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/ag-ui-protocol",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/showcases/strands-file-analyzer/README.md:358"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/ag-ui-protocol"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/frontend-actions",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/crewai-flows/src/app/page.tsx:84",
+        "examples/integrations/llamaindex/src/app/page.tsx:63"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/generative-ui",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/canvas/mastra-pm/src/app/page.tsx:63",
+        "examples/integrations/crewai-flows/src/app/page.tsx:104",
+        "examples/integrations/llamaindex/src/app/page.tsx:81",
+        "examples/v2/interrupts-langgraph/apps/web/src/app/page.tsx:235"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/generative-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/human-in-the-loop",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/v2/interrupts-langgraph/apps/web/src/app/page.tsx:37"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/human-in-the-loop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/human-in-the-loop/node-flow",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/v1/travel/lib/hooks/README.md:48"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/human-in-the-loop/node-flow"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/langgraph/langgraph-native-python",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/showcases/scene-creator/README.md:163"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/langgraph/langgraph-native-python"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/langgraph/shared-state",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/showcases/scene-creator/README.md:164"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/langgraph/shared-state"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/multi-agent-flows",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shared/feature-registry.json:330"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/multi-agent-flows"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/quickstart/langgraph",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "packages/react-core/src/hooks/use-coagent.ts:205"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/quickstart"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/shared-state",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/canvas/mastra-pm/src/app/page.tsx:51",
+        "examples/integrations/crewai-flows/src/app/page.tsx:74",
+        "examples/integrations/llamaindex/src/app/page.tsx:53",
+        "examples/v2/interrupts-langgraph/apps/web/src/app/page.tsx:186",
+        "examples/v2/interrupts-langgraph/apps/web/src/app/page.tsx:207"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/shared-state"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/shared-state/in-app-agent-read",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/v1/travel/lib/hooks/README.md:11"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/shared-state/in-app-agent-read"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/shared-state/in-app-agent-write",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/v1/travel/lib/hooks/README.md:11"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/shared-state/in-app-agent-write"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/shared-state/predictive-state-updates",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "packages/react-core/src/hooks/use-coagent-state-render.ts:56"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/shared-state/predictive-state-updates"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coagents/troubleshooting/common-issues",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "packages/react-ui/src/components/help-modal/modal.tsx:70"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/troubleshooting/common-issues"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coding-agent-setup",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/coding-agents"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/coding-agents"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/contributing/code-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/contributing/code-contributions"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/contributing/code-contributions/package-linking",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/contributing/code-contributions/package-linking"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/contributing/docs-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/contributing/docs-contributions"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/contributing/docs-contributions#how-to-contribute",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "CODE_OF_CONDUCT.md:114"
+      ],
+      "redirect_destination": "/docs/contributing/docs-contributions"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/contributing/docs-contributions?ref=github_readme",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "README.md:194"
+      ],
+      "redirect_destination": "/docs/contributing/docs-contributions"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/copilot-suggestions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/prebuilt-components"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/crewai-crews/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/crewai-crews/docs-links.json:21"
+      ],
+      "redirect_destination": "/docs/integrations/crewai-flows/generative-ui/state-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/crewai-crews/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/crewai-crews/docs-links.json:13"
+      ],
+      "redirect_destination": "/docs/integrations/crewai-flows/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/crewai-crews/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/crewai-crews/docs-links.json:17"
+      ],
+      "redirect_destination": "/docs/integrations/crewai-flows/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/crewai-crews/human-in-the-loop",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/crewai-crews/docs-links.json:9"
+      ],
+      "redirect_destination": "/docs/integrations/crewai-flows/human-in-the-loop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/crewai-crews/prebuilt-components",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/crewai-crews/docs-links.json:5"
+      ],
+      "redirect_destination": "/docs/integrations/crewai-flows/prebuilt-components"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/crewai-crews/shared-state/in-app-agent-write",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/crewai-crews/docs-links.json:25"
+      ],
+      "redirect_destination": "/docs/integrations/crewai-flows/shared-state/in-app-agent-write"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/crewai-crews/shared-state/predictive-state-updates",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/crewai-crews/docs-links.json:29"
+      ],
+      "redirect_destination": "/docs/integrations/crewai-flows/shared-state/predictive-state-updates"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/crewai-flows",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:505"
+      ],
+      "redirect_destination": "/docs/integrations/crewai-flows"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/custom-look-and-feel",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shared/feature-registry.json:106"
+      ],
+      "redirect_destination": "/docs/custom-look-and-feel"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/custom-look-and-feel/css",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "dev-docs/langgraph-python-column-wave1-bugs.md:83"
+      ],
+      "redirect_destination": "/docs/custom-look-and-feel/css"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/built-in-agent/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/claude-sdk-python/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/claude-sdk-typescript/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/google-adk/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/langgraph-fastapi/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/langgraph-python/src/app/demos/chat-customization-css/README.md:25",
+        "showcase/integrations/langgraph-python/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/langgraph-typescript/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/langroid/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/mastra/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/chat-customization-css/README.md:20",
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/ms-agent-python/src/app/demos/chat-customization-css/README.md:16",
+        "showcase/integrations/ms-agent-python/src/app/demos/chat-customization-css/page.tsx:7",
+        "showcase/integrations/strands/src/app/demos/chat-customization-css/page.tsx:7"
+      ],
+      "redirect_destination": "/docs/custom-look-and-feel/customize-built-in-ui-components"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/custom-look-and-feel/headless-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/custom-look-and-feel/reasoning-messages",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/google-adk/docs-links.json:37",
+        "showcase/integrations/google-adk/docs-links.json:41",
+        "showcase/integrations/langgraph-python/docs-links.json:41",
+        "showcase/integrations/langgraph-python/docs-links.json:45",
+        "showcase/shared/feature-registry.json:256",
+        "showcase/shared/feature-registry.json:266"
+      ],
+      "redirect_destination": "/docs/custom-look-and-feel/reasoning-messages"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/custom-look-and-feel/slots",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shared/feature-registry.json:98"
+      ],
+      "redirect_destination": "/docs/custom-look-and-feel/slots"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/deploy/agentcore",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/direct-to-llm",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:498"
+      ],
+      "redirect_destination": "/docs/unselected"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/direct-to-llm/guides/connect-your-data/frontend",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shell-docs/src/content/docs/integrations/ag2/readables.mdx:18",
+        "showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/agent-app-context.mdx:17"
+      ],
+      "redirect_destination": "/docs/unselected/guides/connect-your-data/frontend"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/direct-to-llm/guides/model-context-protocol",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/showcases/mcp-demo/src/components/canvas.tsx:58"
+      ],
+      "redirect_destination": "/docs/unselected/guides/model-context-protocol"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/direct-to-llm/guides/quickstart",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "community/content/CONTRIBUTING.md:11",
+        "showcase/shell-docs/src/content/ag-ui/integrations.mdx:60",
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:565"
+      ],
+      "redirect_destination": "/docs/unselected/guides/quickstart"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/direct-to-llm/guides/quickstart?copilot-hosting=self-hosted#set-up-a-copilot-runtime-endpoint",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "docs/content/docs/integrations/crewai-flows/multi-agent-flows.mdx:39",
+        "docs/content/docs/integrations/llamaindex/multi-agent-flows.mdx:39",
+        "showcase/shell-docs/src/content/docs/integrations/crewai-flows/multi-agent-flows.mdx:43",
+        "showcase/shell-docs/src/content/docs/integrations/langgraph/multi-agent-flows.mdx:53",
+        "showcase/shell-docs/src/content/docs/integrations/llamaindex/multi-agent-flows.mdx:43",
+        "showcase/shell-docs/src/content/docs/integrations/pydantic-ai/multi-agent-flows.mdx:50"
+      ],
+      "redirect_destination": "/docs/unselected/guides/quickstart"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/examples",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/faq",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/faq"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/features/",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "dev-docs/langgraph-python-column-wave1-bugs.md:53"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/frontend-actions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/frontend-tools",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shared/feature-registry.json:281",
+        "showcase/shared/feature-registry.json:289"
+      ],
+      "redirect_destination": "/docs/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/showcases/generative-ui/README.md:114",
+        "examples/showcases/generative-ui/README.md:209",
+        "examples/showcases/generative-ui/README.md:248",
+        "examples/showcases/generative-ui/README.md:8"
+      ],
+      "redirect_destination": "/docs/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/a2ui",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shared/feature-registry.json:181",
+        "showcase/shared/feature-registry.json:189"
+      ],
+      "redirect_destination": "/docs/generative-ui/a2ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/display",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/generative-ui/your-components/interactive"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/mcp-apps",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-mcp-apps/route.ts:10",
+        "showcase/shared/feature-registry.json:197"
+      ],
+      "redirect_destination": "/docs/generative-ui/mcp-apps"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/open-generative-ui",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/src/app/demos/beautiful-chat/README.md:67",
+        "showcase/integrations/ag2/src/app/demos/open-gen-ui-advanced/README.md:33",
+        "showcase/integrations/ag2/src/app/demos/open-gen-ui-advanced/page.tsx:13",
+        "showcase/integrations/ag2/src/app/demos/open-gen-ui/README.md:35",
+        "showcase/integrations/ag2/src/app/demos/open-gen-ui/page.tsx:18",
+        "showcase/integrations/agno/src/app/demos/open-gen-ui-advanced/page.tsx:15",
+        "showcase/integrations/agno/src/app/demos/open-gen-ui/page.tsx:16",
+        "showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx:13",
+        "showcase/integrations/claude-sdk-typescript/src/app/demos/open-gen-ui-advanced/page.tsx:13",
+        "showcase/integrations/claude-sdk-typescript/src/app/demos/open-gen-ui/page.tsx:18",
+        "showcase/integrations/crewai-crews/src/app/demos/open-gen-ui/page.tsx:11",
+        "showcase/integrations/google-adk/docs-links.json:73",
+        "showcase/integrations/google-adk/docs-links.json:77",
+        "showcase/integrations/google-adk/src/app/demos/open-gen-ui-advanced/page.tsx:13",
+        "showcase/integrations/google-adk/src/app/demos/open-gen-ui/page.tsx:21",
+        "showcase/integrations/langgraph-fastapi/src/app/demos/open-gen-ui-advanced/page.tsx:13",
+        "showcase/integrations/langgraph-fastapi/src/app/demos/open-gen-ui/page.tsx:18",
+        "showcase/integrations/langgraph-python/docs-links.json:89",
+        "showcase/integrations/langgraph-python/docs-links.json:93",
+        "showcase/integrations/langgraph-python/src/app/demos/open-gen-ui-advanced/page.tsx:13",
+        "showcase/integrations/langgraph-python/src/app/demos/open-gen-ui/page.tsx:18",
+        "showcase/integrations/langgraph-typescript/src/app/demos/open-gen-ui-advanced/page.tsx:13",
+        "showcase/integrations/langgraph-typescript/src/app/demos/open-gen-ui/page.tsx:18",
+        "showcase/integrations/langroid/src/app/demos/open-gen-ui-advanced/page.tsx:16",
+        "showcase/integrations/langroid/src/app/demos/open-gen-ui/page.tsx:21",
+        "showcase/integrations/llamaindex/src/app/demos/open-gen-ui-advanced/page.tsx:13",
+        "showcase/integrations/llamaindex/src/app/demos/open-gen-ui/page.tsx:18",
+        "showcase/integrations/mastra/src/app/demos/open-gen-ui-advanced/page.tsx:13",
+        "showcase/integrations/mastra/src/app/demos/open-gen-ui/page.tsx:18",
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/open-gen-ui-advanced/README.md:26",
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/open-gen-ui-advanced/page.tsx:17",
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/open-gen-ui/README.md:23",
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/open-gen-ui/page.tsx:18",
+        "showcase/integrations/ms-agent-python/src/app/demos/open-gen-ui-advanced/page.tsx:21",
+        "showcase/integrations/ms-agent-python/src/app/demos/open-gen-ui/page.tsx:18",
+        "showcase/integrations/pydantic-ai/src/app/demos/open-gen-ui-advanced/page.tsx:13",
+        "showcase/integrations/pydantic-ai/src/app/demos/open-gen-ui/page.tsx:18",
+        "showcase/integrations/spring-ai/src/app/demos/open-gen-ui-advanced/page.tsx:13",
+        "showcase/integrations/spring-ai/src/app/demos/open-gen-ui/page.tsx:17",
+        "showcase/shared/feature-registry.json:205",
+        "showcase/shared/feature-registry.json:213"
+      ],
+      "redirect_destination": "/docs/generative-ui/open-generative-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/specs/a2ui#using-a2ui-with-copilotkit",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "README.md:143"
+      ],
+      "redirect_destination": "/docs/generative-ui/specs/a2ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/specs/mcp-apps",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "README.md:144",
+        "examples/showcases/generative-ui/README.md:58"
+      ],
+      "redirect_destination": "/docs/generative-ui/specs/mcp-apps"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/agno/docs-links.json:21",
+        "showcase/integrations/claude-sdk-python/docs-links.json:21",
+        "showcase/integrations/claude-sdk-typescript/docs-links.json:21",
+        "showcase/integrations/spring-ai/docs-links.json:21",
+        "showcase/shared/feature-registry.json:273"
+      ],
+      "redirect_destination": "/docs/generative-ui/state-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/claude-sdk-python/docs-links.json:13",
+        "showcase/integrations/claude-sdk-typescript/docs-links.json:13",
+        "showcase/integrations/spring-ai/docs-links.json:13",
+        "showcase/shared/feature-registry.json:222",
+        "showcase/shared/feature-registry.json:231",
+        "showcase/shared/feature-registry.json:239",
+        "showcase/shared/feature-registry.json:248"
+      ],
+      "redirect_destination": "/docs/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/claude-sdk-python/docs-links.json:17",
+        "showcase/integrations/claude-sdk-typescript/docs-links.json:17",
+        "showcase/integrations/spring-ai/docs-links.json:17",
+        "showcase/shared/feature-registry.json:130"
+      ],
+      "redirect_destination": "/docs/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/generative-ui/your-components/interactive",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shared/feature-registry.json:138",
+        "showcase/shared/feature-registry.json:155",
+        "showcase/shared/feature-registry.json:164"
+      ],
+      "redirect_destination": "/docs/generative-ui/your-components/interactive"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/getting-started/quickstart-chatbot",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "examples/showcases/presentation/README.md:49",
+        "examples/showcases/spreadsheet/README.md:60"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/guides/frontend-actions",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/canvas/mastra-pm/src/app/page.tsx:13",
+        "examples/integrations/agno/src/app/page.tsx:16",
+        "examples/integrations/crewai-flows/src/app/page.tsx:10",
+        "examples/integrations/llamaindex/src/app/page.tsx:12",
+        "examples/integrations/strands-python/src/app/page.tsx:21",
+        "examples/v2/interrupts-langgraph/apps/web/src/app/page.tsx:11",
+        "showcase/shell-docs/src/content/ag-ui/concepts/agents.mdx:231",
+        "showcase/shell-docs/src/content/ag-ui/concepts/tools.mdx:195"
+      ],
+      "redirect_destination": "/docs/unselected/guides/frontend-actions"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/headless",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shared/feature-registry.json:114",
+        "showcase/shared/feature-registry.json:122",
+        "showcase/shared/feature-registry.json:174"
+      ],
+      "redirect_destination": "/docs/custom-look-and-feel/headless-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/human-in-the-loop",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/src/app/demos/gen-ui-interrupt/README.md:39",
+        "showcase/integrations/ag2/src/app/demos/interrupt-headless/README.md:33",
+        "showcase/integrations/claude-sdk-python/docs-links.json:9",
+        "showcase/integrations/claude-sdk-typescript/docs-links.json:9",
+        "showcase/integrations/spring-ai/docs-links.json:9",
+        "showcase/integrations/strands/docs-links.json:9",
+        "showcase/shared/feature-registry.json:146",
+        "showcase/shared/feature-registry.json:297"
+      ],
+      "redirect_destination": "/docs/human-in-the-loop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/a2a",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/a2a/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/a2a/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/a2a/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/a2a/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/a2a/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/a2a/generative-ui/declarative-a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/a2a/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/a2a/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/a2a/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/mcp-apps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/state-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/shared-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/shared-state/in-app-agent-read",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/shared-state/in-app-agent-write",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/shared-state/predictive-state-updates",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/shared-state/state-inputs-outputs",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/shared-state/workflow-execution",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/adk/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/auth",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/contributing/code-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/contributing/code-contributions/package-linking",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/contributing/docs-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/mcp-apps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/state-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/readables",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/shared-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/shared-state/read",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/shared-state/write",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/telemetry",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/ag2/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/generative-ui/mcp-apps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/langgraph",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/shared-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agent-spec/wayflow",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/contributing/code-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/contributing/code-contributions/package-linking",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/contributing/docs-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/generative-ui/mcp-apps",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/agno/src/app/api/copilotkit-mcp-apps/route.ts:15",
+        "showcase/integrations/agno/src/app/demos/mcp-apps/page.tsx:19"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/telemetry",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/agno/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/contributing/code-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/contributing/code-contributions/package-linking",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/contributing/docs-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/deploy-agentcore",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/mcp-apps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/state-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/shared-state/in-app-agent-read",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/shared-state/in-app-agent-write",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/telemetry",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/aws-strands/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/advanced-configuration",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/agent-app-context",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/custom-agent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/generative-ui/mcp-apps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/mcp-servers",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/model-selection",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/server-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/shared-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/next-steps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/step-1-checkout-repo",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/step-2-setup-copilotkit",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/step-3-copilot-textarea",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/step-4-copilot-readable-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/next-steps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/step-1-checkout-repo",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/step-2-setup-copilotkit",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/step-3-copilot-readable-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/step-4-frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/claude-agent-sdk-python/generative-ui/mcp-apps",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/claude-sdk-python/src/agents/mcp_apps_agent.py:28",
+        "showcase/integrations/claude-sdk-python/src/app/api/copilotkit-mcp-apps/route.ts:13",
+        "showcase/integrations/claude-sdk-python/src/app/demos/mcp-apps/page.tsx:18"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-crews/generative-ui/mcp-apps",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/crewai-crews/src/app/api/copilotkit-mcp-apps/route.ts:13",
+        "showcase/integrations/crewai-crews/src/app/demos/mcp-apps/README.md:7",
+        "showcase/integrations/crewai-crews/src/app/demos/mcp-apps/page.tsx:19"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/advanced/disabling-state-streaming",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/advanced/emit-messages",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/advanced/exit-agent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/contributing/code-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/contributing/code-contributions/package-linking",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/contributing/docs-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/mcp-apps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/state-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/human-in-the-loop/flow",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/multi-agent-flows",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/persistence/loading-agent-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/persistence/loading-message-history",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/persistence/message-persistence",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/shared-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/shared-state/in-app-agent-read",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/shared-state/in-app-agent-write",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/shared-state/predictive-state-updates",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/telemetry",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/crewai-flows/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/a2ui/advanced",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/a2ui/dynamic-schema",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/a2ui/fixed-schema",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/a2ui/styling",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/mcp-apps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/state-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/your-components/interrupt-based",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/human-in-the-loop/interrupt-flow",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/shared-state/in-app-agent-read",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/shared-state/in-app-agent-write",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/shared-state/predictive-state-updates",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/shared-state/state-inputs-outputs",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/deepagents/shared-state/workflow-execution",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/disabling-state-streaming",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/emit-messages",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/exit-agent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/persistence/loading-agent-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/persistence/loading-message-history",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/persistence/message-persistence",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/agent-app-context",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/auth",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/coagent-troubleshooting/common-coagent-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/coagent-troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/coagent-troubleshooting/migrate-from-v0.2-to-v0.3",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/configurable",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/contributing/code-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/contributing/code-contributions/package-linking",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/contributing/docs-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/deep-agents",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "examples/showcases/deep-agents-job-search/README.md:5",
+        "examples/showcases/deep-agents/README.md:153"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/deploy-agentcore",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/src/app/demos/beautiful-chat/README.md:66",
+        "showcase/integrations/ag2/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/ag2/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/ag2/src/app/demos/declarative-gen-ui/page.tsx:23",
+        "showcase/integrations/agno/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/agno/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/agno/src/app/demos/declarative-gen-ui/page.tsx:21",
+        "showcase/integrations/built-in-agent/src/app/demos/declarative-gen-ui/README.md:42",
+        "showcase/integrations/built-in-agent/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/built-in-agent/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/built-in-agent/src/app/demos/declarative-gen-ui/page.tsx:21",
+        "showcase/integrations/claude-sdk-python/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/claude-sdk-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/claude-sdk-python/src/app/demos/declarative-gen-ui/page.tsx:23",
+        "showcase/integrations/claude-sdk-typescript/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/claude-sdk-typescript/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/claude-sdk-typescript/src/app/demos/declarative-gen-ui/page.tsx:23",
+        "showcase/integrations/crewai-crews/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/crewai-crews/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/google-adk/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/google-adk/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/google-adk/src/app/demos/declarative-gen-ui/page.tsx:24",
+        "showcase/integrations/langgraph-fastapi/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/langgraph-fastapi/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/langgraph-fastapi/src/app/demos/declarative-gen-ui/page.tsx:23",
+        "showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/page.tsx:23",
+        "showcase/integrations/langgraph-typescript/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/langgraph-typescript/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/langgraph-typescript/src/app/demos/declarative-gen-ui/page.tsx:23",
+        "showcase/integrations/langroid/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/langroid/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/langroid/src/app/demos/declarative-gen-ui/page.tsx:23",
+        "showcase/integrations/llamaindex/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/llamaindex/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/mastra/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/mastra/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/mastra/src/app/demos/declarative-gen-ui/page.tsx:20",
+        "showcase/integrations/ms-agent-python/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/ms-agent-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/ms-agent-python/src/app/demos/declarative-gen-ui/page.tsx:21",
+        "showcase/integrations/pydantic-ai/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/pydantic-ai/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/pydantic-ai/src/app/demos/declarative-gen-ui/page.tsx:21",
+        "showcase/integrations/spring-ai/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/spring-ai/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/spring-ai/src/app/demos/declarative-gen-ui/page.tsx:23",
+        "showcase/integrations/strands/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/strands/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/strands/src/app/demos/declarative-gen-ui/page.tsx:23"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui/advanced",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui/dynamic-schema",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui/fixed-schema",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/integrations/agno/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/integrations/built-in-agent/src/app/demos/a2ui-fixed-schema/README.md:39",
+        "showcase/integrations/built-in-agent/src/app/demos/a2ui-fixed-schema/page.tsx:19",
+        "showcase/integrations/claude-sdk-python/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/integrations/claude-sdk-typescript/src/app/demos/a2ui-fixed-schema/README.md:32",
+        "showcase/integrations/claude-sdk-typescript/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/integrations/google-adk/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/integrations/langgraph-fastapi/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/integrations/langgraph-python/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/integrations/langgraph-typescript/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/integrations/langroid/src/app/demos/a2ui-fixed-schema/README.md:33",
+        "showcase/integrations/langroid/src/app/demos/a2ui-fixed-schema/page.tsx:18",
+        "showcase/integrations/mastra/src/app/demos/a2ui-fixed-schema/page.tsx:14",
+        "showcase/integrations/ms-agent-python/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/integrations/pydantic-ai/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/integrations/strands/src/app/demos/a2ui-fixed-schema/page.tsx:17",
+        "showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx:230"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui/styling",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/mcp-apps",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/ag2/src/app/demos/mcp-apps/page.tsx:18",
+        "showcase/integrations/claude-sdk-typescript/src/app/demos/mcp-apps/page.tsx:18",
+        "showcase/integrations/google-adk/src/agents/mcp_apps_agent.py:11",
+        "showcase/integrations/google-adk/src/app/api/copilotkit-mcp-apps/route.ts:10",
+        "showcase/integrations/google-adk/src/app/demos/mcp-apps/README.md:36",
+        "showcase/integrations/google-adk/src/app/demos/mcp-apps/page.tsx:18",
+        "showcase/integrations/langgraph-fastapi/src/agents/src/mcp_apps_agent.py:13",
+        "showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-mcp-apps/route.ts:14",
+        "showcase/integrations/langgraph-fastapi/src/app/demos/mcp-apps/page.tsx:18",
+        "showcase/integrations/langgraph-python/src/agents/mcp_apps_agent.py:13",
+        "showcase/integrations/langgraph-python/src/app/api/copilotkit-mcp-apps/route.ts:10",
+        "showcase/integrations/langgraph-python/src/app/demos/mcp-apps/page.tsx:18",
+        "showcase/integrations/langgraph-typescript/src/app/api/copilotkit-mcp-apps/route.ts:13",
+        "showcase/integrations/langgraph-typescript/src/app/demos/mcp-apps/page.tsx:18",
+        "showcase/integrations/langroid/src/app/api/copilotkit-mcp-apps/route.ts:16",
+        "showcase/integrations/langroid/src/app/demos/mcp-apps/page.tsx:19",
+        "showcase/integrations/llamaindex/src/app/demos/mcp-apps/page.tsx:18",
+        "showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-mcp-apps/route.ts:14",
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/mcp-apps/README.md:37",
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/mcp-apps/page.tsx:19",
+        "showcase/integrations/pydantic-ai/src/agents/mcp_apps_agent.py:14",
+        "showcase/integrations/pydantic-ai/src/app/api/copilotkit-mcp-apps/route.ts:14",
+        "showcase/integrations/pydantic-ai/src/app/demos/mcp-apps/page.tsx:24",
+        "showcase/integrations/spring-ai/src/app/demos/mcp-apps/page.tsx:18"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-fastapi/docs-links.json:21"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-fastapi/docs-links.json:9"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-fastapi/docs-links.json:17"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/your-components/interactive",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-fastapi/docs-links.json:13"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/your-components/interrupt-based",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/human-in-the-loop/interrupt-flow",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/multi-agent-flows",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-fastapi/docs-links.json:33"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/prebuilt-components",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-fastapi/docs-links.json:5"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/shared-state/in-app-agent-read",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/shared-state/in-app-agent-write",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-fastapi/docs-links.json:25"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/shared-state/predictive-state-updates",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-fastapi/docs-links.json:29",
+        "showcase/integrations/langgraph-python/src/agents/shared_state_streaming.py:12"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/shared-state/state-inputs-outputs",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/shared-state/workflow-execution",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/subgraphs",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/telemetry",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/troubleshooting/migrate-to-agui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/next-steps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-1-checkout-repo",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-2-start-the-agent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-3-setup-copilotkit",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-4-agentic-chat-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-5-human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-6-shared-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-7-generative-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-8-progressive-state-updates",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/next-steps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-1-checkout-repo",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-2-langgraph-agent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-3-setup-copilotkit",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-4-integrate-the-agent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-5-stream-progress",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-6-human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/langgraph/videos/research-canvas",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/contributing/code-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/contributing/code-contributions/package-linking",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/contributing/docs-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/mcp-apps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/state-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/multi-agent-flows",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state/in-app-agent-read",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state/in-app-agent-write",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state/predictive-state-updates",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state/state-inputs-outputs",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state/workflow-execution",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/telemetry",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/llamaindex/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/agent-app-context",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/contributing/code-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/contributing/code-contributions/package-linking",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/contributing/docs-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/mcp-apps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/state-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/human-in-the-loop/interrupt-flow",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/human-in-the-loop/tool-based",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/shared-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/shared-state/in-app-agent-read",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/shared-state/in-app-agent-write",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/telemetry",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/mastra/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/agent-app-context",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/auth",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/contributing/code-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/contributing/code-contributions/package-linking",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/contributing/docs-contributions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/a2ui",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx:11",
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/declarative-gen-ui/page.tsx:21"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/a2ui/fixed-schema",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-dotnet/src/app/demos/a2ui-fixed-schema/page.tsx:17"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/mcp-apps",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-python/src/agents/mcp_apps_agent.py:13",
+        "showcase/integrations/ms-agent-python/src/app/api/copilotkit-mcp-apps/route.ts:13",
+        "showcase/integrations/ms-agent-python/src/app/demos/mcp-apps/page.tsx:18"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/state-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/shared-state/in-app-agent-read",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/shared-state/in-app-agent-write",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/shared-state/predictive-state-updates",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/telemetry",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/ag-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/coding-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/copilot-runtime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/custom-look-and-feel/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/custom-look-and-feel/slots",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/frontend-tools",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/a2ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/mcp-apps",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/state-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/tool-rendering",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/your-components/display-only",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/your-components/interactive",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/human-in-the-loop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/human-in-the-loop/agent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/human-in-the-loop/index",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/multi-agent-flows",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/prebuilt-components",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/quickstart",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/quickstart/pydantic-ai",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/shared-state",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/shared-state/in-app-agent-read",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/shared-state/in-app-agent-write",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/shared-state/predictive-state-updates",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/troubleshooting/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/troubleshooting/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/troubleshooting/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:504"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/advanced/exit-agent",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "docs/content/docs/integrations/langgraph/multi-agent-flows.mdx:43",
+        "showcase/shell-docs/src/content/docs/integrations/langgraph/multi-agent-flows.mdx:48"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/advanced/exit-agent"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/agent-app-context",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:125"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/agent-app-context"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/auth",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:133"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/auth"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/custom-look-and-feel",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:29"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/custom-look-and-feel"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/custom-look-and-feel/css",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "dev-docs/langgraph-python-column-wave1-bugs.md:81"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/custom-look-and-feel/css"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/custom-look-and-feel/headless-ui",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:33",
+        "showcase/integrations/langgraph-python/docs-links.json:37"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/custom-look-and-feel/headless-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/custom-look-and-feel/slots",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:25"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/custom-look-and-feel/slots"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/frontend-tools",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:49",
+        "showcase/integrations/langgraph-python/docs-links.json:53",
+        "showcase/integrations/langgraph-python/docs-links.json:65"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/generative-ui/a2ui/dynamic-schema",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:77"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/generative-ui/a2ui/dynamic-schema"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/generative-ui/a2ui/fixed-schema",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:81"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/generative-ui/mcp-apps",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:85"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/generative-ui/mcp-apps"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:97",
+        "showcase/integrations/langgraph-typescript/docs-links.json:21"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/generative-ui/state-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:101",
+        "showcase/integrations/langgraph-python/docs-links.json:105",
+        "showcase/integrations/langgraph-python/docs-links.json:109",
+        "showcase/integrations/langgraph-python/docs-links.json:113",
+        "showcase/integrations/langgraph-typescript/docs-links.json:13"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:57",
+        "showcase/integrations/langgraph-typescript/docs-links.json:17"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/generative-ui/your-components/interactive",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:61",
+        "showcase/integrations/langgraph-typescript/docs-links.json:9"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/generative-ui/your-components/interactive"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/generative-ui/your-components/interrupt-based",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:69"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/generative-ui/your-components/interrupt-based"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/human-in-the-loop/interrupt-flow",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:73"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/human-in-the-loop/interrupt-flow"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/multi-agent-flows",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:129",
+        "showcase/integrations/langgraph-typescript/docs-links.json:33"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/multi-agent-flows"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/prebuilt-components",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "dev-docs/langgraph-python-column-wave1-bugs.md:37",
+        "showcase/integrations/langgraph-python/docs-links.json:13",
+        "showcase/integrations/langgraph-python/docs-links.json:17",
+        "showcase/integrations/langgraph-python/docs-links.json:21",
+        "showcase/integrations/langgraph-python/docs-links.json:5",
+        "showcase/integrations/langgraph-typescript/docs-links.json:5"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/prebuilt-components"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/quickstart",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "README.md:95",
+        "showcase/integrations/langgraph-python/docs-links.json:9"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/quickstart"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/quickstart?theme=dark",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "docs/POSTHOG_BROKEN_LINKS.md:12"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/quickstart"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/shared-state/in-app-agent-write",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:117",
+        "showcase/integrations/langgraph-typescript/docs-links.json:25"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/shared-state/in-app-agent-write"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/langgraph/shared-state/predictive-state-updates",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/langgraph-python/docs-links.json:121",
+        "showcase/integrations/langgraph-typescript/docs-links.json:29"
+      ],
+      "redirect_destination": "/docs/integrations/langgraph/shared-state/predictive-state-updates"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/a2a-protocol",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/a2a-protocol"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/ag-ui-protocol",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/ag-ui-protocol"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/agentic-protocols",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/agentic-protocols"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/architecture",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/architecture"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/connect-mcp-servers",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/connect-mcp-servers"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/generative-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/generative-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/generative-ui/specs",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/showcases/generative-ui/README.md:115"
+      ],
+      "redirect_destination": "/docs/learn/generative-ui/specs"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/generative-ui/specs/a2ui",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/showcases/generative-ui/README.md:211",
+        "examples/showcases/generative-ui/README.md:57"
+      ],
+      "redirect_destination": "/docs/learn/generative-ui/specs/a2ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/generative-ui/specs/mcp-apps",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/showcases/generative-ui/README.md:249"
+      ],
+      "redirect_destination": "/docs/learn/generative-ui/specs/mcp-apps"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/generative-ui/specs/open-json-ui",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/showcases/generative-ui/README.md:130",
+        "examples/showcases/generative-ui/README.md:210",
+        "examples/showcases/generative-ui/README.md:57"
+      ],
+      "redirect_destination": "/docs/learn/generative-ui/specs/open-json-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/intelligence-platform",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/intelligence-platform"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/threads"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/tutorials/multi-conversation-chat",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/tutorials/multi-conversation-chat"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/whats-new",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/whats-new"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/whats-new/a2a-mcp-handshake",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/whats-new/a2a-mcp-handshake"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/whats-new/a2ui-launch",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/whats-new/a2ui-launch"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/whats-new/generative-ui-spec-support",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/whats-new/generative-ui-spec-support"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/whats-new/langgraph-deep-agents",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/whats-new/langgraph-deep-agents"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/whats-new/mcp-apps-support",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/whats-new/mcp-apps-support"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/learn/whats-new/v1-50",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/learn/whats-new/v1-50"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llamaindex/",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:518"
+      ],
+      "redirect_destination": "/docs/integrations/llamaindex/"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llamaindex/custom-look-and-feel/customize-built-in-ui-components",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/canvas/llamaindex-composio/README.md:509"
+      ],
+      "redirect_destination": "/docs/integrations/llamaindex/custom-look-and-feel/slots"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llamaindex/frontend-tools",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/llamaindex/docs-links.json:5"
+      ],
+      "redirect_destination": "/docs/integrations/llamaindex/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llamaindex/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/llamaindex/docs-links.json:21"
+      ],
+      "redirect_destination": "/docs/integrations/llamaindex/generative-ui/state-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llamaindex/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/llamaindex/docs-links.json:13"
+      ],
+      "redirect_destination": "/docs/integrations/llamaindex/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llamaindex/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/llamaindex/docs-links.json:17"
+      ],
+      "redirect_destination": "/docs/integrations/llamaindex/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llamaindex/human-in-the-loop",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/llamaindex/docs-links.json:9"
+      ],
+      "redirect_destination": "/docs/integrations/llamaindex/human-in-the-loop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llamaindex/multi-agent-flows",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/llamaindex/docs-links.json:33"
+      ],
+      "redirect_destination": "/docs/integrations/llamaindex/multi-agent-flows"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llamaindex/shared-state/in-app-agent-write",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/llamaindex/docs-links.json:25"
+      ],
+      "redirect_destination": "/docs/integrations/llamaindex/shared-state/in-app-agent-write"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llamaindex/shared-state/predictive-state-updates",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/llamaindex/docs-links.json:29"
+      ],
+      "redirect_destination": "/docs/integrations/llamaindex/shared-state/predictive-state-updates"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/llms.txt",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "examples/showcases/generative-ui/README.md:305"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/mastra/docs-links.json:33",
+        "showcase/integrations/mastra/docs-links.json:5"
+      ],
+      "redirect_destination": "/docs/integrations/mastra"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:515"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/frontend-actions",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/mastra/src/app/page.tsx:14"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/mastra/docs-links.json:21"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/generative-ui/state-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/generative-ui/tool-based",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/mastra/src/app/page.tsx:87"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/mastra/docs-links.json:13"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/mastra/docs-links.json:17"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/human-in-the-loop",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/mastra/src/app/page.tsx:101"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/human-in-the-loop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/human-in-the-loop/tool-based",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/mastra/docs-links.json:9"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/human-in-the-loop/tool-based"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/shared-state",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/mastra/docs-links.json:25"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/shared-state"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/shared-state/in-app-agent-read",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/mastra/src/app/page.tsx:77"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/shared-state/in-app-agent-read"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/mastra/shared-state/in-app-agent-write",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/mastra/docs-links.json:29"
+      ],
+      "redirect_destination": "/docs/integrations/mastra/shared-state/in-app-agent-write"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-dotnet/docs-links.json:33",
+        "showcase/integrations/ms-agent-python/docs-links.json:33",
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:511"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/auth",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-dotnet/docs-links.json:37",
+        "showcase/integrations/ms-agent-python/docs-links.json:37"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/auth"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/frontend-actions",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx:19",
+        "examples/integrations/ms-agent-framework-python/src/app/page.tsx:14"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/ms-agent-framework-python/src/app/page.tsx:87"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/generative-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-dotnet/docs-links.json:21",
+        "showcase/integrations/ms-agent-python/docs-links.json:21"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/generative-ui/state-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-dotnet/docs-links.json:13",
+        "showcase/integrations/ms-agent-python/docs-links.json:13"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-dotnet/docs-links.json:17",
+        "showcase/integrations/ms-agent-python/docs-links.json:17"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/human-in-the-loop",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/ms-agent-framework-python/src/app/page.tsx:101",
+        "showcase/integrations/ms-agent-dotnet/docs-links.json:9",
+        "showcase/integrations/ms-agent-python/docs-links.json:9"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/human-in-the-loop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/human-in-the-loop/frontend-tool-based",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx:107"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/human-in-the-loop/frontend-tool-based"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/quickstart",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-dotnet/docs-links.json:5",
+        "showcase/integrations/ms-agent-python/docs-links.json:5"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/quickstart"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/shared-state",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/ms-agent-framework-python/src/app/page.tsx:77"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/shared-state"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/shared-state/in-app-agent-write",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-dotnet/docs-links.json:25",
+        "showcase/integrations/ms-agent-python/docs-links.json:25"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/shared-state/in-app-agent-write"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/microsoft-agent-framework/shared-state/predictive-state-updates",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/ms-agent-dotnet/docs-links.json:29",
+        "showcase/integrations/ms-agent-python/docs-links.json:29"
+      ],
+      "redirect_destination": "/docs/integrations/microsoft-agent-framework/shared-state/predictive-state-updates"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/migration-guides/migrate-attachments",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "packages/react-ui/src/components/chat/AttachmentQueue.tsx:122",
+        "packages/react-ui/src/components/chat/Chat.tsx:218",
+        "packages/react-ui/src/components/chat/Chat.tsx:228",
+        "packages/react-ui/src/components/chat/Chat.tsx:337",
+        "packages/react-ui/src/components/chat/Chat.tsx:383",
+        "packages/react-ui/src/components/chat/Chat.tsx:449",
+        "packages/react-ui/src/components/chat/messages/ImageRenderer.tsx:7",
+        "packages/react-ui/src/components/chat/props.ts:353",
+        "packages/react-ui/src/components/chat/props.ts:361",
+        "packages/shared/src/types/message.ts:21",
+        "packages/shared/src/types/message.ts:49"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/migration-guides/migrate-to-1.10.X",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/migration-guides/migrate-to-1.8.2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/migration-guides/migrate-to-v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/migration/render-message",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "packages/react-ui/src/components/chat/Messages.tsx:58"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/multimodal-attachments",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/shared/feature-registry.json:359"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/prebuilt-components",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shared/feature-registry.json:82",
+        "showcase/shared/feature-registry.json:90"
+      ],
+      "redirect_destination": "/docs/prebuilt-components"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/premium",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "packages/shared/src/utils/console-styling.ts:64"
+      ],
+      "redirect_destination": "/docs/premium"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/premium#how-do-i-get-access-to-premium-features",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "packages/react-core/src/components/usage-banner.tsx:226"
+      ],
+      "redirect_destination": "/docs/premium"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/premium/headless-ui",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/premium/headless-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/premium/observability",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/premium/observability"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/premium/overview",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/premium/overview"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/premium/self-hosting",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/premium/self-hosting"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/programmatic-control",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shell-docs/src/content/ag-ui/introduction.mdx:516"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/frontend-actions",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/pydantic-ai/src/app/page.tsx:20"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/frontend-tools"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx:94",
+        "examples/integrations/pydantic-ai/src/app/page.tsx:93"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/generative-ui"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui/state-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/pydantic-ai/docs-links.json:21"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/generative-ui/state-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui/tool-rendering",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/pydantic-ai/docs-links.json:13"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/generative-ui/tool-rendering"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui/your-components/display-only",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/pydantic-ai/docs-links.json:17"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/generative-ui/your-components/display-only"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui/your-components/interactive",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/pydantic-ai/docs-links.json:9"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/generative-ui/your-components/interactive"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/human-in-the-loop",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/pydantic-ai/src/app/page.tsx:106"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/human-in-the-loop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/multi-agent-flows",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/pydantic-ai/docs-links.json:33"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/multi-agent-flows"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/prebuilt-components",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/pydantic-ai/docs-links.json:5"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/prebuilt-components"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/shared-state",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx:84",
+        "examples/integrations/pydantic-ai/src/app/page.tsx:83"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/shared-state"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/shared-state/in-app-agent-write",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/pydantic-ai/docs-links.json:25"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/shared-state/in-app-agent-write"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/pydantic-ai/shared-state/predictive-state-updates",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/integrations/pydantic-ai/docs-links.json:29"
+      ],
+      "redirect_destination": "/docs/integrations/pydantic-ai/shared-state/predictive-state-updates"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/quickstart",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "showcase/shared/feature-registry.json:56"
+      ],
+      "redirect_destination": "/docs/quickstart"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/quickstart#get-a-copilot-cloud-public-api-key",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "packages/runtime/src/lib/observability.ts:52"
+      ],
+      "redirect_destination": "/docs/quickstart"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/hooks/useCoAgent",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "examples/showcases/strands-file-analyzer/README.md:357"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/classes/CopilotRuntime",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/classes/CopilotTask",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/AnthropicAdapter",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/GoogleGenerativeAIAdapter",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/GroqAdapter",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/LangChainAdapter",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/OpenAIAdapter",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/OpenAIAssistantAdapter",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/components/CopilotKit",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/components/CopilotTextarea",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/components/chat",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/components/chat/CopilotChat",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/components/chat/CopilotPopup",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/components/chat/CopilotSidebar",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useAgent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCoAgent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCoAgentStateRender",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotAction",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotAdditionalInstructions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotChat",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotChatHeadless_c",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "docs/content/docs/reference/v1/hooks/useCopilotChat.mdx:23",
+        "packages/react-core/src/hooks/use-copilot-chat.ts:8"
+      ],
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotChatSuggestions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotReadable",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useDefaultTool",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useFrontendTool",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "docs/content/docs/integrations/built-in-agent/tutorials/ai-todo-app/step-4-frontend-tools.mdx:79",
+        "showcase/shell-docs/src/content/docs/tutorials/ai-todo-app/step-4-frontend-tools.mdx:76"
+      ],
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useHumanInTheLoop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useLangGraphInterrupt",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/hooks/useRenderToolCall",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/sdk/js/LangGraph",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/sdk/python/CrewAI",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/sdk/python/CrewAIAgent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/sdk/python/LangGraph",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/sdk/python/LangGraphAgent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v1/sdk/python/RemoteEndpoints",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChat",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/components/CopilotChat"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChatAssistantMessage",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/components/CopilotChatAssistantMessage"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChatInput",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/components/CopilotChatInput"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChatMessageView",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/components/CopilotChatMessageView"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChatUserMessage",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/components/CopilotChatUserMessage"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChatView",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/components/CopilotChatView"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotKit",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/components/CopilotKit"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotPopup",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/components/CopilotPopup"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotSidebar",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/components/CopilotSidebar"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useAgent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useAgent"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useAgentContext",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useAgentContext"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useCapabilities",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useCapabilities"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useComponent",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useComponent"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useConfigureSuggestions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useConfigureSuggestions"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useCopilotChatConfiguration",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useCopilotChatConfiguration"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useCopilotKit",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useCopilotKit"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useDefaultRenderTool",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useDefaultRenderTool"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useFrontendTool",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useFrontendTool"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useHumanInTheLoop",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useHumanInTheLoop"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useInterrupt",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useInterrupt"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useRenderTool",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useRenderTool"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useRenderToolCall",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useRenderToolCall"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useSuggestions",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useSuggestions"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/reference/v2/hooks/useThreads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/reference/hooks/useThreads"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/runtime-server-adapter",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/backend/copilot-runtime"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/shared-state",
+      "sources": [
+        "monorepo_grep",
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "showcase/integrations/agno/docs-links.json:25",
+        "showcase/integrations/agno/docs-links.json:29",
+        "showcase/integrations/claude-sdk-python/docs-links.json:25",
+        "showcase/integrations/claude-sdk-python/docs-links.json:29",
+        "showcase/integrations/claude-sdk-typescript/docs-links.json:25",
+        "showcase/integrations/claude-sdk-typescript/docs-links.json:29",
+        "showcase/integrations/spring-ai/docs-links.json:25",
+        "showcase/integrations/spring-ai/docs-links.json:29",
+        "showcase/integrations/strands/docs-links.json:29",
+        "showcase/shared/feature-registry.json:305",
+        "showcase/shared/feature-registry.json:313",
+        "showcase/shared/feature-registry.json:321"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/strands/generative-ui/backend-tools",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "examples/integrations/strands-python/src/app/page.tsx:106",
+        "examples/integrations/strands-python/src/app/page.tsx:88"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/telemetry",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/telemetry"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/threads",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/troubleshooting/common-issues",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/troubleshooting/common-issues"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/troubleshooting/debug-mode",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/troubleshooting/debug-mode"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/troubleshooting/error-debugging",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/troubleshooting/error-debugging"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/troubleshooting/event-inspector",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/troubleshooting/event-inspector"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/troubleshooting/hook-explorer",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/troubleshooting/hook-explorer"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/troubleshooting/observability-connectors",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": true,
+      "redirect_destination": "/docs/troubleshooting/observability-connectors"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/vibe-coding-mcp",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": true,
+      "monorepo_locations": [
+        "examples/canvas/llamaindex-composio/README.md:49"
+      ],
+      "redirect_destination": "/docs/coding-agents"
+    },
+    {
+      "url": "https://docs.copilotkit.ai/vs-code-extension",
+      "sources": [
+        "sitemap"
+      ],
+      "covered_by_seo_redirects": false
+    },
+    {
+      "url": "https://docs.copilotkit.ai/what-is-copilotkit",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "community/content/CONTRIBUTING.md:43"
+      ]
+    },
+    {
+      "url": "https://docs.copilotkit.ai/whats-new",
+      "sources": [
+        "monorepo_grep"
+      ],
+      "covered_by_seo_redirects": false,
+      "monorepo_locations": [
+        "README.md:166"
+      ]
+    }
+  ],
+  "summary": {
+    "total_urls": 813,
+    "by_source": {
+      "sitemap": 646,
+      "monorepo_grep": 206,
+      "wget_orphans": 0
+    },
+    "coverage": {
+      "covered": 275,
+      "uncovered": 538,
+      "uncovered_pct": 66.2
+    },
+    "uncovered_by_top_level_prefix": {
+      "/integrations": 513,
+      "/migration-guides": 4,
+      "/": 2,
+      "/built-in-agent": 2,
+      "/ag-ui-middleware": 1,
+      "/deploy": 1,
+      "/examples": 1,
+      "/features": 1,
+      "/getting-started": 1,
+      "/inspector": 1,
+      "/llms.txt": 1,
+      "/migration": 1,
+      "/multimodal-attachments": 1,
+      "/programmatic-control": 1,
+      "/reference": 1,
+      "/shared-state": 1,
+      "/strands": 1,
+      "/threads": 1,
+      "/vs-code-extension": 1,
+      "/what-is-copilotkit": 1,
+      "/whats-new": 1
+    },
+    "top_uncovered": [
+      {
+        "url": "https://docs.copilotkit.ai/",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/?ref=github_readme",
+        "sources": [
+          "monorepo_grep"
+        ],
+        "covered_by_seo_redirects": false,
+        "monorepo_locations": [
+          "README.md:171",
+          "README.md:9",
+          "community/content/README.md:34"
+        ]
+      },
+      {
+        "url": "https://docs.copilotkit.ai/ag-ui-middleware",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/built-in-agent/quickstart",
+        "sources": [
+          "monorepo_grep"
+        ],
+        "covered_by_seo_redirects": false,
+        "monorepo_locations": [
+          "showcase/integrations/built-in-agent/docs-links.json:4"
+        ]
+      },
+      {
+        "url": "https://docs.copilotkit.ai/built-in-agent/shared-state",
+        "sources": [
+          "monorepo_grep"
+        ],
+        "covered_by_seo_redirects": false,
+        "monorepo_locations": [
+          "showcase/integrations/built-in-agent/docs-links.json:8"
+        ]
+      },
+      {
+        "url": "https://docs.copilotkit.ai/deploy/agentcore",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/examples",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/features/",
+        "sources": [
+          "monorepo_grep"
+        ],
+        "covered_by_seo_redirects": false,
+        "monorepo_locations": [
+          "dev-docs/langgraph-python-column-wave1-bugs.md:53"
+        ]
+      },
+      {
+        "url": "https://docs.copilotkit.ai/getting-started/quickstart-chatbot",
+        "sources": [
+          "monorepo_grep"
+        ],
+        "covered_by_seo_redirects": false,
+        "monorepo_locations": [
+          "examples/showcases/presentation/README.md:49",
+          "examples/showcases/spreadsheet/README.md:60"
+        ]
+      },
+      {
+        "url": "https://docs.copilotkit.ai/inspector",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/a2a",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/a2a/ag-ui",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/a2a/coding-agents",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/a2a/copilot-runtime",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/a2a/custom-look-and-feel/headless-ui",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/a2a/custom-look-and-feel/slots",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/a2a/generative-ui/declarative-a2ui",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/a2a/prebuilt-components",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/a2a/programmatic-control",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/a2a/quickstart",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/adk",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/adk/ag-ui",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/adk/coding-agents",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      },
+      {
+        "url": "https://docs.copilotkit.ai/integrations/adk/copilot-runtime",
+        "sources": [
+          "sitemap"
+        ],
+        "covered_by_seo_redirects": false
+      }
+    ]
+  }
+}

--- a/redirect-inventory.json
+++ b/redirect-inventory.json
@@ -1,31 +1,22 @@
 {
   "refreshed_at": "2026-05-06T22:06:22.267Z",
-  "sources_completed": [
-    "sitemap",
-    "monorepo_grep"
-  ],
+  "sources_completed": ["sitemap", "monorepo_grep"],
   "sources_failed": [
     {
       "source": "wget_orphans",
       "reason": "wget --spider --recursive --level=4 against https://docs.copilotkit.ai/ returned only 29 URLs, all of which were _next/static/* assets, fonts, and robots.txt — no HTML page links. The docs site is a Next.js client-rendered SPA whose nav menu is hydrated in JavaScript, so wget has no anchor hrefs to follow. The sitemap is the canonical source of doc URLs and supersedes the wget crawl. Source documented as failed but not blocking."
     }
   ],
-  "sources_deferred": [
-    "gsc_export"
-  ],
+  "sources_deferred": ["gsc_export"],
   "urls": [
     {
       "url": "https://docs.copilotkit.ai/",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/?ref=github_readme",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "README.md:171",
@@ -35,20 +26,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/a2a",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/integrations/a2a-a2ui/README.md:90"
-      ],
+      "monorepo_locations": ["examples/integrations/a2a-a2ui/README.md:90"],
       "redirect_destination": "/docs/integrations/a2a"
     },
     {
       "url": "https://docs.copilotkit.ai/a2a-protocol",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shell-docs/src/content/ag-ui/introduction.mdx:533"
@@ -57,9 +42,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:17",
@@ -75,20 +58,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk/frontend-actions",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/integrations/adk/src/app/page.tsx:19"
-      ],
+      "monorepo_locations": ["examples/integrations/adk/src/app/page.tsx:19"],
       "redirect_destination": "/docs/integrations/adk/frontend-tools"
     },
     {
       "url": "https://docs.copilotkit.ai/adk/frontend-tools",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:45",
@@ -99,20 +76,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk/generative-ui",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/integrations/adk/src/app/page.tsx:89"
-      ],
+      "monorepo_locations": ["examples/integrations/adk/src/app/page.tsx:89"],
       "redirect_destination": "/docs/integrations/adk/generative-ui"
     },
     {
       "url": "https://docs.copilotkit.ai/adk/generative-ui/a2ui",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:65",
@@ -122,9 +93,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:81"
@@ -133,9 +102,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:85",
@@ -147,9 +114,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:53"
@@ -158,9 +123,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk/human-in-the-loop",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:57"
@@ -169,9 +132,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk/quickstart",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:13"
@@ -180,20 +141,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk/shared-state",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/integrations/adk/src/app/page.tsx:79"
-      ],
+      "monorepo_locations": ["examples/integrations/adk/src/app/page.tsx:79"],
       "redirect_destination": "/docs/integrations/adk/shared-state"
     },
     {
       "url": "https://docs.copilotkit.ai/adk/shared-state/in-app-agent-read",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:109"
@@ -202,9 +157,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk/shared-state/in-app-agent-write",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:101"
@@ -213,9 +166,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/adk/shared-state/predictive-state-updates",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:105"
@@ -224,38 +175,26 @@
     },
     {
       "url": "https://docs.copilotkit.ai/ag-ui-middleware",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/ag-ui-protocol",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "README.md:142"
-      ],
+      "monorepo_locations": ["README.md:142"],
       "redirect_destination": "/docs/learn/ag-ui-protocol"
     },
     {
       "url": "https://docs.copilotkit.ai/ag2",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/ag2/docs-links.json:33"
-      ],
+      "monorepo_locations": ["showcase/integrations/ag2/docs-links.json:33"],
       "redirect_destination": "/docs/integrations/ag2"
     },
     {
       "url": "https://docs.copilotkit.ai/ag2/",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shell-docs/src/content/ag-ui/introduction.mdx:519"
@@ -264,98 +203,63 @@
     },
     {
       "url": "https://docs.copilotkit.ai/ag2/auth",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/ag2/docs-links.json:37"
-      ],
+      "monorepo_locations": ["showcase/integrations/ag2/docs-links.json:37"],
       "redirect_destination": "/docs/integrations/ag2/auth"
     },
     {
       "url": "https://docs.copilotkit.ai/ag2/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/ag2/docs-links.json:21"
-      ],
+      "monorepo_locations": ["showcase/integrations/ag2/docs-links.json:21"],
       "redirect_destination": "/docs/integrations/ag2/generative-ui/state-rendering"
     },
     {
       "url": "https://docs.copilotkit.ai/ag2/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/ag2/docs-links.json:13"
-      ],
+      "monorepo_locations": ["showcase/integrations/ag2/docs-links.json:13"],
       "redirect_destination": "/docs/integrations/ag2/generative-ui/tool-rendering"
     },
     {
       "url": "https://docs.copilotkit.ai/ag2/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/ag2/docs-links.json:17"
-      ],
+      "monorepo_locations": ["showcase/integrations/ag2/docs-links.json:17"],
       "redirect_destination": "/docs/integrations/ag2/generative-ui/your-components/display-only"
     },
     {
       "url": "https://docs.copilotkit.ai/ag2/human-in-the-loop",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/ag2/docs-links.json:9"
-      ],
+      "monorepo_locations": ["showcase/integrations/ag2/docs-links.json:9"],
       "redirect_destination": "/docs/integrations/ag2/human-in-the-loop"
     },
     {
       "url": "https://docs.copilotkit.ai/ag2/prebuilt-components",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/ag2/docs-links.json:5"
-      ],
+      "monorepo_locations": ["showcase/integrations/ag2/docs-links.json:5"],
       "redirect_destination": "/docs/integrations/ag2/prebuilt-components"
     },
     {
       "url": "https://docs.copilotkit.ai/ag2/shared-state",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/ag2/docs-links.json:25"
-      ],
+      "monorepo_locations": ["showcase/integrations/ag2/docs-links.json:25"],
       "redirect_destination": "/docs/integrations/ag2/shared-state"
     },
     {
       "url": "https://docs.copilotkit.ai/ag2/shared-state/write",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/ag2/docs-links.json:29"
-      ],
+      "monorepo_locations": ["showcase/integrations/ag2/docs-links.json:29"],
       "redirect_destination": "/docs/integrations/ag2/shared-state/write"
     },
     {
       "url": "https://docs.copilotkit.ai/agentic-chat-ui",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/claude-sdk-python/docs-links.json:5",
@@ -368,20 +272,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/agno",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/agno/docs-links.json:33"
-      ],
+      "monorepo_locations": ["showcase/integrations/agno/docs-links.json:33"],
       "redirect_destination": "/docs/integrations/agno"
     },
     {
       "url": "https://docs.copilotkit.ai/agno/",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shell-docs/src/content/ag-ui/introduction.mdx:517"
@@ -390,9 +288,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/agno/frontend-tools",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/agno/src/app/page.tsx:79",
@@ -402,9 +298,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/agno/generative-ui/backend-tools",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/agno/src/app/page.tsx:113",
@@ -414,42 +308,28 @@
     },
     {
       "url": "https://docs.copilotkit.ai/agno/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/agno/docs-links.json:13"
-      ],
+      "monorepo_locations": ["showcase/integrations/agno/docs-links.json:13"],
       "redirect_destination": "/docs/integrations/agno/generative-ui/tool-rendering"
     },
     {
       "url": "https://docs.copilotkit.ai/agno/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/agno/docs-links.json:17"
-      ],
+      "monorepo_locations": ["showcase/integrations/agno/docs-links.json:17"],
       "redirect_destination": "/docs/integrations/agno/generative-ui/your-components/display-only"
     },
     {
       "url": "https://docs.copilotkit.ai/agno/human-in-the-loop",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/agno/docs-links.json:9"
-      ],
+      "monorepo_locations": ["showcase/integrations/agno/docs-links.json:9"],
       "redirect_destination": "/docs/integrations/agno/human-in-the-loop"
     },
     {
       "url": "https://docs.copilotkit.ai/aws-strands",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/strands/docs-links.json:33",
@@ -459,9 +339,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/aws-strands/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/strands/docs-links.json:21"
@@ -470,9 +348,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/aws-strands/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/strands/docs-links.json:13"
@@ -481,9 +357,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/aws-strands/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/strands/docs-links.json:17"
@@ -492,20 +366,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/aws-strands/prebuilt-components",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/strands/docs-links.json:5"
-      ],
+      "monorepo_locations": ["showcase/integrations/strands/docs-links.json:5"],
       "redirect_destination": "/docs/integrations/aws-strands/prebuilt-components"
     },
     {
       "url": "https://docs.copilotkit.ai/aws-strands/shared-state/in-app-agent-write",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/strands/docs-links.json:25"
@@ -514,33 +382,25 @@
     },
     {
       "url": "https://docs.copilotkit.ai/backend/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/backend/ag-ui"
     },
     {
       "url": "https://docs.copilotkit.ai/backend/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/backend/copilot-runtime"
     },
     {
       "url": "https://docs.copilotkit.ai/backend/custom-agent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/backend/custom-agent"
     },
     {
       "url": "https://docs.copilotkit.ai/built-in-agent/quickstart",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/built-in-agent/docs-links.json:4"
@@ -548,9 +408,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/built-in-agent/shared-state",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/built-in-agent/docs-links.json:8"
@@ -558,9 +416,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/coagents",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/showcases/multi-agent-canvas/README.md:102",
@@ -575,9 +431,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/ag-ui-protocol",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/showcases/strands-file-analyzer/README.md:358"
@@ -586,9 +440,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/frontend-actions",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/crewai-flows/src/app/page.tsx:84",
@@ -598,9 +450,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/generative-ui",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/canvas/mastra-pm/src/app/page.tsx:63",
@@ -612,9 +462,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/human-in-the-loop",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/v2/interrupts-langgraph/apps/web/src/app/page.tsx:37"
@@ -623,53 +471,35 @@
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/human-in-the-loop/node-flow",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/v1/travel/lib/hooks/README.md:48"
-      ],
+      "monorepo_locations": ["examples/v1/travel/lib/hooks/README.md:48"],
       "redirect_destination": "/docs/integrations/langgraph/human-in-the-loop/node-flow"
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/langgraph/langgraph-native-python",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/showcases/scene-creator/README.md:163"
-      ],
+      "monorepo_locations": ["examples/showcases/scene-creator/README.md:163"],
       "redirect_destination": "/docs/integrations/langgraph/langgraph/langgraph-native-python"
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/langgraph/shared-state",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/showcases/scene-creator/README.md:164"
-      ],
+      "monorepo_locations": ["examples/showcases/scene-creator/README.md:164"],
       "redirect_destination": "/docs/integrations/langgraph/langgraph/shared-state"
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/multi-agent-flows",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/shared/feature-registry.json:330"
-      ],
+      "monorepo_locations": ["showcase/shared/feature-registry.json:330"],
       "redirect_destination": "/docs/integrations/langgraph/multi-agent-flows"
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/quickstart/langgraph",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "packages/react-core/src/hooks/use-coagent.ts:205"
@@ -678,9 +508,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/shared-state",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/canvas/mastra-pm/src/app/page.tsx:51",
@@ -693,31 +521,21 @@
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/shared-state/in-app-agent-read",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/v1/travel/lib/hooks/README.md:11"
-      ],
+      "monorepo_locations": ["examples/v1/travel/lib/hooks/README.md:11"],
       "redirect_destination": "/docs/integrations/langgraph/shared-state/in-app-agent-read"
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/shared-state/in-app-agent-write",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/v1/travel/lib/hooks/README.md:11"
-      ],
+      "monorepo_locations": ["examples/v1/travel/lib/hooks/README.md:11"],
       "redirect_destination": "/docs/integrations/langgraph/shared-state/in-app-agent-write"
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/shared-state/predictive-state-updates",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "packages/react-core/src/hooks/use-coagent-state-render.ts:56"
@@ -726,9 +544,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/coagents/troubleshooting/common-issues",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "packages/react-ui/src/components/help-modal/modal.tsx:70"
@@ -737,79 +553,57 @@
     },
     {
       "url": "https://docs.copilotkit.ai/coding-agent-setup",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/coding-agents"
     },
     {
       "url": "https://docs.copilotkit.ai/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/coding-agents"
     },
     {
       "url": "https://docs.copilotkit.ai/contributing/code-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/contributing/code-contributions"
     },
     {
       "url": "https://docs.copilotkit.ai/contributing/code-contributions/package-linking",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/contributing/code-contributions/package-linking"
     },
     {
       "url": "https://docs.copilotkit.ai/contributing/docs-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/contributing/docs-contributions"
     },
     {
       "url": "https://docs.copilotkit.ai/contributing/docs-contributions#how-to-contribute",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "CODE_OF_CONDUCT.md:114"
-      ],
+      "monorepo_locations": ["CODE_OF_CONDUCT.md:114"],
       "redirect_destination": "/docs/contributing/docs-contributions"
     },
     {
       "url": "https://docs.copilotkit.ai/contributing/docs-contributions?ref=github_readme",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "README.md:194"
-      ],
+      "monorepo_locations": ["README.md:194"],
       "redirect_destination": "/docs/contributing/docs-contributions"
     },
     {
       "url": "https://docs.copilotkit.ai/copilot-suggestions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/prebuilt-components"
     },
     {
       "url": "https://docs.copilotkit.ai/crewai-crews/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/crewai-crews/docs-links.json:21"
@@ -818,9 +612,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/crewai-crews/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/crewai-crews/docs-links.json:13"
@@ -829,9 +621,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/crewai-crews/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/crewai-crews/docs-links.json:17"
@@ -840,9 +630,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/crewai-crews/human-in-the-loop",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/crewai-crews/docs-links.json:9"
@@ -851,9 +639,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/crewai-crews/prebuilt-components",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/crewai-crews/docs-links.json:5"
@@ -862,9 +648,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/crewai-crews/shared-state/in-app-agent-write",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/crewai-crews/docs-links.json:25"
@@ -873,9 +657,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/crewai-crews/shared-state/predictive-state-updates",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/crewai-crews/docs-links.json:29"
@@ -884,9 +666,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/crewai-flows",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shell-docs/src/content/ag-ui/introduction.mdx:505"
@@ -895,20 +675,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/custom-look-and-feel",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/shared/feature-registry.json:106"
-      ],
+      "monorepo_locations": ["showcase/shared/feature-registry.json:106"],
       "redirect_destination": "/docs/custom-look-and-feel"
     },
     {
       "url": "https://docs.copilotkit.ai/custom-look-and-feel/css",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "dev-docs/langgraph-python-column-wave1-bugs.md:83"
@@ -917,9 +691,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/built-in-agent/src/app/demos/chat-customization-css/page.tsx:7",
@@ -942,18 +714,13 @@
     },
     {
       "url": "https://docs.copilotkit.ai/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/custom-look-and-feel/headless-ui"
     },
     {
       "url": "https://docs.copilotkit.ai/custom-look-and-feel/reasoning-messages",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/google-adk/docs-links.json:37",
@@ -967,28 +734,19 @@
     },
     {
       "url": "https://docs.copilotkit.ai/custom-look-and-feel/slots",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/shared/feature-registry.json:98"
-      ],
+      "monorepo_locations": ["showcase/shared/feature-registry.json:98"],
       "redirect_destination": "/docs/custom-look-and-feel/slots"
     },
     {
       "url": "https://docs.copilotkit.ai/deploy/agentcore",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/direct-to-llm",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shell-docs/src/content/ag-ui/introduction.mdx:498"
@@ -997,9 +755,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/direct-to-llm/guides/connect-your-data/frontend",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shell-docs/src/content/docs/integrations/ag2/readables.mdx:18",
@@ -1009,9 +765,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/direct-to-llm/guides/model-context-protocol",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/showcases/mcp-demo/src/components/canvas.tsx:58"
@@ -1020,9 +774,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/direct-to-llm/guides/quickstart",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "community/content/CONTRIBUTING.md:11",
@@ -1033,9 +785,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/direct-to-llm/guides/quickstart?copilot-hosting=self-hosted#set-up-a-copilot-runtime-endpoint",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "docs/content/docs/integrations/crewai-flows/multi-agent-flows.mdx:39",
@@ -1049,24 +799,18 @@
     },
     {
       "url": "https://docs.copilotkit.ai/examples",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/faq",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/faq"
     },
     {
       "url": "https://docs.copilotkit.ai/features/",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "dev-docs/langgraph-python-column-wave1-bugs.md:53"
@@ -1074,18 +818,13 @@
     },
     {
       "url": "https://docs.copilotkit.ai/frontend-actions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/frontend-tools"
     },
     {
       "url": "https://docs.copilotkit.ai/frontend-tools",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shared/feature-registry.json:281",
@@ -1095,9 +834,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/showcases/generative-ui/README.md:114",
@@ -1109,10 +846,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/a2ui",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shared/feature-registry.json:181",
@@ -1122,26 +856,19 @@
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/display",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/generative-ui/your-components/display-only"
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/generative-ui/your-components/interactive"
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/mcp-apps",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-mcp-apps/route.ts:10",
@@ -1151,10 +878,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/open-generative-ui",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/ag2/src/app/demos/beautiful-chat/README.md:67",
@@ -1203,20 +927,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/specs/a2ui#using-a2ui-with-copilotkit",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "README.md:143"
-      ],
+      "monorepo_locations": ["README.md:143"],
       "redirect_destination": "/docs/generative-ui/specs/a2ui"
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/specs/mcp-apps",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "README.md:144",
@@ -1226,10 +944,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/agno/docs-links.json:21",
@@ -1242,10 +957,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/claude-sdk-python/docs-links.json:13",
@@ -1260,10 +972,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/claude-sdk-python/docs-links.json:17",
@@ -1275,10 +984,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/generative-ui/your-components/interactive",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shared/feature-registry.json:138",
@@ -1289,9 +995,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/getting-started/quickstart-chatbot",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "examples/showcases/presentation/README.md:49",
@@ -1300,9 +1004,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/guides/frontend-actions",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/canvas/mastra-pm/src/app/page.tsx:13",
@@ -1318,10 +1020,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/headless",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shared/feature-registry.json:114",
@@ -1332,10 +1031,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/human-in-the-loop",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/ag2/src/app/demos/gen-ui-interrupt/README.md:39",
@@ -1351,878 +1047,627 @@
     },
     {
       "url": "https://docs.copilotkit.ai/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/a2a",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/a2a/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/a2a/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/a2a/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/a2a/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/a2a/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/a2a/generative-ui/declarative-a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/a2a/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/a2a/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/a2a/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/mcp-apps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/state-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/shared-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/shared-state/in-app-agent-read",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/shared-state/in-app-agent-write",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/shared-state/predictive-state-updates",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/shared-state/state-inputs-outputs",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/shared-state/workflow-execution",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/adk/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/auth",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/contributing/code-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/contributing/code-contributions/package-linking",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/contributing/docs-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/mcp-apps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/state-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/readables",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/shared-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/shared-state/read",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/shared-state/write",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/telemetry",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/ag2/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/generative-ui/mcp-apps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/langgraph",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/shared-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agent-spec/wayflow",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/contributing/code-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/contributing/code-contributions/package-linking",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/contributing/docs-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/generative-ui/mcp-apps",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/agno/src/app/api/copilotkit-mcp-apps/route.ts:15",
@@ -2231,695 +1676,497 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/telemetry",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/agno/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/contributing/code-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/contributing/code-contributions/package-linking",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/contributing/docs-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/deploy-agentcore",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/mcp-apps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/state-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/shared-state/in-app-agent-read",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/shared-state/in-app-agent-write",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/telemetry",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/aws-strands/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/advanced-configuration",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/agent-app-context",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/custom-agent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/generative-ui/mcp-apps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/mcp-servers",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/model-selection",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/server-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/shared-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/next-steps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/step-1-checkout-repo",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/step-2-setup-copilotkit",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/step-3-copilot-textarea",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-powered-textarea/step-4-copilot-readable-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/next-steps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/step-1-checkout-repo",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/step-2-setup-copilotkit",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/step-3-copilot-readable-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/built-in-agent/tutorials/ai-todo-app/step-4-frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/claude-agent-sdk-python/generative-ui/mcp-apps",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/claude-sdk-python/src/agents/mcp_apps_agent.py:28",
@@ -2929,9 +2176,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-crews/generative-ui/mcp-apps",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/crewai-crews/src/app/api/copilotkit-mcp-apps/route.ts:13",
@@ -2941,605 +2186,432 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/advanced/disabling-state-streaming",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/advanced/emit-messages",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/advanced/exit-agent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/contributing/code-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/contributing/code-contributions/package-linking",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/contributing/docs-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/mcp-apps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/state-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/human-in-the-loop/flow",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/multi-agent-flows",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/persistence/loading-agent-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/persistence/loading-message-history",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/persistence/message-persistence",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/shared-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/shared-state/in-app-agent-read",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/shared-state/in-app-agent-write",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/shared-state/predictive-state-updates",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/telemetry",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/crewai-flows/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/a2ui/advanced",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/a2ui/dynamic-schema",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/a2ui/fixed-schema",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/a2ui/styling",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/mcp-apps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/state-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/generative-ui/your-components/interrupt-based",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/human-in-the-loop/interrupt-flow",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/shared-state/in-app-agent-read",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/shared-state/in-app-agent-write",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/shared-state/predictive-state-updates",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/shared-state/state-inputs-outputs",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/deepagents/shared-state/workflow-execution",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/disabling-state-streaming",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/emit-messages",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/exit-agent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/persistence/loading-agent-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/persistence/loading-message-history",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/advanced/persistence/message-persistence",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/agent-app-context",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/auth",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/coagent-troubleshooting/common-coagent-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/coagent-troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/coagent-troubleshooting/migrate-from-v0.2-to-v0.3",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/configurable",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/contributing/code-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/contributing/code-contributions/package-linking",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/contributing/docs-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/deep-agents",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "examples/showcases/deep-agents-job-search/README.md:5",
@@ -3548,24 +2620,17 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/deploy-agentcore",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/ag2/src/app/demos/beautiful-chat/README.md:66",
@@ -3623,24 +2688,17 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui/advanced",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui/dynamic-schema",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui/fixed-schema",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/ag2/src/app/demos/a2ui-fixed-schema/page.tsx:17",
@@ -3665,17 +2723,12 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui/styling",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/mcp-apps",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/ag2/src/app/demos/mcp-apps/page.tsx:18",
@@ -3706,10 +2759,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/langgraph-fastapi/docs-links.json:21"
@@ -3717,10 +2767,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/langgraph-fastapi/docs-links.json:9"
@@ -3728,10 +2775,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/langgraph-fastapi/docs-links.json:17"
@@ -3739,10 +2783,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/your-components/interactive",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/langgraph-fastapi/docs-links.json:13"
@@ -3750,31 +2791,22 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/generative-ui/your-components/interrupt-based",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/human-in-the-loop/interrupt-flow",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/multi-agent-flows",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/langgraph-fastapi/docs-links.json:33"
@@ -3782,10 +2814,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/prebuilt-components",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/langgraph-fastapi/docs-links.json:5"
@@ -3793,59 +2822,42 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/shared-state/in-app-agent-read",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/shared-state/in-app-agent-write",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/langgraph-fastapi/docs-links.json:25"
@@ -3853,10 +2865,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/shared-state/predictive-state-updates",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/langgraph-fastapi/docs-links.json:29",
@@ -3865,836 +2874,597 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/shared-state/state-inputs-outputs",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/shared-state/workflow-execution",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/subgraphs",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/telemetry",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/troubleshooting/migrate-to-agui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/next-steps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-1-checkout-repo",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-2-start-the-agent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-3-setup-copilotkit",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-4-agentic-chat-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-5-human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-6-shared-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-7-generative-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/agent-native-app/step-8-progressive-state-updates",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/next-steps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-1-checkout-repo",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-2-langgraph-agent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-3-setup-copilotkit",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-4-integrate-the-agent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-5-stream-progress",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/tutorials/ai-travel-app/step-6-human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/langgraph/videos/research-canvas",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/contributing/code-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/contributing/code-contributions/package-linking",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/contributing/docs-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/mcp-apps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/state-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/multi-agent-flows",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state/in-app-agent-read",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state/in-app-agent-write",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state/predictive-state-updates",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state/state-inputs-outputs",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/shared-state/workflow-execution",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/telemetry",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/llamaindex/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/agent-app-context",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/contributing/code-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/contributing/code-contributions/package-linking",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/contributing/docs-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/mcp-apps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/state-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/human-in-the-loop/interrupt-flow",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/human-in-the-loop/tool-based",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/shared-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/shared-state/in-app-agent-read",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/shared-state/in-app-agent-write",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/telemetry",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/mastra/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/agent-app-context",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/auth",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/contributing/code-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/contributing/code-contributions/package-linking",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/contributing/docs-contributions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/a2ui",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-dotnet/src/app/demos/declarative-gen-ui/a2ui/catalog.ts:12",
@@ -4704,9 +3474,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/a2ui/fixed-schema",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-dotnet/src/app/demos/a2ui-fixed-schema/page.tsx:17"
@@ -4714,10 +3482,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/mcp-apps",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-python/src/agents/mcp_apps_agent.py:13",
@@ -4727,401 +3492,287 @@
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/state-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/shared-state/in-app-agent-read",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/shared-state/in-app-agent-write",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/shared-state/predictive-state-updates",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/telemetry",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/microsoft-agent-framework/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/ag-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/coding-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/copilot-runtime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/custom-look-and-feel/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/custom-look-and-feel/slots",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/frontend-tools",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/a2ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/mcp-apps",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/state-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/tool-rendering",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/your-components/display-only",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/generative-ui/your-components/interactive",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/human-in-the-loop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/human-in-the-loop/agent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/human-in-the-loop/index",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/multi-agent-flows",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/prebuilt-components",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/quickstart",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/quickstart/pydantic-ai",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/shared-state",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/shared-state/in-app-agent-read",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/shared-state/in-app-agent-write",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/shared-state/predictive-state-updates",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/troubleshooting/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/troubleshooting/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/integrations/pydantic-ai/troubleshooting/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shell-docs/src/content/ag-ui/introduction.mdx:504"
@@ -5130,9 +3781,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/advanced/exit-agent",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "docs/content/docs/integrations/langgraph/multi-agent-flows.mdx:43",
@@ -5142,9 +3791,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/agent-app-context",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:125"
@@ -5153,9 +3800,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/auth",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:133"
@@ -5164,9 +3809,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/custom-look-and-feel",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:29"
@@ -5175,9 +3818,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/custom-look-and-feel/css",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "dev-docs/langgraph-python-column-wave1-bugs.md:81"
@@ -5186,9 +3827,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/custom-look-and-feel/headless-ui",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:33",
@@ -5198,9 +3837,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/custom-look-and-feel/slots",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:25"
@@ -5209,9 +3846,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/frontend-tools",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:49",
@@ -5222,9 +3857,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/generative-ui/a2ui/dynamic-schema",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:77"
@@ -5233,9 +3866,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/generative-ui/a2ui/fixed-schema",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:81"
@@ -5244,9 +3875,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/generative-ui/mcp-apps",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:85"
@@ -5255,9 +3884,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:97",
@@ -5267,9 +3894,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:101",
@@ -5282,9 +3907,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:57",
@@ -5294,9 +3917,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/generative-ui/your-components/interactive",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:61",
@@ -5306,9 +3927,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/generative-ui/your-components/interrupt-based",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:69"
@@ -5317,9 +3936,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/human-in-the-loop/interrupt-flow",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:73"
@@ -5328,9 +3945,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/multi-agent-flows",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:129",
@@ -5340,9 +3955,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/prebuilt-components",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "dev-docs/langgraph-python-column-wave1-bugs.md:37",
@@ -5356,9 +3969,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/quickstart",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "README.md:95",
@@ -5368,20 +3979,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/quickstart?theme=dark",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "docs/POSTHOG_BROKEN_LINKS.md:12"
-      ],
+      "monorepo_locations": ["docs/POSTHOG_BROKEN_LINKS.md:12"],
       "redirect_destination": "/docs/integrations/langgraph/quickstart"
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/shared-state/in-app-agent-write",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:117",
@@ -5391,9 +3996,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/langgraph/shared-state/predictive-state-updates",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/langgraph-python/docs-links.json:121",
@@ -5403,78 +4006,56 @@
     },
     {
       "url": "https://docs.copilotkit.ai/learn",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/a2a-protocol",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/a2a-protocol"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/ag-ui-protocol",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/ag-ui-protocol"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/agentic-protocols",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/agentic-protocols"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/architecture",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/architecture"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/connect-mcp-servers",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/connect-mcp-servers"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/generative-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/generative-ui"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/generative-ui/specs",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/showcases/generative-ui/README.md:115"
-      ],
+      "monorepo_locations": ["examples/showcases/generative-ui/README.md:115"],
       "redirect_destination": "/docs/learn/generative-ui/specs"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/generative-ui/specs/a2ui",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/showcases/generative-ui/README.md:211",
@@ -5484,22 +4065,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/learn/generative-ui/specs/mcp-apps",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "examples/showcases/generative-ui/README.md:249"
-      ],
+      "monorepo_locations": ["examples/showcases/generative-ui/README.md:249"],
       "redirect_destination": "/docs/learn/generative-ui/specs/mcp-apps"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/generative-ui/specs/open-json-ui",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/showcases/generative-ui/README.md:130",
@@ -5510,89 +4083,67 @@
     },
     {
       "url": "https://docs.copilotkit.ai/learn/intelligence-platform",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/intelligence-platform"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/threads"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/tutorials/multi-conversation-chat",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/tutorials/multi-conversation-chat"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/whats-new",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/whats-new"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/whats-new/a2a-mcp-handshake",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/whats-new/a2a-mcp-handshake"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/whats-new/a2ui-launch",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/whats-new/a2ui-launch"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/whats-new/generative-ui-spec-support",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/whats-new/generative-ui-spec-support"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/whats-new/langgraph-deep-agents",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/whats-new/langgraph-deep-agents"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/whats-new/mcp-apps-support",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/whats-new/mcp-apps-support"
     },
     {
       "url": "https://docs.copilotkit.ai/learn/whats-new/v1-50",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/learn/whats-new/v1-50"
     },
     {
       "url": "https://docs.copilotkit.ai/llamaindex/",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shell-docs/src/content/ag-ui/introduction.mdx:518"
@@ -5601,9 +4152,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/llamaindex/custom-look-and-feel/customize-built-in-ui-components",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/canvas/llamaindex-composio/README.md:509"
@@ -5612,9 +4161,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/llamaindex/frontend-tools",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/llamaindex/docs-links.json:5"
@@ -5623,9 +4170,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/llamaindex/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/llamaindex/docs-links.json:21"
@@ -5634,9 +4179,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/llamaindex/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/llamaindex/docs-links.json:13"
@@ -5645,9 +4188,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/llamaindex/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/llamaindex/docs-links.json:17"
@@ -5656,9 +4197,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/llamaindex/human-in-the-loop",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/llamaindex/docs-links.json:9"
@@ -5667,9 +4206,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/llamaindex/multi-agent-flows",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/llamaindex/docs-links.json:33"
@@ -5678,9 +4215,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/llamaindex/shared-state/in-app-agent-write",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/llamaindex/docs-links.json:25"
@@ -5689,9 +4224,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/llamaindex/shared-state/predictive-state-updates",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/llamaindex/docs-links.json:29"
@@ -5700,19 +4233,13 @@
     },
     {
       "url": "https://docs.copilotkit.ai/llms.txt",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
-      "monorepo_locations": [
-        "examples/showcases/generative-ui/README.md:305"
-      ]
+      "monorepo_locations": ["examples/showcases/generative-ui/README.md:305"]
     },
     {
       "url": "https://docs.copilotkit.ai/mastra",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/mastra/docs-links.json:33",
@@ -5722,9 +4249,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shell-docs/src/content/ag-ui/introduction.mdx:515"
@@ -5733,9 +4258,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/frontend-actions",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/mastra/src/app/page.tsx:14"
@@ -5744,20 +4267,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/mastra/docs-links.json:21"
-      ],
+      "monorepo_locations": ["showcase/integrations/mastra/docs-links.json:21"],
       "redirect_destination": "/docs/integrations/mastra/generative-ui/state-rendering"
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/generative-ui/tool-based",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/mastra/src/app/page.tsx:87"
@@ -5766,31 +4283,21 @@
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/mastra/docs-links.json:13"
-      ],
+      "monorepo_locations": ["showcase/integrations/mastra/docs-links.json:13"],
       "redirect_destination": "/docs/integrations/mastra/generative-ui/tool-rendering"
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/mastra/docs-links.json:17"
-      ],
+      "monorepo_locations": ["showcase/integrations/mastra/docs-links.json:17"],
       "redirect_destination": "/docs/integrations/mastra/generative-ui/your-components/display-only"
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/human-in-the-loop",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/mastra/src/app/page.tsx:101"
@@ -5799,31 +4306,21 @@
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/human-in-the-loop/tool-based",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/mastra/docs-links.json:9"
-      ],
+      "monorepo_locations": ["showcase/integrations/mastra/docs-links.json:9"],
       "redirect_destination": "/docs/integrations/mastra/human-in-the-loop/tool-based"
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/shared-state",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/mastra/docs-links.json:25"
-      ],
+      "monorepo_locations": ["showcase/integrations/mastra/docs-links.json:25"],
       "redirect_destination": "/docs/integrations/mastra/shared-state"
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/shared-state/in-app-agent-read",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/mastra/src/app/page.tsx:77"
@@ -5832,20 +4329,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/mastra/shared-state/in-app-agent-write",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/integrations/mastra/docs-links.json:29"
-      ],
+      "monorepo_locations": ["showcase/integrations/mastra/docs-links.json:29"],
       "redirect_destination": "/docs/integrations/mastra/shared-state/in-app-agent-write"
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-dotnet/docs-links.json:33",
@@ -5856,9 +4347,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/auth",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-dotnet/docs-links.json:37",
@@ -5868,9 +4357,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/frontend-actions",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx:19",
@@ -5880,9 +4367,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/ms-agent-framework-python/src/app/page.tsx:87"
@@ -5891,9 +4376,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-dotnet/docs-links.json:21",
@@ -5903,9 +4386,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-dotnet/docs-links.json:13",
@@ -5915,9 +4396,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-dotnet/docs-links.json:17",
@@ -5927,9 +4406,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/human-in-the-loop",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/ms-agent-framework-python/src/app/page.tsx:101",
@@ -5940,9 +4417,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/human-in-the-loop/frontend-tool-based",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx:107"
@@ -5951,9 +4426,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/quickstart",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-dotnet/docs-links.json:5",
@@ -5963,9 +4436,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/shared-state",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/ms-agent-framework-python/src/app/page.tsx:77"
@@ -5974,9 +4445,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/shared-state/in-app-agent-write",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-dotnet/docs-links.json:25",
@@ -5986,9 +4455,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/microsoft-agent-framework/shared-state/predictive-state-updates",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/ms-agent-dotnet/docs-links.json:29",
@@ -5998,10 +4465,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/migration-guides/migrate-attachments",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "packages/react-ui/src/components/chat/AttachmentQueue.tsx:122",
@@ -6019,30 +4483,22 @@
     },
     {
       "url": "https://docs.copilotkit.ai/migration-guides/migrate-to-1.10.X",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/migration-guides/migrate-to-1.8.2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/migration-guides/migrate-to-v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/migration/render-message",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "packages/react-ui/src/components/chat/Messages.tsx:58"
@@ -6050,21 +4506,13 @@
     },
     {
       "url": "https://docs.copilotkit.ai/multimodal-attachments",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
-      "monorepo_locations": [
-        "showcase/shared/feature-registry.json:359"
-      ]
+      "monorepo_locations": ["showcase/shared/feature-registry.json:359"]
     },
     {
       "url": "https://docs.copilotkit.ai/prebuilt-components",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shared/feature-registry.json:82",
@@ -6074,20 +4522,14 @@
     },
     {
       "url": "https://docs.copilotkit.ai/premium",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "packages/shared/src/utils/console-styling.ts:64"
-      ],
+      "monorepo_locations": ["packages/shared/src/utils/console-styling.ts:64"],
       "redirect_destination": "/docs/premium"
     },
     {
       "url": "https://docs.copilotkit.ai/premium#how-do-i-get-access-to-premium-features",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "packages/react-core/src/components/usage-banner.tsx:226"
@@ -6096,48 +4538,36 @@
     },
     {
       "url": "https://docs.copilotkit.ai/premium/headless-ui",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/premium/headless-ui"
     },
     {
       "url": "https://docs.copilotkit.ai/premium/observability",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/premium/observability"
     },
     {
       "url": "https://docs.copilotkit.ai/premium/overview",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/premium/overview"
     },
     {
       "url": "https://docs.copilotkit.ai/premium/self-hosting",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/premium/self-hosting"
     },
     {
       "url": "https://docs.copilotkit.ai/programmatic-control",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/shell-docs/src/content/ag-ui/introduction.mdx:516"
@@ -6146,9 +4576,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/frontend-actions",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/pydantic-ai/src/app/page.tsx:20"
@@ -6157,9 +4585,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx:94",
@@ -6169,9 +4595,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui/state-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/pydantic-ai/docs-links.json:21"
@@ -6180,9 +4604,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui/tool-rendering",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/pydantic-ai/docs-links.json:13"
@@ -6191,9 +4613,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui/your-components/display-only",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/pydantic-ai/docs-links.json:17"
@@ -6202,9 +4622,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui/your-components/interactive",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/pydantic-ai/docs-links.json:9"
@@ -6213,9 +4631,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/human-in-the-loop",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/pydantic-ai/src/app/page.tsx:106"
@@ -6224,9 +4640,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/multi-agent-flows",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/pydantic-ai/docs-links.json:33"
@@ -6235,9 +4649,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/prebuilt-components",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/pydantic-ai/docs-links.json:5"
@@ -6246,9 +4658,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/shared-state",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx:84",
@@ -6258,9 +4668,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/shared-state/in-app-agent-write",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/pydantic-ai/docs-links.json:25"
@@ -6269,9 +4677,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/pydantic-ai/shared-state/predictive-state-updates",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "showcase/integrations/pydantic-ai/docs-links.json:29"
@@ -6280,32 +4686,21 @@
     },
     {
       "url": "https://docs.copilotkit.ai/quickstart",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "showcase/shared/feature-registry.json:56"
-      ],
+      "monorepo_locations": ["showcase/shared/feature-registry.json:56"],
       "redirect_destination": "/docs/quickstart"
     },
     {
       "url": "https://docs.copilotkit.ai/quickstart#get-a-copilot-cloud-public-api-key",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
-      "monorepo_locations": [
-        "packages/runtime/src/lib/observability.ts:52"
-      ],
+      "monorepo_locations": ["packages/runtime/src/lib/observability.ts:52"],
       "redirect_destination": "/docs/quickstart"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/hooks/useCoAgent",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "examples/showcases/strands-file-analyzer/README.md:357"
@@ -6313,178 +4708,133 @@
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/classes/CopilotRuntime",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/classes/CopilotTask",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/AnthropicAdapter",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/GoogleGenerativeAIAdapter",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/GroqAdapter",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/LangChainAdapter",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/OpenAIAdapter",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/classes/llm-adapters/OpenAIAssistantAdapter",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/components/CopilotKit",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/components/CopilotTextarea",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/components/chat",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/components/chat/CopilotChat",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/components/chat/CopilotPopup",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/components/chat/CopilotSidebar",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useAgent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCoAgent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCoAgentStateRender",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotAction",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotAdditionalInstructions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotChat",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotChatHeadless_c",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "docs/content/docs/reference/v1/hooks/useCopilotChat.mdx:23",
@@ -6494,34 +4844,25 @@
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotChatSuggestions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useCopilotReadable",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useDefaultTool",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useFrontendTool",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "docs/content/docs/integrations/built-in-agent/tutorials/ai-todo-app/step-4-frontend-tools.mdx:79",
@@ -6531,290 +4872,217 @@
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useHumanInTheLoop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useLangGraphInterrupt",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/hooks/useRenderToolCall",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/sdk/js/LangGraph",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/sdk/python/CrewAI",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/sdk/python/CrewAIAgent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/sdk/python/LangGraph",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/sdk/python/LangGraphAgent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v1/sdk/python/RemoteEndpoints",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChat",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/components/CopilotChat"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChatAssistantMessage",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/components/CopilotChatAssistantMessage"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChatInput",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/components/CopilotChatInput"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChatMessageView",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/components/CopilotChatMessageView"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChatUserMessage",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/components/CopilotChatUserMessage"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotChatView",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/components/CopilotChatView"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotKit",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/components/CopilotKit"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotPopup",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/components/CopilotPopup"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/components/CopilotSidebar",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/components/CopilotSidebar"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useAgent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useAgent"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useAgentContext",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useAgentContext"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useCapabilities",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useCapabilities"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useComponent",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useComponent"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useConfigureSuggestions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useConfigureSuggestions"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useCopilotChatConfiguration",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useCopilotChatConfiguration"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useCopilotKit",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useCopilotKit"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useDefaultRenderTool",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useDefaultRenderTool"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useFrontendTool",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useFrontendTool"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useHumanInTheLoop",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useHumanInTheLoop"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useInterrupt",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useInterrupt"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useRenderTool",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useRenderTool"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useRenderToolCall",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useRenderToolCall"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useSuggestions",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useSuggestions"
     },
     {
       "url": "https://docs.copilotkit.ai/reference/v2/hooks/useThreads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/reference/hooks/useThreads"
     },
     {
       "url": "https://docs.copilotkit.ai/runtime-server-adapter",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/backend/copilot-runtime"
     },
     {
       "url": "https://docs.copilotkit.ai/shared-state",
-      "sources": [
-        "monorepo_grep",
-        "sitemap"
-      ],
+      "sources": ["monorepo_grep", "sitemap"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "showcase/integrations/agno/docs-links.json:25",
@@ -6833,9 +5101,7 @@
     },
     {
       "url": "https://docs.copilotkit.ai/strands/generative-ui/backend-tools",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
       "monorepo_locations": [
         "examples/integrations/strands-python/src/app/page.tsx:106",
@@ -6844,72 +5110,54 @@
     },
     {
       "url": "https://docs.copilotkit.ai/telemetry",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/telemetry"
     },
     {
       "url": "https://docs.copilotkit.ai/threads",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/troubleshooting/common-issues",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/troubleshooting/common-issues"
     },
     {
       "url": "https://docs.copilotkit.ai/troubleshooting/debug-mode",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/troubleshooting/debug-mode"
     },
     {
       "url": "https://docs.copilotkit.ai/troubleshooting/error-debugging",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/troubleshooting/error-debugging"
     },
     {
       "url": "https://docs.copilotkit.ai/troubleshooting/event-inspector",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/troubleshooting/event-inspector"
     },
     {
       "url": "https://docs.copilotkit.ai/troubleshooting/hook-explorer",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/troubleshooting/hook-explorer"
     },
     {
       "url": "https://docs.copilotkit.ai/troubleshooting/observability-connectors",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": true,
       "redirect_destination": "/docs/troubleshooting/observability-connectors"
     },
     {
       "url": "https://docs.copilotkit.ai/vibe-coding-mcp",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": true,
       "monorepo_locations": [
         "examples/canvas/llamaindex-composio/README.md:49"
@@ -6918,30 +5166,20 @@
     },
     {
       "url": "https://docs.copilotkit.ai/vs-code-extension",
-      "sources": [
-        "sitemap"
-      ],
+      "sources": ["sitemap"],
       "covered_by_seo_redirects": false
     },
     {
       "url": "https://docs.copilotkit.ai/what-is-copilotkit",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
-      "monorepo_locations": [
-        "community/content/CONTRIBUTING.md:43"
-      ]
+      "monorepo_locations": ["community/content/CONTRIBUTING.md:43"]
     },
     {
       "url": "https://docs.copilotkit.ai/whats-new",
-      "sources": [
-        "monorepo_grep"
-      ],
+      "sources": ["monorepo_grep"],
       "covered_by_seo_redirects": false,
-      "monorepo_locations": [
-        "README.md:166"
-      ]
+      "monorepo_locations": ["README.md:166"]
     }
   ],
   "summary": {
@@ -6982,16 +5220,12 @@
     "top_uncovered": [
       {
         "url": "https://docs.copilotkit.ai/",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/?ref=github_readme",
-        "sources": [
-          "monorepo_grep"
-        ],
+        "sources": ["monorepo_grep"],
         "covered_by_seo_redirects": false,
         "monorepo_locations": [
           "README.md:171",
@@ -7001,16 +5235,12 @@
       },
       {
         "url": "https://docs.copilotkit.ai/ag-ui-middleware",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/built-in-agent/quickstart",
-        "sources": [
-          "monorepo_grep"
-        ],
+        "sources": ["monorepo_grep"],
         "covered_by_seo_redirects": false,
         "monorepo_locations": [
           "showcase/integrations/built-in-agent/docs-links.json:4"
@@ -7018,9 +5248,7 @@
       },
       {
         "url": "https://docs.copilotkit.ai/built-in-agent/shared-state",
-        "sources": [
-          "monorepo_grep"
-        ],
+        "sources": ["monorepo_grep"],
         "covered_by_seo_redirects": false,
         "monorepo_locations": [
           "showcase/integrations/built-in-agent/docs-links.json:8"
@@ -7028,23 +5256,17 @@
       },
       {
         "url": "https://docs.copilotkit.ai/deploy/agentcore",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/examples",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/features/",
-        "sources": [
-          "monorepo_grep"
-        ],
+        "sources": ["monorepo_grep"],
         "covered_by_seo_redirects": false,
         "monorepo_locations": [
           "dev-docs/langgraph-python-column-wave1-bugs.md:53"
@@ -7052,9 +5274,7 @@
       },
       {
         "url": "https://docs.copilotkit.ai/getting-started/quickstart-chatbot",
-        "sources": [
-          "monorepo_grep"
-        ],
+        "sources": ["monorepo_grep"],
         "covered_by_seo_redirects": false,
         "monorepo_locations": [
           "examples/showcases/presentation/README.md:49",
@@ -7063,114 +5283,82 @@
       },
       {
         "url": "https://docs.copilotkit.ai/inspector",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/a2a",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/a2a/ag-ui",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/a2a/coding-agents",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/a2a/copilot-runtime",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/a2a/custom-look-and-feel/headless-ui",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/a2a/custom-look-and-feel/slots",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/a2a/generative-ui/declarative-a2ui",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/a2a/prebuilt-components",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/a2a/programmatic-control",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/a2a/quickstart",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/adk",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/adk/ag-ui",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/adk/coding-agents",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       },
       {
         "url": "https://docs.copilotkit.ai/integrations/adk/copilot-runtime",
-        "sources": [
-          "sitemap"
-        ],
+        "sources": ["sitemap"],
         "covered_by_seo_redirects": false
       }
     ]


### PR DESCRIPTION
## Summary
- Adds `redirect-inventory.json` — Phase 1 of the docs cutover. Combines URLs from 3 sources (sitemap.xml, wget orphan crawl, monorepo grep) into a single file with per-URL coverage status against `showcase/shell/src/lib/seo-redirects.ts`. GSC export deferred pending credentials.
- 813 unique URLs inventoried; 33.8% covered by current `seo-redirects.ts`, 66.2% uncovered.
- Dominant uncovered bucket: `/integrations/*` (513 URLs) — the primary Phase 2 retargeting work.
- Surfaced two real bugs in current `seo-redirects.ts` (separately tracked): R15 + R17 use `/builtin-agent` (no hyphen) but real legacy URLs use `/built-in-agent` (with hyphen) — both rules fire on nothing today.

## Test plan
- [ ] `jq '.summary' redirect-inventory.json` — confirm summary stats match the headline numbers above (total_urls=813, covered=275, uncovered=538).
- [ ] Spot-check 5 entries: pick 3 with `covered_by_seo_redirects: true` and confirm a matching rule exists in `seo-redirects.ts`; pick 3 with `covered_by_seo_redirects: false` and confirm no rule.
- [ ] Confirm `sources_failed[0]` documents the wget Next.js-SPA failure (not a blocker; sitemap is canonical).

## Notes
- This is an analysis artifact, not production code. It feeds Phase 2 (retargeting destinations in `seo-redirects.ts`).
- wget couldn't crawl docs.copilotkit.ai (Next.js SPA — JS-hydrated nav, no anchor hrefs). Sitemap supersedes for orphan-detection. If Phase 2 needs deeper orphan coverage, fallback path is Playwright DOM scrape or `__next_data` extraction.