### PR TITLE
docs(genui): link to DeepLearning.AI Generative UI course

### DIFF
--- a/docs/content/docs/(root)/generative-ui/a2ui.mdx
+++ b/docs/content/docs/(root)/generative-ui/a2ui.mdx
@@ -5,10 +5,15 @@ description: "Render declarative UI components using the A2UI specification."
 hideTOC: true
 ---
 import { IntegrationGrid } from "@/components/content/integration-grid";
+import { Callout } from "fumadocs-ui/components/callout";
 
 ## What is this?
 
 A2UI (Agent-to-UI) is a declarative specification for generative UI. It allows agents to render structured UI components using a JSON-based schema, without requiring custom React components for every interaction.
+
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
 
 ## Choose your AI backend
 

--- a/docs/content/docs/(root)/generative-ui/mcp-apps.mdx
+++ b/docs/content/docs/(root)/generative-ui/mcp-apps.mdx
@@ -5,10 +5,15 @@ description: "Render interactive UI components from MCP servers directly in your
 hideTOC: true
 ---
 import { IntegrationGrid } from "@/components/content/integration-grid";
+import { Callout } from "fumadocs-ui/components/callout";
 
 ## What is this?
 
 MCP Apps are MCP servers that expose tools with associated UI resources. When the agent calls one of these tools, CopilotKit automatically fetches and renders the UI component in the chat — no additional frontend code required.
+
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
 
 Key benefits:
 - **Zero frontend code** — UI components are served by the MCP server

--- a/docs/content/docs/(root)/generative-ui/open-generative-ui.mdx
+++ b/docs/content/docs/(root)/generative-ui/open-generative-ui.mdx
@@ -5,10 +5,15 @@ description: "Let agents generate fully interactive HTML/CSS/JS UIs that stream 
 ---
 
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
+import { Callout } from "fumadocs-ui/components/callout";
 
 ## What is this?
 
 Open Generative UI lets the agent generate complete, sandboxed UI on the fly — HTML, CSS, and JavaScript — and stream it live into the chat. The user sees the interface build in real time: styles apply first, then HTML streams in progressively, and finally JavaScript expressions execute one by one.
+
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
 
 Key benefits:
 - **No predefined components** — the agent creates any UI it needs, on demand

--- a/docs/content/docs/(root)/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/(root)/generative-ui/state-rendering.mdx
@@ -5,10 +5,15 @@ description: Render your agent's state with custom UI components in real-time.
 hideTOC: true
 ---
 import { IntegrationGrid } from "@/components/content/integration-grid";
+import { Callout } from "fumadocs-ui/components/callout";
 
 ## What is this?
 
 State rendering lets you build UI that reflects your agent's state in real-time. As your agent progresses through nodes and emits state updates, your frontend renders those changes — showing progress, drafts, or intermediate results.
+
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
 
 ## When should I use this?
 

--- a/docs/content/docs/(root)/generative-ui/tool-rendering.mdx
+++ b/docs/content/docs/(root)/generative-ui/tool-rendering.mdx
@@ -5,10 +5,15 @@ description: Render your agent's tool calls with custom UI components.
 hideTOC: true
 ---
 import { IntegrationGrid } from "@/components/content/integration-grid";
+import { Callout } from "fumadocs-ui/components/callout";
 
 ## What is this?
 
 Tool rendering lets you customize how your agent's backend tool calls appear in the chat. Instead of showing raw tool execution, you can render custom React components that display tool arguments, progress, and results.
+
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
 
 ## When should I use this?
 

--- a/docs/content/docs/(root)/generative-ui/your-components/display-only.mdx
+++ b/docs/content/docs/(root)/generative-ui/your-components/display-only.mdx
@@ -6,10 +6,15 @@ hideTOC: true
 ---
 import { IntegrationGrid } from "@/components/content/integration-grid";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
+import { Callout } from "fumadocs-ui/components/callout";
 
 ## What is this?
 
 Display-only generative UI lets you register React components as tools your agent can invoke. When the agent calls the tool, CopilotKit renders your component directly in the chat with the tool's arguments as props — no handler logic or user interaction required.
+
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
 
 <Tabs items={['page.tsx', 'chart.tsx']}>
   <Tab value="page.tsx">

--- a/docs/content/docs/learn/generative-ui/index.mdx
+++ b/docs/content/docs/learn/generative-ui/index.mdx
@@ -41,6 +41,10 @@ This page covers:
 
 </TwoColumnSection>
 
+<Callout type="info">
+  **Prefer to learn by building?** [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) is a free DeepLearning.AI short course taught by CopilotKit's CEO. It walks through the Controlled, Declarative, and Open-Ended Generative UI patterns end-to-end with React, LangChain, and AG-UI.
+</Callout>
+
 ---
 
 <div>

