### PR TITLE
fix(showcase/langgraph-python): flip auth, frontend-tools, voice from D4 to D5

### DIFF
--- a/showcase/harness/src/probes/helpers/conversation-runner.test.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.test.ts
@@ -730,6 +730,64 @@ describe("runConversation", () => {
     expect(recorded.presses).toEqual(["Enter"]);
   });
 
+  it("preFill mounts the chat input — resolution is deferred past preFill (auth-shape regression)", async () => {
+    // Idiomatic auth demos (langgraph-python) render a SignInCard until
+    // the user clicks "Sign in with demo token". The chat input only
+    // mounts AFTER that click, which preFill performs. Before this
+    // ordering fix, runConversation resolved the input cascade up
+    // front and timed out before preFill ever ran. This test pins the
+    // post-fix invariant: cascade probe throws while unmounted,
+    // preFill makes it visible, the runner then resolves and proceeds.
+    let chatMounted = false;
+    let assistantCalls = 0;
+    const order: string[] = [];
+    const page: Page = {
+      async waitForSelector(selector) {
+        order.push(`waitForSelector:${selector}`);
+        if (!chatMounted) {
+          throw new Error(`no match for ${selector}`);
+        }
+      },
+      async fill(_selector, value) {
+        order.push(`fill:${value}`);
+      },
+      async press() {
+        order.push("press");
+      },
+      evaluate: wrapEvaluateForUserMessages(async () => {
+        // Baseline read returns 0; subsequent assistant reads return
+        // 1 so the message-count growth check settles.
+        assistantCalls += 1;
+        return (assistantCalls === 1 ? 0 : 1) as never;
+      }),
+    };
+
+    const turns: ConversationTurn[] = [
+      {
+        input: "hello",
+        preFill: async () => {
+          order.push("preFill:click-sign-in");
+          chatMounted = true;
+        },
+      },
+    ];
+
+    const result = await runConversation(page, turns, {
+      assistantSettleMs: 30,
+    });
+
+    expect(result.turns_completed).toBe(1);
+    expect(result.failure_turn).toBeUndefined();
+    // preFill must precede the first waitForSelector (cascade probe)
+    // — that ordering is what makes the auth shape work.
+    const preFillIdx = order.indexOf("preFill:click-sign-in");
+    const firstWaitIdx = order.findIndex((s) =>
+      s.startsWith("waitForSelector:"),
+    );
+    expect(preFillIdx).toBeGreaterThanOrEqual(0);
+    expect(firstWaitIdx).toBeGreaterThan(preFillIdx);
+  });
+
   it("stringifies non-Error throws (e.g. a thrown string) into result.error", async () => {
     // Some libraries throw non-Error values. The runner's errorMessage
     // helper falls back to String(err) so callers always see a usable

--- a/showcase/harness/src/probes/helpers/conversation-runner.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.ts
@@ -266,38 +266,20 @@ export async function runConversation(
     };
   }
 
-  // Resolve the chat input ONCE up front — same selector for every
-  // turn. The cascade probe is cheap on the canonical case (first
-  // selector wins on conformant showcases) and the resolved selector
-  // is reused so we don't re-probe per turn.
-  let chatInputSelector: string;
-  try {
-    chatInputSelector = await resolveChatInputSelector(
-      page,
-      opts.chatInputSelector,
-    );
-    console.debug("[conversation-runner] resolved chat input selector", {
-      selector: chatInputSelector,
-    });
-  } catch (err) {
-    console.debug("[conversation-runner] chat input selector cascade FAILED", {
-      error: errorMessage(err),
-    });
-    return {
-      turns_completed: 0,
-      total_turns: total,
-      failure_turn: 1,
-      error: `chat input not found: ${errorMessage(err)}`,
-      turn_durations_ms: [],
-    };
-  }
-
-  // Initial assistant-message count BEFORE turn 1 — usually 0 on a
-  // fresh page, but a probe that lands on a page with prior history
-  // (e.g. a session that was rehydrated) would see a non-zero starting
-  // count, and we need to wait for growth from that baseline rather
-  // than from 0.
-  let baselineCount = await readMessageCount(page);
+  // Resolve the chat input lazily — same selector for every turn once
+  // resolved, but the first resolution is deferred until after turn 1's
+  // preFill runs. Demos with an unauthenticated landing surface (auth)
+  // don't mount the chat textarea until the user clicks "Sign in", so
+  // resolving up front would time out on the SignInCard before preFill
+  // ever got a chance to dismiss it. Subsequent turns reuse the cached
+  // selector so we don't re-probe per turn.
+  let chatInputSelector: string | null = null;
+  // Initial assistant-message count is also computed lazily (after
+  // preFill) for the same reason: on idiomatic-shape auth demos the
+  // chat tree isn't mounted until preFill clicks sign-in, so reading
+  // before preFill would always observe 0 (correct here, but the read
+  // belongs alongside the resolution it pairs with).
+  let baselineCount = 0;
   console.debug(
     "[conversation-runner] initial baseline assistant message count",
     {
@@ -329,6 +311,36 @@ export async function runConversation(
         console.debug(
           `[conversation-runner] turn ${turnNum}/${total} — preFill hook completed`,
         );
+      }
+
+      if (chatInputSelector === null) {
+        try {
+          chatInputSelector = await resolveChatInputSelector(
+            page,
+            opts.chatInputSelector,
+          );
+          console.debug("[conversation-runner] resolved chat input selector", {
+            selector: chatInputSelector,
+            turnNum,
+          });
+          baselineCount = await readMessageCount(page);
+          console.debug(
+            "[conversation-runner] initial baseline assistant message count",
+            { baselineCount },
+          );
+        } catch (err) {
+          console.debug(
+            "[conversation-runner] chat input selector cascade FAILED",
+            { error: errorMessage(err), turnNum },
+          );
+          return {
+            turns_completed: idx,
+            total_turns: total,
+            failure_turn: turnNum,
+            error: `chat input not found: ${errorMessage(err)}`,
+            turn_durations_ms: durations,
+          };
+        }
       }
 
       if (turn.skipFill) {

--- a/showcase/harness/src/probes/scripts/d5-frontend-tools.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-frontend-tools.test.ts
@@ -101,4 +101,28 @@ describe("d5-frontend-tools script", () => {
     const page = makePage(["#0a3d2e green gradient"]);
     await expect(assert(page)).rejects.toThrow(/sunset hint/);
   });
+
+  it("assertion accepts arbitrary green hex codes via channel-dominance fallback (real-LLM nondeterminism)", async () => {
+    // Real OpenAI returned `linear-gradient(to right, #005f00, #4caf50)`
+    // for the forest pill — perfectly valid green, but neither the
+    // word `green` nor any of the fixture-pinned hex codes
+    // (`#0a3d2e`/`#166534`/`#059669`) appears as a substring. The
+    // channel-dominance fallback parses the hex codes and accepts
+    // them because each one has G > R AND G > B. Without the
+    // fallback this assertion would throw.
+    const baseline = { current: "#4f46e5" };
+    const assert = buildPillAssertion("forest", baseline);
+    const page = makePage(["linear-gradient(to right, #005f00, #4caf50)"]);
+    await expect(assert(page)).resolves.toBeUndefined();
+  });
+
+  it("assertion still rejects a gradient with no on-family hex AND no on-family word", async () => {
+    // Forest pill, but page emitted only sunset-family hex codes.
+    // Word match misses (no green/forest etc.) AND channel-dominance
+    // misses (R-dominant, not G-dominant). Must throw.
+    const baseline = { current: "#4f46e5" };
+    const assert = buildPillAssertion("forest", baseline);
+    const page = makePage(["linear-gradient(to right, #ff7e5f, #ff6b6b)"]);
+    await expect(assert(page)).rejects.toThrow(/forest hint/);
+  });
 });

--- a/showcase/harness/src/probes/scripts/d5-frontend-tools.ts
+++ b/showcase/harness/src/probes/scripts/d5-frontend-tools.ts
@@ -114,6 +114,62 @@ export const PILL_GRADIENT_HINTS: Record<string, readonly string[]> = {
   ],
 } as const;
 
+/** Per-pill RGB-channel-dominance test for hex codes parsed out of the
+ *  gradient. The substring hint list above pins the fixture/aimock
+ *  output deterministically; this dominance check is the fallback for
+ *  real-LLM nondeterminism, where the model emits any chromatic-family
+ *  hex (e.g. forest as `#005f00 / #4caf50`) that the fixed substring
+ *  list can't enumerate. A green hex always satisfies G > R AND G > B
+ *  regardless of which exact green; sunset/cosmic mirror that on R/B.
+ *
+ *  The check requires the channel separation to clear MIN_DELTA so a
+ *  near-grey color like `#777` (R≈G≈B) doesn't accidentally satisfy
+ *  every family. MIN_VALUE filters out near-black so a single-channel
+ *  black-ish swatch (e.g. `#020000`) doesn't pass as red.
+ */
+const MIN_DOMINANCE_DELTA = 24;
+const MIN_DOMINANT_VALUE = 64;
+const PILL_HEX_DOMINANCE: Record<
+  string,
+  (rgb: { r: number; g: number; b: number }) => boolean
+> = {
+  sunset: ({ r, g, b }) =>
+    r >= MIN_DOMINANT_VALUE &&
+    r - g >= MIN_DOMINANCE_DELTA &&
+    r - b >= MIN_DOMINANCE_DELTA,
+  forest: ({ r, g, b }) =>
+    g >= MIN_DOMINANT_VALUE &&
+    g - r >= MIN_DOMINANCE_DELTA &&
+    g - b >= MIN_DOMINANCE_DELTA,
+  // Cosmic accepts navy (B dominant) AND purple/magenta (B and R both
+  // beat G — the `#9333ea` / `#6b21a8` family) — both are valid
+  // "cosmic" outputs in the wild.
+  cosmic: ({ r, g, b }) => {
+    const navy = b >= MIN_DOMINANT_VALUE && b - g >= MIN_DOMINANCE_DELTA;
+    const purple =
+      b >= MIN_DOMINANT_VALUE &&
+      r >= MIN_DOMINANT_VALUE &&
+      b - g >= MIN_DOMINANCE_DELTA &&
+      r - g >= MIN_DOMINANCE_DELTA;
+    return navy || purple;
+  },
+};
+
+/** Extract every 6-digit hex code from a CSS string and return them as
+ *  RGB triples. 3-digit shorthand (`#0f0`) is intentionally not
+ *  expanded — every gradient the demo emits uses 6-digit codes. */
+function parseHexes(css: string): { r: number; g: number; b: number }[] {
+  const matches = css.match(/#([0-9a-f]{6})/gi) ?? [];
+  return matches.map((hex) => {
+    const v = hex.slice(1);
+    return {
+      r: parseInt(v.slice(0, 2), 16),
+      g: parseInt(v.slice(2, 4), 16),
+      b: parseInt(v.slice(4, 6), 16),
+    };
+  });
+}
+
 /** Read the live background CSS off the testid'd container. */
 async function readBackgroundCss(page: Page): Promise<string> {
   return (await page.evaluate(() => {
@@ -174,10 +230,14 @@ export function buildPillAssertion(
       pillTag,
     );
     const lower = next.toLowerCase();
-    const matched = hints.some((h) => lower.includes(h));
-    if (!matched) {
+    const wordOrFixtureHexMatch = hints.some((h) => lower.includes(h));
+    const dominance = PILL_HEX_DOMINANCE[pillTag];
+    const hexes = parseHexes(next);
+    const dominanceMatch =
+      dominance !== undefined && hexes.some((rgb) => dominance(rgb));
+    if (!wordOrFixtureHexMatch && !dominanceMatch) {
       throw new Error(
-        `frontend-tools-${pillTag}: background "${next.slice(0, 200)}" does not contain any expected ${pillTag} hint (any of ${hints.join(", ")})`,
+        `frontend-tools-${pillTag}: background "${next.slice(0, 200)}" does not contain any expected ${pillTag} hint (words/fixture-hex: ${hints.join(", ")}; no parsed hex satisfied ${pillTag} channel-dominance either)`,
       );
     }
     baselineRef.current = next;

--- a/showcase/integrations/langgraph-python/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/voice/page.tsx
@@ -10,6 +10,14 @@ export default function VoiceDemoPage() {
       runtimeUrl="/api/copilotkit-voice"
       agent="voice-demo"
       useSingleEndpoint={false}
+      // The dev-only `<cpk-web-inspector>` overlay (auto-enabled on
+      // localhost via shouldShowDevConsole) intercepts pointer events
+      // on top of the voice sample-audio button, so dev/D5 probe runs
+      // can't click it through Playwright. Production isn't localhost
+      // so the inspector never mounts there — voice is D5 in prod and
+      // D4 locally for this reason alone. Disable explicitly here so
+      // the demo behaves the same in both environments.
+      enableInspector={false}
     >
       <VoiceChat />
     </CopilotKit>


### PR DESCRIPTION
## Summary

Three independent D5 fixes for the langgraph-python column. Together these flip 3 cells from D4 → D5 in the showcase dashboard. Production also has these same D4 cells, so the harness/showcase changes here apply to prod as well once merged.

- **auth** — conversation runner now defers chat-input resolution until after the first turn's `preFill` runs, so idiomatic auth demos that mount the chat tree only after a sign-in click work end-to-end.
- **frontend-tools** — D5 assertion accepts any chromatic-family hex via RGB-channel-dominance, not just the fixture-pinned substrings. Real OpenAI returned valid forest greens (`#005f00`, `#4caf50`) that the fixed substring list couldn't enumerate.
- **voice** — disabled `<cpk-web-inspector>` on the voice demo. The dev-only inspector auto-mounts on any localhost host (including local Docker at `localhost:3100`) and intercepts pointer events on the voice sample-audio button. Production isn't localhost, so prod was unaffected — that's why prod was D5 and local was D4.

Each commit is scoped to one fix with regression tests where applicable.

## Verification

Verified locally against a fresh `aimock` + `pocketbase` + `dashboard` + `langgraph-python` stack with real `OPENAI_API_KEY`:

| Cell | Before | After |
|---|---|---|
| `d5:langgraph-python/auth` | red | green |
| `d5:langgraph-python/frontend-tools` | red | green |
| `d5:langgraph-python/voice` | red | green |

Harness tests added:

- `conversation-runner.test.ts` — pins the post-fix invariant: cascade probe throws while the chat input is unmounted, `preFill` makes it visible, runner then resolves and proceeds. Without the fix the runner would resolve up-front and time out.
- `d5-frontend-tools.test.ts` — two new tests: accepts arbitrary green hex via channel-dominance (real-LLM nondeterminism guard), and still rejects sunset-hex emitted under the forest pill (regression guard so the fallback can't degrade into "any color passes").

All 42 tests in the affected files pass; format and oxlint both clean on touched files.

## Test plan

- [ ] CI green on the `langgraph-python` D5 cron (auth, frontend-tools, voice)
- [ ] Production `dashboard.showcase.copilotkit.ai` shows 3 D4 → D5 transitions on the langgraph-python column after deploy
- [ ] No regression on the rest of the langgraph-python column