### PR TITLE
fix(showcase/langgraph-python): remove dead "Show reasoning" pill from chat-slots

### DIFF
--- a/showcase/integrations/langgraph-python/src/app/demos/chat-slots/suggestions.ts
+++ b/showcase/integrations/langgraph-python/src/app/demos/chat-slots/suggestions.ts
@@ -2,16 +2,17 @@
 
 import { useConfigureSuggestions } from "@copilotkit/react-core/v2";
 
+// The chat-slots cell is wired to the neutral `sample_agent` graph
+// (plain ChatOpenAI, no Responses API, no reasoning config), so it never
+// emits AG-UI REASONING_MESSAGE_* events — the `messageView.reasoningMessage`
+// slot is wrapped for the slot-atlas demo but stays dormant here. A
+// "Show reasoning" pill therefore can't light it up; that demo lives at
+// /demos/reasoning-default and /demos/reasoning-custom instead.
 export function useChatSlotsSuggestions() {
   useConfigureSuggestions({
     suggestions: [
       { title: "Write a sonnet", message: "Write a short sonnet about AI." },
       { title: "Tell me a joke", message: "Tell me a short joke." },
-      {
-        title: "Show reasoning",
-        message:
-          "Think out loud step by step about whether 17 is prime, then answer.",
-      },
     ],
     available: "always",
   });


### PR DESCRIPTION
## Summary

- The chat-slots cell is wired to the neutral `sample_agent` graph (plain `ChatOpenAI`, no Responses API, no reasoning config), so it never emits AG-UI `REASONING_MESSAGE_*` events. The "Show reasoning" suggestion pill therefore had no way to light up the wrapped `messageView.reasoningMessage` slot.
- Its prompt — `"Think out loud step by step about whether 17 is prime, then answer."` — also wasn't a substring of any `userMessage` in `showcase/aimock/d5-all.json`, so aimock-backed runs returned `404 "No fixture matched"` rather than the intended reasoning fixture.
- `qa/chat-slots.md` and `tests/e2e/chat-slots.spec.ts` already only assert the two remaining pills ("Write a sonnet" / "Tell me a joke"), so dropping the third pill aligns the demo with what the QA + e2e already expect.

The `CustomReasoningMessage` slot wrapping is intentionally left in place — the chat-slots page is a "Slot Atlas" where every overrideable slot is wrapped, even if dormant for this cell. Live reasoning rendering already has its own dedicated demos at `/demos/reasoning-default` and `/demos/reasoning-custom`, which use the `reasoning_agent` graph (Responses API + `reasoning={"effort":"medium","summary":"detailed"}`).

## Test plan

- [ ] `/demos/chat-slots` renders exactly two suggestion pills: "Write a sonnet" and "Tell me a joke"
- [ ] Both pills produce an assistant reply wrapped in the `CustomAssistantMessage` slot marker
- [ ] No console errors or missing-fixture 404s appear during the flow
- [ ] `/demos/reasoning-default` and `/demos/reasoning-custom` still light up the reasoning slot (unchanged here, but worth a sanity check)