--- a/showcase/shell-docs/src/content/docs/concepts/generative-ui-overview.mdx
+++ b/showcase/shell-docs/src/content/docs/concepts/generative-ui-overview.mdx
@@ -16,6 +16,10 @@ This page covers:
 - **[Ecosystem Mapping](#ecosystem-mapping)** — how the types map to the protocols and specs out there today.
 - **[AG-UI and CopilotKit](#ag-ui-and-copilotkit-are-gen-ui-agnostic)** — how the protocol and the framework support all three types.
 
+<Callout type="info">
+  **Prefer to learn by building?** [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) is a free DeepLearning.AI short course taught by CopilotKit's CEO. It walks through the Controlled, Declarative, and Open-Ended Generative UI patterns end-to-end with React, LangChain, and AG-UI.
+</Callout>
+
 ## Application Surfaces
 
 Generative UI surfaces in different parts of an application depending on how users interact with the agent and how much the application mediates that interaction. Three common shapes:

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui.mdx
@@ -17,6 +17,10 @@ platform) define.
 You can design and preview A2UI schemas visually using the
 [A2UI Composer](https://a2ui-composer.ag-ui.com/).
 
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
+
 ## The two approaches
 
 CopilotKit ships two complementary A2UI approaches:

--- a/showcase/shell-docs/src/content/docs/generative-ui/mcp-apps.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/mcp-apps.mdx
@@ -19,6 +19,10 @@ Key benefits:
 - **Secure sandboxing** — content runs in isolated iframes
 - **Thread persistence** — MCP Apps are stored in conversation history and restored on reconnect
 
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
+
 <InlineDemo demo="mcp-apps" />
 
 ## Wire the runtime to your MCP server(s)

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -20,6 +20,10 @@ Key benefits:
 - **Secure sandboxing** — content runs in an isolated iframe without same-origin access
 - **Sandbox functions** — optionally expose host functions to the generated UI for two-way communication
 
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
+
 <InlineDemo demo="open-gen-ui" />
 
 ## Minimal setup

--- a/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
@@ -9,6 +9,10 @@ hideTOC: true
 
 State rendering lets you build UI that reflects your agent's state in real-time. As your agent progresses through nodes and emits state updates, your frontend renders those changes, showing progress, drafts, or intermediate results.
 
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
+
 ## When should I use this?
 
 Use state rendering when you want to:

--- a/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
@@ -14,6 +14,10 @@ a branded card for the call (arguments, live status, and the eventual
 result). This is the **Generative UI** variant CopilotKit calls **tool
 rendering**.
 
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
+
 <InlineDemo demo="tool-rendering" />
 
 ## When should I use this?

--- a/showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx
@@ -9,6 +9,10 @@ hideTOC: true
 
 Display-only generative UI lets you register React components as tools your agent can invoke. When the agent calls the tool, CopilotKit renders your component directly in the chat with the tool's arguments as props; no handler logic or user interaction required.
 
+<Callout type="info">
+  **Free course:** See this pattern built end-to-end in [Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/) — a free DeepLearning.AI short course taught by CopilotKit's CEO covering the full Generative UI spectrum (Controlled, Declarative, and Open-Ended).
+</Callout>
+
 <Tabs items={['page.tsx', 'chart.tsx']}>
   <Tab value="page.tsx">
   ```tsx


### PR DESCRIPTION
## Summary

Adds a fumadocs `Callout` linking to the new free DeepLearning.AI short course **[Build Interactive Agents with Generative UI](https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/)** (taught by CopilotKit's CEO) on the Generative UI pages most relevant to its content.

The course walks through the Controlled, Declarative, and Open-Ended Generative UI patterns end-to-end with React, LangChain, and AG-UI — which maps cleanly to the existing taxonomy in our docs.

## Files changed (14)

**Overview pages** — full callout introducing the course
- `docs/content/docs/learn/generative-ui/index.mdx`
- `showcase/shell-docs/src/content/docs/concepts/generative-ui-overview.mdx`

**Pattern-specific pages** — short callout, mirrored across docs/ and shell-docs/
- `(root)/generative-ui/your-components/display-only.mdx`
- `(root)/generative-ui/tool-rendering.mdx`
- `(root)/generative-ui/state-rendering.mdx`
- `(root)/generative-ui/open-generative-ui.mdx`
- `(root)/generative-ui/a2ui.mdx`
- `(root)/generative-ui/mcp-apps.mdx`

`docs/` files received an explicit `Callout` import; `shell-docs/` auto-imports it via `mdx-components.tsx`.

## Test plan

- [ ] Verify Callout renders correctly on each page locally (`nx run docs:dev` and `nx run shell-docs:dev`)
- [ ] Confirm external link resolves to the deeplearning.ai course page
- [ ] Spot-check that no existing layout (TwoColumnSection, InlineDemo, Tabs) is disrupted