### PR TITLE
fix(showcase/langgraph-python): force reasoning emission in reasoning-chain agent

### DIFF
--- a/showcase/integrations/langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py
@@ -68,7 +68,14 @@ graph = create_deep_agent(
     model=init_chat_model(
         f"openai:{REASONING_MODEL}",
         use_responses_api=True,
-        reasoning={"effort": "low", "summary": "auto"},
+        # `summary: "detailed"` forces reasoning-summary emission on every
+        # response. The previous `"auto"` lets the model decide, and with
+        # tools present the model often skips reasoning summaries entirely
+        # (the chain-of-thought goes straight to a tool call without the
+        # summary step). That breaks the `<ReasoningBlock>` mount because
+        # no reasoning-role message lands. Match the working
+        # `reasoning_agent.py` config: medium effort + detailed summary.
+        reasoning={"effort": "medium", "summary": "detailed"},
     ),
     tools=[get_weather, search_flights, get_stock_price, roll_dice],
     system_prompt=SYSTEM_PROMPT,


### PR DESCRIPTION
## Summary

`tool-rendering-reasoning-chain` D5 probe has been **sustained red since it was added** (PR #4743) — every tick fails with `expected [data-testid="reasoning-block"] to mount within 30000ms`.

Diagnostic dumps from prod confirmed the failure mode:
- ✅ WeatherCard mounted (toolCalls fire correctly)
- ✅ Assistant text "Tokyo is 22°C and partly cloudy" landed
- ❌ Zero reasoning text — the `reasoningMessage` slot never received an event

## Root cause

Comparing to the working `reasoning_agent.py` (which backs `reasoning-default` + `reasoning-custom`, both D5 green):

| | `reasoning_agent.py` (works) | `tool_rendering_reasoning_chain_agent.py` (was broken) |
|---|---|---|
| `effort` | `"medium"` | `"low"` |
| `summary` | `"detailed"` | `"auto"` |
| tools | `[]` | `[get_weather, search_flights, get_stock_price, roll_dice]` |

`summary: "auto"` lets the model decide whether to emit a reasoning summary. With tools present, the model frequently skips emission entirely — the chain-of-thought goes straight to the tool call without a summary step. That leaves `role: "reasoning"` messages off the wire, so the v2 `<ReasoningBlock>` slot never mounts.

`summary: "detailed"` forces emission on every response. Bumping `effort` to `"medium"` to match the working agent.

## Test plan

- [x] PR #4744 already added `reasoning` field to the aimock fixture for `weather in Tokyo` first leg — that part of the wire is fine
- [x] Confirmed via prod diagnostic: the rest of the demo (tool rendering, assistant text) works
- [ ] Post-merge: `tool-rendering-reasoning-chain` should flip green on the next e2e-deep tick

## Known follow-up (NOT in this PR)

`gen-ui-agent` (Agent State) is intermittently flapping (~22% failure rate over recent ticks), with two distinct error modes ("no assistant response" and "agent-state-card never mounts"). Need to dig deeper to determine root cause — separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)