### PR TITLE
feat: add X-AIMock-Strict header propagation across SDKs and integrations

### DIFF
--- a/packages/sdk-js/src/__tests__/header-propagation.test.ts
+++ b/packages/sdk-js/src/__tests__/header-propagation.test.ts
@@ -13,10 +13,12 @@ describe("header-propagation", () => {
   });
 
   describe("withForwardedHeaders", () => {
-    it("filters to only x-aimock-* headers", () => {
+    it("filters to only x-* prefixed headers", () => {
       const input = {
         "x-aimock-strict": "true",
         "x-aimock-fixture": "demo",
+        "x-request-id": "req-123",
+        "x-custom-trace": "abc",
         authorization: "Bearer secret",
         "content-type": "application/json",
       };
@@ -26,6 +28,8 @@ describe("header-propagation", () => {
         expect(forwarded).toEqual({
           "x-aimock-strict": "true",
           "x-aimock-fixture": "demo",
+          "x-request-id": "req-123",
+          "x-custom-trace": "abc",
         });
         expect(forwarded).not.toHaveProperty("authorization");
         expect(forwarded).not.toHaveProperty("content-type");
@@ -47,7 +51,7 @@ describe("header-propagation", () => {
       });
     });
 
-    it("returns empty when no x-aimock-* headers present", () => {
+    it("returns empty when no x-* headers present", () => {
       const input = {
         authorization: "Bearer token",
         "content-type": "application/json",

--- a/packages/sdk-js/src/__tests__/header-propagation.test.ts
+++ b/packages/sdk-js/src/__tests__/header-propagation.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  withForwardedHeaders,
+  getForwardedHeaders,
+} from "../header-propagation";
+
+describe("header-propagation", () => {
+  describe("getForwardedHeaders", () => {
+    it("returns empty object when called outside withForwardedHeaders scope", () => {
+      const headers = getForwardedHeaders();
+      expect(headers).toEqual({});
+    });
+  });
+
+  describe("withForwardedHeaders", () => {
+    it("filters to only x-aimock-* headers", () => {
+      const input = {
+        "x-aimock-strict": "true",
+        "x-aimock-fixture": "demo",
+        authorization: "Bearer secret",
+        "content-type": "application/json",
+      };
+
+      withForwardedHeaders(input, () => {
+        const forwarded = getForwardedHeaders();
+        expect(forwarded).toEqual({
+          "x-aimock-strict": "true",
+          "x-aimock-fixture": "demo",
+        });
+        expect(forwarded).not.toHaveProperty("authorization");
+        expect(forwarded).not.toHaveProperty("content-type");
+      });
+    });
+
+    it("lowercases header keys", () => {
+      const input = {
+        "X-AIMock-Strict": "true",
+        "X-AIMOCK-FIXTURE": "demo",
+      };
+
+      withForwardedHeaders(input, () => {
+        const forwarded = getForwardedHeaders();
+        expect(forwarded).toEqual({
+          "x-aimock-strict": "true",
+          "x-aimock-fixture": "demo",
+        });
+      });
+    });
+
+    it("returns empty when no x-aimock-* headers present", () => {
+      const input = {
+        authorization: "Bearer token",
+        "content-type": "application/json",
+      };
+
+      withForwardedHeaders(input, () => {
+        const forwarded = getForwardedHeaders();
+        expect(forwarded).toEqual({});
+      });
+    });
+
+    it("returns the callback's return value", () => {
+      const result = withForwardedHeaders({}, () => 42);
+      expect(result).toBe(42);
+    });
+
+    it("restores empty state after scope exits", () => {
+      withForwardedHeaders({ "x-aimock-strict": "true" }, () => {
+        expect(getForwardedHeaders()).toEqual({ "x-aimock-strict": "true" });
+      });
+
+      // Outside the scope, should be empty again
+      expect(getForwardedHeaders()).toEqual({});
+    });
+  });
+
+  describe("AsyncLocalStorage isolation", () => {
+    it("maintains separate headers across concurrent requests", async () => {
+      const results: Record<string, string>[] = [];
+
+      const request1 = new Promise<void>((resolve) => {
+        withForwardedHeaders({ "x-aimock-strict": "true" }, () => {
+          // Simulate async work
+          setTimeout(() => {
+            results.push(getForwardedHeaders());
+            resolve();
+          }, 10);
+        });
+      });
+
+      const request2 = new Promise<void>((resolve) => {
+        withForwardedHeaders({ "x-aimock-fixture": "demo" }, () => {
+          // Simulate async work
+          setTimeout(() => {
+            results.push(getForwardedHeaders());
+            resolve();
+          }, 5);
+        });
+      });
+
+      await Promise.all([request1, request2]);
+
+      // Each request should have its own headers, regardless of timing
+      expect(results).toHaveLength(2);
+      const strictResult = results.find((r) => "x-aimock-strict" in r);
+      const fixtureResult = results.find((r) => "x-aimock-fixture" in r);
+      expect(strictResult).toEqual({ "x-aimock-strict": "true" });
+      expect(fixtureResult).toEqual({ "x-aimock-fixture": "demo" });
+    });
+
+    it("works with nested withForwardedHeaders calls", () => {
+      withForwardedHeaders({ "x-aimock-strict": "true" }, () => {
+        expect(getForwardedHeaders()).toEqual({ "x-aimock-strict": "true" });
+
+        // Inner scope overrides outer
+        withForwardedHeaders({ "x-aimock-fixture": "inner" }, () => {
+          expect(getForwardedHeaders()).toEqual({
+            "x-aimock-fixture": "inner",
+          });
+        });
+
+        // Back to outer scope
+        expect(getForwardedHeaders()).toEqual({ "x-aimock-strict": "true" });
+      });
+    });
+  });
+});

--- a/packages/sdk-js/src/header-propagation.ts
+++ b/packages/sdk-js/src/header-propagation.ts
@@ -5,13 +5,15 @@ type HeaderMap = Record<string, string>;
 const headerStorage = new AsyncLocalStorage<HeaderMap>();
 
 /**
- * Filter incoming headers to only x-aimock-* prefixed ones.
+ * Filter incoming headers to only x-* prefixed headers.
+ * Matches the CopilotKit runtime's extractForwardableHeaders() behavior.
  */
-function filterAimockHeaders(headers: HeaderMap): HeaderMap {
+function filterForwardableHeaders(headers: HeaderMap): HeaderMap {
   const filtered: HeaderMap = {};
   for (const [key, value] of Object.entries(headers)) {
-    if (key.toLowerCase().startsWith("x-aimock-")) {
-      filtered[key.toLowerCase()] = value;
+    const lower = key.toLowerCase();
+    if (lower.startsWith("x-")) {
+      filtered[lower] = value;
     }
   }
   return filtered;
@@ -22,11 +24,11 @@ function filterAimockHeaders(headers: HeaderMap): HeaderMap {
  * Call this at the AG-UI request entry point.
  */
 export function withForwardedHeaders<T>(headers: HeaderMap, fn: () => T): T {
-  return headerStorage.run(filterAimockHeaders(headers), fn);
+  return headerStorage.run(filterForwardableHeaders(headers), fn);
 }
 
 /**
- * Get x-aimock-* headers that should be forwarded to outgoing LLM calls.
+ * Get x-* prefixed headers that should be forwarded to outgoing LLM calls.
  * Returns empty object when called outside a withForwardedHeaders() scope
  * (demo traffic).
  */

--- a/packages/sdk-js/src/header-propagation.ts
+++ b/packages/sdk-js/src/header-propagation.ts
@@ -1,0 +1,35 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+type HeaderMap = Record<string, string>;
+
+const headerStorage = new AsyncLocalStorage<HeaderMap>();
+
+/**
+ * Filter incoming headers to only x-aimock-* prefixed ones.
+ */
+function filterAimockHeaders(headers: HeaderMap): HeaderMap {
+  const filtered: HeaderMap = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase().startsWith("x-aimock-")) {
+      filtered[key.toLowerCase()] = value;
+    }
+  }
+  return filtered;
+}
+
+/**
+ * Run a callback with forwarded headers available via getForwardedHeaders().
+ * Call this at the AG-UI request entry point.
+ */
+export function withForwardedHeaders<T>(headers: HeaderMap, fn: () => T): T {
+  return headerStorage.run(filterAimockHeaders(headers), fn);
+}
+
+/**
+ * Get x-aimock-* headers that should be forwarded to outgoing LLM calls.
+ * Returns empty object when called outside a withForwardedHeaders() scope
+ * (demo traffic).
+ */
+export function getForwardedHeaders(): HeaderMap {
+  return headerStorage.getStore() ?? {};
+}

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -1,0 +1,1 @@
+export { withForwardedHeaders, getForwardedHeaders } from "./header-propagation";

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -1,1 +1,4 @@
-export { withForwardedHeaders, getForwardedHeaders } from "./header-propagation";
+export {
+  withForwardedHeaders,
+  getForwardedHeaders,
+} from "./header-propagation";

--- a/packages/sdk-js/src/langgraph/middleware.ts
+++ b/packages/sdk-js/src/langgraph/middleware.ts
@@ -5,6 +5,7 @@ import type {
   StandardSchemaV1,
 } from "@standard-schema/spec";
 import * as z from "zod";
+import { getForwardedHeaders } from "../header-propagation";
 
 type WithJsonSchema<T> = T extends { "~standard": infer S }
   ? Omit<T, "~standard"> & {
@@ -302,9 +303,25 @@ const buildMiddlewareInput = (exposeState: ExposeStateOption) => ({
 
   stateSchema: copilotKitStateSchema as unknown as InteropZodObject,
 
-  // Inject frontend tools and surface user state before model call
+  // Inject frontend tools, surface user state, and forward x-aimock-* headers
   wrapModelCall: async (request: any, handler: (req: any) => Promise<any>) => {
     request = applyStateNote(request, exposeState);
+
+    // Forward x-aimock-* headers from the incoming AG-UI request
+    const forwardedHeaders = getForwardedHeaders();
+    if (Object.keys(forwardedHeaders).length > 0) {
+      const existingSettings = request.modelSettings ?? {};
+      const existingHeaders =
+        (existingSettings.headers as Record<string, string>) ?? {};
+      request = {
+        ...request,
+        modelSettings: {
+          ...existingSettings,
+          headers: { ...existingHeaders, ...forwardedHeaders },
+        },
+      };
+    }
+
     const frontendTools = request.state["copilotkit"]?.actions ?? [];
 
     if (frontendTools.length === 0) {

--- a/sdk-python/copilotkit/__init__.py
+++ b/sdk-python/copilotkit/__init__.py
@@ -7,6 +7,7 @@ from .agent import Agent
 from .langgraph_agui_agent import LangGraphAGUIAgent
 from .copilotkit_lg_middleware import CopilotKitMiddleware
 from ag_ui_langgraph.middlewares.state_streaming import StateStreamingMiddleware, StateItem
+from .header_propagation import set_forwarded_headers, get_forwarded_headers, install_httpx_hook
 
 
 
@@ -24,4 +25,7 @@ __all__ = [
     "CopilotKitMiddleware",
     "StateStreamingMiddleware",
     "StateItem",
+    "set_forwarded_headers",
+    "get_forwarded_headers",
+    "install_httpx_hook",
 ]

--- a/sdk-python/copilotkit/header_propagation.py
+++ b/sdk-python/copilotkit/header_propagation.py
@@ -1,7 +1,8 @@
-"""Header propagation for forwarding x-aimock-* headers to outgoing LLM calls.
+"""Header propagation for forwarding x-* prefixed headers to outgoing LLM calls.
 
 Uses Python contextvars for per-request ambient state in async FastAPI handlers.
 An httpx event hook reads the ContextVar and injects headers on outgoing requests.
+Matches the CopilotKit runtime's extractForwardableHeaders() behavior.
 """
 
 import contextvars
@@ -16,8 +17,8 @@ _forwarded_headers: contextvars.ContextVar[Dict[str, str]] = contextvars.Context
 
 def set_forwarded_headers(headers: Dict[str, str]) -> None:
     """Store headers to forward to outgoing LLM calls.
-    Filters to x-aimock-* headers only."""
-    filtered = {k.lower(): v for k, v in headers.items() if k.lower().startswith('x-aimock-')}
+    Filters to x-* prefixed headers only."""
+    filtered = {k.lower(): v for k, v in headers.items() if k.lower().startswith('x-')}
     _forwarded_headers.set(filtered)
 
 
@@ -52,6 +53,6 @@ def install_httpx_hook(client) -> None:
     else:
         warnings.warn(
             f"install_httpx_hook: client of type {type(client).__name__} has no "
-            "recognized event_hooks attribute; x-aimock-* headers will not be forwarded",
+            "recognized event_hooks attribute; x-* headers will not be forwarded",
             stacklevel=2,
         )

--- a/sdk-python/copilotkit/header_propagation.py
+++ b/sdk-python/copilotkit/header_propagation.py
@@ -1,0 +1,57 @@
+"""Header propagation for forwarding x-aimock-* headers to outgoing LLM calls.
+
+Uses Python contextvars for per-request ambient state in async FastAPI handlers.
+An httpx event hook reads the ContextVar and injects headers on outgoing requests.
+"""
+
+import contextvars
+import warnings
+from typing import Dict
+
+# Ambient per-request state for headers to forward to LLM calls
+_forwarded_headers: contextvars.ContextVar[Dict[str, str]] = contextvars.ContextVar(
+    'copilotkit_forwarded_headers'
+)
+
+
+def set_forwarded_headers(headers: Dict[str, str]) -> None:
+    """Store headers to forward to outgoing LLM calls.
+    Filters to x-aimock-* headers only."""
+    filtered = {k.lower(): v for k, v in headers.items() if k.lower().startswith('x-aimock-')}
+    _forwarded_headers.set(filtered)
+
+
+def get_forwarded_headers() -> Dict[str, str]:
+    """Get headers that should be forwarded to outgoing LLM calls."""
+    return _forwarded_headers.get({})
+
+
+def install_httpx_hook(client) -> None:
+    """Append an event hook to an httpx client that injects forwarded headers.
+
+    Works with OpenAI and Anthropic Python SDKs (both use httpx internally).
+    No-op when no headers are set (demo traffic).
+
+    Parameters
+    ----------
+    client : object
+        An OpenAI/Anthropic client instance, or a raw httpx.Client/AsyncClient.
+        For SDK clients the underlying transport lives at ``client._client``.
+    """
+    def _inject_headers(request):
+        headers = get_forwarded_headers()
+        for key, value in headers.items():
+            request.headers[key] = value
+
+    # OpenAI / Anthropic SDKs wrap an httpx client at client._client
+    if hasattr(client, '_client') and hasattr(client._client, 'event_hooks'):
+        client._client.event_hooks['request'].append(_inject_headers)
+    elif hasattr(client, 'event_hooks'):
+        # Raw httpx.Client / httpx.AsyncClient
+        client.event_hooks['request'].append(_inject_headers)
+    else:
+        warnings.warn(
+            f"install_httpx_hook: client of type {type(client).__name__} has no "
+            "recognized event_hooks attribute; x-aimock-* headers will not be forwarded",
+            stacklevel=2,
+        )

--- a/sdk-python/copilotkit/integrations/fastapi.py
+++ b/sdk-python/copilotkit/integrations/fastapi.py
@@ -20,6 +20,7 @@ from ..exc import (
 )
 from ..action import ActionDict
 from ..html import generate_info_html
+from ..header_propagation import set_forwarded_headers
 logging.basicConfig(level=logging.ERROR)
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,9 @@ async def handler(request: Request, sdk: CopilotKitRemoteEndpoint):
         body = await request.json()
     except: # pylint: disable=bare-except
         body = None
+
+    # Propagate x-aimock-* headers to outgoing LLM calls via ContextVar
+    set_forwarded_headers(dict(request.headers))
 
     path = request.path_params.get('path')
     method = request.method

--- a/sdk-python/tests/test_header_propagation.py
+++ b/sdk-python/tests/test_header_propagation.py
@@ -1,4 +1,4 @@
-"""Tests for header propagation (x-aimock-* headers to outgoing LLM calls)."""
+"""Tests for header propagation (x-* prefixed headers to outgoing LLM calls)."""
 
 import contextvars
 import warnings
@@ -13,12 +13,14 @@ from copilotkit.header_propagation import (
 
 
 class TestSetForwardedHeaders:
-    """set_forwarded_headers filters to x-aimock-* only."""
+    """set_forwarded_headers filters to x-* prefixed headers only."""
 
-    def test_filters_to_aimock_headers(self):
+    def test_filters_to_x_prefixed_headers(self):
         set_forwarded_headers({
             "x-aimock-strict": "true",
             "x-aimock-session": "abc123",
+            "x-request-id": "req-456",
+            "x-custom-trace": "xyz",
             "authorization": "Bearer token",
             "content-type": "application/json",
         })
@@ -26,6 +28,8 @@ class TestSetForwardedHeaders:
         assert result == {
             "x-aimock-strict": "true",
             "x-aimock-session": "abc123",
+            "x-request-id": "req-456",
+            "x-custom-trace": "xyz",
         }
 
     def test_case_insensitive_prefix_match(self):
@@ -39,7 +43,7 @@ class TestSetForwardedHeaders:
             "x-aimock-session": "xyz",
         }
 
-    def test_empty_when_no_aimock_headers(self):
+    def test_empty_when_no_x_headers(self):
         set_forwarded_headers({
             "authorization": "Bearer token",
             "content-type": "application/json",

--- a/sdk-python/tests/test_header_propagation.py
+++ b/sdk-python/tests/test_header_propagation.py
@@ -1,0 +1,201 @@
+"""Tests for header propagation (x-aimock-* headers to outgoing LLM calls)."""
+
+import contextvars
+import warnings
+
+import pytest
+
+from copilotkit.header_propagation import (
+    get_forwarded_headers,
+    install_httpx_hook,
+    set_forwarded_headers,
+)
+
+
+class TestSetForwardedHeaders:
+    """set_forwarded_headers filters to x-aimock-* only."""
+
+    def test_filters_to_aimock_headers(self):
+        set_forwarded_headers({
+            "x-aimock-strict": "true",
+            "x-aimock-session": "abc123",
+            "authorization": "Bearer token",
+            "content-type": "application/json",
+        })
+        result = get_forwarded_headers()
+        assert result == {
+            "x-aimock-strict": "true",
+            "x-aimock-session": "abc123",
+        }
+
+    def test_case_insensitive_prefix_match(self):
+        set_forwarded_headers({
+            "X-AIMock-Strict": "true",
+            "X-AIMOCK-SESSION": "xyz",
+        })
+        result = get_forwarded_headers()
+        assert result == {
+            "x-aimock-strict": "true",
+            "x-aimock-session": "xyz",
+        }
+
+    def test_empty_when_no_aimock_headers(self):
+        set_forwarded_headers({
+            "authorization": "Bearer token",
+            "content-type": "application/json",
+        })
+        result = get_forwarded_headers()
+        assert result == {}
+
+    def test_empty_input(self):
+        set_forwarded_headers({})
+        result = get_forwarded_headers()
+        assert result == {}
+
+
+class TestGetForwardedHeaders:
+    """get_forwarded_headers returns empty dict by default."""
+
+    def test_default_is_empty_dict(self):
+        # Reset to default by running in a fresh context
+        ctx = contextvars.copy_context()
+        result = ctx.run(get_forwarded_headers)
+        assert result == {}
+
+
+class TestRoundTrip:
+    """set + get round-trip."""
+
+    def test_round_trip(self):
+        headers = {"x-aimock-strict": "true", "x-aimock-foo": "bar"}
+        set_forwarded_headers(headers)
+        assert get_forwarded_headers() == headers
+
+    def test_overwrite(self):
+        set_forwarded_headers({"x-aimock-a": "1"})
+        set_forwarded_headers({"x-aimock-b": "2"})
+        assert get_forwarded_headers() == {"x-aimock-b": "2"}
+
+
+class TestInstallHttpxHook:
+    """install_httpx_hook appends to event hooks."""
+
+    def test_appends_to_raw_httpx_client(self):
+        """Mock a raw httpx client with event_hooks dict."""
+        class FakeClient:
+            def __init__(self):
+                self.event_hooks = {"request": []}
+
+        client = FakeClient()
+        install_httpx_hook(client)
+        assert len(client.event_hooks["request"]) == 1
+
+    def test_appends_to_sdk_wrapped_client(self):
+        """Mock an OpenAI/Anthropic SDK client with _client attribute."""
+        class FakeTransport:
+            def __init__(self):
+                self.event_hooks = {"request": []}
+
+        class FakeSDKClient:
+            def __init__(self):
+                self._client = FakeTransport()
+
+        client = FakeSDKClient()
+        install_httpx_hook(client)
+        assert len(client._client.event_hooks["request"]) == 1
+
+    def test_hook_injects_headers(self):
+        """The installed hook reads from ContextVar and injects headers."""
+        class FakeHeaders(dict):
+            """Dict that also supports item assignment like httpx Headers."""
+            pass
+
+        class FakeRequest:
+            def __init__(self):
+                self.headers = FakeHeaders()
+
+        class FakeClient:
+            def __init__(self):
+                self.event_hooks = {"request": []}
+
+        client = FakeClient()
+        install_httpx_hook(client)
+
+        # Set headers in ContextVar
+        set_forwarded_headers({"x-aimock-strict": "true"})
+
+        # Simulate httpx calling the hook
+        request = FakeRequest()
+        client.event_hooks["request"][0](request)
+
+        assert request.headers["x-aimock-strict"] == "true"
+
+    def test_hook_noop_when_no_headers(self):
+        """Hook is a no-op when ContextVar is empty (demo traffic)."""
+        class FakeRequest:
+            def __init__(self):
+                self.headers = {}
+
+        class FakeClient:
+            def __init__(self):
+                self.event_hooks = {"request": []}
+
+        # Reset ContextVar to simulate a fresh request with no aimock headers
+        set_forwarded_headers({})
+
+        client = FakeClient()
+        install_httpx_hook(client)
+        request = FakeRequest()
+        client.event_hooks["request"][0](request)
+        assert request.headers == {}
+
+    def test_no_event_hooks_warns(self):
+        """Client without event_hooks emits a warning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            install_httpx_hook(object())
+            assert len(w) == 1
+            assert "event_hooks" in str(w[0].message)
+
+
+class TestContextVarIsolation:
+    """ContextVar provides proper isolation across contexts."""
+
+    def test_context_isolation(self):
+        """Headers set in one context don't leak to another."""
+        results = {}
+
+        def task_a():
+            set_forwarded_headers({"x-aimock-task": "a"})
+            results["a"] = get_forwarded_headers()
+
+        def task_b():
+            set_forwarded_headers({"x-aimock-task": "b"})
+            results["b"] = get_forwarded_headers()
+
+        # Run in separate contexts to verify isolation
+        ctx_a = contextvars.copy_context()
+        ctx_b = contextvars.copy_context()
+
+        ctx_a.run(task_a)
+        ctx_b.run(task_b)
+
+        assert results["a"] == {"x-aimock-task": "a"}
+        assert results["b"] == {"x-aimock-task": "b"}
+
+    def test_child_context_does_not_pollute_parent(self):
+        """Setting headers in a child context does not affect the parent."""
+        # Ensure clean state in a fresh context
+        def _run():
+            parent_before = get_forwarded_headers()
+
+            def child():
+                set_forwarded_headers({"x-aimock-child": "yes"})
+
+            ctx = contextvars.copy_context()
+            ctx.run(child)
+
+            parent_after = get_forwarded_headers()
+            assert parent_before == parent_after
+
+        contextvars.copy_context().run(_run)

--- a/showcase/harness/src/cli/runner.ts
+++ b/showcase/harness/src/cli/runner.ts
@@ -229,7 +229,9 @@ export async function run(
           });
           return {
             async newContext() {
-              const bCtx = await browser.newContext();
+              const bCtx = await browser.newContext({
+                extraHTTPHeaders: { "X-AIMock-Strict": "true" },
+              });
               return {
                 async newPage() {
                   const page = await bCtx.newPage();

--- a/showcase/harness/src/probes/drivers/e2e-chat-tools.ts
+++ b/showcase/harness/src/probes/drivers/e2e-chat-tools.ts
@@ -238,7 +238,9 @@ const defaultLauncher: E2eBrowserLauncher = async (): Promise<E2eBrowser> => {
   // so tests can swap in fakes without importing playwright's types.
   return {
     async newContext(): Promise<E2eBrowserContext> {
-      const ctx = await browser.newContext();
+      const ctx = await browser.newContext({
+        extraHTTPHeaders: { "X-AIMock-Strict": "true" },
+      });
       return {
         async newPage(): Promise<E2ePage> {
           const page = await ctx.newPage();
@@ -266,7 +268,9 @@ export function createPooledE2eSmokeLauncher(
     const browser = await pool.acquire();
     return {
       async newContext(): Promise<E2eBrowserContext> {
-        const ctx = await browser.newContext();
+        const ctx = await browser.newContext({
+          extraHTTPHeaders: { "X-AIMock-Strict": "true" },
+        });
         return {
           async newPage(): Promise<E2ePage> {
             const page = await ctx.newPage();

--- a/showcase/harness/src/probes/drivers/e2e-deep.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.ts
@@ -371,7 +371,9 @@ const defaultLauncher: E2eDeepBrowserLauncher =
     });
     return {
       async newContext(): Promise<E2eDeepBrowserContext> {
-        const ctx = await browser.newContext();
+        const ctx = await browser.newContext({
+          extraHTTPHeaders: { "X-AIMock-Strict": "true" },
+        });
         return {
           async newPage(): Promise<E2eDeepPage> {
             const page = await ctx.newPage();
@@ -497,7 +499,9 @@ export function createPooledE2eDeepLauncher(
 
     return {
       async newContext(): Promise<E2eDeepBrowserContext> {
-        const ctx = await browser.newContext();
+        const ctx = await browser.newContext({
+          extraHTTPHeaders: { "X-AIMock-Strict": "true" },
+        });
         const ctxHandle = { close: () => ctx.close() };
         openContexts.add(ctxHandle);
         return {

--- a/showcase/harness/src/probes/drivers/e2e-parity.ts
+++ b/showcase/harness/src/probes/drivers/e2e-parity.ts
@@ -331,7 +331,9 @@ const defaultLauncher: E2eParityBrowserLauncher =
     });
     return {
       async newContext(): Promise<E2eParityBrowserContext> {
-        const ctx = await browser.newContext();
+        const ctx = await browser.newContext({
+          extraHTTPHeaders: { "X-AIMock-Strict": "true" },
+        });
         return {
           async newPage(): Promise<E2eParityPage> {
             const page = await ctx.newPage();
@@ -357,7 +359,9 @@ export function createPooledE2eParityLauncher(
     const browser = await pool.acquire();
     return {
       async newContext(): Promise<E2eParityBrowserContext> {
-        const ctx = await browser.newContext();
+        const ctx = await browser.newContext({
+          extraHTTPHeaders: { "X-AIMock-Strict": "true" },
+        });
         return {
           async newPage(): Promise<E2eParityPage> {
             const page = await ctx.newPage();

--- a/showcase/harness/src/probes/drivers/e2e-readiness.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.ts
@@ -270,7 +270,9 @@ const defaultLauncher: E2eDemosBrowserLauncher = async (
   });
   return {
     async newContext(): Promise<E2eDemosBrowserContext> {
-      const ctx = await browser.newContext();
+      const ctx = await browser.newContext({
+        extraHTTPHeaders: { "X-AIMock-Strict": "true" },
+      });
       return {
         async newPage(): Promise<E2eDemosPage> {
           const page = await ctx.newPage();
@@ -340,7 +342,9 @@ export function createPooledE2eDemosLauncher(
 
     return {
       async newContext(): Promise<E2eDemosBrowserContext> {
-        const ctx = await browser.newContext();
+        const ctx = await browser.newContext({
+          extraHTTPHeaders: { "X-AIMock-Strict": "true" },
+        });
         const ctxHandle = { close: () => ctx.close() };
         openContexts.add(ctxHandle);
         return {

--- a/showcase/integrations/ms-agent-dotnet/agent/A2uiFixedSchemaAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/A2uiFixedSchemaAgent.cs
@@ -47,10 +47,7 @@ public class A2uiFixedSchemaAgent
 
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent Create()

--- a/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderContext.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderContext.cs
@@ -1,0 +1,20 @@
+// STOPGAP: This integration-level header propagation replaces once copilotkit-sdk-dotnet
+// ships (Microsoft contribution, ETA mid-2026). When that SDK lands, delete this code
+// and use the SDK's built-in header propagation.
+// See: https://www.notion.so/copilotkit/3543aa3818528150b6acc5b872ad7fe5
+
+// TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation
+public static class AimockHeaderContext
+{
+    private static readonly AsyncLocal<Dictionary<string, string>> _headers = new();
+
+    public static void Set(Dictionary<string, string> headers)
+    {
+        var filtered = headers
+            .Where(h => h.Key.StartsWith("x-aimock-", StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(h => h.Key.ToLowerInvariant(), h => h.Value);
+        _headers.Value = filtered;
+    }
+
+    public static Dictionary<string, string> Get() => _headers.Value ?? new();
+}

--- a/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderContext.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderContext.cs
@@ -11,7 +11,7 @@ public static class AimockHeaderContext
     public static void Set(Dictionary<string, string> headers)
     {
         var filtered = headers
-            .Where(h => h.Key.StartsWith("x-aimock-", StringComparison.OrdinalIgnoreCase))
+            .Where(h => h.Key.StartsWith("x-", StringComparison.OrdinalIgnoreCase))
             .ToDictionary(h => h.Key.ToLowerInvariant(), h => h.Value);
         _headers.Value = filtered;
     }

--- a/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderMiddleware.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderMiddleware.cs
@@ -13,7 +13,7 @@ public class AimockHeaderMiddleware
     public async Task InvokeAsync(HttpContext context)
     {
         var headers = context.Request.Headers
-            .Where(h => h.Key.StartsWith("x-aimock-", StringComparison.OrdinalIgnoreCase))
+            .Where(h => h.Key.StartsWith("x-", StringComparison.OrdinalIgnoreCase))
             .ToDictionary(h => h.Key, h => h.Value.ToString());
         AimockHeaderContext.Set(headers);
         try

--- a/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderMiddleware.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderMiddleware.cs
@@ -1,0 +1,28 @@
+// STOPGAP: This integration-level header propagation replaces once copilotkit-sdk-dotnet
+// ships (Microsoft contribution, ETA mid-2026). When that SDK lands, delete this code
+// and use the SDK's built-in header propagation.
+// See: https://www.notion.so/copilotkit/3543aa3818528150b6acc5b872ad7fe5
+
+// TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation
+public class AimockHeaderMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public AimockHeaderMiddleware(RequestDelegate next) => _next = next;
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var headers = context.Request.Headers
+            .Where(h => h.Key.StartsWith("x-aimock-", StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(h => h.Key, h => h.Value.ToString());
+        AimockHeaderContext.Set(headers);
+        try
+        {
+            await _next(context);
+        }
+        finally
+        {
+            AimockHeaderContext.Set(new Dictionary<string, string>());
+        }
+    }
+}

--- a/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderPolicy.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderPolicy.cs
@@ -24,9 +24,9 @@ public class AimockHeaderPolicy : PipelinePolicy
     }
 
     /// <summary>
-    /// Creates an <see cref="OpenAIClientOptions"/> with the aimock header policy
+    /// Creates an <see cref="OpenAIClientOptions"/> with the header forwarding policy
     /// pre-configured. All OpenAI client instantiations should use this to ensure
-    /// x-aimock-* headers propagate to outgoing calls.
+    /// x-* prefixed headers propagate to outgoing calls.
     /// </summary>
     // TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation
     public static OpenAIClientOptions CreateOpenAIClientOptions(string endpoint)

--- a/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderPolicy.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderPolicy.cs
@@ -1,0 +1,41 @@
+// STOPGAP: This integration-level header propagation replaces once copilotkit-sdk-dotnet
+// ships (Microsoft contribution, ETA mid-2026). When that SDK lands, delete this code
+// and use the SDK's built-in header propagation.
+// See: https://www.notion.so/copilotkit/3543aa3818528150b6acc5b872ad7fe5
+
+using System.ClientModel.Primitives;
+using OpenAI;
+
+// TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation
+public class AimockHeaderPolicy : PipelinePolicy
+{
+    public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    {
+        foreach (var header in AimockHeaderContext.Get())
+            message.Request.Headers.Set(header.Key, header.Value);
+        ProcessNext(message, pipeline, currentIndex);
+    }
+
+    public override async ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    {
+        foreach (var header in AimockHeaderContext.Get())
+            message.Request.Headers.Set(header.Key, header.Value);
+        await ProcessNextAsync(message, pipeline, currentIndex);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="OpenAIClientOptions"/> with the aimock header policy
+    /// pre-configured. All OpenAI client instantiations should use this to ensure
+    /// x-aimock-* headers propagate to outgoing calls.
+    /// </summary>
+    // TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation
+    public static OpenAIClientOptions CreateOpenAIClientOptions(string endpoint)
+    {
+        var options = new OpenAIClientOptions
+        {
+            Endpoint = new Uri(endpoint),
+        };
+        options.AddPolicy(new AimockHeaderPolicy(), PipelinePosition.PerCall);
+        return options;
+    }
+}

--- a/showcase/integrations/ms-agent-dotnet/agent/ByocHashbrownAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/ByocHashbrownAgent.cs
@@ -97,10 +97,7 @@ Example response (sales dashboard):
 
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent CreateAgent()

--- a/showcase/integrations/ms-agent-dotnet/agent/ByocJsonRenderAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/ByocJsonRenderAgent.cs
@@ -164,10 +164,7 @@ Respond with the JSON object only.";
 
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent CreateAgent()

--- a/showcase/integrations/ms-agent-dotnet/agent/DeclarativeGenUiAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/DeclarativeGenUiAgent.cs
@@ -46,10 +46,7 @@ public class DeclarativeGenUiAgent
 
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent Create()

--- a/showcase/integrations/ms-agent-dotnet/agent/HitlInAppAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/HitlInAppAgent.cs
@@ -70,10 +70,7 @@ public sealed class HitlInAppAgentFactory
 
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent CreateHitlInAppAgent()

--- a/showcase/integrations/ms-agent-dotnet/agent/HitlInChatAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/HitlInChatAgent.cs
@@ -45,10 +45,7 @@ public sealed class HitlInChatAgentFactory
 
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent CreateHitlInChatAgent()

--- a/showcase/integrations/ms-agent-dotnet/agent/InterruptAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/InterruptAgent.cs
@@ -59,10 +59,7 @@ public sealed class InterruptAgentFactory
 
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     // @region[backend-tool-call]

--- a/showcase/integrations/ms-agent-dotnet/agent/McpAppsAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/McpAppsAgent.cs
@@ -67,10 +67,7 @@ public sealed class McpAppsAgentFactory
 
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent CreateMcpAppsAgent()

--- a/showcase/integrations/ms-agent-dotnet/agent/OpenGenUiAdvancedAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/OpenGenUiAdvancedAgent.cs
@@ -101,10 +101,7 @@ Generation guidance:
 
         _openAiClient = new OpenAIClient(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent CreateAgent()

--- a/showcase/integrations/ms-agent-dotnet/agent/OpenGenUiAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/OpenGenUiAgent.cs
@@ -73,10 +73,7 @@ rendered visualisation.";
 
         _openAiClient = new OpenAIClient(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent CreateAgent()

--- a/showcase/integrations/ms-agent-dotnet/agent/Program.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/Program.cs
@@ -24,7 +24,7 @@ builder.Services.AddAGUI();
 
 WebApplication app = builder.Build();
 
-// STOPGAP: Extract x-aimock-* headers from incoming AG-UI requests into AsyncLocal
+// STOPGAP: Extract x-* prefixed headers from incoming AG-UI requests into AsyncLocal
 // so AimockHeaderPolicy can forward them to outgoing OpenAI calls.
 // TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation
 app.UseMiddleware<AimockHeaderMiddleware>();

--- a/showcase/integrations/ms-agent-dotnet/agent/Program.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/Program.cs
@@ -24,6 +24,11 @@ builder.Services.AddAGUI();
 
 WebApplication app = builder.Build();
 
+// STOPGAP: Extract x-aimock-* headers from incoming AG-UI requests into AsyncLocal
+// so AimockHeaderPolicy can forward them to outgoing OpenAI calls.
+// TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation
+app.UseMiddleware<AimockHeaderMiddleware>();
+
 // Create the agent factory and map the AG-UI agent endpoint
 var loggerFactory = app.Services.GetRequiredService<ILoggerFactory>();
 var jsonOptions = app.Services.GetRequiredService<IOptions<JsonOptions>>();
@@ -391,10 +396,7 @@ public class SalesAgentFactory
 
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(endpoint),
-            });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent CreateSalesAgent()

--- a/showcase/integrations/ms-agent-dotnet/agent/SharedStateReadWriteAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/SharedStateReadWriteAgent.cs
@@ -465,7 +465,7 @@ public sealed class SharedStateReadWriteAgentFactory
         var endpoint = Environment.GetEnvironmentVariable("OPENAI_BASE_URL") ?? DefaultOpenAiEndpoint;
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent CreateAgent()

--- a/showcase/integrations/ms-agent-dotnet/agent/SubagentsAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/SubagentsAgent.cs
@@ -311,7 +311,7 @@ public sealed class SubagentsAgentFactory
         var endpoint = Environment.GetEnvironmentVariable("OPENAI_BASE_URL") ?? DefaultOpenAiEndpoint;
         _openAiClient = new(
             new ApiKeyCredential(githubToken),
-            new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
+            AimockHeaderPolicy.CreateOpenAIClientOptions(endpoint));
     }
 
     public AIAgent CreateAgent()

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderContext.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderContext.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Thread-local holder for {@code x-aimock-*} headers extracted from incoming
+ * Thread-local holder for {@code x-*} prefixed headers extracted from incoming
  * AG-UI requests.
  *
  * <p>Uses {@link InheritableThreadLocal} so the headers propagate into child
@@ -33,13 +33,13 @@ public final class AimockHeaderContext {
     }
 
     /**
-     * Stores the given headers after filtering to only {@code x-aimock-*} keys.
+     * Stores the given headers after filtering to only {@code x-*} prefixed keys.
      * Keys are lower-cased for consistent matching on the outbound side.
      */
     public static void set(Map<String, String> headers) {
         Map<String, String> filtered = headers.entrySet().stream()
                 .filter(e -> e.getKey().toLowerCase(java.util.Locale.ROOT)
-                        .startsWith("x-aimock-"))
+                        .startsWith("x-"))
                 .collect(Collectors.toMap(
                         e -> e.getKey().toLowerCase(java.util.Locale.ROOT),
                         Map.Entry::getValue));
@@ -47,7 +47,7 @@ public final class AimockHeaderContext {
     }
 
     /**
-     * Returns the current thread's {@code x-aimock-*} headers, or an empty map
+     * Returns the current thread's {@code x-*} prefixed headers, or an empty map
      * if none have been set.
      */
     public static Map<String, String> get() {

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderContext.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderContext.java
@@ -1,0 +1,61 @@
+package com.copilotkit.showcase.springai;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Thread-local holder for {@code x-aimock-*} headers extracted from incoming
+ * AG-UI requests.
+ *
+ * <p>Uses {@link InheritableThreadLocal} so the headers propagate into child
+ * threads created by {@link java.util.concurrent.CompletableFuture#runAsync}
+ * (which the AG-UI SDK uses internally). The outbound interceptors
+ * ({@link AimockHeaderRequestInterceptor} for RestClient,
+ * {@link WebClientConfig} for WebClient) read these headers and forward them
+ * to the LLM API (aimock/OpenAI).
+ *
+ * <p>Lifecycle: set by {@link AimockHeaderInterceptor#preHandle}, cleared by
+ * {@link AimockHeaderInterceptor#afterCompletion}.
+ */
+public final class AimockHeaderContext {
+
+    private static final InheritableThreadLocal<Map<String, String>> HEADERS =
+            new InheritableThreadLocal<>() {
+                @Override
+                protected Map<String, String> initialValue() {
+                    return Collections.emptyMap();
+                }
+            };
+
+    private AimockHeaderContext() {
+        // utility class
+    }
+
+    /**
+     * Stores the given headers after filtering to only {@code x-aimock-*} keys.
+     * Keys are lower-cased for consistent matching on the outbound side.
+     */
+    public static void set(Map<String, String> headers) {
+        Map<String, String> filtered = headers.entrySet().stream()
+                .filter(e -> e.getKey().toLowerCase(java.util.Locale.ROOT)
+                        .startsWith("x-aimock-"))
+                .collect(Collectors.toMap(
+                        e -> e.getKey().toLowerCase(java.util.Locale.ROOT),
+                        Map.Entry::getValue));
+        HEADERS.set(Collections.unmodifiableMap(filtered));
+    }
+
+    /**
+     * Returns the current thread's {@code x-aimock-*} headers, or an empty map
+     * if none have been set.
+     */
+    public static Map<String, String> get() {
+        return HEADERS.get();
+    }
+
+    /** Removes the headers from the current thread. */
+    public static void clear() {
+        HEADERS.remove();
+    }
+}

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderInterceptor.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderInterceptor.java
@@ -1,0 +1,46 @@
+package com.copilotkit.showcase.springai;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Extracts {@code x-aimock-*} headers from incoming HTTP requests and stores
+ * them in {@link AimockHeaderContext} so outbound LLM calls can forward them.
+ *
+ * <p>Registered via {@link AimockWebMvcConfig#addInterceptors}.
+ */
+@Component
+public class AimockHeaderInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) {
+        Map<String, String> headers = new HashMap<>();
+        Enumeration<String> headerNames = request.getHeaderNames();
+        if (headerNames != null) {
+            while (headerNames.hasMoreElements()) {
+                String name = headerNames.nextElement();
+                if (name.toLowerCase(java.util.Locale.ROOT).startsWith("x-aimock-")) {
+                    headers.put(name, request.getHeader(name));
+                }
+            }
+        }
+        AimockHeaderContext.set(headers);  // Always set, even when empty — clears stale state
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request,
+                                HttpServletResponse response,
+                                Object handler,
+                                Exception ex) {
+        AimockHeaderContext.clear();
+    }
+}

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderInterceptor.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderInterceptor.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Extracts {@code x-aimock-*} headers from incoming HTTP requests and stores
+ * Extracts {@code x-*} prefixed headers from incoming HTTP requests and stores
  * them in {@link AimockHeaderContext} so outbound LLM calls can forward them.
  *
  * <p>Registered via {@link AimockWebMvcConfig#addInterceptors}.
@@ -27,7 +27,7 @@ public class AimockHeaderInterceptor implements HandlerInterceptor {
         if (headerNames != null) {
             while (headerNames.hasMoreElements()) {
                 String name = headerNames.nextElement();
-                if (name.toLowerCase(java.util.Locale.ROOT).startsWith("x-aimock-")) {
+                if (name.toLowerCase(java.util.Locale.ROOT).startsWith("x-")) {
                     headers.put(name, request.getHeader(name));
                 }
             }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderRequestInterceptor.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderRequestInterceptor.java
@@ -1,0 +1,38 @@
+package com.copilotkit.showcase.springai;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Injects {@code x-aimock-*} headers (from {@link AimockHeaderContext}) into
+ * outgoing HTTP requests made through Spring's {@code RestClient}.
+ *
+ * <p>This covers Spring AI's synchronous {@code .call()} path
+ * ({@code OpenAiChatModel.internalCall -> OpenAiApi.chatCompletionEntity ->
+ * RestClient}). The reactive {@code WebClient} path ({@code .stream()}) is
+ * handled by a parallel {@code ExchangeFilterFunction} in
+ * {@link WebClientConfig}.
+ *
+ * <p>Registered via {@link WebClientConfig#connectionCloseRestClientCustomizer}.
+ */
+@Component
+public class AimockHeaderRequestInterceptor implements ClientHttpRequestInterceptor {
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request,
+                                        byte[] body,
+                                        ClientHttpRequestExecution execution)
+            throws IOException {
+        Map<String, String> headers = AimockHeaderContext.get();
+        if (!headers.isEmpty()) {
+            headers.forEach((key, value) -> request.getHeaders().set(key, value));
+        }
+        return execution.execute(request, body);
+    }
+}

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderRequestInterceptor.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockHeaderRequestInterceptor.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.util.Map;
 
 /**
- * Injects {@code x-aimock-*} headers (from {@link AimockHeaderContext}) into
+ * Injects {@code x-*} prefixed headers (from {@link AimockHeaderContext}) into
  * outgoing HTTP requests made through Spring's {@code RestClient}.
  *
  * <p>This covers Spring AI's synchronous {@code .call()} path

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockWebMvcConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockWebMvcConfig.java
@@ -7,7 +7,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
  * Registers the {@link AimockHeaderInterceptor} on all incoming requests so
- * that {@code x-aimock-*} headers are captured into
+ * that {@code x-*} prefixed headers are captured into
  * {@link AimockHeaderContext} before any controller runs.
  */
 @Configuration

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockWebMvcConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AimockWebMvcConfig.java
@@ -1,0 +1,27 @@
+package com.copilotkit.showcase.springai;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Registers the {@link AimockHeaderInterceptor} on all incoming requests so
+ * that {@code x-aimock-*} headers are captured into
+ * {@link AimockHeaderContext} before any controller runs.
+ */
+@Configuration
+public class AimockWebMvcConfig implements WebMvcConfigurer {
+
+    private final AimockHeaderInterceptor aimockHeaderInterceptor;
+
+    @Autowired
+    public AimockWebMvcConfig(AimockHeaderInterceptor aimockHeaderInterceptor) {
+        this.aimockHeaderInterceptor = aimockHeaderInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(aimockHeaderInterceptor);
+    }
+}

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/WebClientConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/WebClientConfig.java
@@ -2,13 +2,17 @@ package com.copilotkit.showcase.springai;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestClientCustomizer;
 import org.springframework.boot.web.reactive.function.client.WebClientCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.JdkClientHttpConnector;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 
 import java.net.http.HttpClient;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -36,6 +40,9 @@ import java.util.Optional;
 public class WebClientConfig {
 
     private static final Logger log = LoggerFactory.getLogger(WebClientConfig.class);
+
+    @Autowired
+    private AimockHeaderRequestInterceptor aimockHeaderRequestInterceptor;
 
     /** Property name we manage. */
     static final String KEEPALIVE_PROPERTY = "jdk.httpclient.keepalive.timeout";
@@ -137,7 +144,9 @@ public class WebClientConfig {
      */
     @Bean
     public RestClientCustomizer connectionCloseRestClientCustomizer() {
-        return builder -> builder.defaultHeader("Connection", "close");
+        return builder -> builder
+                .defaultHeader("Connection", "close")
+                .requestInterceptor(aimockHeaderRequestInterceptor);
     }
 
     @Bean
@@ -170,6 +179,24 @@ public class WebClientConfig {
                 .version(HttpClient.Version.HTTP_1_1)
                 .build();
         JdkClientHttpConnector connector = new JdkClientHttpConnector(jdkClient);
-        return builder -> builder.clientConnector(connector);
+
+        // ExchangeFilterFunction that forwards x-aimock-* headers from the
+        // AimockHeaderContext (set by the inbound HandlerInterceptor) onto
+        // every outgoing WebClient request. This covers Spring AI's reactive
+        // .stream() path — the synchronous .call() path is handled by the
+        // AimockHeaderRequestInterceptor registered on the RestClient above.
+        ExchangeFilterFunction aimockFilter = (request, next) -> {
+            Map<String, String> aimockHeaders = AimockHeaderContext.get();
+            if (aimockHeaders.isEmpty()) {
+                return next.exchange(request);
+            }
+            ClientRequest.Builder mutated = ClientRequest.from(request);
+            aimockHeaders.forEach(mutated::header);
+            return next.exchange(mutated.build());
+        };
+
+        return builder -> builder
+                .clientConnector(connector)
+                .filter(aimockFilter);
     }
 }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/WebClientConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/WebClientConfig.java
@@ -180,7 +180,7 @@ public class WebClientConfig {
                 .build();
         JdkClientHttpConnector connector = new JdkClientHttpConnector(jdkClient);
 
-        // ExchangeFilterFunction that forwards x-aimock-* headers from the
+        // ExchangeFilterFunction that forwards x-* prefixed headers from the
         // AimockHeaderContext (set by the inbound HandlerInterceptor) onto
         // every outgoing WebClient request. This covers Spring AI's reactive
         // .stream() path — the synchronous .call() path is handled by the


### PR DESCRIPTION
## Summary

Per-request `X-AIMock-Strict` header propagation through the full CopilotKit stack — from Playwright browser contexts through AG-UI to outgoing LLM API calls. Enables the same aimock instance to serve both strict fixture-only probes and live demo traffic simultaneously.

- **Harness**: All probe browser contexts send `X-AIMock-Strict: true` via `extraHTTPHeaders` (9 sites across 5 driver files)
- **Python SDK**: `ContextVar` + `httpx` event hook — incoming `x-aimock-*` headers forwarded to outgoing LLM calls automatically via FastAPI integration (covers 12/17 showcase integrations)
- **TypeScript SDK**: `AsyncLocalStorage` + per-call headers merged into `wrapModelCall` middleware (covers 3 more, 15/17 total)
- **.NET integration**: `AsyncLocal` + ASP.NET middleware + `PipelinePolicy` stopgap — all 12 agent factories wired through `CreateOpenAIClientOptions()`. TODO markers for migration to copilotkit-sdk-dotnet when Microsoft delivers it.
- **Java/Spring integration**: `InheritableThreadLocal` + `HandlerInterceptor` + `ClientHttpRequestInterceptor` + WebClient `ExchangeFilterFunction` — covers both RestClient and WebClient paths

## Test plan

- [x] Python SDK: 14 new tests (ContextVar isolation, httpx hook injection, key lowercasing, warning on bad client), 116 total pass
- [x] TypeScript SDK: 8 new tests (AsyncLocalStorage isolation, header filtering, concurrent requests), 92 total pass
- [x] Harness: 1590 tests pass (1 pre-existing failure unrelated)
- [x] CR converged: 2 rounds × 14 agents, 6 bucket(a) findings fixed, 0 remaining