### PR TITLE
chore(showcase): snippet sweep pre-cutover (region markers + state-streaming unsupported flips)

### DIFF
--- a/showcase/integrations/ag2/manifest.yaml
+++ b/showcase/integrations/ag2/manifest.yaml
@@ -16,7 +16,8 @@ generative_ui:
   - constrained-explicit
   - a2ui-fixed-schema
   - a2ui-dynamic-schema
-not_supported_features: []
+not_supported_features:
+  - shared-state-streaming
 interaction_modalities:
   - sidebar
   - embedded
@@ -39,7 +40,6 @@ features:
   - mcp-apps
   - open-gen-ui
   - open-gen-ui-advanced
-  - shared-state-streaming
   - prebuilt-sidebar
   - prebuilt-popup
   - chat-slots

--- a/showcase/integrations/agno/manifest.yaml
+++ b/showcase/integrations/agno/manifest.yaml
@@ -26,7 +26,6 @@ features:
   - tool-rendering
   - gen-ui-agent
   - gen-ui-tool-based
-  - shared-state-streaming
   - shared-state-read-write
   - subagents
   - prebuilt-sidebar
@@ -61,7 +60,8 @@ features:
   - beautiful-chat
   - a2ui-fixed-schema
   - declarative-gen-ui
-not_supported_features: []
+not_supported_features:
+  - shared-state-streaming
 agent_config_pattern: shared-state
 
 a2ui_pattern: schema-loading

--- a/showcase/integrations/built-in-agent/manifest.yaml
+++ b/showcase/integrations/built-in-agent/manifest.yaml
@@ -38,7 +38,6 @@ features:
   - gen-ui-tool-based
   - gen-ui-agent
   - shared-state-read-write
-  - shared-state-streaming
   - readonly-state-agent-context
   - subagents
   - mcp-apps
@@ -63,6 +62,7 @@ features:
   - interrupt-headless
 not_supported_features:
   - hitl
+  - shared-state-streaming
 agent_config_pattern: runtime-properties
 
 a2ui_pattern: schema-inline

--- a/showcase/integrations/claude-sdk-python/manifest.yaml
+++ b/showcase/integrations/claude-sdk-python/manifest.yaml
@@ -21,6 +21,8 @@ interaction_modalities:
   - sidebar
   - embedded
   - chat
+not_supported_features:
+  - shared-state-streaming
 features:
   - cli-start
   - agentic-chat
@@ -28,7 +30,6 @@ features:
   - tool-rendering-default-catchall
   - tool-rendering-custom-catchall
   - gen-ui-agent
-  - shared-state-streaming
   - shared-state-read-write
   - subagents
   - readonly-state-agent-context

--- a/showcase/integrations/claude-sdk-typescript/manifest.yaml
+++ b/showcase/integrations/claude-sdk-typescript/manifest.yaml
@@ -18,6 +18,8 @@ interaction_modalities:
   - sidebar
   - embedded
   - chat
+not_supported_features:
+  - shared-state-streaming
 features:
   - cli-start
   - agentic-chat
@@ -45,7 +47,6 @@ features:
   - declarative-gen-ui
   - gen-ui-agent
   - gen-ui-tool-based
-  - shared-state-streaming
   - shared-state-read-write
   - subagents
   - readonly-state-agent-context

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/gen-ui-interrupt/backend-tool-call.snippet.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/gen-ui-interrupt/backend-tool-call.snippet.ts
@@ -1,0 +1,47 @@
+// Docs-only snippet — not imported or run. The shell-docs page at
+// `/integrations/claude-sdk-typescript/human-in-the-loop/useInterrupt`
+// references the `backend-tool-call` region to teach the Strategy B
+// pattern: the agent has no local `schedule_meeting` implementation,
+// the tool is registered entirely on the frontend via `useFrontendTool`,
+// and the backend's only job is to instruct the model to call the
+// frontend tool whenever the user wants to book a meeting.
+//
+// Why a sibling teaching file instead of in-place markers?
+// In production, claude-sdk-typescript runs a single shared Express
+// agent server (`src/agent/index.ts`) that pass-through-forwards every
+// AG-UI tool definition to Claude with a generic system prompt. There
+// is no per-demo backend file or per-demo system prompt to mark up.
+// Annotating the shared server with `backend-tool-call` markers would
+// either span unrelated runtime plumbing or highlight a generic
+// "You are a helpful AI assistant" string that does not match the MDX
+// caption. This sibling exposes the canonical Strategy B shape so the
+// docs render the right teaching code, mirroring the
+// claude-sdk-python `interrupt_agent.py` reference.
+
+// @region[backend-tool-call]
+// The backend instructs the model to call the frontend-defined
+// `schedule_meeting` tool. The tool itself is registered on the
+// frontend with `useFrontendTool`; AG-UI forwards the frontend tool
+// schemas to Claude, and Claude's tool call is routed back to the
+// frontend handler that renders the picker and resolves with the
+// user's choice.
+const SYSTEM_PROMPT = `
+You are a scheduling assistant. Whenever the user asks you to book a
+call or schedule a meeting, you MUST call the \`schedule_meeting\` tool.
+Pass a short \`topic\` describing the purpose of the meeting and, if
+known, an \`attendee\` describing who the meeting is with.
+
+The \`schedule_meeting\` tool is implemented on the client: it surfaces
+a time-picker UI to the user and returns the user's selection. After
+the tool returns, briefly confirm whether the meeting was scheduled
+and at what time, or note that the user cancelled. Do NOT ask for
+approval yourself — always call the tool and let the picker handle
+the decision.
+
+Keep responses short and friendly. After you finish executing tools,
+always send a brief final assistant message summarizing what happened
+so the message persists.
+`.trim();
+// @endregion[backend-tool-call]
+
+export { SYSTEM_PROMPT };

