### PR TITLE
fix(showcase/aimock): chain tool-rendering follow-ups via toolCallId so multi-pill sessions work

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -87,10 +87,37 @@
       }
     },
     {
-      "_comment": "tool-rendering pill: Chain tools — emit 3 tool calls in one assistant turn (get_weather Tokyo + search_flights SFO->Tokyo + roll_d20=11). MUST appear before the bare 'weather in Tokyo' fixture below; substring match would otherwise leak into this prompt.",
+      "_comment": "tool-rendering pill: Chain tools — follow-up after all 3 tools ran. Matches whichever of the 3 chain-tools tool_call_ids appears last in the request (LangGraph's ToolNode preserves tool_calls order, so roll_d20 is typically last; we register all 3 for safety). MUST come before the toolCalls-emitting fixture below so iteration 2 of the chain-tools loop hits this branch instead of re-emitting.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",
-        "hasToolResult": false
+        "toolCallId": "call_tr_chain_roll_001"
+      },
+      "response": {
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Chain a few tools in this single turn",
+        "toolCallId": "call_tr_chain_flights_001"
+      },
+      "response": {
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Chain a few tools in this single turn",
+        "toolCallId": "call_tr_chain_weather_001"
+      },
+      "response": {
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+      }
+    },
+    {
+      "_comment": "tool-rendering pill: Chain tools — emit 3 tool calls in one assistant turn (get_weather Tokyo + search_flights SFO->Tokyo + roll_d20=11). MUST appear before the bare 'weather in Tokyo' fixture below; substring match would otherwise leak into this prompt. No hasToolResult gate: in multi-pill demo sessions prior clicks leave tool results in the thread, which previously caused this fixture to be skipped in favour of the follow-up content fixture and the pill rendered no cards.",
+      "match": {
+        "userMessage": "Chain a few tools in this single turn"
       },
       "response": {
         "toolCalls": [
@@ -113,19 +140,18 @@
       }
     },
     {
+      "_comment": "tool-rendering pill: Weather in SF — follow-up content after get_weather tool ran. MUST come before the tool-emitting fixture below (first-match-wins) so iteration 2 of the loop hits this branch instead of re-emitting. toolCallId chain keeps the fixture stateless across multi-pill thread history (hasToolResult breaks when a prior pill left tool results in the thread).",
       "match": {
-        "userMessage": "Chain a few tools in this single turn",
-        "hasToolResult": true
+        "userMessage": "What's the weather in San Francisco?",
+        "toolCallId": "call_tr_weather_sf_001"
       },
       "response": {
-        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "San Francisco is currently 68°F and sunny with light winds."
       }
     },
     {
-      "_comment": "tool-rendering pill: Weather in SF — verbatim pill prompt, deterministic San Francisco values.",
       "match": {
-        "userMessage": "What's the weather in San Francisco?",
-        "hasToolResult": false
+        "userMessage": "What's the weather in San Francisco?"
       },
       "response": {
         "toolCalls": [
@@ -135,15 +161,6 @@
             "arguments": "{\"location\":\"San Francisco\"}"
           }
         ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "What's the weather in San Francisco?",
-        "hasToolResult": true
-      },
-      "response": {
-        "content": "San Francisco is currently 68°F and sunny with light winds."
       }
     },
     {
@@ -174,10 +191,18 @@
       }
     },
     {
-      "_comment": "tool-rendering pill: Stock price — verbatim pill prompt, AAPL with deterministic price/change.",
+      "_comment": "tool-rendering pill: Stock price — follow-up content after get_stock_price tool ran. MUST come before the tool-emitting fixture below (first-match-wins) so iteration 2 of the loop hits this branch instead of re-emitting an infinite loop of tool calls.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
-        "hasToolResult": false
+        "toolCallId": "call_tr_stock_aapl_001"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% on the day."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "What's the current price of AAPL?"
       },
       "response": {
         "toolCalls": [
@@ -190,36 +215,10 @@
       }
     },
     {
-      "match": {
-        "userMessage": "What's the current price of AAPL?",
-        "toolCallId": "call_tr_stock_aapl_001"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
-      }
-    },
-    {
-      "_comment": "tool-rendering pill: Roll a d20 — exactly 5 sequential roll_d20 calls returning [7, 14, 3, 19, 20]. Disambiguated by turnIndex (count of assistant messages so far) so the sequence is stateless across test runs.",
+      "_comment": "tool-rendering pill: Roll a d20 — exactly 5 sequential roll_d20 calls returning [7, 14, 3, 19, 20]. Chained by toolCallId so the sequence is stateless across thread history (turnIndex/hasToolResult break in multi-pill demo sessions where prior clicks leave assistant/tool messages in the thread). Specific-toolCallId fixtures MUST come before the userMessage-only fixture below; first-match-wins.",
       "match": {
         "userMessage": "Roll a 20-sided die.",
-        "turnIndex": 0,
-        "hasToolResult": false
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_tr_d20_seq_001",
-            "name": "roll_d20",
-            "arguments": "{\"value\":7}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Roll a 20-sided die.",
-        "turnIndex": 1,
-        "hasToolResult": true
+        "toolCallId": "call_tr_d20_seq_001"
       },
       "response": {
         "toolCalls": [
@@ -234,8 +233,7 @@
     {
       "match": {
         "userMessage": "Roll a 20-sided die.",
-        "turnIndex": 2,
-        "hasToolResult": true
+        "toolCallId": "call_tr_d20_seq_002"
       },
       "response": {
         "toolCalls": [
@@ -250,8 +248,7 @@
     {
       "match": {
         "userMessage": "Roll a 20-sided die.",
-        "turnIndex": 3,
-        "hasToolResult": true
+        "toolCallId": "call_tr_d20_seq_003"
       },
       "response": {
         "toolCalls": [
@@ -266,8 +263,7 @@
     {
       "match": {
         "userMessage": "Roll a 20-sided die.",
-        "turnIndex": 4,
-        "hasToolResult": true
+        "toolCallId": "call_tr_d20_seq_004"
       },
       "response": {
         "toolCalls": [
@@ -282,11 +278,25 @@
     {
       "match": {
         "userMessage": "Roll a 20-sided die.",
-        "turnIndex": 5,
-        "hasToolResult": true
+        "toolCallId": "call_tr_d20_seq_005"
       },
       "response": {
         "content": "Rolled the d20 five times — landed on 20 on the final roll."
+      }
+    },
+    {
+      "_comment": "First roll. Matches the initial user prompt (no prior d20 tool result in this chain yet). Comes after the toolCallId-chained fixtures above so iterations 2-6 of the loop hit those first.",
+      "match": {
+        "userMessage": "Roll a 20-sided die."
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_tr_d20_seq_001",
+            "name": "roll_d20",
+            "arguments": "{\"value\":7}"
+          }
+        ]
       }
     },
     {
@@ -1193,9 +1203,18 @@
       }
     },
     {
+      "_comment": "Follow-up content after get_weather (or get-weather Mastra alias) ran for Tokyo. Keyed on the prior tool's id so it fires after iteration 1 regardless of thread history. Must come BEFORE the tool-emitting fixtures so iteration 2 hits this branch instead of re-emitting get_weather.",
       "match": {
         "userMessage": "weather in Tokyo",
-        "hasToolResult": false,
+        "toolCallId": "call_d5_get_weather_001"
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "weather in Tokyo",
         "toolName": "get_weather"
       },
       "response": {
@@ -1214,7 +1233,6 @@
       "_comment": "Mastra registers the weather tool as get-weather (hyphen); duplicate for compat",
       "match": {
         "userMessage": "weather in Tokyo",
-        "hasToolResult": false,
         "toolName": "get-weather"
       },
       "response": {
@@ -1230,15 +1248,7 @@
       }
     },
     {
-      "match": {
-        "userMessage": "weather in Tokyo",
-        "hasToolResult": true
-      },
-      "response": {
-        "content": "Tokyo is 22°C and partly cloudy."
-      }
-    },
-    {
+      "_comment": "Final fallback when the agent has neither get_weather nor get-weather registered — return narrated content with no tool call. Comes last so the tool-emitting fixtures above win when the tool IS available.",
       "match": {
         "userMessage": "weather in Tokyo"
       },
@@ -1485,10 +1495,31 @@
       }
     },
     {
-      "_comment": "hitl-in-app — refund pill (#12345). 1st turn: emit request_user_approval tool call.",
+      "_comment": "hitl-in-app — refund pill (#12345), 2nd turn after approve. Keyed on the request_user_approval toolCallId AND sequenceIndex 0 (first match = approve branch). Must come BEFORE the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
         "userMessage": "$50 refund to Jordan Rivera on ticket #12345",
-        "hasToolResult": false
+        "toolCallId": "call_d5_hitl_refund_12345_001",
+        "sequenceIndex": 0
+      },
+      "response": {
+        "content": "I am processing the $50 refund to Jordan Rivera on ticket #12345 now."
+      }
+    },
+    {
+      "_comment": "hitl-in-app — refund pill (#12345), 2nd turn after reject. sequenceIndex 1 = reject branch.",
+      "match": {
+        "userMessage": "$50 refund to Jordan Rivera on ticket #12345",
+        "toolCallId": "call_d5_hitl_refund_12345_001",
+        "sequenceIndex": 1
+      },
+      "response": {
+        "content": "Understood — the refund request was not approved. I will not issue the $50 refund on ticket #12345."
+      }
+    },
+    {
+      "_comment": "hitl-in-app — refund pill (#12345). 1st turn: emit request_user_approval tool call. hasToolResult gate was dropped — broke after the user clicked another tool-using pill earlier in the same thread.",
+      "match": {
+        "userMessage": "$50 refund to Jordan Rivera on ticket #12345"
       },
       "response": {
         "toolCalls": [
@@ -1501,32 +1532,31 @@
       }
     },
     {
-      "_comment": "hitl-in-app — refund pill (#12345), 2nd turn after approve. sequenceIndex 0 = approve branch (first match).",
+      "_comment": "hitl-in-app — escalate pill (#12347), 2nd turn after approve. sequenceIndex 0 = approve branch. Must come BEFORE the tool-emitting fixture.",
       "match": {
-        "userMessage": "$50 refund to Jordan Rivera on ticket #12345",
-        "hasToolResult": true,
+        "userMessage": "escalate ticket #12347 to the payments team",
+        "toolCallId": "call_d5_hitl_escalate_12347_001",
         "sequenceIndex": 0
       },
       "response": {
-        "content": "I am processing the $50 refund to Jordan Rivera on ticket #12345 now."
+        "content": "Escalated ticket #12347 to the payments team for Morgan Lee — they will pick this up shortly."
       }
     },
     {
-      "_comment": "hitl-in-app — refund pill (#12345), 2nd turn after reject. sequenceIndex 1 = reject branch (second match).",
+      "_comment": "hitl-in-app — escalate pill (#12347), 2nd turn after reject. sequenceIndex 1 = reject branch.",
       "match": {
-        "userMessage": "$50 refund to Jordan Rivera on ticket #12345",
-        "hasToolResult": true,
+        "userMessage": "escalate ticket #12347 to the payments team",
+        "toolCallId": "call_d5_hitl_escalate_12347_001",
         "sequenceIndex": 1
       },
       "response": {
-        "content": "Understood — the refund request was not approved. I will not issue the $50 refund on ticket #12345."
+        "content": "Not escalated — ticket #12347 will stay with the current owner per your decision."
       }
     },
     {
       "_comment": "hitl-in-app — escalate pill (#12347). 1st turn: emit request_user_approval tool call.",
       "match": {
-        "userMessage": "escalate ticket #12347 to the payments team",
-        "hasToolResult": false
+        "userMessage": "escalate ticket #12347 to the payments team"
       },
       "response": {
         "toolCalls": [
@@ -1539,32 +1569,19 @@
       }
     },
     {
-      "_comment": "hitl-in-app — escalate pill (#12347), 2nd turn after approve. sequenceIndex 0 = approve branch.",
+      "_comment": "frontend-tools-async — project-planning pill, follow-up content keyed on the prior tool's id. Comes BEFORE the tool-emitting fixture so iteration 2 (after the async handler returns) hits this branch instead of re-emitting query_notes. hasToolResult gates were dropped because they broke after the user clicked another tool-using pill earlier in the same thread.",
       "match": {
-        "userMessage": "escalate ticket #12347 to the payments team",
-        "hasToolResult": true,
-        "sequenceIndex": 0
+        "userMessage": "Find my notes about project planning",
+        "toolCallId": "call_d5_query_notes_project_planning_001"
       },
       "response": {
-        "content": "Escalated ticket #12347 to the payments team for Morgan Lee — they will pick this up shortly."
-      }
-    },
-    {
-      "_comment": "hitl-in-app — escalate pill (#12347), 2nd turn after reject. sequenceIndex 1 = reject branch.",
-      "match": {
-        "userMessage": "escalate ticket #12347 to the payments team",
-        "hasToolResult": true,
-        "sequenceIndex": 1
-      },
-      "response": {
-        "content": "Not escalated — ticket #12347 will stay with the current owner per your decision."
+        "content": "You have notes on project planning: \"Q2 project planning kickoff\" and \"Project planning retrospective notes\". Let me know if you want a summary of either."
       }
     },
     {
       "_comment": "frontend-tools-async — project-planning pill. 1st turn: query_notes tool call. Specific match wins over the broad 'plan' fixture in feature-parity.json (d5-all.json loads first).",
       "match": {
-        "userMessage": "Find my notes about project planning",
-        "hasToolResult": false
+        "userMessage": "Find my notes about project planning"
       },
       "response": {
         "toolCalls": [
@@ -1577,20 +1594,19 @@
       }
     },
     {
-      "_comment": "frontend-tools-async — project-planning pill. 2nd turn: narration referencing the project-planning notes returned by the async handler.",
+      "_comment": "frontend-tools-async — auth pill, follow-up content keyed on the prior tool's id. Must come BEFORE the tool-emitting fixture.",
       "match": {
-        "userMessage": "Find my notes about project planning",
-        "hasToolResult": true
+        "userMessage": "Search my notes for anything related to auth",
+        "toolCallId": "call_d5_query_notes_auth_001"
       },
       "response": {
-        "content": "You have notes on project planning: \"Q2 project planning kickoff\" and \"Project planning retrospective notes\". Let me know if you want a summary of either."
+        "content": "You have one note related to auth: \"Planning: migrate auth to passkeys\" — it covers WebAuthn library options and a fallback for unsupported browsers."
       }
     },
     {
       "_comment": "frontend-tools-async — auth pill. 1st turn: query_notes tool call. Beats the showcase-assistant catch-all in feature-parity.json by virtue of d5-all.json's load order and a longer specific substring match.",
       "match": {
-        "userMessage": "Search my notes for anything related to auth",
-        "hasToolResult": false
+        "userMessage": "Search my notes for anything related to auth"
       },
       "response": {
         "toolCalls": [
@@ -1603,20 +1619,19 @@
       }
     },
     {
-      "_comment": "frontend-tools-async — auth pill. 2nd turn: narration referencing the auth note returned by the async handler.",
+      "_comment": "frontend-tools-async — reading pill, follow-up content keyed on the prior tool's id. Must come BEFORE the tool-emitting fixture. Locked narration leading phrase per spec test #4 assertion.",
       "match": {
-        "userMessage": "Search my notes for anything related to auth",
-        "hasToolResult": true
+        "userMessage": "Do I have any notes tagged reading",
+        "toolCallId": "call_d5_query_notes_reading_001"
       },
       "response": {
-        "content": "You have one note related to auth: \"Planning: migrate auth to passkeys\" — it covers WebAuthn library options and a fallback for unsupported browsers."
+        "content": "You have a note titled \"Book recommendations\" that is tagged with \"reading.\" It includes the following books: Thinking Fast and Slow by Daniel Kahneman, The Design of Everyday Things by Don Norman."
       }
     },
     {
       "_comment": "frontend-tools-async — reading pill. 1st turn: query_notes tool call.",
       "match": {
-        "userMessage": "Do I have any notes tagged reading",
-        "hasToolResult": false
+        "userMessage": "Do I have any notes tagged reading"
       },
       "response": {
         "toolCalls": [
@@ -1626,16 +1641,6 @@
             "arguments": "{\"keyword\":\"reading\"}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "frontend-tools-async — reading pill. 2nd turn: locked narration leading phrase per spec test #4 assertion.",
-      "match": {
-        "userMessage": "Do I have any notes tagged reading",
-        "hasToolResult": true
-      },
-      "response": {
-        "content": "You have a note titled \"Book recommendations\" that is tagged with \"reading.\" It includes the following books: Thinking Fast and Slow by Daniel Kahneman, The Design of Everyday Things by Don Norman."
       }
     },
     {

--- a/showcase/integrations/langgraph-python/tests/e2e/frontend-tools-async.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/frontend-tools-async.spec.ts
@@ -136,4 +136,51 @@ test.describe("Frontend Tools (async query_notes)", () => {
         .first(),
     ).toBeVisible({ timeout: 60_000 });
   });
+
+  // Regression for the aimock multi-pill bug:
+  // The three frontend-tools-async fixtures used `hasToolResult: false/true`
+  // gates to split first-turn (emit `query_notes`) vs. follow-up (narration).
+  // After the user clicked a tool-using pill earlier in the same thread, the
+  // first-turn fixture was skipped (the thread already had a prior tool
+  // result), the follow-up fixture fired immediately with just narration,
+  // and the Notes DB card never rendered. Fix: chain via `toolCallId`, drop
+  // the gates. This test drives all three pills in a single thread and
+  // asserts every pill renders its own Notes DB card.
+  test("sequential pills in one thread each render their own Notes DB card", async ({
+    page,
+  }) => {
+    // Three pills × async-handler latency × LLM mock chain; the existing
+    // describe-level 120s is not enough once we drive all three in one test.
+    test.setTimeout(240_000);
+
+    const cards = page.locator('[data-testid="notes-card"]');
+
+    await page
+      .getByRole("button", { name: /Find project-planning notes/i })
+      .click();
+    await expect.poll(() => cards.count(), { timeout: 60_000 }).toBe(1);
+    await expect(
+      page.locator('[data-testid="notes-keyword"]', {
+        hasText: /Matching\s+"project planning"/i,
+      }),
+    ).toBeVisible({ timeout: 60_000 });
+
+    await page.getByRole("button", { name: /Search for 'auth'/i }).click();
+    await expect.poll(() => cards.count(), { timeout: 60_000 }).toBe(2);
+    await expect(
+      page.locator('[data-testid="notes-keyword"]', {
+        hasText: /Matching\s+"auth"/i,
+      }),
+    ).toBeVisible({ timeout: 60_000 });
+
+    await page
+      .getByRole("button", { name: /What do I have about reading\?/i })
+      .click();
+    await expect.poll(() => cards.count(), { timeout: 60_000 }).toBe(3);
+    await expect(
+      page.locator('[data-testid="notes-keyword"]', {
+        hasText: /Matching\s+"reading"/i,
+      }),
+    ).toBeVisible({ timeout: 60_000 });
+  });
 });

--- a/showcase/integrations/langgraph-python/tests/e2e/hitl-in-app.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/hitl-in-app.spec.ts
@@ -184,4 +184,61 @@ test.describe("HITL In-App (approval dialog portaled to <body>)", () => {
     // for the genuine-pass rewrite. Re-enable when the upstream demo
     // reliably emits request_user_approval for the downgrade prompt.
   });
+
+  // Regression for the aimock multi-pill bug:
+  // The refund (#12345) and escalate (#12347) fixtures used
+  // `hasToolResult: false/true` to split the request_user_approval emit
+  // from the approve/reject narration. After approving the first pill, the
+  // thread already had a tool result, so the second pill's first-turn
+  // fixture was skipped — the approve/reject branch fired immediately with
+  // no approval dialog. Fix: chain the follow-up fixtures via the
+  // request_user_approval `toolCallId`, drop `hasToolResult: false` from
+  // the tool-emitting fixture. This test approves refund #12345 then
+  // clicks escalate #12347 in the same thread and asserts the second pill
+  // mounts its own approval dialog.
+  test("approve refund then click escalate — each pill mounts its own approval dialog", async ({
+    page,
+  }) => {
+    test.setTimeout(240_000);
+
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Approve refund for #12345" })
+      .first()
+      .click();
+
+    const refundDialog = page.locator(
+      'body > [data-testid="approval-dialog-overlay"]',
+    );
+    await expect(refundDialog).toBeVisible({ timeout: 60_000 });
+    // The first dialog targets ticket #12345.
+    await expect(refundDialog.getByText(/#12345/)).toBeVisible();
+
+    await page.getByTestId("approval-dialog-approve").click();
+    await expect(
+      page.locator('[data-testid="approval-dialog-overlay"]'),
+    ).toHaveCount(0, { timeout: 5_000 });
+
+    // First pill's approve narration lands before we click the next pill.
+    await expect(
+      page
+        .locator('[data-testid="copilot-assistant-message"]')
+        .filter({ hasText: "processing the $50 refund" })
+        .first(),
+    ).toBeVisible({ timeout: 60_000 });
+
+    // Second pill: must trigger its OWN request_user_approval tool call
+    // and mount a fresh approval dialog targeting ticket #12347.
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Escalate ticket #12347" })
+      .first()
+      .click();
+
+    const escalateDialog = page.locator(
+      'body > [data-testid="approval-dialog-overlay"]',
+    );
+    await expect(escalateDialog).toBeVisible({ timeout: 60_000 });
+    await expect(escalateDialog.getByText(/#12347/)).toBeVisible();
+  });
 });

--- a/showcase/integrations/langgraph-python/tests/e2e/tool-rendering-custom-catchall.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/tool-rendering-custom-catchall.spec.ts
@@ -195,4 +195,59 @@ test.describe("Tool Rendering — Custom Catch-all (branded wildcard)", () => {
       page.locator('[data-testid="copilot-tool-render"]'),
     ).toHaveCount(0);
   });
+
+  // Regression for the aimock multi-pill bug:
+  // The d20 and Chain-tools fixtures used global thread state
+  // (`turnIndex`, `hasToolResult`) to drive sequencing. After clicking
+  // Find flights, the d20 loop entered at turnIndex=2 (rendering only 3
+  // cards instead of 5) and the Chain-tools tool-emitting fixture was
+  // skipped entirely (no tool cards, just the final "Done — Tokyo is
+  // sunny…" content). Fix: chain all follow-ups via `toolCallId`. This
+  // test drives Find flights → Roll a d20 → Chain tools in one thread
+  // and asserts the wildcard renderer paints the full card sequence for
+  // every pill (1 + 5 + 3 = 9 cards).
+  test("sequential pills in one thread render full card sequences for each", async ({
+    page,
+  }) => {
+    // Three sequential pills × multi-tool chains × LLM-mock latency easily
+    // exceeds Playwright's 30s default. Bumped to cover the worst case.
+    test.setTimeout(240_000);
+
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Find flights" })
+      .first()
+      .click();
+    const cards = page.locator('[data-testid="custom-wildcard-card"]');
+    await expect
+      .poll(async () => cards.count(), { timeout: TOOL_TIMEOUT })
+      .toBe(1);
+
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Roll a d20" })
+      .first()
+      .click();
+    // 1 (flights) + 5 (d20) = 6 cards once d20 chain finishes.
+    await expect
+      .poll(async () => cards.count(), { timeout: TOOL_TIMEOUT })
+      .toBe(6);
+    await expect(page.getByText("Rolled the d20 five times")).toBeVisible({
+      timeout: TOOL_TIMEOUT,
+    });
+
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Chain tools" })
+      .first()
+      .click();
+    // 1 + 5 + 3 = 9 once chain tools mounts get_weather + search_flights +
+    // roll_d20 cards.
+    await expect
+      .poll(async () => cards.count(), { timeout: TOOL_TIMEOUT })
+      .toBe(9);
+    await expect(page.getByText("Done — Tokyo is sunny")).toBeVisible({
+      timeout: TOOL_TIMEOUT,
+    });
+  });
 });

--- a/showcase/integrations/langgraph-python/tests/e2e/tool-rendering-default-catchall.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/tool-rendering-default-catchall.spec.ts
@@ -159,6 +159,58 @@ test.describe("Tool Rendering — Default Catch-all", () => {
     ).toBeVisible({ timeout: TOOL_TIMEOUT });
   });
 
+  // Regression for the aimock multi-pill bug:
+  // The d20 and Chain-tools fixtures used `turnIndex` + `hasToolResult` to
+  // disambiguate sequential iterations of the same prompt. Those gates
+  // count *global* thread state: clicking Find flights first left two
+  // assistant messages and one tool message behind, so the d20 loop
+  // entered at `turnIndex=2` (skipping rolls 7 and 14, hence only 3
+  // cards), and the Chain-tools tool-emitting fixture was skipped
+  // entirely (`hasToolResult: false` failed) so the pill went straight to
+  // the "Done — Tokyo is sunny…" content with no tool cards. Fix: chain
+  // all follow-ups via `toolCallId`, drop the global gates. This test
+  // drives the three offending pills in a single thread and asserts the
+  // expected card counts for each.
+  test("sequential pills in one thread render full card sequences for each", async ({
+    page,
+  }) => {
+    // Three sequential pills × multi-tool chains × LLM-mock latency easily
+    // exceeds Playwright's 30s default. Bumped to cover the worst case.
+    test.setTimeout(240_000);
+
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Find flights" })
+      .first()
+      .click();
+    const flights = page.locator(
+      '[data-testid="copilot-tool-render"][data-tool-name="search_flights"]',
+    );
+    await expect(flights).toHaveCount(1, { timeout: TOOL_TIMEOUT });
+
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Roll a d20" })
+      .first()
+      .click();
+    const d20 = page.locator(
+      '[data-testid="copilot-tool-render"][data-tool-name="roll_d20"]',
+    );
+    await expect
+      .poll(async () => d20.count(), { timeout: TOOL_TIMEOUT })
+      .toBe(5);
+    // Final scripted roll lands the 20 — proves the chain advanced through
+    // all 5 fixtures, not just the first two before bailing to content.
+    await expect
+      .poll(async () => d20.nth(4).getAttribute("data-result"), {
+        timeout: TOOL_TIMEOUT,
+      })
+      .toMatch(/"value":\s*20|"result":\s*20/);
+    await expect(page.getByText("Rolled the d20 five times")).toBeVisible({
+      timeout: TOOL_TIMEOUT,
+    });
+  });
+
   test("every rendered card matches the built-in default-renderer DOM signature", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

Multi-pill sessions in the showcase demos were silently breaking because aimock fixtures gated their tool-emit vs. follow-up branches on global thread state (`hasToolResult`, `turnIndex`). Once the user clicked a tool-using pill, the thread already had tool/assistant messages so the next pill's first-leg fixture got skipped and the matcher fell through to the wrong branch.

Concrete failures Alem reported:
- **tool-rendering**: Find flights then Roll a d20 rendered only 3 d20 cards instead of 5; Chain tools emitted zero cards and went straight to "Done — Tokyo is sunny…".
- **frontend-tools-async**: First pill rendered the NOTES DB card; second and third pills only rendered narration with no card.
- **hitl-in-app**: After approving the first pill the second pill skipped its approval dialog entirely.

## Fix

- Re-key every follow-up fixture on the prior step's `toolCallId` (the matcher checks `messages[last].tool_call_id`).
- Drop `hasToolResult: false` from the tool-emitting fixtures so they fire on any iteration whose last message is the user prompt.
- Reorder so the `toolCallId`-specific fixtures come first under first-match-wins.
- `userMessage` matchers are unchanged — fixtures still match the same prompt text they always did.

D20 becomes a linear `toolCallId` graph (`seq_001 → _002 → … → _005`); Chain tools gets disambiguator fixtures for each of its three parallel `tool_call_id`s; Weather / AAPL / query_notes / HITL approve+reject branches all gate on the specific `request_user_approval` / `get_weather` / `query_notes` / `get_stock_price` id that landed last.

## Regression coverage

Adds a multi-pill Playwright test to each affected spec — clicks every pill sequentially in one thread and asserts the full card count for each:
- `tool-rendering-default-catchall`: Find flights → 5 d20 rolls (with 20 last)
- `tool-rendering-custom-catchall`: 1 flights + 5 d20 + 3 chain = 9 wildcard cards
- `frontend-tools-async`: 3 NOTES DB cards with the right keyword per pill
- `hitl-in-app`: refund approve then escalate, each with its own approval dialog

## Test plan
- [x] Verified each fix end-to-end via Playwright MCP against local dev server
- [ ] CI runs the new regression specs against the canonical Docker stack
- [ ] Existing aimock fixture validation suites still pass (verified locally: 21/21)