### PR TITLE
fix(showcase): realign D5 probes/fixtures with idiomatic langgraph-python demos

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -1046,6 +1046,7 @@
         "userMessage": "show your reasoning step by step"
       },
       "response": {
+        "reasoning": "First, I identified that the question requires step-by-step reasoning. Then I broke it into sub-steps and worked through each one. Finally, I aggregated the partial answers into a single response.",
         "content": "Reasoning: first, I identified the question requires step-by-step thinking. Then, I broke it into sub-steps and worked through each one. Finally, I aggregated the partial answers into a single response. The reasoning block above the answer demonstrates intermediate-thought rendering."
       }
     },
@@ -2017,7 +2018,7 @@
           {
             "id": "call_d5_write_document_poem_001",
             "name": "write_document",
-            "arguments": "{\"content\":\"Crimson and amber in slow descent, / each leaf a quiet ledger of summer spent. / The wind, a courier with nothing to say, / files them gently into the morning's gray. / Somewhere a kettle hums, and afternoons grow brief — / autumn keeps its books in vermilion and gold leaf.\"}"
+            "arguments": "{\"document\":\"Crimson and amber in slow descent, / each leaf a quiet ledger of summer spent. / The wind, a courier with nothing to say, / files them gently into the morning's gray. / Somewhere a kettle hums, and afternoons grow brief — / autumn keeps its books in vermilion and gold leaf.\"}"
           }
         ]
       }
@@ -2033,7 +2034,7 @@
           {
             "id": "call_d5_write_document_email_001",
             "name": "write_document",
-            "arguments": "{\"content\":\"Hi — thanks for sending the invite for Tuesday afternoon. Unfortunately I won't be able to make it this week. I'd love to find time later in the month if your schedule allows. In the meantime, feel free to send any pre-reads my way and I'll review them async so we don't lose momentum. Best, [name]\"}"
+            "arguments": "{\"document\":\"Hi — thanks for sending the invite for Tuesday afternoon. Unfortunately I won't be able to make it this week. I'd love to find time later in the month if your schedule allows. In the meantime, feel free to send any pre-reads my way and I'll review them async so we don't lose momentum. Best, [name]\"}"
           }
         ]
       }
@@ -2049,7 +2050,7 @@
           {
             "id": "call_d5_write_document_quantum_001",
             "name": "write_document",
-            "arguments": "{\"content\":\"A regular computer stores information in bits — tiny switches that are either on (1) or off (0). A quantum computer uses qubits, which can sit in a fuzzy superposition of both states at once until you check them. Stack many qubits together and they can explore lots of possibilities in parallel, which is why people are excited.\\n\\nThis doesn't make quantum computers faster at everything. They're great at problems with hidden structure — like factoring big numbers, simulating molecules, or searching certain databases — but useless for, say, opening Excel. Today's machines are noisy and small, so we mostly use them to test ideas rather than replace your laptop.\"}"
+            "arguments": "{\"document\":\"A regular computer stores information in bits — tiny switches that are either on (1) or off (0). A quantum computer uses qubits, which can sit in a fuzzy superposition of both states at once until you check them. Stack many qubits together and they can explore lots of possibilities in parallel, which is why people are excited.\\n\\nThis doesn't make quantum computers faster at everything. They're great at problems with hidden structure — like factoring big numbers, simulating molecules, or searching certain databases — but useless for, say, opening Excel. Today's machines are noisy and small, so we mostly use them to test ideas rather than replace your laptop.\"}"
           }
         ]
       }