--- a/showcase/integrations/crewai-crews/manifest.yaml
+++ b/showcase/integrations/crewai-crews/manifest.yaml
@@ -21,6 +21,8 @@ interaction_modalities:
 managed_platform:
   name: CrewAI Enterprise
   url: https://crewai.com/amp
+not_supported_features:
+  - shared-state-streaming
 features:
   - cli-start
   - agentic-chat
@@ -44,7 +46,6 @@ features:
   - gen-ui-tool-based
   - frontend-tools
   - frontend-tools-async
-  - shared-state-streaming
   - shared-state-read-write
   - subagents
   - readonly-state-agent-context

--- a/showcase/integrations/google-adk/manifest.yaml
+++ b/showcase/integrations/google-adk/manifest.yaml
@@ -25,6 +25,8 @@ interaction_modalities:
 managed_platform:
   name: Google AI Studio
   url: https://aistudio.google.com
+not_supported_features:
+  - shared-state-streaming
 features:
   - beautiful-chat
   - cli-start
@@ -52,7 +54,6 @@ features:
   - tool-rendering
   - tool-rendering-reasoning-chain
   - shared-state-read-write
-  - shared-state-streaming
   - readonly-state-agent-context
   - subagents
   - multimodal

--- a/showcase/integrations/langgraph-fastapi/manifest.yaml
+++ b/showcase/integrations/langgraph-fastapi/manifest.yaml
@@ -21,6 +21,8 @@ interaction_modalities:
 managed_platform:
   name: LangGraph Platform
   url: https://langsmith.com
+not_supported_features:
+  - shared-state-streaming
 features:
   - cli-start
   - agentic-chat
@@ -38,7 +40,6 @@ features:
   - a2ui-fixed-schema
   - mcp-apps
   - gen-ui-tool-based
-  - shared-state-streaming
   - shared-state-read-write
   - subagents
   - beautiful-chat

--- a/showcase/integrations/langgraph-typescript/manifest.yaml
+++ b/showcase/integrations/langgraph-typescript/manifest.yaml
@@ -24,6 +24,8 @@ interaction_modalities:
 managed_platform:
   name: LangGraph Platform
   url: https://langsmith.com
+not_supported_features:
+  - shared-state-streaming
 features:
   - cli-start
   - agentic-chat
@@ -41,7 +43,6 @@ features:
   - agentic-chat-reasoning
   - reasoning-default-render
   - gen-ui-agent
-  - shared-state-streaming
   - beautiful-chat
   - prebuilt-sidebar
   - prebuilt-popup

--- a/showcase/integrations/langroid/manifest.yaml
+++ b/showcase/integrations/langroid/manifest.yaml
@@ -18,6 +18,8 @@ interaction_modalities:
   - sidebar
   - embedded
   - chat
+not_supported_features:
+  - shared-state-streaming
 features:
   - cli-start
   - agentic-chat
@@ -28,7 +30,6 @@ features:
   - tool-rendering
   - gen-ui-agent
   - gen-ui-tool-based
-  - shared-state-streaming
   - shared-state-read-write
   - subagents
   - chat-customization-css

--- a/showcase/integrations/langroid/src/agents/agent.py
+++ b/showcase/integrations/langroid/src/agents/agent.py
@@ -720,6 +720,12 @@ class GenerateHaikuTool(ToolMessage):
         return "Haiku generated!"
 
 
