### PR TITLE
test(react-core): drain virtualizer animation frames

### DIFF
--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatPerf.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatPerf.e2e.test.tsx
@@ -96,6 +96,16 @@ async function emitBatch(agent: MockStepwiseAgent, n: number) {
   );
 }
 
+async function drainAnimationFrames(frameCount = 25) {
+  await act(async () => {
+    for (let i = 0; i < frameCount; i++) {
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve()),
+      );
+    }
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -230,16 +240,13 @@ describe("CopilotChat perf — re-render regression", () => {
     // Drain pending animation frames before unmounting. TanStack Virtual
     // schedules rAF callbacks for measurement; if they fire after jsdom tears
     // down (window === null) they produce a spurious uncaught exception.
-    await act(async () => {
-      await new Promise<void>((r) => requestAnimationFrame(() => r()));
-      await new Promise<void>((r) => requestAnimationFrame(() => r()));
-    });
+    await drainAnimationFrames();
     unmount();
   });
 
   it("renders 100 messages without error and within 5 s", async () => {
     const agent = new MockStepwiseAgent();
-    renderWithCopilotKit({ agent });
+    const { unmount } = renderWithCopilotKit({ agent });
 
     await triggerRun();
 
@@ -264,5 +271,8 @@ describe("CopilotChat perf — re-render regression", () => {
     // 5 000 ms is a generous CI-safe ceiling; the /perf page is the right tool
     // for tighter measurements against browser rendering.
     expect(elapsed).toBeLessThan(5_000);
+
+    await drainAnimationFrames();
+    unmount();
   });
 });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatPerf.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatPerf.e2e.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../../__tests__/utils/test-helpers";
 import { CopilotChat } from "../CopilotChat";
 import { CopilotChatAssistantMessage } from "../CopilotChatAssistantMessage";
-import CopilotChatMessageView from "../CopilotChatMessageView";
+import DefaultCopilotChatMessageView from "../CopilotChatMessageView";
 import { ScrollElementContext } from "../scroll-element-context";
 import type { Message } from "@ag-ui/core";
 
@@ -216,7 +216,7 @@ describe("CopilotChat perf — re-render regression", () => {
       children: (
         <ScrollElementContext.Provider value={fakeScrollEl}>
           <div style={{ height: 600 }}>
-            <CopilotChatMessageView messages={messages} />
+            <DefaultCopilotChatMessageView messages={messages} />
           </div>
         </ScrollElementContext.Provider>
       ),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Describe the changes introduced in this PR)

I've fixed a flaky React Core perf test failure that I ran into while validating #4727.

While running the full package test suite, all tests in `CopilotChatPerf.e2e.test.tsx` were passing, but Vitest still reported an unhandled error after the test run:

`Cannot read properties of null (reading 'requestAnimationFrame')`

I traced this to the virtualized message path. The test calls into TanStack Virtual, which can schedule follow-up `requestAnimationFrame` callbacks while measuring and scrolling virtualized items. In the full test suite, those callbacks could still be pending when jsdom/React Testing Library cleanup started tearing down the window. If a delayed virtualizer callback ran after teardown, it could try to schedule another frame through a `null` window and fail as an unhandled exception.

This PR makes the perf test cleanup explicit by draining pending animation frames before unmounting the virtualized test renders. This keeps the test behavior the same, but prevents virtualizer callbacks from leaking past jsdom teardown.

I also cleaned up the default import name in the same test file to avoid the existing `no-named-as-default` lint warning.

## Testing

Passed locally:

- React Core perf test file
- Full `@copilotkit/react-core` test suite
- Full package test suite via the repository test command
- Targeted lint check for the changed test file

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)
- Found while validating https://github.com/CopilotKit/CopilotKit/pull/4727
- Related to https://github.com/CopilotKit/CopilotKit/issues/4676
 
## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)
