### PR TITLE
fix(showcase): auth-readiness SignInCard + bump LGP models to gpt-5.4

### DIFF
--- a/showcase/harness/src/probes/drivers/e2e-readiness.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.ts
@@ -241,6 +241,13 @@ const READY_SELECTORS = [
   'input[placeholder="Type a message"]',
   'input[type="text"]',
   '[role="textbox"]',
+  // /demos/auth (and any future demo using the same pattern) renders a
+  // sign-in card BEFORE mounting the chat surface — the chat-input
+  // testids only appear post-authentication. Treat the SignInCard as a
+  // valid "demo mounted" signal so the readiness probe doesn't time
+  // out on the auth landing state. Per-demo end-to-end auth flow is
+  // covered by auth.spec.ts (e2e-demos), not this readiness probe.
+  '[data-testid="auth-sign-in-card"]',
 ] as const;
 
 /** Compound CSS selector: Playwright matches ANY of the comma-separated

--- a/showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py
@@ -115,7 +115,7 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     # SSE streams) sees this secondary LLM call. Without it the call
     # bypasses fixture matching in replay mode, surfacing as
     # "An internal error occurred" on the demo page.
-    model = ChatOpenAI(model="gpt-4.1", streaming=True)
+    model = ChatOpenAI(model="gpt-5.4", streaming=True)
     model_with_tool = model.bind_tools(
         [_design_a2ui_surface],
         tool_choice="_design_a2ui_surface",
@@ -180,7 +180,7 @@ SYSTEM_PROMPT = (
 
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4.1"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[generate_a2ui],
     middleware=[CopilotKitMiddleware()],
     system_prompt=SYSTEM_PROMPT,

--- a/showcase/integrations/langgraph-python/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/langgraph-python/src/agents/a2ui_fixed.py
@@ -87,7 +87,7 @@ def display_flight(origin: str, destination: str, airline: str, price: str) -> s
 
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[display_flight],
     middleware=[CopilotKitMiddleware()],
     system_prompt=(

--- a/showcase/integrations/langgraph-python/src/agents/agent_config_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/agent_config_agent.py
@@ -46,7 +46,7 @@ SYSTEM_PROMPT = (
 
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini", temperature=0.4),
+    model=ChatOpenAI(model="gpt-5.4", temperature=0.4),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt=SYSTEM_PROMPT,

--- a/showcase/integrations/langgraph-python/src/agents/agentic_chat.py
+++ b/showcase/integrations/langgraph-python/src/agents/agentic_chat.py
@@ -9,7 +9,7 @@ from langchain_openai import ChatOpenAI
 from copilotkit import CopilotKitMiddleware
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt="You are a helpful, concise assistant.",

--- a/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
+++ b/showcase/integrations/langgraph-python/src/agents/beautiful_chat.py
@@ -269,7 +269,7 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
 
     prompt = f"{_GENERATE_A2UI_PROMPT_HEADER}\n\n{context_text}".strip()
 
-    model = ChatOpenAI(model="gpt-4.1")
+    model = ChatOpenAI(model="gpt-5.4")
     model_with_tool = model.bind_tools(
         [_design_a2ui_surface],
         tool_choice="_design_a2ui_surface",
@@ -317,7 +317,7 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
 
 # ─── Graph ──────────────────────────────────────────────────────────
 
-model = ChatOpenAI(model="gpt-5-mini", model_kwargs={"parallel_tool_calls": False})
+model = ChatOpenAI(model="gpt-5.4", model_kwargs={"parallel_tool_calls": False})
 
 agent = create_agent(
     model=model,

--- a/showcase/integrations/langgraph-python/src/agents/byoc_hashbrown_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/byoc_hashbrown_agent.py
@@ -95,7 +95,7 @@ Example response (sales dashboard):
 # aligns the wire-level contract with what the parser accepts.
 graph = create_agent(
     model=ChatOpenAI(
-        model="gpt-4o-mini",
+        model="gpt-5.4",
         model_kwargs={"response_format": {"type": "json_object"}},
     ),
     tools=[],

--- a/showcase/integrations/langgraph-python/src/agents/byoc_json_render_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/byoc_json_render_agent.py
@@ -150,7 +150,7 @@ Respond with the JSON object only.
 # which is exactly what `<Renderer />` needs.
 graph = create_agent(
     model=ChatOpenAI(
-        model="gpt-4o-mini",
+        model="gpt-5.4",
         temperature=0.2,
         model_kwargs={"response_format": {"type": "json_object"}},
     ),

--- a/showcase/integrations/langgraph-python/src/agents/frontend_tools.py
+++ b/showcase/integrations/langgraph-python/src/agents/frontend_tools.py
@@ -10,7 +10,7 @@ from langchain_openai import ChatOpenAI
 from copilotkit import CopilotKitMiddleware
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt="You are a helpful, concise assistant.",

--- a/showcase/integrations/langgraph-python/src/agents/frontend_tools_async.py
+++ b/showcase/integrations/langgraph-python/src/agents/frontend_tools_async.py
@@ -25,7 +25,7 @@ SYSTEM_PROMPT = (
 )
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt=SYSTEM_PROMPT,

--- a/showcase/integrations/langgraph-python/src/agents/gen_ui_tool_based.py
+++ b/showcase/integrations/langgraph-python/src/agents/gen_ui_tool_based.py
@@ -19,7 +19,7 @@ categories; pick pie for composition / share-of-whole.
 Keep chat responses brief -- let the chart do the talking."""
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt=SYSTEM_PROMPT,

--- a/showcase/integrations/langgraph-python/src/agents/headless_complete.py
+++ b/showcase/integrations/langgraph-python/src/agents/headless_complete.py
@@ -103,7 +103,7 @@ def get_revenue_chart() -> dict:
 
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[get_weather, get_stock_price, get_revenue_chart],
     middleware=[CopilotKitMiddleware()],
     system_prompt=SYSTEM_PROMPT,

--- a/showcase/integrations/langgraph-python/src/agents/hitl_in_app.py
+++ b/showcase/integrations/langgraph-python/src/agents/hitl_in_app.py
@@ -54,7 +54,7 @@ SYSTEM_PROMPT = (
 
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt=SYSTEM_PROMPT,

--- a/showcase/integrations/langgraph-python/src/agents/hitl_in_chat_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/hitl_in_chat_agent.py
@@ -10,7 +10,7 @@ from langchain_openai import ChatOpenAI
 from copilotkit import CopilotKitMiddleware
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt=(

--- a/showcase/integrations/langgraph-python/src/agents/interrupt_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/interrupt_agent.py
@@ -92,7 +92,7 @@ def schedule_meeting(topic: str, attendee: Optional[str] = None) -> str:
 # @endregion[backend-interrupt-tool]
 
 
-model = ChatOpenAI(model="gpt-4o-mini")
+model = ChatOpenAI(model="gpt-5.4")
 
 graph = create_agent(
     model=model,

--- a/showcase/integrations/langgraph-python/src/agents/main.py
+++ b/showcase/integrations/langgraph-python/src/agents/main.py
@@ -13,7 +13,7 @@ from copilotkit import CopilotKitMiddleware
 
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt="You are a helpful, concise assistant.",

--- a/showcase/integrations/langgraph-python/src/agents/mcp_apps_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/mcp_apps_agent.py
@@ -56,7 +56,7 @@ graph = create_agent(
     # gpt-4o-mini for speed — Excalidraw element emission is simple
     # JSON and we're biasing hard toward sub-30s generation. A faster
     # model produces shorter, quicker outputs with acceptable layouts.
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt=SYSTEM_PROMPT,

--- a/showcase/integrations/langgraph-python/src/agents/multimodal_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/multimodal_agent.py
@@ -238,7 +238,7 @@ class _PdfFlattenMiddleware(AgentMiddleware):
 
 
 # Vision-capable model. gpt-4o consumes `image_url` content parts natively.
-_MODEL = ChatOpenAI(model="gpt-4o", temperature=0.2)
+_MODEL = ChatOpenAI(model="gpt-5.4", temperature=0.2)
 
 
 graph = create_agent(

--- a/showcase/integrations/langgraph-python/src/agents/open_gen_ui_advanced_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/open_gen_ui_advanced_agent.py
@@ -83,7 +83,7 @@ Generation guidance:
 
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4.1", model_kwargs={"parallel_tool_calls": False}),
+    model=ChatOpenAI(model="gpt-5.4", model_kwargs={"parallel_tool_calls": False}),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt=SYSTEM_PROMPT,

--- a/showcase/integrations/langgraph-python/src/agents/open_gen_ui_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/open_gen_ui_agent.py
@@ -58,7 +58,7 @@ rendered visualisation.
 
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4.1", model_kwargs={"parallel_tool_calls": False}),
+    model=ChatOpenAI(model="gpt-5.4", model_kwargs={"parallel_tool_calls": False}),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt=SYSTEM_PROMPT,

--- a/showcase/integrations/langgraph-python/src/agents/readonly_state_agent_context.py
+++ b/showcase/integrations/langgraph-python/src/agents/readonly_state_agent_context.py
@@ -19,7 +19,7 @@ from copilotkit import CopilotKitMiddleware
 
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[],
     middleware=[CopilotKitMiddleware()],
     system_prompt=(

--- a/showcase/integrations/langgraph-python/src/agents/reasoning_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/reasoning_agent.py
@@ -24,7 +24,7 @@ SYSTEM_PROMPT = (
     "step-by-step about the approach, then give a concise answer."
 )
 
-REASONING_MODEL = os.environ.get("OPENAI_REASONING_MODEL", "gpt-5-mini")
+REASONING_MODEL = os.environ.get("OPENAI_REASONING_MODEL", "gpt-5.4")
 
 graph = create_deep_agent(
     model=init_chat_model(

--- a/showcase/integrations/langgraph-python/src/agents/shared_state_read_write.py
+++ b/showcase/integrations/langgraph-python/src/agents/shared_state_read_write.py
@@ -136,7 +136,7 @@ class PreferencesInjectorMiddleware(AgentMiddleware[AgentState, Any]):
 
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[set_notes],
     middleware=[CopilotKitMiddleware(), PreferencesInjectorMiddleware()],
     state_schema=AgentState,

--- a/showcase/integrations/langgraph-python/src/agents/shared_state_streaming.py
+++ b/showcase/integrations/langgraph-python/src/agents/shared_state_streaming.py
@@ -60,7 +60,7 @@ def write_document(document: str, runtime: ToolRuntime) -> Command:
 
 # @region[state-streaming-middleware]
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[write_document],
     middleware=[
         CopilotKitMiddleware(),

--- a/showcase/integrations/langgraph-python/src/agents/subagents.py
+++ b/showcase/integrations/langgraph-python/src/agents/subagents.py
@@ -73,7 +73,7 @@ class AgentState(BaseAgentState):
 # Each sub-agent is a full-fledged `create_agent(...)` with its own
 # system prompt. They don't share memory or tools with the supervisor —
 # the supervisor only sees their return value.
-_sub_model = ChatOpenAI(model="gpt-4o-mini")
+_sub_model = ChatOpenAI(model="gpt-5.4")
 
 _research_agent = create_agent(
     model=_sub_model,
@@ -278,7 +278,7 @@ def critique_agent(task: str, runtime: ToolRuntime) -> Command:
 # ---------------------------------------------------------------------------
 
 graph = create_agent(
-    model=ChatOpenAI(model="gpt-4o-mini"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[research_agent, writing_agent, critique_agent],
     middleware=[CopilotKitMiddleware()],
     state_schema=AgentState,

--- a/showcase/integrations/langgraph-python/src/agents/tool_rendering_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/tool_rendering_agent.py
@@ -134,7 +134,7 @@ def roll_d20(value: int = 0) -> dict:
     return {"sides": 20, "value": rolled, "result": rolled}
 
 
-model = ChatOpenAI(model="gpt-4o-mini")
+model = ChatOpenAI(model="gpt-5.4")
 
 graph = create_agent(
     model=model,

--- a/showcase/integrations/langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py
@@ -62,7 +62,7 @@ SYSTEM_PROMPT = (
     "reason step-by-step and call 2+ tools in succession when relevant."
 )
 
-REASONING_MODEL = os.environ.get("OPENAI_REASONING_MODEL", "gpt-5-mini")
+REASONING_MODEL = os.environ.get("OPENAI_REASONING_MODEL", "gpt-5.4")
 
 graph = create_deep_agent(
     model=init_chat_model(


### PR DESCRIPTION
Two related changes for the LGP gold-standard view:

## 1. e2e-readiness accepts `/demos/auth` SignInCard

Fixes the spurious **D2 / RT ✗** state on the LGP `auth` cell. The demo itself works fine end-to-end — the issue was the `e2e-readiness` probe waits for chat-input testids in [`READY_SELECTORS`](showcase/harness/src/probes/drivers/e2e-readiness.ts:236), but `/demos/auth` renders a `<SignInCard>` BEFORE mounting the chat surface (chat input only appears post-authentication). Result: 30s timeout (`per-demo deadline exceeded after 30000ms`).

Added `[data-testid="auth-sign-in-card"]` to `READY_SELECTORS` so the probe accepts SignInCard as a valid "demo mounted" signal. End-to-end auth flow stays covered by `auth.spec.ts` under e2e-demos.

## 2. Bump all LGP agents to `gpt-5.4`

Swapped every `ChatOpenAI` / `init_chat_model` call across the 26 LGP agents from the prior mix (`gpt-4o-mini`, `gpt-4o`, `gpt-4.1`, `gpt-5-mini`) to the unified `gpt-5.4`. Also updated the `OPENAI_REASONING_MODEL` env default in `reasoning_agent.py` and `tool_rendering_reasoning_chain_agent.py` so reasoning demos pick up the new model unless explicitly overridden.

Verified locally — all 39 LGP demos render and respond correctly with `gpt-5.4`. The probe sweep on prod will confirm end-to-end.

## Test plan

- [x] `pnpm vitest run e2e-readiness` in `showcase/harness/` → **31 / 31 passing**
- [x] Local LGP container running gpt-5.4 against real OpenAI — all demos respond
- [ ] Post-merge: `e2e:langgraph-python/auth` flips green on next e2e-demos tick (hourly at `:10`)
- [ ] Post-merge: every D5 cell across LGP confirms model resolves on next e2e-deep tick

## Companion observation (NOT in this PR)

While diagnosing the auth issue, also noticed 3 LGP D5 cells went red recently:
- `gen-ui-interrupt`, `interrupt-headless` — testid mount timeouts
- `shared-state-streaming` — document content didn't stream

Subagent investigation found **no code-side regression** — fixtures, agents, and probe scripts are intact; the cells were green a few hours earlier with the same code. Most likely a transient aimock blip or cold-start. The driver-level retry-once added in PR #4743 should self-heal them on the next 1-2 ticks. Monitor; if persistent, check aimock Railway logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)