### PR TITLE
fix(examples/langgraph-python-threads): fail loudly when uv or Docker is missing

### DIFF
--- a/examples/integrations/langgraph-python-threads/README.md
+++ b/examples/integrations/langgraph-python-threads/README.md
@@ -26,7 +26,8 @@ When threads are enabled, additional infrastructure runs via Docker Compose:
 - Python 3.12+
 - npm 10+
 - OpenAI API Key
-- Docker (for threads/intelligence support)
+- [`uv`](https://docs.astral.sh/uv/getting-started/installation/) — required to install the Python agent's dependencies
+- [Docker](https://docs.docker.com/get-started/get-docker/) — required for the threads/intelligence services (must be running)
 
 ## Getting Started
 

--- a/examples/integrations/langgraph-python-threads/package.json
+++ b/examples/integrations/langgraph-python-threads/package.json
@@ -5,6 +5,8 @@
     "apps/*"
   ],
   "scripts": {
+    "preinstall": "node scripts/check-prereqs.mjs install",
+    "predev": "node scripts/check-prereqs.mjs dev",
     "dev:infra": "docker compose up -d --wait",
     "dev": "npm run dev:infra && concurrently -k -n app,bff,agent -c auto \"npm run dev:app\" \"npm run dev:bff\" \"npm run dev:agent\"",
     "dev:app": "npm run dev --workspace @repo/app",

--- a/examples/integrations/langgraph-python-threads/scripts/check-prereqs.mjs
+++ b/examples/integrations/langgraph-python-threads/scripts/check-prereqs.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+const PREREQS = {
+  install: [
+    {
+      command: "uv",
+      label: "uv",
+      url: "https://docs.astral.sh/uv/getting-started/installation/",
+      reason:
+        "Required to install the Python agent's dependencies via `uv sync`.",
+    },
+  ],
+  dev: [
+    {
+      command: "uv",
+      label: "uv",
+      url: "https://docs.astral.sh/uv/getting-started/installation/",
+      reason: "Required to run the LangGraph Python agent.",
+    },
+    {
+      command: "docker",
+      label: "Docker",
+      url: "https://docs.docker.com/get-started/get-docker/",
+      reason:
+        "Required to start the Postgres, Redis, and Intelligence services.",
+      check: (cmd) => {
+        if (!hasCommand(cmd)) return "missing";
+        const probe = spawnSync(cmd, ["info"], { stdio: "ignore" });
+        return probe.status === 0 ? "ok" : "not-running";
+      },
+    },
+  ],
+};
+
+function hasCommand(cmd) {
+  const probe = spawnSync(
+    process.platform === "win32" ? "where" : "which",
+    [cmd],
+    { stdio: "ignore" },
+  );
+  return probe.status === 0;
+}
+
+const phase = process.argv[2];
+const list = PREREQS[phase];
+if (!list) {
+  console.error(`check-prereqs: unknown phase "${phase}"`);
+  process.exit(2);
+}
+
+const failures = [];
+for (const prereq of list) {
+  const status = prereq.check
+    ? prereq.check(prereq.command)
+    : hasCommand(prereq.command)
+      ? "ok"
+      : "missing";
+  if (status !== "ok") failures.push({ ...prereq, status });
+}
+
+if (failures.length === 0) process.exit(0);
+
+const red = (s) => `\x1b[31m${s}\x1b[0m`;
+const bold = (s) => `\x1b[1m${s}\x1b[0m`;
+const dim = (s) => `\x1b[2m${s}\x1b[0m`;
+
+console.error("");
+console.error(red(bold("✖ Missing prerequisites for this template")));
+console.error("");
+for (const f of failures) {
+  const headline =
+    f.status === "not-running"
+      ? `${f.label} is installed but does not appear to be running.`
+      : `${f.label} is not installed.`;
+  console.error(`  • ${bold(headline)}`);
+  console.error(`    ${f.reason}`);
+  console.error(`    Install / docs: ${f.url}`);
+  console.error("");
+}
+console.error(dim("After resolving the items above, re-run the command."));
+console.error("");
+process.exit(1);


### PR DESCRIPTION
## Summary

The `langgraph-python-threads` example requires both `uv` (for the Python agent's `postinstall: uv sync`) and Docker (for Postgres / Redis / Intelligence), but nothing surfaced that until `npm install` errored with a bare `sh: uv: command not found`.

This PR makes the requirements explicit:

- **README** — adds `uv` and a Docker install link to the prerequisites list.
- **Preflight script** (`scripts/check-prereqs.mjs`) — checks for `uv` on `npm install` (`preinstall`), and for `uv` + a running Docker daemon on `npm run dev` (`predev`). Prints a formatted error pointing at the install docs and exits non-zero before the failing command runs.

## Test plan

- [ ] `npm install` with `uv` removed from PATH — fails with the friendly preflight error, not the postinstall stack trace.
- [ ] `npm run dev` with Docker installed but not running — fails with the "Docker is installed but does not appear to be running" message.
- [ ] `npm install` / `npm run dev` with both prereqs present — runs normally.