### PR TITLE
fix(showcase/langgraph-python): close remaining D5 cells (framework + fixtures)

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -2,6 +2,15 @@
   "_comment": "Bundled D5 (e2e-deep) fixtures. Source files: showcase/harness/fixtures/d5/*.json (auto-merged). Uses hasToolResult matching for multi-turn disambiguation. Loaded by aimock before feature-parity.json for match precedence. Ordering convention: high-priority verbatim-prompt fixtures appear first so they win first-match-wins ordering against the showcase-assistant 'hi' catch-all in feature-parity.json (and against any later, broader substring matchers in this file). The exact set of high-priority entries shifts as features land — do not rely on a specific position for any group; rely on the per-fixture _comment headers and the source-of-truth note on each per-feature file under showcase/harness/fixtures/d5/.",
   "fixtures": [
     {
+      "_comment": "Voice probe fast-path: exact-match content-only response.",
+      "match": {
+        "userMessage": "What is the weather in Tokyo?"
+      },
+      "response": {
+        "content": "The weather in Tokyo is currently 22°C with partly cloudy skies and light easterly winds."
+      }
+    },
+    {
       "_comment": "headless-simple pill 1: locks the deterministic greeting leading phrase. The reply is intentionally NON-boilerplate (i.e. NOT the showcase-assistant catch-all 'I can help you with weather lookups...') so the headless-simple spec's HELLO_LEADING assertion fails when fixture priority misroutes this prompt to the catch-all.",
       "match": {
         "userMessage": "Say hello in one short sentence"
@@ -54,10 +63,18 @@
       }
     },
     {
-      "_comment": "headless-complete revenue chart pill: locks the deterministic chart leading phrase. Two-turn fixture: turn 1 emits the get_revenue_chart tool call (no parameters per the python tool); turn 2 emits the narration that the headless message-assistant bubble renders alongside the ChartCard.",
       "match": {
         "userMessage": "chart of revenue over the last six months",
-        "hasToolResult": false
+        "toolCallId": "call_d5_headless_revenue_chart_001"
+      },
+      "response": {
+        "content": "Here is the chart of revenue over the last six months — quarterly revenue grew steadily, peaking in June."
+      }
+    },
+    {
+      "_comment": "headless-complete revenue chart pill: locks the deterministic chart leading phrase. Two-turn fixture: turn 1 emits the get_revenue_chart tool call (no parameters per the python tool); turn 2 emits the narration that the headless message-assistant bubble renders alongside the ChartCard.",
+      "match": {
+        "userMessage": "chart of revenue over the last six months"
       },
       "response": {
         "toolCalls": [
@@ -67,15 +84,6 @@
             "arguments": "{}"
           }
         ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "chart of revenue over the last six months",
-        "hasToolResult": true
-      },
-      "response": {
-        "content": "Here is the chart of revenue over the last six months — quarterly revenue grew steadily, peaking in June."
       }
     },
     {
@@ -182,7 +190,7 @@
     {
       "match": {
         "userMessage": "What's the current price of AAPL?",
-        "hasToolResult": true
+        "toolCallId": "call_tr_stock_aapl_001"
       },
       "response": {
         "content": "AAPL is trading at $338.37, down 2.96% on the day."
@@ -281,6 +289,15 @@
     },
     {
       "match": {
+        "userMessage": "3D axis visualization (model airplane)",
+        "toolCallId": "call_d5_open_gen_ui_3d_axis_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
+      }
+    },
+    {
+      "match": {
         "userMessage": "3D axis visualization (model airplane)"
       },
       "response": {
@@ -291,6 +308,15 @@
             "arguments": "{\"initialHeight\":480,\"placeholderMessages\":[\"Composing 3D axis scene…\"],\"css\":\"body{margin:0;font-family:system-ui;background:#0f172a;color:#e2e8f0}.wrap{padding:16px}h1{font-size:14px;margin:0 0 8px}svg{display:block;background:#1e293b;border-radius:8px}\",\"html\":\"<div class=\\\"wrap\\\"><h1>3D axis visualization (pitch / yaw / roll)</h1><svg width=\\\"320\\\" height=\\\"260\\\" viewBox=\\\"-80 -80 160 160\\\" data-testid=\\\"ogui-3d-axis\\\"><line x1=\\\"-60\\\" y1=\\\"0\\\" x2=\\\"60\\\" y2=\\\"0\\\" stroke=\\\"#f59e0b\\\"/><line x1=\\\"0\\\" y1=\\\"-60\\\" x2=\\\"0\\\" y2=\\\"60\\\" stroke=\\\"#6366f1\\\"/><line x1=\\\"-40\\\" y1=\\\"40\\\" x2=\\\"40\\\" y2=\\\"-40\\\" stroke=\\\"#10b981\\\"/><text x=\\\"62\\\" y=\\\"4\\\" font-size=\\\"8\\\" fill=\\\"#f59e0b\\\">X pitch</text><text x=\\\"4\\\" y=\\\"-62\\\" font-size=\\\"8\\\" fill=\\\"#6366f1\\\">Y yaw</text><text x=\\\"42\\\" y=\\\"-42\\\" font-size=\\\"8\\\" fill=\\\"#10b981\\\">Z roll</text></svg></div>\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "How a neural network works",
+        "toolCallId": "call_d5_open_gen_ui_neural_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
       }
     },
     {
@@ -309,6 +335,15 @@
     },
     {
       "match": {
+        "userMessage": "Quicksort visualization",
+        "toolCallId": "call_d5_open_gen_ui_quicksort_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
+      }
+    },
+    {
+      "match": {
         "userMessage": "Quicksort visualization"
       },
       "response": {
@@ -319,6 +354,15 @@
             "arguments": "{\"initialHeight\":480,\"placeholderMessages\":[\"Composing quicksort animation…\"],\"css\":\"body{margin:0;font-family:system-ui;background:#0f172a;color:#e2e8f0}.wrap{padding:16px}h1{font-size:14px;margin:0 0 8px}svg{display:block;background:#1e293b;border-radius:8px}rect{fill:#64748b}\",\"html\":\"<div class=\\\"wrap\\\"><h1>Quicksort: partition around pivot</h1><svg width=\\\"320\\\" height=\\\"220\\\" data-testid=\\\"ogui-quicksort\\\"><rect x=\\\"10\\\"  y=\\\"170\\\" width=\\\"24\\\" height=\\\"40\\\"/><rect x=\\\"40\\\"  y=\\\"130\\\" width=\\\"24\\\" height=\\\"80\\\"/><rect x=\\\"70\\\"  y=\\\"100\\\" width=\\\"24\\\" height=\\\"110\\\"/><rect x=\\\"100\\\" y=\\\"60\\\"  width=\\\"24\\\" height=\\\"150\\\" fill=\\\"#f59e0b\\\"/><rect x=\\\"130\\\" y=\\\"80\\\"  width=\\\"24\\\" height=\\\"130\\\" fill=\\\"#6366f1\\\"/><rect x=\\\"160\\\" y=\\\"110\\\" width=\\\"24\\\" height=\\\"100\\\"/><rect x=\\\"190\\\" y=\\\"50\\\"  width=\\\"24\\\" height=\\\"160\\\"/><rect x=\\\"220\\\" y=\\\"90\\\"  width=\\\"24\\\" height=\\\"120\\\"/><rect x=\\\"250\\\" y=\\\"140\\\" width=\\\"24\\\" height=\\\"70\\\"/><rect x=\\\"280\\\" y=\\\"160\\\" width=\\\"24\\\" height=\\\"50\\\"/></svg></div>\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Fourier: square wave from sines",
+        "toolCallId": "call_d5_open_gen_ui_fourier_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
       }
     },
     {
@@ -337,6 +381,15 @@
     },
     {
       "match": {
+        "userMessage": "Calculator (calls evaluateExpression)",
+        "toolCallId": "call_d5_open_gen_ui_calc_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
+      }
+    },
+    {
+      "match": {
         "userMessage": "Calculator (calls evaluateExpression)"
       },
       "response": {
@@ -351,6 +404,15 @@
     },
     {
       "match": {
+        "userMessage": "Ping the host (calls notifyHost)",
+        "toolCallId": "call_d5_open_gen_ui_ping_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
+      }
+    },
+    {
+      "match": {
         "userMessage": "Ping the host (calls notifyHost)"
       },
       "response": {
@@ -361,6 +423,15 @@
             "arguments": "{\"initialHeight\":320,\"placeholderMessages\":[\"Composing host-ping card…\"],\"css\":\"body{margin:0;font-family:system-ui;background:#0f172a;color:#e2e8f0}.card{padding:24px;background:#1e293b;border-radius:12px;margin:16px;text-align:center}button{padding:10px 20px;background:#6366f1;border:0;color:#fff;border-radius:8px;font-size:14px;cursor:pointer}.out{margin-top:12px;font-size:12px;color:#94a3b8}\",\"html\":\"<div class=\\\"card\\\" data-testid=\\\"ogui-ping\\\"><h2>Notify the host</h2><button id=\\\"hi\\\">Say hi to the host</button><div class=\\\"out\\\" id=\\\"out\\\">awaiting click…</div></div>\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Inline expression evaluator",
+        "toolCallId": "call_d5_open_gen_ui_inline_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
       }
     },
     {
@@ -1640,6 +1711,15 @@
     },
     {
       "match": {
+        "userMessage": "Plan a product launch",
+        "toolCallId": "call_d5_set_steps_launch_001"
+      },
+      "response": {
+        "content": "All steps complete."
+      }
+    },
+    {
+      "match": {
         "userMessage": "Plan a product launch"
       },
       "response": {
@@ -1655,6 +1735,15 @@
     },
     {
       "match": {
+        "userMessage": "team offsite",
+        "toolCallId": "call_d5_set_steps_offsite_001"
+      },
+      "response": {
+        "content": "Itinerary fully set."
+      }
+    },
+    {
+      "match": {
         "userMessage": "team offsite"
       },
       "response": {
@@ -1666,6 +1755,15 @@
             "arguments": "{\"steps\":[{\"id\":\"offsite-1\",\"title\":\"Reserve venue near downtown for 30 engineers\",\"status\":\"completed\"},{\"id\":\"offsite-2\",\"title\":\"Build day-by-day agenda with workshop slots\",\"status\":\"completed\"},{\"id\":\"offsite-3\",\"title\":\"Arrange travel, lodging and group meals\",\"status\":\"completed\"}]}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Research our top competitor",
+        "toolCallId": "call_d5_set_steps_competitor_001"
+      },
+      "response": {
+        "content": "Brief assembled."
       }
     },
     {
@@ -1686,6 +1784,15 @@
     {
       "match": {
         "userMessage": "KPI dashboard",
+        "toolCallId": "call_d5_a2ui_dynamic_kpi_001"
+      },
+      "response": {
+        "content": "KPI dashboard rendered."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "KPI dashboard",
         "toolName": "generate_a2ui"
       },
       "response": {
@@ -1693,9 +1800,34 @@
         "toolCalls": [
           {
             "name": "generate_a2ui",
-            "arguments": {}
+            "arguments": {},
+            "id": "call_d5_a2ui_dynamic_kpi_001"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "KPI dashboard",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_design_a2ui_kpi_001",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\": \"kpi-dashboard\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"Card\", \"title\": \"Quarterly KPIs\", \"subtitle\": \"Revenue, signups, and churn\", \"child\": \"metrics-row\"}, {\"id\": \"metrics-row\", \"component\": \"Row\", \"children\": [\"m-rev\", \"m-sign\", \"m-churn\"], \"gap\": 16}, {\"id\": \"m-rev\", \"component\": \"Metric\", \"label\": \"Revenue\", \"value\": \"$1.24M\", \"trend\": \"up\"}, {\"id\": \"m-sign\", \"component\": \"Metric\", \"label\": \"Signups\", \"value\": \"8,420\", \"trend\": \"up\"}, {\"id\": \"m-churn\", \"component\": \"Metric\", \"label\": \"Churn\", \"value\": \"2.3%\", \"trend\": \"down\"}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "pie chart of sales by region",
+        "toolCallId": "call_d5_a2ui_dynamic_pie_001"
+      },
+      "response": {
+        "content": "Pie chart rendered."
       }
     },
     {
@@ -1708,9 +1840,34 @@
         "toolCalls": [
           {
             "name": "generate_a2ui",
-            "arguments": {}
+            "arguments": {},
+            "id": "call_d5_a2ui_dynamic_pie_001"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "pie chart of sales by region",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_design_a2ui_pie_001",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\": \"pie-sales\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"PieChart\", \"title\": \"Sales by region\", \"description\": \"Q4 revenue split\", \"data\": [{\"label\": \"NA\", \"value\": 540}, {\"label\": \"EMEA\", \"value\": 320}, {\"label\": \"APAC\", \"value\": 210}, {\"label\": \"LATAM\", \"value\": 90}]}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "bar chart of quarterly revenue",
+        "toolCallId": "call_d5_a2ui_dynamic_bar_001"
+      },
+      "response": {
+        "content": "Bar chart rendered."
       }
     },
     {
@@ -1723,9 +1880,34 @@
         "toolCalls": [
           {
             "name": "generate_a2ui",
-            "arguments": {}
+            "arguments": {},
+            "id": "call_d5_a2ui_dynamic_bar_001"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "bar chart of quarterly revenue",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_design_a2ui_bar_001",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\": \"bar-quarterly\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"BarChart\", \"title\": \"Quarterly revenue\", \"description\": \"FY 2025 per quarter\", \"data\": [{\"label\": \"Q1\", \"value\": 820}, {\"label\": \"Q2\", \"value\": 950}, {\"label\": \"Q3\", \"value\": 1100}, {\"label\": \"Q4\", \"value\": 1240}]}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "status report on system health",
+        "toolCallId": "call_d5_a2ui_dynamic_status_001"
+      },
+      "response": {
+        "content": "Status report rendered."
       }
     },
     {
@@ -1738,7 +1920,23 @@
         "toolCalls": [
           {
             "name": "generate_a2ui",
-            "arguments": {}
+            "arguments": {},
+            "id": "call_d5_a2ui_dynamic_status_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "status report on system health",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_design_a2ui_status_001",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\": \"status-report\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"Card\", \"title\": \"System health\", \"subtitle\": \"Live status\", \"child\": \"rows\"}, {\"id\": \"rows\", \"component\": \"Column\", \"children\": [\"r-api\", \"r-db\", \"r-bg\"], \"gap\": 8}, {\"id\": \"r-api\", \"component\": \"Row\", \"children\": [\"l-api\", \"b-api\"], \"gap\": 8}, {\"id\": \"l-api\", \"component\": \"InfoRow\", \"label\": \"API\", \"value\": \"p99 142ms\"}, {\"id\": \"b-api\", \"component\": \"StatusBadge\", \"text\": \"Healthy\", \"variant\": \"success\"}, {\"id\": \"r-db\", \"component\": \"Row\", \"children\": [\"l-db\", \"b-db\"], \"gap\": 8}, {\"id\": \"l-db\", \"component\": \"InfoRow\", \"label\": \"Database\", \"value\": \"Replication lag 220ms\"}, {\"id\": \"b-db\", \"component\": \"StatusBadge\", \"text\": \"Degraded\", \"variant\": \"warning\"}, {\"id\": \"r-bg\", \"component\": \"Row\", \"children\": [\"l-bg\", \"b-bg\"], \"gap\": 8}, {\"id\": \"l-bg\", \"component\": \"InfoRow\", \"label\": \"Background workers\", \"value\": \"Queue depth 12\"}, {\"id\": \"b-bg\", \"component\": \"StatusBadge\", \"text\": \"Healthy\", \"variant\": \"success\"}]}"
           }
         ]
       }
@@ -1989,6 +2187,15 @@
     {
       "match": {
         "userMessage": "SFO to JFK",
+        "toolCallId": "call_d5_display_flight_001"
+      },
+      "response": {
+        "content": "Flight rendered. Tap 'Book flight' to confirm."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "SFO to JFK",
         "toolName": "display_flight"
       },
       "response": {
@@ -2001,9 +2208,19 @@
               "destination": "JFK",
               "airline": "United",
               "price": "$289"
-            }
+            },
+            "id": "call_d5_display_flight_001"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "intro call with the sales team",
+        "toolCallId": "call_d5_schedule_sales_001"
+      },
+      "response": {
+        "content": "Booked: Sales intro call confirmed for the slot you picked."
       }
     },
     {
@@ -2029,9 +2246,19 @@
                   "iso": "2026-05-12T14:00:00Z"
                 }
               ]
-            }
+            },
+            "id": "call_d5_schedule_sales_001"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "1:1 with Alice",
+        "toolCallId": "call_d5_schedule_alice_001"
+      },
+      "response": {
+        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
       }
     },
     {
@@ -2057,7 +2284,8 @@
                   "iso": "2026-05-14T15:30:00Z"
                 }
               ]
-            }
+            },
+            "id": "call_d5_schedule_alice_001"
           }
         ]
       }

