### PR TITLE
fix: add LICENSE file to @copilotkit/license-verifier

### DIFF
--- a/packages/license-verifier/LICENSE
+++ b/packages/license-verifier/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Atai Barkai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
## What does this PR do?

Adds the MIT LICENSE file to the `@copilotkit/license-verifier` package directory to resolve missing license issues when pulling the package into organization npm registries.

## Summary

The `@copilotkit/license-verifier` npm package is published without a LICENSE file, causing organization registries to reject the package and blocking upgrades of dependent packages like `@copilotkit/runtime` (v1.56.5+) and `@copilotkit/react-core`.

## Root Cause

The `packages/license-verifier/` directory in the monorepo is missing a LICENSE file, which means the published npm package tarball also lacks one.

## Fix

Copy the MIT LICENSE from the repository root into `packages/license-verifier/LICENSE`. This is the same license used by the rest of the CopilotKit monorepo.

## Changes

- Created `packages/license-verifier/LICENSE` (MIT License, same as root LICENSE)

## Testing

- Verified the root LICENSE file content matches the added package LICENSE file
- The fix ensures the next publish of `@copilotkit/license-verifier` will include the LICENSE file

## Related PRs and Issues

- Fixes #4704

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked