### PR TITLE
fix(react-core): re-render replaced activity snapshots

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -84,6 +84,24 @@ export type CopilotChatProps = Omit<
    */
   throttleMs?: number;
 };
+
+function getContentMemoKey(message: {
+  role: string;
+  content?: unknown;
+}): number | string {
+  if (message.role === "activity") {
+    try {
+      return JSON.stringify(message.content) ?? "";
+    } catch {
+      return "unserializable";
+    }
+  }
+
+  if (typeof message.content === "string") return message.content.length;
+  if (Array.isArray(message.content)) return message.content.length;
+  return 0;
+}
+
 export function CopilotChat({
   agentId,
   threadId,
@@ -524,14 +542,14 @@ export function CopilotChat({
   //   - message id, role, content length (text streaming)
   //   - content part count (multimodal additions)
   //   - tool call ids + argument lengths (tool call streaming)
+  //   - serialized activity content (activity snapshots are object-shaped)
   const messagesMemoKey = agent.messages
     .map((m) => {
-      const contentKey =
-        typeof m.content === "string"
-          ? m.content.length
-          : Array.isArray(m.content)
-            ? m.content.length
-            : 0;
+      const contentKey = getContentMemoKey(m);
+      const activityTypeKey =
+        m.role === "activity" && "activityType" in m
+          ? String(m.activityType)
+          : "";
       const toolCallsKey =
         "toolCalls" in m && Array.isArray(m.toolCalls)
           ? m.toolCalls
@@ -540,7 +558,7 @@ export function CopilotChat({
               )
               .join(";")
           : "";
-      return `${m.id}:${m.role}:${contentKey}:${toolCallsKey}`;
+      return `${m.id}:${m.role}:${activityTypeKey}:${contentKey}:${toolCallsKey}`;
     })
     .join(",");
   const messages = useMemo(

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -56,6 +56,16 @@ function resolveSlotComponent<T extends React.ComponentType<any>>(
   return { Component: DefaultComponent, slotProps: undefined };
 }
 
+function getActivityContentMemoKey(
+  content: ActivityMessage["content"],
+): string {
+  try {
+    return JSON.stringify(content) ?? "";
+  } catch {
+    return "unserializable";
+  }
+}
+
 /**
  * Memoized wrapper for assistant messages to prevent re-renders when other messages change.
  */
@@ -183,6 +193,8 @@ const MemoizedActivityMessage = React.memo(
     renderActivityMessage,
   }: {
     message: ActivityMessage;
+    activityType: string;
+    contentKey: string;
     renderActivityMessage: (
       message: ActivityMessage,
     ) => React.ReactElement | null;
@@ -194,15 +206,10 @@ const MemoizedActivityMessage = React.memo(
     if (prevProps.message.id !== nextProps.message.id) return false;
 
     // Activity type changed = must re-render
-    if (prevProps.message.activityType !== nextProps.message.activityType)
-      return false;
+    if (prevProps.activityType !== nextProps.activityType) return false;
 
-    // Compare content using JSON.stringify (native code, handles deep comparison)
-    if (
-      JSON.stringify(prevProps.message.content) !==
-      JSON.stringify(nextProps.message.content)
-    )
-      return false;
+    // Compare the render-time content key so in-place message mutation is visible.
+    if (prevProps.contentKey !== nextProps.contentKey) return false;
 
     return true;
   },
@@ -574,10 +581,13 @@ export function CopilotChatMessageView({
         />,
       );
     } else if (message.role === "activity") {
+      const activityMessage = message as ActivityMessage;
       elements.push(
         <MemoizedActivityMessage
           key={message.id}
-          message={message as ActivityMessage}
+          message={activityMessage}
+          activityType={activityMessage.activityType}
+          contentKey={getActivityContentMemoKey(activityMessage.content)}
           renderActivityMessage={renderActivityMessage}
         />,
       );

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
@@ -220,6 +220,63 @@ describe("CopilotChat activity message rendering", () => {
     });
   });
 
+  it("re-renders replaced activity snapshots with the same message id", async () => {
+    const agent = new MockStepwiseAgent();
+
+    const activityRenderer: ReactActivityMessageRenderer<{
+      page: number;
+    }> = {
+      activityType: "pagination",
+      content: z.object({ page: z.number() }),
+      render: ({ content }) => (
+        <div data-testid="activity-page">Page {content.page}</div>
+      ),
+    };
+
+    renderWithCopilotKit({
+      agent,
+      renderActivityMessages: [activityRenderer],
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "Show page" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Show page")).toBeDefined();
+    });
+
+    const activityMessageId = testId("activity-replace");
+    agent.emit(runStartedEvent());
+    agent.emit({
+      ...activitySnapshotEvent({
+        messageId: activityMessageId,
+        activityType: "pagination",
+        content: { page: 1 },
+      }),
+      replace: true,
+    } as ReturnType<typeof activitySnapshotEvent> & { replace: true });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-page").textContent).toBe("Page 1");
+    });
+
+    agent.emit({
+      ...activitySnapshotEvent({
+        messageId: activityMessageId,
+        activityType: "pagination",
+        content: { page: 2 },
+      }),
+      replace: true,
+    } as ReturnType<typeof activitySnapshotEvent> & { replace: true });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-page").textContent).toBe("Page 2");
+    });
+
+    agent.emit(runFinishedEvent());
+  });
+
   it("skips unmatched activity types when no renderer exists", async () => {
     const agent = new MockStepwiseAgent();
 

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRerenders.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRerenders.e2e.test.tsx
@@ -1232,6 +1232,85 @@ describe("Activity Message Re-render Prevention", () => {
     });
   });
 
+  it("should re-render an activity message when its content changes in place", async () => {
+    const renderCounts: Record<string, number> = {};
+    const capturedContent: { status: string; percent: number }[] = [];
+
+    const activityRenderer: ReactActivityMessageRenderer<{
+      status: string;
+      percent: number;
+    }> = {
+      activityType: "progress",
+      content: z.object({ status: z.string(), percent: z.number() }),
+      render: ({ content, message }) => {
+        renderCounts[message.id] = (renderCounts[message.id] || 0) + 1;
+        capturedContent.push({ ...content });
+        return (
+          <div data-testid={`activity-${message.id}`}>
+            <span data-testid={`activity-status-${message.id}`}>
+              {content.status}
+            </span>
+            <span data-testid={`activity-percent-${message.id}`}>
+              {content.percent}
+            </span>
+          </div>
+        );
+      },
+    };
+
+    const activityMessage = {
+      id: "activity-1",
+      role: "activity",
+      activityType: "progress",
+      content: { status: "Starting", percent: 0 },
+    } as ActivityMessage;
+    const initialMessages: Message[] = [activityMessage];
+
+    const { rerender } = render(
+      <CopilotKitProvider renderActivityMessages={[activityRenderer]}>
+        <CopilotChatConfigurationProvider agentId="default" threadId="test">
+          <CopilotChatMessageView messages={initialMessages} isRunning={true} />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-activity-1")).toBeDefined();
+    });
+
+    const renderCountAfterInitial = renderCounts["activity-1"]!;
+    expect(renderCountAfterInitial).toBe(1);
+
+    activityMessage.content = { status: "Processing", percent: 50 };
+    const updatedMessages: Message[] = [activityMessage];
+
+    rerender(
+      <CopilotKitProvider renderActivityMessages={[activityRenderer]}>
+        <CopilotChatConfigurationProvider agentId="default" threadId="test">
+          <CopilotChatMessageView messages={updatedMessages} isRunning={true} />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("activity-status-activity-1").textContent).toBe(
+        "Processing",
+      );
+      expect(
+        screen.getByTestId("activity-percent-activity-1").textContent,
+      ).toBe("50");
+    });
+
+    const renderCountAfterUpdate = renderCounts["activity-1"]!;
+
+    expect(renderCountAfterUpdate).toBeGreaterThan(renderCountAfterInitial);
+    expect(capturedContent).toContainEqual({ status: "Starting", percent: 0 });
+    expect(capturedContent).toContainEqual({
+      status: "Processing",
+      percent: 50,
+    });
+  });
+
   it("should re-render an activity message when its activityType changes", async () => {
     const renderCounts: Record<string, number> = {};
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Describe the changes introduced in this PR)

I've fixed a stale rendering issue for activity messages updated via `ACTIVITY_SNAPSHOT` with `replace: true` and the same `messageId`.

Previously, the activity message content in `agent.messages` could be updated correctly, but the visible activity UI stayed stale. This happened because the activity message object can be mutated in place, while the React memoization checks were comparing props that still pointed to the same object reference.

To fix this, I added render-time memo keys for activity message content and activity type. These keys are computed before entering the memoized activity message component, so in-place content updates are visible to the memo comparator and correctly trigger a re-render.

I kept the existing cheap `length`-based memo key behavior for non-activity text/multimodal messages, so regular large message payloads are not fully serialized.

Regression coverage added for:

- `ACTIVITY_SNAPSHOT` replacement with the same activity message id
- In-place activity message content mutation in `CopilotChatMessageView`

Testing passed:

- Activity message rendering tests, including the new same-message-id `ACTIVITY_SNAPSHOT replace: true` regression case
- Activity/tool re-render tests, including the new in-place activity content mutation regression case
- Existing CopilotChat performance regression tests

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)
- Fixes https://github.com/CopilotKit/CopilotKit/issues/4676 

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)