### PR TITLE
chore(reference): handle langgraph_agent → langgraph_agui_agent rename

### DIFF
--- a/scripts/docs/lib/files.ts
+++ b/scripts/docs/lib/files.ts
@@ -1,4 +1,4 @@
-import { ReferenceDocConfiguration } from "./reference-doc";
+import type { ReferenceDocConfiguration } from "./reference-doc";
 
 export const REFERENCE_DOCS: ReferenceDocConfiguration[] = [
   /* Runtime */
@@ -199,13 +199,13 @@ export const REFERENCE_DOCS: ReferenceDocConfiguration[] = [
 
   /* Agents */
   {
-    sourcePath: "sdk-python/copilotkit/langgraph_agent.py",
+    sourcePath: "sdk-python/copilotkit/langgraph_agui_agent.py",
     destinationPath:
-      "showcase/shell-docs/src/content/reference/sdk/python/LangGraphAgent.mdx",
-    title: "LangGraphAgent",
+      "showcase/shell-docs/src/content/reference/sdk/python/LangGraphAGUIAgent.mdx",
+    title: "LangGraphAGUIAgent",
     description:
-      "LangGraphAgent lets you define your agent for use with CopilotKit.",
-    pythonSymbols: ["LangGraphAgent", "CopilotKitConfig"],
+      "LangGraphAGUIAgent lets you define your agent for use with CopilotKit.",
+    pythonSymbols: ["LangGraphAGUIAgent", "CopilotKitConfig"],
   },
   {
     sourcePath: "sdk-python/copilotkit/crewai/crewai_agent.py",

--- a/showcase/shell-docs/src/content/reference/sdk/python/LangGraphAGUIAgent.mdx
+++ b/showcase/shell-docs/src/content/reference/sdk/python/LangGraphAGUIAgent.mdx
@@ -1,0 +1,12 @@
+---
+title: "LangGraphAGUIAgent"
+description: "LangGraphAGUIAgent lets you define your agent for use with CopilotKit."
+---
+
+{
+ /*
+  * ATTENTION! DO NOT MODIFY THIS FILE!
+  * This page is auto-generated. If you want to make any changes to this page, changes must be made at:
+  * sdk-python/copilotkit/langgraph_agui_agent.py
+  */
+}


### PR DESCRIPTION
## Summary

- Updates the V1 reference autogen entry in `scripts/docs/lib/files.ts` for the upstream rename of `sdk-python/copilotkit/langgraph_agent.py` to `langgraph_agui_agent.py`. The class also renamed from `LangGraphAgent` to `LangGraphAGUIAgent` (now subclasses the upstream `LangGraphAgent`).
- Updates `sourcePath`, `destinationPath` (now `LangGraphAGUIAgent.mdx`), `title`, `description`, and `pythonSymbols` to match.
- Regenerates `showcase/shell-docs/src/content/reference/sdk/python/LangGraphAGUIAgent.mdx`. The autogen run now reports 26/26 entries succeeding (was 25/26 — the previous entry failed silently via `Promise.allSettled` because the source file no longer existed).

Stacked on top of #4693 (autogen-retarget). Once that lands this PR can be retargeted at `main`.

## Test plan

- [x] `tsx scripts/docs/gen.ts` from repo root succeeds with `All reference docs processed (26/26 succeeded)`.
- [x] `npm run build` in `showcase/shell-docs/` clean (Next build prerendered 27/27 routes).
- [ ] Spot-check rendered `/reference/sdk/python/LangGraphAGUIAgent` on a dev server. Note: the new `LangGraphAGUIAgent` class in `sdk-python` does not yet carry a class-level docstring, so the generated MDX is currently frontmatter-only. Adding a docstring upstream will populate the page on the next pipeline run.