+# @region[backend-tool-call]
+# `schedule_meeting` is declared here as a `ToolMessage` subclass so Langroid's
+# LLM knows the tool's schema, but it executes client-side: the AG-UI adapter
+# intercepts the call and forwards it to the frontend's `useFrontendTool`
+# handler, which renders the time picker and resolves a Promise with the
+# user's choice. `handle()` only runs if that interception regresses.
 class ScheduleMeetingTool(ToolMessage):
     request: str = "schedule_meeting"
     purpose: str = "Schedule a meeting. The user will be asked to pick a time via the meeting time picker UI."
@@ -736,6 +742,7 @@ class ScheduleMeetingTool(ToolMessage):
                 error=_ToolErrorKind.SCHEDULE_MEETING_FAILED,
                 message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
             )
+# @endregion[backend-tool-call]
 
 
 class SearchFlightsTool(ToolMessage):

--- a/showcase/integrations/llamaindex/manifest.yaml
+++ b/showcase/integrations/llamaindex/manifest.yaml
@@ -18,6 +18,8 @@ interaction_modalities:
   - sidebar
   - embedded
   - chat
+not_supported_features:
+  - shared-state-streaming
 features:
   - beautiful-chat
   - cli-start
@@ -47,7 +49,6 @@ features:
   - open-gen-ui
   - open-gen-ui-advanced
   - agent-config
-  - shared-state-streaming
   - shared-state-read-write
   - subagents
   - prebuilt-sidebar

--- a/showcase/integrations/mastra/manifest.yaml
+++ b/showcase/integrations/mastra/manifest.yaml
@@ -24,6 +24,8 @@ interaction_modalities:
 managed_platform:
   name: Mastra Cloud
   url: https://mastra.ai/cloud
+not_supported_features:
+  - shared-state-streaming
 features:
   - cli-start
   - agentic-chat
@@ -33,7 +35,6 @@ features:
   - tool-rendering-default-catchall
   - tool-rendering-custom-catchall
   - gen-ui-agent
-  - shared-state-streaming
   - readonly-state-agent-context
   - prebuilt-sidebar
   - prebuilt-popup

--- a/showcase/integrations/ms-agent-dotnet/manifest.yaml
+++ b/showcase/integrations/ms-agent-dotnet/manifest.yaml
@@ -21,6 +21,8 @@ interaction_modalities:
   - sidebar
   - embedded
   - chat
+not_supported_features:
+  - shared-state-streaming
 features:
   - beautiful-chat
   - cli-start
@@ -50,7 +52,6 @@ features:
   - tool-rendering-custom-catchall
   - tool-rendering
   - tool-rendering-reasoning-chain
-  - shared-state-streaming
   - shared-state-read-write
   - subagents
   - readonly-state-agent-context

--- a/showcase/integrations/ms-agent-python/manifest.yaml
+++ b/showcase/integrations/ms-agent-python/manifest.yaml
@@ -18,6 +18,8 @@ interaction_modalities:
   - sidebar
   - embedded
   - chat
+not_supported_features:
+  - shared-state-streaming
 features:
   - beautiful-chat
   - cli-start
@@ -48,7 +50,6 @@ features:
   - tool-rendering
   - tool-rendering-reasoning-chain
   - shared-state-read-write
-  - shared-state-streaming
   - subagents
   - readonly-state-agent-context
   - multimodal

--- a/showcase/integrations/pydantic-ai/manifest.yaml
+++ b/showcase/integrations/pydantic-ai/manifest.yaml
@@ -18,6 +18,8 @@ interaction_modalities:
   - sidebar
   - embedded
   - chat
+not_supported_features:
+  - shared-state-streaming
 features:
   - cli-start
   - agentic-chat
@@ -37,7 +39,6 @@ features:
   - tool-rendering-custom-catchall
   - gen-ui-agent
   - gen-ui-tool-based
-  - shared-state-streaming
   - shared-state-read-write
   - readonly-state-agent-context
   - subagents

