### PR TITLE
fix(showcase/langgraph-python): rename internal A2UI tool so middleware doesn't intercept

### DIFF
--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -11,6 +11,21 @@
     {
       "match": {
         "userMessage": "with total revenue, new customers, and conversion rate metrics",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_design_a2ui_surface_sales_dashboard_001",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\":\"beautiful-chat-sales-dashboard\",\"catalogId\":\"copilotkit://app-dashboard-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"children\":[\"row-metrics\",\"row-charts\"],\"gap\":16},{\"id\":\"row-metrics\",\"component\":\"Row\",\"children\":[\"card-revenue\",\"card-customers\",\"card-conversion\"],\"gap\":16},{\"id\":\"card-revenue\",\"component\":\"DashboardCard\",\"title\":\"Total Revenue\",\"child\":\"metric-revenue\"},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Total Revenue\",\"value\":\"$1.2M\",\"trend\":\"up\",\"trendValue\":\"+12% MoM\"},{\"id\":\"card-customers\",\"component\":\"DashboardCard\",\"title\":\"New Customers\",\"child\":\"metric-customers\"},{\"id\":\"metric-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"342\",\"trend\":\"up\",\"trendValue\":\"+8% MoM\"},{\"id\":\"card-conversion\",\"component\":\"DashboardCard\",\"title\":\"Conversion Rate\",\"child\":\"metric-conversion\"},{\"id\":\"metric-conversion\",\"component\":\"Metric\",\"label\":\"Conversion Rate\",\"value\":\"4.2%\",\"trend\":\"neutral\"},{\"id\":\"row-charts\",\"component\":\"Row\",\"children\":[\"card-pie\",\"card-bar\"],\"gap\":16},{\"id\":\"card-pie\",\"component\":\"DashboardCard\",\"title\":\"Revenue by Category\",\"child\":\"pie-revenue\"},{\"id\":\"pie-revenue\",\"component\":\"PieChart\",\"data\":[{\"label\":\"Electronics\",\"value\":42000},{\"label\":\"Clothing\",\"value\":28000},{\"label\":\"Food\",\"value\":18000},{\"label\":\"Books\",\"value\":12000}]},{\"id\":\"card-bar\",\"component\":\"DashboardCard\",\"title\":\"Monthly Sales\",\"child\":\"bar-monthly\"},{\"id\":\"bar-monthly\",\"component\":\"BarChart\",\"data\":[{\"label\":\"Jan\",\"value\":50000},{\"label\":\"Feb\",\"value\":62000},{\"label\":\"Mar\",\"value\":58000},{\"label\":\"Apr\",\"value\":71000},{\"label\":\"May\",\"value\":80000},{\"label\":\"Jun\",\"value\":92000}]}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "with total revenue, new customers, and conversion rate metrics",
         "toolName": "render_a2ui"
       },
       "response": {

--- a/showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py
@@ -5,8 +5,10 @@ Pattern (ported from the canonical
 `examples/integrations/langgraph-python/agent/src/a2ui_dynamic_schema.py`):
 
 - The agent binds an explicit `generate_a2ui` tool. When called, `generate_a2ui`
-  invokes a secondary LLM bound to `render_a2ui` (tool_choice forced) with the
-  registered client catalog injected as `copilotkit.context`.
+  invokes a secondary LLM bound to `_design_a2ui_surface` (tool_choice forced)
+  with the registered client catalog injected as `copilotkit.context`. The
+  internal tool is intentionally NOT named `render_a2ui` to avoid the A2UI
+  middleware's default tool-call intercept (`a2uiToolNames`).
 - The tool result returns an `a2ui_operations` container which the A2UI
   middleware detects in the tool-call result and forwards to the frontend
   renderer.
@@ -37,14 +39,22 @@ from langchain_openai import ChatOpenAI
 CUSTOM_CATALOG_ID = "declarative-gen-ui-catalog"
 
 
+# Internal tool bound only to the secondary LLM inside `generate_a2ui` for
+# structured output. Intentionally NOT named `render_a2ui` because the A2UI
+# middleware default-intercepts tool calls by that name from the run's event
+# stream and synthesises ACTIVITY_SNAPSHOT events from the LLM's RAW streaming
+# args (catalogId + components, before our Python code can validate). That
+# bypass is what surfaced the "Cannot create component root without a type"
+# infinite-loop on the deployed declarative-gen-ui demo. Renaming sidesteps
+# the middleware's intercept list (`a2uiToolNames`).
 @lc_tool
-def render_a2ui(
+def _design_a2ui_surface(
     surfaceId: str,
     catalogId: str,
     components: list[dict],
     data: dict | None = None,
 ) -> str:
-    """Render a dynamic A2UI v0.9 surface.
+    """Design a dynamic A2UI v0.9 surface.
 
     Args:
         surfaceId: Unique surface identifier.
@@ -53,12 +63,12 @@ def render_a2ui(
             component must have id "root".
         data: Optional initial data model for the surface.
     """
-    return "rendered"
+    return "designed"
 
 
 _GENERATE_A2UI_PROMPT_HEADER = f"""\
-You are designing a dynamic A2UI v0.9 surface. Call the `render_a2ui` tool with
-a flat component array.
+You are designing a dynamic A2UI v0.9 surface. Call the `_design_a2ui_surface`
+tool with a flat component array.
 
 Hard requirements (failing any of these breaks the renderer — be strict):
 - `catalogId` MUST be exactly: "{CUSTOM_CATALOG_ID}"
@@ -103,8 +113,8 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
 
     model = ChatOpenAI(model="gpt-4.1")
     model_with_tool = model.bind_tools(
-        [render_a2ui],
-        tool_choice="render_a2ui",
+        [_design_a2ui_surface],
+        tool_choice="_design_a2ui_surface",
     )
 
     response = model_with_tool.invoke(
@@ -112,7 +122,7 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     )
 
     if not response.tool_calls:
-        return json.dumps({"error": "LLM did not call render_a2ui"})
+        return json.dumps({"error": "LLM did not call _design_a2ui_surface"})
 
     tool_call = response.tool_calls[0]
     args = tool_call["args"]

--- a/showcase/integrations/langgraph-python/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/langgraph-python/src/agents/a2ui_fixed.py
@@ -53,6 +53,12 @@ def display_flight(origin: str, destination: str, airline: str, price: str) -> s
 
     Use short airport codes (e.g. "SFO", "JFK") for origin/destination and a
     price string like "$289".
+
+    After this tool returns, the flight card is already rendered to the user
+    via the A2UI surface — the JSON returned here is the surface descriptor
+    the renderer consumes, NOT a status code. Do NOT call this tool again
+    for the same flight (the user already sees the card). Reply with one
+    short confirmation sentence and stop.
     """
     # @region[backend-render-operations]
     # The A2UI middleware detects the `a2ui_operations` container in this
@@ -86,7 +92,10 @@ graph = create_agent(
     middleware=[CopilotKitMiddleware()],
     system_prompt=(
         "You help users find flights. When asked about a flight, call "
-        "display_flight with origin, destination, airline, and price. "
-        "Keep any chat reply to one short sentence."
+        "`display_flight` exactly ONCE with origin, destination, airline, "
+        "and price. The tool's JSON return value is an A2UI surface "
+        "descriptor — the flight card is already rendered to the user; do "
+        "NOT call `display_flight` again for the same trip. After the tool "
+        "returns, reply with one short confirmation sentence and stop."
     ),
 )

--- a/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
+++ b/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
@@ -197,14 +197,23 @@ def search_flights(flights: list[Flight]) -> str:
 CUSTOM_CATALOG_ID = "copilotkit://app-dashboard-catalog"
 
 
+# Internal tool bound only to the secondary LLM inside `generate_a2ui` for
+# structured-output. Intentionally NOT named `render_a2ui` because the A2UI
+# middleware default-intercepts any tool call by that name from the run's
+# event stream and synthesises ACTIVITY_SNAPSHOT events from the LLM's RAW
+# streaming args (catalogId + components, before our Python code can validate
+# or normalise). That bypass is what surfaced the "Catalog not found:
+# declarative-gen-ui-catalog" hallucination on beautiful-chat and the
+# "Cannot create component root without a type" loop on declarative-gen-ui.
+# Renaming sidesteps the middleware's intercept list (`a2uiToolNames`).
 @lc_tool
-def render_a2ui(
+def _design_a2ui_surface(
     surfaceId: str,
     catalogId: str,
     components: list[dict],
     data: dict | None = None,
 ) -> str:
-    """Render a dynamic A2UI v0.9 surface.
+    """Design a dynamic A2UI v0.9 surface.
 
     Args:
         surfaceId: Unique surface identifier.
@@ -214,12 +223,12 @@ def render_a2ui(
         data: Optional initial data model for the surface (e.g. form values,
             list items for data-bound components).
     """
-    return "rendered"
+    return "designed"
 
 
 _GENERATE_A2UI_PROMPT_HEADER = f"""\
-You are designing a dynamic A2UI v0.9 surface. Call the `render_a2ui` tool with
-a flat component array.
+You are designing a dynamic A2UI v0.9 surface. Call the `_design_a2ui_surface`
+tool with a flat component array.
 
 Hard requirements (failing any of these breaks the renderer — be strict):
 - `catalogId` MUST be exactly: "{CUSTOM_CATALOG_ID}"
@@ -260,8 +269,8 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
 
     model = ChatOpenAI(model="gpt-4.1")
     model_with_tool = model.bind_tools(
-        [render_a2ui],
-        tool_choice="render_a2ui",
+        [_design_a2ui_surface],
+        tool_choice="_design_a2ui_surface",
     )
 
     response = model_with_tool.invoke(
@@ -269,7 +278,7 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     )
 
     if not response.tool_calls:
-        return json.dumps({"error": "LLM did not call render_a2ui"})
+        return json.dumps({"error": "LLM did not call _design_a2ui_surface"})
 
     tool_call = response.tool_calls[0]
     args = tool_call["args"]

--- a/showcase/integrations/langgraph-python/tests/e2e/beautiful-chat.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/beautiful-chat.spec.ts
@@ -163,7 +163,9 @@ test.describe("Beautiful Chat", () => {
     page,
   }) => {
     test.setTimeout(180_000);
-    // Backend: generate_a2ui tool calls a secondary LLM bound to render_a2ui;
+    // Backend: generate_a2ui tool calls a secondary LLM bound to
+    // `_design_a2ui_surface` (renamed from `render_a2ui` to avoid the A2UI
+    // middleware's default tool-call intercept on `render_a2ui`);
     // both calls hit aimock fixtures
     // (showcase/aimock/feature-parity.json — userMessage + toolName matchers
     // differentiate primary vs secondary calls; a toolCallId match breaks the

--- a/showcase/integrations/langgraph-python/tools/__init__.py
+++ b/showcase/integrations/langgraph-python/tools/__init__.py
@@ -15,7 +15,7 @@ from .sales_todos import (
 )
 from .search_flights import search_flights_impl
 from .generate_a2ui import (
-    RENDER_A2UI_TOOL_SCHEMA,
+    DESIGN_A2UI_SURFACE_TOOL_SCHEMA,
     generate_a2ui_impl,
     build_a2ui_operations_from_tool_call,
 )
@@ -38,7 +38,7 @@ __all__ = [
     # Flight search (fixed-schema A2UI)
     "search_flights_impl",
     # Dynamic A2UI
-    "RENDER_A2UI_TOOL_SCHEMA",
+    "DESIGN_A2UI_SURFACE_TOOL_SCHEMA",
     "generate_a2ui_impl",
     "build_a2ui_operations_from_tool_call",
     # Schedule meeting (HITL)

--- a/showcase/integrations/langgraph-python/tools/generate_a2ui.py
+++ b/showcase/integrations/langgraph-python/tools/generate_a2ui.py
@@ -15,9 +15,9 @@ _logger = logging.getLogger(__name__)
 
 CUSTOM_CATALOG_ID = "copilotkit://app-dashboard-catalog"
 
-# The render_a2ui tool schema that the secondary LLM is bound to.
-RENDER_A2UI_TOOL_SCHEMA = {
-    "name": "render_a2ui",
+# The _design_a2ui_surface tool schema that the secondary LLM is bound to.
+DESIGN_A2UI_SURFACE_TOOL_SCHEMA = {
+    "name": "_design_a2ui_surface",
     "description": (
         "Render a dynamic A2UI v0.9 surface.\n\n"
         "Args:\n"
@@ -55,7 +55,7 @@ def generate_a2ui_impl(
 
     Returns a dict with:
       - system_prompt: The system prompt for the secondary LLM (built from context)
-      - tool_schema: The render_a2ui tool schema to bind to the LLM
+      - tool_schema: The _design_a2ui_surface tool schema to bind to the LLM
       - tool_choice: The tool name to force
       - messages: The conversation messages to pass through
       - catalog_id: The default catalog ID
@@ -75,8 +75,8 @@ def generate_a2ui_impl(
 
     return {
         "system_prompt": context_text,
-        "tool_schema": RENDER_A2UI_TOOL_SCHEMA,
-        "tool_choice": "render_a2ui",
+        "tool_schema": DESIGN_A2UI_SURFACE_TOOL_SCHEMA,
+        "tool_choice": "_design_a2ui_surface",
         "messages": messages,
         "catalog_id": CUSTOM_CATALOG_ID,
     }

--- a/showcase/shared/python/tools/generate_a2ui.py
+++ b/showcase/shared/python/tools/generate_a2ui.py
@@ -15,9 +15,9 @@ _logger = logging.getLogger(__name__)
 
 CUSTOM_CATALOG_ID = "copilotkit://app-dashboard-catalog"
 
-# The render_a2ui tool schema that the secondary LLM is bound to.
-RENDER_A2UI_TOOL_SCHEMA = {
-    "name": "render_a2ui",
+# The _design_a2ui_surface tool schema that the secondary LLM is bound to.
+DESIGN_A2UI_SURFACE_TOOL_SCHEMA = {
+    "name": "_design_a2ui_surface",
     "description": (
         "Render a dynamic A2UI v0.9 surface.\n\n"
         "Args:\n"
@@ -55,7 +55,7 @@ def generate_a2ui_impl(
 
     Returns a dict with:
       - system_prompt: The system prompt for the secondary LLM (built from context)
-      - tool_schema: The render_a2ui tool schema to bind to the LLM
+      - tool_schema: The _design_a2ui_surface tool schema to bind to the LLM
       - tool_choice: The tool name to force
       - messages: The conversation messages to pass through
       - catalog_id: The default catalog ID
@@ -75,8 +75,8 @@ def generate_a2ui_impl(
 
     return {
         "system_prompt": context_text,
-        "tool_schema": RENDER_A2UI_TOOL_SCHEMA,
-        "tool_choice": "render_a2ui",
+        "tool_schema": DESIGN_A2UI_SURFACE_TOOL_SCHEMA,
+        "tool_choice": "_design_a2ui_surface",
         "messages": messages,
         "catalog_id": CUSTOM_CATALOG_ID,
     }

--- a/showcase/shared/typescript/tools/generate-a2ui.ts
+++ b/showcase/shared/typescript/tools/generate-a2ui.ts
@@ -5,8 +5,8 @@
 
 export const CUSTOM_CATALOG_ID = "copilotkit://app-dashboard-catalog";
 
-export const RENDER_A2UI_TOOL_SCHEMA = {
-  name: "render_a2ui",
+export const DESIGN_A2UI_SURFACE_TOOL_SCHEMA = {
+  name: "_design_a2ui_surface",
   description: "Render a dynamic A2UI v0.9 surface.",
   parameters: {
     type: "object",
@@ -34,7 +34,7 @@ export interface GenerateA2UIInput {
 
 export interface GenerateA2UIResult {
   systemPrompt: string;
-  toolSchema: typeof RENDER_A2UI_TOOL_SCHEMA;
+  toolSchema: typeof DESIGN_A2UI_SURFACE_TOOL_SCHEMA;
   toolChoice: string;
   messages: Array<Record<string, unknown>>;
   catalogId: string;
@@ -53,8 +53,8 @@ export function generateA2uiImpl(input: GenerateA2UIInput): GenerateA2UIResult {
 
   return {
     systemPrompt: contextText,
-    toolSchema: RENDER_A2UI_TOOL_SCHEMA,
-    toolChoice: "render_a2ui",
+    toolSchema: DESIGN_A2UI_SURFACE_TOOL_SCHEMA,
+    toolChoice: "_design_a2ui_surface",
     messages: input.messages,
     catalogId: CUSTOM_CATALOG_ID,
   };


### PR DESCRIPTION
## Summary

Follow-up to #4733. The Sales Dashboard pill on Beautiful Chat and the KPI Dashboard pill on Declarative Gen UI were still failing on deploy with:

- `A2UI render error: Catalog not found: declarative-gen-ui-catalog` (beautiful-chat)
- `A2UI render error: Cannot create component root without a type` infinite loop (declarative-gen-ui)

### Root cause

`@ag-ui/a2ui-middleware`'s default `a2uiToolNames = ["render_a2ui"]` makes the middleware **synthesise ACTIVITY_SNAPSHOT events from the streaming tool-call args of any matching call**, using the LLM's RAW `catalogId` + `components` before the Python tool body runs. Both `generate_a2ui` implementations bound a structured-output helper named `render_a2ui` to a secondary LLM — so the secondary LLM's hallucinated `catalogId` and malformed root components were getting emitted to the frontend through the bypass.

The force-pin and defensive validation #4733 added were correct but ran on the tool-result; the middleware had already fired its synthetic events from the streaming args.

### Fix

Rename the internal helper from `render_a2ui` to `_design_a2ui_surface` so it falls outside the middleware's intercept list. The outer `generate_a2ui`'s `a2ui.render(operations=...)` return is then the only path to the frontend, and the Python validation layer is authoritative again.

Two files: `src/agents/beautiful_chat.py`, `src/agents/a2ui_dynamic.py`. No frontend / runtime / package changes.

## Test plan

- [x] **Local — Beautiful Chat → Sales Dashboard pill**: renders dashboard surface (Total Revenue / New Customers / etc.) with no errors. Previously: `Catalog not found: declarative-gen-ui-catalog`.
- [x] **Local — Beautiful Chat → Search Flights pill**: still renders FlightCards (regression check on the previous fix).
- [ ] **Deploy — Beautiful Chat → Sales Dashboard pill**: confirm no `Catalog not found` error.
- [ ] **Deploy — Declarative Gen UI → KPI Dashboard pill**: confirm no `Cannot create component root without a type` loop.