### PR TITLE
chore(showcase): pydantic-ai gen-ui-tool-based/bar-chart-renderer region marker

### DIFF
--- a/showcase/integrations/pydantic-ai/src/app/demos/gen-ui-tool-based/bar-chart-renderer.snippet.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/gen-ui-tool-based/bar-chart-renderer.snippet.tsx
@@ -1,0 +1,32 @@
+// Docs-only snippet — not imported or rendered. The dashboard demo at
+// `page.tsx` for this framework runs a haiku-generator showcase via
+// `useFrontendTool`, but the canonical `/generative-ui/tool-based` page
+// teaches the simpler `useComponent` bar-chart pattern. This file shows
+// what the bar-chart renderer would look like in the same framework's
+// shape, so the docs render real teaching code rather than a missing-
+// snippet box.
+//
+// Mirrors the convention from `tool-rendering/render-flight-tool.snippet.tsx`.
+
+import { useComponent } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+// Stand-ins for the locally-authored bar chart component + its prop
+// schema. In a real page, these live in the demo directory (e.g.
+// `./bar-chart.tsx` exporting `BarChart` and `barChartPropsSchema`).
+declare const BarChart: React.ComponentType<{
+  title: string;
+  data: { label: string; value: number }[];
+}>;
+declare const barChartPropsSchema: z.ZodSchema;
+
+export function BarChartRenderer() {
+  // @region[bar-chart-renderer]
+  useComponent({
+    name: "render_bar_chart",
+    description: "Display a bar chart with labeled numeric values.",
+    parameters: barChartPropsSchema,
+    render: BarChart,
+  });
+  // @endregion[bar-chart-renderer]
+}


### PR DESCRIPTION
## Summary

- Adds a docs-only `bar-chart-renderer.snippet.tsx` sibling to `showcase/integrations/pydantic-ai/src/app/demos/gen-ui-tool-based/` with `// @region[bar-chart-renderer]` markers so the canonical `/generative-ui/tool-based` page can render real teaching code for the pydantic-ai cell instead of a missing-snippet box.
- The pydantic-ai `page.tsx` for this cell is a haiku-generator showcase via `useFrontendTool`, not a `useComponent` bar-chart demo, so an in-place region would teach the wrong shape. Sibling snippet matches the existing pydantic-ai convention (see `tool-rendering/render-flight-tool.snippet.tsx`) and is consistent with mastra, claude-sdk, langgraph-typescript, spring-ai, etc.
- Comment-only; no runtime code is touched.

## Verification

- `npx tsx showcase/scripts/bundle-demo-content.ts` now reports `pydantic-ai::gen-ui-tool-based: 7 files (5 highlighted) + README + 1 regions` (was `+ 0 regions`), matching the baseline of mastra/spring-ai/langgraph-typescript.

## Test plan

- [ ] Render `/generative-ui/tool-based` for pydantic-ai in shell-docs and confirm the `bar-chart-renderer` snippet shows the `useComponent` block.