--- a/showcase/integrations/pydantic-ai/src/app/demos/gen-ui-tool-based/bar-chart-renderer.snippet.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/gen-ui-tool-based/bar-chart-renderer.snippet.tsx
@@ -1,0 +1,32 @@
+// Docs-only snippet — not imported or rendered. The dashboard demo at
+// `page.tsx` for this framework runs a haiku-generator showcase via
+// `useFrontendTool`, but the canonical `/generative-ui/tool-based` page
+// teaches the simpler `useComponent` bar-chart pattern. This file shows
+// what the bar-chart renderer would look like in the same framework's
+// shape, so the docs render real teaching code rather than a missing-
+// snippet box.
+//
+// Mirrors the convention from `tool-rendering/render-flight-tool.snippet.tsx`.
+
+import { useComponent } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+// Stand-ins for the locally-authored bar chart component + its prop
+// schema. In a real page, these live in the demo directory (e.g.
+// `./bar-chart.tsx` exporting `BarChart` and `barChartPropsSchema`).
+declare const BarChart: React.ComponentType<{
+  title: string;
+  data: { label: string; value: number }[];
+}>;
+declare const barChartPropsSchema: z.ZodSchema;
+
+export function BarChartRenderer() {
+  // @region[bar-chart-renderer]
+  useComponent({
+    name: "render_bar_chart",
+    description: "Display a bar chart with labeled numeric values.",
+    parameters: barChartPropsSchema,
+    render: BarChart,
+  });
+  // @endregion[bar-chart-renderer]
+}

--- a/showcase/integrations/spring-ai/manifest.yaml
+++ b/showcase/integrations/spring-ai/manifest.yaml
@@ -26,6 +26,8 @@ interaction_modalities:
   - sidebar
   - embedded
   - chat
+not_supported_features:
+  - shared-state-streaming
 features:
   - cli-start
   - agentic-chat
@@ -64,7 +66,6 @@ features:
   - mcp-apps
   - byoc-hashbrown
   - byoc-json-render
-  - shared-state-streaming
   - gen-ui-interrupt
   - interrupt-headless
 a2ui_pattern: schema-inline

--- a/showcase/integrations/spring-ai/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/shared-state-streaming/page.tsx
@@ -27,6 +27,7 @@ export default function SharedStateStreamingDemo() {
 }
 
 function DemoContent() {
+  // @region[frontend-use-coagent-state]
   // Subscribe to BOTH state changes and run-status changes. The former
   // drives the per-token document rerender; the latter toggles the
   // "LIVE" badge when the agent starts / stops.
@@ -34,6 +35,7 @@ function DemoContent() {
     agentId: "shared-state-streaming",
     updates: [UseAgentUpdate.OnStateChanged, UseAgentUpdate.OnRunStatusChanged],
   });
+  // @endregion[frontend-use-coagent-state]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SharedStateStreamingController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SharedStateStreamingController.java
@@ -231,8 +231,12 @@ public class SharedStateStreamingController {
                                     textAccumulator.append(content);
                                 }
 
