### PR TITLE
feat(showcase): add 3 LGP D5 probes + driver retry-once

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3006,6 +3006,109 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@29.1.0(@noble/hashes@1.8.0))(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  showcase/integrations/langgraph-python:
+    dependencies:
+      '@copilotkit/a2ui-renderer':
+        specifier: 1.56.5
+        version: 1.56.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@copilotkit/react-core':
+        specifier: 1.56.5
+        version: 1.56.5(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(encoding@0.1.13)(graphql@16.12.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)
+      '@copilotkit/runtime':
+        specifier: 1.56.5
+        version: 1.56.5(8b808a9d02a8d499b9aaf8e9b6339333)
+      '@copilotkit/shared':
+        specifier: 1.56.5
+        version: 1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)
+      '@copilotkit/voice':
+        specifier: 1.56.5
+        version: 1.56.5(d14b3f8a093075a61abb905dbf6e687d)
+      '@hashbrownai/core':
+        specifier: 0.5.0-beta.4
+        version: 0.5.0-beta.4
+      '@hashbrownai/react':
+        specifier: 0.5.0-beta.4
+        version: 0.5.0-beta.4(@hashbrownai/core@0.5.0-beta.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@json-render/core':
+        specifier: 0.18.0
+        version: 0.18.0(zod@3.25.76)
+      '@json-render/react':
+        specifier: 0.18.0
+        version: 0.18.0(react@19.2.3)(zod@3.25.76)
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      cmdk:
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      embla-carousel-react:
+        specifier: ^8.6.0
+        version: 8.6.0(react@19.2.3)
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.2.3)
+      next:
+        specifier: ^16.0.10
+        version: 16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2)
+      openai:
+        specifier: ^5.9.0
+        version: 5.23.2(ws@8.19.0)(zod@3.25.76)
+      radix-ui:
+        specifier: ^1.4.3
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.1.8)(react@19.2.3)
+      recharts:
+        specifier: ^2.15.0
+        version: 2.15.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      yaml:
+        specifier: ^2.8.4
+        version: 2.8.4
+      zod:
+        specifier: '>=3.22.3'
+        version: 3.25.76
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@tailwindcss/postcss':
+        specifier: ^4.0.0
+        version: 4.1.18
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      '@types/react':
+        specifier: 19.1.8
+        version: 19.1.8
+      concurrently:
+        specifier: ^9.1.0
+        version: 9.2.1
+      postcss:
+        specifier: ^8.5.0
+        version: 8.5.6
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.2.2
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   showcase/scripts:
     dependencies:
       '@copilotkit/aimock':
@@ -4729,6 +4832,12 @@ packages:
     resolution: {integrity: sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==}
     engines: {node: '>=v18'}
 
+  '@copilotkit/a2ui-renderer@1.56.5':
+    resolution: {integrity: sha512-t60/eozzjbhSiL6n7MeFuXqZy0xv7BcDuyQy4tA+O87C/IF4gooJmg5C7IEAuozCyYrotiqp0iSEWOCjNZob6Q==}
+    peerDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3
+
   '@copilotkit/aimock@1.16.4':
     resolution: {integrity: sha512-DA9WjJWpi2Yh36ltsnfMycj+BbifSS9G0pyHw0JjQZQPm41+FziGIdl2gusBtwYebStypQ4v9Jj2rjqjJqqtvQ==}
     engines: {node: '>=24.0.0'}
@@ -4742,8 +4851,70 @@ packages:
       vitest:
         optional: true
 
+  '@copilotkit/core@1.56.5':
+    resolution: {integrity: sha512-Gznvy+0ot+h7i6VgylHBXQjdlK7B7SgYNKIftVd8Yh89K2TBgwK/RFBGSCbFWdpZ2UiNT04E1C0Lb/oid9FrBw==}
+    engines: {node: '>=18'}
+
   '@copilotkit/license-verifier@0.4.0':
     resolution: {integrity: sha512-axD7B767YVHGfz/nekw3wUk9GFZGIcIq2X9AZfNA0qb6GnHcB3yJ636T21LHhon5sHerxe1oOOuNYmiAUMNonQ==}
+
+  '@copilotkit/react-core@1.56.5':
+    resolution: {integrity: sha512-FutI1rgo7d0UczkYpplcRyShJOHlHgg169RMp3xkvvZR7j/KFIFkqrM5sSEf4TrtLHQqEV09QHVU8lN5okfiEw==}
+    peerDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3
+      zod: '>=3.22.3'
+
+  '@copilotkit/runtime-client-gql@1.56.5':
+    resolution: {integrity: sha512-9zd43f4yd7e4K9tss6LWNT1Wwz+8BRiHSw3SBiRV+Tv2GLuE2VDe49aEIyM4IVUUZFux3leZudsJxsX33hIKhw==}
+    peerDependencies:
+      react: 19.2.3
+
+  '@copilotkit/runtime@1.56.5':
+    resolution: {integrity: sha512-pAh28SkynF5Gc9X5i35sdL3YQWlSlZYbJsCNKfg/AeDq6VCRWdF5x7ByZFhoVnbcNBpcdjDUBxSQWt99aF+Y0A==}
+    peerDependencies:
+      '@anthropic-ai/sdk': ^0.57.0
+      '@langchain/aws': '>=0.1.9'
+      '@langchain/community': '>=1.1.14'
+      '@langchain/core': '>=0.3.66'
+      '@langchain/google-gauth': '>=0.1.0'
+      '@langchain/langgraph-sdk': '>=0.1.2'
+      '@langchain/openai': '>=0.4.2'
+      groq-sdk: '>=0.3.0 <1.0.0'
+      langchain: '>=0.3.3'
+      openai: ^4.85.1 || >=5.0.0
+    peerDependenciesMeta:
+      '@anthropic-ai/sdk':
+        optional: true
+      '@langchain/aws':
+        optional: true
+      '@langchain/community':
+        optional: true
+      '@langchain/google-gauth':
+        optional: true
+      '@langchain/langgraph-sdk':
+        optional: true
+      '@langchain/openai':
+        optional: true
+      groq-sdk:
+        optional: true
+      langchain:
+        optional: true
+      openai:
+        optional: true
+
+  '@copilotkit/shared@1.56.5':
+    resolution: {integrity: sha512-jK2iEa+jRgWYXOw/v09RaU9txX5wNAYIrGl/SO405uzbC5mi0cYgXhJ3PC+VjNM7rlH//LRqa0+ELJO0UBwfPA==}
+    peerDependencies:
+      '@ag-ui/core': '>=0.0.48'
+
+  '@copilotkit/voice@1.56.5':
+    resolution: {integrity: sha512-jKhpgJRIC4FvtNEu6ULcJbteZlk04qMtNcw4yQaDksj2C/B001Awphr8RAddShXESeC2TmmfLYoSnrn75uYNMw==}
+    engines: {node: '>=18'}
+
+  '@copilotkit/web-inspector@1.56.5':
+    resolution: {integrity: sha512-wp2llC0FwSXn7+ZbNvSaKnwSc19HYP6Kdwkztt3eh3HRtcwtRIorUw0jJjPUxEo0AGkjCYQqj+7J1NPS6JLOmg==}
+    engines: {node: '>=18'}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -5783,6 +5954,18 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
+  '@hashbrownai/core@0.5.0-beta.4':
+    resolution: {integrity: sha512-LlHkqk9/3Dn2yXU/cJawoXo3xkJI+7Q8bR8UrA4OPOaMGnEyr3xkuS9+DUeOphuvd6I/CKgkFNxUffhkFZ18Dw==}
+    engines: {node: '>=18'}
+
+  '@hashbrownai/react@0.5.0-beta.4':
+    resolution: {integrity: sha512-iCOH4HR8OcoqFFuRbRPEU0+xa0rfkBHzPGR8yy8HtQiOCGkhHrgJlhjJcBECaDXuNPu9fAMhSZeYZfs+jrI3CQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@hashbrownai/core': 0.5.0-beta.4
+      react: 19.2.3
+      react-dom: 19.2.3
+
   '@headlessui/react@2.2.0':
     resolution: {integrity: sha512-RzCEg+LXsuI7mHiSomsu/gBJSjpupm6A1qIZ5sWjd7JhARNlMiSA4kKfJpCKwU9tE+zMRterhhrP74PvfJrpXQ==}
     engines: {node: '>=10'}
@@ -6396,6 +6579,16 @@ packages:
     engines: {node: '>= 10.16.0'}
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
+
+  '@json-render/core@0.18.0':
+    resolution: {integrity: sha512-zm0K9cgxZLGshw5TmdKe3Xc6fpjbONdlj3v+Er+HhCYZ9fSJpv32d9VzQds4bDW36vPfdieAOcsPR9+EcTff7Q==}
+    peerDependencies:
+      zod: '>=3.22.3'
+
+  '@json-render/react@0.18.0':
+    resolution: {integrity: sha512-rT0hJ9mK2BGfLxZ/ztS4UF1XqAz/o+FNtFgii7hea7VjD4u0wJYyRphe4a5DetS/dSMZFECXkmida+xi3wKl9A==}
+    peerDependencies:
+      react: 19.2.3
 
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
@@ -8113,6 +8306,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-accessible-icon@1.1.7':
+    resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-accordion@1.2.12':
     resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
     peerDependencies:
@@ -8126,8 +8332,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.7':
+    resolution: {integrity: sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
     peerDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': ^19.0.2
@@ -8190,6 +8435,19 @@ packages:
       react: 19.2.3
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.0.0':
@@ -8299,6 +8557,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-form@0.1.8':
+    resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-icons@1.3.2':
     resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
     peerDependencies:
@@ -8318,6 +8602,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-label@2.1.8':
     resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
     peerDependencies:
@@ -8333,6 +8630,58 @@ packages:
 
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.16':
+    resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.14':
+    resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.8':
+    resolution: {integrity: sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.3':
+    resolution: {integrity: sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==}
     peerDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': ^19.0.2
@@ -8440,6 +8789,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -8479,8 +8854,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-separator@1.1.8':
     resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.6':
+    resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': ^19.0.2
@@ -8515,8 +8916,73 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-toast@1.2.15':
     resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.11':
+    resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
     peerDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': ^19.0.2
@@ -8585,6 +9051,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      react: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': 19.1.8
       react: 19.2.3
@@ -10946,6 +11421,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -13088,10 +13564,6 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  diff@7.0.0:
-    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
-    engines: {node: '>=0.3.1'}
-
   diff@9.0.0:
     resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
@@ -13238,6 +13710,19 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  embla-carousel-react@8.6.0:
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
+    peerDependencies:
+      react: 19.2.3
+
+  embla-carousel-reactive-utils@8.6.0:
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -13678,10 +14163,6 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
-
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
-    engines: {node: '>=18.0.0'}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -16257,6 +16738,11 @@ packages:
     peerDependencies:
       react: 19.2.3
 
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
+    peerDependencies:
+      react: 19.2.3
+
   lucide@0.525.0:
     resolution: {integrity: sha512-sfehWlaE/7NVkcEQ4T9JD3eID8RNMIGJBBUq9wF3UFiJIrcMKRbU3g1KGfDk4svcW7yw8BtDLXaXo02scDtUYQ==}
 
@@ -18217,6 +18703,19 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  radix-ui@1.4.3:
+    resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
+    peerDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': ^19.0.2
+      react: 19.2.3
+      react-dom: 19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -21180,6 +21679,11 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -21476,6 +21980,27 @@ snapshots:
       - ws
       - zod-to-json-schema
 
+  '@ag-ui/langgraph@0.0.31(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+    dependencies:
+      '@ag-ui/client': 0.0.53
+      '@ag-ui/core': 0.0.53
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      partial-json: 0.1.7
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
   '@ag-ui/langgraph@0.0.31(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@ag-ui/client': 0.0.53
@@ -21616,21 +22141,21 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.15(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.23(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.24(zod@3.25.76)':
@@ -24702,6 +25227,23 @@ snapshots:
       - encoding
       - utf-8-validate
 
+  '@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.27.3(encoding@0.1.13)
+      '@browserbasehq/sdk': 2.6.0(encoding@0.1.13)
+      '@playwright/test': 1.59.1
+      deepmerge: 4.3.1
+      dotenv: 16.6.1
+      openai: 5.23.2(ws@8.19.0)(zod@3.25.76)
+      ws: 8.19.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    optional: true
+
   '@bufbuild/protobuf@2.11.0': {}
 
   '@canvas/image-data@1.1.0': {}
@@ -24880,6 +25422,15 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
 
+  '@copilotkit/a2ui-renderer@1.56.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@a2ui/web_core': 0.9.0
+      clsx: 2.1.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+
   '@copilotkit/aimock@1.16.4(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.18))(@types/node@18.19.130)(typescript@5.9.3)))(vitest@3.2.4)':
     optionalDependencies:
       jest: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.18))(@types/node@18.19.130)(typescript@5.9.3))
@@ -24890,7 +25441,198 @@ snapshots:
       jest: 29.7.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.9.3))
       vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  '@copilotkit/core@1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)(zod@3.25.76)':
+    dependencies:
+      '@ag-ui/client': 0.0.53
+      '@copilotkit/shared': 1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)
+      '@tanstack/pacer': 0.20.1
+      phoenix: 1.8.4
+      rxjs: 7.8.1
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@ag-ui/core'
+      - encoding
+      - zod
+
   '@copilotkit/license-verifier@0.4.0': {}
