### PR TITLE
fix(showcase/mcp-apps): route "Draw a flowchart" pill to create_view fixture

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -1330,6 +1330,33 @@
       }
     },
     {
+      "_comment": "D5 mcp-apps suggestion pill #1 (\"Draw a flowchart\"). Sends the verbatim suggestion message \"Use Excalidraw to draw a simple flowchart with three steps.\" The distinctive substring \"draw a simple flowchart\" prevents collision with feature-parity.json's generic `{userMessage: \"steps\"}` fixture, which would otherwise absorb the prompt and return a tool-call-free planning blurb (breaking the iframe). Turn 1 emits `create_view` with three-step flowchart elements so the MCP middleware fetches the Excalidraw UI resource and mounts the iframe; turn 2 (after the tool result) emits the deterministic narration.",
+      "match": {
+        "userMessage": "draw a simple flowchart",
+        "toolName": "create_view"
+      },
+      "response": {
+        "reasoning": "The user wants a simple three-step flowchart. I'll call create_view once with three labelled rectangles connected by arrows and a title, framed by a cameraUpdate.",
+        "content": "Drawing a simple three-step flowchart in Excalidraw.",
+        "toolCalls": [
+          {
+            "id": "call_d5_mcp_apps_create_view_flowchart_001",
+            "name": "create_view",
+            "arguments": "{\"elements\":[{\"id\":\"title\",\"type\":\"text\",\"x\":300,\"y\":40,\"text\":\"Flowchart\",\"fontSize\":24},{\"id\":\"step1\",\"type\":\"rectangle\",\"x\":80,\"y\":160,\"width\":160,\"height\":70,\"label\":{\"text\":\"Start\",\"fontSize\":18}},{\"id\":\"step2\",\"type\":\"rectangle\",\"x\":320,\"y\":160,\"width\":160,\"height\":70,\"label\":{\"text\":\"Process\",\"fontSize\":18}},{\"id\":\"step3\",\"type\":\"rectangle\",\"x\":560,\"y\":160,\"width\":160,\"height\":70,\"label\":{\"text\":\"End\",\"fontSize\":18}},{\"id\":\"a1\",\"type\":\"arrow\",\"x\":240,\"y\":195,\"endX\":320,\"endY\":195},{\"id\":\"a2\",\"type\":\"arrow\",\"x\":480,\"y\":195,\"endX\":560,\"endY\":195},{\"id\":\"camera\",\"type\":\"cameraUpdate\",\"x\":40,\"y\":0,\"width\":800,\"height\":600}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "draw a simple flowchart",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Drew a three-step flowchart (Start → Process → End). Tap the iframe to open it in Excalidraw."
+      }
+    },
+    {
       "match": {
         "userMessage": "Use Excalidraw to sketch"
       },

--- a/showcase/harness/fixtures/d5/mcp-apps.json
+++ b/showcase/harness/fixtures/d5/mcp-apps.json
@@ -26,6 +26,33 @@
       "response": {
         "content": "Sketched a three-box system diagram (Client → Server → Database). Tap the iframe to open it in Excalidraw."
       }
+    },
+    {
+      "_comment": "Mirror of d5-all.json's mcp-apps suggestion pill #1 (\"Draw a flowchart\"). Keyed on the distinctive substring \"draw a simple flowchart\" so a generic feature-parity fixture (e.g. `{userMessage: \"steps\"}`) doesn't absorb the verbatim pill prompt and break the iframe.",
+      "match": {
+        "userMessage": "draw a simple flowchart",
+        "toolName": "create_view"
+      },
+      "response": {
+        "reasoning": "The user wants a simple three-step flowchart. I'll call create_view once with three labelled rectangles connected by arrows and a title, framed by a cameraUpdate.",
+        "content": "Drawing a simple three-step flowchart in Excalidraw.",
+        "toolCalls": [
+          {
+            "id": "call_d5_mcp_apps_create_view_flowchart_001",
+            "name": "create_view",
+            "arguments": "{\"elements\":[{\"id\":\"title\",\"type\":\"text\",\"x\":300,\"y\":40,\"text\":\"Flowchart\",\"fontSize\":24},{\"id\":\"step1\",\"type\":\"rectangle\",\"x\":80,\"y\":160,\"width\":160,\"height\":70,\"label\":{\"text\":\"Start\",\"fontSize\":18}},{\"id\":\"step2\",\"type\":\"rectangle\",\"x\":320,\"y\":160,\"width\":160,\"height\":70,\"label\":{\"text\":\"Process\",\"fontSize\":18}},{\"id\":\"step3\",\"type\":\"rectangle\",\"x\":560,\"y\":160,\"width\":160,\"height\":70,\"label\":{\"text\":\"End\",\"fontSize\":18}},{\"id\":\"a1\",\"type\":\"arrow\",\"x\":240,\"y\":195,\"endX\":320,\"endY\":195},{\"id\":\"a2\",\"type\":\"arrow\",\"x\":480,\"y\":195,\"endX\":560,\"endY\":195},{\"id\":\"camera\",\"type\":\"cameraUpdate\",\"x\":40,\"y\":0,\"width\":800,\"height\":600}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "draw a simple flowchart",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Drew a three-step flowchart (Start → Process → End). Tap the iframe to open it in Excalidraw."
+      }
     }
   ]
 }

--- a/showcase/scripts/__tests__/mcp-apps-suggestion-routing.test.ts
+++ b/showcase/scripts/__tests__/mcp-apps-suggestion-routing.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { loadFixtureFile, matchFixture } from "@copilotkit/aimock";
+import type {
+  ChatCompletionRequest,
+  Fixture,
+  TextResponse,
+  ToolCallResponse,
+} from "@copilotkit/aimock";
+
+// Regression guard for the MCP Apps demo suggestion pills
+// (showcase/integrations/langgraph-python/src/app/demos/mcp-apps/suggestions.ts).
+//
+// Bug class this test catches: a pill's verbatim `message` falls through
+// the d5-all.json mcp-apps fixtures and gets absorbed by a generic
+// substring catch-all later in the load chain (e.g.
+// feature-parity.json's `{userMessage: "steps"}`), producing a
+// content-only response with no `create_view` tool call. The agent
+// never invokes the MCP tool, the runtime never fetches the UI
+// resource, and the sandboxed iframe never mounts. The chat looks like
+// it "works" — it just silently no-ops the demo's whole point.
+//
+// We use aimock's `matchFixture` directly (no HTTP) so the test is
+// fast and deterministic: same matcher, same fixture load order as
+// docker-compose.local.yml.
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const AIMOCK_DIR = path.join(REPO_ROOT, "showcase", "aimock");
+const SUGGESTIONS_PATH = path.join(
+  REPO_ROOT,
+  "showcase",
+  "integrations",
+  "langgraph-python",
+  "src",
+  "app",
+  "demos",
+  "mcp-apps",
+  "suggestions.ts",
+);
+
+// Mirror showcase/docker-compose.local.yml's aimock command:
+//   --fixtures d5-all.json --fixtures smoke.json --fixtures feature-parity.json
+// aimock uses first-match-wins, so this order is load-bearing.
+const FIXTURE_FILES = ["d5-all.json", "smoke.json", "feature-parity.json"];
+
+function loadBundledFixtures(): Fixture[] {
+  return FIXTURE_FILES.flatMap((f) =>
+    loadFixtureFile(path.join(AIMOCK_DIR, f)),
+  );
+}
+
+function buildRequest(opts: {
+  userMessage: string;
+  withCreateViewTool?: boolean;
+  toolResult?: { callId: string };
+}): ChatCompletionRequest {
+  const messages: ChatCompletionRequest["messages"] = [
+    { role: "user", content: opts.userMessage },
+  ];
+  if (opts.toolResult) {
+    messages.push({
+      role: "assistant",
+      content: "",
+      tool_calls: [
+        {
+          id: opts.toolResult.callId,
+          type: "function",
+          function: { name: "create_view", arguments: "{}" },
+        },
+      ],
+    });
+    messages.push({
+      role: "tool",
+      content: "ok",
+      tool_call_id: opts.toolResult.callId,
+    });
+  }
+  return {
+    model: "gpt-5.4",
+    messages,
+    tools: opts.withCreateViewTool
+      ? [
+          {
+            type: "function",
+            function: {
+              name: "create_view",
+              description: "Excalidraw MCP tool",
+              parameters: { type: "object" },
+            },
+          },
+        ]
+      : undefined,
+  };
+}
+
+// One row per suggestion pill in suggestions.ts. `expectedFixtureKey`
+// is the load-bearing substring the d5-all.json fixture is keyed on —
+// it MUST be a substring of `message` (aimock matches `userMessage`
+// case-sensitively via String.prototype.includes — see
+// node_modules/@copilotkit/aimock/dist/router.js#matchFixture).
+const PILLS = [
+  {
+    title: "Draw a flowchart",
+    message: "Use Excalidraw to draw a simple flowchart with three steps.",
+    expectedFixtureKey: "draw a simple flowchart",
+    expectedToolCallId: "call_d5_mcp_apps_create_view_flowchart_001",
+  },
+  {
+    title: "Sketch a system diagram",
+    message:
+      "Open Excalidraw and sketch a system diagram with a client, server, and database.",
+    expectedFixtureKey: "Open Excalidraw and sketch a system diagram",
+    expectedToolCallId: "call_d5_mcp_apps_create_view_001",
+  },
+] as const;
+
+describe("MCP Apps suggestion-pill fixture routing", () => {
+  it("suggestions.ts still uses the exact pill messages this test asserts on", () => {
+    const src = readFileSync(SUGGESTIONS_PATH, "utf8");
+    for (const pill of PILLS) {
+      expect(
+        src.includes(pill.message),
+        `suggestions.ts no longer contains pill message:\n  "${pill.message}"\n` +
+          `If you re-worded a pill, update both the matching fixture in ` +
+          `showcase/aimock/d5-all.json (and its mirror in ` +
+          `showcase/harness/fixtures/d5/mcp-apps.json) AND the PILLS table ` +
+          `in this test so the new wording still routes to the create_view ` +
+          `fixture.`,
+      ).toBe(true);
+      expect(
+        pill.message.includes(pill.expectedFixtureKey),
+        `Pill "${pill.title}" message must contain fixture key ` +
+          `"${pill.expectedFixtureKey}" as a substring — aimock's userMessage ` +
+          `matcher is case-sensitive String.includes.`,
+      ).toBe(true);
+    }
+  });
+
+  it("turn 1: each pill routes to its create_view fixture (not a content-only catch-all)", () => {
+    const fixtures = loadBundledFixtures();
+    for (const pill of PILLS) {
+      const req = buildRequest({
+        userMessage: pill.message,
+        withCreateViewTool: true,
+      });
+      const matched = matchFixture(fixtures, req);
+      expect(
+        matched,
+        `Pill "${pill.title}" — no fixture matched. The pill prompt would ` +
+          `fall through to a 404, leaving the chat hung on the spinner.`,
+      ).not.toBeNull();
+
+      const resp = matched!.response as Partial<ToolCallResponse> &
+        Partial<TextResponse>;
+      const toolName = resp.toolCalls?.[0]?.name;
+      expect(
+        toolName,
+        `Pill "${pill.title}" — matched fixture did not emit a create_view ` +
+          `tool call. Got response: ${JSON.stringify(resp)}. A non-MCP fixture ` +
+          `(e.g. feature-parity.json's \`{userMessage: "steps"}\` content-only ` +
+          `blurb) is absorbing the pill prompt, so the runtime never invokes ` +
+          `the MCP tool and the sandboxed iframe never mounts.`,
+      ).toBe("create_view");
+      expect(
+        resp.toolCalls?.[0]?.id,
+        `Pill "${pill.title}" — matched the wrong create_view fixture ` +
+          `(unexpected tool_call id). The narration fixture won't fire on the ` +
+          `follow-up request and the chat will hang.`,
+      ).toBe(pill.expectedToolCallId);
+    }
+  });
+
+  it("turn 2 (post tool result): each pill routes to its narration fixture", () => {
+    const fixtures = loadBundledFixtures();
+    for (const pill of PILLS) {
+      const req = buildRequest({
+        userMessage: pill.message,
+        toolResult: { callId: pill.expectedToolCallId },
+      });
+      const matched = matchFixture(fixtures, req);
+      expect(
+        matched,
+        `Pill "${pill.title}" — no fixture matched the post-tool-result ` +
+          `request. Without this, the chat will hang waiting for the ` +
+          `agent's final reply after the MCP iframe renders.`,
+      ).not.toBeNull();
+
+      const resp = matched!.response as Partial<TextResponse> &
+        Partial<ToolCallResponse>;
+      expect(
+        typeof resp.content === "string" && resp.content.length > 0,
+        `Pill "${pill.title}" — turn-2 fixture is missing user-visible content.`,
+      ).toBe(true);
+      expect(
+        resp.toolCalls,
+        `Pill "${pill.title}" — turn-2 fixture must be content-only; emitting ` +
+          `another tool call here would loop the agent on the same MCP tool.`,
+      ).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- The mcp-apps demo's "Draw a flowchart" suggestion pill silently broke: clicking it produced a generic "Here is my plan..." response with no MCP tool call, so the sandboxed iframe never mounted.
- Root cause: the verbatim pill prompt `"Use Excalidraw to draw a simple flowchart with three steps."` had no matching `create_view` fixture in `d5-all.json`. aimock's first-match-wins substring matcher fell through to `feature-parity.json`'s `{userMessage: "steps"}` content-only catch-all (matches "with three **steps**.").
- Fix: add a fixture pair keyed on the distinctive substring `"draw a simple flowchart"` to `d5-all.json` and its mirror in `harness/fixtures/d5/mcp-apps.json`. Turn 1 emits `create_view` with a Start → Process → End flowchart; turn 2 (post tool result) emits the narration.
- Regression guard: a fast vitest under `showcase/scripts/__tests__/` loads fixtures in the same order as `docker-compose.local.yml` and uses aimock's `matchFixture` to assert each mcp-apps pill routes to its `create_view` fixture on turn 1 and its narration fixture on turn 2. The test fails loudly with a diagnostic naming the absorbing fixture if the bug returns (verified by reverting the fix locally).

## Test plan

- [x] `pnpm --filter @copilotkit/showcase-scripts test __tests__/mcp-apps-suggestion-routing.test.ts` — 3 tests, ~260 ms, all green.
- [x] `pnpm --filter @copilotkit/showcase-scripts test __tests__/aimock-fixtures.test.ts` — fixture files still validate cleanly with the new entries.
- [x] Reverted just the two new fixtures, re-ran the regression test, confirmed it fails with a diagnostic that explicitly names the wrong fixture (`feature-parity.json`'s `{userMessage: "steps"}` content blurb).
- [x] Local docker stack (`bin/showcase up langgraph-python`) + browser: clicked "Draw a flowchart" at http://localhost:3100/demos/mcp-apps — agent emits `create_view`, MCP middleware fetches the Excalidraw UI resource, sandboxed iframe mounts inline, narration arrives.
- [x] aimock direct POST to `/v1/chat/completions` confirms both legs:
  - Turn 1 (pill + `create_view` in tools[]) → `tool_calls: [{ name: "create_view", id: "call_d5_mcp_apps_create_view_flowchart_001", ... }]`.
  - Turn 2 (with tool result appended) → `content: "Drew a three-step flowchart (Start → Process → End)..."`.