--- a/showcase/harness/fixtures/d5/reasoning-display.json
+++ b/showcase/harness/fixtures/d5/reasoning-display.json
@@ -1,9 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/agentic-chat-reasoning AND /demos/reasoning-default-render (one fixture, two routes). Substring 'show your reasoning step by step' is unique.",
+  "_comment": "D5 fixture for /demos/reasoning-custom AND /demos/reasoning-default. Substring 'show your reasoning step by step' is unique. Includes a `reasoning` field so aimock emits REASONING_MESSAGE_* events (role='reasoning'); without it the v2 `<ReasoningBlock>` (rendered behind `[data-testid=\"reasoning-block\"]`) never mounts because no reasoning-role message lands in the transcript.",
   "fixtures": [
     {
       "match": { "userMessage": "show your reasoning step by step" },
       "response": {
+        "reasoning": "First, I identified that the question requires step-by-step reasoning. Then I broke it into sub-steps and worked through each one. Finally, I aggregated the partial answers into a single response.",
         "content": "Reasoning: first, I identified the question requires step-by-step thinking. Then, I broke it into sub-steps and worked through each one. Finally, I aggregated the partial answers into a single response. The reasoning block above the answer demonstrates intermediate-thought rendering."
       }
     }

--- a/showcase/harness/fixtures/d5/shared-state-streaming.json
+++ b/showcase/harness/fixtures/d5/shared-state-streaming.json
@@ -9,7 +9,7 @@
           {
             "id": "call_d5_write_document_poem_001",
             "name": "write_document",
-            "arguments": "{\"content\":\"Crimson and amber in slow descent, / each leaf a quiet ledger of summer spent. / The wind, a courier with nothing to say, / files them gently into the morning's gray. / Somewhere a kettle hums, and afternoons grow brief — / autumn keeps its books in vermilion and gold leaf.\"}"
+            "arguments": "{\"document\":\"Crimson and amber in slow descent, / each leaf a quiet ledger of summer spent. / The wind, a courier with nothing to say, / files them gently into the morning's gray. / Somewhere a kettle hums, and afternoons grow brief — / autumn keeps its books in vermilion and gold leaf.\"}"
           }
         ]
       }
@@ -22,7 +22,7 @@
           {
             "id": "call_d5_write_document_email_001",
             "name": "write_document",
-            "arguments": "{\"content\":\"Hi — thanks for sending the invite for Tuesday afternoon. Unfortunately I won't be able to make it this week. I'd love to find time later in the month if your schedule allows. In the meantime, feel free to send any pre-reads my way and I'll review them async so we don't lose momentum. Best, [name]\"}"
+            "arguments": "{\"document\":\"Hi — thanks for sending the invite for Tuesday afternoon. Unfortunately I won't be able to make it this week. I'd love to find time later in the month if your schedule allows. In the meantime, feel free to send any pre-reads my way and I'll review them async so we don't lose momentum. Best, [name]\"}"
           }
         ]
       }
@@ -35,7 +35,7 @@
           {
             "id": "call_d5_write_document_quantum_001",
             "name": "write_document",
-            "arguments": "{\"content\":\"A regular computer stores information in bits — tiny switches that are either on (1) or off (0). A quantum computer uses qubits, which can sit in a fuzzy superposition of both states at once until you check them. Stack many qubits together and they can explore lots of possibilities in parallel, which is why people are excited.\\n\\nThis doesn't make quantum computers faster at everything. They're great at problems with hidden structure — like factoring big numbers, simulating molecules, or searching certain databases — but useless for, say, opening Excel. Today's machines are noisy and small, so we mostly use them to test ideas rather than replace your laptop.\"}"
+            "arguments": "{\"document\":\"A regular computer stores information in bits — tiny switches that are either on (1) or off (0). A quantum computer uses qubits, which can sit in a fuzzy superposition of both states at once until you check them. Stack many qubits together and they can explore lots of possibilities in parallel, which is why people are excited.\\n\\nThis doesn't make quantum computers faster at everything. They're great at problems with hidden structure — like factoring big numbers, simulating molecules, or searching certain databases — but useless for, say, opening Excel. Today's machines are noisy and small, so we mostly use them to test ideas rather than replace your laptop.\"}"
           }
         ]
       }

--- a/showcase/harness/src/probes/scripts/d5-chat-css.ts
+++ b/showcase/harness/src/probes/scripts/d5-chat-css.ts
@@ -44,12 +44,15 @@ export const ASSISTANT_BUBBLE_SELECTOR =
  *  background plus the ember left border. The outer message wrapper is
  *  transparent in the new theme; signals all live on this inner node.
  *
