### PR TITLE
chore(showcase): deprecate legacy byoc-* feature IDs

### DIFF
--- a/showcase/shared/feature-registry.json
+++ b/showcase/shared/feature-registry.json
@@ -391,25 +391,27 @@
       "id": "byoc-hashbrown",
       "name": "Declarative UI: Hashbrown",
       "category": "byoc",
-      "description": "Hashbrown-style generative UI"
+      "description": "Hashbrown-style generative UI (legacy slug — superseded by `declarative-hashbrown`; kept so the other 17 integrations whose manifests still declare this ID don't drop out of the catalog before their cross-codebase rename lands)",
+      "deprecated": true
     },
     {
       "id": "byoc-json-render",
       "name": "Declarative UI: json-render",
       "category": "byoc",
-      "description": "Streaming structured-output generative UI via @json-render/react"
+      "description": "Streaming structured-output generative UI via @json-render/react (legacy slug — superseded by `declarative-json-render`; kept for cross-integration parity until the rename completes elsewhere)",
+      "deprecated": true
     },
     {
       "id": "declarative-hashbrown",
       "name": "Declarative UI: Hashbrown",
       "category": "byoc",
-      "description": "Hashbrown-style generative UI (renamed slug — both `byoc-hashbrown` and `declarative-hashbrown` map to the same demo concept; langgraph-python uses the renamed form, every other integration uses the legacy form until the cross-codebase rename lands)"
+      "description": "Hashbrown-style generative UI"
     },
     {
       "id": "declarative-json-render",
       "name": "Declarative UI: json-render",
       "category": "byoc",
-      "description": "Streaming structured-output generative UI via @json-render/react (renamed slug — see `declarative-hashbrown` for the legacy/declarative duality)"
+      "description": "Streaming structured-output generative UI via @json-render/react"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Marks the legacy `byoc-hashbrown` and `byoc-json-render` registry entries as `"deprecated": true` so the dashboard's "Show deprecated" toggle hides them by default.

[#4756](https://github.com/CopilotKit/CopilotKit/pull/4756) renamed langgraph-python's `byoc-*` slugs to `declarative-*` but kept the legacy IDs in the registry so the other 17 integrations (whose manifests still declare `byoc-*`) wouldn't drop out of the catalog. That left the BYOC (Bring Your Own Components) section showing **both** rows for each of the two demos — legacy IDs red-X'd for langgraph-python (no manifest declaration there anymore) and the renamed IDs green.

This PR keeps both ID forms live (the other 17 integrations still need the legacy entries) but hides the legacy duplicates behind the standard `deprecated` flag — same pattern already used for `agentic-chat-reasoning`, `hitl`, `hitl-in-chat-booking`, `reasoning-default-render`. The dashboard's "Show deprecated" toggle in `feature-grid.tsx` decides visibility from there.

## Why

The dashboard view post-#4756 was confusing — two identical-looking "Declarative UI: Hashbrown" / "Declarative UI: json-render" rows where one is green and one is red. Deprecating the legacy entries gives readers one canonical row per demo by default while preserving the data path the other 17 integrations rely on.

## Test plan

- [x] `showcase/scripts` vitest suite green (574 tests)
- [x] `npx tsx generate-registry.ts` regenerates `catalog.json` for all four shells without errors
- [x] No catalog count changes (deprecated cells stay in the catalog, only dashboard visibility changes)

## Related

- [#4756](https://github.com/CopilotKit/CopilotKit/pull/4756) — the slug rename that introduced the duplicate rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)