### PR TITLE
docs(shell-docs): cutover content batch (quickstart CLI two-choice, AG-UI tab removal, BIA voice region)

### DIFF
--- a/showcase/integrations/built-in-agent/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/voice/sample-audio-button.tsx
@@ -18,6 +18,7 @@ export interface SampleAudioButtonProps {
   sampleText: string;
 }
 
+// @region[sample-audio-button]
 export function SampleAudioButton({
   onTranscribed,
   sampleText,
@@ -39,3 +40,4 @@ export function SampleAudioButton({
     </div>
   );
 }
+// @endregion[sample-audio-button]

--- a/showcase/shell-docs/src/components/brand-nav.tsx
+++ b/showcase/shell-docs/src/components/brand-nav.tsx
@@ -234,23 +234,6 @@ export function BrandNav(_props: BrandNavProps = {}) {
               />
             )}
           </Link>
-          <span className="mx-2 text-[var(--border)] select-none">|</span>
-          <Link
-            href="/ag-ui"
-            className="relative flex items-center gap-1.5 px-1 pb-1 text-sm font-bold tracking-tight transition-colors"
-            style={{
-              color: active === "ag-ui" ? "var(--accent)" : "var(--text-faint)",
-            }}
-          >
-            <AgUiIcon />
-            AG-UI
-            {active === "ag-ui" && (
-              <span
-                className="absolute bottom-0 left-0 right-0 h-[2px] rounded-full"
-                style={{ background: "var(--accent)" }}
-              />
-            )}
-          </Link>
         </div>
 
         {/* Context-dependent nav links (desktop) */}

--- a/showcase/shell-docs/src/components/brand-nav.tsx
+++ b/showcase/shell-docs/src/components/brand-nav.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { SearchTrigger } from "./search-trigger";
 
@@ -133,38 +132,6 @@ const CLOUD_CTA = {
   href: "https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar",
 };
 
-function AgUiIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 57 66"
-      width="14"
-      height="16"
-      className={className}
-      aria-hidden="true"
-    >
-      <g
-        transform="translate(2, -2)"
-        stroke="currentColor"
-        strokeWidth="3.3125"
-        fill="none"
-      >
-        <g transform="translate(0, 4)">
-          <path
-            d="M0,25.9335975 L16.5448881,6.52325783e-15 C40.848296,5.37332138 53,8.05998207 53,8.05998207 L43.1229639,62 L0,25.9335975 Z"
-            strokeLinejoin="round"
-          />
-          <line x1="16.5828221" y1="-1.07552856e-15" x2="43.2453988" y2="62" />
-          <line x1="0" y1="25.9335975" x2="53" y2="8.48421053" />
-        </g>
-      </g>
-    </svg>
-  );
-}
-
-type Brand = "copilotkit" | "ag-ui";
-
-const AG_UI_PREFIXES = ["/ag-ui"];
-
 const SHELL_HOST = process.env.NEXT_PUBLIC_SHELL_URL ?? "http://localhost:3000";
 
 const COPILOTKIT_LINKS = [
@@ -172,20 +139,6 @@ const COPILOTKIT_LINKS = [
   { href: `${SHELL_HOST}/integrations`, label: "Integrations" },
   { href: "/reference", label: "Reference" },
 ];
-
-const AG_UI_LINKS = [
-  { href: "/ag-ui", label: "Overview" },
-  { href: "/ag-ui/concepts/architecture", label: "Concepts" },
-  { href: "/ag-ui/quickstart/introduction", label: "Quick Start" },
-  { href: "/ag-ui/sdk/js/core/overview", label: "JS SDK" },
-  { href: "/ag-ui/sdk/python/core/overview", label: "Python SDK" },
-];
-
-function activeBrandFromPath(pathname: string): Brand {
-  return AG_UI_PREFIXES.some((p) => pathname.startsWith(p))
-    ? "ag-ui"
-    : "copilotkit";
-}
 
 export interface BrandNavProps {
   // Note: the framework selector previously lived in the top bar. It's
@@ -197,9 +150,7 @@ export interface BrandNavProps {
 }
 
 export function BrandNav(_props: BrandNavProps = {}) {
-  const pathname = usePathname();
-  const active = activeBrandFromPath(pathname);
-  const links = active === "copilotkit" ? COPILOTKIT_LINKS : AG_UI_LINKS;
+  const links = COPILOTKIT_LINKS;
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const posthog = usePostHog();
 
@@ -220,19 +171,14 @@ export function BrandNav(_props: BrandNavProps = {}) {
           <Link
             href="/"
             className="relative flex items-center gap-1.5 px-1 pb-1 text-sm font-bold tracking-tight transition-colors"
-            style={{
-              color:
-                active === "copilotkit" ? "var(--accent)" : "var(--text-faint)",
-            }}
+            style={{ color: "var(--accent)" }}
           >
             <CopilotKitIcon />
             CopilotKit
-            {active === "copilotkit" && (
-              <span
-                className="absolute bottom-0 left-0 right-0 h-[2px] rounded-full"
-                style={{ background: "var(--accent)" }}
-              />
-            )}
+            <span
+              className="absolute bottom-0 left-0 right-0 h-[2px] rounded-full"
+              style={{ background: "var(--accent)" }}
+            />
           </Link>
         </div>
 
@@ -375,17 +321,6 @@ export function BrandNav(_props: BrandNavProps = {}) {
               >
                 Talk to Our Engineers
               </button>
-            </div>
-            {/* AG-UI link at bottom */}
-            <div className="mt-auto px-4 py-4 border-t border-[var(--border)]">
-              <Link
-                href="/ag-ui"
-                onClick={() => setMobileMenuOpen(false)}
-                className="flex items-center gap-2 rounded-md px-3 py-2.5 text-[13px] font-medium text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] transition-all"
-              >
-                <AgUiIcon />
-                AG-UI
-              </Link>
             </div>
           </div>
           <style jsx global>{`

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -48,8 +48,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f adk
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard ADK setup.
+                - **Framework** — pick **ADK** when prompted.
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -48,14 +48,10 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create
+                npx copilotkit@latest create --framework adk
                 ```
 
-                The CLI walks you through:
-
-                - **Project name**
-                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard ADK setup.
-                - **Framework** — pick **ADK** when prompted.
+                The CLI prompts for a project name, then scaffolds the ADK starter pre-wired for CopilotKit.
             </Step>
             <Step>
                 ### Install dependencies
@@ -218,7 +214,7 @@ Before you begin, you'll need the following:
                 ### Install CopilotKit packages
 
                 ```npm
-                npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/client
+                npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/client
                 ```
             </Step>
             <Step>
@@ -260,8 +256,8 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
-                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
-                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+                import "@copilotkit/react-core/styles.css"; // [!code highlight]
                 import './globals.css';
 
                 // ...
@@ -286,7 +282,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
-              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
+              import { CopilotSidebar } from "@copilotkit/react-core"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -48,10 +48,20 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create --framework adk
+                npx copilotkit@latest create
                 ```
 
-                The CLI prompts for a project name, then scaffolds the ADK starter pre-wired for CopilotKit.
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard ADK setup.
+                - **Framework** — pick **ADK** when prompted.
+
+                Or skip the prompts and pin a framework directly:
+
+                ```bash
+                npx copilotkit@latest create --framework adk
+                ```
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -48,8 +48,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f agno
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Agno setup.
+                - **Framework** — pick **Agno** when prompted.
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -48,10 +48,20 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create --framework agno
+                npx copilotkit@latest create
                 ```
 
-                The CLI prompts for a project name, then scaffolds the Agno starter pre-wired for CopilotKit.
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Agno setup.
+                - **Framework** — pick **Agno** when prompted.
+
+                Or skip the prompts and pin a framework directly:
+
+                ```bash
+                npx copilotkit@latest create --framework agno
+                ```
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -48,14 +48,10 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create
+                npx copilotkit@latest create --framework agno
                 ```
 
-                The CLI walks you through:
-
-                - **Project name**
-                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Agno setup.
-                - **Framework** — pick **Agno** when prompted.
+                The CLI prompts for a project name, then scaffolds the Agno starter pre-wired for CopilotKit.
             </Step>
             <Step>
                 ### Install dependencies
@@ -185,7 +181,7 @@ Before you begin, you'll need the following:
                 ### Install CopilotKit packages
 
                 ```npm
-                npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/agno
+                npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/agno
                 ```
             </Step>
             <Step>
@@ -227,8 +223,8 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
-                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
-                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+                import "@copilotkit/react-core/styles.css"; // [!code highlight]
                 import './globals.css';
 
                 // ...
@@ -253,7 +249,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
-              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
+              import { CopilotSidebar } from "@copilotkit/react-core"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -48,10 +48,20 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create --framework aws-strands-py
+                npx copilotkit@latest create
                 ```
 
-                The CLI prompts for a project name, then scaffolds the AWS Strands starter pre-wired for CopilotKit.
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard AWS Strands setup.
+                - **Framework** — pick **AWS Strands (Python)** when prompted.
+
+                Or skip the prompts and pin a framework directly:
+
+                ```bash
+                npx copilotkit@latest create --framework aws-strands-py
+                ```
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -48,8 +48,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f aws-strands-py
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard AWS Strands setup.
+                - **Framework** — pick **AWS Strands (Python)** when prompted.
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -48,14 +48,10 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create
+                npx copilotkit@latest create --framework aws-strands-py
                 ```
 
-                The CLI walks you through:
-
-                - **Project name**
-                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard AWS Strands setup.
-                - **Framework** — pick **AWS Strands (Python)** when prompted.
+                The CLI prompts for a project name, then scaffolds the AWS Strands starter pre-wired for CopilotKit.
             </Step>
             <Step>
                 ### Install dependencies
@@ -199,7 +195,7 @@ Before you begin, you'll need the following:
                 ### Install CopilotKit packages
 
                 ```npm
-                npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/client
+                npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/client
                 ```
             </Step>
             <Step>
@@ -241,8 +237,8 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
-                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
-                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+                import "@copilotkit/react-core/styles.css"; // [!code highlight]
                 import './globals.css';
 
                 // ...
@@ -267,7 +263,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
-              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
+              import { CopilotSidebar } from "@copilotkit/react-core"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -48,18 +48,24 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                # Python (default)
+                npx copilotkit@latest create
+                ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard LangGraph setup.
+                - **Framework** — pick **LangGraph (Python)** or **LangGraph (JavaScript)** when prompted.
+
+                Or skip the prompts and pin a framework directly:
+
+                ```bash
+                # Python
                 npx copilotkit@latest create --framework langgraph-py
 
                 # JavaScript
                 npx copilotkit@latest create --framework langgraph-js
                 ```
-
-                The CLI prompts for a project name, then scaffolds the LangGraph starter pre-wired for CopilotKit.
-
-                <Callout type="info" title="Want persistent threads, observability, and the inspector?">
-                  Run `npx copilotkit@latest create --intelligence` instead to scaffold a LangGraph-Python project pre-wired for the [Enterprise Intelligence Platform](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt). Threads support for other frameworks is coming soon.
-                </Callout>
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -48,14 +48,18 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create
+                # Python (default)
+                npx copilotkit@latest create --framework langgraph-py
+
+                # JavaScript
+                npx copilotkit@latest create --framework langgraph-js
                 ```
 
-                The CLI walks you through:
+                The CLI prompts for a project name, then scaffolds the LangGraph starter pre-wired for CopilotKit.
 
-                - **Project name**
-                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard LangGraph setup.
-                - **Framework** — pick **LangGraph (Python)** or **LangGraph (JavaScript)**.
+                <Callout type="info" title="Want persistent threads, observability, and the inspector?">
+                  Run `npx copilotkit@latest create --intelligence` instead to scaffold a LangGraph-Python project pre-wired for the [Enterprise Intelligence Platform](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt). Threads support for other frameworks is coming soon.
+                </Callout>
             </Step>
             <Step>
                 ### Install dependencies
@@ -282,7 +286,7 @@ Before you begin, you'll need the following:
               ### Install CopilotKit packages
 
               ```npm
-              npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime
+              npm install @copilotkit/react-core @copilotkit/runtime
               ```
           </Step>
           <Step>
@@ -371,8 +375,8 @@ Before you begin, you'll need the following:
               Wrap your application with the CopilotKit provider:
 
               ```tsx title="app/layout.tsx"
-              import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
-              import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+              import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+              import "@copilotkit/react-core/styles.css"; // [!code highlight]
               import './globals.css';
 
               // ...
@@ -397,7 +401,7 @@ Before you begin, you'll need the following:
             Add the CopilotSidebar component to your page:
 
             ```tsx title="app/page.tsx"
-            import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
+            import { CopilotSidebar } from "@copilotkit/react-core"; // [!code highlight]
 
             export default function Page() {
               return (

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -47,20 +47,15 @@ Before you begin, you'll need the following:
             <Step>
                 ### Run our CLI
 
-                First, we'll use our CLI to create a new project for us. Choose between Python or JavaScript:
+                ```bash
+                npx copilotkit@latest create
+                ```
 
-                <Tabs groupId="language_langgraph_agent" items={['Python', 'JavaScript']} persist>
-                    <Tab value="Python">
-                        ```bash
-                        npx copilotkit@latest create -f langgraph-py
-                        ```
-                    </Tab>
-                    <Tab value="JavaScript">
-                        ```bash
-                        npx copilotkit@latest create -f langgraph-js
-                        ```
-                    </Tab>
-                </Tabs>
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard LangGraph setup.
+                - **Framework** — pick **LangGraph (Python)** or **LangGraph (JavaScript)**.
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -48,8 +48,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f llamaindex
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard LlamaIndex setup.
+                - **Framework** — pick **LlamaIndex** when prompted.
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -48,14 +48,10 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create
+                npx copilotkit@latest create --framework llamaindex
                 ```
 
-                The CLI walks you through:
-
-                - **Project name**
-                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard LlamaIndex setup.
-                - **Framework** — pick **LlamaIndex** when prompted.
+                The CLI prompts for a project name, then scaffolds the LlamaIndex starter pre-wired for CopilotKit.
             </Step>
             <Step>
                 ### Install dependencies
@@ -226,7 +222,7 @@ Before you begin, you'll need the following:
                 ### Install CopilotKit packages
 
                 ```npm
-                npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/llamaindex
+                npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/llamaindex
                 ```
             </Step>
             <Step>
@@ -268,8 +264,8 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
-                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
-                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+                import "@copilotkit/react-core/styles.css"; // [!code highlight]
                 import './globals.css';
 
                 // ...
@@ -294,7 +290,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
-              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
+              import { CopilotSidebar } from "@copilotkit/react-core"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -48,10 +48,20 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create --framework llamaindex
+                npx copilotkit@latest create
                 ```
 
-                The CLI prompts for a project name, then scaffolds the LlamaIndex starter pre-wired for CopilotKit.
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard LlamaIndex setup.
+                - **Framework** — pick **LlamaIndex** when prompted.
+
+                Or skip the prompts and pin a framework directly:
+
+                ```bash
+                npx copilotkit@latest create --framework llamaindex
+                ```
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -46,11 +46,15 @@ Before you begin, you'll need the following:
             <Step>
                 ### Run our CLI
 
-                First, we'll use our CLI to create a new project for us.
-
                 ```bash
-                npx copilotkit@latest create -f mastra
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Mastra setup.
+                - **Framework** — pick **Mastra** when prompted.
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -47,10 +47,20 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create --framework mastra
+                npx copilotkit@latest create
                 ```
 
-                The CLI prompts for a project name, then scaffolds the Mastra starter pre-wired for CopilotKit.
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Mastra setup.
+                - **Framework** — pick **Mastra** when prompted.
+
+                Or skip the prompts and pin a framework directly:
+
+                ```bash
+                npx copilotkit@latest create --framework mastra
+                ```
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -47,14 +47,10 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create
+                npx copilotkit@latest create --framework mastra
                 ```
 
-                The CLI walks you through:
-
-                - **Project name**
-                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Mastra setup.
-                - **Framework** — pick **Mastra** when prompted.
+                The CLI prompts for a project name, then scaffolds the Mastra starter pre-wired for CopilotKit.
             </Step>
             <Step>
                 ### Install dependencies
@@ -170,7 +166,7 @@ Before you begin, you'll need the following:
                 ### Install CopilotKit packages
 
                 ```npm
-                npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/mastra @ag-ui/core @ag-ui/client @mastra/client-js @ai-sdk/openai
+                npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/mastra @ag-ui/core @ag-ui/client @mastra/client-js @ai-sdk/openai
                 ```
             </Step>
             <Step>
@@ -211,8 +207,8 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
-                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
-                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+                import "@copilotkit/react-core/styles.css"; // [!code highlight]
                 import './globals.css';
 
                 // ...
@@ -237,7 +233,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
-              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
+              import { CopilotSidebar } from "@copilotkit/react-core"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -47,14 +47,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create
+                # .NET (default)
+                npx copilotkit@latest create --framework microsoft-agent-framework-dotnet
+
+                # Python
+                npx copilotkit@latest create --framework microsoft-agent-framework-py
                 ```
 
-                The CLI walks you through:
-
-                - **Project name**
-                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Microsoft Agent Framework setup.
-                - **Framework** — pick **Microsoft Agent Framework (.NET)** or **Microsoft Agent Framework (Python)**.
+                The CLI prompts for a project name, then scaffolds the Microsoft Agent Framework starter pre-wired for CopilotKit.
             </Step>
             <Step>
                 ### Install dependencies
@@ -310,7 +310,7 @@ Before you begin, you'll need the following:
                 ### Install CopilotKit packages
 
                 ```npm
-                npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/client
+                npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/client
                 ```
             </Step>
             <Step>
@@ -362,8 +362,8 @@ Before you begin, you'll need the following:
                 via the Microsoft Agent Framework agent.
 
                 ```tsx title="app/layout.tsx"
-                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
-                import "@copilotkit/react-ui/v2/styles.css";
+                import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+                import "@copilotkit/react-core/styles.css";
                 import './globals.css';
 
                 export default function RootLayout({ children }: {children: React.ReactNode}) {
@@ -389,7 +389,7 @@ Before you begin, you'll need the following:
               "use client";
 
               // [!code highlight:1]
-              import { CopilotSidebar } from "@copilotkit/react-core/v2";
+              import { CopilotSidebar } from "@copilotkit/react-core";
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -47,14 +47,24 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                # .NET (default)
+                npx copilotkit@latest create
+                ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Microsoft Agent Framework setup.
+                - **Framework** — pick **Microsoft Agent Framework (.NET)** or **Microsoft Agent Framework (Python)** when prompted.
+
+                Or skip the prompts and pin a framework directly:
+
+                ```bash
+                # .NET
                 npx copilotkit@latest create --framework microsoft-agent-framework-dotnet
 
                 # Python
                 npx copilotkit@latest create --framework microsoft-agent-framework-py
                 ```
-
-                The CLI prompts for a project name, then scaffolds the Microsoft Agent Framework starter pre-wired for CopilotKit.
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -46,20 +46,15 @@ Before you begin, you'll need the following:
             <Step>
                 ### Run our CLI
 
-                First, we'll use our CLI to create a new project for us.
+                ```bash
+                npx copilotkit@latest create
+                ```
 
-                <Tabs groupId="language_microsoft-agent-framework_agent" items={['.NET', 'Python']} persist>
-                    <Tab value=".NET">
-                        ```bash
-                        npx copilotkit@latest create -f microsoft-agent-framework-dotnet
-                        ```
-                    </Tab>
-                    <Tab value="Python">
-                        ```bash
-                        npx copilotkit@latest create -f microsoft-agent-framework-py
-                        ```
-                    </Tab>
-                </Tabs>
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Microsoft Agent Framework setup.
+                - **Framework** — pick **Microsoft Agent Framework (.NET)** or **Microsoft Agent Framework (Python)**.
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -48,10 +48,20 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create --framework pydantic-ai
+                npx copilotkit@latest create
                 ```
 
-                The CLI prompts for a project name, then scaffolds the Pydantic AI starter pre-wired for CopilotKit.
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Pydantic AI setup.
+                - **Framework** — pick **Pydantic AI** when prompted.
+
+                Or skip the prompts and pin a framework directly:
+
+                ```bash
+                npx copilotkit@latest create --framework pydantic-ai
+                ```
             </Step>
             <Step>
                 ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -48,14 +48,10 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create
+                npx copilotkit@latest create --framework pydantic-ai
                 ```
 
-                The CLI walks you through:
-
-                - **Project name**
-                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Pydantic AI setup.
-                - **Framework** — pick **Pydantic AI** when prompted.
+                The CLI prompts for a project name, then scaffolds the Pydantic AI starter pre-wired for CopilotKit.
             </Step>
             <Step>
                 ### Install dependencies
@@ -176,7 +172,7 @@ Before you begin, you'll need the following:
                 ### Install CopilotKit packages
 
                 ```npm
-                npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/client
+                npm install @copilotkit/react-core @copilotkit/runtime @ag-ui/client
                 ```
             </Step>
             <Step>
@@ -218,8 +214,8 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
-                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
-                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+                import "@copilotkit/react-core/styles.css"; // [!code highlight]
                 import './globals.css';
 
                 // ...
@@ -244,7 +240,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
-              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
+              import { CopilotSidebar } from "@copilotkit/react-core"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -48,8 +48,14 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f pydantic-ai
+                npx copilotkit@latest create
                 ```
+
+                The CLI walks you through:
+
+                - **Project name**
+                - **Enterprise Intelligence Platform** — persistent threads, observability, and the inspector. Choose **Yes** to scaffold a project pre-wired for the platform (the CLI walks you through sign-up, or you can [create an account](https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_cli_prompt) first), or **No** for a standard Pydantic AI setup.
+                - **Framework** — pick **Pydantic AI** when prompted.
             </Step>
             <Step>
                 ### Install dependencies


### PR DESCRIPTION
## Summary

Six commits, batched into one PR for the May 12 docs cutover.

- `2c10c735d` Port upstream CLI walkthrough verbatim onto 8 framework quickstarts (adk, agno, aws-strands, langgraph, llamaindex, mastra, microsoft-agent-framework, pydantic-ai). Initial byte-perfect import from upstream `docs/content/docs/integrations/<fw>/quickstart.mdx`.
- `f17c86867` Add `sample-audio-button` region marker on the built-in-agent voice demo. Closes a B-cell snippet gap; the bundler now reports 4 regions on `built-in-agent::voice`.
- `cebca9216` Remove AG-UI brand tab from desktop header for visual parity with `docs.copilotkit.ai` (canonical has zero AG-UI elements in the header).
- `abeb2792b` Also remove AG-UI link from mobile slide-out menu and drop now-unused helpers (`AgUiIcon`, `AG_UI_LINKS`, `AG_UI_PREFIXES`, `Brand` type, `activeBrandFromPath`, `usePathname`). Net 82-line cleanup of `brand-nav.tsx`.
- `99d8ac7a5` Intermediate rewrite of the 8 quickstarts to use `npx copilotkit@latest create --framework <id>` (after CLI accuracy audit found `--intelligence` and `--framework` are mutually exclusive in `copilotkit@2.0.3`). Also applies V2 canonical imports to the same 8 files: `<CopilotKit>` from `@copilotkit/react-core` (root), styles from `@copilotkit/react-core/styles.css`, drop `@copilotkit/react-ui` from npm install.
- `59a8a71a6` Final CLI-section shape: each quickstart now leads with the upstream interactive walkthrough (`npx copilotkit@latest create` plus a bulleted explanation of Project name / Enterprise Intelligence Platform with sign-up link / Framework picker), followed by an "Or skip the prompts and pin a framework directly" `--framework <id>` block. LangGraph and Microsoft Agent Framework show both language variants in the flag block.

## Test plan

- [ ] Visit each of the 8 framework quickstarts on the dev server. Verify the CLI section shows the interactive walkthrough with the EIP/sign-up bullet AND the `--framework <id>` flag block below it.
- [ ] LangGraph quickstart shows both `langgraph-py` and `langgraph-js` flag commands. Microsoft Agent Framework shows both `microsoft-agent-framework-dotnet` and `microsoft-agent-framework-py`.
- [ ] All 8 quickstarts: imports show `@copilotkit/react-core` (root), styles from `@copilotkit/react-core/styles.css`. No `/v2` paths.
- [ ] Inspect shell-docs header at desktop and mobile (narrow viewport). No AG-UI brand tab anywhere.
- [ ] Visit a built-in-agent voice page that consumes the `sample-audio-button` region. The snippet renders.