### PR TITLE
docs: add agent-facing footer with MCP server and Pathfinder links

### DIFF
--- a/docs/content/docs/(root)/index.mdx
+++ b/docs/content/docs/(root)/index.mdx
@@ -121,3 +121,7 @@ Look below to find right guide for your needs, whether you're starting from noth
 import { FeatureMatrix } from "@/components/react/feature-matrix"
 
 <FeatureMatrix />
+
+<div className="mt-16 border-t border-neutral-200 dark:border-neutral-800 pt-4 text-center text-xs text-neutral-400 dark:text-neutral-500">
+  MCP server: <a href="https://mcp.copilotkit.ai/mcp" className="underline hover:text-neutral-500 dark:hover:text-neutral-400">https://mcp.copilotkit.ai/mcp</a> · llms.txt: <a href="https://mcp.copilotkit.ai/llms.txt" className="underline hover:text-neutral-500 dark:hover:text-neutral-400">https://mcp.copilotkit.ai/llms.txt</a> · Powered by <a href="https://pathfinder.copilotkit.dev" className="underline hover:text-neutral-500 dark:hover:text-neutral-400">Pathfinder</a>
+</div>


### PR DESCRIPTION
## Summary
- Add a subtle footer to the docs root page with MCP server, llms.txt, and Pathfinder URLs
- Humanly visible but not dominant — primarily for AI agents hitting the root docs page
- Links: MCP server endpoint, llms.txt file, and Pathfinder (the technology powering both)

## Test plan
- [ ] Verify footer renders on docs root page in preview deploy
- [ ] Confirm links resolve correctly
- [ ] Check dark mode appearance