### PR TITLE
fix(showcase): unbreak multimodal demo end-to-end (auto-send, dedupe, proxy)

### DIFF
--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -563,7 +563,7 @@
     },
     {
       "match": {
-        "userMessage": "this PDF"
+        "userMessage": "can you tell me what is in this demo pdf I just attached"
       },
       "response": {
         "content": "The attached PDF is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
@@ -571,7 +571,7 @@
     },
     {
       "match": {
-        "userMessage": "this image"
+        "userMessage": "can you tell me what is in this demo image I just attached"
       },
       "response": {
         "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."

--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -46,12 +46,21 @@ services:
       - ./aimock/d5-all.json:/showcase-fixtures/d5-all.json:ro
       - ./aimock/smoke.json:/showcase-fixtures/smoke.json:ro
       - ./aimock/feature-parity.json:/showcase-fixtures/feature-parity.json:ro
+    # `--proxy-only` + `--provider-openai` mirrors the Railway aimock setup:
+    # matched fixtures short-circuit deterministically; unmatched requests
+    # fall through to real OpenAI (using OPENAI_API_KEY from .env). Without
+    # these flags aimock returns 404 on no-match, the LangGraph SDK
+    # interprets that as `NotFoundError`, and the demo crashes with
+    # "Failed to fetch" instead of seeing a real model response.
     command:
       [
         "--port",
         "4010",
         "--host",
         "0.0.0.0",
+        "--proxy-only",
+        "--provider-openai",
+        "https://api.openai.com",
         "--fixtures",
         "/showcase-fixtures/d5-all.json",
         "--fixtures",

--- a/showcase/integrations/langgraph-python/package-lock.json
+++ b/showcase/integrations/langgraph-python/package-lock.json
@@ -20,6 +20,9 @@
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-separator": "^1.1.8",
         "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "cmdk": "^0.2.1",
+        "embla-carousel-react": "^8.6.0",
         "lucide-react": "^1.14.0",
         "next": "^15.5.15",
         "openai": "^5.9.0",
@@ -29,11 +32,12 @@
         "react-markdown": "^10.1.0",
         "recharts": "^2.15.0",
         "remark-gfm": "^4.0.1",
+        "tailwind-merge": "^3.5.0",
         "yaml": "^2.8.4",
         "zod": "^3.24.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.50.0",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4.0.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
@@ -71,6 +75,7 @@
     },
     "../../../node_modules/.pnpm/@types+react@19.2.7/node_modules/@types/react": {
       "version": "19.2.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3185,7 +3190,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -6102,6 +6107,269 @@
         "node": ">=6"
       }
     },
+    "node_modules/cmdk": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-0.2.1.tgz",
+      "integrity": "sha512-U6//9lQ6JvT47+6OF6Gi8BvkxYQ8SCRRSKIJkthIMsFsLZRG0cKvTtuTaefyIKMQb8rvvXy0wGdpTNq/jPtm+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-context": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-dialog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.0.tgz",
+      "integrity": "sha512-Yn9YU+QlHYLWwV1XfKiqnGVpWYWk6MeBVM6x/bcoyPvxgjQGoeT35482viLPctTMWoMw0PoHgqfSox7Ig+957Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-dismissable-layer": "1.0.0",
+        "@radix-ui/react-focus-guards": "1.0.0",
+        "@radix-ui/react-focus-scope": "1.0.0",
+        "@radix-ui/react-id": "1.0.0",
+        "@radix-ui/react-portal": "1.0.0",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.0",
+        "@radix-ui/react-slot": "1.0.0",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.0.tgz",
+      "integrity": "sha512-n7kDRfx+LB1zLueRDvZ1Pd0bxdJWDUZNQ/GWoxDn2prnuJKRdxsjulejX/ePkOsLi2tTm6P24mDqlMSgQpsT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.0",
+        "@radix-ui/react-use-callback-ref": "1.0.0",
+        "@radix-ui/react-use-escape-keydown": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz",
+      "integrity": "sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.0.tgz",
+      "integrity": "sha512-C4SWtsULLGf/2L4oGeIHlvWQx7Rf+7cX/vKOAD2dXW0A1b5QXwi3wWeaEgW+wn+SEVrraMUk05vLU9fZZz5HbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.0",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-portal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.0.tgz",
+      "integrity": "sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-presence": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-use-layout-effect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
+      "integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
+      "integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.0.tgz",
+      "integrity": "sha512-JwfBCUIfhXRxKExgIqGa4CQsiMemo1Xt0W/B4ei3fpzpvPENKpMKQ8mZSB6Acj3ebrAEgi2xiQvcI1PAAodvyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/cmdk/node_modules/react-remove-scroll": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.4.tgz",
+      "integrity": "sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.3",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6977,6 +7245,34 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -10327,7 +10623,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -10346,7 +10642,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/showcase/integrations/langgraph-python/src/agents/multimodal_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/multimodal_agent.py
@@ -200,25 +200,36 @@ def _rewrite_messages(messages: list[Any]) -> list[Any]:
 
 
 class _PdfFlattenMiddleware(AgentMiddleware):
-    """Flatten PDF content parts to text before the model call.
+    """Flatten PDF content parts to text for the model call only.
 
-    We run this in ``before_model`` so every model invocation — including
-    retries after tool calls — sees the flattened view. The middleware is
-    idempotent: once a part has been rewritten to ``{"type": "text", ...}``
-    it is returned unchanged on subsequent passes.
+    Uses ``wrap_model_call`` instead of ``before_model`` so the PDF→text
+    rewrite is scoped to the outgoing model request and never persists
+    back into agent state. This matters because the agent state is
+    streamed verbatim to the chat UI: if we mutated state with a
+    ``{"type": "text", "text": "[Attached document]\\n<pdf body>"}``
+    part, the chat would render that flattened text inline in the user
+    message bubble (in addition to the PDF chip preview the modern
+    ``document`` part already drives), turning a clean attachment chip
+    into a wall of raw PDF text.
+
+    With ``wrap_model_call`` we copy the request, rewrite messages on
+    the copy, hand the copy to the model, and return the model's
+    response unchanged. The handler closure keeps state untouched.
     """
 
-    def before_model(self, state, runtime):  # type: ignore[override]
-        del runtime  # unused
-        messages = state.get("messages") if isinstance(state, dict) else None
-        if not messages:
-            return None
+    def wrap_model_call(self, request, handler):  # type: ignore[override]
+        messages = list(request.messages) if request.messages else []
         rewritten = _rewrite_messages(messages)
-        # Only emit a patch if anything actually changed — avoids a
-        # superfluous state update on every model hop.
         if rewritten == messages:
-            return None
-        return {"messages": rewritten}
+            return handler(request)
+        return handler(request.override(messages=rewritten))
+
+    async def awrap_model_call(self, request, handler):  # type: ignore[override]
+        messages = list(request.messages) if request.messages else []
+        rewritten = _rewrite_messages(messages)
+        if rewritten == messages:
+            return await handler(request)
+        return await handler(request.override(messages=rewritten))
 
 
 # Vision-capable model. gpt-4o consumes `image_url` content parts natively.

--- a/showcase/integrations/langgraph-python/src/app/demos/multimodal/legacy-converter-shim.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/multimodal/legacy-converter-shim.tsx
@@ -1,16 +1,35 @@
 "use client";
 
 /**
- * Legacy-shape rewrite shim.
+ * Legacy-shape rewrite + media-dedupe shim.
  *
- * The published `@ag-ui/langgraph` converter (0.0.x) only understands
- * the legacy `{ type: "binary", mimeType, data | url }` content-part
- * shape when forwarding AG-UI messages to LangChain. The modern
- * `{ type: "image" | "document", source: { type: "data" | "url", ... } }`
- * parts that CopilotChat emits are silently dropped. Until the runtime
- * ships an updated converter, we rewrite the outgoing user message in
- * `onRunInitialized` so image/document/audio/video parts round-trip
- * through the legacy shape the converter preserves.
+ * Three problems this fixes:
+ *
+ * 1. **Outgoing modern parts are invisible to the agent.** The published
+ *    `@ag-ui/langgraph` converter (0.0.x) only understands the legacy
+ *    `{ type: "binary", mimeType, data | url }` shape when forwarding
+ *    AG-UI messages to LangChain. Modern
+ *    `{ type: "image" | "document", source: { type, value, mimeType } }`
+ *    parts are silently dropped. In `onRunInitialized` we walk the
+ *    outgoing user message and APPEND a legacy `binary` mirror after
+ *    every modern media part — we cannot REPLACE the modern part with
+ *    `binary` because `CopilotChatUserMessage`'s `getMediaParts` only
+ *    renders `image|audio|video|document`, so replacing would make the
+ *    attachment visually disappear from the chat once the run snapshot
+ *    round-trips through state. APPEND keeps both forms: the modern
+ *    part stays for the UI, the legacy `binary` feeds the converter.
+ *
+ * 2. **Round-tripped media comes back doubled and mistyped.** The
+ *    converter sends our `binary` parts out as LangChain `image_url`
+ *    and pulls incoming `image_url` parts back in as AG-UI `image`
+ *    regardless of mimeType, so PDFs come back as `type: "image"` with
+ *    `mimeType: "application/pdf"` and fall to `ImageAttachment` (which
+ *    renders a broken `<img>`). The user's original modern part also
+ *    survives in state, so the chat shows TWO chips per attachment. On
+ *    every `onMessagesSnapshotEvent` and `onRunFinalized` we dedupe by
+ *    `source.value` and re-key the `type` field from the mimeType so
+ *    PDFs route to `DocumentAttachment` (icon + filename) and images
+ *    to `ImageAttachment`.
  */
 
 import { useEffect, useMemo } from "react";
@@ -30,22 +49,26 @@ type AgentMessage = {
 };
 
 /**
- * Rewrites a single `InputContent` part from the modern multimodal shape
- * (`type: "image" | "document" | "audio" | "video"`, `source.{type,value,mimeType}`)
- * to the legacy binary shape (`type: "binary"`, `mimeType`, `data` | `url`).
+ * Builds the legacy `binary` content part that mirrors a modern
+ * `image | document | audio | video` part. Returns `null` if the input
+ * is not a multimodal part we need to mirror, or if the part is already
+ * a legacy `binary` (idempotent).
  *
- * The published `@ag-ui/langgraph` converter (see `aguiMessagesToLangChain`
- * in that package) only recognizes legacy `binary` parts — modern parts
- * are silently filtered out, so the LangGraph agent never sees them.
- * Returning the legacy shape keeps the attachment visible to the agent
- * while leaving everything else (CopilotChat UI, upload pipeline, etc.)
- * untouched. Text parts and already-legacy parts pass through unchanged.
+ * The published `@ag-ui/langgraph` converter (see `aguiMessagesToLangChain`)
+ * only recognizes legacy `binary` parts; modern parts are silently
+ * filtered out. We APPEND the legacy mirror alongside the modern part
+ * rather than replacing it, because `CopilotChatUserMessage`'s
+ * `getMediaParts` only renders `image|audio|video|document` — replacing
+ * the modern part with `binary` makes the attachment visually disappear
+ * from the chat once the agent run completes (the run-state snapshot
+ * round-trips through state and re-renders the user message). Keeping
+ * both forms gives the UI something to render AND the converter
+ * something to read.
  */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
+function legacyBinaryFor(part: unknown): unknown | null {
+  if (!part || typeof part !== "object") return null;
   const candidate = part as {
     type?: string;
-    text?: string;
     source?: {
       type?: string;
       value?: string;
@@ -59,38 +82,32 @@ function rewriteMultimodalPart(part: unknown): unknown {
     type !== "audio" &&
     type !== "video"
   ) {
-    return part;
+    return null;
   }
   const source = candidate.source;
   if (!source || typeof source.value !== "string") {
-    return part;
+    return null;
   }
   const mimeType = source.mimeType ?? "application/octet-stream";
   if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
+    return { type: "binary", mimeType, data: source.value };
   }
   if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
+    return { type: "binary", mimeType, url: source.value };
   }
-  return part;
+  return null;
 }
 
 /**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Non-user messages and plain-string user
- * messages pass through untouched. Idempotent: already-legacy `binary`
- * parts are a no-op for `rewriteMultimodalPart`.
+ * Walks a message list and APPENDS a legacy `binary` mirror after every
+ * modern `image|document|audio|video` part on user messages, so the
+ * outgoing payload contains both forms. Non-user messages, plain-string
+ * user messages, and parts that already have a sibling `binary` mirror
+ * pass through untouched (idempotent: re-running on already-augmented
+ * messages is a no-op).
  *
- * Returns the same array reference if nothing changed so the subscriber
- * in `onRunInitialized` can skip an unnecessary state write.
+ * Returns null if nothing changed so the subscriber in
+ * `onRunInitialized` can skip a superfluous state write.
  */
 function rewriteMessagesForLegacyConverter(
   messages: ReadonlyArray<Readonly<AgentMessage>>,
@@ -100,28 +117,140 @@ function rewriteMessagesForLegacyConverter(
     if (message.role !== "user") return message as AgentMessage;
     const content = message.content;
     if (!Array.isArray(content)) return message as AgentMessage;
+
+    // Build a key set of `binary` parts already in the message so we
+    // don't double-append on a second run.
+    const existingBinaryKeys = new Set<string>();
+    for (const part of content) {
+      if (
+        part &&
+        typeof part === "object" &&
+        (part as { type?: string }).type === "binary"
+      ) {
+        const p = part as { mimeType?: string; data?: string; url?: string };
+        existingBinaryKeys.add(`${p.mimeType ?? ""}::${p.data ?? p.url ?? ""}`);
+      }
+    }
+
     let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
+    const augmentedParts: unknown[] = [];
+    for (const part of content) {
+      augmentedParts.push(part);
+      const mirror = legacyBinaryFor(part);
+      if (!mirror) continue;
+      const m = mirror as {
+        mimeType?: string;
+        data?: string;
+        url?: string;
+      };
+      const key = `${m.mimeType ?? ""}::${m.data ?? m.url ?? ""}`;
+      if (existingBinaryKeys.has(key)) continue;
+      existingBinaryKeys.add(key);
+      augmentedParts.push(mirror);
+      partMutated = true;
+    }
     if (!partMutated) return message as AgentMessage;
     mutated = true;
     return {
       ...(message as object),
-      content: rewrittenParts,
+      content: augmentedParts,
     } as AgentMessage;
   });
   return mutated ? next : null;
 }
 
 /**
- * Installs the `onRunInitialized` subscriber on the active agent. Scoped
- * to a small inner component so it can use the `useAgent` hook the
- * <CopilotChat> parent already relies on — subscribing there means we
- * rewrite messages on the *same* agent instance CopilotChat dispatches
- * through, even when threads are cloned or swapped.
+ * Normalize + dedupe media content parts within each user message:
+ *
+ * 1. **Type normalization.** The @ag-ui/langgraph round-trip through
+ *    LangChain emits incoming media parts as `type: "image"` regardless
+ *    of the actual mimeType — including `application/pdf` and other
+ *    non-image documents — because the converter generates them from
+ *    LangChain `image_url` parts indiscriminately. The chat
+ *    user-message renderer dispatches by `type` to either
+ *    `ImageAttachment` (renders an `<img>`) or `DocumentAttachment`
+ *    (renders an icon + filename). A PDF tagged as `image` falls to
+ *    `<img>`, fails to load, and shows "Failed to load image" instead
+ *    of a PDF chip. Re-key the part type from the mimeType so the
+ *    correct renderer fires.
+ *
+ * 2. **Dedupe by source value.** The same attachment ends up in the
+ *    user message twice: once as the modern part the client added,
+ *    once as the re-converted shape the snapshot pushes. Strip
+ *    duplicates by `source.value` (or `source.url`) regardless of
+ *    type so both forms collapse to a single chip.
+ */
+function normalizePartType(type: string, mimeType: string | undefined): string {
+  if (type !== "image" && type !== "document") return type;
+  if (!mimeType) return type;
+  if (mimeType.startsWith("image/")) return "image";
+  if (mimeType.startsWith("audio/")) return "audio";
+  if (mimeType.startsWith("video/")) return "video";
+  return "document";
+}
+
+function dedupeUserMessageMedia(
+  messages: ReadonlyArray<Readonly<AgentMessage>>,
+): AgentMessage[] | null {
+  let mutated = false;
+  const next = messages.map((message) => {
+    if (message.role !== "user") return message as AgentMessage;
+    const content = message.content;
+    if (!Array.isArray(content)) return message as AgentMessage;
+    const seen = new Set<string>();
+    const kept: unknown[] = [];
+    let partMutated = false;
+    for (const part of content) {
+      if (!part || typeof part !== "object") {
+        kept.push(part);
+        continue;
+      }
+      const p = part as {
+        type?: string;
+        source?: { value?: string; url?: string; mimeType?: string };
+        data?: string;
+        url?: string;
+        mimeType?: string;
+      };
+      const isMedia =
+        p.type === "image" ||
+        p.type === "document" ||
+        p.type === "audio" ||
+        p.type === "video";
+      if (!isMedia) {
+        kept.push(part);
+        continue;
+      }
+      const sourceValue = p.source?.value ?? p.source?.url ?? "";
+      if (seen.has(sourceValue)) {
+        partMutated = true;
+        continue;
+      }
+      seen.add(sourceValue);
+      const normalizedType = normalizePartType(
+        p.type ?? "",
+        p.source?.mimeType ?? p.mimeType,
+      );
+      if (normalizedType !== p.type) {
+        kept.push({ ...p, type: normalizedType });
+        partMutated = true;
+      } else {
+        kept.push(part);
+      }
+    }
+    if (!partMutated) return message as AgentMessage;
+    mutated = true;
+    return { ...(message as object), content: kept } as AgentMessage;
+  });
+  return mutated ? next : null;
+}
+
+/**
+ * Installs the subscribers on the active agent. Scoped to a small inner
+ * component so it can use the `useAgent` hook the <CopilotChat> parent
+ * already relies on — subscribing there means we rewrite messages on the
+ * *same* agent instance CopilotChat dispatches through, even when threads
+ * are cloned or swapped.
  */
 export function LegacyConverterShim() {
   const { agent } = useAgent({ agentId: "multimodal-demo" });
@@ -137,6 +266,30 @@ export function LegacyConverterShim() {
         if (!rewritten) return;
         return { messages: rewritten };
       },
+      // After every messages snapshot from the server, strip duplicate
+      // media parts and normalize types that the @ag-ui/langgraph
+      // round-trip mangled. We hook both `onMessagesSnapshotEvent` and
+      // `onRunFinalized` to catch incremental events too — the
+      // snapshot fires once at run end, the run-finalized hook fires
+      // when the agent transitions out of running.
+      onMessagesSnapshotEvent: ({
+        messages,
+      }: {
+        messages: ReadonlyArray<Readonly<AgentMessage>>;
+      }) => {
+        const deduped = dedupeUserMessageMedia(messages);
+        if (!deduped) return;
+        return { messages: deduped };
+      },
+      onRunFinalized: ({
+        messages,
+      }: {
+        messages: ReadonlyArray<Readonly<AgentMessage>>;
+      }) => {
+        const deduped = dedupeUserMessageMedia(messages);
+        if (!deduped) return;
+        return { messages: deduped };
+      },
     }),
     [],
   );
@@ -145,8 +298,8 @@ export function LegacyConverterShim() {
     if (!agent) return;
     // AG-UI's AgentSubscriber type is tagged by role; our shim uses a
     // structural message shape and returns only partial mutations, so
-    // cast at the subscribe boundary. The cast is safe: our
-    // onRunInitialized only ever returns a messages-mutation or void.
+    // cast at the subscribe boundary. The cast is safe: our handlers
+    // only ever return a messages-mutation or void.
     const handle = agent.subscribe(
       subscriber as unknown as Parameters<typeof agent.subscribe>[0],
     );

--- a/showcase/integrations/langgraph-python/src/app/demos/multimodal/multimodal-chat.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/multimodal/multimodal-chat.tsx
@@ -7,12 +7,6 @@ import { SampleAttachmentButtons } from "./sample-attachment-buttons";
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 const ACCEPT_MIME = "image/*,application/pdf";
-/**
- * Selector used by <SampleAttachmentButtons /> to locate CopilotChat's
- * hidden file input. Kept as a constant so the wrapper element and the
- * sample buttons cannot drift.
- */
-const CHAT_ROOT_SELECTOR = "[data-multimodal-demo-chat-root]";
 
 export function MultimodalChat() {
   // `onUpload` is passed into CopilotChat's `AttachmentsConfig`. Both the
@@ -65,7 +59,7 @@ export function MultimodalChat() {
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"
       >
-        <SampleAttachmentButtons rootSelector={CHAT_ROOT_SELECTOR} />
+        <SampleAttachmentButtons agentId="multimodal-demo" />
 
         <div
           data-multimodal-demo-chat-root

--- a/showcase/integrations/langgraph-python/src/app/demos/multimodal/sample-attachment-buttons.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/multimodal/sample-attachment-buttons.tsx
@@ -1,24 +1,36 @@
 "use client";
 
 /**
- * Two buttons that inject bundled sample files into the active CopilotChat's
- * attachment queue. The queue is owned internally by <CopilotChat /> (via its
- * `useAttachments` hook), so we inject at the DOM level: find the hidden
- * `<input type="file">` CopilotChat renders, populate its `.files` via
- * DataTransfer, and dispatch a `change` event. This exercises the *same*
- * onChange handler the paperclip / drag-and-drop paths use — which means our
- * sample path runs through the `AttachmentsConfig.onUpload` the page wires
- * on the chat, the same file-size + accept-filter validation, the same
- * placeholder-then-ready lifecycle. No duplicated queueing code.
+ * Two buttons that auto-attach a bundled sample file (image or PDF) and
+ * immediately submit a canned prompt about it.
  *
- * Container scope: the sample buttons live next to the chat inside a
- * `data-multimodal-demo-root` wrapper (see page.tsx). We scope our
- * `querySelector` to that root so multiple CopilotChat instances on the
- * page (there aren't any today, but the pattern should be safe) don't
- * collide.
+ * Implementation note: an earlier version of this component drove the
+ * chat's hidden `<input type="file">` via DataTransfer + a synthetic
+ * `change` event so the sample path went through the same `onUpload` /
+ * `useAttachments` pipeline as the paperclip button. That worked for
+ * "queue the attachment" but auto-sending the canned prompt afterwards
+ * required clicking the send button while the attachment was still in
+ * `status: "uploading"`, which `CopilotChat.onSubmitInput` rejects with
+ * `"Cannot send while attachments are uploading"` and clears the input
+ * regardless. Detecting the upload-complete state from outside the chat
+ * meant scraping the spinner overlay, racy on slow renders.
+ *
+ * This version skips the DOM entirely and goes through the V2 agent
+ * surface directly: `agent.addMessage(...)` to enqueue a fully-formed
+ * user message (text + attachment content parts), then
+ * `copilotkit.runAgent({ agent })` to dispatch it. Matches what
+ * `CopilotChat.onSubmitInput` does internally — same shapes, same
+ * runtime — but with no upload race because we build the
+ * already-base64'd content part ourselves before calling addMessage.
+ *
+ * The `LegacyConverterShim` in page.tsx still rewrites our modern
+ * `image|document` parts to the legacy `binary` shape the published
+ * `@ag-ui/langgraph` converter understands, so the agent ultimately
+ * receives the attachment in the form `multimodal_agent.py` expects.
  */
 
 import { useCallback, useState } from "react";
+import { useAgent, useCopilotKit } from "@copilotkit/react-core/v2";
 
 interface SampleSpec {
   readonly buttonLabel: string;
@@ -26,6 +38,15 @@ interface SampleSpec {
   readonly mimeType: string;
   readonly testId: string;
   readonly fetchUrl: string;
+  /**
+   * Prompt sent alongside the attachment. Rendered as the user message
+   * bubble in chat AND matched against by aimock to return the demo's
+   * canned response. Phrased as a long, specific sentence ("demo pdf I
+   * just attached" / "demo image I just attached") so it both reads
+   * naturally and can't collide with arbitrary user prompts — random
+   * uploads phrase questions differently and fall through to the proxy.
+   */
+  readonly autoPrompt: string;
 }
 
 const SAMPLES: readonly SampleSpec[] = [
@@ -35,6 +56,7 @@ const SAMPLES: readonly SampleSpec[] = [
     mimeType: "image/png",
     testId: "multimodal-sample-image-button",
     fetchUrl: "/demo-files/sample.png",
+    autoPrompt: "can you tell me what is in this demo image I just attached",
   },
   {
     buttonLabel: "Try with sample PDF",
@@ -42,27 +64,17 @@ const SAMPLES: readonly SampleSpec[] = [
     mimeType: "application/pdf",
     testId: "multimodal-sample-pdf-button",
     fetchUrl: "/demo-files/sample.pdf",
+    autoPrompt: "can you tell me what is in this demo pdf I just attached",
   },
 ];
 
 export interface SampleAttachmentButtonsProps {
   /**
-   * Selector (scoped to `document`) that resolves to the wrapper element
-   * rendered around `<CopilotChat />`. The component walks this element's
-   * subtree to find the hidden file input CopilotChat renders.
+   * Agent slug the parent `<CopilotKit agent="...">` provider wires up.
+   * The buttons send via `useAgent({ agentId })` so the message lands on
+   * the same agent the sibling `<CopilotChat />` is bound to.
    */
-  readonly rootSelector: string;
-}
-
-function findChatFileInput(rootSelector: string): HTMLInputElement | null {
-  if (typeof document === "undefined") return null;
-  const root = document.querySelector(rootSelector);
-  if (!root) return null;
-  // CopilotChat renders exactly one hidden `<input type="file">` directly
-  // inside its chatContainerRef div. Match on `type="file"` to avoid
-  // sibling inputs (there are none today but it costs nothing to be
-  // defensive).
-  return root.querySelector<HTMLInputElement>('input[type="file"]');
+  readonly agentId: string;
 }
 
 /**
@@ -71,7 +83,7 @@ function findChatFileInput(rootSelector: string): HTMLInputElement | null {
  * short plain-text stub starting with `version https://git-lfs...`) with
  * a `Content-Type: image/png` header if LFS wasn't pulled at build time.
  * Without this guard, the broken pointer bytes get base64-encoded,
- * fed into CopilotChat as a valid-looking PNG, and rendered as a broken
+ * sent to the agent as a valid-looking PNG, and rendered as a broken
  * <img>. Fail loudly with an actionable error instead.
  */
 const MAGIC_BYTES: Record<string, number[]> = {
@@ -89,7 +101,18 @@ function bytesStartWith(bytes: Uint8Array, prefix: number[]): boolean {
   return true;
 }
 
-async function fetchAsFile(spec: SampleSpec): Promise<File> {
+interface FetchedSample {
+  bytes: Uint8Array;
+  base64: string;
+  size: number;
+}
+
+/**
+ * Fetch the sample file, validate its magic bytes, and return both the
+ * raw bytes (for size accounting) and a base64 string suitable for
+ * dropping into a `source.value` content part.
+ */
+async function fetchSample(spec: SampleSpec): Promise<FetchedSample> {
   const res = await fetch(spec.fetchUrl);
   if (!res.ok) {
     throw new Error(
@@ -100,7 +123,6 @@ async function fetchAsFile(spec: SampleSpec): Promise<File> {
   const buffer = await res.arrayBuffer();
   const bytes = new Uint8Array(buffer);
 
-  // Detect Git LFS pointer stub — the file on disk hasn't been materialized.
   const asciiHead = new TextDecoder("utf-8", { fatal: false }).decode(
     bytes.slice(0, Math.min(bytes.length, 64)),
   );
@@ -121,57 +143,105 @@ async function fetchAsFile(spec: SampleSpec): Promise<File> {
     );
   }
 
-  // Re-wrap the bytes into a blob/File with the explicit MIME type rather than
-  // trusting whatever Content-Type the dev server returned.
+  // Convert to base64 via FileReader for parity with the paperclip path.
+  // The `data:<mime>;base64,<payload>` URL is split — we only need the
+  // payload, which becomes the `source.value` of the content part below.
   const blob = new Blob([buffer], { type: spec.mimeType });
-  return new File([blob], spec.filename, { type: spec.mimeType });
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () =>
+      reject(
+        reader.error ?? new Error(`FileReader failed for ${spec.filename}`),
+      );
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        reject(new Error(`Unexpected FileReader result for ${spec.filename}`));
+        return;
+      }
+      resolve(reader.result);
+    };
+    reader.readAsDataURL(blob);
+  });
+  const commaIdx = dataUrl.indexOf(",");
+  const base64 = commaIdx >= 0 ? dataUrl.slice(commaIdx + 1) : dataUrl;
+
+  return { bytes, base64, size: buffer.byteLength };
+}
+
+/**
+ * Browser-friendly UUID. `crypto.randomUUID` is widely supported but we
+ * fall back to a math-based UUIDv4 for the (rare) older runtime.
+ */
+function generateMessageId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
 }
 
 export function SampleAttachmentButtons({
-  rootSelector,
+  agentId,
 }: SampleAttachmentButtonsProps) {
+  const { agent } = useAgent({ agentId });
+  const { copilotkit } = useCopilotKit();
   const [loading, setLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const injectSample = useCallback(
+  const sendSample = useCallback(
     async (spec: SampleSpec): Promise<void> => {
       setError(null);
       setLoading(spec.testId);
       try {
-        const fileInput = findChatFileInput(rootSelector);
-        if (!fileInput) {
+        if (!agent) {
           throw new Error(
-            `CopilotChat file input not found under "${rootSelector}". ` +
-              "Is <CopilotChat /> mounted with `attachments.enabled: true`?",
+            `Agent "${agentId}" is not yet available. Try again in a moment.`,
           );
         }
-        const file = await fetchAsFile(spec);
+        const sample = await fetchSample(spec);
+        const partType =
+          spec.mimeType === "application/pdf" ? "document" : "image";
 
-        // Populate the file input's `.files` list via a fresh DataTransfer.
-        // This is the only way to programmatically set `HTMLInputElement.files`
-        // — assigning a plain array fails in every browser.
-        const dt = new DataTransfer();
-        dt.items.add(file);
-        fileInput.files = dt.files;
+        // Build a multimodal user message as content parts: prompt text +
+        // the attachment. The `LegacyConverterShim` in page.tsx will
+        // rewrite the modern `image|document` part to the legacy `binary`
+        // shape the @ag-ui/langgraph converter understands before the
+        // request leaves the runtime.
+        agent.addMessage({
+          id: generateMessageId(),
+          role: "user",
+          content: [
+            { type: "text", text: spec.autoPrompt },
+            {
+              type: partType,
+              source: {
+                type: "data",
+                value: sample.base64,
+                mimeType: spec.mimeType,
+              },
+              metadata: {
+                filename: spec.filename,
+                size: sample.size,
+              },
+            },
+          ],
+        } as Parameters<typeof agent.addMessage>[0]);
 
-        // Dispatch a bubbling `change` event. CopilotChat's internal
-        // `useAttachments.handleFileUpload` listens on `onChange`, which
-        // React wires up as a native `change` listener — so a standard
-        // DOM Event with `bubbles: true` reaches it.
-        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+        await copilotkit.runAgent({ agent });
       } catch (err) {
-        console.error(
-          "[multimodal-demo] sample-attachment injection failed",
-          err,
-        );
-        setError(
-          err instanceof Error ? err.message : "Sample injection failed.",
-        );
+        console.error("[multimodal-demo] sample-attachment send failed", err);
+        setError(err instanceof Error ? err.message : "Sample send failed.");
       } finally {
         setLoading(null);
       }
     },
-    [rootSelector],
+    [agent, agentId, copilotkit],
   );
 
   return (
@@ -190,10 +260,10 @@ export function SampleAttachmentButtons({
             type="button"
             data-testid={spec.testId}
             disabled={loading !== null}
-            onClick={() => void injectSample(spec)}
+            onClick={() => void sendSample(spec)}
             className="rounded border border-black/15 bg-white px-3 py-1 text-xs font-medium text-black transition hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-neutral-900 dark:text-white dark:hover:bg-white/5"
           >
-            {isLoading ? "Loading…" : spec.buttonLabel}
+            {isLoading ? "Sending…" : spec.buttonLabel}
           </button>
         );
       })}

--- a/showcase/integrations/langgraph-python/tests/e2e/multimodal.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/multimodal.spec.ts
@@ -72,7 +72,10 @@ async function openDemo(page: Page) {
 async function waitForRoundTrip(
   page: Page,
   index = 0,
-): Promise<{ userMsg: ReturnType<Page["locator"]>; asstMsg: ReturnType<Page["locator"]> }> {
+): Promise<{
+  userMsg: ReturnType<Page["locator"]>;
+  asstMsg: ReturnType<Page["locator"]>;
+}> {
   const userMsg = page.locator(USER_MESSAGE).nth(index);
   await expect(userMsg).toBeVisible({ timeout: 60_000 });
   const asstMsg = page.locator(ASSISTANT_MESSAGE).nth(index);

--- a/showcase/integrations/langgraph-python/tests/e2e/multimodal.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/multimodal.spec.ts
@@ -1,50 +1,83 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 /**
- * E2E spec for the Multimodal Attachments demo (Wave 2b).
+ * E2E spec for the Multimodal Attachments demo.
  *
- * Exercises the sample-file injection path only — the real OS file picker
- * isn't automatable through Playwright without a flakey host-file dependency,
- * whereas the sample path drives the same hidden file input under the hood
- * (DataTransfer + dispatch `change`) and therefore covers the same internal
- * code the paperclip path exercises.
+ * Exercises the sample-file injection path only — the real OS file
+ * picker isn't automatable through Playwright without a flakey host-
+ * file dependency. The sample buttons go through the same V2 agent
+ * surface (`agent.addMessage` + `copilotkit.runAgent`) that the
+ * paperclip path ultimately feeds, so this suite covers the render +
+ * round-trip path end-to-end.
  *
- * Assumes the demo is deployed at BASE_URL/demos/multimodal and that both
- * `public/demo-files/sample.png` and `public/demo-files/sample.pdf` are
- * bundled — the sample buttons fetch them at runtime.
+ * Behavior pinned by this suite (each was an actual regression caught
+ * during the multimodal rewrite — see headers in
+ * sample-attachment-buttons.tsx and legacy-converter-shim.tsx):
  *
- * NOTE: against a live deploy the assistant response depends on a
- * vision-capable model (gpt-4o). When running against aimock, feature-parity
- * fixtures for "Describe this image" and "Summarize this document" ensure
- * deterministic responses that mention "CopilotKit" / "logo" so the soft
- * keyword assertions hold.
+ * 1. Clicking a sample button auto-sends the canned prompt — no manual
+ *    fill / send required. Earlier the DataTransfer-into-file-input
+ *    approach raced the upload state, the send got rejected, and the
+ *    prompt got eaten.
+ * 2. The user message keeps showing exactly ONE attachment chip after
+ *    the assistant response arrives. The @ag-ui/langgraph round-trip
+ *    used to duplicate the attachment (modern + re-converted shape) so
+ *    the user saw two thumbnails for one file.
+ * 3. Sample-PDF specifically renders as a `DocumentAttachment` chip,
+ *    NOT as an `<img>` that errors with "Failed to load image". Earlier
+ *    the round-trip mis-tagged PDFs with `type: "image"` and forced the
+ *    image renderer.
+ * 4. The PDF flattened text doesn't bleed into the rendered user
+ *    message. Earlier `_PdfFlattenMiddleware` ran in `before_model`
+ *    and persisted the flattened "[Attached document]\n<pdf body>"
+ *    into state, which the chat UI rendered inline.
+ * 5. Clicking image then PDF in the same session (and vice versa)
+ *    leaves each user message with its own single, correct chip — no
+ *    cross-contamination, no doubling.
+ *
+ * Assumes the demo is reachable at BASE_URL/demos/multimodal and
+ * aimock is configured with the canned prompts:
+ *   - "can you tell me what is in this demo image I just attached"
+ *   - "can you tell me what is in this demo pdf I just attached"
+ * Both fixtures live in showcase/aimock/feature-parity.json.
  */
 
 const ROUTE = "/demos/multimodal";
 
-// Selectors derived from sample-attachment-buttons.tsx and CopilotChat's
-// internal test ids. The chip selector is best-effort — CopilotChat's
-// AttachmentQueue chip doesn't currently expose a stable data-testid, so we
-// fall back to the attachment preview thumbnail that only appears after a
-// successful onUpload. If the chip selector drifts, tighten here.
 const SAMPLE_IMAGE_BTN = '[data-testid="multimodal-sample-image-button"]';
 const SAMPLE_PDF_BTN = '[data-testid="multimodal-sample-pdf-button"]';
 const CHAT_TEXTAREA = '[data-testid="copilot-chat-textarea"]';
-const SEND_BUTTON = '[data-testid="copilot-send-button"]';
 const ADD_MENU_BUTTON = '[data-testid="copilot-add-menu-button"]';
-// Attachment chip selector — CopilotChat's AttachmentQueue renders chips
-// inside the input toolbar. Until a stable data-testid is added, match on
-// the filename that the sample path always populates.
-const IMAGE_CHIP_LOCATOR = "text=sample.png";
-const PDF_CHIP_LOCATOR = "text=sample.pdf";
+const USER_MESSAGE = '[data-testid="copilot-user-message"]';
+const ASSISTANT_MESSAGE = '[data-testid="copilot-assistant-message"]';
+
+// The canned auto-prompts live in sample-attachment-buttons.tsx — kept in
+// sync here so the user-message bubble assertion stays accurate.
+const IMAGE_PROMPT =
+  "can you tell me what is in this demo image I just attached";
+const PDF_PROMPT = "can you tell me what is in this demo pdf I just attached";
 
 async function openDemo(page: Page) {
   await page.goto(ROUTE);
-  // Demo has no header — assert on the root testid that the
-  // MultimodalChat component owns.
   await expect(
     page.locator('[data-testid="multimodal-demo-root"]'),
   ).toBeVisible();
+}
+
+/**
+ * Wait until the sample-injection flow finishes for the nth user message:
+ * the user bubble shows up, then the matching assistant response. Returns
+ * both locators so the caller can probe for chips and dedup invariants.
+ */
+async function waitForRoundTrip(
+  page: Page,
+  index = 0,
+): Promise<{ userMsg: ReturnType<Page["locator"]>; asstMsg: ReturnType<Page["locator"]> }> {
+  const userMsg = page.locator(USER_MESSAGE).nth(index);
+  await expect(userMsg).toBeVisible({ timeout: 60_000 });
+  const asstMsg = page.locator(ASSISTANT_MESSAGE).nth(index);
+  await expect(asstMsg).toBeVisible({ timeout: 90_000 });
+  return { userMsg, asstMsg };
 }
 
 test.describe("Multimodal Attachments", () => {
@@ -61,70 +94,98 @@ test.describe("Multimodal Attachments", () => {
     await expect(page.locator(SAMPLE_IMAGE_BTN)).toBeEnabled();
     await expect(page.locator(SAMPLE_PDF_BTN)).toBeEnabled();
     await expect(page.locator(CHAT_TEXTAREA)).toBeVisible();
-    // Paperclip / Add attachments menu button — CopilotChatInput's data-testid.
     await expect(page.locator(ADD_MENU_BUTTON)).toBeVisible();
   });
 
-  test("sample image injection queues an attachment chip", async ({ page }) => {
-    await page.locator(SAMPLE_IMAGE_BTN).click();
-    // Attachment chip appears within 10s — FileReader + base64 on a <50KB PNG
-    // should finish in <1s on a reasonable machine, but allow generously for
-    // CI variance.
-    await expect(page.locator(IMAGE_CHIP_LOCATOR).first()).toBeVisible({
-      timeout: 10000,
-    });
-  });
-
-  test("sample PDF injection queues an attachment chip", async ({ page }) => {
-    await page.locator(SAMPLE_PDF_BTN).click();
-    await expect(page.locator(PDF_CHIP_LOCATOR).first()).toBeVisible({
-      timeout: 10000,
-    });
-  });
-
-  test("sending with an image attachment produces an agent response that references the image", async ({
+  test("sample image: auto-sends, user msg shows EXACTLY ONE image, assistant references it", async ({
     page,
   }) => {
     await page.locator(SAMPLE_IMAGE_BTN).click();
-    await expect(page.locator(IMAGE_CHIP_LOCATOR).first()).toBeVisible({
-      timeout: 10000,
-    });
+    const { userMsg, asstMsg } = await waitForRoundTrip(page);
 
-    await page.locator(CHAT_TEXTAREA).fill("Describe this image");
-    await page.locator(SEND_BUTTON).click();
+    // Auto-prompt landed as the user message body — confirms the
+    // useAgent / runAgent path fired and the prompt wasn't eaten.
+    await expect(userMsg).toContainText(IMAGE_PROMPT);
 
-    // Assistant message renders — use role-based locator as a stable anchor.
-    const assistantMessage = page
-      .locator('[data-testid="copilot-assistant-message"]')
-      .first();
-    await expect(assistantMessage).toBeVisible({ timeout: 90000 });
-    // Soft assertion: mentions CopilotKit, logo, or image-ish keywords.
-    // Loosened to avoid flakes when the vision model paraphrases; the
-    // aimock fixture response hits both keywords so deterministic CI is fine.
-    await expect(assistantMessage).toContainText(/copilotkit|logo|image/i, {
-      timeout: 5000,
-    });
+    // Exactly ONE rendered image — pin the dedupe + normalize behavior
+    // so the @ag-ui/langgraph round-trip can't quietly start doubling
+    // attachments again.
+    await expect(userMsg.locator("img")).toHaveCount(1);
+    await expect(userMsg.getByText(/Failed to load image/i)).toHaveCount(0);
+
+    await expect(asstMsg).toContainText(/copilotkit|logo|image/i);
   });
 
-  test("sending with a PDF attachment produces an agent response mentioning CopilotKit", async ({
+  test("sample PDF: auto-sends, user msg shows EXACTLY ONE document chip (not a broken image)", async ({
     page,
   }) => {
     await page.locator(SAMPLE_PDF_BTN).click();
-    await expect(page.locator(PDF_CHIP_LOCATOR).first()).toBeVisible({
-      timeout: 10000,
-    });
+    const { userMsg, asstMsg } = await waitForRoundTrip(page);
 
-    await page.locator(CHAT_TEXTAREA).fill("Summarize this document");
-    await page.locator(SEND_BUTTON).click();
+    await expect(userMsg).toContainText(PDF_PROMPT);
 
-    const assistantMessage = page
-      .locator('[data-testid="copilot-assistant-message"]')
-      .first();
-    await expect(assistantMessage).toBeVisible({ timeout: 90000 });
-    // The sample PDF contains the word "CopilotKit" multiple times and the
-    // aimock fixture mirrors that in its response.
-    await expect(assistantMessage).toContainText(/copilotkit/i, {
-      timeout: 5000,
-    });
+    // Pinned regression: PDFs round-tripped through @ag-ui/langgraph
+    // used to come back as `type: "image"` with `mimeType:
+    // application/pdf`, forcing the image renderer to fail load and
+    // show "Failed to load image" twice. The page-level dedupe + type-
+    // normalize subscriber turns them back into `document` parts so
+    // the icon-+-filename renderer fires exactly once.
+    await expect(userMsg.getByText(/Failed to load image/i)).toHaveCount(0);
+    await expect(userMsg.locator("img")).toHaveCount(0);
+    // DocumentAttachment surfaces a "PDF" label via getDocumentIcon.
+    await expect(userMsg.getByText(/^PDF$/)).toBeVisible();
+
+    // Pinned regression: the PDF flattened text used to bleed into the
+    // rendered user message when the Python middleware mutated state
+    // via `before_model`. Switching to `wrap_model_call` scopes the
+    // rewrite to the model request only — the bracket-tagged dump must
+    // never appear in the UI bubble.
+    await expect(userMsg).not.toContainText("[Attached document]");
+
+    await expect(asstMsg).toContainText(/copilotkit/i);
+  });
+
+  test("image then PDF in same session: each message keeps its own chip, no doubling", async ({
+    page,
+  }) => {
+    await page.locator(SAMPLE_IMAGE_BTN).click();
+    const first = await waitForRoundTrip(page, 0);
+    await expect(first.userMsg.locator("img")).toHaveCount(1);
+
+    await page.locator(SAMPLE_PDF_BTN).click();
+    const second = await waitForRoundTrip(page, 1);
+
+    // First message still shows exactly one image — the second send
+    // must not re-render or double the prior attachment.
+    await expect(first.userMsg.locator("img")).toHaveCount(1);
+
+    // Second message is a clean PDF chip.
+    await expect(second.userMsg.locator("img")).toHaveCount(0);
+    await expect(second.userMsg.getByText(/Failed to load image/i)).toHaveCount(
+      0,
+    );
+    await expect(second.userMsg.getByText(/^PDF$/)).toBeVisible();
+  });
+
+  test("PDF then image in same session: each message keeps its own chip, no doubling", async ({
+    page,
+  }) => {
+    await page.locator(SAMPLE_PDF_BTN).click();
+    const first = await waitForRoundTrip(page, 0);
+    await expect(first.userMsg.locator("img")).toHaveCount(0);
+    await expect(first.userMsg.getByText(/^PDF$/)).toBeVisible();
+
+    await page.locator(SAMPLE_IMAGE_BTN).click();
+    const second = await waitForRoundTrip(page, 1);
+
+    // First message still shows the PDF chip — no contamination.
+    await expect(first.userMsg.getByText(/^PDF$/)).toBeVisible();
+    await expect(first.userMsg.locator("img")).toHaveCount(0);
+
+    // Second message has exactly one image, no broken-image fallback.
+    await expect(second.userMsg.locator("img")).toHaveCount(1);
+    await expect(second.userMsg.getByText(/Failed to load image/i)).toHaveCount(
+      0,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Re-lands the multimodal-attachments fix from #4584 (May 1, never merged) onto current `main`, ported to the post-refactor file layout where `page.tsx` was split into `legacy-converter-shim.tsx`, `multimodal-chat.tsx`, and `file-to-data-attachment.ts`.

Auto-send was the visible regression: clicking **Try with sample image / Try with sample PDF** only queued the attachment chip instead of sending the canned prompt. This PR restores the full end-to-end behavior plus five regression tests so it can't silently break again.

## What was broken and what changed

1. **Random uploads crashed with `Failed to fetch`.** aimock returned HTTP 404 on no-match, the LangGraph SDK surfaced `NotFoundError`, the AG-UI stream surfaced a `RUN_ERROR`, the demo crashed. → Added `--proxy-only` + `--provider-openai https://api.openai.com` to the local aimock command so unmatched user prompts fall through to real OpenAI (mirrors Railway).

2. **Bundled-sample fixtures keyed on user-visible canned prompts.** Auto-prompts are now natural and specific ("can you tell me what is in this demo image/pdf I just attached") so they render cleanly as the user message bubble AND can't collide with arbitrary user prompts — random uploads phrase questions differently and fall through to the proxy.

3. **Sample buttons now auto-send via `useAgent`.** The previous DataTransfer path queued the attachment via the chat's hidden file input but required clicking send while the attachment was still uploading — `CopilotChat.onSubmitInput` rejects submits during upload AND clears the input regardless, so the canned prompt was eaten. Rewrite calls `agent.addMessage(...)` + `copilotkit.runAgent({ agent })` directly with the base64'd content part.

4. **PDF flattened text bled into the rendered user message.** `_PdfFlattenMiddleware` ran in `before_model` and persisted the rewrite to agent state. Switched to `wrap_model_call` so the PDF→text rewrite is scoped to the model request only.

5. **Attachments doubled (and PDFs rendered as broken `<img>`).** The `@ag-ui/langgraph` round-trip mis-tags PDFs as `image` and re-injects the user's original modern part, doubling chips. Added `dedupeUserMessageMedia` subscriber on `onMessagesSnapshotEvent` + `onRunFinalized` to dedupe by `source.value` and re-key type from mimeType. Also flipped `onRunInitialized` from REPLACE to APPEND so the modern part stays for the UI alongside a legacy `binary` sibling for the converter.

6. **Regression suite (`tests/e2e/multimodal.spec.ts`).** Five focused tests, all pass against live local stack (15.4s):
   - page loads with all expected affordances
   - sample image: auto-sends, EXACTLY ONE `<img>`, assistant references the logo
   - sample PDF: auto-sends, EXACTLY ONE `DocumentAttachment` chip ("PDF" label), NO `<img>`, no `[Attached document]` text bleed
   - image then PDF in the same session: each message keeps its own single chip
   - PDF then image in the same session: symmetric

## Test plan

- [x] `showcase up langgraph-python` — both sample buttons auto-send; image renders as `<img>`, PDF renders as PDF chip; random paperclip uploads go through proxy
- [x] `BASE_URL=http://localhost:3100 CI=1 npx playwright test multimodal.spec.ts` — **5 / 5 passing**
- [ ] Post-merge: e2e-deep cycle for langgraph-python multimodal cell stays green

## Closes

Closes #4584.