### PR TITLE
feat(showcase): align demo names + add Show Deprecated toggle

### DIFF
--- a/showcase/integrations/langgraph-python/manifest.yaml
+++ b/showcase/integrations/langgraph-python/manifest.yaml
@@ -77,7 +77,7 @@ demos:
       - chat-ui
     command: "npx copilotkit@latest init --framework langgraph-python"
   - id: agentic-chat
-    name: "Prebuilt: CopilotChat"
+    name: "Pre-Built: CopilotChat"
     description: Natural conversation with frontend tool execution
     tags:
       - chat-ui
@@ -100,7 +100,7 @@ demos:
       - src/app/demos/chat-customization-css/theme.css
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering-default-catchall
-    name: "Generative UI: Tool Rendering - Default"
+    name: "Generative UI: Tool Rendering (Default)"
     description: Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI
     tags:
       - generative-ui
@@ -111,7 +111,7 @@ demos:
       - src/agents/tool_rendering_agent.py
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering-custom-catchall
-    name: "Generative UI: Tool Rendering - Custom Default"
+    name: "Generative UI: Tool Rendering (Custom default)"
     description: Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call
     tags:
       - generative-ui
@@ -123,7 +123,7 @@ demos:
       - src/agents/tool_rendering_agent.py
       - src/app/api/copilotkit/route.ts
   - id: frontend-tools
-    name: "Frontend Tools: In-App Actions"
+    name: "Frontend Tools: In-app Actions"
     description: Agent invokes client-side handlers registered with useFrontendTool
     tags:
       - interactivity
@@ -146,7 +146,7 @@ demos:
       - src/app/demos/frontend-tools-async/notes-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: hitl-in-chat
-    name: "Human in the Loop: In-chat"
+    name: "Human In the Loop: In-chat"
     description: Time-slot picker rendered inline in the chat via `useHumanInTheLoop` — the agent requests user input, the frontend renders a TimePickerCard, and the user's choice resumes the agent.
     tags:
       - interactivity
@@ -158,7 +158,7 @@ demos:
       - src/agents/hitl_in_chat_agent.py
       - src/app/api/copilotkit/route.ts
   - id: hitl-in-app
-    name: "Human in the Loop: In-App"
+    name: "Human in the Loop: In-app"
     description: Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision
     tags:
       - interactivity
@@ -170,7 +170,7 @@ demos:
       - src/app/demos/hitl-in-app/approval-dialog.tsx
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering
-    name: "Generative UI: Tool Rendering - Specific"
+    name: "Generative UI: Tool Rendering (Specific)"
     description: Custom per-tool renderers (WeatherCard, FlightListCard) plus a wildcard catch-all for every other tool
     tags:
       - generative-ui
@@ -183,7 +183,7 @@ demos:
       - src/app/demos/tool-rendering/flight-list-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering-reasoning-chain
-    name: "Generative UI: Tool Rendering + Reasoning Chain"
+    name: "Generative UI: Rendering multiple tools"
     description: "Per-tool renderers (WeatherCard, FlightListCard, custom catchall) interleaved with a reasoningMessage slot rendering the agent's reasoning tokens — combines reasoning-display + tool-rendering in one chat surface."
     tags:
       - generative-ui
@@ -247,7 +247,7 @@ demos:
       - src/app/demos/shared-state-read-write/notes-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: shared-state-read
-    name: "Shared State: Read-Only Recipe Editor"
+    name: "Shared State: Read-only"
     description: "Recipe editor publishes form state via agent.setState; the agent reads the recipe context but does not mutate it (no backend tool — neutral default agent)."
     tags:
       - agent-state
@@ -291,7 +291,7 @@ demos:
       - src/app/demos/prebuilt-popup/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: chat-slots
-    name: Chat Customization (Slots)
+    name: "Chat Customization: Slots"
     description: Customize CopilotChat via its slot system
     tags:
       - chat-ui
@@ -354,7 +354,7 @@ demos:
       - src/agents/reasoning_agent.py
       - src/app/api/copilotkit/route.ts
   - id: gen-ui-interrupt
