### PR TITLE
chore(showcase): spring-ai shared-state-streaming region markers

### DIFF
--- a/showcase/integrations/spring-ai/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/shared-state-streaming/page.tsx
@@ -27,6 +27,7 @@ export default function SharedStateStreamingDemo() {
 }
 
 function DemoContent() {
+  // @region[frontend-use-coagent-state]
   // Subscribe to BOTH state changes and run-status changes. The former
   // drives the per-token document rerender; the latter toggles the
   // "LIVE" badge when the agent starts / stops.
@@ -34,6 +35,7 @@ function DemoContent() {
     agentId: "shared-state-streaming",
     updates: [UseAgentUpdate.OnStateChanged, UseAgentUpdate.OnRunStatusChanged],
   });
+  // @endregion[frontend-use-coagent-state]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SharedStateStreamingController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SharedStateStreamingController.java
@@ -231,8 +231,12 @@ public class SharedStateStreamingController {
                                     textAccumulator.append(content);
                                 }
 
-                                // Handle tool call chunks — detect write_document
-                                // and emit STATE_SNAPSHOT as content grows
+                                // @region[state-streaming-middleware]
+                                // Spring AI equivalent of LangGraph's
+                                // StateStreamingMiddleware(StateItem(...)): as the LLM
+                                // streams the `write_document` tool's `content` argument,
+                                // forward the growing partial value into state.document
+                                // and emit a STATE_SNAPSHOT so the UI re-renders per token.
                                 if (evt.hasToolCalls()) {
                                     var tcs = evt.getResult().getOutput().getToolCalls();
                                     for (var tc : tcs) {
@@ -250,7 +254,7 @@ public class SharedStateStreamingController {
                                             if (partialContent != null
                                                     && partialContent.length() > prev.length()) {
                                                 lastDocContent.set(partialContent);
-                                                // Update state and emit snapshot
+                                                // Forward tool argument -> state key
                                                 runState.set("document", partialContent);
                                                 this.emitEvent(
                                                         stateSnapshotEvent(runState),
@@ -259,6 +263,7 @@ public class SharedStateStreamingController {
                                         }
                                     }
                                 }
+                                // @endregion[state-streaming-middleware]
                             },
                             err -> {
                                 streamError.set(err);


### PR DESCRIPTION
## Summary

- Add two missing snippet region markers in the spring-ai shared-state-streaming demo so the `/shared-state/streaming` doc page resolves both Snippet regions when the spring-ai tab is active.
- `frontend-use-coagent-state` wraps the `useAgent({ updates: [OnStateChanged, OnRunStatusChanged] })` block in `src/app/demos/shared-state-streaming/page.tsx` (matches the langgraph-python reference exactly).
- `state-streaming-middleware` wraps the streaming subscriber's tool-call detection block in `SharedStateStreamingController.java` — the Spring AI equivalent of LangGraph's `StateStreamingMiddleware(StateItem(...))` that forwards the `write_document.content` argument into `state.document` and emits `STATE_SNAPSHOT`.

Comment-only changes. The Java file is already bundled via the demo's `manifest.yaml` `highlight:` list, so no manifest edits were required.

## Test plan

- [x] `npx tsx showcase/scripts/bundle-demo-content.ts` — spring-ai::shared-state-streaming reports `4 files (4 highlighted) + README + 2 regions`.
- [x] Both `frontend-use-coagent-state` and `state-streaming-middleware` resolve in the bundled `demo-content.json` for the spring-ai cell.