--- a/showcase/harness/fixtures/d5/beautiful-chat-schedule-meeting.json
+++ b/showcase/harness/fixtures/d5/beautiful-chat-schedule-meeting.json
@@ -7,6 +7,7 @@
         "hasToolResult": false
       },
       "response": {
+        "content": "Sure — pulling up a 30-minute slot.",
         "toolCalls": [
           {
             "id": "call_d5_bc_schedule_time_001",

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-headless-complete.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-headless-complete.ts
@@ -199,11 +199,11 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
       try {
         await page.waitForSelector(exp.cardSelector, {
           state: "visible",
-          timeout: 15_000,
+          timeout: 60_000,
         });
       } catch {
         throw new Error(
-          `gen-ui-headless-complete ${exp.chipMatchAliases.join("|")}: expected ${exp.cardSelector} to mount within 15s — tool result may not have landed or the renderer wiring drifted`,
+          `gen-ui-headless-complete ${exp.chipMatchAliases.join("|")}: expected ${exp.cardSelector} to mount within 60s — tool result may not have landed or the renderer wiring drifted`,
         );
       }
       const text = await readAllAssistantText(page);

--- a/showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py
@@ -111,7 +111,11 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
 
     prompt = f"{_GENERATE_A2UI_PROMPT_HEADER}\n\n{context_text}".strip()
 
-    model = ChatOpenAI(model="gpt-4.1")
+    # `streaming=True` so aimock's record/replay (which only intercepts
+    # SSE streams) sees this secondary LLM call. Without it the call
+    # bypasses fixture matching in replay mode, surfacing as
+    # "An internal error occurred" on the demo page.
+    model = ChatOpenAI(model="gpt-4.1", streaming=True)
     model_with_tool = model.bind_tools(
         [_design_a2ui_surface],
         tool_choice="_design_a2ui_surface",

--- a/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
+++ b/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
@@ -66,6 +66,8 @@ def manage_todos(todos: list[Todo], runtime: ToolRuntime) -> Command:
         "messages": [
             ToolMessage(
                 content="Successfully updated todos",
+                name="manage_todos",
+                id=str(uuid.uuid4()),
                 tool_call_id=runtime.tool_call_id
             )
         ]

--- a/showcase/integrations/langgraph-python/src/agents/gen_ui_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/gen_ui_agent.py
@@ -17,6 +17,7 @@ middleware-only workaround.
 
 from __future__ import annotations
 
+import uuid
 from typing import Annotated, Any, Literal
 
 from copilotkit import CopilotKitMiddleware
@@ -57,7 +58,10 @@ def set_steps(
             "steps": steps,
             "messages": [
                 ToolMessage(
-                    f"Published {len(steps)} step(s).", tool_call_id=tool_call_id
+                    f"Published {len(steps)} step(s).",
+                    name="set_steps",
+                    id=str(uuid.uuid4()),
+                    tool_call_id=tool_call_id,
                 )
             ],
         }

--- a/showcase/integrations/langgraph-python/src/agents/shared_state_read_write.py
+++ b/showcase/integrations/langgraph-python/src/agents/shared_state_read_write.py
@@ -15,6 +15,7 @@ Together this shows the canonical LangGraph-Python bidirectional shared
 state: frontend writes, backend reads AND writes, frontend re-renders.
 """
 
+import uuid
 from typing import Any, Awaitable, Callable, TypedDict
 
 from langchain.agents import AgentState as BaseAgentState, create_agent
@@ -65,6 +66,8 @@ def set_notes(notes: list[str], runtime: ToolRuntime) -> Command:
             "messages": [
                 ToolMessage(
                     content="Notes updated.",
+                    name="set_notes",
+                    id=str(uuid.uuid4()),
                     tool_call_id=runtime.tool_call_id,
                 )
             ],

--- a/showcase/integrations/langgraph-python/src/agents/shared_state_streaming.py
+++ b/showcase/integrations/langgraph-python/src/agents/shared_state_streaming.py
@@ -12,6 +12,8 @@ This is the canonical per-token state-streaming pattern:
 docs.copilotkit.ai/integrations/langgraph/shared-state/predictive-state-updates
 """
 
+import uuid
+
 from langchain.agents import AgentState as BaseAgentState, create_agent
 from langchain.tools import ToolRuntime, tool
 from langchain_core.messages import ToolMessage
@@ -47,6 +49,8 @@ def write_document(document: str, runtime: ToolRuntime) -> Command:
             "messages": [
                 ToolMessage(
                     content="Document written to shared state.",
+                    name="write_document",
+                    id=str(uuid.uuid4()),
                     tool_call_id=runtime.tool_call_id,
                 )
             ],

--- a/showcase/integrations/langgraph-python/src/agents/subagents.py
+++ b/showcase/integrations/langgraph-python/src/agents/subagents.py
@@ -181,6 +181,8 @@ def _delegation_update(
             "messages": [
                 ToolMessage(
                     content=result,
+                    name=sub_agent,
+                    id=str(uuid.uuid4()),
                     tool_call_id=tool_call_id,
                 )
             ],
@@ -257,6 +259,8 @@ def critique_agent(task: str, runtime: ToolRuntime) -> Command:
                 "messages": [
                     ToolMessage(
                         content=skip_message,
+                        name="critique_agent",
+                        id=str(uuid.uuid4()),
                         tool_call_id=runtime.tool_call_id,
                     )
                 ],

--- a/showcase/shell-dojo/src/lib/registry.ts
+++ b/showcase/shell-dojo/src/lib/registry.ts
@@ -49,16 +49,29 @@ export interface Registry {
 
 const registry = registryData as Registry;
 
+// Hide registry entries with no dojo route. Kept in the registry so
+// harness/parity/dashboard still see them.
+const HIDDEN_DOJO_FEATURE_IDS = new Set<string>(["cli-start"]);
+
+function withVisibleDemos(integration: Integration): Integration {
+  const visible = integration.demos.filter(
+    (d) => !HIDDEN_DOJO_FEATURE_IDS.has(d.id),
+  );
+  if (visible.length === integration.demos.length) return integration;
+  return { ...integration, demos: visible };
+}
+
 export function getRegistry(): Registry {
   return registry;
 }
 
 export function getIntegrations(): Integration[] {
-  return registry.integrations;
+  return registry.integrations.map(withVisibleDemos);
 }
 
 export function getIntegration(slug: string): Integration | undefined {
-  return registry.integrations.find((i) => i.slug === slug);
+  const found = registry.integrations.find((i) => i.slug === slug);
+  return found ? withVisibleDemos(found) : undefined;
 }
 
 export function getFeatures(): Feature[] {


### PR DESCRIPTION
## Summary
- **Framework fix**: every Python `ToolMessage` now sets `name=` and `id=str(uuid.uuid4())`. Without these, `@ag-ui/langgraph` synthesises `TOOL_CALL_START` events with `toolCallName: null` / `parentMessageId: null`, which `@ag-ui/client@0.0.53`'s Zod schema rejects. The rejection is silently swallowed by `withAbortErrorHandling → EMPTY`, completing the SSE observable mid-stream so post-tool state never reaches the consumer. Fixes Bucket A (shared-state-streaming, open-gen-ui-advanced) plus several other multi-step demos.
- **Fixtures**: added `toolCallId`-keyed follow-up fixtures for every multi-turn pill (set_steps, display_flight, generate_a2ui, schedule_meeting, generateSandboxedUi, revenue chart) so the agent doesn't recurse into 100-step loops; tightened `hasToolResult: true` follow-ups to `toolCallId` so they don't match cross-turn after prior turns' tool results; added 4 hand-crafted secondary `_design_a2ui_surface` fixtures for A2UI dynamic.
- **Probe**: bumped per-card `waitForSelector` in `d5-gen-ui-headless-complete` from 15s → 60s (recharts is slow under 4 sequential turns).
- **Shell-dojo**: hide CLI Start Command from the dojo navigation via `HIDDEN_DOJO_FEATURE_IDS`. Registry/manifests untouched so harness/parity/dashboard still see it.

## What this PR does NOT fix
- **`mcp-apps` D5 probe stays red.** I tried a fixture that emits a `create_view` MCP tool call so the runtime middleware fetches the iframe from the real Excalidraw MCP server. `validate-fixture-tool-surface.ts` correctly rejected it: my `system diagram` substring would match all 17 integrations' mcp-apps demos but only langgraph-python has the MCP wiring to handle `create_view`. Reverted. The probe remains a known aimock false-negative — fix needs MCP-aware fixture infrastructure (extend the validator to read `mcpApps.servers`, or per-agent fixture files, or a probe-skip flag). Tracking as separate work.

## Test plan
- [x] `./showcase/bin/showcase test langgraph-python --d5` — passes for every D5 cell except mcp-apps (which was already red before this PR)
- [x] Browser smoke (replay mode) for shared-state-streaming, gen-ui-agent, a2ui-fixed-schema, declarative-gen-ui (4 pills), open-gen-ui (default + advanced), gen-ui-interrupt
- [x] Wire-level verification that `TOOL_CALL_START` carries non-null `toolCallName` + `parentMessageId` for the affected agents
- [x] `validate-fixture-tool-surface.ts` passes locally (280 fixtures × 627 demos, no drift)
- [x] No regression on previously-green probes
- [x] CI green