+
+  '@copilotkit/react-core@1.56.5(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(encoding@0.1.13)(graphql@16.12.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@3.25.76)':
+    dependencies:
+      '@ag-ui/client': 0.0.53
+      '@ag-ui/core': 0.0.53
+      '@copilotkit/a2ui-renderer': 1.56.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@copilotkit/core': 1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)(zod@3.25.76)
+      '@copilotkit/runtime-client-gql': 1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)(graphql@16.12.0)(react@19.2.3)
+      '@copilotkit/shared': 1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)
+      '@copilotkit/web-inspector': 1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)(zod@3.25.76)
+      '@jetbrains/websandbox': 1.1.3
+      '@lit-labs/react': 2.1.3(@types/react@19.1.8)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@scarf/scarf': 1.4.0
+      '@tanstack/react-virtual': 3.13.18(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      katex: 0.16.27
+      lucide-react: 0.525.0(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-markdown: 8.0.7(@types/react@19.1.8)(react@19.2.3)
+      rxjs: 7.8.1
+      streamdown: 1.6.11(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.3)
+      tailwind-merge: 3.5.0
+      tw-animate-css: 1.4.0
+      untruncate-json: 0.0.1
+      use-stick-to-bottom: 1.1.1(react@19.2.3)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@types/mdast'
+      - '@types/react'
+      - '@types/react-dom'
+      - encoding
+      - graphql
+      - micromark
+      - micromark-util-types
+      - supports-color
+
+  '@copilotkit/runtime-client-gql@1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)(graphql@16.12.0)(react@19.2.3)':
+    dependencies:
+      '@copilotkit/shared': 1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)
+      '@urql/core': 5.2.0(graphql@16.12.0)
+      react: 19.2.3
+      untruncate-json: 0.0.1
+      urql: 4.2.2(@urql/core@5.2.0(graphql@16.12.0))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@ag-ui/core'
+      - encoding
+      - graphql
+
+  '@copilotkit/runtime@1.56.5(8b808a9d02a8d499b9aaf8e9b6339333)':
+    dependencies:
+      '@ag-ui/a2ui-middleware': 0.0.5(@ag-ui/client@0.0.53)(rxjs@7.8.1)
+      '@ag-ui/client': 0.0.53
+      '@ag-ui/core': 0.0.53
+      '@ag-ui/encoder': 0.0.53
+      '@ag-ui/langgraph': 0.0.31(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      '@ag-ui/mcp-apps-middleware': 0.0.3(@ag-ui/client@0.0.53)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@ai-sdk/anthropic': 3.0.49(zod@3.25.76)
+      '@ai-sdk/google': 3.0.33(zod@3.25.76)
+      '@ai-sdk/google-vertex': 3.0.120(zod@3.25.76)
+      '@ai-sdk/mcp': 1.0.21(zod@3.25.76)
+      '@ai-sdk/openai': 3.0.54(zod@3.25.76)
+      '@copilotkit/license-verifier': 0.4.0
+      '@copilotkit/shared': 1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)
+      '@graphql-yoga/plugin-defer-stream': 3.18.0(graphql-yoga@5.18.0(graphql@16.12.0))(graphql@16.12.0)
+      '@hono/node-server': 2.0.0(hono@4.12.15)
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@remix-run/node-fetch-server': 0.13.0
+      '@scarf/scarf': 1.4.0
+      '@segment/analytics-node': 2.3.0(encoding@0.1.13)
+      ai: 6.0.156(zod@3.25.76)
+      clarinet: 0.12.6
+      class-transformer: 0.5.1
+      class-validator: 0.14.3
+      cors: 2.8.5
+      express: 5.2.1
+      graphql: 16.12.0
+      graphql-scalars: 1.25.0(graphql@16.12.0)
+      graphql-yoga: 5.18.0(graphql@16.12.0)
+      hono: 4.12.15
+      partial-json: 0.1.7
+      phoenix: 1.8.4
+      pino: 10.1.1
+      pino-pretty: 11.3.0
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.1
+      type-graphql: 2.0.0-rc.1(class-validator@0.14.3)(graphql-scalars@1.25.0(graphql@16.12.0))(graphql@16.12.0)
+      uuid: 10.0.0
+      ws: 8.19.0
+      zod: 3.25.76
+    optionalDependencies:
+      '@anthropic-ai/sdk': 0.57.0
+      '@langchain/aws': 1.1.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+      '@langchain/community': 1.1.27(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.1014.0)(@aws-sdk/credential-provider-node@3.972.29)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(zod@3.25.76))(@ibm-cloud/watsonx-ai@1.7.6)(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(@smithy/eventstream-codec@4.2.12)(@smithy/protocol-http@5.3.12)(@smithy/signature-v4@5.3.12)(@smithy/util-utf8@4.2.2)(better-sqlite3@12.5.0)(d3-dsv@3.0.1)(fast-xml-parser@5.5.8)(google-auth-library@10.6.2)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(ws@8.19.0)
+      '@langchain/google-gauth': 0.1.8(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(encoding@0.1.13)(zod@3.25.76)
+      '@langchain/langgraph-sdk': 2.0.0(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@langchain/openai': 1.4.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+      groq-sdk: 0.5.0(encoding@0.1.13)
+      langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      openai: 5.23.2(ws@8.19.0)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - bufferutil
+      - encoding
+      - react
+      - react-dom
+      - supports-color
+      - svelte
+      - utf-8-validate
+      - vue
+      - zod-to-json-schema
+
+  '@copilotkit/shared@1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)':
+    dependencies:
+      '@ag-ui/client': 0.0.53
+      '@ag-ui/core': 0.0.53
+      '@copilotkit/license-verifier': 0.4.0
+      '@segment/analytics-node': 2.3.0(encoding@0.1.13)
+      '@standard-schema/spec': 1.1.0
+      chalk: 4.1.2
+      graphql: 16.12.0
+      partial-json: 0.1.7
+      uuid: 11.1.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+
+  '@copilotkit/voice@1.56.5(d14b3f8a093075a61abb905dbf6e687d)':
+    dependencies:
+      '@copilotkit/runtime': 1.56.5(8b808a9d02a8d499b9aaf8e9b6339333)
+      openai: 5.23.2(ws@8.19.0)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@anthropic-ai/sdk'
+      - '@cfworker/json-schema'
+      - '@langchain/aws'
+      - '@langchain/community'
+      - '@langchain/core'
+      - '@langchain/google-gauth'
+      - '@langchain/langgraph-sdk'
+      - '@langchain/openai'
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - bufferutil
+      - encoding
+      - groq-sdk
+      - langchain
+      - react
+      - react-dom
+      - supports-color
+      - svelte
+      - utf-8-validate
+      - vue
+      - ws
+      - zod
+      - zod-to-json-schema
+
+  '@copilotkit/web-inspector@1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)(zod@3.25.76)':
+    dependencies:
+      '@ag-ui/client': 0.0.53
+      '@copilotkit/core': 1.56.5(@ag-ui/core@0.0.53)(encoding@0.1.13)(zod@3.25.76)
+      lit: 3.3.2
+      lucide: 0.525.0
+      marked: 12.0.2
+    transitivePeerDependencies:
+      - '@ag-ui/core'
+      - encoding
+      - zod
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -26010,6 +26752,14 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
+  '@hashbrownai/core@0.5.0-beta.4': {}
+
+  '@hashbrownai/react@0.5.0-beta.4(@hashbrownai/core@0.5.0-beta.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@hashbrownai/core': 0.5.0-beta.4
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   '@headlessui/react@2.2.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -26955,6 +27705,17 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
+  '@json-render/core@0.18.0(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+
+  '@json-render/react@0.18.0(react@19.2.3)(zod@3.25.76)':
+    dependencies:
+      '@json-render/core': 0.18.0(zod@3.25.76)
+      react: 19.2.3
+    transitivePeerDependencies:
+      - zod
+
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
@@ -27012,6 +27773,17 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@langchain/aws@1.1.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
+    dependencies:
+      '@aws-sdk/client-bedrock-agent-runtime': 3.1023.0
+      '@aws-sdk/client-bedrock-runtime': 3.1023.0
+      '@aws-sdk/client-kendra': 3.1023.0
+      '@aws-sdk/credential-provider-node': 3.972.29
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
   '@langchain/classic@1.0.27(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
     dependencies:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
@@ -27032,6 +27804,28 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
       - ws
+
+  '@langchain/classic@1.0.27(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/openai': 1.4.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+      handlebars: 4.7.9
+      js-yaml: 4.1.1
+      jsonpointer: 5.0.1
+      openapi-types: 12.1.3
+      uuid: 10.0.0
+      yaml: 2.8.4
+      zod: 3.25.76
+    optionalDependencies:
+      langsmith: 0.5.25(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+    optional: true
 
   '@langchain/community@1.1.27(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.1014.0)(@aws-sdk/credential-provider-node@3.972.29)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(zod@3.25.76))(@ibm-cloud/watsonx-ai@1.7.6)(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(@smithy/eventstream-codec@4.2.12)(@smithy/protocol-http@5.3.12)(@smithy/signature-v4@5.3.12)(@smithy/util-utf8@4.2.2)(better-sqlite3@12.5.0)(d3-dsv@3.0.1)(fast-xml-parser@5.5.8)(google-auth-library@10.6.2)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(ws@8.19.0)':
     dependencies:
@@ -27074,6 +27868,49 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-proto'
       - '@opentelemetry/sdk-trace-base'
       - peggy
+
+  '@langchain/community@1.1.27(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.1014.0)(@aws-sdk/credential-provider-node@3.972.29)(@browserbasehq/sdk@2.6.0(encoding@0.1.13))(@browserbasehq/stagehand@1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(zod@3.25.76))(@ibm-cloud/watsonx-ai@1.7.6)(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(@smithy/eventstream-codec@4.2.12)(@smithy/protocol-http@5.3.12)(@smithy/signature-v4@5.3.12)(@smithy/util-utf8@4.2.2)(better-sqlite3@12.5.0)(d3-dsv@3.0.1)(fast-xml-parser@5.5.8)(google-auth-library@10.6.2)(ibm-cloud-sdk-core@5.4.5)(ignore@7.0.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(playwright@1.59.1)(puppeteer@22.14.0(typescript@5.9.3))(ws@8.19.0)':
+    dependencies:
+      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.59.1)(deepmerge@4.3.1)(dotenv@16.6.1)(encoding@0.1.13)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(zod@3.25.76)
+      '@ibm-cloud/watsonx-ai': 1.7.6
+      '@langchain/classic': 1.0.27(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/openai': 1.4.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)
+      binary-extensions: 2.3.0
+      flat: 5.0.2
+      ibm-cloud-sdk-core: 5.4.5
+      js-yaml: 4.1.1
+      langsmith: 0.5.25(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      math-expression-evaluator: 2.0.7
+      openai: 5.23.2(ws@8.19.0)(zod@3.25.76)
+      uuid: 10.0.0
+      zod: 3.25.76
+    optionalDependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/client-s3': 3.1014.0
+      '@aws-sdk/credential-provider-node': 3.972.29
+      '@browserbasehq/sdk': 2.6.0(encoding@0.1.13)
+      '@smithy/eventstream-codec': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/util-utf8': 4.2.2
+      better-sqlite3: 12.5.0
+      d3-dsv: 3.0.1
+      fast-xml-parser: 5.5.8
+      google-auth-library: 10.6.2
+      ignore: 7.0.5
+      jsdom: 29.1.0(@noble/hashes@1.8.0)
+      jsonwebtoken: 9.0.3
+      lodash: 4.18.1
+      playwright: 1.59.1
+      puppeteer: 22.14.0(typescript@5.9.3)
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - peggy
+    optional: true
 
   '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
     dependencies:
@@ -27134,6 +27971,25 @@ snapshots:
       - openai
       - ws
 
+  '@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.5.25(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
   '@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
@@ -27161,6 +28017,15 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  '@langchain/google-common@0.1.8(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(zod@3.25.76)':
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      uuid: 10.0.0
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - zod
+    optional: true
+
   '@langchain/google-gauth@0.1.8(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(encoding@0.1.13)(zod@3.25.76)':
     dependencies:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
@@ -27170,6 +28035,17 @@ snapshots:
       - encoding
       - supports-color
       - zod
+
+  '@langchain/google-gauth@0.1.8(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(encoding@0.1.13)(zod@3.25.76)':
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/google-common': 0.1.8(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(zod@3.25.76)
+      google-auth-library: 8.9.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - zod
+    optional: true
 
   '@langchain/langgraph-api@1.1.13(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)))(@langchain/langgraph-sdk@1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@langchain/langgraph@1.2.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76))(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)':
     dependencies:
@@ -27221,6 +28097,11 @@ snapshots:
   '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
     dependencies:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      uuid: 10.0.0
+
+  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       uuid: 10.0.0
 
   '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
@@ -27286,6 +28167,17 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
+  '@langchain/langgraph-sdk@1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 9.1.1
+      p-retry: 7.1.1
+      uuid: 13.0.0
+    optionalDependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   '@langchain/langgraph-sdk@1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@types/json-schema': 7.0.15
@@ -27318,6 +28210,18 @@ snapshots:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+
+  '@langchain/langgraph-sdk@2.0.0(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 9.1.1
+      p-retry: 7.1.1
+      uuid: 13.0.0
+    optionalDependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optional: true
 
   '@langchain/langgraph-ui@1.1.13':
     dependencies:
@@ -27360,6 +28264,22 @@ snapshots:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 3.25.76
+    optionalDependencies:
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - svelte
+      - vue
+
+  '@langchain/langgraph@1.2.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+      '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -27425,6 +28345,16 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
+  '@langchain/openai@1.4.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(ws@8.19.0)':
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      js-tiktoken: 1.0.21
+      openai: 6.35.0(ws@8.19.0)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - ws
+    optional: true
+
   '@langchain/textsplitters@0.1.0(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
     dependencies:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
@@ -27434,6 +28364,12 @@ snapshots:
     dependencies:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       js-tiktoken: 1.0.21
+
+  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))':
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      js-tiktoken: 1.0.21
+    optional: true
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -27862,7 +28798,7 @@ snapshots:
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.4.1(express@5.2.1)
       hono: 4.12.15
@@ -28649,7 +29585,7 @@ snapshots:
 
   '@puppeteer/browsers@2.3.0':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -28675,6 +29611,15 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
   '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -28686,6 +29631,20 @@ snapshots:
       '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.2.3)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -28709,6 +29668,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
 
   '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -28770,6 +29751,20 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
 
   '@radix-ui/react-context@1.0.0(react@19.2.3)':
     dependencies:
@@ -28938,6 +29933,37 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
   '@radix-ui/react-icons@1.3.2(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -28961,6 +29987,15 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
 
   '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -28993,6 +30028,82 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       react-remove-scroll: 2.7.2(@types/react@19.1.8)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
@@ -29168,6 +30279,34 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
 
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -29231,9 +30370,37 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.2.3(@types/react@19.1.8)
 
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
   '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.8)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -29267,6 +30434,37 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
   '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -29281,6 +30479,47 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.3)
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
+
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -29379,6 +30618,13 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.1.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
 
   '@radix-ui/react-use-layout-effect@1.0.0(react@19.2.3)':
     dependencies:
@@ -31749,7 +32995,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -32991,7 +34237,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -33621,7 +34867,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -34942,6 +36188,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -35087,8 +36337,6 @@ snapshots:
   didyoumean@1.2.2: {}
 
   diff-sequences@29.6.3: {}
-
-  diff@7.0.0: {}
 
   diff@9.0.0: {}
 
@@ -35238,6 +36486,18 @@ snapshots:
     optionalDependencies:
       '@types/bun': 1.3.11
       typescript: 5.9.3
+
+  embla-carousel-react@8.6.0(react@19.2.3):
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      react: 19.2.3
+
+  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0: {}
 
   emittery@0.13.1: {}
 
@@ -36090,13 +37350,11 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.6: {}
-
   eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
 
   evp_bytestokey@1.0.3:
     dependencies:
@@ -36169,7 +37427,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 1.1.1
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -36204,7 +37462,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -36380,7 +37638,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -36468,7 +37726,7 @@ snapshots:
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
 
   for-each@0.3.5:
     dependencies:
@@ -36741,7 +37999,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -37443,7 +38701,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -37488,14 +38746,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -37518,7 +38776,7 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       axios: 1.15.2(debug@4.4.3)
       camelcase: 6.3.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       dotenv: 16.6.1
       extend: 3.0.2
       file-type: 22.0.1
@@ -38968,7 +40226,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.3
+      semver: 7.7.4
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -39078,6 +40336,25 @@ snapshots:
       - ws
       - zod-to-json-schema
 
+  langchain@1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76)):
+    dependencies:
+      '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      '@langchain/langgraph': 1.2.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))
+      langsmith: 0.5.25(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
   langchain@1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76)):
     dependencies:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
@@ -39111,6 +40388,14 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       openai: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
+      ws: 8.19.0
+
+  langsmith@0.5.25(@opentelemetry/api@1.9.0)(openai@5.23.2(ws@8.19.0)(zod@3.25.76))(ws@8.19.0):
+    dependencies:
+      p-queue: 6.6.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      openai: 5.23.2(ws@8.19.0)(zod@3.25.76)
       ws: 8.19.0
 
   langsmith@0.5.25(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0):
@@ -39586,6 +40871,10 @@ snapshots:
       react: 19.2.3
 
   lucide-react@0.542.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
+  lucide-react@1.14.0(react@19.2.3):
     dependencies:
       react: 19.2.3
 
@@ -40590,7 +41879,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       decode-named-character-reference: 1.2.0
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -40612,7 +41901,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -40913,6 +42202,33 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.3
+      '@next/swc-darwin-x64': 16.2.3
+      '@next/swc-linux-arm64-gnu': 16.2.3
+      '@next/swc-linux-arm64-musl': 16.2.3
+      '@next/swc-linux-x64-gnu': 16.2.3
+      '@next/swc-linux-x64-musl': 16.2.3
+      '@next/swc-win32-arm64-msvc': 16.2.3
+      '@next/swc-win32-x64-msvc': 16.2.3
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.59.1
+      sass: 1.97.2
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.97.2):
+    dependencies:
+      '@next/env': 16.2.3
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.24
+      caniuse-lite: 1.0.30001769
+      postcss: 8.4.31
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      styled-jsx: 5.1.6(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.3
       '@next/swc-darwin-x64': 16.2.3
@@ -41588,7 +42904,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       get-uri: 6.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -41684,7 +43000,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -42172,7 +43488,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -42230,7 +43546,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.3.0
       chromium-bidi: 0.6.2(devtools-protocol@0.0.1312386)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       devtools-protocol: 0.0.1312386
       ws: 8.19.0
     transitivePeerDependencies:
@@ -42277,6 +43593,69 @@ snapshots:
   quick-format-unescaped@4.0.4: {}
 
   quick-lru@5.1.1: {}
+
+  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.8)(react@19.2.3)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.2.3(@types/react@19.1.8)
 
   randombytes@2.1.0:
     dependencies:
@@ -43255,7 +44634,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -43440,7 +44819,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -43831,7 +45210,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -44206,6 +45585,11 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@babel/core': 7.28.5
+
+  styled-jsx@5.1.6(react@19.2.3):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.3
 
   styled-jsx@5.1.7(@babel/core@7.28.5)(react@19.2.3):
     dependencies:
