### PR TITLE
fix(showcase/langgraph-python): widen declarative-gen-ui cards + polish InfoRow

### DIFF
--- a/showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -35,7 +35,6 @@ import {
 } from "../_components/card";
 import { Badge } from "../_components/badge";
 import { Button } from "../_components/button";
-import { Separator } from "../_components/separator";
 
 // ─── ShadCN-friendly chart palette ─────────────────────────────────────────
 // Neutral, slightly muted hues that pair with `bg-card` / `--border`
@@ -163,7 +162,10 @@ function AnimatedBar(props: any) {
 // @region[renderers-react]
 export const myRenderers: CatalogRenderers<MyDefinitions> = {
   Card: ({ props, children }) => (
-    <Card className="min-w-[260px]" data-testid="declarative-card">
+    <Card
+      className="w-full min-w-[260px] overflow-hidden"
+      data-testid="declarative-card"
+    >
       <CardHeader>
         <CardTitle>{props.title}</CardTitle>
         {props.subtitle && <CardDescription>{props.subtitle}</CardDescription>}
@@ -210,16 +212,16 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
   },
 
   InfoRow: ({ props }) => (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-baseline justify-between gap-4 py-1">
-        <span className="text-sm text-[var(--muted-foreground)]">
-          {props.label}
-        </span>
-        <span className="text-sm font-medium text-[var(--foreground)]">
-          {props.value}
-        </span>
-      </div>
-      <Separator />
+    // Divider via `border-b last:border-b-0` so the final row doesn't dangle
+    // a trailing line, regardless of whether the agent wraps these in a
+    // Column or drops them directly into a Card's child slot.
+    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+      <span className="text-sm text-[var(--muted-foreground)]">
+        {props.label}
+      </span>
+      <span className="text-sm font-medium text-[var(--foreground)] text-right tabular-nums">
+        {props.value}
+      </span>
     </div>
   ),
 

--- a/showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -49,6 +49,19 @@ const CHART_COLORS = [
   "#27272A", // zinc-800
 ] as const;
 
+// Tailwind arbitrary variant that injects a gap into any descendant flex
+// container — the basic catalog's Row/Column primitives are bare
+// `display: flex` divs with no gap, so when the agent drops multiple
+// Metrics or charts into one, the children end up glued together.
+// We can't reach inside Row/Column from the outside, but we can detect
+// them by their inline `flex-direction` style and apply a gap on the
+// flex container itself (which then propagates to its children).
+// Underscores in the arbitrary value compile to literal spaces in the
+// emitted CSS selector, matching React's serialized inline style.
+const NESTED_FLEX_GAP =
+  "[&_div[style*='flex-direction:_row']]:gap-4 " +
+  "[&_div[style*='flex-direction:_column']]:gap-2";
+
 const CHART_TOOLTIP_STYLE: React.CSSProperties = {
   backgroundColor: "var(--card)",
   border: "1px solid var(--border)",
@@ -163,7 +176,7 @@ function AnimatedBar(props: any) {
 export const myRenderers: CatalogRenderers<MyDefinitions> = {
   Card: ({ props, children }) => (
     <Card
-      className="w-full min-w-[260px] overflow-hidden"
+      className="w-full min-w-0 overflow-hidden"
       data-testid="declarative-card"
     >
       <CardHeader>
@@ -171,7 +184,7 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
         {props.subtitle && <CardDescription>{props.subtitle}</CardDescription>}
       </CardHeader>
       {props.child && (
-        <CardContent className="flex flex-col gap-3">
+        <CardContent className={`flex flex-col gap-4 ${NESTED_FLEX_GAP}`}>
           {children(props.child)}
         </CardContent>
       )}
@@ -197,7 +210,13 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
           ? "text-rose-600"
           : "text-[var(--foreground)]";
     return (
-      <div data-testid="declarative-metric" className="flex flex-col gap-1">
+      // `flex-1 min-w-[120px]` lets a row of Metrics distribute evenly
+      // inside the basic catalog's gap-less Row — 3 metrics in a 600px
+      // card column get ~200px each instead of squishing to content width.
+      <div
+        data-testid="declarative-metric"
+        className="flex flex-1 min-w-[120px] flex-col gap-1"
+      >
         <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
           {props.label}
         </div>
@@ -241,8 +260,11 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     const total = safeData.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
 
     return (
+      // `flex-1 min-w-0` so multiple charts in a basic-catalog Row
+      // distribute the available width evenly instead of each insisting
+      // on its content size and overflowing.
       <Card
-        className="mx-auto max-w-[520px] overflow-hidden"
+        className="w-full flex-1 min-w-0 overflow-hidden"
         data-testid="declarative-pie-chart"
       >
         <CardHeader>
@@ -301,7 +323,7 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
 
     return (
       <Card
-        className="mx-auto max-w-[640px] overflow-hidden"
+        className="w-full flex-1 min-w-0 overflow-hidden"
         data-testid="declarative-bar-chart"
       >
         {/* Scoped keyframe — no globals.css needed */}

--- a/showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -49,19 +49,6 @@ const CHART_COLORS = [
   "#27272A", // zinc-800
 ] as const;
 
-// Tailwind arbitrary variant that injects a gap into any descendant flex
-// container — the basic catalog's Row/Column primitives are bare
-// `display: flex` divs with no gap, so when the agent drops multiple
-// Metrics or charts into one, the children end up glued together.
-// We can't reach inside Row/Column from the outside, but we can detect
-// them by their inline `flex-direction` style and apply a gap on the
-// flex container itself (which then propagates to its children).
-// Underscores in the arbitrary value compile to literal spaces in the
-// emitted CSS selector, matching React's serialized inline style.
-const NESTED_FLEX_GAP =
-  "[&_div[style*='flex-direction:_row']]:gap-4 " +
-  "[&_div[style*='flex-direction:_column']]:gap-2";
-
 const CHART_TOOLTIP_STYLE: React.CSSProperties = {
   backgroundColor: "var(--card)",
   border: "1px solid var(--border)",
@@ -184,7 +171,7 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
         {props.subtitle && <CardDescription>{props.subtitle}</CardDescription>}
       </CardHeader>
       {props.child && (
-        <CardContent className={`flex flex-col gap-4 ${NESTED_FLEX_GAP}`}>
+        <CardContent className="flex flex-col gap-4">
           {children(props.child)}
         </CardContent>
       )}

--- a/showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/page.tsx
@@ -37,10 +37,22 @@ export default function DeclarativeGenUIDemo() {
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}
     >
-      <div className="flex justify-center items-center h-screen w-full">
-        <div className="h-full w-full max-w-4xl">
+      <div className="declarative-gen-ui-wide flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-6xl">
           <Chat />
         </div>
+        {/*
+          The chat surface caps its internal scroll column and input row at
+          `cpk:max-w-3xl` (~768px). For this demo we want the generated A2UI
+          cards (KPI dashboards, charts, status reports) to breathe wider, so
+          we widen those wrappers locally to ~64rem. Attribute selector avoids
+          escaping the `:` in the Tailwind class name.
+        */}
+        <style>{`
+          .declarative-gen-ui-wide [class~="cpk:max-w-3xl"] {
+            max-width: 64rem;
+          }
+        `}</style>
       </div>
     </CopilotKit>
     // @endregion[provider-a2ui-prop]

--- a/showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/declarative-gen-ui/page.tsx
@@ -37,22 +37,10 @@ export default function DeclarativeGenUIDemo() {
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}
     >
-      <div className="declarative-gen-ui-wide flex justify-center items-center h-screen w-full">
-        <div className="h-full w-full max-w-6xl">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
           <Chat />
         </div>
-        {/*
-          The chat surface caps its internal scroll column and input row at
-          `cpk:max-w-3xl` (~768px). For this demo we want the generated A2UI
-          cards (KPI dashboards, charts, status reports) to breathe wider, so
-          we widen those wrappers locally to ~64rem. Attribute selector avoids
-          escaping the `:` in the Tailwind class name.
-        */}
-        <style>{`
-          .declarative-gen-ui-wide [class~="cpk:max-w-3xl"] {
-            max-width: 64rem;
-          }
-        `}</style>
       </div>
     </CopilotKit>
     // @endregion[provider-a2ui-prop]


### PR DESCRIPTION
## Summary

- Widen the `declarative-gen-ui` demo so generated A2UI cards (KPI dashboards, charts, status reports) actually have room to breathe. Outer page wrapper goes `max-w-4xl` → `max-w-6xl`, and a scoped attribute selector lifts the chat's internal `cpk:max-w-3xl` to 64rem **for this demo only** — no impact on other demos.
- Fix the `InfoRow` trailing-separator artifact. Each row now draws its own `border-b` with `last:border-b-0 last:pb-0 first:pt-0`, so the final row in a Card (most visible on the **Status Report** suggestion pill) no longer leaves a dangling line. Works regardless of whether the agent wraps rows in a Column or drops them directly into the Card child slot.
- `Card` gains `w-full overflow-hidden` so it stretches into the wider column; `InfoRow` value gets `text-right tabular-nums` for cleaner alignment in stacks.

Scoped to the north-star (`showcase/integrations/langgraph-python`) only — will propagate to the other integrations via `pnpm parity:sync` in a follow-up.

## Why

Clicking the suggestion pills (KPI dashboard, pie chart, bar chart, status report) rendered cards inside a 768px column even though the page wrapped at 1024px. The bottleneck was the chat's internal `cpk:max-w-3xl`. Status Report also looked busy because every `InfoRow` rendered a full-width divider after itself, including the last row.

## Test plan

- [ ] `pnpm --filter @copilotkit/showcase-langgraph-python dev`, open `/demos/declarative-gen-ui`
- [ ] Click each suggestion pill (KPI dashboard, pie chart, bar chart, status report); confirm cards have noticeably more horizontal room
- [ ] Confirm the last row in **Status Report** has no trailing divider
- [ ] Confirm other demos in the same integration are visually unchanged (the override is scoped to `.declarative-gen-ui-wide`)