### PR TITLE
ENT-510 - fix(core): only reset agent state on actual thread switch (supersedes #4720)

### DIFF
--- a/.changeset/fix-thread-switch-state-reset.md
+++ b/.changeset/fix-thread-switch-state-reset.md
@@ -1,0 +1,13 @@
+---
+"@copilotkit/core": patch
+---
+
+fix(core): only reset agent state and replay cursor on actual thread switch
+
+`RunHandler.connectAgent` previously called `agent.setMessages([])` + `agent.setState({})` and the IntelligenceAgent delegate's `clearReconnectCursor` on every connect, including effect-dep churn re-connects on the same thread. That forced the realtime gateway to replay the topic's full event history every time the chat re-opened a socket — which under React effect churn happens 3-5 times per thread switch — and produced both halves of Tyler's bug: duplicate `cpki_event_id` rows in the inspector and intermittent "Message not found" toasts.
+
+This change tracks the most recent connected threadId on `RunHandler` and gates the state-reset + cursor-clear on that threadId actually changing. Same-thread churn re-connects now preserve local messages/state and the gateway can resume from `lastSeenEventId`. Actual thread switches still wipe local state and ask for a full historical replay.
+
+Supersedes #4720, which attempted to solve only the inspector duplicate-row symptom by adding a dispatcher dedup but introduced a regression in the A → B → A restore path (the dedup blocked the gateway's restore replay for thread A on second visit). The dispatcher dedup is removed entirely; the orchestrator-level gate is sufficient.
+
+Adds focused unit tests covering: same-thread churn does not reset, cross-thread switch does reset, A → B → A resets each transition, and a regression test that replays the same `cpki_event_id` after a thread switch and verifies rehydrate still works.

--- a/packages/core/src/__tests__/core-connect-thread-switch.test.ts
+++ b/packages/core/src/__tests__/core-connect-thread-switch.test.ts
@@ -1,0 +1,136 @@
+import type { AbstractAgent } from "@ag-ui/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CopilotKitCore } from "../core";
+
+/**
+ * Tests for RunHandler.connectAgent's thread-switch detection. The
+ * orchestrator gates `setMessages([])` + `setState({})` + replay-cursor
+ * clear on the agent's threadId actually changing between successive
+ * connectAgent calls. Same-thread churn re-connects must preserve
+ * local state so the gateway can resume from `lastSeenEventId` instead
+ * of forcing a full historical replay.
+ */
+
+class StubAgent {
+  public agentId: string;
+  public threadId: string | undefined;
+  public messages: unknown[] = [{ id: "preexisting" }];
+  public state: Record<string, unknown> = { hello: "world" };
+
+  public setMessagesSpy = vi.fn();
+  public setStateSpy = vi.fn();
+  public detachActiveRunSpy = vi.fn();
+  public connectAgentSpy = vi.fn();
+  public clearReplayCursorSpy = vi.fn();
+
+  constructor(agentId: string, threadId?: string) {
+    this.agentId = agentId;
+    this.threadId = threadId;
+  }
+
+  setMessages(messages: unknown[]) {
+    this.setMessagesSpy(messages);
+    this.messages = messages;
+  }
+  setState(state: Record<string, unknown>) {
+    this.setStateSpy(state);
+    this.state = state;
+  }
+  async detachActiveRun() {
+    this.detachActiveRunSpy();
+  }
+  async connectAgent() {
+    this.connectAgentSpy();
+    return { newMessages: [] };
+  }
+  clearReplayCursor(threadId: string) {
+    this.clearReplayCursorSpy(threadId);
+  }
+  // Surfaces consumed by core.connectAgent / processAgentResult.
+  subscribe() {
+    return { unsubscribe() {} };
+  }
+}
+
+describe("CopilotKitCore.connectAgent — thread-switch detection", () => {
+  let core: CopilotKitCore;
+
+  beforeEach(() => {
+    core = new CopilotKitCore({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("a same-thread churn re-connect does NOT clear messages, state, or the replay cursor", async () => {
+    const agent = new StubAgent("test", "thread-A");
+
+    await core.connectAgent({ agent: agent as unknown as AbstractAgent });
+    expect(agent.setMessagesSpy).toHaveBeenCalledTimes(1);
+    expect(agent.setStateSpy).toHaveBeenCalledTimes(1);
+    expect(agent.clearReplayCursorSpy).toHaveBeenCalledTimes(1);
+
+    // Pretend the chat re-fired its connect effect on the same thread
+    // (effect-dep churn — agent.threadId hasn't changed). Reset mocks
+    // and call again.
+    agent.setMessagesSpy.mockClear();
+    agent.setStateSpy.mockClear();
+    agent.clearReplayCursorSpy.mockClear();
+    await core.connectAgent({ agent: agent as unknown as AbstractAgent });
+
+    expect(agent.setMessagesSpy).not.toHaveBeenCalled();
+    expect(agent.setStateSpy).not.toHaveBeenCalled();
+    expect(agent.clearReplayCursorSpy).not.toHaveBeenCalled();
+
+    // The connect itself still fires every time — we always tear down
+    // and re-establish the socket so the runtime can recover from
+    // transient disconnects.
+    expect(agent.connectAgentSpy).toHaveBeenCalledTimes(2);
+    expect(agent.detachActiveRunSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("switching to a different thread DOES clear messages, state, and the replay cursor", async () => {
+    const agentA = new StubAgent("test", "thread-A");
+    const agentB = new StubAgent("test", "thread-B");
+
+    await core.connectAgent({ agent: agentA as unknown as AbstractAgent });
+    expect(agentA.setMessagesSpy).toHaveBeenCalledTimes(1);
+    expect(agentA.clearReplayCursorSpy).toHaveBeenCalledWith("thread-A");
+
+    await core.connectAgent({ agent: agentB as unknown as AbstractAgent });
+    expect(agentB.setMessagesSpy).toHaveBeenCalledTimes(1);
+    expect(agentB.clearReplayCursorSpy).toHaveBeenCalledWith("thread-B");
+  });
+
+  it("A → B → A switches reset state on every transition", async () => {
+    const agentA = new StubAgent("test", "thread-A");
+    const agentB = new StubAgent("test", "thread-B");
+
+    await core.connectAgent({ agent: agentA as unknown as AbstractAgent });
+    await core.connectAgent({ agent: agentB as unknown as AbstractAgent });
+
+    // Returning to thread A must reset and ask for a full replay (the
+    // local state was wiped when we switched to B).
+    agentA.setMessagesSpy.mockClear();
+    agentA.setStateSpy.mockClear();
+    agentA.clearReplayCursorSpy.mockClear();
+    await core.connectAgent({ agent: agentA as unknown as AbstractAgent });
+
+    expect(agentA.setMessagesSpy).toHaveBeenCalledTimes(1);
+    expect(agentA.setStateSpy).toHaveBeenCalledTimes(1);
+    expect(agentA.clearReplayCursorSpy).toHaveBeenCalledWith("thread-A");
+  });
+
+  it("agents without a clearReplayCursor method (non-Intelligence runtimes) are still handled cleanly on switch", async () => {
+    const agent = new StubAgent("test", "thread-A");
+    // Simulate an HttpAgent-style runtime that doesn't expose clearReplayCursor.
+    delete (agent as unknown as { clearReplayCursor?: unknown })
+      .clearReplayCursor;
+
+    await expect(
+      core.connectAgent({ agent: agent as unknown as AbstractAgent }),
+    ).resolves.toBeDefined();
+    expect(agent.setMessagesSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -839,7 +839,13 @@ describe("IntelligenceAgent", () => {
       expect(channel.pushLog).toHaveLength(0);
     });
 
-    it("clears the latest cpki_event_id value on fresh thread restore", async () => {
+    // The reconnect cursor is now controlled explicitly by the caller.
+    // `connect()` preserves whatever cursor is in `sharedState.lastSeenEventIds`
+    // so churn re-connects can resume from `lastSeenEventId` instead of
+    // forcing the gateway to replay the entire thread history. Callers
+    // that *want* a full historical replay (e.g. RunHandler on a detected
+    // thread switch) call `agent.clearReconnectCursor(threadId)` first.
+    it("preserves the cursor on a direct connect() (resume semantics)", async () => {
       const agent = createAgent();
       agent.run(defaultInput).subscribe({ next: () => {}, error: () => {} });
       await waitForConnection(agent);
@@ -853,6 +859,40 @@ describe("IntelligenceAgent", () => {
           cpki_event_seq: 1,
         },
       } as BaseEvent);
+
+      mockFetch.mockResolvedValueOnce(await jsonResponse(runtimeCredentials()));
+
+      connectWithTestAccess(agent, defaultInput).subscribe({
+        next: () => {},
+        error: () => {},
+      });
+      await waitForConnection(agent);
+
+      const connectChannel = getChannel(agent)!;
+      expect(connectChannel.params).toEqual({
+        stream_mode: "connect",
+        last_seen_event_id: "event-1",
+      });
+    });
+
+    it("clearReconnectCursor() empties the cursor for the next connect", async () => {
+      const agent = createAgent();
+      agent.run(defaultInput).subscribe({ next: () => {}, error: () => {} });
+      await waitForConnection(agent);
+
+      const runChannel = getChannel(agent)!;
+      runChannel.triggerJoin("ok");
+      runChannel.serverPush("ag_ui_event", {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        metadata: {
+          cpki_event_id: "event-1",
+          cpki_event_seq: 1,
+        },
+      } as BaseEvent);
+
+      // Explicitly clear the cursor — this is what RunHandler does on a
+      // detected thread switch.
+      agent.clearReconnectCursor("thread-1");
 
       mockFetch.mockResolvedValueOnce(await jsonResponse(runtimeCredentials()));
 
@@ -935,6 +975,12 @@ describe("IntelligenceAgent", () => {
 
       setThreadIdForTest(agent, "thread-a");
       replaceMessagesForTest(agent, []);
+      // Mimic RunHandler's behaviour on a detected thread switch:
+      // explicitly clear the cursor so the gateway is asked for a full
+      // historical replay of thread-a. Without this, the cursor from
+      // the first thread-a pass ("event-a-1") is preserved and the
+      // gateway would resume from there.
+      agent.clearReconnectCursor("thread-a");
       const secondThreadAPromise = agent.connectAgent({ runId: "run-a" });
       await waitForConnection(agent);
 
@@ -947,6 +993,11 @@ describe("IntelligenceAgent", () => {
         last_seen_event_id: null,
       });
 
+      // Mike's regression: persisted replays reuse the original
+      // `cpki_event_id`. Push event-a-1 (NOT event-a-2) and verify the
+      // rehydrate still produces the user message — i.e. nothing
+      // downstream is suppressing it as a duplicate of the earlier
+      // pass.
       secondThreadAChannel.triggerJoin("ok");
       secondThreadAChannel.serverPush("ag_ui_event", {
         type: EventType.RUN_STARTED,
@@ -956,12 +1007,12 @@ describe("IntelligenceAgent", () => {
           messages: [{ id: "msg-a", role: "user", content: "thread A" }],
         },
         metadata: {
-          cpki_event_id: "event-a-2",
-          cpki_event_seq: 2,
+          cpki_event_id: "event-a-1",
+          cpki_event_seq: 1,
         },
       } as BaseEvent);
       secondThreadAChannel.serverPush("stream_idle", {
-        latestEventId: "event-a-2",
+        latestEventId: "event-a-1",
       });
 
       const secondThreadAResult = await secondThreadAPromise;
@@ -1306,7 +1357,7 @@ describe("IntelligenceAgent", () => {
       expect(getConfigForTest(cloned)).toEqual(getConfigForTest(agent));
     });
 
-    it("clears shared replay cursor state across clones on fresh thread restore", async () => {
+    it("shares the replay cursor across clones (clearing on one clears for both)", async () => {
       const agent = createAgent();
       agent.run(defaultInput).subscribe({ next: () => {}, error: () => {} });
       await waitForConnection(agent);
@@ -1322,6 +1373,12 @@ describe("IntelligenceAgent", () => {
       } as BaseEvent);
 
       const cloned = agent.clone();
+      // Clearing the cursor on the original should be reflected on the
+      // clone because they share `sharedState`. This is what makes a
+      // RunHandler-driven thread switch work end-to-end across the
+      // proxy clones returned by useAgent's per-thread WeakMap.
+      agent.clearReconnectCursor("thread-1");
+
       const reconnectInput: RunAgentInput = {
         ...defaultInput,
         messages: [
@@ -1346,7 +1403,7 @@ describe("IntelligenceAgent", () => {
       });
     });
 
-    it("does not reuse a cached replay cursor on fresh thread restore with no local messages", async () => {
+    it("a clone's connect() resumes from the cursor inherited via sharedState", async () => {
       const agent = createAgent();
       agent.run(defaultInput).subscribe({ next: () => {}, error: () => {} });
       await waitForConnection(agent);
@@ -1369,14 +1426,16 @@ describe("IntelligenceAgent", () => {
       });
       await waitForConnection(cloned);
 
+      // No explicit clearReconnectCursor — the clone inherits the
+      // original's `lastSeenEventIds` map and resumes from event-2.
       expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
-        lastSeenEventId: null,
+        lastSeenEventId: "event-2",
       });
 
       const connectChannel = getChannel(cloned)!;
       expect(connectChannel.params).toEqual({
         stream_mode: "connect",
-        last_seen_event_id: null,
+        last_seen_event_id: "event-2",
       });
     });
   });

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -431,6 +431,27 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     return cloned;
   }
 
+  /**
+   * Drop the delegate's cached `lastSeenEventId` for this thread so
+   * the next connect requests a full historical replay from the
+   * gateway. Used by `RunHandler.connectAgent` on a detected thread
+   * switch (the chat moved between threads, so its local
+   * messages/state are about to be cleared and need rebuilding from
+   * the gateway). Skipped on same-thread churn re-connects so the
+   * gateway can resume from the cursor instead.
+   *
+   * No-op for non-Intelligence runtime modes — the HTTP transport
+   * doesn't replay.
+   */
+  public clearReplayCursor(threadId: string): void {
+    if (this.runtimeMode !== RUNTIME_MODE_INTELLIGENCE) return;
+    const delegate = this.delegate as
+      | { clearReconnectCursor?: (id: string) => void }
+      | null
+      | undefined;
+    delegate?.clearReconnectCursor?.(threadId);
+  }
+
   private async resolveDelegate(): Promise<RunnableAgent> {
     await this.ensureRuntimeMode();
 

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -91,6 +91,24 @@ export class RunHandler {
    */
   private _runDepth = 0;
 
+  /**
+   * Tracks the threadId of the most recent `connectAgent` call so we
+   * can distinguish a fresh thread restore (different threadId than
+   * last time — chat is rebuilding state from scratch, must clear
+   * messages/state and ask the gateway for a full replay) from a
+   * same-thread churn re-connect (effect-dep churn or transient
+   * disconnect — local messages/state are still meaningful, must
+   * preserve them and let the gateway resume from
+   * `lastSeenEventId`).
+   *
+   * Tyler's bug fired because every `connectAgent` was treated as a
+   * fresh restore, which forced the gateway to replay the full
+   * thread history on every churn re-connect and amplified the
+   * downstream churn into duplicate `cpki_event_id` rows in the
+   * inspector and intermittent "Message not found" toasts.
+   */
+  private _lastConnectedThreadId: string | null = null;
+
   constructor(private core: CopilotKitCore) {}
 
   /**
@@ -195,10 +213,32 @@ export class RunHandler {
     agent,
   }: CopilotKitCoreConnectAgentParams): Promise<RunAgentResult> {
     try {
-      // Detach any active run before connecting to avoid previous runs interfering
+      const incomingThreadId = agent.threadId ?? null;
+      const isFreshRestore = incomingThreadId !== this._lastConnectedThreadId;
+      this._lastConnectedThreadId = incomingThreadId;
+
+      // Detach any active run before connecting to avoid previous runs
+      // interfering. This stays unconditional — both fresh restores and
+      // churn re-connects need the previous socket torn down before a new
+      // one can open.
       await agent.detachActiveRun();
-      agent.setMessages([]);
-      agent.setState({});
+
+      // State reset + replay-cursor clear are gated on actually moving
+      // to a different thread. On same-thread churn, the local
+      // messages/state are still the right view of the thread, and the
+      // gateway can resume from `lastSeenEventId` instead of replaying
+      // the full history.
+      if (isFreshRestore) {
+        agent.setMessages([]);
+        agent.setState({});
+        const proxied = agent as { clearReplayCursor?: (id: string) => void };
+        if (
+          incomingThreadId &&
+          typeof proxied.clearReplayCursor === "function"
+        ) {
+          proxied.clearReplayCursor(incomingThreadId);
+        }
+      }
 
       if (agent instanceof HttpAgent) {
         agent.headers = {

--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -279,10 +279,22 @@ export class IntelligenceAgent extends AbstractAgent {
    * Reconnect to an existing thread by fetching websocket credentials and
    * joining the realtime thread channel.
    */
+  /**
+   * Reconnect to an existing thread by fetching websocket credentials
+   * and joining the realtime thread channel.
+   *
+   * Note: this method does NOT clear the replay cursor. Whether to
+   * request a full historical replay vs. resume from
+   * `lastSeenEventId` is a decision the caller (typically
+   * `RunHandler.connectAgent`) makes by calling
+   * {@link clearReconnectCursor} ahead of time on a fresh thread
+   * restore. Same-thread churn re-connects preserve the cursor so the
+   * gateway only streams events past it instead of replaying the
+   * entire history every time the chat re-opens a socket.
+   */
   protected connect(input: RunAgentInput): Observable<BaseEvent> {
     this.threadId = input.threadId;
     this.canonicalRunId = null;
-    this.clearReconnectCursor(input.threadId);
 
     return defer(() => this.requestJoinCredentials$("connect", input)).pipe(
       switchMap((credentials) => {
@@ -685,7 +697,15 @@ export class IntelligenceAgent extends AbstractAgent {
     return this.getLastSeenEventId(input.threadId);
   }
 
-  private clearReconnectCursor(threadId: string): void {
+  /**
+   * Drop the cached `lastSeenEventId` cursor for `threadId` so the
+   * next connect to that topic asks the gateway for a full historical
+   * replay (rather than resuming). Public because
+   * `RunHandler.connectAgent` calls it on a detected thread switch
+   * to rebuild local state from scratch, and skips it on same-thread
+   * churn so the gateway can resume.
+   */
+  public clearReconnectCursor(threadId: string): void {
     this.sharedState.lastSeenEventIds.delete(threadId);
   }
 


### PR DESCRIPTION
## Summary

Supersedes #4720, which Mike correctly identified as introducing a blocking regression in the fresh-thread-restore path. This PR takes Mike's framing as the authoritative restatement of the bug and lands the proxy/orchestrator-level fix that addresses both halves of Tyler's symptom without that regression.

## The actual bug, restated

When the chat's connect effect re-fires due to React effect-dep churn, it calls `copilotkit.connectAgent({ agent })` on the same thread again. `RunHandler.connectAgent` previously did `agent.setMessages([])` + `agent.setState({})` and (transitively) called `clearReconnectCursor` on every invocation, **including the churn re-connects**. That forced the realtime gateway to replay the topic's full event history every time the chat re-opened a socket — sending the same persisted `cpki_event_id`s 2-3 times per thread switch — and produced both halves of Tyler's video:

- **Cosmetic surface**: duplicate `cpki_event_id` rows in the inspector AG-UI Events tab.
- **Functional surface**: `agent.messages` got cleared, the replay started rebuilding it, then another churn re-connect came along, called `setMessages([])` again, and the next `runAgent` fired with `messages.length = 1` while the server had N. `prepareRegenerateStream` triggered, the new user-message id wasn't in any checkpoint, and the server threw "Message not found".

PR #4720 only addressed the cosmetic surface and made the functional surface deterministic. Mike's review caught it.

## What this PR changes

- **`RunHandler.connectAgent`** tracks `_lastConnectedThreadId` across calls. The `setMessages([])` + `setState({})` + replay-cursor clear are now gated on the threadId actually changing. Same-thread churn re-connects preserve local state and let the gateway resume from `lastSeenEventId` instead of replaying. Thread switches still wipe state and ask for a full replay.
- **`IntelligenceAgent.connect()`** no longer auto-clears the replay cursor. Cursor management is the caller's decision now. `clearReconnectCursor` is made `public` so the orchestrator (and tests) can call it explicitly.
- **`ProxiedCopilotRuntimeAgent`** exposes a public `clearReplayCursor(threadId)` method that delegates to the IntelligenceAgent's `clearReconnectCursor`. Non-Intelligence runtime modes are a safe no-op.

The dispatcher-level dedup from #4720 is **removed entirely**. The orchestrator-level gate is sufficient and a much smaller, more obviously correct surface.

## Why this approach

Mike's two suggestions in the #4720 review were "clear the dedup table when the cursor is cleared" or "scope dedup to a connection/replay window." Both alone left a regression in the other direction:
- Coupling dedup to `clearReconnectCursor` (which was unconditional) reset dedup on every churn re-connect, so the original symptom returned.
- Per-connection-window dedup couldn't catch dups across the multiple sockets that fire during churn.

The right move is one level up: stop the underlying state-reset cascade that was forcing the replay storm in the first place. Once same-thread churn no longer wipes local state, the gateway can resume cleanly, the wire-level replays don't happen, and both Tyler's symptoms disappear naturally — no dispatcher dedup needed.

## Tests

- **`intelligence-agent.test.ts`**: 4 existing tests updated to reflect the new contract. `connect()` preserves the cursor by default; `clearReconnectCursor()` is the explicit primitive. Includes the regression test Mike asked for: replay the same `cpki_event_id` after `A → B → A` and verify the rehydrate still produces the user message.
- **`core-connect-thread-switch.test.ts`** (new): 4 focused tests for the orchestrator gate — same-thread churn does not reset, cross-thread switch does reset, `A → B → A` resets each transition, and a non-Intelligence runtime path is handled cleanly.

All 430 core tests pass:
```
Test Files  40 passed (40)
     Tests  430 passed (430)
```

## Test plan

- [ ] Pull the canary build into `gen-ui-studio` (a fresh `npx copilotkit create`).
- [ ] Manually walk Tyler's recipe with the inspector open: open thread A, switch to B, switch back to A. AG-UI Events tab should show one row per `cpki_event_id`. No "Message not found" toast.
- [ ] Send a message after the switch-back. Run completes cleanly.
- [ ] (Repro harness) `recipe-rehydrate.spec.ts` from kingston's transport-dup-repro asserts on user-visible state (DOM messages + absence of "Message not found"). Should pass against this canary; fails against `origin/main` and against #4720's commit.

## Why "supersedes #4720" not "build on top of"

The dispatcher dedup in #4720 isn't load-bearing under this fix — once the orchestrator stops cascading state-resets, there's no replay storm for the dispatcher to filter. Keeping the dedup would just be unused machinery with non-trivial memory accounting. Cleaner to drop it entirely and revisit only if a real overlap scenario surfaces later (network blips, retries, etc.).
