### PR TITLE
fix(docs): generate proper markdown llms.txt

### DIFF
--- a/docs/app/llms-full.txt/route.ts
+++ b/docs/app/llms-full.txt/route.ts
@@ -1,0 +1,20 @@
+import { source } from "@/app/source";
+import { getLLMText } from "@/lib/get-llm-text";
+
+export const revalidate = false;
+
+export async function GET() {
+  const scanned = await Promise.all(
+    source
+      .getPages()
+      .slice()
+      .sort((a, b) => a.url.localeCompare(b.url))
+      .map(getLLMText),
+  );
+
+  return new Response(scanned.join("\n\n"), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -1,0 +1,27 @@
+import { source } from "@/app/source";
+import { getLLMText } from "@/lib/get-llm-text";
+import { notFound } from "next/navigation";
+
+export const revalidate = false;
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug?: string[] }> },
+) {
+  const { slug } = await params;
+  const page = source.getPage(slug);
+
+  if (!page) {
+    notFound();
+  }
+
+  return new Response(await getLLMText(page), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}
+
+export function generateStaticParams() {
+  return source.generateParams();
+}

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -1,0 +1,38 @@
+import { source } from "@/app/source";
+import { getMarkdownPath } from "@/lib/get-llm-text";
+
+export const revalidate = false;
+
+export function GET(request: Request) {
+  const origin = new URL(request.url).origin;
+  const pages = source
+    .getPages()
+    .slice()
+    .sort((a, b) => a.url.localeCompare(b.url));
+
+  const lines = [
+    "# CopilotKit Docs",
+    "",
+    "> AI-friendly markdown index for CopilotKit documentation.",
+    "",
+    "Every link below points to a markdown version of the corresponding docs page.",
+    "Use llms-full.txt when you want the full docs corpus in one file.",
+    "",
+    "## Docs",
+    "",
+    ...pages.map((page) => {
+      const description = page.data.description ? `: ${page.data.description}` : "";
+      return `- [${page.data.title}](${origin}${getMarkdownPath(page.url)})${description}`;
+    }),
+    "",
+    "## Optional",
+    "",
+    `- [Full documentation](${origin}/llms-full.txt): Complete CopilotKit docs in a single markdown file.`,
+  ];
+
+  return new Response(lines.join("\n"), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/docs/content/docs/(root)/index.mdx
+++ b/docs/content/docs/(root)/index.mdx
@@ -123,5 +123,5 @@ import { FeatureMatrix } from "@/components/react/feature-matrix"
 <FeatureMatrix />
 
 <div className="mt-16 border-t border-neutral-200 dark:border-neutral-800 pt-4 text-center text-xs text-neutral-400 dark:text-neutral-500">
-  MCP server: <a href="https://mcp.copilotkit.ai/mcp" className="underline hover:text-neutral-500 dark:hover:text-neutral-400">https://mcp.copilotkit.ai/mcp</a> · llms.txt: <a href="https://mcp.copilotkit.ai/llms.txt" className="underline hover:text-neutral-500 dark:hover:text-neutral-400">https://mcp.copilotkit.ai/llms.txt</a> · Powered by <a href="https://pathfinder.copilotkit.dev" className="underline hover:text-neutral-500 dark:hover:text-neutral-400">Pathfinder</a>
+  MCP server: <a href="https://mcp.copilotkit.ai/mcp" className="underline hover:text-neutral-500 dark:hover:text-neutral-400">https://mcp.copilotkit.ai/mcp</a> · llms.txt: <a href="https://docs.copilotkit.ai/llms.txt" className="underline hover:text-neutral-500 dark:hover:text-neutral-400">https://docs.copilotkit.ai/llms.txt</a> · Powered by <a href="https://pathfinder.copilotkit.dev" className="underline hover:text-neutral-500 dark:hover:text-neutral-400">Pathfinder</a>
 </div>

--- a/docs/lib/get-llm-text.ts
+++ b/docs/lib/get-llm-text.ts
@@ -1,0 +1,16 @@
+import { source } from "@/app/source";
+
+type DocPage = ReturnType<typeof source.getPages>[number];
+
+export function getMarkdownPath(url: string) {
+  return url === "/" ? "/index.md" : `${url}.md`;
+}
+
+export async function getLLMText(page: DocPage) {
+  const processed = await page.data.getText("processed");
+  const description = page.data.description
+    ? `> ${page.data.description}\n\n`
+    : "";
+
+  return `# ${page.data.title} (${page.url})\n\n${description}${processed}`;
+}

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -149,6 +149,14 @@ const config = {
           source: '/ingest/:path*',
           destination: 'https://eu.i.posthog.com/:path*',
         },
+        {
+          source: '/index.md',
+          destination: '/llms.mdx',
+        },
+        {
+          source: '/:path*.md',
+          destination: '/llms.mdx/:path*',
+        },
         // Map /guides/* to /built-in-agent/guides/* (legacy path)
         {
           source: '/guides/:path*',
@@ -174,17 +182,6 @@ const config = {
 
     // Manual redirects for specific cases
     const manualRedirects = [
-      // llms.txt files are served from mcp.copilotkit.ai
-      {
-        source: '/llms.txt',
-        destination: 'https://mcp.copilotkit.ai/llms.txt',
-        permanent: true,
-      },
-      {
-        source: '/llms-full.txt',
-        destination: 'https://mcp.copilotkit.ai/llms-full.txt',
-        permanent: true,
-      },
       // Redirect /whats-new/v1-50 to /learn/whats-new/v1-50
       {
         source: '/whats-new/v1-50',

--- a/docs/snippets/shared/guides/mcp-server-setup.mdx
+++ b/docs/snippets/shared/guides/mcp-server-setup.mdx
@@ -10,10 +10,10 @@ development environment, it enables AI assistants to:
 For tools that don't support MCP — or when you want to drop CopilotKit's docs straight into a model's context — the same knowledge is published as an [llms.txt](https://llmstxt.org/) file:
 
 ```
-https://mcp.copilotkit.ai/llms.txt
+https://docs.copilotkit.ai/llms.txt
 ```
 
-Point your AI tool at that URL (or paste its contents into a system prompt) to give it the same CopilotKit reference material the MCP server uses.
+Point your AI tool at that URL (or paste its contents into a system prompt) to give it a markdown index of the CopilotKit docs. For the full docs corpus in one file, use `https://docs.copilotkit.ai/llms-full.txt`.
 
 ## Cursor
 [Cursor](https://cursor.sh/) is an AI-powered code editor built for productivity. It features built-in AI assistance and supports MCP for extending AI capabilities with external tools.

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -29,6 +29,9 @@ const extendedFrontmatterSchema = frontmatterSchema.extend({
 export const docs = defineDocs({
   docs: {
     schema: extendedFrontmatterSchema,
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
   },
   meta: {
     schema: metaSchema,


### PR DESCRIPTION
## Summary
- generate `docs.copilotkit.ai/llms.txt` from the Fumadocs source instead of redirecting to the MCP index
- add `/llms-full.txt` and per-page `.md` markdown routes for AI-friendly docs access
- update docs copy to point to the new docs-hosted llms endpoints

## Validation
- `npx next build`