-    name: "Human in the Loop: Interrupt based"
+    name: "Human in the Loop: Interrupts"
     description: Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle
     tags:
       - interactivity
@@ -366,7 +366,7 @@ demos:
       - src/app/demos/gen-ui-interrupt/_components/time-picker-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: interrupt-headless
-    name: "Human in the Loop: Headless Interrupt"
+    name: "Human in the Loop: Headless Interrupts"
     description: "Same interrupt(...) backend pattern as gen-ui-interrupt, but the time-picker mounts in a separate app-surface pane (left) instead of inline inside the chat — uses useHeadlessInterrupt (custom-event subscribe + manual runAgent forwardedProps.command.resume)."
     tags:
       - interactivity
@@ -377,7 +377,7 @@ demos:
       - src/app/demos/interrupt-headless/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: declarative-gen-ui
-    name: "Declarative UI: A2UI"
+    name: "Declarative UI: Dynamic A2UI"
     description: Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; runtime injects the render_a2ui tool automatically
     tags:
       - generative-ui
@@ -391,7 +391,7 @@ demos:
       - src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
       - src/app/api/copilotkit/route.ts
   - id: a2ui-fixed-schema
-    name: "Declarative UI: A2UI (Fixed Schema)"
+    name: "Declarative UI: Fixed A2UI"
     description: Render an A2UI tree from a fixed, server-side schema — the agent streams data into a pre-authored component tree
     tags:
       - generative-ui
@@ -417,7 +417,7 @@ demos:
       - src/app/demos/mcp-apps/page.tsx
       - src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
   - id: readonly-state-agent-context
-    name: Frontend Context Sharing
+    name: "Shared State: Frontend Context"
     description: Frontend provides read-only context to the agent via useAgentContext
     tags:
       - agent-state
@@ -464,7 +464,7 @@ demos:
       - src/app/demos/beautiful-chat/hooks/use-generative-ui-examples.tsx
       - src/app/api/copilotkit-beautiful-chat/route.ts
   - id: multimodal
-    name: Multimodal Attachments
+    name: Attachments
     description: Image and PDF uploads via CopilotChat attachments, processed by a vision-capable agent
     tags:
       - chat-ui
@@ -518,7 +518,7 @@ demos:
       - src/app/demos/open-gen-ui/page.tsx
       - src/app/api/copilotkit-ogui/route.ts
   - id: open-gen-ui-advanced
-    name: "Open Generative UI: Advanced"
+    name: "Open Generative UI: Custom"
     description: Agent-authored UI that can invoke frontend sandbox functions from inside the iframe
     tags:
       - generative-ui
@@ -531,7 +531,7 @@ demos:
       - src/app/demos/open-gen-ui-advanced/suggestions.ts
       - src/app/api/copilotkit-ogui/route.ts
   - id: voice
-    name: Voice Input
+    name: Voice
     description: Speech-to-text via @copilotkit/voice with a bundled sample audio button
     tags:
       - chat-ui

--- a/showcase/scripts/__tests__/generate-catalog.test.ts
+++ b/showcase/scripts/__tests__/generate-catalog.test.ts
@@ -109,22 +109,20 @@ describe("Catalog Generator", () => {
       (c: any) => c.manifestation === "starter",
     );
 
-    // 43 features x 18 integrations = 774 nominal, but 4 deprecated
-    // features (agentic-chat-reasoning, hitl, hitl-in-chat-booking,
-    // reasoning-default-render) are filtered when an integration's
-    // manifest doesn't declare them — see deprecatedFeatureIds in
-    // generate-registry.ts. LGP doesn't declare any of the 4 (gold-
-    // standard reference uses the modern shape), so 4 LGP cells are
-    // dropped: 774 - 4 = 770.
-    expect(integrated.length).toBe(770);
+    // 43 features × 18 integrations = 774 cells. The catalog emits cells
+    // uniformly for all (integration × feature) pairs; deprecated-feature
+    // visibility is controlled at the dashboard layer via the "Show
+    // deprecated" toggle in feature-grid.tsx so the catalog stays
+    // shape-stable.
+    expect(integrated.length).toBe(774);
     expect(starters.length).toBe(0);
-    expect(catalog.cells.length).toBe(770);
+    expect(catalog.cells.length).toBe(774);
     // total_cells excludes docs-only features (currently 1 feature x 18 integrations = 18)
-    expect(catalog.metadata.total_cells).toBe(752);
+    expect(catalog.metadata.total_cells).toBe(756);
     expect(catalog.metadata.docs_only).toBe(18);
   });
 