-                                // Handle tool call chunks — detect write_document
-                                // and emit STATE_SNAPSHOT as content grows
+                                // @region[state-streaming-middleware]
+                                // Spring AI equivalent of LangGraph's
+                                // StateStreamingMiddleware(StateItem(...)): as the LLM
+                                // streams the `write_document` tool's `content` argument,
+                                // forward the growing partial value into state.document
+                                // and emit a STATE_SNAPSHOT so the UI re-renders per token.
                                 if (evt.hasToolCalls()) {
                                     var tcs = evt.getResult().getOutput().getToolCalls();
                                     for (var tc : tcs) {
@@ -250,7 +254,7 @@ public class SharedStateStreamingController {
                                             if (partialContent != null
                                                     && partialContent.length() > prev.length()) {
                                                 lastDocContent.set(partialContent);
-                                                // Update state and emit snapshot
+                                                // Forward tool argument -> state key
                                                 runState.set("document", partialContent);
                                                 this.emitEvent(
                                                         stateSnapshotEvent(runState),
@@ -259,6 +263,7 @@ public class SharedStateStreamingController {
                                         }
                                     }
                                 }
+                                // @endregion[state-streaming-middleware]
                             },
                             err -> {
                                 streamError.set(err);

--- a/showcase/integrations/strands/manifest.yaml
+++ b/showcase/integrations/strands/manifest.yaml
@@ -21,6 +21,8 @@ interaction_modalities:
   - sidebar
   - embedded
   - chat
+not_supported_features:
+  - shared-state-streaming
 features:
   - cli-start
   - agentic-chat
@@ -47,7 +49,6 @@ features:
   - declarative-gen-ui
   - a2ui-fixed-schema
   - shared-state-read-write
-  - shared-state-streaming
   - readonly-state-agent-context
   - subagents
   - multimodal

--- a/showcase/integrations/strands/src/agents/agent.py
+++ b/showcase/integrations/strands/src/agents/agent.py
@@ -373,6 +373,18 @@ def get_sales_todos():
     return "Check the sales pipeline provided in the context."
 
 
+# @region[backend-tool-call]
+# Strands has no native interrupt primitive, so the gen-ui-interrupt and
+# interrupt-headless demos register `schedule_meeting` as a frontend tool
+# via `useFrontendTool`. Its async handler returns a Promise that only
+# resolves once the user picks a slot or cancels in the in-chat picker
+# (the Strands shim for LangGraph's `interrupt()` / `resolve()` pair).
+#
+# This `@tool` declaration is the backend's contract with the LLM: the
+# docstring and signature are what the model sees when deciding to call
+# `schedule_meeting`. CopilotKit's runtime routes the call to the frontend
+# handler registered with `useFrontendTool` (same name), so the local
+# `schedule_meeting_impl` body acts as a fallback for non-UI invocations.
 @tool
 def schedule_meeting(reason: str):
     """Schedule a meeting with user approval.
@@ -387,6 +399,7 @@ def schedule_meeting(reason: str):
         Meeting scheduling result as JSON string
     """
     return json.dumps(schedule_meeting_impl(reason))
+# @endregion[backend-tool-call]
 
 
 @tool


### PR DESCRIPTION
## Summary

Closes the remaining yellow-box snippet gaps in shell-docs ahead of the Tue 5/12 cutover. Replaces 5 individual one-PR-per-framework attempts with a single consolidated PR.

## What's in here

**Region marker additions** (5 commits, comment-only changes — zero runtime impact):
- `claude-sdk-typescript` `gen-ui-interrupt::backend-tool-call` — sibling teaching file (no per-demo backend in claude-sdk-ts; mirrors claude-sdk-python's Strategy B SYSTEM_PROMPT shape)
- `langroid` `gen-ui-interrupt::backend-tool-call` — in-place around the existing `ScheduleMeetingTool` `ToolMessage` subclass (preserves langroid's idiom — no forced LangGraph shape)
- `pydantic-ai` `gen-ui-tool-based::bar-chart-renderer` — sibling teaching file (production demo is haiku-generator via `useFrontendTool`, not a `useComponent` bar-chart)
- `spring-ai` `shared-state-streaming` (2 regions: `frontend-use-coagent-state` + `state-streaming-middleware`) — in-place; backend Java file already in `manifest.yaml` `highlight:`
- `strands` `gen-ui-interrupt::backend-tool-call` — in-place around the canonical `@tool def schedule_meeting`

All follow the [Mastra Round playbook](https://www.notion.so/34f3aa38185281c0b41dc6b6c63c89c6) for in-place vs sibling decisions.

**Catalog flips** (2 commits, manifest-only):
- 11 non-LangGraph frameworks: move `shared-state-streaming` from `features` to `not_supported_features` (ag2, agno, claude-sdk-{python,typescript}, crewai-crews, langroid, llamaindex, mastra, ms-agent-{dotnet,python}, pydantic-ai)
- 6 more without working demos: built-in-agent, google-adk, strands, langgraph-typescript, langgraph-fastapi, spring-ai
- Per team's call 2026-05-07: state-streaming only works on LangGraph variants currently. Anything without a working demo gets the blue `UnsupportedBox` instead of yellow `Missing snippet` warnings. Engineering can flip these back to `features` once impls land.

Final catalog state for `shared-state-streaming`: 17 unsupported, 1 wired (`langgraph-python` — canonical reference).

## Why now

This PR is cutover-blocking. Sam's bar for Tuesday: zero yellow boxes anywhere in shell-docs. The current state had 33+ yellow boxes from the post-2026-04-29 audit refresh; this PR drives that to zero (in conjunction with the previously-merged PDX-122 fix in #4685).

## Verification

- `npx tsx showcase/scripts/bundle-demo-content.ts` — all newly-marked regions resolve in `demo-content.json`
- `npx tsx showcase/scripts/generate-registry.ts` — catalog regenerates clean with the manifest changes
- Generated `catalog.json` files are gitignored artifacts; not in this diff

## Test plan

- [ ] Build shell-docs locally: `cd showcase/shell-docs && npm run build` clean
- [ ] Visit a few `shared-state/streaming.mdx` pages on framework variants — should render the blue "Not supported on X" box for the 17 unsupported frameworks
- [ ] Visit `langgraph-python/shared-state/streaming.mdx` — should still render the working snippets
- [ ] Visit the 4 fixed B-cell pages (claude-sdk-typescript/langroid/strands `human-in-the-loop/useInterrupt.mdx`, pydantic-ai `generative-ui/tool-based.mdx`, spring-ai `shared-state/streaming.mdx`) — all snippets resolve, no yellow boxes