### PR TITLE
chore(showcase): strands gen-ui-interrupt/backend-tool-call region marker

### DIFF
--- a/showcase/integrations/strands/src/agents/agent.py
+++ b/showcase/integrations/strands/src/agents/agent.py
@@ -373,6 +373,18 @@ def get_sales_todos():
     return "Check the sales pipeline provided in the context."
 
 
+# @region[backend-tool-call]
+# Strands has no native interrupt primitive, so the gen-ui-interrupt and
+# interrupt-headless demos register `schedule_meeting` as a frontend tool
+# via `useFrontendTool`. Its async handler returns a Promise that only
+# resolves once the user picks a slot or cancels in the in-chat picker
+# (the Strands shim for LangGraph's `interrupt()` / `resolve()` pair).
+#
+# This `@tool` declaration is the backend's contract with the LLM: the
+# docstring and signature are what the model sees when deciding to call
+# `schedule_meeting`. CopilotKit's runtime routes the call to the frontend
+# handler registered with `useFrontendTool` (same name), so the local
+# `schedule_meeting_impl` body acts as a fallback for non-UI invocations.
 @tool
 def schedule_meeting(reason: str):
     """Schedule a meeting with user approval.
@@ -387,6 +399,7 @@ def schedule_meeting(reason: str):
         Meeting scheduling result as JSON string
     """
     return json.dumps(schedule_meeting_impl(reason))
+# @endregion[backend-tool-call]
 
 
 @tool


### PR DESCRIPTION
## Summary

- Adds `# @region[backend-tool-call] ... # @endregion[backend-tool-call]` markers around the `schedule_meeting` `@tool` declaration in `showcase/integrations/strands/src/agents/agent.py`, so the `gen-ui-interrupt` cell can resolve the `<Snippet region="backend-tool-call" />` reference in `human-in-the-loop/useInterrupt.mdx`.
- In-place region (no sibling `.snippet.py` needed): the `@tool` declaration is the canonical "instruct the LLM" surface for Strands and carries no QA hooks the docs shouldn't teach.
- Comment-only change. The accompanying lead-in comment explains the promise-based interrupt adaptation (`useFrontendTool` returning a Promise) and clarifies that the local `schedule_meeting_impl` body acts as a fallback when the same-named frontend handler isn't registered.

## Verification

- `npx tsx showcase/scripts/bundle-demo-content.ts` runs clean; `strands::gen-ui-interrupt` now bundles 6 regions (was 5), with `backend-tool-call` resolving to `src/agents/agent.py` lines 374-398.

## Test plan

- [ ] Open `/integrations/strands/human-in-the-loop/useInterrupt` in shell-docs and confirm the `backend - agent instructed to call schedule_meeting` snippet renders the `schedule_meeting` `@tool` block.
- [ ] Confirm the `gen-ui-interrupt` demo still loads at `/demos/gen-ui-interrupt` (markers are comment-only, no runtime impact).