### PR TITLE
fix(shell-docs): pre-cutover cleanup — programmatic-control fallback, /migrate redirect, MCP sync exclusion

### DIFF
--- a/showcase/scripts/sync-docs-from-main.ts
+++ b/showcase/scripts/sync-docs-from-main.ts
@@ -65,6 +65,13 @@ const LANGCHAIN_EXCLUSIONS = [
  * redirect). The root path stays excluded so future syncs don't restore
  * the duplicate.
  *
+ * The shared `mcp-server-setup.mdx` snippet is also excluded
+ * (PDX-117 — https://linear.app/copilotkit/issue/PDX-117). Shell-docs
+ * ships an enhanced version with HTTP/SSE transport Tabs, the
+ * `mcp-remote` bridge, and a Tadata Callout; upstream still carries
+ * the older single-`url` JSON shape, so syncing would regress the
+ * shell-docs experience.
+ *
  * Upstream keeps all of these copies — removing them there means touching
  * every parallel framework tree, which is upstream-IA work outside this
  * branch's scope. The exclusion is the durable shell-docs-only fix.
@@ -75,6 +82,7 @@ const PATH_EXCLUSIONS: RegExp[] = [
   /^docs\/content\/docs\/integrations\/[^/]+\/premium\/self-hosting\.mdx$/,
   /^docs\/content\/docs\/learn\//,
   /^docs\/content\/docs\/\(root\)\/ag-ui-middleware\.mdx$/,
+  /^docs\/snippets\/shared\/guides\/mcp-server-setup\.mdx$/,
   // PR #4494 dropped these stale workflow-execution / state-inputs-outputs
   // duplicates from shell-docs. Each shared-state meta.json wires only one
   // of the two files; the other was an orphan. Block the sync from

--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -370,7 +370,7 @@ const nextConfig: NextConfig = {
       // point.
       {
         source: "/migrate/1.10.X",
-        destination: "/migrate",
+        destination: "/migrate/v2",
         permanent: false,
       },
 

--- a/showcase/shell-docs/src/content/docs/programmatic-control.mdx
+++ b/showcase/shell-docs/src/content/docs/programmatic-control.mdx
@@ -99,6 +99,23 @@ UI.
 
 </WhenFrameworkHas>
 
+<WhenFrameworkHas flag="interrupt_pattern" absent>
+
+## Resolving a pause from a button
+
+> **Interrupt-style pause/resume isn't available on this framework.**
+> The headless interrupt pattern shown above requires the underlying
+> runtime to expose either a native `interrupt(...)` primitive
+> (LangGraph) or a Promise-resolving frontend-tool path (Microsoft
+> Agent Framework). For all other integrations, drive pauses through
+> [`useHumanInTheLoop`](./human-in-the-loop) instead — it's the
+> standard hook for tool-call-based pause/resume flows and works on
+> every framework that supports tool calls. The `agent.addMessage`,
+> `copilotkit.runAgent`, and `agent.subscribe` primitives above still
+> apply — only the interrupt-resolution path is framework-specific.
+
+</WhenFrameworkHas>
+
 ## See also
 
 - [Headless UI](./headless) — the full `useRenderedMessages` composition


### PR DESCRIPTION
## Summary

Three small pre-cutover cleanup fixes batched into one PR (consolidation of the prior #4680, #4681, #4682 — same content, fewer review queues).

- `b3ec38720` — Add `<WhenFrameworkHas absent>` fallback to `programmatic-control.mdx` for the 7 frameworks without `interrupt_pattern` (ag2, agno, built-in-agent, crewai-crews, google-adk, mastra, spring-ai), mirroring the canonical pattern from PR #4496.
- `c080ca062` — Retarget `/migrate/1.10.X` redirect destination from `/migrate` (which 404s) to `/migrate/v2`. `permanent: false` preserved.
- `e61e8c36d` — Add `mcp-server-setup.mdx` exclusion to docs sync script. Shell-docs version is intentionally ahead of upstream (HTTP/SSE Tabs + `mcp-remote` + Tadata callout); without exclusion the next sync would clobber it.

Supersedes #4680, #4681, #4682.

## Test plan

- [ ] `nx run shell-docs:dev` and visit `/programmatic-control` while switching the framework selector to non-native fws — verify fallback callout renders and links to `/human-in-the-loop`.
- [ ] Visit `/migrate/1.10.X` — should redirect to `/migrate/v2` and render the V2 migration page.
- [ ] Inspect `showcase/scripts/sync-docs-from-main.ts` PATH_EXCLUSIONS for the `mcp-server-setup` regex.