### PR TITLE
chore: retarget "Talk to engineers" CTAs to /talk-to-an-engineer

### DIFF
--- a/docs/components/layout/navbar.tsx
+++ b/docs/components/layout/navbar.tsx
@@ -84,7 +84,7 @@ const Navbar = ({ pageTree }: NavbarProps) => {
 
   const handleTalkToEngineersClick = () => {
     posthog?.capture("talk_to_us_clicked", { location: "docs_nav" });
-    window.location.href = "https://copilotkit.ai/contact-us";
+    window.location.href = "https://copilotkit.ai/talk-to-an-engineer";
   };
 
   // Read sessionStorage on client only to avoid hydration mismatch (tab-specific)

--- a/showcase/shell-docs/src/components/brand-nav.tsx
+++ b/showcase/shell-docs/src/components/brand-nav.tsx
@@ -156,7 +156,7 @@ export function BrandNav(_props: BrandNavProps = {}) {
 
   const handleTalkToEngineersClick = () => {
     posthog?.capture("talk_to_us_clicked", { location: "docs_nav" });
-    window.location.href = "https://copilotkit.ai/contact-us";
+    window.location.href = "https://copilotkit.ai/talk-to-an-engineer";
   };
 
   const handleFreeDeveloperAccessClick = (location: string) => {


### PR DESCRIPTION
## Summary
- Retargets the docs navbar and showcase shell-docs brand-nav "Talk to engineers" CTAs from `copilotkit.ai/contact-us` to `copilotkit.ai/talk-to-an-engineer`.
- PostHog `talk_to_us_clicked` capture is unchanged — only the destination URL moves.

## Test plan
- [ ] Click "Talk to engineers" in the docs navbar and confirm it lands on `/talk-to-an-engineer`.
- [ ] Click "Talk to engineers" in the showcase shell-docs brand-nav and confirm the same destination.
- [ ] Verify `talk_to_us_clicked` still fires in PostHog with `location: "docs_nav"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)