- *  Uses `[class~="bg-muted"]` (whole-token match in space-separated
- *  class lists) rather than `[class*="bg-muted"]` (substring match):
- *  the latter accidentally also matches `bg-muted-foreground`, which
- *  appears on nested children in real Tailwind output and would cause
- *  the probe to read computed styles off the wrong element. */
-export const USER_BUBBLE_INNER_SELECTOR = `${USER_BUBBLE_SELECTOR} [class~="bg-muted"]`;
+ *  v2 emits prefixed Tailwind utilities (e.g. `cpk:bg-muted`) on this
+ *  bubble, see CopilotChatUserMessage.tsx. Uses `[class~="cpk:bg-muted"]`
+ *  (whole-token match on the PREFIXED name) so:
+ *    - bare `[class~="bg-muted"]` wouldn't match (token is `cpk:bg-muted`)
+ *    - `[class*="bg-muted"]` would also match `cpk:bg-muted-foreground`
+ *      on nested children (Reasoning message dots) and read styles off
+ *      the wrong element.
+ *  The whole-token form on the prefixed string is unambiguous. */
+export const USER_BUBBLE_INNER_SELECTOR = `${USER_BUBBLE_SELECTOR} [class~="cpk:bg-muted"]`;
 
 // ── HALCYON theme anchors (langgraph-python) ──────────────────────────
 /** halcyon-ember rgb anchor (`#c44a1f`) on the user-bubble inner border-left. */
@@ -122,13 +125,12 @@ export async function probeChatCss(page: Page): Promise<ChatCssProbeResult> {
     const userOuter = win.document.querySelector(
       ".copilotKitMessage.copilotKitUserMessage",
     );
-    // The inner node is the v2 framework's bubble that consumes the
-    // `bg-muted` Tailwind utility — HALCYON hooks the substring
-    // class-match because the upstream Tailwind class composition
-    // includes `bg-muted` on the bubble div.
+    // The inner node is v2's CopilotChatUserMessage bubble. v2 emits
+    // PREFIXED Tailwind classes (`cpk:bg-muted`), so we whole-token-
+    // match on the prefixed name — see USER_BUBBLE_INNER_SELECTOR docs.
     const userInner = (
       userOuter as { querySelector?(sel: string): unknown } | null
-    )?.querySelector?.('[class~="bg-muted"]');
+    )?.querySelector?.('[class~="cpk:bg-muted"]');
     const assistantEl = win.document.querySelector(
       ".copilotKitMessage.copilotKitAssistantMessage",
     );

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-agent.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-agent.test.ts
@@ -4,9 +4,7 @@ import type { Page } from "../helpers/conversation-runner.js";
 import {
   buildTurns,
   buildAgentStateAssertion,
-  buildBaselineCapture,
   GEN_UI_AGENT_PILLS,
-  type AgentStepBaselineRef,
 } from "./d5-gen-ui-agent.js";
 
 function makePage(state: { stepCount: number; stepText: string }): Page {
@@ -18,17 +16,6 @@ function makePage(state: { stepCount: number; stepText: string }): Page {
       return state as unknown as R;
     },
   };
