### PR TITLE
chore(showcase): langroid gen-ui-interrupt/backend-tool-call region marker

### DIFF
--- a/showcase/integrations/langroid/src/agents/agent.py
+++ b/showcase/integrations/langroid/src/agents/agent.py
@@ -720,6 +720,12 @@ class GenerateHaikuTool(ToolMessage):
         return "Haiku generated!"
 
 
+# @region[backend-tool-call]
+# `schedule_meeting` is declared here as a `ToolMessage` subclass so Langroid's
+# LLM knows the tool's schema, but it executes client-side: the AG-UI adapter
+# intercepts the call and forwards it to the frontend's `useFrontendTool`
+# handler, which renders the time picker and resolves a Promise with the
+# user's choice. `handle()` only runs if that interception regresses.
 class ScheduleMeetingTool(ToolMessage):
     request: str = "schedule_meeting"
     purpose: str = "Schedule a meeting. The user will be asked to pick a time via the meeting time picker UI."
@@ -736,6 +742,7 @@ class ScheduleMeetingTool(ToolMessage):
                 error=_ToolErrorKind.SCHEDULE_MEETING_FAILED,
                 message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
             )
+# @endregion[backend-tool-call]
 
 
 class SearchFlightsTool(ToolMessage):


### PR DESCRIPTION
## Summary

- Adds the missing `# @region[backend-tool-call] ... # @endregion[backend-tool-call]` markers to `showcase/integrations/langroid/src/agents/agent.py` around the `ScheduleMeetingTool` `ToolMessage` subclass.
- Closes the snippet gap referenced by `<Snippet region="backend-tool-call" />` in `showcase/shell-docs/src/content/docs/human-in-the-loop/useInterrupt.mdx` for the langroid promise-based interrupt cell.

## Architectural divergence

Langroid's frontend tools are declared as `ToolMessage` subclasses that the AG-UI adapter intercepts client-side, rather than the langgraph-python `@tool` + `Command` pattern. The region wraps the langroid-idiomatic shape so the docs render the framework's actual approach (gated through `WhenFrameworkHas flag="interrupt_pattern" equals="promise-based"`).

Comment-only change.

## Test plan

- [x] `npx tsx showcase/scripts/bundle-demo-content.ts` — `langroid::gen-ui-interrupt` now reports 3 regions (was 2) and the bundled `regions['backend-tool-call']` resolves to `src/agents/agent.py:721-741`.
- [ ] Render `/integrations/langroid/human-in-the-loop/useInterrupt` in shell-docs and confirm the backend snippet renders without the placeholder warning.