-  it("LGP has 39 cells: 38 wired + 1 stub (deprecated features filtered)", () => {
+  it("LGP has 43 cells: 38 wired + 1 stub + 4 unshipped (deprecated features included; dashboard hides them by default)", () => {
     runGenerator();
     const catalog = readCatalog();
 
@@ -133,10 +131,11 @@ describe("Catalog Generator", () => {
         c.integration === "langgraph-python" &&
         c.manifestation === "integrated",
     );
-    // 39 = 39 features in LGP manifest (the 4 deprecated features are
-    // filtered out at catalog-generation time since LGP doesn't declare
-    // them — see deprecatedFeatureIds in generate-registry.ts).
-    expect(lgpCells.length).toBe(39);
+    // 43 = 39 LGP-declared features + 4 deprecated features (cells
+    // emitted as `unshipped` since LGP doesn't declare them in its
+    // manifest). The dashboard's `Show deprecated` toggle in
+    // feature-grid.tsx hides those rows by default.
+    expect(lgpCells.length).toBe(43);
 
     const wired = lgpCells.filter((c: any) => c.status === "wired");
     const stub = lgpCells.filter((c: any) => c.status === "stub");
@@ -144,38 +143,7 @@ describe("Catalog Generator", () => {
 
     expect(wired.length).toBe(38);
     expect(stub.length).toBe(1);
-    expect(unshipped.length).toBe(0);
-  });
-
-  it("deprecated features are emitted only for integrations that declare them", () => {
-    runGenerator();
-    const catalog = readCatalog();
-
-    // 4 features marked deprecated:true in feature-registry.json. LGP
-    // doesn't declare any of them (modern-shape reference); other
-    // integrations that DO declare them still get a cell so the
-    // cross-integration audit trail is preserved.
-    const deprecated = [
-      "agentic-chat-reasoning",
-      "hitl",
-      "hitl-in-chat-booking",
-      "reasoning-default-render",
-    ];
-
-    for (const feat of deprecated) {
-      const lgpCell = catalog.cells.find(
-        (c: any) => c.integration === "langgraph-python" && c.feature === feat,
-      );
-      expect(lgpCell).toBeUndefined();
-    }
-
-    // ag2 declares agentic-chat-reasoning + hitl + reasoning-default-render
-    // (per its manifest), so those cells exist.
-    const ag2Acr = catalog.cells.find(
-      (c: any) =>
-        c.integration === "ag2" && c.feature === "agentic-chat-reasoning",
-    );
-    expect(ag2Acr).toBeDefined();
+    expect(unshipped.length).toBe(4);
   });
 
   it("stub detection: LGP/cli-start has stub status (demo exists, no route)", () => {
@@ -237,10 +205,8 @@ describe("Catalog Generator", () => {
     const catalog = readCatalog();
 
     expect(catalog.metadata).toBeDefined();
-    // total_cells excludes docs-only features (and deprecated-feature cells
-    // that were filtered during catalog generation when an integration
-    // didn't declare them).
-    expect(catalog.metadata.total_cells).toBe(752);
+    // total_cells excludes docs-only features
+    expect(catalog.metadata.total_cells).toBe(756);
 
     // Headline counts exclude docs-only cells; must sum to total_cells.
     expect(
@@ -340,7 +306,7 @@ describe("Catalog Generator", () => {
     );
     expect(lgpAgenticChat).toBeDefined();
     expect(lgpAgenticChat.integration_name).toBe("LangGraph (Python)");
-    expect(lgpAgenticChat.feature_name).toBe("Pre-Built CopilotChat");
+    expect(lgpAgenticChat.feature_name).toBe("Pre-Built: CopilotChat");
     expect(lgpAgenticChat.category_name).toBe("Chat & UI");
 
     // All integrated cells must have non-null display names

--- a/showcase/scripts/generate-registry.ts
+++ b/showcase/scripts/generate-registry.ts
@@ -317,18 +317,13 @@ function generateCatalog(
 
   // Deprecated features — consolidated/replaced patterns that LGP (the
   // gold-standard reference integration) intentionally does NOT implement,
-  // but legacy integrations still serve. We only EMIT a cell for a
-  // deprecated feature when the integration's manifest actively declares
-  // it; integrations that don't claim it (notably the gold-standard
-  // reference) get no row at all, so the dashboard's gold-standard view
-  // doesn't render confusing X-marked rows for patterns LGP intentionally
-  // skipped. The cross-integration audit trail is preserved on the
-  // integrations that DO declare the feature.
-  const deprecatedFeatureIds = new Set(
-    featureRegistry.features
-      .filter((f) => f.deprecated === true)
-      .map((f) => f.id),
-  );
+  // but legacy integrations still serve. The catalog emits cells for all
+  // (integration × feature) pairs uniformly; visibility is controlled at
+  // the dashboard layer via a "Show deprecated" toggle that filters whole
+  // FEATURE ROWS based on `feature.deprecated`. That way toggle-on
+  // surfaces both the audit trail (integrations that declare these
+  // legacy patterns) and the empty cells (LGP shows N/A for them) in one
+  // pass without missing-data artifacts.
 
   // Step 1: Cross-join to produce integrated cells and collect wired features
   // and unsupported features per integration.
@@ -344,16 +339,6 @@ function generateCatalog(
 
     for (const featureId of allFeatureIds) {
       const status = determineCellStatus(featureId, integration);
-
-      // Deprecated-feature filter: skip emitting the cell entirely when
-      // the feature is deprecated AND this integration's manifest does
-      // NOT declare it. The cell would otherwise render as an
-      // unshipped/X row that's misleading — it implies LGP is missing
-      // something it intentionally doesn't have. Integrations that DO
-      // declare the deprecated feature still get their row (audit trail).
-      if (deprecatedFeatureIds.has(featureId) && status === "unshipped") {
-        continue;
-      }
 
       if (status === "wired") {
         wiredFeatures.add(featureId);

--- a/showcase/shared/feature-registry.json
+++ b/showcase/shared/feature-registry.json
@@ -67,7 +67,7 @@
     },
     {
       "id": "agentic-chat",
-      "name": "Pre-Built CopilotChat",
+      "name": "Pre-Built: CopilotChat",
       "category": "chat-ui",
       "description": "Pre-built <CopilotChat /> component for full-screen/embedded chat",
       "kind": "primary",
@@ -92,7 +92,7 @@
     },
     {
       "id": "chat-slots",
-      "name": "Chat Customization (Slots)",
+      "name": "Chat Customization: Slots",
       "category": "chat-ui",
       "description": "Customizing chat components via the slot system",
       "og_docs_url": "https://docs.copilotkit.ai/custom-look-and-feel/slots",
@@ -100,7 +100,7 @@
     },
     {
       "id": "chat-customization-css",
-      "name": "Chat Customization (CSS)",
+      "name": "Chat Customization: CSS",
       "category": "chat-ui",
       "description": "Customizing chat components via CSS",
       "og_docs_url": "https://docs.copilotkit.ai/custom-look-and-feel",
@@ -108,7 +108,7 @@
     },
     {
       "id": "headless-simple",
-      "name": "Headless Chat (Simple)",
+      "name": "Headless UI: Simple",
       "category": "chat-ui",
       "description": "Simple headless UI getting started",
       "og_docs_url": "https://docs.copilotkit.ai/headless",
@@ -116,7 +116,7 @@
     },
     {
       "id": "headless-complete",
-      "name": "Headless Chat (Complete)",
+      "name": "Headless UI: Complete",
       "category": "chat-ui",
       "description": "Full headless UI with messages, tools, gen UI",
       "og_docs_url": "https://docs.copilotkit.ai/headless",
@@ -124,7 +124,7 @@
     },
     {
       "id": "gen-ui-tool-based",
-      "name": "Controlled Gen-UI (Display)",
+      "name": "Generative UI: useComponent",
       "category": "controlled-generative-ui",
       "description": "Agent renders typed React components via the useComponent hook",
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/your-components/display-only",
@@ -132,7 +132,7 @@
     },
     {
       "id": "hitl-in-chat",
-      "name": "In-Chat HITL (useHumanInTheLoop \u2014 ergonomic API)",
+      "name": "Human In the Loop: In-chat",
       "category": "controlled-generative-ui",
       "description": "Interactive approval/decision surface rendered inline in the chat. Uses the high-level `useHumanInTheLoop` hook \u2014 handles the interrupt lifecycle for you.",
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/your-components/interactive",
@@ -140,7 +140,7 @@
     },
     {
       "id": "gen-ui-interrupt",
-      "name": "In-Chat HITL (useInterrupt \u2014 low-level primitive)",
+      "name": "Human in the Loop: Interrupts",
       "category": "controlled-generative-ui",
       "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive \u2014 direct control over the LangGraph interrupt lifecycle.",
       "og_docs_url": "https://docs.copilotkit.ai/human-in-the-loop",
@@ -168,7 +168,7 @@
     },
     {
       "id": "interrupt-headless",
-      "name": "Headless Interrupt",
+      "name": "Human in the Loop: Headless Interrupts",
       "category": "controlled-generative-ui",
       "description": "Resolve langgraph interrupts headlessly via agent.subscribe + copilotkit.runAgent \u2014 no chat, no useInterrupt render prop",
       "kind": "testing",
@@ -177,7 +177,7 @@
     },
     {
       "id": "declarative-gen-ui",
-      "name": "Declarative Generative UI (A2UI \u2014 Dynamic Schema)",
+      "name": "Declarative UI: Dynamic A2UI",
       "category": "declarative-generative-ui",
       "description": "Canonical A2UI BYOC \u2014 custom catalog wired via a2ui.catalog; runtime injects render_a2ui automatically",
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/a2ui",
@@ -185,7 +185,7 @@
     },
     {
       "id": "a2ui-fixed-schema",
-      "name": "Declarative Generative UI (A2UI \u2014 Fixed Schema)",
+      "name": "Declarative UI: Fixed A2UI",
       "category": "declarative-generative-ui",
       "description": "A2UI rendering against a known, fixed client-side schema",
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/a2ui",
@@ -201,7 +201,7 @@
     },
     {
       "id": "open-gen-ui",
-      "name": "Fully Open-Ended Generative UI",
+      "name": "Open Generative UI: Default",
       "category": "open-generative-ui",
       "description": "Agent-generated UI from arbitrary component libraries",
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/open-generative-ui",
@@ -209,7 +209,7 @@
     },
     {
       "id": "open-gen-ui-advanced",
-      "name": "Open-Ended Gen UI (Advanced: with frontend function calling)",
+      "name": "Open Generative UI: Custom",
       "category": "open-generative-ui",
       "description": "Agent-authored UI that can invoke frontend sandbox functions from inside the iframe",
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/open-generative-ui",
@@ -217,7 +217,7 @@
     },
     {
       "id": "tool-rendering-default-catchall",
-      "name": "Tool Rendering (Default Catch-all)",
+      "name": "Generative UI: Tool Rendering (Default)",
       "category": "operational-generative-ui",
       "description": "Out-of-the-box rendering: backend tools surfaced via CopilotKit's built-in default catch-all renderer; no frontend customization",
       "kind": "primary",
@@ -226,7 +226,7 @@
     },
     {
       "id": "tool-rendering-custom-catchall",
-      "name": "Tool Rendering (Custom Catch-all)",
+      "name": "Generative UI: Tool Rendering (Custom default)",
       "category": "operational-generative-ui",
       "description": "Single branded wildcard renderer that paints every tool call \u2014 one card handles them all",
       "kind": "primary",
@@ -235,7 +235,7 @@
     },
     {
       "id": "tool-rendering",
-      "name": "Tool Rendering",
+      "name": "Generative UI: Tool Rendering (Specific)",
       "category": "operational-generative-ui",
       "description": "Custom per-tool renderers for the tools you care about, plus a wildcard catch-all for the rest",
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/tool-rendering",
@@ -243,7 +243,7 @@
     },
     {
       "id": "tool-rendering-reasoning-chain",
-      "name": "Tool Rendering + Reasoning Chain",
+      "name": "Generative UI: Rendering multiple tools",
       "category": "operational-generative-ui",
       "description": "Sequential tool calls with reasoning tokens rendered side-by-side",
       "kind": "testing",
@@ -287,7 +287,7 @@
     },
     {
       "id": "gen-ui-agent",
-      "name": "Agentic Generative UI (In-Chat State Rendering)",
+      "name": "Generative UI: Agent State",
       "category": "operational-generative-ui",
       "description": "Agent-state-driven inline UI: the agent emits a live `steps` plan via copilotkit_emit_state and the frontend renders it with useCoAgentStateRender (v1 hook)",
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/state-rendering",
@@ -295,7 +295,7 @@
     },
     {
       "id": "frontend-tools",
-      "name": "Frontend Tools (In-app actions)",
+      "name": "Frontend Tools: In-app Actions",
       "category": "interactivity",
       "description": "Frontend tool execution triggered by the agent",
       "og_docs_url": "https://docs.copilotkit.ai/frontend-tools",
@@ -303,7 +303,7 @@
     },
     {
       "id": "frontend-tools-async",
-      "name": "Frontend Tools (Async)",
+      "name": "Frontend Tools: Async",
       "category": "interactivity",
       "description": "useFrontendTool with an async handler \u2014 agent awaits a client-side async operation (e.g. DB query) and uses the returned result",
       "og_docs_url": "https://docs.copilotkit.ai/frontend-tools",
@@ -311,7 +311,7 @@
     },
     {
       "id": "hitl-in-app",
-      "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
+      "name": "Human in the Loop: In-app",
       "category": "interactivity",
       "description": "Agent calls useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
       "og_docs_url": "https://docs.copilotkit.ai/human-in-the-loop",
@@ -319,7 +319,7 @@
     },
     {
       "id": "shared-state-read-write",
-      "name": "Shared State (Read + Write)",
+      "name": "Shared State: Read + Write",
       "category": "agent-state",
       "description": "Bidirectional agent state \u2014 UI writes preferences, agent writes notes back",
       "og_docs_url": "https://docs.copilotkit.ai/shared-state",
@@ -327,7 +327,7 @@
     },
     {
       "id": "shared-state-read",
-      "name": "Shared State (Read-Only Recipe Editor)",
+      "name": "Shared State: Read-only",
       "category": "agent-state",
       "description": "Frontend recipe form publishes shared state via agent.setState; agent reads but does not mutate the recipe (neutral default agent, no backend tool)",
       "kind": "testing",
@@ -336,7 +336,7 @@
     },
     {
       "id": "shared-state-streaming",
-      "name": "State Streaming",
+      "name": "Shared State: Streaming",
       "category": "agent-state",
       "description": "Per-token state delta streaming from agent to UI",
       "og_docs_url": "https://docs.copilotkit.ai/shared-state",
@@ -344,7 +344,7 @@
     },
     {
       "id": "readonly-state-agent-context",
-      "name": "Readonly State (Agent Context)",
+      "name": "Shared State: Frontend Context",
       "category": "agent-state",
       "description": "Frontend provides read-only context to the agent via useAgentContext",
       "og_docs_url": "https://docs.copilotkit.ai/shared-state",
@@ -381,7 +381,7 @@
     },
     {
       "id": "multimodal",
-      "name": "Multi-modal / File Uploads",
+      "name": "Attachments",
       "category": "platform",
       "description": "File upload and agent processing",
       "shell_docs_path": "/multimodal-attachments",
@@ -389,13 +389,13 @@
     },
     {
       "id": "byoc-hashbrown",
-      "name": "BYOC Hashbrown",
+      "name": "Declarative UI: Hashbrown",
       "category": "byoc",
       "description": "Hashbrown-style generative UI"
     },
     {
       "id": "byoc-json-render",
-      "name": "BYOC json-render",
+      "name": "Declarative UI: json-render",
       "category": "byoc",
       "description": "Streaming structured-output generative UI via @json-render/react"
     }

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { Fragment, useMemo } from "react";
+import React, { Fragment, useMemo, useState } from "react";
 import {
   getIntegrations,
   getFeatures,
@@ -484,15 +484,33 @@ export function FeatureGrid({
     return map;
   }, [catalog, showRefDepth]);
 
+  // "Show deprecated" toggle — default OFF so the LGP gold-standard view
+  // doesn't render rows for legacy/replaced patterns (e.g. `hitl`,
+  // `agentic-chat-reasoning`). Operators can flip it on to surface
+  // deprecated features for cross-integration audit.
+  const [showDeprecated, setShowDeprecated] = useState(false);
+
+  const visibleFeatures = useMemo(
+    () =>
+      showDeprecated
+        ? features
+        : features.filter((f) => f.deprecated !== true),
+    [features, showDeprecated],
+  );
+  const deprecatedCount = useMemo(
+    () => features.filter((f) => f.deprecated === true).length,
+    [features],
+  );
+
   const featuresByCategory = useMemo(
     () =>
       categories
         .map((cat) => ({
           ...cat,
-          features: features.filter((f) => f.category === cat.id),
+          features: visibleFeatures.filter((f) => f.category === cat.id),
         }))
         .filter((cat) => cat.features.length > 0),
-    [categories, features],
+    [categories, visibleFeatures],
   );
 
   // Colspan for category separator row: base (Feature col) + integrations + optional ref-depth
@@ -504,10 +522,35 @@ export function FeatureGrid({
         <div className="flex items-center gap-3">
           <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
           <LiveIndicator status={connection} />
+          {deprecatedCount > 0 && (
+            <label
+              data-testid="show-deprecated-toggle"
+              className="ml-auto flex cursor-pointer items-center gap-1.5 text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              title={`${deprecatedCount} deprecated feature${deprecatedCount === 1 ? "" : "s"} hidden by default — toggle to show legacy/replaced patterns.`}
+            >
+              <input
+                type="checkbox"
+                checked={showDeprecated}
+                onChange={(e) => setShowDeprecated(e.target.checked)}
+                className="h-3.5 w-3.5 cursor-pointer accent-[var(--accent)]"
+              />
+              <span>
+                Show deprecated{" "}
+                <span className="text-[var(--text-muted)]">
+                  ({deprecatedCount})
+                </span>
+              </span>
+            </label>
+          )}
         </div>
         <p className="mt-1 text-sm text-[var(--text-secondary)]">
           {subtitle ? <>{subtitle} · </> : null}
-          {features.length} features × {integrations.length} integrations.
+          {visibleFeatures.length} features × {integrations.length}{" "}
+          integrations
+          {!showDeprecated && deprecatedCount > 0
+            ? ` (${deprecatedCount} deprecated hidden)`
+            : ""}
+          .
         </p>
       </header>
 

--- a/showcase/shell-dashboard/src/lib/registry.ts
+++ b/showcase/shell-dashboard/src/lib/registry.ts
@@ -11,6 +11,14 @@ export interface Feature {
   kind?: FeatureKind;
   og_docs_url?: string;
   shell_docs_path?: string;
+  /**
+   * `true` when the feature represents a legacy/replaced pattern that the
+   * gold-standard integration (LangGraph Python) intentionally does NOT
+   * implement. Other integrations may still serve the legacy demo, but
+   * the dashboard hides deprecated rows behind a "Show deprecated" toggle
+   * so the default gold-standard view stays clean.
+   */
+  deprecated?: boolean;
 }
 
 export interface FeatureCategory {


### PR DESCRIPTION
Brings the dashboard's gold-standard view in line with the desired naming and surfaces deprecated rows behind a toggle (instead of dropping them at catalog generation).

## Summary

- **28 renames in feature-registry.json + 20 in LGP `manifest.yaml`** — `name` and `demos[].name` aligned per the user-provided mapping. Same label everywhere so the dojo and dashboard agree.
- **`Show deprecated` toggle in feature-grid.tsx** — checkbox in the matrix header, default OFF. Filters feature rows where `feature.deprecated === true`. Toggle ON surfaces all deprecated features across all integrations (audit trail); toggle OFF hides them so the gold-standard view stays clean.
- **Reverted catalog-side filter from #4744** — the catalog now emits cells uniformly for all (integration × feature) pairs (back to 774 cells, 756 metadata.total_cells). Visibility is controlled at the dashboard layer. Toggling on shows complete cross-integration data without missing-cell artifacts.

## Naming highlights

| Was | Now |
|---|---|
| Pre-Built CopilotChat | Pre-Built: CopilotChat |
| Headless Chat (Simple/Complete) | Headless UI: Simple/Complete |
| Multi-modal / File Uploads | Attachments |
| Controlled Gen-UI (Display) | Generative UI: useComponent |
| In-Chat HITL (useHumanInTheLoop / useInterrupt) | Human In the Loop: In-chat / Interrupts |
| Headless Interrupt | Human in the Loop: Headless Interrupts |
| Declarative Generative UI (A2UI — Dynamic / Fixed Schema) | Declarative UI: Dynamic / Fixed A2UI |
| Fully Open-Ended Generative UI | Open Generative UI: Default |
| Open-Ended Gen UI (Advanced ...) | Open Generative UI: Custom |
| Tool Rendering (Default/Custom Catch-all/Specific) | Generative UI: Tool Rendering (...) |
| Tool Rendering + Reasoning Chain | Generative UI: Rendering multiple tools |
| Agentic Generative UI (...) | Generative UI: Agent State |
| Frontend Tools (In-app / Async) | Frontend Tools: In-app Actions / Async |
| In-App Human in the Loop (Frontend Tools + async HITL) | Human in the Loop: In-app |
| Shared State (Read + Write / Recipe Editor) | Shared State: Read + Write / Read-only |
| State Streaming | Shared State: Streaming |
| Readonly State (Agent Context) | Shared State: Frontend Context |
| BYOC Hashbrown / json-render | Declarative UI: Hashbrown / json-render |

## Deprecated toggle behavior

4 features marked `deprecated: true` in feature-registry.json: `agentic-chat-reasoning`, `hitl`, `hitl-in-chat-booking`, `reasoning-default-render`.

- **OFF (default)**: rows hidden across the matrix
- **ON**: rows render with normal cells. LGP shows N/A (unshipped) for the 4 since LGP doesn't declare them; other integrations show their actual probe state

Header text shows `(N deprecated hidden)` when toggle is off. Toggle only renders when `deprecatedCount > 0`.

## Test plan

- [x] `pnpm vitest run` in `showcase/scripts/__tests__/` → **18 / 18 passing**
- [x] `pnpm vitest run` in `showcase/harness/` → **1588 / 1588 passing**
- [x] `npx tsx showcase/scripts/validate-fixture-tool-surface.ts` → clean
- [x] `npx tsx showcase/scripts/generate-registry.ts` → 18 integrations, 38 wired LGP, 774 cells
- [ ] Verify the toggle on Vercel preview — it should appear in the matrix header, default unchecked, click expands rows by 4 (the 4 deprecated features rendering as new cells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)