-}
-
-function newBaseline(): AgentStepBaselineRef {
-  return { stepCount: 0, stepText: "", captured: false };
-}
-
-function newCapturedBaseline(state: {
-  stepCount: number;
-  stepText: string;
-}): AgentStepBaselineRef {
-  return { ...state, captured: true };
 }
 
 describe("d5-gen-ui-agent script", () => {
@@ -51,19 +38,6 @@ describe("d5-gen-ui-agent script", () => {
     expect(turns[2]!.input).toContain("top competitor");
   });
 
-  it("each turn carries a preFill baseline-capture hook", () => {
-    const ctx: D5BuildContext = {
-      integrationSlug: "x",
-      featureType: "gen-ui-agent",
-      baseUrl: "https://x.test",
-    };
-    const turns = buildTurns(ctx);
-    for (const turn of turns) {
-      expect(typeof turn.preFill).toBe("function");
-      expect(typeof turn.assertions).toBe("function");
-    }
-  });
-
   it("GEN_UI_AGENT_PILLS lists three tags", () => {
     const tags = GEN_UI_AGENT_PILLS.map((p) => p.tag);
     expect(tags).toEqual([
@@ -73,25 +47,9 @@ describe("d5-gen-ui-agent script", () => {
     ]);
   });
 
-  it("baseline-capture writes the current step state into the ref", async () => {
-    const ref = newBaseline();
-    const capture = buildBaselineCapture(ref);
-    const page = makePage({ stepCount: 4, stepText: "leftover rows" });
-    await capture(page);
-    expect(ref.captured).toBe(true);
-    expect(ref.stepCount).toBe(4);
-    expect(ref.stepText).toBe("leftover rows");
-  });
-
-  it("assertion succeeds when ≥ 2 NEW rows render past baseline", async () => {
+  it("assertion succeeds when ≥ 2 step rows render with novel content", async () => {
     const seen = { values: [] as string[] };
-    // Pre-pill baseline has 0 rows; pill produces 3 → delta = 3.
-    const baseline = newCapturedBaseline({ stepCount: 0, stepText: "" });
-    const assertion = buildAgentStateAssertion(
-      "product-launch",
-      baseline,
-      seen,
-    );
+    const assertion = buildAgentStateAssertion("product-launch", seen);
     const page = makePage({
       stepCount: 3,
       stepText: "Define launch goals Coordinate marketing rollout",
@@ -100,76 +58,44 @@ describe("d5-gen-ui-agent script", () => {
     expect(seen.values).toHaveLength(1);
   });
 
-  it("assertion fails when no NEW rows render (cross-pill leftover)", async () => {
+  it("assertion succeeds across pills under last-write-wins state swap", async () => {
+    // First pill establishes a fingerprint; second pill swaps state
+    // (DOM still has 3 rows, but the textContent reflects the NEW
+    // pill's steps), assertion accepts because content differs from
+    // the seen-set.
     const seen = { values: [] as string[] };
-    // Baseline is 3 rows from a previous pill; final is also 3 → delta = 0.
-    const baseline = newCapturedBaseline({
+    const firstAssertion = buildAgentStateAssertion("product-launch", seen);
+    const firstPage = makePage({
       stepCount: 3,
-      stepText: "leftover steps from prior pill",
+      stepText: "launch goals marketing rollout post-launch metrics",
     });
-    const assertion = buildAgentStateAssertion("team-offsite", baseline, seen);
-    const page: Page = {
-      async waitForSelector() {},
-      async fill() {},
-      async press() {},
-      async evaluate<R>() {
-        // Always return the leftover state — delta stays 0, the
-        // 15s deadline fires and surfaces the "expected ≥ 2 NEW"
-        // message, proving the leftover guard fires.
-        return {
-          stepCount: 3,
-          stepText: "leftover steps from prior pill",
-        } as unknown as R;
-      },
-    };
-    await expect(assertion(page)).rejects.toThrow(/expected ≥ 2 NEW/);
+    await expect(firstAssertion(firstPage)).resolves.toBeUndefined();
+
+    const secondAssertion = buildAgentStateAssertion("team-offsite", seen);
+    const secondPage = makePage({
+      stepCount: 3,
+      stepText: "venue agenda travel",
+    });
+    await expect(secondAssertion(secondPage)).resolves.toBeUndefined();
+    expect(seen.values).toHaveLength(2);
+  });
+
+  it("assertion fails when fewer than 2 rows render in 15s", async () => {
+    const seen = { values: [] as string[] };
+    const assertion = buildAgentStateAssertion("team-offsite", seen);
+    const page = makePage({ stepCount: 1, stepText: "only one step" });
+    await expect(assertion(page)).rejects.toThrow(
+      /expected ≥ 2 \[data-testid="agent-step"\] rows/,
+    );
   }, 20_000);
-
-  it("assertion fails when baseline was never captured", async () => {
-    const seen = { values: [] as string[] };
-    const baseline = newBaseline(); // captured: false
-    const assertion = buildAgentStateAssertion(
-      "product-launch",
-      baseline,
-      seen,
-    );
-    const page = makePage({ stepCount: 5, stepText: "lots of steps" });
-    await expect(assertion(page)).rejects.toThrow(/baseline was not captured/);
-  });
-
-  it("assertion rejects when evaluate cannot produce settled state", async () => {
-    const seen = { values: [] as string[] };
-    const baseline = newCapturedBaseline({ stepCount: 0, stepText: "" });
-    const assertion = buildAgentStateAssertion(
-      "product-launch",
-      baseline,
-      seen,
-    );
-    let calls = 0;
-    const page: Page = {
-      async waitForSelector() {},
-      async fill() {},
-      async press() {},
-      async evaluate<R>() {
-        calls += 1;
-        // Throw after a few polls — the throw propagates out of
-        // `readAgentStepState` and aborts the polling loop, so the
-        // test exits quickly without waiting for the 15s deadline.
-        if (calls > 3) throw new Error("simulated abort");
-        return { stepCount: 0, stepText: "" } as unknown as R;
-      },
-    };
-    await expect(assertion(page)).rejects.toThrow();
-  });
 
   it("assertion fails when step content duplicates an earlier pill", async () => {
     const seen = { values: ["shared steps content"] };
-    const baseline = newCapturedBaseline({ stepCount: 0, stepText: "" });
-    const assertion = buildAgentStateAssertion("team-offsite", baseline, seen);
+    const assertion = buildAgentStateAssertion("team-offsite", seen);
     const page = makePage({
       stepCount: 3,
       stepText: "shared steps content",
     });
     await expect(assertion(page)).rejects.toThrow(/duplicates/);
-  });
+  }, 20_000);
 });

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-agent.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-agent.ts
@@ -66,50 +66,27 @@ async function readAgentStepState(page: Page): Promise<{
   })) as { stepCount: number; stepText: string };
 }
 
-/** Per-pill baseline ref for the step count BEFORE the pill is sent.
- *  Closed over by both the `preFill` hook (writes) and the assertion
- *  (reads). This is essential because `[data-testid="agent-step"]`
- *  rows from pill N persist into pill N+1's DOM — without baselining,
- *  the assertion can't distinguish "this pill produced ≥ 2 new rows"
- *  from "leftover rows from earlier pills". */
-export interface AgentStepBaselineRef {
-  stepCount: number;
-  stepText: string;
-  captured: boolean;
-}
-
-/** Build the `preFill` hook that captures the agent-step DOM state
- *  before the pill is sent. The runner invokes this once per turn,
- *  before the chat input fill+press. */
-export function buildBaselineCapture(
-  ref: AgentStepBaselineRef,
-): (page: Page) => Promise<void> {
-  return async (page: Page): Promise<void> => {
-    const state = await readAgentStepState(page);
-    ref.stepCount = state.stepCount;
-    ref.stepText = state.stepText;
-    ref.captured = true;
-  };
-}
-
 /** Build a per-pill assertion. `seenStepTextsRef` accumulates the
  *  observed step-text fingerprint across pills — a regression where
  *  every pill produces the SAME steps would fail at the second pill
  *  because `stepText` would equal a previous entry.
  *
- *  Primary signal: the step-count delta against the pre-pill baseline
- *  must be ≥ 2 (the pill produced at least two NEW step rows). The
- *  absolute count check used previously could trivially pass on
- *  leftover rows from an earlier pill — see Phase-2C gen-ui-agent
- *  cross-pill DOM accumulation finding.
+ *  Note on the swap-not-accumulate model: the backend's `set_steps`
+ *  reducer is `last-write-wins` (see `gen_ui_agent.py`), so each pill
+ *  REPLACES `state.steps` rather than appending. The DOM mirrors
+ *  state, so step-row count after pill N reflects ONLY pill N's
+ *  steps — earlier pills' rows unmount. An earlier "delta vs.
+ *  pre-pill baseline ≥ 2" check assumed accumulation and failed at
+ *  pill 2+ even when the new steps rendered correctly.
  *
- *  Secondary signal: cumulative-text fingerprint across pills must
- *  not duplicate a previous pill (catches a fixture that returns the
- *  same canned step list regardless of prompt).
+ *  Primary signal: ≥ 2 step rows visible after the pill settles. The
+ *  fingerprint deduplication keeps catching a fixture that returns
+ *  identical content regardless of prompt — that probe still works
+ *  under the swap model, since the textContent of the visible rows
+ *  IS the per-pill content.
  */
 export function buildAgentStateAssertion(
   pillTag: string,
-  baselineRef: AgentStepBaselineRef,
   seenStepTextsRef: { values: string[] },
 ): (page: Page) => Promise<void> {
   return async (page: Page): Promise<void> => {
@@ -119,57 +96,52 @@ export function buildAgentStateAssertion(
       FIRST_SIGNAL_TIMEOUT_MS,
       `gen-ui-agent-${pillTag}`,
     );
-    if (!baselineRef.captured) {
-      throw new Error(
-        `gen-ui-agent-${pillTag}: baseline was not captured by preFill (test wiring error)`,
-      );
-    }
-    // Wait briefly for step rows to settle (the agent streams them
-    // one set_steps call at a time). We need the step count to grow
-    // past the pre-pill baseline by at least 2.
+    // Wait briefly for the swap to settle. We need ≥ 2 step rows
+    // visible, AND we need the visible textContent to differ from
+    // any earlier pill (fingerprint dedup).
     const deadline = Date.now() + 15_000;
     let last = { stepCount: 0, stepText: "" };
-    let delta = 0;
     while (Date.now() < deadline) {
       last = await readAgentStepState(page);
-      delta = last.stepCount - baselineRef.stepCount;
-      if (delta >= 2) break;
+      if (last.stepCount >= 2) {
+        const fingerprint = last.stepText.trim().toLowerCase();
+        if (
+          seenStepTextsRef.values.length > 0 &&
+          seenStepTextsRef.values.includes(fingerprint)
+        ) {
+          // Same content as earlier pill — wait for the swap to
+          // finish landing. (Brief window where the DOM still
+          // shows the previous pill's rows.)
+          await new Promise((r) => setTimeout(r, 300));
+          continue;
+        }
+        // Stable, ≥ 2 rows, content differs from earlier pills.
+        seenStepTextsRef.values.push(fingerprint);
+        return;
+      }
       await new Promise((r) => setTimeout(r, 300));
     }
-    if (delta < 2) {
+    if (last.stepCount < 2) {
       throw new Error(
-        `gen-ui-agent-${pillTag}: expected ≥ 2 NEW [data-testid="agent-step"] rows ` +
-          `(baseline=${baselineRef.stepCount}, final=${last.stepCount}, delta=${delta})`,
+        `gen-ui-agent-${pillTag}: expected ≥ 2 [data-testid="agent-step"] rows ` +
+          `(observed=${last.stepCount}) within 15s — pill set_steps tool call may not have streamed state`,
       );
     }
-    const fingerprint = last.stepText.trim().toLowerCase();
-    if (
-      seenStepTextsRef.values.length > 0 &&
-      seenStepTextsRef.values.includes(fingerprint)
-    ) {
-      throw new Error(
-        `gen-ui-agent-${pillTag}: step content duplicates an earlier pill — fixture is not differentiating by prompt`,
-      );
-    }
-    seenStepTextsRef.values.push(fingerprint);
+    // Reached deadline with enough rows but content kept duplicating
+    // an earlier pill — fixture is not differentiating by prompt.
+    throw new Error(
+      `gen-ui-agent-${pillTag}: step content duplicates an earlier pill — fixture is not differentiating by prompt`,
+    );
   };
 }
 
 export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
   const seenStepTextsRef = { values: [] as string[] };
-  return GEN_UI_AGENT_PILLS.map(({ tag, prompt }) => {
-    const baselineRef: AgentStepBaselineRef = {
-      stepCount: 0,
-      stepText: "",
-      captured: false,
-    };
-    return {
-      input: prompt,
-      preFill: buildBaselineCapture(baselineRef),
-      assertions: buildAgentStateAssertion(tag, baselineRef, seenStepTextsRef),
-      responseTimeoutMs: 60_000,
-    };
-  });
+  return GEN_UI_AGENT_PILLS.map(({ tag, prompt }) => ({
+    input: prompt,
+    assertions: buildAgentStateAssertion(tag, seenStepTextsRef),
+    responseTimeoutMs: 60_000,
+  }));
 }
 
 registerD5Script({

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-headless-complete.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-headless-complete.ts
@@ -74,8 +74,12 @@ const TURN_EXPECTATIONS: readonly ChipExpectation[] = [
 ];
 
 /** Click a suggestion chip by its visible title. The SuggestionBar
- *  renders chips as `<Badge asChild><button>{title}</button></Badge>`,
- *  so a `button >> text="<title>"` selector hits the right node.
+ *  renders chips as `<Badge asChild><button aria-label="Suggestion: ${title}">{title}</button></Badge>`,
+ *  so the aria-label attribute selector is the most reliable hook —
+ *  text-content selectors have to wait for hydration of the inner text
+ *  node, while the aria-label is set inline at JSX time and shows up as
+ *  soon as the button DOM exists. The bare-text fallback also catches
+ *  any reordering / stripping of the aria-label.
  *
  *  Same runtime-guard cast pattern as `_beautiful-chat-shared.ts` —
  *  the runner's structural Page shim doesn't expose `click()` on its
@@ -91,7 +95,9 @@ async function clickChip(page: Page, title: string): Promise<void> {
         "must expose click() for chip-driven turns",
     );
   }
-  await candidate.click(`button >> text="${title}"`, { timeout: 10_000 });
+  await candidate.click(`button[aria-label="Suggestion: ${title}"]`, {
+    timeout: 10_000,
+  });
 }
 
 /** Read all assistant-message bubbles' textContent and concatenate to


### PR DESCRIPTION
## Summary

Five targeted fixes for the post-merge red rows on langgraph-python's D5 column, all driven from PB error-class diagnostics on the cycles after #4718 + #4722. Each is independently load-bearing.

- **chat-css**: probe selector now matches v2's PREFIXED utility classes (`cpk:bg-muted`) instead of bare `bg-muted`.
- **gen-ui-agent**: probe rewritten for the `last-write-wins` reducer model — drop the cross-pill baseline assumption, assert ≥ 2 visible rows + content fingerprint dedup.
- **gen-ui-headless-complete**: chip click via stable `aria-label` attribute, not text-content chained selector.
- **shared-state-streaming**: fixture argument key was `content`, but `write_document(document: str)` tool expects `document` — renamed in both per-feature fixture and `d5-all.json`.
- **reasoning-display**: fixture now emits a `reasoning` field so aimock fires REASONING_MESSAGE_* events; probe's `[data-testid="reasoning-block"]` mounts only when a reasoning-role message lands.

The remaining 6 reds (auth, frontend-tools, gen-ui-open*, agent-config, beautiful-chat-toggle-theme, beautiful-chat-search-flights, gen-ui-declarative, tool-rendering-{default,custom}-catchall, gen-ui-interrupt) need either runtime debugging or more investigation; they're tracked separately.

## Test plan

- [ ] Land + watch the next e2e-deep cycle in PB
- [ ] Confirm chat-css, gen-ui-agent, gen-ui-headless-complete, shared-state-streaming, reasoning-display all flip green
- [ ] No regression on previously-green features

🤖 Generated with [Claude Code](https://claude.com/claude-code)