### PR TITLE
fix(showcase/aimock): correct D5 fixture matching for agent-config + shared-state-streaming

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -379,14 +379,6 @@
     },
     {
       "match": {
-        "userMessage": "introduce yourself per your config"
-      },
-      "response": {
-        "content": "Hello — I'm operating with the configured tone, expertise, and responseLength forwarded by the CopilotKit provider. Adjust the controls above the chat and my system prompt will rebuild on the next turn."
-      }
-    },
-    {
-      "match": {
         "userMessage": "good name for a goldfish"
       },
       "response": {
@@ -1052,10 +1044,82 @@
     },
     {
       "match": {
+        "userMessage": "poem about autumn leaves",
+        "toolCallId": "call_d5_write_document_poem_001"
+      },
+      "response": {
+        "content": "Done — the poem has been written into the shared document state."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "poem about autumn leaves"
+      },
+      "response": {
+        "content": "Streaming the poem now.",
+        "toolCalls": [
+          {
+            "id": "call_d5_write_document_poem_001",
+            "name": "write_document",
+            "arguments": "{\"document\":\"Crimson and amber in slow descent, / each leaf a quiet ledger of summer spent. / The wind, a courier with nothing to say, / files them gently into the morning's gray. / Somewhere a kettle hums, and afternoons grow brief — / autumn keeps its books in vermilion and gold leaf.\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "polite email declining",
+        "toolCallId": "call_d5_write_document_email_001"
+      },
+      "response": {
+        "content": "Done — the decline-email draft has been written into the shared document state."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "polite email declining"
+      },
+      "response": {
+        "content": "Drafting the email now.",
+        "toolCalls": [
+          {
+            "id": "call_d5_write_document_email_001",
+            "name": "write_document",
+            "arguments": "{\"document\":\"Hi — thanks for sending the invite for Tuesday afternoon. Unfortunately I won't be able to make it this week. I'd love to find time later in the month if your schedule allows. In the meantime, feel free to send any pre-reads my way and I'll review them async so we don't lose momentum. Best, [name]\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "quantum computing for a curious teenager",
+        "toolCallId": "call_d5_write_document_quantum_001"
+      },
+      "response": {
+        "content": "Done — the quantum-computing explainer has been written into the shared document state."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "quantum computing for a curious teenager"
+      },
+      "response": {
+        "content": "Streaming the explainer now.",
+        "toolCalls": [
+          {
+            "id": "call_d5_write_document_quantum_001",
+            "name": "write_document",
+            "arguments": "{\"document\":\"A regular computer stores information in bits — tiny switches that are either on (1) or off (0). A quantum computer uses qubits, which can sit in a fuzzy superposition of both states at once until you check them. Stack many qubits together and they can explore lots of possibilities in parallel, which is why people are excited.\\n\\nThis doesn't make quantum computers faster at everything. They're great at problems with hidden structure — like factoring big numbers, simulating molecules, or searching certain databases — but useless for, say, opening Excel. Today's machines are noisy and small, so we mostly use them to test ideas rather than replace your laptop.\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
         "userMessage": "stream the counter to 5"
       },
       "response": {
-        "content": "Streaming state updates: counter advanced from 0 through 1, 2, 3, 4 to 5. Each intermediate value was reflected in the shared state and visible to the UI mid-stream."
+        "content": "Streaming counter from 0 to 5."
       }
     },
     {
@@ -2066,54 +2130,6 @@
                 }
               ]
             }
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "poem about autumn leaves",
-        "toolName": "write_document"
-      },
-      "response": {
-        "content": "Streaming the poem now.",
-        "toolCalls": [
-          {
-            "id": "call_d5_write_document_poem_001",
-            "name": "write_document",
-            "arguments": "{\"document\":\"Crimson and amber in slow descent, / each leaf a quiet ledger of summer spent. / The wind, a courier with nothing to say, / files them gently into the morning's gray. / Somewhere a kettle hums, and afternoons grow brief — / autumn keeps its books in vermilion and gold leaf.\"}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "polite email declining",
-        "toolName": "write_document"
-      },
-      "response": {
-        "content": "Drafting the email now.",
-        "toolCalls": [
-          {
-            "id": "call_d5_write_document_email_001",
-            "name": "write_document",
-            "arguments": "{\"document\":\"Hi — thanks for sending the invite for Tuesday afternoon. Unfortunately I won't be able to make it this week. I'd love to find time later in the month if your schedule allows. In the meantime, feel free to send any pre-reads my way and I'll review them async so we don't lose momentum. Best, [name]\"}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "quantum computing for a curious teenager",
-        "toolName": "write_document"
-      },
-      "response": {
-        "content": "Streaming the explainer now.",
-        "toolCalls": [
-          {
-            "id": "call_d5_write_document_quantum_001",
-            "name": "write_document",
-            "arguments": "{\"document\":\"A regular computer stores information in bits — tiny switches that are either on (1) or off (0). A quantum computer uses qubits, which can sit in a fuzzy superposition of both states at once until you check them. Stack many qubits together and they can explore lots of possibilities in parallel, which is why people are excited.\\n\\nThis doesn't make quantum computers faster at everything. They're great at problems with hidden structure — like factoring big numbers, simulating molecules, or searching certain databases — but useless for, say, opening Excel. Today's machines are noisy and small, so we mostly use them to test ideas rather than replace your laptop.\"}"
           }
         ]
       }

--- a/showcase/harness/fixtures/d5/agent-config.json
+++ b/showcase/harness/fixtures/d5/agent-config.json
@@ -2,45 +2,51 @@
   "_comment": "D5 fixture for /demos/agent-config. Six prompts, three knob pairs (tone / expertise / responseLength), with each value producing a distinct response. Substring keys are uncommon enough not to collide with adjacent fixtures in d5-all.json.",
   "fixtures": [
     {
-      "match": { "userMessage": "tone:professional" },
+      "match": {
+        "userMessage": "tone:professional"
+      },
       "response": {
         "content": "Greetings. I am operating in professional tone. I will provide measured, formal responses calibrated to your stated preferences and refrain from colloquialisms in my replies."
       }
     },
     {
-      "match": { "userMessage": "tone:casual" },
+      "match": {
+        "userMessage": "tone:casual"
+      },
       "response": {
         "content": "Hey! Casual mode here — I'll keep things friendly and easygoing. Just shoot me whatever you want to know and I'll riff on it without sounding like a press release."
       }
     },
     {
-      "match": { "userMessage": "expertise:beginner" },
+      "match": {
+        "userMessage": "expertise:beginner"
+      },
       "response": {
         "content": "Sure! Think of CopilotKit as a friendly toolkit. It helps you add an AI helper to your app. The helper can answer questions, run small tasks, and show buttons or charts when needed."
       }
     },
     {
-      "match": { "userMessage": "expertise:expert" },
+      "match": {
+        "userMessage": "expertise:expert"
+      },
       "response": {
         "content": "CopilotKit composes a runtime adapter (Express/Hono) over the AG-UI SSE protocol; the React client wires hooks (useFrontendTool, useAgentContext) into a typed agent runner. The architecture front-runs round-trip latency by streaming TEXT_MESSAGE_CHUNK and TOOL_CALL events on the same channel."
       }
     },
     {
-      "match": { "userMessage": "responseLength:concise" },
+      "match": {
+        "userMessage": "responseLength:concise"
+      },
       "response": {
         "content": "Agent context is a typed payload sent each turn."
       }
     },
     {
-      "match": { "userMessage": "responseLength:detailed" },
+      "match": {
+        "userMessage": "responseLength:detailed"
+      },
       "response": {
         "content": "Agent context is a typed payload published from the frontend on every turn through the useAgentContext hook. The payload is forwarded into the agent's runtime context (LangGraph 0.6 introduced the `context` channel as the supported relay for per-run frontend-supplied data; legacy `properties` flowed via `forwardedProps` and did not land in `RunnableConfig`). On the Python side, CopilotKitMiddleware reads the value off the runtime context, then routes it into the system-prompt builder so the model sees the user's tone, expertise, and length preferences before each call. The result is per-turn behavior change without a model swap."
-      }
-    },
-    {
-      "match": { "userMessage": "introduce yourself per your config" },
-      "response": {
-        "content": "Hello — I'm operating with the configured tone, expertise, and responseLength forwarded by the CopilotKit provider. Adjust the controls above the chat and my system prompt will rebuild on the next turn."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/shared-state-streaming.json
+++ b/showcase/harness/fixtures/d5/shared-state-streaming.json
@@ -1,6 +1,15 @@
 {
-  "_comment": "D5 fixture for /demos/shared-state-streaming. Three pill prompts produce `write_document` tool calls with non-trivial content payloads (≥ 100 chars) so the document streams into shared state and the DocumentView's char-count assertion can verify a substantive document was written. `arguments` is shown JSON-stringified here for parity with the OpenAI wire shape; aimock's `normalizeResponse` (see node_modules/@copilotkit/aimock/dist/fixture-loader) auto-stringifies object-valued arguments at load time, so raw-object form would also work.",
+  "_comment": "D5 fixture for /demos/shared-state-streaming. Three pill prompts produce `write_document` tool calls with non-trivial content payloads (≥ 100 chars) so the document streams into shared state and the DocumentView's char-count assertion can verify a substantive document was written. Each pill has TWO entries: a first-turn (matches by userMessage substring) returning toolCall + content with a STATIC tool_call_id, and a follow-up keyed on userMessage + that toolCallId returning content-only. The follow-up MUST appear ABOVE the first-turn entry so the matcher returns it after the tool result is appended (otherwise the unchanged last user message keeps re-matching the first-turn fixture, the agent re-fires write_document, and langgraph runs into its 100-step recursion limit). See showcase/harness/fixtures/d5/README.md (\"Mid-loop re-invocations after a tool call\"). `arguments` is shown JSON-stringified here for parity with the OpenAI wire shape; aimock auto-stringifies object-valued arguments at load time, so raw-object form would also work.",
   "fixtures": [
+    {
+      "match": {
+        "userMessage": "poem about autumn leaves",
+        "toolCallId": "call_d5_write_document_poem_001"
+      },
+      "response": {
+        "content": "Done — the poem has been written into the shared document state."
+      }
+    },
     {
       "match": { "userMessage": "poem about autumn leaves" },
       "response": {
@@ -15,6 +24,15 @@
       }
     },
     {
+      "match": {
+        "userMessage": "polite email declining",
+        "toolCallId": "call_d5_write_document_email_001"
+      },
+      "response": {
+        "content": "Done — the decline-email draft has been written into the shared document state."
+      }
+    },
+    {
       "match": { "userMessage": "polite email declining" },
       "response": {
         "content": "Drafting the email now.",
@@ -25,6 +43,15 @@
             "arguments": "{\"document\":\"Hi — thanks for sending the invite for Tuesday afternoon. Unfortunately I won't be able to make it this week. I'd love to find time later in the month if your schedule allows. In the meantime, feel free to send any pre-reads my way and I'll review them async so we don't lose momentum. Best, [name]\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "quantum computing for a curious teenager",
+        "toolCallId": "call_d5_write_document_quantum_001"
+      },
+      "response": {
+        "content": "Done — the quantum-computing explainer has been written into the shared document state."
       }
     },
     {


### PR DESCRIPTION
## Summary

Two D5 fixture-correctness fixes for the langgraph-python column. Together they flip `agent-config` to D5 and unblock the recursion-loop failure mode for `shared-state-streaming` (the cell still has a separate framework-level state-binding regression that prevents it from rendering — tracked separately).

- **agent-config**: drop the "introduce yourself per your config" baseline fixture. It substring-matched every prefixed probe prompt (`tone:professional`, `expertise:beginner`, `responseLength:concise`, …), forcing byte-identical responses across all six knob probes and masking the per-knob behavior the cell is meant to demonstrate.
- **shared-state-streaming**: add toolCallId-keyed follow-up fixtures (poem / email / quantum) above each first-turn entry so aimock returns content-only after the tool result lands. Without these, the unchanged last user message kept re-matching the first-turn fixture, the agent re-fired `write_document`, and langgraph hit its 100-step recursion limit.

Synced to `showcase/aimock/d5-all.json` so replay-mode picks up both fixes.

## Test plan

- [x] Local replay: `agent-config` flips GREEN (each knob probe receives its dedicated fixture)
- [x] Local replay: `shared-state-streaming` no longer hits `GraphRecursionError`; remaining failure is the framework state-binding bug (separate work)
- [x] aimock fixture count went up by the expected amount on container restart (`Loaded N fixture(s)`)
- [x] lefthook hooks pass (lint-fix, sync-lockfile, test-and-check-packages all clean)