### PR TITLE
fix(showcase/langgraph-python): restore A2UI rendering for beautiful-chat + declarative-gen-ui

### DIFF
--- a/showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py
@@ -56,6 +56,25 @@ def render_a2ui(
     return "rendered"
 
 
+_GENERATE_A2UI_PROMPT_HEADER = f"""\
+You are designing a dynamic A2UI v0.9 surface. Call the `render_a2ui` tool with
+a flat component array.
+
+Hard requirements (failing any of these breaks the renderer — be strict):
+- `catalogId` MUST be exactly: "{CUSTOM_CATALOG_ID}"
+- `surfaceId` is a short kebab-case identifier (e.g. "kpi-dashboard").
+- `components` is a FLAT array. Every entry MUST include both an `id` (unique
+  string) AND a `component` (string — the catalog component name). The root
+  entry MUST have `id: "root"` AND a valid `component` field — never emit
+  a root entry without a component type.
+- Container components (Row, Column, Card) reference children by id via their
+  `children` (array of strings) or `child` (single string) prop. Do NOT inline
+  children objects. Define each child as its own entry in the flat array and
+  reference its id.
+- Use only catalog component names listed in the schema below.
+"""
+
+
 @tool()
 def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     """Generate dynamic A2UI components based on the conversation.
@@ -69,12 +88,18 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     # Pull the A2UI component schema + usage guidelines from the runtime's
     # `copilotkit.context` (the runtime injects them automatically when the
     # frontend registers a catalog via `<CopilotKit a2ui={{ catalog }}>`).
+    # We prepend an explicit instruction header because the runtime context
+    # alone leaves room for the LLM to hallucinate catalog IDs or emit a root
+    # component without a `component` field — both surface as "Cannot create
+    # component root without a type" infinite-loops in the renderer.
     context_entries = runtime.state.get("copilotkit", {}).get("context", [])
     context_text = "\n\n".join(
         entry.get("value", "")
         for entry in context_entries
         if isinstance(entry, dict) and entry.get("value")
     )
+
+    prompt = f"{_GENERATE_A2UI_PROMPT_HEADER}\n\n{context_text}".strip()
 
     model = ChatOpenAI(model="gpt-4.1")
     model_with_tool = model.bind_tools(
@@ -83,7 +108,7 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     )
 
     response = model_with_tool.invoke(
-        [SystemMessage(content=context_text), *messages],
+        [SystemMessage(content=prompt), *messages],
     )
 
     if not response.tool_calls:
@@ -93,9 +118,24 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     args = tool_call["args"]
 
     surface_id = args.get("surfaceId", "dynamic-surface")
-    catalog_id = args.get("catalogId", CUSTOM_CATALOG_ID)
+    # Force the canonical catalog ID — the secondary LLM has been observed
+    # hallucinating IDs from sibling demos when context is sparse.
+    catalog_id = CUSTOM_CATALOG_ID
     components = args.get("components", [])
     data = args.get("data", {})
+
+    # Defensive: every component must have an `id` AND a `component` field, or
+    # the frontend renderer throws "Cannot create component <id> without a
+    # type" and never recovers. Drop malformed entries so a valid surface
+    # still renders.
+    components = [
+        c for c in components
+        if isinstance(c, dict) and c.get("id") and c.get("component")
+    ]
+    if not any(c.get("id") == "root" for c in components):
+        return json.dumps({
+            "error": "LLM produced no valid root component for the A2UI surface."
+        })
 
     ops = [
         a2ui.create_surface(surface_id, catalog_id=catalog_id),

--- a/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
+++ b/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
@@ -108,11 +108,15 @@ def query_data(query: str):
 
 CATALOG_ID = "copilotkit://app-dashboard-catalog"
 SURFACE_ID = "flight-search-results"
-FLIGHT_SCHEMA = a2ui.load_schema(_DATA_DIR / "schemas" / "flight_schema.json")
 
 
-class Flight(TypedDict):
-    id: str
+class Flight(TypedDict, total=False):
+    # All fields marked optional (`total=False`) so the LLM (or aimock fixture)
+    # can omit auxiliary fields like `id` / `statusIcon` without tripping
+    # langchain's tool-arg validation. Previously these were required and any
+    # missing field surfaced as `Error invoking tool 'search_flights' with
+    # kwargs ... flights.N.id: Field required` — the agent treated the error
+    # string as the tool result and the surface never rendered.
     airline: str
     airlineLogo: str
     flightNumber: str
@@ -123,15 +127,52 @@ class Flight(TypedDict):
     arrivalTime: str
     duration: str
     status: str
-    statusIcon: str
     price: str
+
+
+def _build_flight_components(flights: list[dict]) -> list[dict]:
+    """Build a flat A2UI component tree with one literal FlightCard per flight.
+
+    Avoids the structural-children template form (Row.children = { componentId,
+    path }), which the GenericBinder only expands correctly for components whose
+    schema declares STRUCTURAL children — sibling demos work because their
+    schemas use literal-string-array children. Inlining the values per-flight
+    sidesteps the template path entirely and renders identically.
+    """
+    flight_card_ids: list[str] = []
+    components: list[dict] = []
+    for index, flight in enumerate(flights):
+        card_id = f"flight-card-{index}"
+        flight_card_ids.append(card_id)
+        components.append({
+            "id": card_id,
+            "component": "FlightCard",
+            "airline": flight.get("airline", ""),
+            "airlineLogo": flight.get("airlineLogo", ""),
+            "flightNumber": flight.get("flightNumber", ""),
+            "origin": flight.get("origin", ""),
+            "destination": flight.get("destination", ""),
+            "date": flight.get("date", ""),
+            "departureTime": flight.get("departureTime", ""),
+            "arrivalTime": flight.get("arrivalTime", ""),
+            "duration": flight.get("duration", ""),
+            "status": flight.get("status", ""),
+            "price": flight.get("price", ""),
+        })
+    root: dict = {
+        "id": "root",
+        "component": "Row",
+        "children": flight_card_ids,
+        "gap": 16,
+    }
+    return [root, *components]
 
 
 @tool
 def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display the results as rich cards. Return exactly 2 flights.
 
-    Each flight must have: id, airline (e.g. "United Airlines"),
+    Each flight must have: airline (e.g. "United Airlines"),
     airlineLogo (use Google favicon API: https://www.google.com/s2/favicons?domain={airline_domain}&sz=128
     e.g. "https://www.google.com/s2/favicons?domain=united.com&sz=128" for United,
     "https://www.google.com/s2/favicons?domain=delta.com&sz=128" for Delta,
@@ -141,16 +182,12 @@ def search_flights(flights: list[Flight]) -> str:
     date (short readable format like "Tue, Mar 18" — use near-future dates),
     departureTime, arrivalTime,
     duration (e.g. "4h 25m"), status (e.g. "On Time" or "Delayed"),
-    statusIcon (colored dot: use "https://placehold.co/12/22c55e/22c55e.png"
-    for On Time, "https://placehold.co/12/eab308/eab308.png" for Delayed,
-    "https://placehold.co/12/ef4444/ef4444.png" for Cancelled),
     and price (e.g. "$289").
     """
     return a2ui.render(
         operations=[
             a2ui.create_surface(SURFACE_ID, catalog_id=CATALOG_ID),
-            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
+            a2ui.update_components(SURFACE_ID, _build_flight_components(flights)),
         ],
     )
 
@@ -180,6 +217,25 @@ def render_a2ui(
     return "rendered"
 
 
+_GENERATE_A2UI_PROMPT_HEADER = f"""\
+You are designing a dynamic A2UI v0.9 surface. Call the `render_a2ui` tool with
+a flat component array.
+
+Hard requirements (failing any of these breaks the renderer — be strict):
+- `catalogId` MUST be exactly: "{CUSTOM_CATALOG_ID}"
+- `surfaceId` is a short kebab-case identifier (e.g. "sales-dashboard").
+- `components` is a FLAT array. Every entry MUST include both an `id` (unique
+  string) AND a `component` (string — the catalog component name). The root
+  entry MUST have `id: "root"` AND a valid `component` field — never emit
+  a root entry without a component type.
+- Container components (Row, Column, DashboardCard, Card) reference children
+  by id via their `children` (array of strings) or `child` (single string)
+  prop. Do NOT inline children objects. Define each child as its own entry in
+  the flat array and reference its id.
+- Use only catalog component names listed in the schema below.
+"""
+
+
 @tool()
 def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     """Generate dynamic A2UI components based on the conversation.
@@ -189,14 +245,18 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     """
     messages = runtime.state["messages"][:-1]
 
-    # Get context entries from copilotkit state (catalog capabilities + component schema)
+    # Pull catalog descriptor + component schemas the runtime injects from the
+    # frontend's registered catalog. We prepend an explicit instruction header
+    # because `injectA2UITool: false` can leave the context sparse, in which
+    # case the secondary LLM hallucinates catalog IDs and root components
+    # without a `component` field — both of which break the renderer.
     context_entries = runtime.state.get("copilotkit", {}).get("context", [])
     context_text = "\n\n".join(
         entry.get("value", "") for entry in context_entries
         if isinstance(entry, dict) and entry.get("value")
     )
 
-    prompt = context_text
+    prompt = f"{_GENERATE_A2UI_PROMPT_HEADER}\n\n{context_text}".strip()
 
     model = ChatOpenAI(model="gpt-4.1")
     model_with_tool = model.bind_tools(
@@ -215,9 +275,24 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     args = tool_call["args"]
 
     surface_id = args.get("surfaceId", "dynamic-surface")
-    catalog_id = args.get("catalogId", CUSTOM_CATALOG_ID)
+    # Force the canonical catalog ID — the secondary LLM has been observed
+    # hallucinating IDs from sibling demos when context is sparse.
+    catalog_id = CUSTOM_CATALOG_ID
     components = args.get("components", [])
     data = args.get("data", {})
+
+    # Defensive: every component must have an `id` AND a `component` field, or
+    # the frontend renderer throws "Cannot create component <id> without a
+    # type" and never recovers. Drop malformed entries so a valid surface
+    # still renders.
+    components = [
+        c for c in components
+        if isinstance(c, dict) and c.get("id") and c.get("component")
+    ]
+    if not any(c.get("id") == "root" for c in components):
+        return json.dumps({
+            "error": "LLM produced no valid root component for the A2UI surface."
+        })
 
     ops = [
         a2ui.create_surface(surface_id, catalog_id=catalog_id),


### PR DESCRIPTION
## Summary

- Beautiful Chat **Search Flights** pill: restored `_build_flight_components` so the agent emits a flat literal-children FlightCard tree (the structural-children template form via `flight_schema.json` + `update_data_model` doesn't expand correctly through GenericBinder for our custom catalog — it was working until the recent flagship-cell pass swapped it back). FlightCards render again instead of falling through to the default tool card.
- Beautiful Chat **Sales Dashboard** pill: hardened `generate_a2ui` so the secondary LLM gets explicit catalog-id + component-shape rules and the resulting `catalog_id` is force-pinned to the registered catalog. Kills the "Catalog not found: declarative-gen-ui-catalog" sibling-demo hallucination.
- **Declarative Gen UI** (`a2ui_dynamic.py`): same `generate_a2ui` hardening, plus a defensive sweep that drops malformed components and bails clean when the LLM omits a typed root. Kills the "Cannot create component root without a type" infinite-loop renderer error reported on the KPI Dashboard pill.

Two files touched (`src/agents/beautiful_chat.py`, `src/agents/a2ui_dynamic.py`); no frontend / runtime / package changes. Existing aimock fixtures in `feature-parity.json` already use the canonical catalogId and well-formed components, so e2e specs should pass without fixture changes.

## Test plan

- [x] Verified locally: `langgraph_cli dev` + `next dev`, clicked **Search Flights** on `/demos/beautiful-chat` — Delta DL 405 ($329) and United UA 120 ($289) FlightCards rendered live with airline, route, times, status, Select.
- [x] Verified locally: clicked **Show a KPI dashboard** on `/demos/declarative-gen-ui` — REVENUE / SIGNUPS / CHURN metric tree rendered cleanly, no "Cannot create component root without a type" error.
- [ ] CI / `nx run @copilotkit/showcase-langgraph-python:e2e` (beautiful-chat spec already authored against the literal-children form).