### PR TITLE
fix(showcase/langgraph-python): collapse gen-ui-agent to single set_steps call

### DIFF
--- a/showcase/integrations/langgraph-python/src/agents/gen_ui_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/gen_ui_agent.py
@@ -69,28 +69,33 @@ def set_steps(
 
 
 SYSTEM_PROMPT = (
-    "You are an agentic planner. For each user request, follow this exact "
-    "sequence:\n"
-    "1. Plan exactly 3 concrete steps and call `set_steps` ONCE with all "
-    'three steps at status="pending".\n'
-    '2. Step 1: call `set_steps` with step 1 at status="in_progress", '
-    'then call `set_steps` again with step 1 at status="completed".\n'
-    '3. Step 2: call `set_steps` with step 2 at status="in_progress", '
-    'then call `set_steps` again with step 2 at status="completed".\n'
-    '4. Step 3: call `set_steps` with step 3 at status="in_progress", '
-    'then call `set_steps` again with step 3 at status="completed".\n'
-    "5. Send ONE final conversational assistant message summarizing the "
-    "plan, then stop. Do not call any more tools after step 3 is "
-    "completed.\n"
+    "You are an agentic planner. For each user request:\n"
     "\n"
-    "Rules: never call set_steps in parallel — always wait for one call to "
-    "return before the next. After all three steps are completed you MUST "
-    "send a final assistant message and terminate."
+    "1. Plan exactly 3 concrete steps and call `set_steps` ONCE with all "
+    "three steps in a single call. Use the appropriate status for each "
+    '(typically `"completed"` for all three when the plan is fully '
+    "specified, or a mix of statuses for in-progress work — but always "
+    "emit ALL three steps in a single call).\n"
+    "2. Send ONE final conversational assistant message summarizing the "
+    "plan, then stop. Do NOT call set_steps again.\n"
+    "\n"
+    "Rules: ONE set_steps call total — never call it twice. Never call "
+    "tools in parallel. After the single set_steps call you MUST send a "
+    "final assistant message and terminate.\n"
+    "\n"
+    "Why one call: the frontend renders state.steps as a single live "
+    "card; one all-at-once update keeps the UX consistent and the "
+    "agent-loop deterministic. Iterating set_steps multiple times "
+    "(e.g. pending → in_progress → completed transitions) is "
+    "non-deterministic against fixture-driven test runs and adds "
+    "supersteps that can blow the recursion limit on flaky LLM responses."
 )
 
 
-# Worst-case supersteps for a clean run: 1 plan + 6 transitions + 1 final
-# message = ~14. Doubled for headroom against retries inside the LLM loop.
+# Worst-case supersteps for a clean run: 1 set_steps + 1 final message + a
+# few LangGraph plumbing supersteps = ~5. Keeping recursion_limit=50 as
+# generous headroom that should never be hit when the LLM follows the
+# single-set_steps-call instruction.
 graph = create_agent(
     model=init_chat_model(
         "openai:gpt-4o-mini", temperature=0, use_responses_api=False


### PR DESCRIPTION
## Summary

`gen-ui-agent` (Agent State) D5 cell has been intermittently flapping at **~22% red rate** with two distinct error modes:
- `timeout: assistant did not respond within 60000ms (baseline=0, current=0)`
- `expected [data-testid="agent-state-card"] to mount within 60000ms`

## Root cause

The system prompt instructed the agent to call `set_steps` **seven times**:
1. Plan all 3 with `status="pending"`
2. Step 1: in_progress → completed (2 calls)
3. Step 2: in_progress → completed (2 calls)
4. Step 3: in_progress → completed (2 calls)
5. Final assistant message

But the **aimock fixture returns all 3 steps already at `status="completed"`** in a single response. The LLM (gpt-4o-mini @ temp=0) sees both the iterate-7-times prompt AND the all-completed return — sometimes it follows the prompt and tries to iterate (burning supersteps + emitting tool calls aimock can't disambiguate), sometimes it reads the all-completed state and terminates early. Non-deterministic.

## Fix

Simplify the system prompt to a **single `set_steps` call** with all three steps emitted at once, matching the fixture shape. Trade-off: lose progressive visual transitions in the demo (which the fixture wasn't producing anyway), gain deterministic agent-loop behavior across both fixture-driven probe runs and real-LLM testing. The agent-state-card renders the same either way.

## Test plan

- [x] System prompt now describes a single set_steps call with all 3 steps at appropriate final status
- [ ] Post-merge: `gen-ui-agent` should hold green across consecutive e2e-deep ticks (was 7/9 green before; should be 9/9 with the deterministic flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)