### PR TITLE
fix(shell-docs): cutover-blocker fixes from Phase 4 validation

### DIFF
--- a/showcase/integrations/langgraph-python/src/app/demos/chat-slots/slot-overrides.snippet.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/chat-slots/slot-overrides.snippet.tsx
@@ -1,0 +1,45 @@
+// Docs-only snippet — not imported or rendered. The langgraph-python
+// chat-slots production demo registers a dozen slot overrides at once
+// (see page.tsx) with `as unknown as typeof X` casts that exist to
+// satisfy the WithSlots types when the wrappers are structurally
+// compatible but not nominally identical. That's necessary in the
+// running app but obscures the teaching shape.
+//
+// This file gives the slots docs page (custom-look-and-feel/slots.mdx)
+// three minimal teaching examples — the welcome screen, assistant
+// message, and disclaimer slot patterns — without changing the
+// production demo's runtime behavior. See agentic-chat /
+// chat-component.snippet.tsx for the same sibling-file pattern.
+
+import type {
+  CopilotChatAssistantMessage,
+  CopilotChatInput,
+  CopilotChatView,
+} from "@copilotkit/react-core/v2";
+
+declare const CustomWelcomeScreen: React.ComponentType;
+declare const CustomAssistantMessage: React.ComponentType;
+declare const CustomDisclaimer: React.ComponentType;
+
+export function ChatSlotsTeachingExtracts() {
+  // @region[register-welcome-slot]
+  const welcomeScreen =
+    CustomWelcomeScreen as unknown as typeof CopilotChatView.WelcomeScreen;
+  // @endregion[register-welcome-slot]
+
+  // @region[register-assistant-message-slot]
+  const messageView = {
+    assistantMessage:
+      CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
+  };
+  // @endregion[register-assistant-message-slot]
+
+  // @region[register-disclaimer-slot]
+  const input = {
+    disclaimer:
+      CustomDisclaimer as unknown as typeof CopilotChatInput.Disclaimer,
+  };
+  // @endregion[register-disclaimer-slot]
+
+  return { welcomeScreen, messageView, input };
+}