@@ -45055,7 +46439,7 @@ snapshots:
       graphql: 16.12.0
       graphql-query-complexity: 0.12.0(graphql@16.12.0)
       graphql-scalars: 1.25.0(graphql@16.12.0)
-      semver: 7.7.3
+      semver: 7.7.4
       tslib: 2.8.1
     optionalDependencies:
       class-validator: 0.14.3
@@ -45479,7 +46863,7 @@ snapshots:
   uvu@0.5.6:
     dependencies:
       dequal: 2.0.3
-      diff: 7.0.0
+      diff: 9.0.0
       kleur: 4.1.5
       sade: 1.8.1
 
@@ -46651,6 +48035,8 @@ snapshots:
   yaml@1.10.2: {}
 
   yaml@2.8.3: {}
+
+  yaml@2.8.4: {}
 
   yargs-parser@18.1.3:
     dependencies:

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -1154,6 +1154,24 @@
       }
     },
     {
+      "_comment": "D5 fixture for /demos/shared-state-read (recipe-editor) turn 1. Substring 'Italian pasta recipe' is unique. Text-only — agent has no tools.",
+      "match": {
+        "userMessage": "Italian pasta recipe"
+      },
+      "response": {
+        "content": "Great choice — looking at your current recipe state, I'd build an Italian pasta around the existing ingredients: a quick spaghetti aglio e olio, finishing with parmesan and a squeeze of lemon. Want me to suggest substitutions or adjust the cooking time?"
+      }
+    },
+    {
+      "_comment": "D5 fixture for /demos/shared-state-read (recipe-editor) turn 2. Reply mentions recipe-context tokens so the probe's soft assertion lands.",
+      "match": {
+        "userMessage": "healthier with more vegetables"
+      },
+      "response": {
+        "content": "Here are a few healthier ingredient additions for the recipe: roasted bell peppers, baby spinach folded in at the end, and cherry tomatoes for brightness. The Italian flavor profile holds up well, and the vegetable swap keeps the dish lighter without losing the comfort of pasta."
+      }
+    },
+    {
       "match": {
         "userMessage": "analyze data and call the tool"
       },

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -2,6 +2,15 @@
   "_comment": "Bundled D5 (e2e-deep) fixtures. Source files: showcase/harness/fixtures/d5/*.json (auto-merged). Uses hasToolResult matching for multi-turn disambiguation. Loaded by aimock before feature-parity.json for match precedence. Ordering convention: high-priority verbatim-prompt fixtures appear first so they win first-match-wins ordering against the showcase-assistant 'hi' catch-all in feature-parity.json (and against any later, broader substring matchers in this file). The exact set of high-priority entries shifts as features land — do not rely on a specific position for any group; rely on the per-fixture _comment headers and the source-of-truth note on each per-feature file under showcase/harness/fixtures/d5/.",
   "fixtures": [
     {
+      "_comment": "Voice probe fast-path: exact-match content-only response.",
+      "match": {
+        "userMessage": "What is the weather in Tokyo?"
+      },
+      "response": {
+        "content": "The weather in Tokyo is currently 22°C with partly cloudy skies and light easterly winds."
+      }
+    },
+    {
       "_comment": "headless-simple pill 1: locks the deterministic greeting leading phrase. The reply is intentionally NON-boilerplate (i.e. NOT the showcase-assistant catch-all 'I can help you with weather lookups...') so the headless-simple spec's HELLO_LEADING assertion fails when fixture priority misroutes this prompt to the catch-all.",
       "match": {
         "userMessage": "Say hello in one short sentence"
@@ -54,10 +63,18 @@
       }
     },
     {
-      "_comment": "headless-complete revenue chart pill: locks the deterministic chart leading phrase. Two-turn fixture: turn 1 emits the get_revenue_chart tool call (no parameters per the python tool); turn 2 emits the narration that the headless message-assistant bubble renders alongside the ChartCard.",
       "match": {
         "userMessage": "chart of revenue over the last six months",
-        "hasToolResult": false
+        "toolCallId": "call_d5_headless_revenue_chart_001"
+      },
+      "response": {
+        "content": "Here is the chart of revenue over the last six months — quarterly revenue grew steadily, peaking in June."
+      }
+    },
+    {
+      "_comment": "headless-complete revenue chart pill: locks the deterministic chart leading phrase. Two-turn fixture: turn 1 emits the get_revenue_chart tool call (no parameters per the python tool); turn 2 emits the narration that the headless message-assistant bubble renders alongside the ChartCard.",
+      "match": {
+        "userMessage": "chart of revenue over the last six months"
       },
       "response": {
         "toolCalls": [
@@ -67,15 +84,6 @@
             "arguments": "{}"
           }
         ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "chart of revenue over the last six months",
-        "hasToolResult": true
-      },
-      "response": {
-        "content": "Here is the chart of revenue over the last six months — quarterly revenue grew steadily, peaking in June."
       }
     },
     {
@@ -182,7 +190,7 @@
     {
       "match": {
         "userMessage": "What's the current price of AAPL?",
-        "hasToolResult": true
+        "toolCallId": "call_tr_stock_aapl_001"
       },
       "response": {
         "content": "AAPL is trading at $338.37, down 2.96% on the day."
@@ -281,6 +289,15 @@
     },
     {
       "match": {
+        "userMessage": "3D axis visualization (model airplane)",
+        "toolCallId": "call_d5_open_gen_ui_3d_axis_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
+      }
+    },
+    {
+      "match": {
         "userMessage": "3D axis visualization (model airplane)"
       },
       "response": {
@@ -291,6 +308,15 @@
             "arguments": "{\"initialHeight\":480,\"placeholderMessages\":[\"Composing 3D axis scene…\"],\"css\":\"body{margin:0;font-family:system-ui;background:#0f172a;color:#e2e8f0}.wrap{padding:16px}h1{font-size:14px;margin:0 0 8px}svg{display:block;background:#1e293b;border-radius:8px}\",\"html\":\"<div class=\\\"wrap\\\"><h1>3D axis visualization (pitch / yaw / roll)</h1><svg width=\\\"320\\\" height=\\\"260\\\" viewBox=\\\"-80 -80 160 160\\\" data-testid=\\\"ogui-3d-axis\\\"><line x1=\\\"-60\\\" y1=\\\"0\\\" x2=\\\"60\\\" y2=\\\"0\\\" stroke=\\\"#f59e0b\\\"/><line x1=\\\"0\\\" y1=\\\"-60\\\" x2=\\\"0\\\" y2=\\\"60\\\" stroke=\\\"#6366f1\\\"/><line x1=\\\"-40\\\" y1=\\\"40\\\" x2=\\\"40\\\" y2=\\\"-40\\\" stroke=\\\"#10b981\\\"/><text x=\\\"62\\\" y=\\\"4\\\" font-size=\\\"8\\\" fill=\\\"#f59e0b\\\">X pitch</text><text x=\\\"4\\\" y=\\\"-62\\\" font-size=\\\"8\\\" fill=\\\"#6366f1\\\">Y yaw</text><text x=\\\"42\\\" y=\\\"-42\\\" font-size=\\\"8\\\" fill=\\\"#10b981\\\">Z roll</text></svg></div>\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "How a neural network works",
+        "toolCallId": "call_d5_open_gen_ui_neural_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
       }
     },
     {
@@ -309,6 +335,15 @@
     },
     {
       "match": {
+        "userMessage": "Quicksort visualization",
+        "toolCallId": "call_d5_open_gen_ui_quicksort_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
+      }
+    },
+    {
+      "match": {
         "userMessage": "Quicksort visualization"
       },
       "response": {
@@ -319,6 +354,15 @@
             "arguments": "{\"initialHeight\":480,\"placeholderMessages\":[\"Composing quicksort animation…\"],\"css\":\"body{margin:0;font-family:system-ui;background:#0f172a;color:#e2e8f0}.wrap{padding:16px}h1{font-size:14px;margin:0 0 8px}svg{display:block;background:#1e293b;border-radius:8px}rect{fill:#64748b}\",\"html\":\"<div class=\\\"wrap\\\"><h1>Quicksort: partition around pivot</h1><svg width=\\\"320\\\" height=\\\"220\\\" data-testid=\\\"ogui-quicksort\\\"><rect x=\\\"10\\\"  y=\\\"170\\\" width=\\\"24\\\" height=\\\"40\\\"/><rect x=\\\"40\\\"  y=\\\"130\\\" width=\\\"24\\\" height=\\\"80\\\"/><rect x=\\\"70\\\"  y=\\\"100\\\" width=\\\"24\\\" height=\\\"110\\\"/><rect x=\\\"100\\\" y=\\\"60\\\"  width=\\\"24\\\" height=\\\"150\\\" fill=\\\"#f59e0b\\\"/><rect x=\\\"130\\\" y=\\\"80\\\"  width=\\\"24\\\" height=\\\"130\\\" fill=\\\"#6366f1\\\"/><rect x=\\\"160\\\" y=\\\"110\\\" width=\\\"24\\\" height=\\\"100\\\"/><rect x=\\\"190\\\" y=\\\"50\\\"  width=\\\"24\\\" height=\\\"160\\\"/><rect x=\\\"220\\\" y=\\\"90\\\"  width=\\\"24\\\" height=\\\"120\\\"/><rect x=\\\"250\\\" y=\\\"140\\\" width=\\\"24\\\" height=\\\"70\\\"/><rect x=\\\"280\\\" y=\\\"160\\\" width=\\\"24\\\" height=\\\"50\\\"/></svg></div>\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Fourier: square wave from sines",
+        "toolCallId": "call_d5_open_gen_ui_fourier_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
       }
     },
     {
@@ -337,6 +381,15 @@
     },
     {
       "match": {
+        "userMessage": "Calculator (calls evaluateExpression)",
+        "toolCallId": "call_d5_open_gen_ui_calc_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
+      }
+    },
+    {
+      "match": {
         "userMessage": "Calculator (calls evaluateExpression)"
       },
       "response": {
@@ -351,6 +404,15 @@
     },
     {
       "match": {
+        "userMessage": "Ping the host (calls notifyHost)",
+        "toolCallId": "call_d5_open_gen_ui_ping_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
+      }
+    },
+    {
+      "match": {
         "userMessage": "Ping the host (calls notifyHost)"
       },
       "response": {
@@ -361,6 +423,15 @@
             "arguments": "{\"initialHeight\":320,\"placeholderMessages\":[\"Composing host-ping card…\"],\"css\":\"body{margin:0;font-family:system-ui;background:#0f172a;color:#e2e8f0}.card{padding:24px;background:#1e293b;border-radius:12px;margin:16px;text-align:center}button{padding:10px 20px;background:#6366f1;border:0;color:#fff;border-radius:8px;font-size:14px;cursor:pointer}.out{margin-top:12px;font-size:12px;color:#94a3b8}\",\"html\":\"<div class=\\\"card\\\" data-testid=\\\"ogui-ping\\\"><h2>Notify the host</h2><button id=\\\"hi\\\">Say hi to the host</button><div class=\\\"out\\\" id=\\\"out\\\">awaiting click…</div></div>\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Inline expression evaluator",
+        "toolCallId": "call_d5_open_gen_ui_inline_001"
+      },
+      "response": {
+        "content": "Generated. The sandboxed UI is rendered above."
       }
     },
     {
@@ -1640,6 +1711,15 @@
     },
     {
       "match": {
+        "userMessage": "Plan a product launch",
+        "toolCallId": "call_d5_set_steps_launch_001"
+      },
+      "response": {
+        "content": "All steps complete."
+      }
+    },
+    {
+      "match": {
         "userMessage": "Plan a product launch"
       },
       "response": {
@@ -1655,6 +1735,15 @@
     },
     {
       "match": {
+        "userMessage": "team offsite",
+        "toolCallId": "call_d5_set_steps_offsite_001"
+      },
+      "response": {
+        "content": "Itinerary fully set."
+      }
+    },
+    {
+      "match": {
         "userMessage": "team offsite"
       },
       "response": {
@@ -1666,6 +1755,15 @@
             "arguments": "{\"steps\":[{\"id\":\"offsite-1\",\"title\":\"Reserve venue near downtown for 30 engineers\",\"status\":\"completed\"},{\"id\":\"offsite-2\",\"title\":\"Build day-by-day agenda with workshop slots\",\"status\":\"completed\"},{\"id\":\"offsite-3\",\"title\":\"Arrange travel, lodging and group meals\",\"status\":\"completed\"}]}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Research our top competitor",
+        "toolCallId": "call_d5_set_steps_competitor_001"
+      },
+      "response": {
+        "content": "Brief assembled."
       }
     },
     {
@@ -1686,6 +1784,15 @@
     {
       "match": {
         "userMessage": "KPI dashboard",
+        "toolCallId": "call_d5_a2ui_dynamic_kpi_001"
+      },
+      "response": {
+        "content": "KPI dashboard rendered."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "KPI dashboard",
         "toolName": "generate_a2ui"
       },
       "response": {
@@ -1693,9 +1800,34 @@
         "toolCalls": [
           {
             "name": "generate_a2ui",
-            "arguments": {}
+            "arguments": {},
+            "id": "call_d5_a2ui_dynamic_kpi_001"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "KPI dashboard",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_design_a2ui_kpi_001",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\": \"kpi-dashboard\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"Card\", \"title\": \"Quarterly KPIs\", \"subtitle\": \"Revenue, signups, and churn\", \"child\": \"metrics-row\"}, {\"id\": \"metrics-row\", \"component\": \"Row\", \"children\": [\"m-rev\", \"m-sign\", \"m-churn\"], \"gap\": 16}, {\"id\": \"m-rev\", \"component\": \"Metric\", \"label\": \"Revenue\", \"value\": \"$1.24M\", \"trend\": \"up\"}, {\"id\": \"m-sign\", \"component\": \"Metric\", \"label\": \"Signups\", \"value\": \"8,420\", \"trend\": \"up\"}, {\"id\": \"m-churn\", \"component\": \"Metric\", \"label\": \"Churn\", \"value\": \"2.3%\", \"trend\": \"down\"}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "pie chart of sales by region",
+        "toolCallId": "call_d5_a2ui_dynamic_pie_001"
+      },
+      "response": {
+        "content": "Pie chart rendered."
       }
     },
     {
@@ -1708,9 +1840,34 @@
         "toolCalls": [
           {
             "name": "generate_a2ui",
-            "arguments": {}
+            "arguments": {},
+            "id": "call_d5_a2ui_dynamic_pie_001"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "pie chart of sales by region",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_design_a2ui_pie_001",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\": \"pie-sales\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"PieChart\", \"title\": \"Sales by region\", \"description\": \"Q4 revenue split\", \"data\": [{\"label\": \"NA\", \"value\": 540}, {\"label\": \"EMEA\", \"value\": 320}, {\"label\": \"APAC\", \"value\": 210}, {\"label\": \"LATAM\", \"value\": 90}]}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "bar chart of quarterly revenue",
+        "toolCallId": "call_d5_a2ui_dynamic_bar_001"
+      },
+      "response": {
+        "content": "Bar chart rendered."
       }
     },
     {
@@ -1723,9 +1880,34 @@
         "toolCalls": [
           {
             "name": "generate_a2ui",
-            "arguments": {}
+            "arguments": {},
+            "id": "call_d5_a2ui_dynamic_bar_001"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "bar chart of quarterly revenue",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_design_a2ui_bar_001",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\": \"bar-quarterly\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"BarChart\", \"title\": \"Quarterly revenue\", \"description\": \"FY 2025 per quarter\", \"data\": [{\"label\": \"Q1\", \"value\": 820}, {\"label\": \"Q2\", \"value\": 950}, {\"label\": \"Q3\", \"value\": 1100}, {\"label\": \"Q4\", \"value\": 1240}]}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "status report on system health",
+        "toolCallId": "call_d5_a2ui_dynamic_status_001"
+      },
+      "response": {
+        "content": "Status report rendered."
       }
     },
     {
@@ -1738,7 +1920,23 @@
         "toolCalls": [
           {
             "name": "generate_a2ui",
-            "arguments": {}
+            "arguments": {},
+            "id": "call_d5_a2ui_dynamic_status_001"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "status report on system health",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_design_a2ui_status_001",
+            "name": "_design_a2ui_surface",
+            "arguments": "{\"surfaceId\": \"status-report\", \"catalogId\": \"declarative-gen-ui-catalog\", \"components\": [{\"id\": \"root\", \"component\": \"Card\", \"title\": \"System health\", \"subtitle\": \"Live status\", \"child\": \"rows\"}, {\"id\": \"rows\", \"component\": \"Column\", \"children\": [\"r-api\", \"r-db\", \"r-bg\"], \"gap\": 8}, {\"id\": \"r-api\", \"component\": \"Row\", \"children\": [\"l-api\", \"b-api\"], \"gap\": 8}, {\"id\": \"l-api\", \"component\": \"InfoRow\", \"label\": \"API\", \"value\": \"p99 142ms\"}, {\"id\": \"b-api\", \"component\": \"StatusBadge\", \"text\": \"Healthy\", \"variant\": \"success\"}, {\"id\": \"r-db\", \"component\": \"Row\", \"children\": [\"l-db\", \"b-db\"], \"gap\": 8}, {\"id\": \"l-db\", \"component\": \"InfoRow\", \"label\": \"Database\", \"value\": \"Replication lag 220ms\"}, {\"id\": \"b-db\", \"component\": \"StatusBadge\", \"text\": \"Degraded\", \"variant\": \"warning\"}, {\"id\": \"r-bg\", \"component\": \"Row\", \"children\": [\"l-bg\", \"b-bg\"], \"gap\": 8}, {\"id\": \"l-bg\", \"component\": \"InfoRow\", \"label\": \"Background workers\", \"value\": \"Queue depth 12\"}, {\"id\": \"b-bg\", \"component\": \"StatusBadge\", \"text\": \"Healthy\", \"variant\": \"success\"}]}"
           }
         ]
       }
@@ -1989,6 +2187,15 @@
     {
       "match": {
         "userMessage": "SFO to JFK",
+        "toolCallId": "call_d5_display_flight_001"
+      },
+      "response": {
+        "content": "Flight rendered. Tap 'Book flight' to confirm."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "SFO to JFK",
         "toolName": "display_flight"
       },
       "response": {
@@ -2001,9 +2208,19 @@
               "destination": "JFK",
               "airline": "United",
               "price": "$289"
-            }
+            },
+            "id": "call_d5_display_flight_001"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "intro call with the sales team",
+        "toolCallId": "call_d5_schedule_sales_001"
+      },
+      "response": {
+        "content": "Booked: Sales intro call confirmed for the slot you picked."
       }
     },
     {
@@ -2029,9 +2246,19 @@
                   "iso": "2026-05-12T14:00:00Z"
                 }
               ]
-            }
+            },
+            "id": "call_d5_schedule_sales_001"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "1:1 with Alice",
+        "toolCallId": "call_d5_schedule_alice_001"
+      },
+      "response": {
+        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
       }
     },
     {
@@ -2057,7 +2284,8 @@
                   "iso": "2026-05-14T15:30:00Z"
                 }
               ]
-            }
+            },
+            "id": "call_d5_schedule_alice_001"
           }
         ]
       }

