### PR TITLE
fix(showcase/voice): use real Whisper for mic transcription

### DIFF
--- a/showcase/integrations/langgraph-python/langgraph.json
+++ b/showcase/integrations/langgraph-python/langgraph.json
@@ -1,5 +1,6 @@
 {
   "dependencies": ["."],
+  "env": ".env",
   "graphs": {
     "sample_agent": "./src/agents/main.py:graph",
     "tool_rendering": "./src/agents/tool_rendering_agent.py:graph",

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-voice/[[...slug]]/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-voice/[[...slug]]/route.ts
@@ -47,10 +47,15 @@ const voiceDemoAgent = new LangGraphAgent({
  * the real OpenAI-backed service; any upstream Whisper error keeps its
  * natural categorization.
  *
- * Note: The `new OpenAI({ apiKey })` call below intentionally omits
- * `baseURL` so the SDK falls through to `process.env.OPENAI_BASE_URL`.
- * In D5 tests this env var points at aimock, giving deterministic
- * transcription responses without hitting real Whisper.
+ * Note: We pin `baseURL` to real OpenAI (or `OPENAI_TRANSCRIPTION_BASE_URL`
+ * when explicitly set) instead of falling through to `OPENAI_BASE_URL`. In
+ * local docker / Railway preview environments `OPENAI_BASE_URL` points at
+ * aimock so LLM completions stay deterministic, but aimock has a catchall
+ * `endpoint: "transcription"` fixture that would otherwise intercept every
+ * real mic recording and return the canned "What is the weather in Tokyo?"
+ * phrase regardless of what the user actually said. The sample-audio button
+ * is the deterministic affordance (synchronous text injection); the mic is
+ * the only path that should exercise real Whisper.
  */
 // @region[transcription-service-guard]
 class GuardedOpenAITranscriptionService extends TranscriptionService {
@@ -59,8 +64,12 @@ class GuardedOpenAITranscriptionService extends TranscriptionService {
   constructor() {
     super();
     const apiKey = process.env.OPENAI_API_KEY;
+    const baseURL =
+      process.env.OPENAI_TRANSCRIPTION_BASE_URL ?? "https://api.openai.com/v1";
     this.delegate = apiKey
-      ? new TranscriptionServiceOpenAI({ openai: new OpenAI({ apiKey }) })
+      ? new TranscriptionServiceOpenAI({
+          openai: new OpenAI({ apiKey, baseURL }),
+        })
       : null;
   }
 

--- a/showcase/integrations/langgraph-python/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/voice/sample-audio-button.tsx
@@ -37,7 +37,7 @@ export function SampleAudioButton({
       className="inline-flex w-fit items-center gap-2 rounded-md border border-black/10 bg-white px-3 py-1.5 text-xs font-medium hover:bg-black/5 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
     >
       <span aria-hidden>🎙</span>
-      <span>Try a sample question</span>
+      <span>Try a sample audio</span>
     </button>
   );
 }

--- a/showcase/integrations/langgraph-python/tests/e2e/voice.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/voice.spec.ts
@@ -27,23 +27,20 @@ test.describe("Voice Input", () => {
       page.getByRole("heading", { name: "Voice input" }),
     ).toBeVisible();
     await expect(
-      page.locator('[data-testid="voice-sample-audio"]'),
-    ).toBeVisible();
-    await expect(
       page.locator('[data-testid="voice-sample-audio-button"]'),
     ).toBeEnabled();
-    await expect(
-      page.getByText('Sample: "What is the weather in Tokyo?"'),
-    ).toBeVisible();
+    await expect(page.getByText("Try a sample audio")).toBeVisible();
     await expect(
       page.locator('[data-testid="copilot-chat-input"]'),
     ).toBeVisible();
     // The mic button is the authoritative signal that the runtime advertised
     // `audioFileTranscriptionEnabled: true` — i.e. transcriptionService is
     // wired on /api/copilotkit-voice. Exposed by react-core's v2 CopilotChatInput.
+    // It renders after the /info round trip resolves on the client, which on
+    // a cold dev server can exceed Playwright's 5s default — give it room.
     await expect(
       page.locator('[data-testid="copilot-start-transcribe-button"]'),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
   });
 
   test("sample audio button injects the canned phrase into the input", async ({
@@ -68,6 +65,10 @@ test.describe("Voice Input", () => {
   test("sending the transcribed text produces a weather tool render", async ({
     page,
   }) => {
+    // The end-to-end flow (click → run agent → first assistant chunk) can run
+    // up to ~50s on a cold langgraph dev server, so override the default 30s
+    // suite timeout to give the locator's own 45s timeout headroom.
+    test.setTimeout(90_000);
     const sampleButton = page.locator(
       '[data-testid="voice-sample-audio-button"]',
     );


### PR DESCRIPTION
## Summary

- The voice route's OpenAI client used to fall through to `OPENAI_BASE_URL`, which `docker-compose.local.yml` sets to `http://aimock:4010/v1`. Aimock has a catchall `endpoint: "transcription"` fixture that returns `"What is the weather in Tokyo?"` for every audio file, so the mic button always produced that phrase regardless of what the user actually said into the microphone. Pin `baseURL` to real OpenAI Whisper (overridable via `OPENAI_TRANSCRIPTION_BASE_URL`). The sample-audio button stays as synchronous text injection — that's the documented design and what the e2e + d5 probe rely on.
- Tidy the sample-audio button label so the affordance matches what it does: "Try a sample question" → "Try a sample audio".
- Realign `tests/e2e/voice.spec.ts` with the shipped component (the spec was asserting on a `voice-sample-audio` container testid and a `Sample: "..."` caption that never existed in the current `sample-audio-button.tsx`), and add cold-start timeout headroom for the mic button render (waits on `/info` round trip) and the agent-flow test.
- Add `"env": ".env"` to `langgraph.json` so `langgraph_cli dev` picks up `OPENAI_API_KEY` for local dev. Docker/Railway paths inject env vars directly via `env_file`, so this is a no-op there.

Scope was deliberately limited to `langgraph-python` (north-star) per the user's request — the other 17 integrations still route mic transcription through aimock. Demo parity sync can propagate this when desired.

## Test plan

- [x] `pnpm exec playwright test voice.spec.ts` — all 3 tests pass (`page loads…`, `sample audio button injects the canned phrase…`, `sending the transcribed text produces a weather tool render`)
- [x] Manual mic verification on `http://localhost:3000/demos/voice` with a real `OPENAI_API_KEY` — speaking "hello" now returns "Hello." instead of the Tokyo fixture
- [ ] Visual check the new "Try a sample audio" label in the deployed preview
- [ ] Confirm Railway/Docker deploys still transcribe through real Whisper (this path was unaffected — `OPENAI_TRANSCRIPTION_BASE_URL` stays unset, defaulting to api.openai.com)