### PR TITLE
docs: fix useCopilotContext import path in persistence guides

### DIFF
--- a/docs/content/docs/integrations/crewai-flows/persistence/loading-message-history.mdx
+++ b/docs/content/docs/integrations/crewai-flows/persistence/loading-message-history.mdx
@@ -69,7 +69,7 @@ const YourApp = ({ setThreadId }) => {
 CopilotKit provides the current `threadId` and a `setThreadId` function from the `useCopilotContext` hook:
 
 ```tsx
-import { useCopilotContext } from "@copilotkit/react-core/v2";
+import { useCopilotContext } from "@copilotkit/react-core";
 
 const ChangeThreadButton = () => {
   const { threadId, setThreadId } = useCopilotContext();

--- a/docs/content/docs/integrations/langgraph/advanced/persistence/loading-message-history.mdx
+++ b/docs/content/docs/integrations/langgraph/advanced/persistence/loading-message-history.mdx
@@ -59,7 +59,7 @@ const YourApp = ({ setThreadId }) => {
 CopilotKit will also return the current `threadId` and a `setThreadId` function from the `useCopilotContext` hook. You can use `setThreadId` to change the `threadId`.
 
 ```tsx
-import { useCopilotContext } from "@copilotkit/react-core/v2";
+import { useCopilotContext } from "@copilotkit/react-core";
 
 const ChangeThreadButton = () => {
   const { threadId, setThreadId } = useCopilotContext(); // [!code highlight]


### PR DESCRIPTION
## Problem

In the LangGraph and CrewAI Flows persistence guides, the "Using setThreadId" code samples import `useCopilotContext` from `@copilotkit/react-core/v2`:

```tsx
import { useCopilotContext } from "@copilotkit/react-core/v2";
```

This subpath does not export `useCopilotContext` — only the V1 entry (`@copilotkit/react-core`) does, via [`packages/react-core/src/context/index.ts`](https://github.com/CopilotKit/CopilotKit/blob/main/packages/react-core/src/context/index.ts). Copy-pasting the snippet fails to compile with:

```
Module '"@copilotkit/react-core/v2"' has no exported member 'useCopilotContext'.
```

Reported in #3860.

## Solution

Update the import path in both guides to `@copilotkit/react-core` so the snippet matches the actual public API.

Files changed:
- `docs/content/docs/integrations/langgraph/advanced/persistence/loading-message-history.mdx`
- `docs/content/docs/integrations/crewai-flows/persistence/loading-message-history.mdx`

## Testing

Doc-only change; no runtime behavior. Verified that `useCopilotContext` is exported from `@copilotkit/react-core` and not from the `/v2` subpath.

Closes #3860