### PR TITLE
Docs(DeepAgents): Interrupt Flow Python Code Fixes

### DIFF
--- a/docs/content/docs/integrations/deepagents/generative-ui/your-components/interrupt-based.mdx
+++ b/docs/content/docs/integrations/deepagents/generative-ui/your-components/interrupt-based.mdx
@@ -104,7 +104,7 @@ We're going to have the agent ask us to name it, so we'll need a state property 
         <Tab value="Python">
             ```python title="agent.py"
             from typing import Any
-            from copilotkit import CopilotKitState
+            from copilotkit import CopilotKitState, CopilotKitMiddleware
             from langchain.agents.middleware import AgentMiddleware # [!code highlight]
             from langgraph.runtime import Runtime
             from langgraph.types import interrupt # [!code highlight]
@@ -122,6 +122,13 @@ We're going to have the agent ask us to name it, so we'll need a state property 
                         name = interrupt("Before we start, what would you like to call me?") # [!code highlight]
                         return {"agent_name": name}
                     return None
+            
+            agent = create_deep_agent(
+            model="openai:gpt-4o",
+            tools=[get_weather],
+            middleware=[CopilotKitMiddleware(expose_state=["agent_name"]), AgentNameMiddleware()], # for frontend tools and context
+            system_prompt="You are a helpful research assistant.",
+            )
             ```
         </Tab>
         <Tab value="TypeScript">
@@ -165,6 +172,7 @@ We're going to have the agent ask us to name it, so we'll need a state property 
     // [!code highlight:15]
     // styles omitted for brevity
     useInterrupt({
+        agentId: "sample_agent",
         render: ({ event, resolve }) => (
             <div>
                 <p>{event.value}</p>

--- a/docs/content/docs/integrations/deepagents/human-in-the-loop/interrupt-flow.mdx
+++ b/docs/content/docs/integrations/deepagents/human-in-the-loop/interrupt-flow.mdx
@@ -104,7 +104,7 @@ We're going to have the agent ask us to name it, so we'll need a state property 
         <Tab value="Python">
             ```python title="agent.py"
             from typing import Any
-            from copilotkit import CopilotKitState
+            from copilotkit import CopilotKitState, CopilotKitMiddleware
             from langchain.agents.middleware import AgentMiddleware # [!code highlight]
             from langgraph.runtime import Runtime
             from langgraph.types import interrupt # [!code highlight]
@@ -122,6 +122,14 @@ We're going to have the agent ask us to name it, so we'll need a state property 
                         name = interrupt("Before we start, what would you like to call me?") # [!code highlight]
                         return {"agent_name": name}
                     return None
+
+            agent = create_deep_agent(
+            model="openai:gpt-4o",
+            tools=[get_weather],
+            middleware=[CopilotKitMiddleware(expose_state=["agent_name"]), AgentNameMiddleware()], # for frontend tools and context
+            system_prompt="You are a helpful research assistant.",
+            )
+
             ```
         </Tab>
         <Tab value="TypeScript">
@@ -165,6 +173,7 @@ We're going to have the agent ask us to name it, so we'll need a state property 
     // [!code highlight:15]
     // styles omitted for brevity
     useInterrupt({
+        agentId: "sample_agent",
         render: ({ event, resolve }) => (
             <div>
                 <p>{event.value}</p>


### PR DESCRIPTION
## Summary
In python variant of DeepAgents, fixed the middleware to work correctly by accepting agent_name, and using expose_state on CopilotKitMiddleware to inject dynamic agent_name in system prompt. Also fixed missing agentId in useInterrupt Hook

## Changes

1. used `CopilotKitMiddleware(expose_state=["agent_name"])` in agent configuration so agent_name can be injected in agent's system prompt and can be recognized. Otherwise, it was only visible in AG-UI events inspector, and agent would not respond to the given agent_name that the user would set

2. Added `agentId: "sample_agent"` in `useInterrupt()` without it, the following error is thrown 

```
useAgent: Agent 'default' not found after runtime sync (runtimeUrl=/api/copilotkit).
Known agents: [sample_agent]
```
This is because `useInterrupt` calls `useAgent({ agentId: config.agentId })` and `useAgent` falls back to the literal string `"default"` when no `agentId` is given. 