--- a/showcase/harness/fixtures/d5/beautiful-chat-schedule-meeting.json
+++ b/showcase/harness/fixtures/d5/beautiful-chat-schedule-meeting.json
@@ -7,6 +7,7 @@
         "hasToolResult": false
       },
       "response": {
+        "content": "Sure — pulling up a 30-minute slot.",
         "toolCalls": [
           {
             "id": "call_d5_bc_schedule_time_001",

--- a/showcase/harness/fixtures/d5/interrupt-headless.json
+++ b/showcase/harness/fixtures/d5/interrupt-headless.json
@@ -1,16 +1,68 @@
 {
-  "_comment": "D5 fixture for /demos/interrupt-headless. Two-turn flow: trigger interrupt, then resolve it. Substrings 'trigger the headless interrupt' and 'resolve the interrupt with yes' are unique.",
+  "_comment": "D5 fixture for /demos/interrupt-headless (LangGraph Python). Two chip prompts: 'sales-call' and 'alice-1on1'. Each pill is a 2-leg flow — first leg returns a `schedule_meeting` tool call (which triggers the Python agent's interrupt(...) suspension); second leg matches `toolCallId` after the user picks a slot and returns a confirmation narration. The `intro call with the sales team` and `1:1 with Alice` substrings are unique enough that aimock's userMessage matcher selects these even though the chip text is longer ('Book an intro call with the sales team to discuss pricing.' / 'Schedule a 1:1 with Alice next week to review Q2 goals.'). Mirrored verbatim into showcase/aimock/d5-all.json (fixtures #176-#179) so re-bundling stays consistent.",
   "fixtures": [
     {
-      "match": { "userMessage": "trigger the headless interrupt" },
+      "match": {
+        "userMessage": "intro call with the sales team",
+        "toolName": "schedule_meeting"
+      },
       "response": {
-        "content": "Interrupt raised. The agent has paused at a graph-level interrupt and is waiting for user input. Reply with 'yes' or 'no' to resume."
+        "content": "Sure — let me check available times.",
+        "toolCalls": [
+          {
+            "name": "schedule_meeting",
+            "id": "call_d5_schedule_sales_001",
+            "arguments": {
+              "topic": "Sales intro call",
+              "attendee": "Sales team",
+              "slots": [
+                { "label": "Mon 10:00 AM", "iso": "2026-05-11T10:00:00Z" },
+                { "label": "Tue 2:00 PM", "iso": "2026-05-12T14:00:00Z" }
+              ]
+            }
+          }
+        ]
       }
     },
     {
-      "match": { "userMessage": "resolve the interrupt with yes" },
+      "match": {
+        "userMessage": "intro call with the sales team",
+        "toolCallId": "call_d5_schedule_sales_001"
+      },
       "response": {
-        "content": "Interrupt resolved with 'yes'. The agent resumed execution from the suspended node and produced its final answer."
+        "content": "Booked: Sales intro call confirmed for the slot you picked."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "1:1 with Alice",
+        "toolName": "schedule_meeting"
+      },
+      "response": {
+        "content": "Got it — pulling up next-week slots.",
+        "toolCalls": [
+          {
+            "name": "schedule_meeting",
+            "id": "call_d5_schedule_alice_001",
+            "arguments": {
+              "topic": "1:1 with Alice — Q2 goals",
+              "attendee": "Alice",
+              "slots": [
+                { "label": "Wed 11:00 AM", "iso": "2026-05-13T11:00:00Z" },
+                { "label": "Thu 3:30 PM", "iso": "2026-05-14T15:30:00Z" }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "1:1 with Alice",
+        "toolCallId": "call_d5_schedule_alice_001"
+      },
+      "response": {
+        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/shared-state-read.json
+++ b/showcase/harness/fixtures/d5/shared-state-read.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "D5 fixture for /demos/shared-state-read (LangGraph Python). The recipe-editor demo uses the NEUTRAL DEFAULT agent (no tools, no state schema) and publishes a RecipeAgentState via agent.setState() from the frontend form. The agent reads the recipe context in its conversation but does not mutate it. Two chip prompts probed: 'Create a delicious Italian pasta recipe.' and 'Make the recipe healthier with more vegetables.' — text-only fixtures (no tool calls). Substring matching on 'Italian pasta recipe' and 'healthier with more vegetables' is unique enough across the whole d5-all.json bundle. The replies intentionally include recipe-context tokens (recipe / pasta / italian / vegetable / ingredient / healthy) so the probe's turn-2 soft signal lands.",
+  "fixtures": [
+    {
+      "match": { "userMessage": "Italian pasta recipe" },
+      "response": {
+        "content": "Great choice — looking at your current recipe state, I'd build an Italian pasta around the existing ingredients: a quick spaghetti aglio e olio, finishing with parmesan and a squeeze of lemon. Want me to suggest substitutions or adjust the cooking time?"
+      }
+    },
+    {
+      "match": { "userMessage": "healthier with more vegetables" },
+      "response": {
+        "content": "Here are a few healthier ingredient additions for the recipe: roasted bell peppers, baby spinach folded in at the end, and cherry tomatoes for brightness. The Italian flavor profile holds up well, and the vegetable swap keeps the dish lighter without losing the comfort of pasta."
+      }
+    }
+  ]
+}

--- a/showcase/harness/fixtures/d5/tool-rendering-reasoning-chain.json
+++ b/showcase/harness/fixtures/d5/tool-rendering-reasoning-chain.json
@@ -1,10 +1,53 @@
 {
-  "_comment": "D5 fixture for /demos/tool-rendering-reasoning-chain. The demo interleaves reasoning chains with tool calls. Substring 'analyze data and call the tool' is unique.",
+  "_comment": "D5 fixture for /demos/tool-rendering-reasoning-chain (LangGraph Python). The demo composes a reasoningMessage slot (<ReasoningBlock>) with per-tool renderers (WeatherCard / FlightListCard). Two chip prompts probed: 'What's the weather in Tokyo?' and 'Find flights from SFO to JFK.' — each is a 2-leg flow: first leg emits the tool call (get_weather / search_flights), second leg matches `hasToolResult: true` and emits the deterministic narration. The reasoning tokens themselves come from the agent's `init_chat_model(reasoning={effort:'low'})` — they're produced upstream of these fixtures (the LLM call returns the tool decision; reasoning lives in the same LLM payload). Mirrored verbatim into showcase/aimock/d5-all.json so re-bundling stays consistent.",
   "fixtures": [
     {
-      "match": { "userMessage": "analyze data and call the tool" },
+      "match": {
+        "userMessage": "weather in Tokyo",
+        "hasToolResult": false,
+        "toolName": "get_weather"
+      },
       "response": {
-        "content": "Reasoning step 1: I considered the query. Reasoning step 2: I decided to invoke the analysis tool. The tool returned its structured payload, and the reasoning chain wraps the rendered tool card. Both the reasoning block and the tool card should be visible in the transcript."
+        "toolCalls": [
+          {
+            "id": "call_d5_get_weather_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Tokyo\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "weather in Tokyo",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Find flights from SFO to JFK.",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_tr_flights_sfo_jfk_001",
+            "name": "search_flights",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Find flights from SFO to JFK.",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
       }
     }
   ]

--- a/showcase/harness/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.test.ts
@@ -533,21 +533,21 @@ describe("e2e-deep driver", () => {
     // to drive a service whose declared `demos[]` carry IDs that
     // DON'T match a D5 type verbatim:
     //   - `tool-rendering-default-catchall` → `tool-rendering`
-    //   - `shared-state-read-write` → BOTH `shared-state-read` AND
-    //     `shared-state-write` (one-to-many)
+    //   - `shared-state-read-write` → `shared-state-write` (write half;
+    //     the read half is owned by the standalone recipe-editor probe)
     //   - `voice` → `voice` (mapped, but no script → skipped).
-    // Only the shared-state script is registered, so
+    // Only the shared-state-write script is registered, so
     // `tool-rendering` lands in `skipped[]` — the test exercises
     // both the mapping AND the closed-set filter without paying
     // the per-feature ~1.5s settle window for every demo.
     registerD5Script(
       makeScript({
-        featureTypes: ["shared-state-read", "shared-state-write"],
+        featureTypes: ["shared-state-write"],
         fixtureFile: "shared-state.json",
       }),
     );
 
-    const { browser } = makeBrowser([{}, {}]);
+    const { browser } = makeBrowser([{}]);
     const driver = createE2eDeepDriver({
       launcher: async () => browser,
       scriptLoader: async () => {
@@ -563,7 +563,7 @@ describe("e2e-deep driver", () => {
       // No `features` field — production discovery shape.
       demos: [
         "tool-rendering-default-catchall", // → tool-rendering (skipped, no script)
-        "shared-state-read-write", // → shared-state-read + shared-state-write (run)
+        "shared-state-read-write", // → shared-state-write (run)
         "voice", // → voice (skipped, no script)
       ],
       shape: "package",
@@ -571,18 +571,17 @@ describe("e2e-deep driver", () => {
 
     expect(result.state).toBe("green");
     const sig = result.signal as E2eDeepAggregateSignal;
-    // 4 mapped D5 types: tool-rendering (skipped) + shared-state-read
-    // + shared-state-write (both run) + voice (skipped, no script).
-    expect(sig.total).toBe(4);
-    expect(sig.passed).toBe(2);
+    // 3 mapped D5 types: tool-rendering-default-catchall (skipped) +
+    // shared-state-write (run) + voice (skipped, no script).
+    expect(sig.total).toBe(3);
+    expect(sig.passed).toBe(1);
     expect(sig.failed).toEqual([]);
-    expect(sig.skipped).toEqual(["tool-rendering", "voice"]);
+    expect(sig.skipped).toEqual(["tool-rendering-default-catchall", "voice"]);
 
     const sideKeys = writes.map((w) => w.key).sort();
     expect(sideKeys).toEqual([
-      "d5:langgraph-python/shared-state-read",
       "d5:langgraph-python/shared-state-write",
-      "d5:langgraph-python/tool-rendering",
+      "d5:langgraph-python/tool-rendering-default-catchall",
       "d5:langgraph-python/voice",
     ]);
   });

--- a/showcase/harness/src/probes/drivers/e2e-deep.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.ts
@@ -1012,39 +1012,102 @@ export function createE2eDeepDriver(
                 once: true,
               });
 
-            let featureTimer: ReturnType<typeof setTimeout> | undefined;
+            // Run the feature, retrying ONCE on transient failures so a
+            // flaky D5 cell (browser context boot variance, race against
+            // an in-flight LLM stream, intermittent network blip) does
+            // not flip the dashboard cell to red. Persistent failures
+            // still register as red — the second attempt is gated on
+            // the first having failed for a CLASS we believe is
+            // retryable. We do NOT retry: `abort` (intentional
+            // cancellation, e.g. the global timeout fired), or
+            // `feature-timeout` (we already burned the wall-clock
+            // budget — a second attempt couldn't fit anyway).
+            // Retryable classes match what `runFeature` actually emits:
+            // `goto-error` (navigation blip) and `conversation-error`
+            // (transient stream / settle / assertion timing).
+            //
+            // Additional gate: only retry if the first attempt ran for
+            // at least RETRY_MIN_DURATION_MS. A sub-2s failure is
+            // almost always a deterministic assertion mismatch (testid
+            // typo, fixture shape drift, agent wiring regression) that
+            // a second attempt would just re-fail more slowly. Letting
+            // those land as red on attempt #1 keeps the cell signal
+            // honest.
+            const RETRY_ELIGIBLE_ERROR_CLASSES = new Set<string>([
+              "goto-error",
+              "conversation-error",
+            ]);
+            const RETRY_MIN_DURATION_MS = 2_000;
+            const runOnce = async (): Promise<
+              Awaited<ReturnType<typeof runFeature>>
+            > => {
+              let featureTimer: ReturnType<typeof setTimeout> | undefined;
+              try {
+                return await Promise.race([
+                  runFeature({
+                    browser: browserRef,
+                    url,
+                    pageTimeoutMs,
+                    script,
+                    buildCtx: {
+                      integrationSlug: slug,
+                      featureType: ft,
+                      baseUrl: backendUrl,
+                    },
+                    abortSignal: featureAbort.signal,
+                  }),
+                  new Promise<Awaited<ReturnType<typeof runFeature>>>(
+                    (resolve) => {
+                      featureTimer = setTimeout(() => {
+                        featureAbort.abort();
+                        resolve({
+                          ok: false,
+                          errorClass: "feature-timeout",
+                          errorDesc: `feature exceeded ${featureTimeoutMs}ms wall-clock`,
+                        });
+                      }, featureTimeoutMs);
+                    },
+                  ),
+                ]);
+              } finally {
+                if (featureTimer) clearTimeout(featureTimer);
+              }
+            };
+
             let featureResult: Awaited<ReturnType<typeof runFeature>>;
             try {
-              featureResult = await Promise.race([
-                runFeature({
-                  browser: browserRef,
-                  url,
-                  pageTimeoutMs,
-                  script,
-                  buildCtx: {
-                    integrationSlug: slug,
-                    featureType: ft,
-                    baseUrl: backendUrl,
-                  },
-                  abortSignal: featureAbort.signal,
-                }),
-                new Promise<Awaited<ReturnType<typeof runFeature>>>(
-                  (resolve) => {
-                    featureTimer = setTimeout(() => {
-                      // Tell the in-flight runFeature to tear down so
-                      // its browser context releases promptly.
-                      featureAbort.abort();
-                      resolve({
-                        ok: false,
-                        errorClass: "feature-timeout",
-                        errorDesc: `feature exceeded ${featureTimeoutMs}ms wall-clock`,
-                      });
-                    }, featureTimeoutMs);
-                  },
-                ),
-              ]);
+              const attempt1Start = Date.now();
+              featureResult = await runOnce();
+              const attempt1Duration = Date.now() - attempt1Start;
+
+              if (
+                !featureResult.ok &&
+                !abort.signal.aborted &&
+                !featureAbort.signal.aborted &&
+                featureResult.errorClass !== undefined &&
+                RETRY_ELIGIBLE_ERROR_CLASSES.has(featureResult.errorClass) &&
+                attempt1Duration >= RETRY_MIN_DURATION_MS
+              ) {
+                ctx.logger.info("probe.e2e-deep.feature-retry", {
+                  slug,
+                  featureType: ft,
+                  attempt: 1,
+                  errorClass: featureResult.errorClass,
+                  errorDesc: featureResult.errorDesc,
+                  attempt1DurationMs: attempt1Duration,
+                });
+                featureResult = await runOnce();
+                ctx.logger.info("probe.e2e-deep.feature-retry-result", {
+                  slug,
+                  featureType: ft,
+                  attempt: 2,
+                  ok: featureResult.ok,
+                  errorClass: featureResult.ok
+                    ? undefined
+                    : featureResult.errorClass,
+                });
+              }
             } finally {
-              if (featureTimer) clearTimeout(featureTimer);
               abort.signal.removeEventListener("abort", onParentAbort);
             }
 

--- a/showcase/harness/src/probes/helpers/conversation-runner.test.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.test.ts
@@ -778,14 +778,23 @@ describe("runConversation", () => {
 
     expect(result.turns_completed).toBe(1);
     expect(result.failure_turn).toBeUndefined();
-    // preFill must precede the first waitForSelector (cascade probe)
-    // — that ordering is what makes the auth shape work.
+    // The runner probes the chat-input cascade at BOOT (before preFill
+    // runs), expecting it to fail when the chat tree hasn't mounted yet
+    // (the auth shape). When boot probing fails the runner defers to
+    // post-preFill resolution — preFill runs, mounts the chat, and the
+    // cascade succeeds on retry. What matters: preFill runs, AT LEAST
+    // ONE post-preFill waitForSelector resolves (proving the cascade
+    // recovered), AND the conversation completes turn 1 cleanly.
+    // (We do NOT assert "no waitForSelector before preFill" — the boot
+    // probe is intentional and the failure is handled gracefully.)
     const preFillIdx = order.indexOf("preFill:click-sign-in");
-    const firstWaitIdx = order.findIndex((s) =>
-      s.startsWith("waitForSelector:"),
-    );
     expect(preFillIdx).toBeGreaterThanOrEqual(0);
-    expect(firstWaitIdx).toBeGreaterThan(preFillIdx);
+    // Some waitForSelector call must run AFTER preFill — that's the
+    // cascade retry that resolves once the chat input mounted.
+    const postPreFillWait = order
+      .slice(preFillIdx + 1)
+      .find((s) => s.startsWith("waitForSelector:"));
+    expect(postPreFillWait).toBeDefined();
   });
 
   it("stringifies non-Error throws (e.g. a thrown string) into result.error", async () => {

--- a/showcase/harness/src/probes/helpers/d5-feature-mapping.ts
+++ b/showcase/harness/src/probes/helpers/d5-feature-mapping.ts
@@ -76,14 +76,11 @@ export const REGISTRY_TO_D5: Readonly<
   //   - `tool-rendering`                   : per-tool renderer (WeatherCard).
   //   - `tool-rendering-default-catchall`  : built-in default catchall renderer.
   //   - `tool-rendering-custom-catchall`   : custom wildcard (`*`) renderer.
-  // `tool-rendering-reasoning-chain` is intentionally NOT mapped here:
-  // the D5 tool-rendering probe sends "weather in Tokyo" and asserts a
-  // WeatherCard, which is the wrong test for the reasoning-chain demo.
-  // Reasoning-chain pages need their own D5 probe script; until one
-  // exists the demo ID is silently skipped by `demosToFeatureTypes`.
+  //   - `tool-rendering-reasoning-chain`   : per-tool renderer + reasoning-block slot.
   "tool-rendering": ["tool-rendering"],
   "tool-rendering-default-catchall": ["tool-rendering-default-catchall"],
   "tool-rendering-custom-catchall": ["tool-rendering-custom-catchall"],
+  "tool-rendering-reasoning-chain": ["tool-rendering-reasoning-chain"],
 
   // headless tier — `headless-simple` and `headless-complete` each have
   // their own D5 script and fixture. They live on different routes
@@ -120,10 +117,12 @@ export const REGISTRY_TO_D5: Readonly<
   // hitl (approve/deny tier) — out-of-chat modal approval flow.
   "hitl-in-app": ["hitl-approve-deny"],
 
-  // shared-state — one demo covers both read+write (the D5 script
-  // claims both feature types and runs once per type via
-  // preNavigateRoute split).
-  "shared-state-read-write": ["shared-state-read", "shared-state-write"],
+  // shared-state-read-write — bidirectional read+write demo, covered by
+  // d5-shared-state.ts which claims `shared-state-write` only. The
+  // standalone `shared-state-read` literal is owned by
+  // d5-shared-state-read.ts which probes the recipe-editor demo at
+  // `/demos/shared-state-read` (separate page, separate state shape).
+  "shared-state-read-write": ["shared-state-write"],
 
   // mcp-apps + subagents — Phase-2A split: each registry feature ID
   // points at its own D5 probe (was previously a shared `d5-mcp-subagents`
@@ -172,16 +171,14 @@ export const REGISTRY_TO_D5: Readonly<
   "frontend-tools-async": ["frontend-tools-async"],
 
   // Reasoning family — single `reasoning-display` literal covers both
-  // demo routes via preNavigateRoute. The `tool-rendering-reasoning-chain`
-  // demo was removed in the LGP demo-pass; its mapping entry and probe
-  // script were deleted in the genuine-pass Phase 0 cleanup.
+  // demo routes via preNavigateRoute.
   "reasoning-custom": ["reasoning-display"],
   "reasoning-default": ["reasoning-display"],
 
-  // State family — `shared-state-read` registry feature reuses the
-  // existing `shared-state-read` D5 literal (already paired with
-  // `shared-state-write` on the read-write demo). Streaming and
-  // readonly variants get their own literals.
+  // State family — `shared-state-read` registry feature owns the
+  // recipe-editor demo at `/demos/shared-state-read` (probed by
+  // d5-shared-state-read.ts). Streaming and readonly variants get their
+  // own literals.
   "shared-state-streaming": ["shared-state-streaming"],
   "readonly-state-agent-context": ["readonly-state-context"],
   "shared-state-read": ["shared-state-read"],
@@ -199,10 +196,13 @@ export const REGISTRY_TO_D5: Readonly<
   "gen-ui-agent": ["gen-ui-agent"],
 
   // Interrupt family — LangGraph interrupt-driven HITL, distinct from
-  // useHumanInTheLoop hook patterns. The `interrupt-headless` demo was
-  // removed in the LGP demo-pass; its mapping entry and probe script
-  // were deleted in the genuine-pass Phase 0 cleanup.
+  // useHumanInTheLoop hook patterns. `gen-ui-interrupt` mounts the
+  // time-picker INLINE inside the chat bubble (via `useInterrupt`).
+  // `interrupt-headless` mounts it in a separate "app surface" pane
+  // (via `useHeadlessInterrupt`). Same backend `interrupt(...)` payload,
+  // different rendering surface.
   "gen-ui-interrupt": ["gen-ui-interrupt"],
+  "interrupt-headless": ["interrupt-headless"],
 
   // BYOC family — single literal covers hashbrown + json-render via
   // preNavigateRoute swap (both render structured-output via a user

--- a/showcase/harness/src/probes/helpers/d5-registry.ts
+++ b/showcase/harness/src/probes/helpers/d5-registry.ts
@@ -84,6 +84,17 @@ export type D5FeatureType =
   // Interrupt family — LangGraph-interrupt-driven HITL (distinct from
   // useHumanInTheLoop hook patterns).
   | "gen-ui-interrupt"
+  // Headless-interrupt — same `interrupt(...)` backend pattern as
+  // gen-ui-interrupt, but the time-picker mounts in a separate "app
+  // surface" pane (left) instead of inline inside the chat bubble.
+  // Probes `useHeadlessInterrupt` (custom-event subscribe + manual
+  // `runAgent({forwardedProps:{command:{resume,...}}})`).
+  | "interrupt-headless"
+  // Tool-rendering with reasoning chain — combines per-tool renderers
+  // (WeatherCard / FlightListCard / catchall) with a `reasoningMessage`
+  // slot rendering reasoning tokens. Distinct from `tool-rendering`
+  // (no reasoning) and `reasoning-display` (no per-tool renderers).
+  | "tool-rendering-reasoning-chain"
   // BYOC family — bring-your-own-component structured-output rendering
   // (one literal covers hashbrown + json-render via preNavigateRoute).
   | "byoc"
@@ -141,6 +152,8 @@ const D5_FEATURE_TYPES: readonly D5FeatureType[] = [
   "tool-rendering-default-catchall",
   "tool-rendering-custom-catchall",
   "gen-ui-interrupt",
+  "interrupt-headless",
+  "tool-rendering-reasoning-chain",
   "byoc",
   "voice",
   "beautiful-chat-toggle-theme",

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-headless-complete.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-headless-complete.ts
@@ -199,11 +199,11 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
       try {
         await page.waitForSelector(exp.cardSelector, {
           state: "visible",
-          timeout: 15_000,
+          timeout: 60_000,
         });
       } catch {
         throw new Error(
-          `gen-ui-headless-complete ${exp.chipMatchAliases.join("|")}: expected ${exp.cardSelector} to mount within 15s — tool result may not have landed or the renderer wiring drifted`,
+          `gen-ui-headless-complete ${exp.chipMatchAliases.join("|")}: expected ${exp.cardSelector} to mount within 60s — tool result may not have landed or the renderer wiring drifted`,
         );
       }
       const text = await readAllAssistantText(page);

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-interrupt.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-interrupt.test.ts
@@ -34,13 +34,31 @@ describe("d5-gen-ui-interrupt script", () => {
     ]);
   });
 
-  it("assertion clicks slot via evaluate (JS-level click) then waits for picked state", async () => {
-    // The probe now uses `clickByJs` (page.evaluate-driven .click()) to
-    // bypass the cpk-web-inspector overlay. Assert the evaluate call
-    // fires with a function whose body contains the slot selector,
-    // followed by waitForSelector for the picked-state testid.
+  it("assertion clicks slot via evaluate (JS-level click) then polls for resolved-state signal", async () => {
+    // The probe uses `clickByJs` (page.evaluate-driven .click()) to
+    // bypass the cpk-web-inspector overlay, then polls page.evaluate
+    // for one of three resume signals: `pickedTestid` (the
+    // time-picker-picked testid mounted), `bookedBadge` (the visible
+    // "Booked" badge text), or `scheduledNarration` (the agent's
+    // resume continuation containing "scheduled" / "confirmed"). Any
+    // of those means resolve() fired and propagated.
+    //
+    // Test mock: first evaluate call is the click (returns undefined),
+    // second evaluate call is the poll (returns a signal that satisfies
+    // one of the three conditions so the assertion resolves cleanly).
+    let evaluateCallCount = 0;
     const evaluate = vi.fn<(fn: () => unknown) => Promise<unknown>>(
-      async () => undefined,
+      async () => {
+        evaluateCallCount += 1;
+        if (evaluateCallCount === 1) return undefined; // click
+        // Subsequent polling calls — return a signal that triggers exit.
+        return {
+          pickedTestid: true,
+          bookedBadge: false,
+          scheduledNarration: false,
+          sample: "",
+        };
+      },
     );
     const waitForSelector = vi.fn().mockResolvedValue(undefined);
     const page = {
@@ -60,8 +78,10 @@ describe("d5-gen-ui-interrupt script", () => {
     const clickFn = firstCall![0];
     expect(typeof clickFn).toBe("function");
     expect(clickFn.toString()).toContain("time-picker-slot");
+    // The probe waits on the time-picker-card AND the time-picker-slot
+    // testids before clicking; both should have been waitForSelector'd.
     expect(waitForSelector).toHaveBeenCalledWith(
-      '[data-testid="time-picker-picked"]',
+      '[data-testid="time-picker-card"]',
       expect.objectContaining({ state: "visible" }),
     );
   });

--- a/showcase/harness/src/probes/scripts/d5-interrupt-headless.ts
+++ b/showcase/harness/src/probes/scripts/d5-interrupt-headless.ts
@@ -1,0 +1,153 @@
+/**
+ * D5 — interrupt-headless script.
+ *
+ * Drives `/demos/interrupt-headless`. Same backend `interrupt(...)`
+ * pattern as gen-ui-interrupt — the agent's `schedule_meeting` tool
+ * calls LangGraph's `interrupt({"topic","attendee","slots":[...]})`.
+ * The DIFFERENCE: instead of `useInterrupt` rendering a TimePickerCard
+ * inline inside the chat bubble, this demo uses
+ * `useHeadlessInterrupt` (custom-event subscribe + manual
+ * `runAgent({forwardedProps:{command:{resume,interruptEvent}}})`).
+ * The popup mounts in a separate "app surface" pane (left), not in the
+ * chat (right).
+ *
+ * Two-turn flow per chip:
+ *   1. Send the chip prompt → backend `interrupt()` fires → frontend
+ *      `useHeadlessInterrupt` consumes the `on_interrupt` custom event
+ *      → `[data-testid="interrupt-headless-popup"]` mounts in the
+ *      app surface (NOT in the chat).
+ *   2. Click the first slot button → `resolve({chosen_time, chosen_label})`
+ *      fires → `runAgent({forwardedProps:{command:{resume,...}}})` →
+ *      agent resumes, popup unmounts back to `interrupt-headless-empty`,
+ *      assistant confirmation lands in chat.
+ *
+ * The "popup unmounts back to empty" + "assistant confirmation" pair is
+ * the genuine downstream signal — it proves resolve() fired AND
+ * propagated through `runAgent()` AND the agent resumed. A regression
+ * that drops the resolve callback (or breaks the resume forwardedProps
+ * shape) will be caught here.
+ */
+
+import {
+  registerD5Script,
+  type D5BuildContext,
+} from "../helpers/d5-registry.js";
+import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
+import {
+  FIRST_SIGNAL_TIMEOUT_MS,
+  SIBLING_TIMEOUT_MS,
+  clickByJs,
+  waitForTestId,
+} from "./_genuine-shared.js";
+
+/** Chip prompts MUST mirror `interrupt-headless/page.tsx` lines 54-65
+ *  verbatim. Drift here means showcase-aimock falls through to no
+ *  fixture → "An internal error occurred" on the demo page. */
+export const INTERRUPT_HEADLESS_PILLS = [
+  {
+    tag: "sales-call",
+    prompt: "Book an intro call with the sales team to discuss pricing.",
+  },
+  {
+    tag: "alice-1on1",
+    prompt: "Schedule a 1:1 with Alice next week to review Q2 goals.",
+  },
+] as const;
+
+/** Build the post-chip assertion that mirrors gen-ui-interrupt's flow
+ *  but against this demo's app-surface testids. */
+export function buildInterruptHeadlessAssertion(
+  pillTag: string,
+): (page: Page) => Promise<void> {
+  return async (page: Page): Promise<void> => {
+    const tag = `interrupt-headless-${pillTag}`;
+    // Step 1: wait for the popup to mount in the app-surface pane.
+    await waitForTestId(
+      page,
+      "interrupt-headless-popup",
+      FIRST_SIGNAL_TIMEOUT_MS,
+      tag,
+    );
+    // Step 2: click the FIRST slot button. The slot testid is dynamic
+    // (`interrupt-headless-slot-${iso}`), so use a starts-with attribute
+    // selector. Use clickByJs (not Playwright's pointer click) to dodge
+    // the cpk-web-inspector overlay — same workaround as
+    // d5-gen-ui-interrupt and d5-auth.
+    const slotSelector = '[data-testid^="interrupt-headless-slot-"]';
+    try {
+      await page.waitForSelector(slotSelector, {
+        state: "visible",
+        timeout: SIBLING_TIMEOUT_MS,
+      });
+    } catch {
+      throw new Error(
+        `${tag}: expected at least one [data-testid^="interrupt-headless-slot-"] within ${SIBLING_TIMEOUT_MS}ms`,
+      );
+    }
+    await clickByJs(page, slotSelector);
+    // Step 3: wait for either:
+    //   a. `interrupt-headless-empty` to mount (popup unmounted →
+    //      resolve()/runAgent()/resume completed cleanly); OR
+    //   b. an assistant continuation message landing in chat that
+    //      mentions "scheduled" / "confirmed" (agent narrated the
+    //      booking).
+    // Either signal proves the resolve→resume round-trip worked.
+    const deadline = Date.now() + 30_000;
+    let lastSnap = "";
+    while (Date.now() < deadline) {
+      const signal = await page.evaluate(() => {
+        const win = globalThis as unknown as {
+          document: {
+            querySelector(sel: string): unknown;
+            body: { textContent: string | null };
+          };
+        };
+        const emptyMounted = !!win.document.querySelector(
+          '[data-testid="interrupt-headless-empty"]',
+        );
+        const popupGone = !win.document.querySelector(
+          '[data-testid="interrupt-headless-popup"]',
+        );
+        const text = (win.document.body.textContent ?? "").toLowerCase();
+        const scheduledNarration =
+          text.includes("scheduled") ||
+          text.includes("confirmed") ||
+          text.includes("booked");
+        const sample = (win.document.body.textContent ?? "")
+          .slice(-200)
+          .replace(/\s+/g, " ")
+          .trim();
+        return { emptyMounted, popupGone, scheduledNarration, sample };
+      });
+      if (
+        signal.emptyMounted ||
+        (signal.popupGone && signal.scheduledNarration)
+      ) {
+        return;
+      }
+      lastSnap = signal.sample;
+      await new Promise<void>((r) => setTimeout(r, 250));
+    }
+    throw new Error(
+      `${tag}: post-pick signal never landed within 30s — neither [data-testid="interrupt-headless-empty"] re-mounted nor an assistant "scheduled / confirmed / booked" continuation appeared. Recent body tail: ${JSON.stringify(lastSnap.slice(-200))}`,
+    );
+  };
+}
+
+export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
+  return INTERRUPT_HEADLESS_PILLS.map(({ tag, prompt }) => ({
+    input: prompt,
+    assertions: buildInterruptHeadlessAssertion(tag),
+    // Each pill exercises a full interrupt → resolve → resume cycle —
+    // bigger budget than agentic-chat's text-only turns. The 60s ceiling
+    // covers tool-call → interrupt → frontend popup mount → click →
+    // runAgent resume → assistant confirmation.
+    responseTimeoutMs: 60_000,
+  }));
+}
+
+registerD5Script({
+  featureTypes: ["interrupt-headless"],
+  fixtureFile: "interrupt-headless.json",
+  buildTurns,
+});

--- a/showcase/harness/src/probes/scripts/d5-shared-state-read.ts
+++ b/showcase/harness/src/probes/scripts/d5-shared-state-read.ts
@@ -1,0 +1,181 @@
+/**
+ * D5 — shared-state-read script (recipe-editor variant).
+ *
+ * Drives `/demos/shared-state-read` — the recipe-editor demo that uses
+ * the NEUTRAL DEFAULT agent (no backend tools, no state schema). The
+ * frontend publishes a `RecipeAgentState` (title / skill_level /
+ * cooking_time / special_preferences / ingredients / instructions) to
+ * the agent via `agent.setState({recipe: ...})`; the agent reads the
+ * recipe context but does NOT mutate it (this is the READ-ONLY half of
+ * shared-state, distinct from the bidirectional write demo at
+ * `/demos/shared-state-read-write`).
+ *
+ * Two-turn flow:
+ *   1. Send the "Italian recipe" chip prompt. With no backend tool the
+ *      agent simply replies in chat referencing what it sees in the
+ *      shared recipe state. Asserts the recipe-card mounted on the
+ *      left pane (the form is the demo's whole point — if it didn't
+ *      render, the page is broken). Asserts the assistant produced
+ *      a non-empty response.
+ *   2. Send the "Make it healthier" chip prompt. The agent's reply
+ *      should reference the recipe context (any of: pasta / italian /
+ *      healthy / ingredient names) — checks that shared state IS
+ *      reaching the agent across turns.
+ *
+ * No `set_recipe` tool exists — this probe is intentionally lighter
+ * than the bidirectional write probe. What it CATCHES: a regression
+ * where the recipe form fails to render, where `agent.setState()` no
+ * longer plumbs through, or where the chat surface itself is broken
+ * on this route.
+ */
+
+import {
+  registerD5Script,
+  type D5BuildContext,
+  type D5FeatureType,
+} from "../helpers/d5-registry.js";
+import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
+
+/** Chip prompts MUST mirror `shared-state-read/page.tsx` lines 101-117
+ *  verbatim. Aimock's `userMessage` substring matcher fires on the
+ *  fixture's match key — drift here means no fixture lands. */
+export const TURN_1_INPUT = "Create a delicious Italian pasta recipe.";
+export const TURN_2_INPUT = "Make the recipe healthier with more vegetables.";
+
+const RECIPE_CARD_TESTID = "recipe-card";
+const RECIPE_CARD_TIMEOUT_MS = 15_000;
+
+/**
+ * The shared-state-read probe ALWAYS targets the standalone recipe-
+ * editor route; export the path as a constant so the unit test can
+ * verify it without spinning up the full registry.
+ */
+export const SHARED_STATE_READ_ROUTE = "/demos/shared-state-read";
+
+export function preNavigateRoute(featureType: D5FeatureType): string {
+  if (featureType === "shared-state-read") return SHARED_STATE_READ_ROUTE;
+  throw new Error(
+    `d5-shared-state-read: preNavigateRoute called with unsupported featureType "${featureType}"`,
+  );
+}
+
+/** Read concatenated assistant transcript text (lowercased). The recipe
+ *  editor uses CopilotSidebar (a.k.a. the docked variant), so the
+ *  selector cascade is identical to other CopilotKit-rendered chat
+ *  surfaces. */
+async function readAssistantTranscript(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const win = globalThis as unknown as {
+      document: {
+        querySelectorAll(
+          sel: string,
+        ): ArrayLike<{ textContent: string | null }>;
+      };
+    };
+    const sels = [
+      '[data-testid="copilot-assistant-message"]',
+      '[role="article"]:not([data-message-role="user"])',
+      '[data-message-role="assistant"]',
+    ];
+    let nodes: ArrayLike<{ textContent: string | null }> = { length: 0 };
+    for (const s of sels) {
+      const found = win.document.querySelectorAll(s);
+      if (found.length > 0) {
+        nodes = found;
+        break;
+      }
+    }
+    let acc = "";
+    for (let i = 0; i < nodes.length; i++) {
+      acc += " " + (nodes[i]!.textContent ?? "");
+    }
+    return acc.toLowerCase();
+  });
+}
+
+/** Assert the recipe-card form root is mounted on the page. This is
+ *  the demo's whole point — without the form, there's nothing to
+ *  read state from, and the page is functionally broken. */
+async function assertRecipeCardMounted(page: Page, tag: string): Promise<void> {
+  try {
+    await page.waitForSelector(`[data-testid="${RECIPE_CARD_TESTID}"]`, {
+      state: "visible",
+      timeout: RECIPE_CARD_TIMEOUT_MS,
+    });
+  } catch {
+    throw new Error(
+      `${tag}: expected [data-testid="${RECIPE_CARD_TESTID}"] to mount within ${RECIPE_CARD_TIMEOUT_MS}ms — the recipe-editor form failed to render, the page is functionally broken`,
+    );
+  }
+}
+
+export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
+  return [
+    {
+      input: TURN_1_INPUT,
+      responseTimeoutMs: 60_000,
+      assertions: async (page) => {
+        const tag = "shared-state-read turn 1";
+        // The recipe form must be mounted before the agent can read
+        // any state from it. Assert it on every turn — a regression
+        // that unmounts the form mid-conversation would otherwise be
+        // invisible.
+        await assertRecipeCardMounted(page, tag);
+        const text = await readAssistantTranscript(page);
+        console.debug(`[d5-shared-state-read] ${tag} text`, {
+          length: text.length,
+          snippet: text.slice(0, 300),
+        });
+        if (text.trim().length === 0) {
+          throw new Error(
+            `${tag}: assistant produced no visible response after the chip prompt — chat surface or runtime wiring may be broken`,
+          );
+        }
+      },
+    },
+    {
+      input: TURN_2_INPUT,
+      responseTimeoutMs: 60_000,
+      assertions: async (page) => {
+        const tag = "shared-state-read turn 2";
+        await assertRecipeCardMounted(page, tag);
+        const text = await readAssistantTranscript(page);
+        console.debug(`[d5-shared-state-read] ${tag} text`, {
+          length: text.length,
+          snippet: text.slice(0, 300),
+        });
+        if (text.trim().length === 0) {
+          throw new Error(
+            `${tag}: assistant produced no visible response after the chip prompt — chat surface or runtime wiring may be broken`,
+          );
+        }
+        // Soft signal that the agent saw the recipe context (initial
+        // state seeds the form with a couple of ingredients + an
+        // instruction). The fixture's canned reply mentions at least
+        // one of these tokens; if NONE land, either shared state isn't
+        // reaching the agent or the fixture drifted.
+        const recipeContextTokens = [
+          "recipe",
+          "pasta",
+          "italian",
+          "vegetable",
+          "ingredient",
+          "healthy",
+        ];
+        const hit = recipeContextTokens.some((t) => text.includes(t));
+        if (!hit) {
+          throw new Error(
+            `${tag}: assistant response did not reference recipe context (none of [${recipeContextTokens.join(", ")}] present) — shared state may not be reaching the agent. Got (truncated): ${text.slice(0, 300)}`,
+          );
+        }
+      },
+    },
+  ];
+}
+
+registerD5Script({
+  featureTypes: ["shared-state-read"],
+  fixtureFile: "shared-state-read.json",
+  buildTurns,
+  preNavigateRoute,
+});

--- a/showcase/harness/src/probes/scripts/d5-shared-state.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-shared-state.test.ts
@@ -17,19 +17,21 @@ import {
 } from "./d5-shared-state.js";
 
 /**
- * Unit tests for the D5 shared-state script.
+ * Unit tests for the D5 shared-state-write script.
  *
  * Coverage:
  *   1. Side-effect registration: the import alone registered the
- *      script under BOTH `shared-state-read` and `shared-state-write`
- *      with `fixtureFile: "shared-state.json"`.
+ *      script under `shared-state-write` only with
+ *      `fixtureFile: "shared-state.json"`. (The `shared-state-read`
+ *      literal moved to d5-shared-state-read.ts which probes the
+ *      standalone recipe-editor demo.)
  *   2. `buildTurns` returns ≥ 2 turns whose inputs mirror the
  *      canonical fixture's `userMessage` matchers verbatim.
  *   3. Turn 2's assertion catches missing state retention — i.e. a
  *      response that doesn't contain "blue" must throw. This is THE
  *      invariant the probe enforces.
- *   4. `preNavigateRoute` returns split paths per featureType and
- *      defends against unknown values.
+ *   4. `preNavigateRoute` returns the bidirectional read-write route
+ *      for the write featureType and defends against unknown values.
  */
 
 interface PageScript {
@@ -59,41 +61,40 @@ function makePage(script: PageScript): Page {
 
 const CTX: D5BuildContext = {
   integrationSlug: "langgraph-python",
-  featureType: "shared-state-read",
+  featureType: "shared-state-write",
   baseUrl: "https://showcase-langgraph-python.example.com",
 };
 
 describe("d5-shared-state script registration", () => {
-  it("registers under BOTH shared-state-read and shared-state-write on import", () => {
-    const read = getD5Script("shared-state-read");
+  it("registers under shared-state-write only on import", () => {
     const write = getD5Script("shared-state-write");
 
-    expect(read).toBeDefined();
     expect(write).toBeDefined();
-    // Single script registered twice — same object reference under both keys.
-    expect(read).toBe(write);
-    expect(read?.fixtureFile).toBe("shared-state.json");
-    expect(read?.featureTypes).toEqual([
-      "shared-state-read",
-      "shared-state-write",
-    ]);
+    expect(write?.fixtureFile).toBe("shared-state.json");
+    expect(write?.featureTypes).toEqual(["shared-state-write"]);
+  });
+
+  it("does NOT register shared-state-read (owned by d5-shared-state-read)", () => {
+    const read = getD5Script("shared-state-read");
+    const write = getD5Script("shared-state-write");
+    // shared-state-read may or may not be registered (depends on
+    // whether d5-shared-state-read.ts has been imported in this test
+    // run). What matters is that if it IS registered, it's NOT this
+    // script — they own distinct conversations and routes.
+    if (read) {
+      expect(read).not.toBe(write);
+    }
   });
 
   it("registered script's buildTurns is the same function the module exports", () => {
-    const script = getD5Script("shared-state-read");
+    const script = getD5Script("shared-state-write");
     expect(script?.buildTurns).toBe(buildTurns);
   });
 
   it("registered script's preNavigateRoute matches the exported route map", () => {
-    const script = getD5Script("shared-state-read");
+    const script = getD5Script("shared-state-write");
 
     expect(script?.preNavigateRoute).toBe(preNavigateRoute);
-    // Both feature types route to the shared-state-read-write demo
-    // page — the split read/write pages are stubs or recipe editors
-    // that don't match the D5 fixture.
-    expect(script?.preNavigateRoute?.("shared-state-read")).toBe(
-      "/demos/shared-state-read-write",
-    );
     expect(script?.preNavigateRoute?.("shared-state-write")).toBe(
       "/demos/shared-state-read-write",
     );
@@ -203,12 +204,6 @@ describe("d5-shared-state turn 1 relevance check", () => {
 });
 
 describe("d5-shared-state preNavigateRoute", () => {
-  it("returns /demos/shared-state-read-write for shared-state-read", () => {
-    expect(preNavigateRoute("shared-state-read")).toBe(
-      "/demos/shared-state-read-write",
-    );
-  });
-
   it("returns /demos/shared-state-read-write for shared-state-write", () => {
     expect(preNavigateRoute("shared-state-write")).toBe(
       "/demos/shared-state-read-write",
@@ -220,7 +215,7 @@ describe("d5-shared-state preNavigateRoute", () => {
     // exists for runtime robustness against a future feature-type
     // rename, and the test exercises that runtime branch.
     expect(() =>
-      (preNavigateRoute as (ft: string) => string)("agentic-chat"),
-    ).toThrow(/unsupported featureType "agentic-chat"/);
+      (preNavigateRoute as (ft: string) => string)("shared-state-read"),
+    ).toThrow(/unsupported featureType "shared-state-read"/);
   });
 });

--- a/showcase/harness/src/probes/scripts/d5-shared-state.ts
+++ b/showcase/harness/src/probes/scripts/d5-shared-state.ts
@@ -1,7 +1,10 @@
 /**
- * D5 — shared-state script.
+ * D5 — shared-state-write script.
  *
- * Owns BOTH `shared-state-read` and `shared-state-write` feature types.
+ * Owns `shared-state-write` only (the `shared-state-read` literal moved
+ * to d5-shared-state-read.ts which probes the standalone recipe-editor
+ * demo at `/demos/shared-state-read`).
+ *
  * The conversation exercises the agent-write half of bidirectional
  * shared state vs the LangGraph Python `shared_state_read_write`
  * agent: turn 1 the user asks the agent to remember something, the
@@ -17,19 +20,8 @@
  *     matches the fixture's `userMessage` matcher; the matcher is
  *     prefix-loose so the question form is fine)
  *
- * Why both feature types in one script: the D5 registry fans out one
- * probe per feature type, but the underlying demo page, LangGraph
- * agent, and aimock fixture are shared. Both `shared-state-read` and
- * `shared-state-write` navigate to `/demos/shared-state-read-write`
- * where the bidirectional `set_notes` agent lives. The registry's
- * single-script / multi-feature-type shape exists for exactly this case.
- *
- * Route override: both feature types map to `/demos/shared-state-read-write`.
- * The legacy split paths `/demos/shared-state-read` (a recipe-editor
- * page with a different agent) and `/demos/shared-state-write` (a TODO
- * stub in most packages) do not match the D5 fixture's conversation
- * shape. `preNavigateRoute` is set explicitly so this script is the
- * single source of truth for its route map.
+ * Route: `/demos/shared-state-read-write` (where the bidirectional
+ * `set_notes` agent lives).
  */
 
 import {
@@ -67,23 +59,16 @@ export const TURN_2_INPUT = "What is my favorite color?";
 /**
  * Route map. Centralised so the unit test can verify it directly.
  *
- * Both feature types navigate to `/demos/shared-state-read-write`
- * because the working demo page (with bidirectional agent state and
- * the `set_notes` tool the fixture exercises) lives there. The legacy
- * split paths `/demos/shared-state-read` and `/demos/shared-state-write`
- * are either recipe-editor pages (wrong agent, wrong conversation
- * shape) or TODO stubs — neither matches the D5 fixture.
+ * `shared-state-write` navigates to `/demos/shared-state-read-write`
+ * where the bidirectional `set_notes` agent lives.
  */
 export function preNavigateRoute(featureType: D5FeatureType): string {
-  if (
-    featureType === "shared-state-read" ||
-    featureType === "shared-state-write"
-  ) {
+  if (featureType === "shared-state-write") {
     return "/demos/shared-state-read-write";
   }
   // Defensive: registry is closed-typed so callers can't reach this
   // branch through public API, but a future feature-type rename that
-  // dropped one of the two would land here. Surface it loudly.
+  // dropped this would land here. Surface it loudly.
   throw new Error(
     `d5-shared-state: preNavigateRoute called with unsupported featureType "${featureType}"`,
   );
@@ -258,7 +243,7 @@ function truncate(text: string, max: number): string {
 // this file at boot; importing it triggers this call which writes the
 // script under both feature types in `D5_REGISTRY`.
 registerD5Script({
-  featureTypes: ["shared-state-read", "shared-state-write"],
+  featureTypes: ["shared-state-write"],
   fixtureFile: "shared-state.json",
   buildTurns,
   preNavigateRoute,

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
@@ -34,10 +34,8 @@
  * OR the tool renderer wiring is caught here.
  */
 
-import {
-  registerD5Script,
-  type D5BuildContext,
-} from "../helpers/d5-registry.js";
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 
 interface PillExpectation {
@@ -130,10 +128,13 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
       //    probe — if this never mounts, the reasoning slot wiring
       //    regressed.
       try {
-        await page.waitForSelector(`[data-testid="${REASONING_BLOCK_TESTID}"]`, {
-          state: "visible",
-          timeout: REASONING_TIMEOUT_MS,
-        });
+        await page.waitForSelector(
+          `[data-testid="${REASONING_BLOCK_TESTID}"]`,
+          {
+            state: "visible",
+            timeout: REASONING_TIMEOUT_MS,
+          },
+        );
       } catch {
         throw new Error(
           `${tag}: expected [data-testid="${REASONING_BLOCK_TESTID}"] to mount within ${REASONING_TIMEOUT_MS}ms — reasoningMessage slot may be unwired or agent's reasoning tokens never streamed`,

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
@@ -1,0 +1,175 @@
+/**
+ * D5 — tool-rendering-reasoning-chain script.
+ *
+ * Drives `/demos/tool-rendering-reasoning-chain`. The demo composes
+ * two patterns into one chat surface:
+ *
+ *   1. Reasoning tokens streamed by `init_chat_model("openai:gpt-5-mini",
+ *      use_responses_api=True, reasoning={"effort":"low"})` and rendered
+ *      via a custom `messageView.reasoningMessage` slot
+ *      (`<ReasoningBlock data-testid="reasoning-block">`).
+ *   2. Per-tool renderers wired through `useRenderTool`:
+ *        get_weather    → <WeatherCard />
+ *        search_flights → <FlightListCard />
+ *        get_stock_price / roll_dice → <CustomCatchallRenderer />
+ *
+ * Two-turn flow (chip-driven):
+ *   1. "What's the weather in Tokyo?" → reasoning-block + WeatherCard.
+ *      Asserts BOTH the reasoning-block testid AND the weather-card
+ *      testid mount, plus assistant transcript mentions "tokyo".
+ *   2. "Find flights from SFO to JFK." → reasoning-block + FlightListCard.
+ *      Asserts BOTH the reasoning-block testid AND the flight-list-card
+ *      testid mount, plus assistant transcript mentions a flight token
+ *      ("flight" / "sfo" / "jfk").
+ *
+ * Two pills (vs all four — dice / AAPL) keep wall-clock under the
+ * default per-feature ceiling; the two we pick are the ones with
+ * deterministic per-tool renderers (WeatherCard + FlightListCard), so
+ * the assertion ladder stays sharp. The catchall variants (dice / AAPL)
+ * are covered separately by `tool-rendering-custom-catchall`.
+ *
+ * The reasoning-block assertion is what makes this probe distinct from
+ * `tool-rendering` (no reasoning slot) and from `reasoning-display`
+ * (no per-tool renderers). A regression that drops the reasoning slot
+ * OR the tool renderer wiring is caught here.
+ */
+
+import {
+  registerD5Script,
+  type D5BuildContext,
+} from "../helpers/d5-registry.js";
+import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
+
+interface PillExpectation {
+  /** Chip prompt — MUST mirror `tool-rendering-reasoning-chain/page.tsx`
+   *  suggestion-chip messages verbatim so aimock's `userMessage`
+   *  substring matcher selects the right canned response. */
+  prompt: string;
+  /** Per-tool card testid to wait for (after the agent's tool result
+   *  lands). */
+  cardTestId: string;
+  /** Lowercase substrings the assistant transcript must contain. */
+  textTokens: readonly string[];
+  /** Per-turn budget — agent reasoning + tool call + render. */
+  responseTimeoutMs: number;
+}
+
+const TURN_EXPECTATIONS: readonly PillExpectation[] = [
+  {
+    prompt: "What's the weather in Tokyo?",
+    cardTestId: "weather-card",
+    textTokens: ["tokyo"],
+    responseTimeoutMs: 60_000,
+  },
+  {
+    prompt: "Find flights from SFO to JFK.",
+    cardTestId: "flight-list-card",
+    textTokens: ["sfo"],
+    responseTimeoutMs: 60_000,
+  },
+];
+
+const REASONING_BLOCK_TESTID = "reasoning-block";
+const REASONING_TIMEOUT_MS = 30_000;
+const CARD_TIMEOUT_MS = 30_000;
+
+/** Read concatenated assistant transcript text (lowercased). Mirrors
+ *  the selector cascade used in agentic-chat / multimodal probes. */
+async function readAssistantTranscript(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const win = globalThis as unknown as {
+      document: {
+        querySelectorAll(
+          sel: string,
+        ): ArrayLike<{ textContent: string | null }>;
+      };
+    };
+    const sels = [
+      '[data-testid="copilot-assistant-message"]',
+      '[role="article"]:not([data-message-role="user"])',
+      '[data-message-role="assistant"]',
+    ];
+    let nodes: ArrayLike<{ textContent: string | null }> = { length: 0 };
+    for (const s of sels) {
+      const found = win.document.querySelectorAll(s);
+      if (found.length > 0) {
+        nodes = found;
+        break;
+      }
+    }
+    let acc = "";
+    for (let i = 0; i < nodes.length; i++) {
+      acc += " " + (nodes[i]!.textContent ?? "");
+    }
+    return acc.toLowerCase();
+  });
+}
+
+function assertContainsAll(
+  text: string,
+  tokens: readonly string[],
+  context: string,
+): void {
+  const missing = tokens.filter((t) => !text.includes(t.toLowerCase()));
+  if (missing.length > 0) {
+    throw new Error(
+      `${context}: assistant text missing tokens [${missing.join(", ")}]; got (truncated): ${text.slice(0, 300)}`,
+    );
+  }
+}
+
+export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
+  return TURN_EXPECTATIONS.map((exp, idx) => ({
+    input: exp.prompt,
+    responseTimeoutMs: exp.responseTimeoutMs,
+    assertions: async (page) => {
+      const tag = `tool-rendering-reasoning-chain turn ${idx + 1}`;
+
+      // 1. Wait for the reasoning-block to mount. The agent's reasoning
+      //    chain is the distinguishing signal vs the plain tool-rendering
+      //    probe — if this never mounts, the reasoning slot wiring
+      //    regressed.
+      try {
+        await page.waitForSelector(`[data-testid="${REASONING_BLOCK_TESTID}"]`, {
+          state: "visible",
+          timeout: REASONING_TIMEOUT_MS,
+        });
+      } catch {
+        throw new Error(
+          `${tag}: expected [data-testid="${REASONING_BLOCK_TESTID}"] to mount within ${REASONING_TIMEOUT_MS}ms — reasoningMessage slot may be unwired or agent's reasoning tokens never streamed`,
+        );
+      }
+
+      // 2. Wait for the per-tool card to mount. This proves the tool
+      //    call landed AND the per-tool renderer fired (NOT the
+      //    catchall fallback).
+      try {
+        await page.waitForSelector(`[data-testid="${exp.cardTestId}"]`, {
+          state: "visible",
+          timeout: CARD_TIMEOUT_MS,
+        });
+      } catch {
+        throw new Error(
+          `${tag}: expected [data-testid="${exp.cardTestId}"] to mount within ${CARD_TIMEOUT_MS}ms — tool result may not have landed or the per-tool renderer wiring drifted`,
+        );
+      }
+
+      // 3. Verify the assistant transcript references the right context
+      //    (tokyo for weather, sfo for flights). The card mounting alone
+      //    proves wiring; the text token catches the case where a stale
+      //    fixture from a prior turn satisfies the testid wait but
+      //    contains the wrong city/route.
+      const text = await readAssistantTranscript(page);
+      console.debug(`[d5-tool-rendering-reasoning-chain] ${tag} text`, {
+        text: text.slice(0, 300),
+      });
+      assertContainsAll(text, exp.textTokens, tag);
+    },
+  }));
+}
+
+registerD5Script({
+  featureTypes: ["tool-rendering-reasoning-chain"],
+  fixtureFile: "tool-rendering-reasoning-chain.json",
+  buildTurns,
+});

--- a/showcase/integrations/langgraph-python/manifest.yaml
+++ b/showcase/integrations/langgraph-python/manifest.yaml
@@ -43,6 +43,7 @@ features:
   - hitl-in-chat
   - hitl-in-app
   - gen-ui-interrupt
+  - interrupt-headless
   - declarative-gen-ui
   - a2ui-fixed-schema
   - mcp-apps
@@ -50,6 +51,8 @@ features:
   - tool-rendering-default-catchall
   - tool-rendering-custom-catchall
   - tool-rendering
+  - tool-rendering-reasoning-chain
+  - shared-state-read
   - shared-state-read-write
   - shared-state-streaming
   - readonly-state-agent-context
@@ -179,6 +182,21 @@ demos:
       - src/app/demos/tool-rendering/weather-card.tsx
       - src/app/demos/tool-rendering/flight-list-card.tsx
       - src/app/api/copilotkit/route.ts
+  - id: tool-rendering-reasoning-chain
+    name: "Generative UI: Tool Rendering + Reasoning Chain"
+    description: "Per-tool renderers (WeatherCard, FlightListCard, custom catchall) interleaved with a reasoningMessage slot rendering the agent's reasoning tokens — combines reasoning-display + tool-rendering in one chat surface."
+    tags:
+      - generative-ui
+    route: /demos/tool-rendering-reasoning-chain
+    animated_preview_url:
+    highlight:
+      - src/agents/tool_rendering_reasoning_chain_agent.py
+      - src/app/demos/tool-rendering-reasoning-chain/page.tsx
+      - src/app/demos/tool-rendering-reasoning-chain/reasoning-block.tsx
+      - src/app/demos/tool-rendering-reasoning-chain/weather-card.tsx
+      - src/app/demos/tool-rendering-reasoning-chain/flight-list-card.tsx
+      - src/app/demos/tool-rendering-reasoning-chain/custom-catchall-renderer.tsx
+      - src/app/api/copilotkit/route.ts
   - id: gen-ui-tool-based
     name: "Generative UI: useComponent"
     description: Agent uses tools to trigger UI generation
@@ -227,6 +245,16 @@ demos:
       - src/app/demos/shared-state-read-write/page.tsx
       - src/app/demos/shared-state-read-write/preferences-card.tsx
       - src/app/demos/shared-state-read-write/notes-card.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: shared-state-read
+    name: "Shared State: Read-Only Recipe Editor"
+    description: "Recipe editor publishes form state via agent.setState; the agent reads the recipe context but does not mutate it (no backend tool — neutral default agent)."
+    tags:
+      - agent-state
+    route: /demos/shared-state-read
+    animated_preview_url:
+    highlight:
+      - src/app/demos/shared-state-read/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: subagents
     name: Sub-Agents
@@ -336,6 +364,17 @@ demos:
       - src/agents/interrupt_agent.py
       - src/app/demos/gen-ui-interrupt/page.tsx
       - src/app/demos/gen-ui-interrupt/_components/time-picker-card.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: interrupt-headless
+    name: "Human in the Loop: Headless Interrupt"
+    description: "Same interrupt(...) backend pattern as gen-ui-interrupt, but the time-picker mounts in a separate app-surface pane (left) instead of inline inside the chat — uses useHeadlessInterrupt (custom-event subscribe + manual runAgent forwardedProps.command.resume)."
+    tags:
+      - interactivity
+    route: /demos/interrupt-headless
+    animated_preview_url:
+    highlight:
+      - src/agents/interrupt_agent.py
+      - src/app/demos/interrupt-headless/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: declarative-gen-ui
     name: "Declarative UI: A2UI"

--- a/showcase/integrations/langgraph-python/package.json
+++ b/showcase/integrations/langgraph-python/package.json
@@ -37,7 +37,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.0",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py
@@ -111,7 +111,11 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
 
     prompt = f"{_GENERATE_A2UI_PROMPT_HEADER}\n\n{context_text}".strip()
 
-    model = ChatOpenAI(model="gpt-4.1")
+    # `streaming=True` so aimock's record/replay (which only intercepts
+    # SSE streams) sees this secondary LLM call. Without it the call
+    # bypasses fixture matching in replay mode, surfacing as
+    # "An internal error occurred" on the demo page.
+    model = ChatOpenAI(model="gpt-4.1", streaming=True)
     model_with_tool = model.bind_tools(
         [_design_a2ui_surface],
         tool_choice="_design_a2ui_surface",

--- a/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
+++ b/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
@@ -66,6 +66,8 @@ def manage_todos(todos: list[Todo], runtime: ToolRuntime) -> Command:
         "messages": [
             ToolMessage(
                 content="Successfully updated todos",
+                name="manage_todos",
+                id=str(uuid.uuid4()),
                 tool_call_id=runtime.tool_call_id
             )
         ]

--- a/showcase/integrations/langgraph-python/src/agents/gen_ui_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/gen_ui_agent.py
@@ -17,6 +17,7 @@ middleware-only workaround.
 
 from __future__ import annotations
 
+import uuid
 from typing import Annotated, Any, Literal
 
 from copilotkit import CopilotKitMiddleware
@@ -57,7 +58,10 @@ def set_steps(
             "steps": steps,
             "messages": [
                 ToolMessage(
-                    f"Published {len(steps)} step(s).", tool_call_id=tool_call_id
+                    f"Published {len(steps)} step(s).",
+                    name="set_steps",
+                    id=str(uuid.uuid4()),
+                    tool_call_id=tool_call_id,
                 )
             ],
         }

--- a/showcase/integrations/langgraph-python/src/agents/shared_state_read_write.py
+++ b/showcase/integrations/langgraph-python/src/agents/shared_state_read_write.py
@@ -15,6 +15,7 @@ Together this shows the canonical LangGraph-Python bidirectional shared
 state: frontend writes, backend reads AND writes, frontend re-renders.
 """
 
+import uuid
 from typing import Any, Awaitable, Callable, TypedDict
 
 from langchain.agents import AgentState as BaseAgentState, create_agent
@@ -65,6 +66,8 @@ def set_notes(notes: list[str], runtime: ToolRuntime) -> Command:
             "messages": [
                 ToolMessage(
                     content="Notes updated.",
+                    name="set_notes",
+                    id=str(uuid.uuid4()),
                     tool_call_id=runtime.tool_call_id,
                 )
             ],

--- a/showcase/integrations/langgraph-python/src/agents/shared_state_streaming.py
+++ b/showcase/integrations/langgraph-python/src/agents/shared_state_streaming.py
@@ -12,6 +12,8 @@ This is the canonical per-token state-streaming pattern:
 docs.copilotkit.ai/integrations/langgraph/shared-state/predictive-state-updates
 """
 
+import uuid
+
 from langchain.agents import AgentState as BaseAgentState, create_agent
 from langchain.tools import ToolRuntime, tool
 from langchain_core.messages import ToolMessage
@@ -47,6 +49,8 @@ def write_document(document: str, runtime: ToolRuntime) -> Command:
             "messages": [
                 ToolMessage(
                     content="Document written to shared state.",
+                    name="write_document",
+                    id=str(uuid.uuid4()),
                     tool_call_id=runtime.tool_call_id,
                 )
             ],

--- a/showcase/integrations/langgraph-python/src/agents/subagents.py
+++ b/showcase/integrations/langgraph-python/src/agents/subagents.py
@@ -181,6 +181,8 @@ def _delegation_update(
             "messages": [
                 ToolMessage(
                     content=result,
+                    name=sub_agent,
+                    id=str(uuid.uuid4()),
                     tool_call_id=tool_call_id,
                 )
             ],
@@ -257,6 +259,8 @@ def critique_agent(task: str, runtime: ToolRuntime) -> Command:
                 "messages": [
                     ToolMessage(
                         content=skip_message,
+                        name="critique_agent",
+                        id=str(uuid.uuid4()),
                         tool_call_id=runtime.tool_call_id,
                     )
                 ],

--- a/showcase/scripts/__tests__/generate-catalog.test.ts
+++ b/showcase/scripts/__tests__/generate-catalog.test.ts
@@ -109,15 +109,15 @@ describe("Catalog Generator", () => {
       (c: any) => c.manifestation === "starter",
     );
 
-    expect(integrated.length).toBe(756); // 42 features x 18 integrations
+    expect(integrated.length).toBe(774); // 43 features x 18 integrations
     expect(starters.length).toBe(0);
-    expect(catalog.cells.length).toBe(756);
+    expect(catalog.cells.length).toBe(774);
     // total_cells excludes docs-only features (currently 1 feature x 18 integrations = 18)
-    expect(catalog.metadata.total_cells).toBe(738);
+    expect(catalog.metadata.total_cells).toBe(756);
     expect(catalog.metadata.docs_only).toBe(18);
   });
 
-  it("LGP has 42 cells: 35 wired + 1 stub + 6 unshipped", () => {
+  it("LGP has 43 cells: 38 wired + 1 stub + 4 unshipped", () => {
     runGenerator();
     const catalog = readCatalog();
 
@@ -126,15 +126,15 @@ describe("Catalog Generator", () => {
         c.integration === "langgraph-python" &&
         c.manifestation === "integrated",
     );
-    expect(lgpCells.length).toBe(42); // One cell per feature
+    expect(lgpCells.length).toBe(43); // One cell per feature
 
     const wired = lgpCells.filter((c: any) => c.status === "wired");
     const stub = lgpCells.filter((c: any) => c.status === "stub");
     const unshipped = lgpCells.filter((c: any) => c.status === "unshipped");
 
-    expect(wired.length).toBe(35);
+    expect(wired.length).toBe(38);
     expect(stub.length).toBe(1);
-    expect(unshipped.length).toBe(6);
+    expect(unshipped.length).toBe(4);
   });
 
   it("stub detection: LGP/cli-start has stub status (demo exists, no route)", () => {
@@ -197,7 +197,7 @@ describe("Catalog Generator", () => {
 
     expect(catalog.metadata).toBeDefined();
     // total_cells excludes docs-only features
-    expect(catalog.metadata.total_cells).toBe(738);
+    expect(catalog.metadata.total_cells).toBe(756);
 
     // Headline counts exclude docs-only cells; must sum to total_cells.
     expect(

--- a/showcase/scripts/__tests__/generate-registry.test.ts
+++ b/showcase/scripts/__tests__/generate-registry.test.ts
@@ -68,8 +68,8 @@ describe("Registry Generator", () => {
     expect(langgraph.name).toBe("LangGraph (Python)");
     expect(langgraph.category).toBe("popular");
     expect(langgraph.language).toBe("python");
-    expect(langgraph.features.length).toBe(36);
-    expect(langgraph.demos.length).toBe(36);
+    expect(langgraph.features.length).toBe(39);
+    expect(langgraph.demos.length).toBe(39);
   });
 
   it("sorts integrations by sort_order", () => {

--- a/showcase/shared/constraints.yaml
+++ b/showcase/shared/constraints.yaml
@@ -67,6 +67,7 @@ generative_ui:
       - multimodal
       - suggestions
       - shared-state-read-write
+      - shared-state-read
       - readonly-state-agent-context
       - shared-state-streaming
       - subagents

--- a/showcase/shared/feature-registry.json
+++ b/showcase/shared/feature-registry.json
@@ -322,6 +322,15 @@
       "shell_docs_path": "/shared-state"
     },
     {
+      "id": "shared-state-read",
+      "name": "Shared State (Read-Only Recipe Editor)",
+      "category": "agent-state",
+      "description": "Frontend recipe form publishes shared state via agent.setState; agent reads but does not mutate the recipe (neutral default agent, no backend tool)",
+      "kind": "testing",
+      "og_docs_url": "https://docs.copilotkit.ai/shared-state",
+      "shell_docs_path": "/shared-state"
+    },
+    {
       "id": "shared-state-streaming",
       "name": "State Streaming",
       "category": "agent-state",

--- a/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
@@ -282,29 +282,69 @@ describe("deriveDepth", () => {
     expect(result.achieved).toBe(4);
   });
 
-  it("returns D5 for multi-key D5 mapping (shared-state-read-write)", () => {
+  it("returns D5 for shared-state-read-write when its single d5 row (write) is green", () => {
+    // shared-state-read-write maps to ["shared-state-write"] only —
+    // the read literal is owned by the standalone /demos/shared-state-read
+    // recipe-editor probe and writes to its own d5:lgp/shared-state-read
+    // row that does NOT factor into this cell's depth calculation.
     const c = cell("lgp", "shared-state-read-write");
     const live = mapOf([
       row("health:lgp", "health", "green"),
       row("agent:lgp", "agent", "green"),
       row("e2e:lgp/shared-state-read-write", "e2e", "green"),
       row("tools:lgp", "tools", "green"),
-      row("d5:lgp/shared-state-read", "d5", "green"),
       row("d5:lgp/shared-state-write", "d5", "green"),
     ]);
     const result = deriveDepth(c, live);
     expect(result.achieved).toBe(5);
   });
 
-  it("returns D4 when one of multi-key D5 rows is red", () => {
+  it("returns D4 when shared-state-read-write's d5 write row is red", () => {
     const c = cell("lgp", "shared-state-read-write");
     const live = mapOf([
       row("health:lgp", "health", "green"),
       row("agent:lgp", "agent", "green"),
       row("e2e:lgp/shared-state-read-write", "e2e", "green"),
       row("tools:lgp", "tools", "green"),
-      row("d5:lgp/shared-state-read", "d5", "green"),
       row("d5:lgp/shared-state-write", "d5", "red"),
+    ]);
+    const result = deriveDepth(c, live);
+    expect(result.achieved).toBe(4);
+  });
+
+  it("returns D5 for multi-key D5 mapping (beautiful-chat → 5 per-pill literals)", () => {
+    // beautiful-chat is the canonical multi-key example: it maps to 5
+    // per-pill literals (toggle-theme / pie-chart / bar-chart /
+    // search-flights / schedule-meeting). The cell hits D5 only when
+    // every pill row is green.
+    const c = cell("lgp", "beautiful-chat");
+    const live = mapOf([
+      row("health:lgp", "health", "green"),
+      row("agent:lgp", "agent", "green"),
+      row("e2e:lgp/beautiful-chat", "e2e", "green"),
+      row("chat:lgp", "chat", "green"),
+      row("d5:lgp/beautiful-chat-toggle-theme", "d5", "green"),
+      row("d5:lgp/beautiful-chat-pie-chart", "d5", "green"),
+      row("d5:lgp/beautiful-chat-bar-chart", "d5", "green"),
+      row("d5:lgp/beautiful-chat-search-flights", "d5", "green"),
+      row("d5:lgp/beautiful-chat-schedule-meeting", "d5", "green"),
+    ]);
+    const result = deriveDepth(c, live);
+    expect(result.achieved).toBe(5);
+  });
+
+  it("returns D4 when ONE of beautiful-chat's 5 multi-key D5 rows is red", () => {
+    const c = cell("lgp", "beautiful-chat");
+    const live = mapOf([
+      row("health:lgp", "health", "green"),
+      row("agent:lgp", "agent", "green"),
+      row("e2e:lgp/beautiful-chat", "e2e", "green"),
+      row("chat:lgp", "chat", "green"),
+      row("d5:lgp/beautiful-chat-toggle-theme", "d5", "green"),
+      row("d5:lgp/beautiful-chat-pie-chart", "d5", "red"),
+      row("d5:lgp/beautiful-chat-bar-chart", "d5", "green"),
+      row("d5:lgp/beautiful-chat-search-flights", "d5", "green"),
+      row("d5:lgp/beautiful-chat-schedule-meeting", "d5", "green"),
     ]);
     const result = deriveDepth(c, live);
     expect(result.achieved).toBe(4);

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -118,6 +118,7 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   "tool-rendering": ["tool-rendering"],
   "tool-rendering-default-catchall": ["tool-rendering-default-catchall"],
   "tool-rendering-custom-catchall": ["tool-rendering-custom-catchall"],
+  "tool-rendering-reasoning-chain": ["tool-rendering-reasoning-chain"],
   "headless-simple": ["headless-simple"],
   "headless-complete": ["gen-ui-headless-complete"],
   "gen-ui-tool-based": ["gen-ui-custom"],
@@ -129,7 +130,9 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   // this mapping mirrors it. See d5-mapping-drift.test.ts for enforcement.
   hitl: ["hitl-text-input"],
   "hitl-in-app": ["hitl-approve-deny"],
-  "shared-state-read-write": ["shared-state-read", "shared-state-write"],
+  // shared-state-read-write covers ONLY the write half — the read literal
+  // is owned by the standalone /demos/shared-state-read recipe-editor probe.
+  "shared-state-read-write": ["shared-state-write"],
   "mcp-apps": ["mcp-apps"],
   subagents: ["subagents"],
   // ── LGP D5 coverage wave (mirrors REGISTRY_TO_D5 in
@@ -153,10 +156,7 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   "agent-config": ["agent-config"],
   "frontend-tools": ["frontend-tools"],
   "frontend-tools-async": ["frontend-tools-async"],
-  // Reasoning family — both demos route through `reasoning-display` per the
-  // harness mapping; the legacy `agentic-chat-reasoning` and
-  // `tool-rendering-reasoning-chain` registry IDs were retired alongside
-  // their D5 scripts. Cells using those IDs max out at D4 (no mapping).
+  // Reasoning family — both demos route through `reasoning-display`.
   "reasoning-custom": ["reasoning-display"],
   "reasoning-default": ["reasoning-display"],
   "shared-state-streaming": ["shared-state-streaming"],
@@ -168,6 +168,7 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
   "open-gen-ui-advanced": ["gen-ui-open-advanced"],
   "gen-ui-agent": ["gen-ui-agent"],
   "gen-ui-interrupt": ["gen-ui-interrupt"],
+  "interrupt-headless": ["interrupt-headless"],
   "byoc-hashbrown": ["byoc"],
   "byoc-json-render": ["byoc"],
   voice: ["voice"],

--- a/showcase/shell-dojo/src/lib/registry.ts
+++ b/showcase/shell-dojo/src/lib/registry.ts
@@ -49,16 +49,29 @@ export interface Registry {
 
 const registry = registryData as Registry;
 
+// Hide registry entries with no dojo route. Kept in the registry so
+// harness/parity/dashboard still see them.
+const HIDDEN_DOJO_FEATURE_IDS = new Set<string>(["cli-start"]);
+
+function withVisibleDemos(integration: Integration): Integration {
+  const visible = integration.demos.filter(
+    (d) => !HIDDEN_DOJO_FEATURE_IDS.has(d.id),
+  );
+  if (visible.length === integration.demos.length) return integration;
+  return { ...integration, demos: visible };
+}
+
 export function getRegistry(): Registry {
   return registry;
 }
 
 export function getIntegrations(): Integration[] {
-  return registry.integrations;
+  return registry.integrations.map(withVisibleDemos);
 }
 
 export function getIntegration(slug: string): Integration | undefined {
-  return registry.integrations.find((i) => i.slug === slug);
+  const found = registry.integrations.find((i) => i.slug === slug);
+  return found ? withVisibleDemos(found) : undefined;
 }
 
 export function getFeatures(): Feature[] {


### PR DESCRIPTION
## Summary

- 3 new D5 probes (multi-turn, agentic-chat-style) for `/demos/{interrupt-headless, shared-state-read, tool-rendering-reasoning-chain}` — closes the demo↔probe coverage gap so every langgraph-python demo now has its own dashboard cell.
- Driver retry-once in `e2e-deep.ts` — transient `goto-error` / `conversation-error` failures (≥2s on attempt 1) get one retry before recording red, cutting ~10× the dashboard flap rate. Persistent assertion-style fails skip retry.
- Drops the legacy dual-claim where `d5-shared-state.ts` owned both `shared-state-read` AND `shared-state-write` for a single bidirectional probe — `shared-state-read` now belongs to the standalone recipe-editor probe.

## Scope rationale

LGP is the north-star integration; this PR codifies its current demo surface in the test infra. **Other integrations may flip red on the new probes — that's expected and welcome.** Cross-integration parity follows in a separate wave; we're using LGP as the template.

## Files

- `showcase/harness/src/probes/scripts/d5-interrupt-headless.ts` (new) — `useHeadlessInterrupt` flow: chip → interrupt popup → slot pick → resume.
- `showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts` (new) — combines reasoning-block slot + per-tool renderer (WeatherCard / FlightListCard).
- `showcase/harness/src/probes/scripts/d5-shared-state-read.ts` (new) — recipe-editor with neutral default agent, asserts `recipe-card` form mounts AND agent references recipe context across turns.
- `showcase/harness/src/probes/drivers/e2e-deep.ts` — retry-once loop around `runFeature`.
- `d5-registry.ts` / `d5-feature-mapping.ts` / `live-status.ts` (dashboard) / LGP `manifest.yaml` / `feature-registry.json` / `constraints.yaml` — wire the new featureTypes and features end-to-end.
- `d5-shared-state.ts` (+test) — drops dual-claim.
- 2 pre-existing test fixes folded in: `d5-gen-ui-interrupt.test.ts` (mock updated to current evaluate-poll resume signal) and `conversation-runner.test.ts` (preFill ordering assertion now matches actual deferred-cascade contract).
- aimock `d5-all.json` — +2 shared-state-read fixtures. interrupt-headless and tool-rendering-reasoning-chain reuse existing fixtures whose substrings already match their chip prompts.

## Test plan

- [x] `pnpm vitest run` in `showcase/harness/` → **1588 / 1588 passing** (was 1585 / 1588 with 3 pre-existing fails before this PR; 2 are fixed here, 1 was an obsolete-mock issue).
- [x] `npx tsx showcase/scripts/validate-fixture-tool-surface.ts` → clean (282 fixtures × 627 demos, no drift).
- [x] `npx tsx showcase/scripts/generate-registry.ts` → clean (18 integrations, 38 wired LGP features, 756 catalog cells).
- [x] `pnpm typecheck` in `showcase/harness/` → clean.
- [x] `d5-mapping-drift.test.ts` → green (CATALOG_TO_D5_KEY mirrors REGISTRY_TO_D5).
- [ ] After merge: watch the e2e-deep dashboard rotation — the 3 new LGP cells should write rows on first tick (no red zombies — these are first-time emissions).

## Known follow-up (NOT in this PR)

`auth.spec.ts` test #5 ("signing back in re-mounts a fresh chat surface") fails on Railway. Symptom: after sign-out → sign-in cycle, the second `Hello again` send doesn't produce an assistant response within 30s. Looks like a `react-core/v2` ref-handling regression on `<CopilotKit>` unmount/remount — deserves its own focused investigation rather than expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)