--- a/showcase/integrations/langgraph-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/frontend-tools/page.tsx
@@ -21,6 +21,7 @@ export default function FrontendToolsDemo() {
 function Chat() {
   const [background, setBackground] = useState<string>(DEFAULT_BACKGROUND);
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -30,11 +31,14 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }) => {
       setBackground(background);
       return { status: "success" };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useFrontendToolsSuggestions();
 

--- a/showcase/shell-docs/src/content/docs/integrations/adk/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/shared-state/predictive-state-updates.mdx
@@ -5,7 +5,7 @@ description: Stream in-progress agent state updates to the frontend.
 ---
 
 {/* TODO: Re-add once the dojo example is updated and works */}
-{/\* <IframeSwitcher
+{/* <IframeSwitcher
   id="predictive-state-updates-example"
   exampleUrl="https://feature-viewer.copilotkit.ai/adk-middleware/feature/predictive_state_updates?sidebar=false&chatDefaultOpen=false"
   codeUrl="https://feature-viewer.copilotkit.ai/adk-middleware/feature/predictive_state_updates?view=code&sidebar=false&codeLayout=tabs"

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/human-in-the-loop/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/human-in-the-loop/index.mdx
@@ -15,7 +15,7 @@ description: Allow your agent and users to collaborate on complex tasks.
 />
 
 {/* TODO-DOCS-CREWAI-FLOWS: Add Travel App Example */}
-{/\* <Callout>
+{/* <Callout>
 This video shows an example of our [AI Travel App](/langgraph/tutorials/ai-travel-app) using HITL to get user feedback.
 
 </Callout> */}

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/agent-native-app/step-6-shared-state.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/agent-native-app/step-6-shared-state.mdx
@@ -118,7 +118,8 @@ In this example, we use the `useCoAgent` hook to wire up the application's state
 - For the generic type, we pass the `AgentState` type that was already defined for the application in `@/lib/types.ts`.
 - For the `name` parameter, we pass the name of the graph as defined in `agent/langgraph.json`.
 - For the `initialState` parameter, we pass the initial state of the LangGraph agent which is already defined in `@/lib/trips.ts`.
-    </Step>
+
+</Step>
 </Steps>
 
 ## Recap

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-3-setup-copilotkit.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-3-setup-copilotkit.mdx
@@ -137,7 +137,8 @@ And we're done! Here's what we did:
 - We setup our Copilot cloud account and got an API key.
 - We configured the CopilotKit provider in our application to use our API key.
 - We added the CopilotSidebar to our application.
-  </Step>
+
+</Step>
 
 </Step>
 </Steps>
@@ -215,7 +216,8 @@ Here's what we did:
 - We imported the `<CopilotSidebar />` component from `@copilotkit/react-ui`.
 - We wrapped the page with the `<CopilotKit>` provider.
 - We imported the built-in styles from `@copilotkit/react-ui`.
-    </TailoredContentOption>
+
+</TailoredContentOption>
 </TailoredContent>
 
 Now, head back to the app and you'll find a chat sidebar on the left side of the page. At this point, you can start interacting with your copilot! 🎉

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-4-integrate-the-agent.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-4-integrate-the-agent.mdx
@@ -168,7 +168,8 @@ In this example, we use the `useCoAgent` hook to wire up the application's state
 - For the generic type, we pass the `AgentState` type that was already defined for the application in `@/lib/types.ts`.
 - For the `name` parameter, we pass the name of the graph as defined in `agent/langgraph.json`.
 - For the `initialState` parameter, we pass the initial state of the LangGraph agent which is already defined in `@/lib/trips.ts`.
-    </Step>
+
+</Step>
 </Steps>
 
 ## Try it out!

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/predictive-state-updates.mdx
@@ -5,7 +5,7 @@ description: Stream in-progress agent state updates to the frontend.
 ---
 
 {/* TODO: Re-add once the dojo example is updated and works */}
-{/\* <IframeSwitcher
+{/* <IframeSwitcher
   id="predictive-state-updates-example"
   exampleUrl="https://feature-viewer.copilotkit.ai/llama-index/feature/predictive_state_updates?sidebar=false&chatDefaultOpen=false"
   codeUrl="https://feature-viewer.copilotkit.ai/llama-index/feature/predictive_state_updates?view=code&sidebar=false&codeLayout=tabs"

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/human-in-the-loop/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/human-in-the-loop/index.mdx
@@ -15,7 +15,7 @@ description: Allow your agent and users to collaborate on complex tasks.
 />
 
 {/* TODO: Add Example */}
-{/\* <Callout>
+{/* <Callout>
 This video shows an example of our [AI Travel App](/langgraph/tutorials/ai-travel-app) using HITL to get user feedback.
 
 </Callout> */}

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-write.mdx
@@ -179,6 +179,6 @@ function YourMainContent() {
 By default, the Pydantic AI Agent state will only update _between_ Pydantic AI Agent node transitions --
 which means state updates will be discontinuous and delayed.
 
-{/\* You likely want to render the agent state as it updates **continuously.**
+{/* You likely want to render the agent state as it updates **continuously.**
 
-See **[emit intermediate state](/pydantic-ai/shared-state/predictive-state-updates).** \*/}
+See **[emit intermediate state](/pydantic-ai/shared-state/predictive-state-updates).** */}

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -350,6 +350,13 @@ export const docsComponents = {
   SharedContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
+  // <Content framework="..." /> is used by orphaned `deploy-agentcore`
+  // pages (langgraph/* + aws-strands) as a placeholder for content
+  // that was never authored. Without a registered shim, MDX rendering
+  // throws and ships a 500 in the public sitemap.
+  Content: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   IframeSwitcher: RealIframeSwitcher,
   IframeSwitcherGroup: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -691,6 +698,15 @@ export const docsComponents = {
   }: {
     children?: React.ReactNode;
   }) => <div>{children}</div>,
+  // Alias of CopilotCloudConfigureCopilotKitProvider — historical
+  // spelling without the `Provider` suffix appears in tutorials
+  // (`ai-powered-textarea/step-2`, `ai-todo-app/step-2`). Keeping both
+  // keys so existing MDX renders without throwing.
+  CopilotCloudConfigureCopilotKit: ({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }) => <div>{children}</div>,
   GenerativeUISpecsOverview: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -876,12 +892,26 @@ export const docsComponents = {
   CloudCopilotKitProvider: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
+  // Alias of CloudCopilotKitProvider — `crewai-flows/quickstart` and
+  // other historical MDX use the unsuffixed spelling. Without this,
+  // MDX rendering throws "Expected component CloudCopilotKit to be
+  // defined" at runtime → 500 in production.
+  CloudCopilotKit: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   SelfHostingCopilotRuntimeCreateEndpoint: ({
     children,
   }: {
     children?: React.ReactNode;
   }) => <div>{children}</div>,
   SelfHostingCopilotRuntimeConfigureCopilotKitProvider: ({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }) => <div>{children}</div>,
+  // Alias of SelfHostingCopilotRuntimeConfigureCopilotKitProvider —
+  // `ai-todo-app/step-2-setup-copilotkit` uses the unsuffixed name.
+  SelfHostingCopilotRuntimeConfigureCopilotKit: ({
     children,
   }: {
     children?: React.ReactNode;

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -26,7 +26,11 @@ import { IntegrationGrid } from "@/components/integration-grid";
 import { DocsLandingNext } from "@/components/docs-landing-next";
 import { WhenFrameworkHas } from "@/components/when-framework-has";
 import { AgentCoreCommandTabs } from "@/components/agentcore-command-tabs";
-import { getRegistry, getDocsFolder } from "@/lib/registry";
+import {
+  getRegistry,
+  getFeatureViewerSlug,
+  getFeatureViewerDemoId,
+} from "@/lib/registry";
 
 const Callout = DocsCallout;
 
@@ -162,16 +166,24 @@ export const docsComponents = {
     const shellHost =
       process.env.NEXT_PUBLIC_SHELL_URL || "https://showcase.copilotkit.ai";
     const profileUrl = `${shellHost}/integrations/${integration}?demo=${demo}`;
-    // Feature-viewer expects the upstream framework folder name (e.g.
-    // `langgraph`), not the registry's URL slug (e.g. `langgraph-python`).
-    // `getDocsFolder` performs the same translation used elsewhere in
-    // shell-docs so both URL variants resolve to the right viewer entry.
-    const upstreamFramework = getDocsFolder(integration);
-    // Feature-viewer slugs are underscore-form (`agentic_chat`,
-    // `human_in_the_loop`); the registry uses dash-form (`agentic-chat`).
-    // Translate so the Code iframe resolves.
-    const codeFeatureSlug = demo.replace(/-/g, "_");
-    const codeUrl = `https://feature-viewer.copilotkit.ai/${upstreamFramework}/feature/${codeFeatureSlug}?view=code&sidebar=false&codeLayout=tabs`;
+    // Feature-viewer.copilotkit.ai uses its own framework slug + demo-ID
+    // scheme, distinct from both the registry URL slug AND the docs
+    // folder name (e.g. `crewai-crews` → `crewai`, `gen-ui-tool-based`
+    // → `tool_based_generative_ui`). `getFeatureViewerSlug` returns
+    // `null` for integrations with no feature-viewer page (built-in-agent,
+    // google-adk, claude-sdk-*, ms-agent-*); `getFeatureViewerDemoId`
+    // returns `null` for demos that have no feature-viewer counterpart
+    // (anything outside the canonical six: agentic_chat,
+    // tool_based_generative_ui, agentic_generative_ui,
+    // predictive_state_updates, shared_state, human_in_the_loop). In
+    // either case the Code tab is suppressed and the Demo iframe
+    // renders standalone.
+    const featureViewerSlug = getFeatureViewerSlug(integration);
+    const codeDemoSlug = getFeatureViewerDemoId(demo.replace(/-/g, "_"));
+    const codeUrl =
+      featureViewerSlug && codeDemoSlug
+        ? `https://feature-viewer.copilotkit.ai/${featureViewerSlug}/feature/${codeDemoSlug}?view=code&sidebar=false&codeLayout=tabs`
+        : null;
     const iframeStyle: React.CSSProperties = {
       width: "100%",
       height: "500px",
@@ -191,24 +203,33 @@ export const docsComponents = {
             Open full demo →
           </a>
         </div>
-        <DocsTabs items={["Demo", "Code"]}>
-          <DocsTab value="Demo">
-            <iframe
-              src={demoUrl}
-              style={iframeStyle}
-              sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-              loading="lazy"
-            />
-          </DocsTab>
-          <DocsTab value="Code">
-            <iframe
-              src={codeUrl}
-              style={iframeStyle}
-              sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-              loading="lazy"
-            />
-          </DocsTab>
-        </DocsTabs>
+        {codeUrl ? (
+          <DocsTabs items={["Demo", "Code"]}>
+            <DocsTab value="Demo">
+              <iframe
+                src={demoUrl}
+                style={iframeStyle}
+                sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+                loading="lazy"
+              />
+            </DocsTab>
+            <DocsTab value="Code">
+              <iframe
+                src={codeUrl}
+                style={iframeStyle}
+                sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+                loading="lazy"
+              />
+            </DocsTab>
+          </DocsTabs>
+        ) : (
+          <iframe
+            src={demoUrl}
+            style={iframeStyle}
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+            loading="lazy"
+          />
+        )}
       </div>
     );
   },

--- a/showcase/shell-docs/src/lib/registry.ts
+++ b/showcase/shell-docs/src/lib/registry.ts
@@ -131,6 +131,89 @@ export function getDocsFolder(slug: string): string {
 }
 
 /**
+ * Maps a registry slug to the framework slug expected by
+ * feature-viewer.copilotkit.ai (which hosts the Code tab iframe in
+ * `<InlineDemo>`). Most slugs differ from `getDocsFolder` because
+ * feature-viewer was deployed with its own naming scheme that
+ * predates the shell-docs rename pass.
+ *
+ * Returning `null` means the integration has no feature-viewer
+ * counterpart at all; the `<InlineDemo>` Code tab is suppressed in
+ * that case (Demo tab still renders).
+ *
+ * Verified 2026-05-08 by probing each
+ * `https://feature-viewer.copilotkit.ai/<slug>/feature/agentic_chat?view=code&sidebar=false&codeLayout=tabs`
+ * URL — entries marked `null` returned a hard 404
+ * (`NEXT_HTTP_ERROR_FALLBACK;404`); entries returning a value were
+ * confirmed to render real code panels for at least one supported
+ * demo.
+ */
+const FEATURE_VIEWER_SLUG_OVERRIDES: Record<string, string | null> = {
+  // Three LangChain/LangGraph URL variants share one feature-viewer
+  // entry — same as the docs-folder mapping.
+  "langgraph-python": "langgraph",
+  "langgraph-typescript": "langgraph",
+  "langgraph-fastapi": "langgraph",
+  // feature-viewer renames `crewai-crews` to `crewai` (the
+  // docs-folder uses `crewai-flows`, distinct from both).
+  "crewai-crews": "crewai",
+  // feature-viewer uses dashed `llama-index`; registry uses
+  // unhyphenated `llamaindex`.
+  llamaindex: "llama-index",
+  // Registry slug `strands`; docs folder `aws-strands`;
+  // feature-viewer also uses `aws-strands`.
+  strands: "aws-strands",
+  // No feature-viewer page exists for these integrations — hide the
+  // Code tab on InlineDemo rather than rendering a 404.
+  "built-in-agent": null,
+  "google-adk": null,
+  "claude-sdk-python": null,
+  "claude-sdk-typescript": null,
+  "ms-agent-python": null,
+  "ms-agent-dotnet": null,
+};
+
+export function getFeatureViewerSlug(slug: string): string | null {
+  if (slug in FEATURE_VIEWER_SLUG_OVERRIDES) {
+    return FEATURE_VIEWER_SLUG_OVERRIDES[slug];
+  }
+  return slug;
+}
+
+/**
+ * Maps a registry demo ID (after dash→underscore normalization, e.g.
+ * `gen_ui_tool_based`) to the demo ID feature-viewer expects (e.g.
+ * `tool_based_generative_ui`). The two namespaces diverged historically;
+ * feature-viewer keeps its older descriptive names.
+ *
+ * Returning `null` means feature-viewer has no entry for this demo at
+ * all — the `<InlineDemo>` Code tab is suppressed for it. Feature-viewer
+ * currently ships only the six canonical demos listed below; everything
+ * else (`tool-rendering`, `subagents`, `frontend-tools`, `voice`, etc.)
+ * exists in the showcase backends but has no Code-view counterpart.
+ *
+ * Verified 2026-05-08 against
+ * `https://feature-viewer.copilotkit.ai/langgraph/feature/<demo>?view=code&sidebar=false&codeLayout=tabs`
+ * — only these six demos rendered real code panels for `langgraph`;
+ * any other demo ID returned the `_not-found` page.
+ */
+const FEATURE_VIEWER_DEMOS: Record<string, string> = {
+  // Identity mappings — shell uses the same name as feature-viewer.
+  agentic_chat: "agentic_chat",
+  // Renames — shell-docs adopted shorter names; feature-viewer kept
+  // the original descriptive ones.
+  gen_ui_tool_based: "tool_based_generative_ui",
+  gen_ui_agent: "agentic_generative_ui",
+  shared_state_streaming: "predictive_state_updates",
+  shared_state_read_write: "shared_state",
+  hitl_in_chat: "human_in_the_loop",
+};
+
+export function getFeatureViewerDemoId(demo: string): string | null {
+  return FEATURE_VIEWER_DEMOS[demo] ?? null;
+}
+
+/**
  * Per-slug default-tab selections for the in-page `<Tabs>` component,
  * keyed by the MDX `groupId` prop. When a page renders under one of
  * these slugs, any tab whose `groupId` matches opens with the mapped

--- a/showcase/shell-docs/src/lib/seo-redirects.ts
+++ b/showcase/shell-docs/src/lib/seo-redirects.ts
@@ -430,11 +430,6 @@ const ROOT_RENAMES: RedirectEntry[] = [
   { id: "R18", source: "/mcp", destination: "/coding-agents" },
   { id: "R19", source: "/vibe-coding-mcp", destination: "/coding-agents" },
   {
-    id: "R20",
-    source: "/agentic-protocols",
-    destination: "/agentic-protocols",
-  },
-  {
     id: "R21",
     source: "/ag-ui-protocol",
     destination: "/agentic-protocols/ag-ui",
@@ -459,27 +454,8 @@ const ROOT_RENAMES: RedirectEntry[] = [
     source: "/runtime-server-adapter",
     destination: "/backend/copilot-runtime",
   },
-  {
-    id: "R27",
-    source: "/whats-new/v1-50",
-    destination: "/whats-new/v1-50",
-  },
   // Manual overrides (Category 7) — root-level doc pages
   { id: "M2", source: "/quickstart", destination: "/" },
-  { id: "M3", source: "/faq", destination: "/faq" },
-  { id: "M4", source: "/frontend-tools", destination: "/frontend-tools" },
-  {
-    id: "M5",
-    source: "/human-in-the-loop",
-    destination: "/human-in-the-loop",
-  },
-  {
-    id: "M6",
-    source: "/prebuilt-components",
-    destination: "/prebuilt-components",
-  },
-  { id: "M7", source: "/coding-agents", destination: "/coding-agents" },
-  { id: "M8", source: "/telemetry", destination: "/telemetry" },
   // Broken link fixes (B1-B3)
   {
     id: "B1",
@@ -558,13 +534,6 @@ const LEGACY_CHAINS_EXACT: RedirectEntry[] = [
     id: "L11",
     source: "/coagents/videos",
     destination: "/langgraph-python/videos",
-  },
-  // /crewai-crews is now the canonical slug — historical /crewai-crews
-  // URLs land directly on the new framework root.
-  {
-    id: "L14",
-    source: "/crewai-crews",
-    destination: "/crewai-crews",
   },
 ];
 
@@ -708,11 +677,6 @@ const WILDCARD_REDIRECTS: RedirectEntry[] = [
     source: "/coagents/:path*",
     destination: "/langgraph-python/:path*",
   },
-  {
-    id: "L13",
-    source: "/crewai-crews/:path*",
-    destination: "/crewai-crews/:path*",
-  },
   // Category 4 wildcards — direct-to-llm and /integrations/built-in-agent retire to BIA
   {
     id: "R16",
@@ -742,48 +706,22 @@ const WILDCARD_REDIRECTS: RedirectEntry[] = [
     destination: "/generative-ui/specs/:path*",
   },
   // Category 1: Pattern rules (bulk coverage)
-  {
-    id: "P9",
-    source: "/reference/v2/:path*",
-    destination: "/reference/v2/:path*",
-  },
   { id: "P10", source: "/reference/v1/:path*", destination: "/reference/v2" },
   {
     id: "P11",
     source: "/guides/:path*",
     destination: "/built-in-agent/guides/:path*",
   },
-  { id: "P12", source: "/backend/:path*", destination: "/backend/:path*" },
   { id: "P3", source: "/learn/:path*", destination: "/concepts/:path*" },
-  {
-    id: "P4",
-    source: "/troubleshooting/:path*",
-    destination: "/troubleshooting/:path*",
-  },
-  {
-    id: "P5",
-    source: "/custom-look-and-feel/:path*",
-    destination: "/custom-look-and-feel/:path*",
-  },
-  {
-    id: "P6",
-    source: "/generative-ui/:path*",
-    destination: "/generative-ui/:path*",
-  },
-  { id: "P7", source: "/premium/:path*", destination: "/premium/:path*" },
-  {
-    id: "P8",
-    source: "/contributing/:path*",
-    destination: "/contributing/:path*",
-  },
   // P1 + P2: Per-framework catch-alls (MUST be last — they match any /{framework}/*)
-  // Source is the legacy slug; destination uses canonical slug.
-  ...FRAMEWORKS.map((fw) => ({
+  // Source is the legacy slug; destination uses canonical slug. Skip
+  // frameworks whose slug is unchanged — those would be self-loops.
+  ...FRAMEWORKS.filter((fw) => canonicalSlug(fw) !== fw).map((fw) => ({
     id: `P1×${fw}`,
     source: `/${fw}/:path*`,
     destination: `/${canonicalSlug(fw)}/:path*`,
   })),
-  ...FRAMEWORKS.map((fw) => ({
+  ...FRAMEWORKS.filter((fw) => canonicalSlug(fw) !== fw).map((fw) => ({
     id: `P2×${fw}`,
     source: `/${fw}`,
     destination: `/${canonicalSlug(fw)}`,

--- a/showcase/shell-docs/src/middleware.ts
+++ b/showcase/shell-docs/src/middleware.ts
@@ -139,11 +139,13 @@ async function capturePageView(
 // Framework slug short-circuit
 //
 // shell-docs serves canonical framework docs at /<fw-slug>/<...> using
-// the registry slugs (e.g. /langgraph-python/quickstart). Any path
-// whose first segment matches a registry slug is a first-class
-// framework-scoped URL — the SEO-redirect table must NOT hijack it. We
-// short-circuit those paths past the redirect lookup so the canonical
-// route handler renders normally.
+// the registry slugs (e.g. /langgraph-python/quickstart). A first-class
+// framework-scoped URL should fall through to the canonical route
+// handler when no explicit catalog rule matches — but explicit catalog
+// rules (e.g. slug-rename entries like S3×agno
+// /agno/frontend-actions → /agno/frontend-tools) MUST still fire. So
+// the catalog is consulted first; only on a catalog miss do we let
+// framework-scoped paths bypass the wildcard fallthroughs.
 // ---------------------------------------------------------------------------
 
 const REGISTRY_FRAMEWORK_SLUGS: Set<string> = new Set(
@@ -152,9 +154,13 @@ const REGISTRY_FRAMEWORK_SLUGS: Set<string> = new Set(
   ) ?? [],
 );
 
+function firstSegment(p: string): string | undefined {
+  return p.split("/").filter(Boolean)[0];
+}
+
 function pathIsFrameworkScoped(pathname: string): boolean {
-  const first = pathname.split("/").filter(Boolean)[0];
-  return Boolean(first) && REGISTRY_FRAMEWORK_SLUGS.has(first);
+  const first = firstSegment(pathname);
+  return first !== undefined && REGISTRY_FRAMEWORK_SLUGS.has(first);
 }
 
 // ---------------------------------------------------------------------------
@@ -167,33 +173,57 @@ export function middleware(
 ): NextResponse {
   const { pathname } = request.nextUrl;
 
-  // 1. Redirect lookup — but skip framework-scoped paths so canonical
-  //    /<fw-slug>/<...> URLs are never hijacked by legacy patterns.
-  if (!pathIsFrameworkScoped(pathname)) {
-    // Exact match (O(1) Map lookup)
-    const exact = exactMap.get(pathname);
-    if (exact) {
-      trackRedirect(exact.id, pathname, exact.destination);
-      return NextResponse.redirect(
-        new URL(exact.destination, request.url),
-        301,
-      );
-    }
+  // 1. Redirect lookup.
+  //
+  //   1a. Exact match (O(1) Map lookup) is consulted FIRST for every
+  //       request — including framework-scoped paths — so explicit
+  //       slug-rename catalog entries fire instead of being shadowed
+  //       by the framework short-circuit below.
+  const exact = exactMap.get(pathname);
+  if (exact && exact.destination !== pathname) {
+    trackRedirect(exact.id, pathname, exact.destination);
+    return NextResponse.redirect(new URL(exact.destination, request.url), 301);
+  }
 
-    // Wildcard match (linear scan — short-circuits on first match)
-    for (const wc of wildcardEntries) {
-      if (pathname.startsWith(wc.prefix)) {
-        const rest = pathname.slice(wc.prefix.length);
-        let destination: string;
-        if (wc.destinationTemplate.includes(":path*")) {
-          destination = wc.destinationTemplate.replace(":path*", rest);
-        } else {
-          destination = wc.destinationTemplate;
-        }
-        trackRedirect(wc.id, pathname, destination);
-        return NextResponse.redirect(new URL(destination, request.url), 301);
+  //   1b. Wildcard scan. We must avoid letting a too-broad legacy
+  //       wildcard (e.g. /coagents/:path*) hijack a canonical
+  //       framework-scoped URL (e.g. /langgraph-python/...). For a
+  //       framework-scoped request, only allow wildcards whose own
+  //       prefix is rooted in the SAME framework slug — those are
+  //       same-framework rewrites (e.g. /agno/concepts/:path* →
+  //       /agno) and are explicitly authored to fire. Wildcards
+  //       whose prefix is a different framework slug, or has no
+  //       framework slug at all, are skipped.
+  const requestFw = pathIsFrameworkScoped(pathname)
+    ? firstSegment(pathname)
+    : undefined;
+
+  for (const wc of wildcardEntries) {
+    if (!pathname.startsWith(wc.prefix)) {
+      continue;
+    }
+    if (requestFw !== undefined) {
+      const wcFw = firstSegment(wc.prefix);
+      if (wcFw !== requestFw) {
+        continue;
       }
     }
+    const rest = pathname.slice(wc.prefix.length);
+    let destination: string;
+    if (wc.destinationTemplate.includes(":path*")) {
+      destination = wc.destinationTemplate.replace(":path*", rest);
+    } else {
+      destination = wc.destinationTemplate;
+    }
+    // Defense-in-depth: skip if the wildcard expansion produced a
+    // destination identical to the source. Catches catalog drift
+    // (e.g. a future entry where source and destination templates
+    // resolve to the same path) before it 301-loops.
+    if (destination === pathname) {
+      continue;
+    }
+    trackRedirect(wc.id, pathname, destination);
+    return NextResponse.redirect(new URL(destination, request.url), 301);
   }
 
   // 2. Pageview tracking — only on real GET pageviews, not prefetches.


### PR DESCRIPTION
## Summary

Phase 4 validation (run today against `docs.showcase.copilotkit.ai`) surfaced four cutover-blocking issues. This PR fixes all of them in four focused commits.

## Commits

1. **chore(showcase): close last 2 yellow Missing snippet boxes for cutover** — adds in-place region markers to `langgraph-python::frontend-tools` and a sibling `slot-overrides.snippet.tsx` teaching file for `langgraph-python::chat-slots`. Both pages now render zero `Missing snippet` warnings.

2. **fix(shell-docs): correct feature-viewer slug + demo-id translation for code tab** — adds `getFeatureViewerSlug()` and `getFeatureViewerDemoId()` helpers in `registry.ts`, with explicit override maps for the 8 framework-name mismatches (built-in-agent, google-adk, claude-sdk-{python,typescript}, ms-agent-{python,dotnet}, crewai-crews, llamaindex) and 5 demo-id mismatches (gen_ui_tool_based, gen_ui_agent, shared_state_streaming, shared_state_read_write, hitl_in_chat). When the framework or demo has no feature-viewer equivalent, the helper returns null and the Code tab is hidden on that page (graceful degradation; Demo tab still renders).

3. **fix(shell-docs): redirect catalog hygiene (self-loops + framework-scoped gap)** — removes 31 self-redirect entries from `seo-redirects.ts` (where source === destination caused infinite 301 loops on canonical URLs like /frontend-tools, /faq, /human-in-the-loop). Reorders middleware logic so the redirect catalog is consulted before the framework-scoped short-circuit fires, fixing 97 framework-scoped slug-rename URLs that were soft-404ing instead of redirecting. Adds defense-in-depth skip-when-equal guard in middleware.

4. **fix(shell-docs): resolve 53 sitemap 500s before cutover** — three independent root causes in MDX rendering:
   - 4 missing \`<Component />\` registrations in \`mdx-registry.tsx\` (CopilotCloudConfigureCopilotKit, SelfHostingCopilotRuntimeConfigureCopilotKit, CloudCopilotKit, Content) — affected ~37 pages.
   - 3 langgraph tutorial pages had markdown lists immediately preceding JSX closing tags, causing remark to bail. Fix = blank line between bullet and close tag (~9 pages).
   - 5 MDX files used escaped JSX comments that Acorn cannot parse — replaced with proper unescaped form (~7 pages).

## Verification

- Production build clean: 27 static pages generated, 0 errors
- Local probes: all 53 sitemap-500 URLs return 200; all 31 former self-loop URLs return 200; all 85 framework-scoped non-loop catalog entries 301 to expected destinations
- Code tab: 47/60 (framework × demo) URLs resolve to real code panels post-fix; remaining 13 are feature-viewer per-framework deploy-coverage gaps in the \`ag-ui-protocol/ag-ui\` repo, not this one
- Both langgraph-python pages render 0 \`Missing snippet\` boxes after re-bundling demo-content

## Test plan

- [ ] CI passes
- [ ] Sitemap probe: every URL in \`/sitemap.xml\` returns 200
- [ ] Redirect probe: spot-check 5 framework-scoped slug renames (e.g. \`/agno/frontend-actions\`, \`/pydantic-ai/use-agent-hook\`)
- [ ] Self-loop probe: \`/frontend-tools\` returns 200, not infinite 301
- [ ] Code tab: visit \`/built-in-agent/frontend-tools\` (tab should be hidden), \`/langgraph-python/agentic-chat\` (tab should render code), \`/llamaindex/agentic-chat\` (tab should render after llama-index slug rename)
- [ ] Yellow boxes: visit \`/langgraph-python/frontend-tools\` and \`/langgraph-python/custom-look-and-feel/slots\` — zero Missing snippet warnings