### PR TITLE
fix(showcase/ms-agent-python): modernize to gpt-5.2, native reasoning + multimodal, fix multi-turn A2UI

### DIFF
--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
@@ -1,17 +1,20 @@
-import { map, Observable } from "rxjs";
+import type { Observable } from "rxjs";
+import { map } from "rxjs";
 import { LangGraphEventTypes } from "../../../../agents/langgraph/events";
-import { BaseEvent, RawEvent } from "@ag-ui/core";
+import type { BaseEvent, RawEvent } from "@ag-ui/core";
+import type {
+  ProcessedEvents,
+  SchemaKeys,
+  StateEnrichment,
+} from "@ag-ui/langgraph";
 import {
   LangGraphAgent as AGUILangGraphAgent,
   LangGraphHttpAgent,
   type LangGraphAgentConfig,
-  ProcessedEvents,
-  SchemaKeys,
   type State,
-  StateEnrichment,
 } from "@ag-ui/langgraph";
-import { Message as LangGraphMessage } from "@langchain/langgraph-sdk/dist/types.messages";
-import { ThreadState } from "@langchain/langgraph-sdk";
+import type { Message as LangGraphMessage } from "@langchain/langgraph-sdk/dist/types.messages";
+import type { ThreadState } from "@langchain/langgraph-sdk";
 
 interface CopilotKitStateEnrichment {
   copilotkit: {
@@ -20,15 +23,16 @@ interface CopilotKitStateEnrichment {
   };
 }
 
-import { RunAgentInput, EventType, CustomEvent } from "@ag-ui/client";
+import type { RunAgentInput, CustomEvent } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
 
 // Import and re-export from separate file to maintain API compatibility
-import {
-  CustomEventNames,
+import type {
   TextMessageEvents,
   ToolCallEvents,
   PredictStateTool,
 } from "./consts";
+import { CustomEventNames } from "./consts";
 export { CustomEventNames };
 
 export class LangGraphAgent extends AGUILangGraphAgent {
@@ -154,8 +158,18 @@ export class LangGraphAgent extends AGUILangGraphAgent {
 
   // @ts-ignore
   run(input: RunAgentInput): Observable<BaseEvent> {
+    // @ag-ui/langgraph's message converter throws "message role is not
+    // supported." on any role it doesn't enumerate (user|assistant|system|tool).
+    // Reasoning-stream agents (e.g. OpenAI Responses API with reasoning summaries)
+    // emit AG-UI messages with role:"reasoning" that the client then replays on
+    // subsequent turns; without this filter the second turn crashes before the
+    // model is ever called.
+    const messages = (input.messages ?? []).filter(
+      (m: { role?: string }) => m?.role !== "reasoning",
+    );
     const enrichedInput = {
       ...input,
+      messages,
       forwardedProps: {
         ...input.forwardedProps,
         streamSubgraphs: input.forwardedProps?.streamSubgraphs ?? true,

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -11,6 +11,141 @@
       }
     },
     {
+      "_comment": "tool-rendering-reasoning-chain pill 1 (stocks) — final narration after the MSFT tool result lands. Specific toolCallId so this matches BEFORE the first-leg fixture below despite the same userMessage substring. Source: showcase/harness/fixtures/d5/tool-rendering-reasoning-chain.json.",
+      "match": {
+        "userMessage": "Compare AAPL and MSFT stocks",
+        "toolCallId": "call_rc_stock_msft_001"
+      },
+      "response": {
+        "content": "AAPL is at $338.37 (-2.96% on the day) while MSFT is at $412.18 (+1.08%). MSFT is outpacing AAPL by roughly 4 points today — strong day for MSFT, rough one for AAPL."
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 1 (stocks) — second leg: after get_stock_price(AAPL) returns, chain to MSFT for the comparison.",
+      "match": {
+        "userMessage": "Compare AAPL and MSFT stocks",
+        "toolCallId": "call_rc_stock_aapl_001"
+      },
+      "response": {
+        "reasoning": "AAPL quote is in hand. The user explicitly asked to compare AAPL with MSFT, so I'll fetch MSFT next and then summarize the side-by-side.",
+        "content": "Now pulling MSFT to complete the comparison.",
+        "toolCalls": [
+          {
+            "id": "call_rc_stock_msft_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"MSFT\",\"price_usd\":412.18,\"change_pct\":1.08}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 1 (stocks) — first leg: emit get_stock_price(AAPL). The `Compare AAPL and MSFT stocks` substring is unique to this demo's pill prompt — other integrations' reasoning-chain demos still send the older `How is AAPL doing?` prompt — so we don't need a tool-name gate and the fixture stays scoped to langgraph-python without affecting fleet-wide aimock traffic. MUST appear before the bare 'AAPL' fixtures later in this file.",
+      "match": {
+        "userMessage": "Compare AAPL and MSFT stocks"
+      },
+      "response": {
+        "reasoning": "The user asked to compare AAPL and MSFT. I'll fetch AAPL first, then MSFT, then summarize the deltas in a single sentence so the comparison is the punchline.",
+        "content": "Pulling the AAPL quote first.",
+        "toolCalls": [
+          {
+            "id": "call_rc_stock_aapl_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 2 (dice) — final narration after the d6 contrast roll lands. userMessage is the LANGGRAPH-PYTHON-UNIQUE tail of the pill prompt ('compare it to a smaller one'); other integrations' reasoning-chain demos still send the older 'Roll a 20-sided die for me.' (no period-after-die substring match against 'Roll a 20-sided die.') which lacks this suffix — so this fixture stays scoped to this demo and does NOT hijack the older 5x roll_d20 fixtures further down in this file.",
+      "match": {
+        "userMessage": "compare it to a smaller one",
+        "toolCallId": "call_rc_dice_d6_001"
+      },
+      "response": {
+        "content": "The d20 came up 14, and a d6 for contrast landed on 4 — the d20's range is much wider, which is the whole point of the comparison."
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 2 (dice) — second leg: after roll_dice(sides=20) returns, chain a smaller die for contrast.",
+      "match": {
+        "userMessage": "compare it to a smaller one",
+        "toolCallId": "call_rc_dice_d20_001"
+      },
+      "response": {
+        "reasoning": "Got the d20 result. The user explicitly asked to compare it to a smaller die — a d6 is a natural choice because its 1-6 range is what most people picture when they think 'die'. Rolling that next.",
+        "content": "Now rolling a d6 for contrast.",
+        "toolCalls": [
+          {
+            "id": "call_rc_dice_d6_001",
+            "name": "roll_dice",
+            "arguments": "{\"sides\":6}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 2 (dice) — first leg: emit roll_dice(sides=20). Unique substring 'compare it to a smaller one' keeps us scoped to this demo (other integrations' dice pills still send 'Roll a 20-sided die for me.' and fall through to the older 5x roll_d20 fixtures further down). NB: aimock's `toolName` gate is a tool-LIST gate, not a tool-CALL gate; we don't use it here because the reasoning-chain agents across the fleet all register `roll_dice`, so a `toolName: roll_dice` claim would NOT have distinguished this demo from the others.",
+      "match": {
+        "userMessage": "compare it to a smaller one"
+      },
+      "response": {
+        "reasoning": "The user asked for a d20 roll and wants to compare it against a smaller die. I'll roll the d20 first, then chain a smaller die so the contrast in possible-value ranges is concrete and observable.",
+        "content": "Rolling the d20 now.",
+        "toolCalls": [
+          {
+            "id": "call_rc_dice_d20_001",
+            "name": "roll_dice",
+            "arguments": "{\"sides\":20}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 3 (flights + destination weather) — final narration after get_weather(JFK) lands. userMessage is the LANGGRAPH-PYTHON-UNIQUE tail 'show me the weather there'; the basic tool-rendering demos AND every other integration's reasoning-chain demo still send 'Find flights from SFO to JFK.' (no destination-weather request) which lacks this substring, so this fixture stays scoped to this demo without affecting fleet-wide aimock traffic.",
+      "match": {
+        "userMessage": "show me the weather there",
+        "toolCallId": "call_rc_weather_jfk_001"
+      },
+      "response": {
+        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289). JFK is currently 68°F and sunny — easy travel weather on the receiving end."
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 3 (flights + destination weather) — second leg: after search_flights(SFO,JFK) returns, chain to destination weather.",
+      "match": {
+        "userMessage": "show me the weather there",
+        "toolCallId": "call_rc_flights_jfk_001"
+      },
+      "response": {
+        "reasoning": "Flights are in hand. The user explicitly asked for the destination weather as part of the request, so pulling JFK weather next to round out the trip plan.",
+        "content": "Pulling JFK weather to round out the trip plan.",
+        "toolCalls": [
+          {
+            "id": "call_rc_weather_jfk_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"JFK\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 3 (flights + destination weather) — first leg: emit search_flights(SFO,JFK). The 'show me the weather there' substring is unique to this demo's pill, so the basic tool-rendering demo's bare 'Find flights from SFO to JFK.' prompt (and the equivalent prompts in other integrations' reasoning-chain demos that have not yet been ported to the chained phrasing) flow through to the basic single-tool flights fixture later in the file.",
+      "match": {
+        "userMessage": "show me the weather there"
+      },
+      "response": {
+        "reasoning": "The user wants flights from SFO to JFK AND the destination weather. I'll call search_flights first, then chain get_weather on JFK so they have flight options and arrival conditions in one reply.",
+        "content": "Searching SFO→JFK flights.",
+        "toolCalls": [
+          {
+            "id": "call_rc_flights_jfk_001",
+            "name": "search_flights",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\"}"
+          }
+        ]
+      }
+    },
+    {
       "_comment": "headless-simple pill 1: locks the deterministic greeting leading phrase. The reply is intentionally NON-boilerplate (i.e. NOT the showcase-assistant catch-all 'I can help you with weather lookups...') so the headless-simple spec's HELLO_LEADING assertion fails when fixture priority misroutes this prompt to the catch-all.",
       "match": {
         "userMessage": "Say hello in one short sentence"

--- a/showcase/harness/fixtures/d5/tool-rendering-reasoning-chain.json
+++ b/showcase/harness/fixtures/d5/tool-rendering-reasoning-chain.json
@@ -1,52 +1,135 @@
 {
-  "_comment": "D5 fixture for /demos/tool-rendering-reasoning-chain (LangGraph Python). The demo composes a reasoningMessage slot (<ReasoningBlock data-testid=\"reasoning-block\">) with per-tool renderers (WeatherCard / FlightListCard). Two chip prompts probed: 'What's the weather in Tokyo?' (Turn 1) and 'Find flights from SFO to JFK.' (Turn 2). Each pill is a 2-leg flow: first leg emits the tool call (get_weather / search_flights), a `reasoning` field, AND a non-empty `content` field. The non-empty `content` is load-bearing: aimock's Responses-API dispatch routes tool-call-only responses (no `content`) through `buildToolCallResponse`, which silently drops the `reasoning` payload. Adding a `content` string shifts dispatch to `buildContentWithToolCallsResponse`, which emits the reasoning_summary events the v2 <ReasoningBlock> needs to mount. SFO/JFK (Turn 2) deliberately uses `toolCallId` matching for its second leg and omits `hasToolResult` from its first leg — `hasToolResult` is broken for the second turn of a multi-turn flow because Turn 1's tool result is still in the conversation, so a `hasToolResult: false` first-leg fixture would not match Turn 2's first leg and the matcher would fall through to the `hasToolResult: true` second-leg fixture, returning narration without the tool call and breaking the FlightListCard assertion. With `toolCallId` matching, the second-leg fixture only matches when the LAST conversation message is the tool result for that specific call_id, so it cannot accidentally swallow first-leg requests. The second-leg fixture must come BEFORE the first-leg in this file because the matcher is first-match-wins. Tokyo (Turn 1) keeps the simpler `hasToolResult` pattern because it has no prior turns. The agent uses `init_chat_model(... use_responses_api=True, reasoning={effort:'medium', summary:'detailed'})` — Responses-API mode delivers reasoning summaries alongside tool calls. Mirrored verbatim into showcase/aimock/d5-all.json so re-bundling stays consistent.",
+  "_comment": "D5 fixture for /demos/tool-rendering-reasoning-chain (LangGraph Python). The demo composes a reasoningMessage slot (<ReasoningBlock data-testid=\"reasoning-block\">) with per-tool renderers (WeatherCard / FlightListCard / catchall for stocks & dice). Three pills, all CHAINED — each user prompt drives two tool calls in succession before a final narration. Each first-leg fixture is gated on a `userMessage` substring that ONLY appears in this demo's pill prompts ('Compare AAPL and MSFT stocks for me', 'compare it to a smaller one', 'show me the weather there'). That keeps these fixtures from cross-contaminating the other 14+ integrations whose reasoning-chain demos share `showcase-aimock` on Railway and use overlapping prompts like 'Roll a 20-sided die for me.' or 'Find flights from SFO to JFK.' — those substrings would have been hijacked if we relied on `toolName: roll_dice` alone, because most reasoning-chain agents across the fleet also register `roll_dice`. For multi-pill safety in a single thread each follow-up leg is keyed on the prior step's `toolCallId`; the matcher checks `messages[last].tool_call_id`, which is stable regardless of how many prior pills left tool history in the thread. Ordering within each pill is final-content → second-leg → first-leg (first-match-wins) so the toolCallId-specific fixtures win before the bare first-leg can re-emit. Non-empty `content` is load-bearing on tool-emitting fixtures: aimock's Responses-API dispatch routes tool-call-only responses (no `content`) through `buildToolCallResponse`, which silently drops the `reasoning` payload, and the v2 <ReasoningBlock> never mounts. Mirrored verbatim into showcase/aimock/d5-all.json so re-bundling stays consistent.",
   "fixtures": [
     {
+      "_comment": "Pill 1 (stocks) — final narration after the MSFT tool result lands. Specific toolCallId so this matches BEFORE the first-leg fixture below despite the same userMessage substring.",
       "match": {
-        "userMessage": "weather in Tokyo",
-        "hasToolResult": false,
-        "toolName": "get_weather"
+        "userMessage": "Compare AAPL and MSFT stocks",
+        "toolCallId": "call_rc_stock_msft_001"
       },
       "response": {
-        "reasoning": "The user asked about Tokyo weather. I'll call get_weather with location='Tokyo' to get the current conditions.",
-        "content": "Looking up the weather in Tokyo for you.",
+        "content": "AAPL is at $338.37 (-2.96% on the day) while MSFT is at $412.18 (+1.08%). MSFT is outpacing AAPL by roughly 4 points today — strong day for MSFT, rough one for AAPL."
+      }
+    },
+    {
+      "_comment": "Pill 1 (stocks) — second leg: after get_stock_price(AAPL) returns, chain to MSFT for the comparison.",
+      "match": {
+        "userMessage": "Compare AAPL and MSFT stocks",
+        "toolCallId": "call_rc_stock_aapl_001"
+      },
+      "response": {
+        "reasoning": "AAPL quote is in hand. The user explicitly asked to compare AAPL with MSFT, so I'll fetch MSFT next and then summarize the side-by-side.",
+        "content": "Now pulling MSFT to complete the comparison.",
         "toolCalls": [
           {
-            "id": "call_d5_get_weather_001",
-            "name": "get_weather",
-            "arguments": "{\"location\":\"Tokyo\"}"
+            "id": "call_rc_stock_msft_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"MSFT\",\"price_usd\":412.18,\"change_pct\":1.08}"
           }
         ]
       }
     },
     {
+      "_comment": "Pill 1 (stocks) — first leg: emit get_stock_price(AAPL). The `Compare AAPL and MSFT stocks` substring is unique to this demo's pill — other integrations' reasoning-chain demos still ship the older `How is AAPL doing?` prompt — so we don't need an additional tool-name gate.",
       "match": {
-        "userMessage": "weather in Tokyo",
-        "hasToolResult": true
+        "userMessage": "Compare AAPL and MSFT stocks"
       },
       "response": {
-        "content": "Tokyo is 22°C and partly cloudy."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Find flights from SFO to JFK.",
-        "toolCallId": "call_tr_flights_sfo_jfk_001"
-      },
-      "response": {
-        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Find flights from SFO to JFK."
-      },
-      "response": {
-        "reasoning": "The user wants flights from SFO to JFK. I'll call search_flights with those airports to look up options.",
-        "content": "Searching for flights from SFO to JFK.",
+        "reasoning": "The user asked to compare AAPL and MSFT. I'll fetch AAPL first, then MSFT, then summarize the deltas in a single sentence so the comparison is the punchline.",
+        "content": "Pulling the AAPL quote first.",
         "toolCalls": [
           {
-            "id": "call_tr_flights_sfo_jfk_001",
+            "id": "call_rc_stock_aapl_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Pill 2 (dice) — final narration after the d6 contrast roll lands. userMessage is the LANGGRAPH-PYTHON-UNIQUE tail of the pill prompt ('compare it to a smaller one'); other integrations' dice pills (e.g. agno, ms-agent-python) still send the older 'Roll a 20-sided die for me.' which does NOT contain this substring, so this fixture stays scoped to this demo without needing a fragile tool-name gate.",
+      "match": {
+        "userMessage": "compare it to a smaller one",
+        "toolCallId": "call_rc_dice_d6_001"
+      },
+      "response": {
+        "content": "The d20 came up 14, and a d6 for contrast landed on 4 — the d20's range is much wider, which is the whole point of the comparison."
+      }
+    },
+    {
+      "_comment": "Pill 2 (dice) — second leg: after roll_dice(sides=20) returns, chain a smaller die for contrast.",
+      "match": {
+        "userMessage": "compare it to a smaller one",
+        "toolCallId": "call_rc_dice_d20_001"
+      },
+      "response": {
+        "reasoning": "Got the d20 result. The user explicitly asked to compare it to a smaller die — a d6 is a natural choice because its 1-6 range is what most people picture when they think 'die'. Rolling that next.",
+        "content": "Now rolling a d6 for contrast.",
+        "toolCalls": [
+          {
+            "id": "call_rc_dice_d6_001",
+            "name": "roll_dice",
+            "arguments": "{\"sides\":6}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Pill 2 (dice) — first leg: emit roll_dice(sides=20). Unique substring keeps us scoped to this demo (other integrations send the bare 'Roll a 20-sided die for me.' which falls through to the older 5x roll_d20 fixtures further down in d5-all.json).",
+      "match": {
+        "userMessage": "compare it to a smaller one"
+      },
+      "response": {
+        "reasoning": "The user asked for a d20 roll and wants to compare it against a smaller die. I'll roll the d20 first, then chain a smaller die so the contrast in possible-value ranges is concrete and observable.",
+        "content": "Rolling the d20 now.",
+        "toolCalls": [
+          {
+            "id": "call_rc_dice_d20_001",
+            "name": "roll_dice",
+            "arguments": "{\"sides\":20}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Pill 3 (flights + destination weather) — final narration after get_weather(JFK) lands. userMessage is the LANGGRAPH-PYTHON-UNIQUE tail of the pill prompt ('show me the weather there'); the basic tool-rendering demos AND the other integrations' reasoning-chain demos still send 'Find flights from SFO to JFK.' which lacks this substring, so this fixture stays scoped to this demo.",
+      "match": {
+        "userMessage": "show me the weather there",
+        "toolCallId": "call_rc_weather_jfk_001"
+      },
+      "response": {
+        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289). JFK is currently 68°F and sunny — easy travel weather on the receiving end."
+      }
+    },
+    {
+      "_comment": "Pill 3 (flights + destination weather) — second leg: after search_flights(SFO,JFK) returns, chain to destination weather.",
+      "match": {
+        "userMessage": "show me the weather there",
+        "toolCallId": "call_rc_flights_jfk_001"
+      },
+      "response": {
+        "reasoning": "Flights are in hand. The user explicitly asked for the destination weather as part of the request, so pulling JFK weather next to round out the trip plan.",
+        "content": "Pulling JFK weather to round out the trip plan.",
+        "toolCalls": [
+          {
+            "id": "call_rc_weather_jfk_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"JFK\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Pill 3 (flights + destination weather) — first leg: emit search_flights(SFO,JFK). The unique 'show me the weather there' substring keeps this fixture from absorbing the basic tool-rendering demo's bare 'Find flights from SFO to JFK.' prompt (and the equivalent prompt in other integrations' reasoning-chain demos that have not yet been ported to the chained phrasing).",
+      "match": {
+        "userMessage": "show me the weather there"
+      },
+      "response": {
+        "reasoning": "The user wants flights from SFO to JFK AND the destination weather. I'll call search_flights first, then chain get_weather on JFK so they have flight options and arrival conditions in one reply.",
+        "content": "Searching SFO→JFK flights.",
+        "toolCalls": [
+          {
+            "id": "call_rc_flights_jfk_001",
             "name": "search_flights",
             "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\"}"
           }

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
@@ -4,34 +4,31 @@
  * Drives `/demos/tool-rendering-reasoning-chain`. The demo composes
  * two patterns into one chat surface:
  *
- *   1. Reasoning tokens streamed by `init_chat_model("openai:gpt-5-mini",
- *      use_responses_api=True, reasoning={"effort":"low"})` and rendered
- *      via a custom `messageView.reasoningMessage` slot
+ *   1. Reasoning tokens streamed by `init_chat_model("openai:gpt-5.4",
+ *      use_responses_api=True, reasoning={"effort":"medium",
+ *      "summary":"detailed"})` and rendered via a custom
+ *      `messageView.reasoningMessage` slot
  *      (`<ReasoningBlock data-testid="reasoning-block">`).
  *   2. Per-tool renderers wired through `useRenderTool`:
  *        get_weather    → <WeatherCard />
  *        search_flights → <FlightListCard />
  *        get_stock_price / roll_dice → <CustomCatchallRenderer />
  *
- * Two-turn flow (chip-driven):
- *   1. "What's the weather in Tokyo?" → reasoning-block + WeatherCard.
- *      Asserts BOTH the reasoning-block testid AND the weather-card
- *      testid mount, plus assistant transcript mentions "tokyo".
- *   2. "Find flights from SFO to JFK." → reasoning-block + FlightListCard.
- *      Asserts BOTH the reasoning-block testid AND the flight-list-card
- *      testid mount, plus assistant transcript mentions a flight token
- *      ("flight" / "sfo" / "jfk").
- *
- * Two pills (vs all four — dice / AAPL) keep wall-clock under the
- * default per-feature ceiling; the two we pick are the ones with
- * deterministic per-tool renderers (WeatherCard + FlightListCard), so
- * the assertion ladder stays sharp. The catchall variants (dice / AAPL)
- * are covered separately by `tool-rendering-custom-catchall`.
+ * Single-turn flow (chip-driven):
+ *   "Find flights from SFO to JFK and show me the weather there."
+ *     → reasoning-block + FlightListCard + WeatherCard.
+ *   This pill is CHAINED (search_flights → get_weather(JFK)) so a single
+ *   turn exercises BOTH per-tool renderers — covering all the wiring the
+ *   previous two-turn Tokyo+SFO script covered, at half the wall-clock.
+ *   Asserts ALL THREE testids mount (reasoning-block, flight-list-card,
+ *   weather-card), plus assistant transcript mentions "sfo".
  *
  * The reasoning-block assertion is what makes this probe distinct from
  * `tool-rendering` (no reasoning slot) and from `reasoning-display`
  * (no per-tool renderers). A regression that drops the reasoning slot
- * OR the tool renderer wiring is caught here.
+ * OR the tool-renderer wiring OR the chained-tool-call behavior is
+ * caught here. The catchall variants (dice / stocks) are covered
+ * separately by `tool-rendering-custom-catchall`.
  */
 
 import { registerD5Script } from "../helpers/d5-registry.js";
@@ -43,9 +40,10 @@ interface PillExpectation {
    *  suggestion-chip messages verbatim so aimock's `userMessage`
    *  substring matcher selects the right canned response. */
   prompt: string;
-  /** Per-tool card testid to wait for (after the agent's tool result
-   *  lands). */
-  cardTestId: string;
+  /** Per-tool card testids to wait for. Chained pills emit multiple tool
+   *  calls in succession, so this is a list — the assertion succeeds only
+   *  if EVERY listed testid mounts within `CARD_TIMEOUT_MS`. */
+  cardTestIds: readonly string[];
   /** Lowercase substrings the assistant transcript must contain. */
   textTokens: readonly string[];
   /** Per-turn budget — agent reasoning + tool call + render. */
@@ -54,14 +52,11 @@ interface PillExpectation {
 
 const TURN_EXPECTATIONS: readonly PillExpectation[] = [
   {
-    prompt: "What's the weather in Tokyo?",
-    cardTestId: "weather-card",
-    textTokens: ["tokyo"],
-    responseTimeoutMs: 60_000,
-  },
-  {
-    prompt: "Find flights from SFO to JFK.",
-    cardTestId: "flight-list-card",
+    // Pill 3 in page.tsx — chained flights + destination weather.
+    // Exercises BOTH per-tool renderers (FlightListCard + WeatherCard) in
+    // a single turn, so this one prompt covers the full per-tool wiring.
+    prompt: "Find flights from SFO to JFK and show me the weather there.",
+    cardTestIds: ["flight-list-card", "weather-card"],
     textTokens: ["sfo"],
     responseTimeoutMs: 60_000,
   },
@@ -141,25 +136,29 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
         );
       }
 
-      // 2. Wait for the per-tool card to mount. This proves the tool
-      //    call landed AND the per-tool renderer fired (NOT the
-      //    catchall fallback).
-      try {
-        await page.waitForSelector(`[data-testid="${exp.cardTestId}"]`, {
-          state: "visible",
-          timeout: CARD_TIMEOUT_MS,
-        });
-      } catch {
-        throw new Error(
-          `${tag}: expected [data-testid="${exp.cardTestId}"] to mount within ${CARD_TIMEOUT_MS}ms — tool result may not have landed or the per-tool renderer wiring drifted`,
-        );
+      // 2. Wait for every per-tool card to mount. Chained pills emit
+      //    multiple tool calls in one turn — each must land its dedicated
+      //    renderer (NOT the catchall fallback). Asserting all of them
+      //    catches the case where the second tool call regresses while
+      //    the first still works.
+      for (const cardTestId of exp.cardTestIds) {
+        try {
+          await page.waitForSelector(`[data-testid="${cardTestId}"]`, {
+            state: "visible",
+            timeout: CARD_TIMEOUT_MS,
+          });
+        } catch {
+          throw new Error(
+            `${tag}: expected [data-testid="${cardTestId}"] to mount within ${CARD_TIMEOUT_MS}ms — tool result may not have landed or the per-tool renderer wiring drifted`,
+          );
+        }
       }
 
       // 3. Verify the assistant transcript references the right context
-      //    (tokyo for weather, sfo for flights). The card mounting alone
+      //    (e.g. "sfo" for the SFO→JFK chain). The card mounting alone
       //    proves wiring; the text token catches the case where a stale
       //    fixture from a prior turn satisfies the testid wait but
-      //    contains the wrong city/route.
+      //    contains the wrong route.
       const text = await readAssistantTranscript(page);
       console.debug(`[d5-tool-rendering-reasoning-chain] ${tag} text`, {
         text: text.slice(0, 300),

--- a/showcase/integrations/langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py
@@ -58,8 +58,27 @@ def roll_dice(sides: int = 6) -> dict:
 
 
 SYSTEM_PROMPT = (
-    "You are a travel & lifestyle concierge. When a user asks a question, "
-    "reason step-by-step and call 2+ tools in succession when relevant."
+    "You are a helpful travel & lifestyle concierge with mock tools for "
+    "weather, flights, stock prices, and dice rolls — they all return "
+    "fake data, so call them liberally.\n\n"
+    "Your habit is to CHAIN tools when one answer naturally invites "
+    "another. For a single user question, call at least TWO tools in "
+    "succession when the topic allows, then compose your final reply. "
+    "Default chains:\n"
+    "  - 'What's the weather in <city>?' -> call get_weather(<city>), "
+    "then call search_flights(origin='SFO', destination=<city>) so the "
+    "user also sees how to get there.\n"
+    "  - 'How is <ticker> doing?' -> call get_stock_price(<ticker>), "
+    "then call get_stock_price on a comparable ticker (e.g. 'MSFT' or "
+    "'GOOGL') so the user can compare.\n"
+    "  - 'Roll a 20-sided die' -> call roll_dice(sides=20), then call "
+    "roll_dice again with a different number of sides so the user sees "
+    "a contrast.\n"
+    "  - 'Find flights from <a> to <b>' -> call search_flights(a, b), "
+    "then call get_weather(<b>) for the destination.\n\n"
+    "Only skip chaining when the user has clearly asked for a single, "
+    "atomic answer and more tool calls would feel intrusive. Never "
+    "fabricate data that a tool could provide."
 )
 
 REASONING_MODEL = os.environ.get("OPENAI_REASONING_MODEL", "gpt-5.4")

--- a/showcase/integrations/langgraph-python/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -123,14 +123,16 @@ function Chat() {
   useConfigureSuggestions({
     suggestions: [
       {
-        title: "Weather + flights to Tokyo",
-        message: "What's the weather in Tokyo?",
+        title: "Compare two stocks",
+        message: "Compare AAPL and MSFT stocks for me.",
       },
-      { title: "Compare two stocks", message: "How is AAPL doing?" },
-      { title: "Chain of dice rolls", message: "Roll a 20-sided die for me." },
+      {
+        title: "Chain of dice rolls",
+        message: "Roll a 20-sided die for me and compare it to a smaller one.",
+      },
       {
         title: "Flights + destination weather",
-        message: "Find flights from SFO to JFK.",
+        message: "Find flights from SFO to JFK and show me the weather there.",
       },
     ],
     available: "always",

--- a/showcase/integrations/ms-agent-python/package-lock.json
+++ b/showcase/integrations/ms-agent-python/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@copilotkit/showcase-ms-agent-python",
       "version": "0.1.0",
       "dependencies": {
-        "@ag-ui/client": "^0.0.43",
+        "@ag-ui/client": "^0.0.52",
         "@copilotkit/a2ui-renderer": "next",
         "@copilotkit/react-core": "next",
         "@copilotkit/runtime": "next",
@@ -34,251 +34,6 @@
         "postcss": "^8.5.0",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0"
-      }
-    },
-    "../../../node_modules/.pnpm/@ag-ui+client@0.0.43/node_modules/@ag-ui/client": {
-      "version": "0.0.43",
-      "dependencies": {
-        "@ag-ui/core": "0.0.43",
-        "@ag-ui/encoder": "0.0.43",
-        "@ag-ui/proto": "0.0.43",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      },
-      "devDependencies": {
-        "@types/jest": "^29.5.14",
-        "@types/node": "^20.11.19",
-        "jest": "^29.7.0",
-        "ts-jest": "^29.1.2",
-        "tsup": "^8.0.2",
-        "typescript": "^5.3.3"
-      }
-    },
-    "../../../node_modules/.pnpm/@playwright+test@1.57.0/node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.57.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "../../../node_modules/.pnpm/@tailwindcss+postcss@4.1.18/node_modules/@tailwindcss/postcss": {
-      "version": "4.1.18",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.1.18",
-        "@tailwindcss/oxide": "4.1.18",
-        "postcss": "^8.4.41",
-        "tailwindcss": "4.1.18"
-      },
-      "devDependencies": {
-        "@types/node": "^20.19.0",
-        "@types/postcss-import": "14.0.3",
-        "dedent": "1.7.0",
-        "internal-example-plugin": "0.0.0",
-        "postcss-import": "^16.1.1"
-      }
-    },
-    "../../../node_modules/.pnpm/@types+node@22.19.11/node_modules/@types/node": {
-      "version": "22.19.11",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "../../../node_modules/.pnpm/@types+react@19.2.7/node_modules/@types/react": {
-      "version": "19.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "../../../node_modules/.pnpm/concurrently@9.2.1/node_modules/concurrently": {
-      "version": "9.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "4.1.2",
-        "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
-        "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.33.0",
-        "@hirez_io/observer-spy": "^2.2.0",
-        "@types/node": "^18.19.123",
-        "@types/shell-quote": "^1.7.5",
-        "@types/supports-color": "^8.1.3",
-        "@types/yargs": "^17.0.33",
-        "@vitest/coverage-v8": "^3.2.4",
-        "@vitest/eslint-plugin": "^1.3.4",
-        "coveralls-next": "^5.0.0",
-        "ctrlc-wrapper": "^0.0.5",
-        "esbuild": "~0.25.9",
-        "eslint": "^9.33.0",
-        "eslint-config-flat-gitignore": "^2.1.0",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-import-lite": "^0.3.0",
-        "eslint-plugin-prettier": "^5.5.4",
-        "eslint-plugin-simple-import-sort": "^12.1.1",
-        "globals": "16.3.0",
-        "husky": "^9.1.7",
-        "lint-staged": "^15.5.2",
-        "prettier": "^3.6.2",
-        "safe-publish-latest": "^2.0.0",
-        "string-argv": "^0.3.2",
-        "typescript": "~5.9.2",
-        "typescript-eslint": "^8.40.0",
-        "vitest": "^3.2.4"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "../../../node_modules/.pnpm/postcss@8.5.6/node_modules/postcss": {
-      "version": "8.5.6",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "../../../node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom": {
-      "version": "19.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.3"
-      }
-    },
-    "../../../node_modules/.pnpm/react@19.2.3/node_modules/react": {
-      "version": "19.2.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "../../../node_modules/.pnpm/tailwindcss@4.1.18/node_modules/tailwindcss": {
-      "version": "4.1.18",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@jridgewell/remapping": "^2.3.4",
-        "@tailwindcss/oxide": "^4.1.18",
-        "@types/node": "^20.19.0",
-        "dedent": "1.7.0",
-        "lightningcss": "1.30.2",
-        "magic-string": "^0.30.21",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript": {
-      "version": "5.9.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "devDependencies": {
-        "@dprint/formatter": "^0.4.1",
-        "@dprint/typescript": "0.93.4",
-        "@esfx/canceltoken": "^1.0.0",
-        "@eslint/js": "^9.20.0",
-        "@octokit/rest": "^21.1.1",
-        "@types/chai": "^4.3.20",
-        "@types/diff": "^7.0.1",
-        "@types/minimist": "^1.2.5",
-        "@types/mocha": "^10.0.10",
-        "@types/ms": "^0.7.34",
-        "@types/node": "latest",
-        "@types/source-map-support": "^0.5.10",
-        "@types/which": "^3.0.4",
-        "@typescript-eslint/rule-tester": "^8.24.1",
-        "@typescript-eslint/type-utils": "^8.24.1",
-        "@typescript-eslint/utils": "^8.24.1",
-        "azure-devops-node-api": "^14.1.0",
-        "c8": "^10.1.3",
-        "chai": "^4.5.0",
-        "chokidar": "^4.0.3",
-        "diff": "^7.0.0",
-        "dprint": "^0.49.0",
-        "esbuild": "^0.25.0",
-        "eslint": "^9.20.1",
-        "eslint-formatter-autolinkable-stylish": "^1.4.0",
-        "eslint-plugin-regexp": "^2.7.0",
-        "fast-xml-parser": "^4.5.2",
-        "glob": "^10.4.5",
-        "globals": "^15.15.0",
-        "hereby": "^1.10.0",
-        "jsonc-parser": "^3.3.1",
-        "knip": "^5.44.4",
-        "minimist": "^1.2.8",
-        "mocha": "^10.8.2",
-        "mocha-fivemat-progress-reporter": "^0.1.0",
-        "monocart-coverage-reports": "^2.12.1",
-        "ms": "^2.1.3",
-        "picocolors": "^1.1.1",
-        "playwright": "^1.50.1",
-        "source-map-support": "^0.5.21",
-        "tslib": "^2.8.1",
-        "typescript": "^5.7.3",
-        "typescript-eslint": "^8.24.1",
-        "which": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "../../../node_modules/.pnpm/zod@3.25.76/node_modules/zod": {
-      "version": "3.25.76",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -320,8 +75,21 @@
       }
     },
     "node_modules/@ag-ui/client": {
-      "resolved": "../../../node_modules/.pnpm/@ag-ui+client@0.0.43/node_modules/@ag-ui/client",
-      "link": true
+      "version": "0.0.52",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
+      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.52",
+        "@ag-ui/encoder": "0.0.52",
+        "@ag-ui/proto": "0.0.52",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
     },
     "node_modules/@ag-ui/core": {
       "version": "0.0.52",
@@ -356,63 +124,6 @@
         "@ag-ui/core": ">=0.0.42"
       }
     },
-    "node_modules/@ag-ui/langgraph/node_modules/@langchain/core": {
-      "version": "0.3.80",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
-      "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
-      "license": "MIT",
-      "dependencies": {
-        "@cfworker/json-schema": "^4.0.2",
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
-        "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.67",
-        "mustache": "^4.2.0",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "zod": "^3.25.32",
-        "zod-to-json-schema": "^3.22.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ag-ui/langgraph/node_modules/langsmith": {
-      "version": "0.3.87",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
-      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "*",
-        "@opentelemetry/exporter-trace-otlp-proto": "*",
-        "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@ag-ui/mcp-apps-middleware": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@ag-ui/mcp-apps-middleware/-/mcp-apps-middleware-0.0.3.tgz",
@@ -436,13 +147,13 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.69",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.69.tgz",
-      "integrity": "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==",
+      "version": "3.0.76",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.76.tgz",
+      "integrity": "sha512-kOuvT9e6PygFvgYpkr4v9gjvmcMPfJp79jaXjeRl9Gpoj2OXdtc3ero7o1ic+tiSBw5IMubxXFO68BCA/axGJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       },
       "engines": {
         "node": ">=18"
@@ -452,14 +163,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.95",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.95.tgz",
-      "integrity": "sha512-ZmUNNbZl3V42xwQzPaNUi+s8eqR2lnrxf0bvB6YbLXpLjHYv0k2Y78t12cNOfY0bxGeuVVTLyk856uLuQIuXEQ==",
+      "version": "3.0.112",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.112.tgz",
+      "integrity": "sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -469,13 +180,13 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "3.0.62",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.62.tgz",
-      "integrity": "sha512-cC9HAjR5WZxjqGyEJrJqFTlVqyPE9UOFmmGdf5dINaimgfPmzqXYN1qTYEJ+1knbyTVsNMub0KAF5SOqqtO8IQ==",
+      "version": "3.0.72",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.72.tgz",
+      "integrity": "sha512-9EVG0AdUhs0hJ2+sqRb4IURZnsBahuU1CQELu+hfItm0wUTzxnVhIbQ4/jJkG/QFPtBUvMefCwDT7HX8T2HVbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       },
       "engines": {
         "node": ">=18"
@@ -485,16 +196,16 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex": {
-      "version": "3.0.127",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-3.0.127.tgz",
-      "integrity": "sha512-kD2xC1HFbhNe5/yCJqkIP2rV40mlyK3IJiCoI6bwkjC5aPvWdBVoMIYvYcmM/eYlDYkPwC3pkUWd1HqRdLyzZw==",
+      "version": "3.0.137",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-3.0.137.tgz",
+      "integrity": "sha512-vDtCmwMy4CzVsv3PESmkE96qDSqnsArDDEc22eggujZI/WxmIeKa+8vyUYjJUx9HZLOCPo7HhYDXjH0R2mcM+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "2.0.74",
-        "@ai-sdk/google": "2.0.67",
-        "@ai-sdk/openai-compatible": "1.0.35",
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.23",
+        "@ai-sdk/anthropic": "2.0.79",
+        "@ai-sdk/google": "2.0.72",
+        "@ai-sdk/openai-compatible": "1.0.39",
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25",
         "google-auth-library": "^10.5.0"
       },
       "engines": {
@@ -505,13 +216,13 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/anthropic": {
-      "version": "2.0.74",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.74.tgz",
-      "integrity": "sha512-1Z7142GVIF4XkcSvQpL6ij2c7J51dtm4/Z84P+O0bGBDZI1Nbvz897hXkJf2cfNhq5XdpvUYbI+oExXM7Ko8Zw==",
+      "version": "2.0.79",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.79.tgz",
+      "integrity": "sha512-K0U09FPDO1kmLPjRLXFcNSvmnKHJBMARCb8r3Ulw7wU6/+Zh9djWcFDiPPNsklg6yAezcdLTcYPszgWJJ6iOTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.23"
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25"
       },
       "engines": {
         "node": ">=18"
@@ -521,13 +232,13 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/google": {
-      "version": "2.0.67",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.67.tgz",
-      "integrity": "sha512-A7iZeJf3RbNIrFBKsskd2s4c52tK0S0nX4rGlehjVHSYBvIZzrX+RW3Oxe7WnpeI0aON+5dVsqfGLFNYNGWEXw==",
+      "version": "2.0.72",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.72.tgz",
+      "integrity": "sha512-BjDY6l+rV4CmHKjZe4H0uRXW3M2o+g7PaYM8oFpW+9PP1qKNEybnJ6//Si7BSf6DT+86dKARrtEl09lxSSaMaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.23"
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25"
       },
       "engines": {
         "node": ">=18"
@@ -537,9 +248,9 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
-      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -549,12 +260,12 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.23.tgz",
-      "integrity": "sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.25.tgz",
+      "integrity": "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider": "2.0.3",
         "@standard-schema/spec": "^1.0.0",
         "eventsource-parser": "^3.0.6"
       },
@@ -566,13 +277,13 @@
       }
     },
     "node_modules/@ai-sdk/mcp": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.36.tgz",
-      "integrity": "sha512-THQKwlknp7OU2ViLPfIU7W01XvDRM2eqH+4UULQgP64AopnwI9mGqqJeGIx2l/pxUu9yIDQtW9YtYM8kHm2CQg==",
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.42.tgz",
+      "integrity": "sha512-ctRhX9vNLXvjGSFf+RlM+ZutIhlzIgMPWzo2BoJKfIW9JzLneA/57bZkkaUvWSdbYFu1FCyxMarNV/4D/pOUzA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
         "pkce-challenge": "^5.0.0"
       },
       "engines": {
@@ -583,13 +294,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.52",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.52.tgz",
-      "integrity": "sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw==",
+      "version": "3.0.63",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.63.tgz",
+      "integrity": "sha512-4yY/m8a57MNNVoJCsXuNblKf6BO4yuAuLKRX4tzSNffBEBSp1FlcWdPE0Z4FkqUeS0AJhYSSqp0GIiA/cIcDNA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       },
       "engines": {
         "node": ">=18"
@@ -599,13 +310,13 @@
       }
     },
     "node_modules/@ai-sdk/openai-compatible": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-1.0.35.tgz",
-      "integrity": "sha512-wDN0NfYNfe/i+12YR3n6g7zETHNQrw8WJhL9IjgNG1shXdoFDCqzitSz2rYqfqbuKirUIcChrMvjIpcr5nX14w==",
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-1.0.39.tgz",
+      "integrity": "sha512-001hdQPPXxYBWrz5d+eAmBVYmwzsB+guIey1DFXi1ZEE5H3j7fRrhPpX55MdM9Fle2DS7WZ8b3qkumCIWE92YQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@ai-sdk/provider-utils": "3.0.23"
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25"
       },
       "engines": {
         "node": ">=18"
@@ -615,9 +326,9 @@
       }
     },
     "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
-      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -627,12 +338,12 @@
       }
     },
     "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.23.tgz",
-      "integrity": "sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.25.tgz",
+      "integrity": "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider": "2.0.3",
         "@standard-schema/spec": "^1.0.0",
         "eventsource-parser": "^3.0.6"
       },
@@ -644,9 +355,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -656,20 +367,33 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
-      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider": "3.0.10",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -701,9 +425,9 @@
       "license": "MIT"
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
-      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cfworker/json-schema": {
@@ -712,41 +436,10 @@
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
       "license": "MIT"
     },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
-      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "12.0.0",
-        "@chevrotain/types": "12.0.0"
-      }
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
-      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "12.0.0"
-      }
-    },
-    "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
-      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@chevrotain/types": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
-      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
-      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
     },
     "node_modules/@copilotkit/a2ui-renderer": {
@@ -778,36 +471,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@copilotkit/license-verifier": {
@@ -852,36 +515,6 @@
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc",
         "zod": ">=3.0.0"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@copilotkit/runtime": {
@@ -987,36 +620,6 @@
         "react": "^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/@copilotkit/runtime/node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/@ag-ui/client/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@copilotkit/runtime/node_modules/@types/node": {
       "version": "18.19.130",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
@@ -1056,6 +659,26 @@
         }
       }
     },
+    "node_modules/@copilotkit/runtime/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@copilotkit/runtime/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@copilotkit/shared": {
       "version": "1.55.2-next.1",
       "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.55.2-next.1.tgz",
@@ -1075,36 +698,6 @@
       },
       "peerDependencies": {
         "@ag-ui/core": ">=0.0.48"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@copilotkit/voice": {
@@ -1132,36 +725,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1260,12 +823,12 @@
       "license": "MIT"
     },
     "node_modules/@graphql-tools/executor": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.5.2.tgz",
-      "integrity": "sha512-V7QaW/59Dml7DK0MApMP/Z+qx2qkQ0inGJGi/n1JwBHRZehXTKDNKO7OFRA0h6V1w2afmcVso2GFwlDnPyusGA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.5.3.tgz",
+      "integrity": "sha512-mgBFC0bsrZPZLu9EnydpMnAuQ8Iiq0CEbUcsmvXsm2/iYektGHDN/+bmb7hicA6dWZtdPfklYJmr21WD0GnOfA==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^11.0.1",
+        "@graphql-tools/utils": "^11.1.0",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@repeaterjs/repeater": "^3.0.4",
         "@whatwg-node/disposablestack": "^0.0.6",
@@ -1280,9 +843,9 @@
       }
     },
     "node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.0.1.tgz",
-      "integrity": "sha512-pNyCOb95ab/z3zkkiPwIPYxigX7IcpyFVcgD1XACDEvg/7yGnKCESx3k/XHEeneKYx/aWKGzEh/uuf6M6Q8HOw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.1.0.tgz",
+      "integrity": "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -1298,12 +861,12 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "9.1.8",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.8.tgz",
-      "integrity": "sha512-25V7WDrODo1cPrmuUCrqf5qlMA4a/Ow4aHaqJ1MnTUaluwsV3UiqzCHWux3HSLb0H63mkoZiuOrU5xJhxRcoCg==",
+      "version": "9.1.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.9.tgz",
+      "integrity": "sha512-iHUWNjRHeQRYdgIMIuChThOwoKzA9vrzYeslgfBo5eUYEyHGZCoDPjAavssoYXLwstYt1dZj2J22jSzc2DrN0Q==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/utils": "^11.0.1",
+        "@graphql-tools/utils": "^11.1.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -1314,9 +877,9 @@
       }
     },
     "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.0.1.tgz",
-      "integrity": "sha512-pNyCOb95ab/z3zkkiPwIPYxigX7IcpyFVcgD1XACDEvg/7yGnKCESx3k/XHEeneKYx/aWKGzEh/uuf6M6Q8HOw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.1.0.tgz",
+      "integrity": "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -1332,13 +895,13 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "10.0.32",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.32.tgz",
-      "integrity": "sha512-kJ1Qn20MPnlaEVH37639E6rzQ1tEtr6XTUhNdR4EKydl+FijtLhWX2WLZbGnvrYuG8XUcMxsZU9mRRYYNvK02w==",
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.33.tgz",
+      "integrity": "sha512-O6P3RIftO0jafnSsFAqpjurUuUxJ43s/AdPVLQsBkI6y4Ic/tKm4C1Qm1KKQsCDTOxXPJClh/v3g7k7yLKCFBQ==",
       "license": "MIT",
       "dependencies": {
-        "@graphql-tools/merge": "^9.1.8",
-        "@graphql-tools/utils": "^11.0.1",
+        "@graphql-tools/merge": "^9.1.9",
+        "@graphql-tools/utils": "^11.1.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -1349,9 +912,9 @@
       }
     },
     "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.0.1.tgz",
-      "integrity": "sha512-pNyCOb95ab/z3zkkiPwIPYxigX7IcpyFVcgD1XACDEvg/7yGnKCESx3k/XHEeneKYx/aWKGzEh/uuf6M6Q8HOw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.1.0.tgz",
+      "integrity": "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -1499,14 +1062,14 @@
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
-      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
       "license": "MIT",
       "dependencies": {
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
-        "mlly": "^1.8.0"
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@img/colour": {
@@ -1602,9 +1165,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1620,9 +1180,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1640,9 +1197,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1658,9 +1212,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1678,9 +1229,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1696,9 +1244,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1716,9 +1261,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1735,9 +1277,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1753,9 +1292,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1779,9 +1315,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1803,9 +1336,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1829,9 +1359,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1853,9 +1380,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1879,9 +1403,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1904,9 +1425,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1928,9 +1446,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2024,10 +1539,60 @@
       }
     },
     "node_modules/@jetbrains/websandbox": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jetbrains/websandbox/-/websandbox-1.1.3.tgz",
-      "integrity": "sha512-My7EHJvN4DNBqefZivTHiivz7auiAl49QixQeYQT48dItkBvMr/WwcQPzUb3RP9CXEZXnMPKOatPlZ/MOjI34g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jetbrains/websandbox/-/websandbox-1.2.1.tgz",
+      "integrity": "sha512-FXg2JZ4O4DPf3Tj3MGwnQuJ8jEzddqEZszBEVD4SFPkq44FrbLomS7BLY3Q3eKV312oQRJU9api1YvX3uhNelw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@json-render/core": {
       "version": "0.18.0",
@@ -2042,9 +1607,9 @@
       }
     },
     "node_modules/@json-render/core/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -2062,14 +1627,52 @@
         "react": "^19.2.3"
       }
     },
-    "node_modules/@langchain/langgraph": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.8.tgz",
-      "integrity": "sha512-kKkRpC5xFz1e6vPivE7lwRJa5oahLAMaVQvVGZdTa6uJIchIYJDIuM1n93FqGvg8aYVcgYU4FENtKKC5Eh1JYw==",
+    "node_modules/@langchain/core": {
+      "version": "0.3.80",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
+      "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.1",
-        "@langchain/langgraph-sdk": "~1.8.8",
+        "@cfworker/json-schema": "^4.0.2",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": "^0.3.67",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^10.0.0",
+        "zod": "^3.25.32",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.0.tgz",
+      "integrity": "sha512-QvhTjiyqFPz81A+y6LHs223w6DTjv5+882DT4mup72bd72rRhNjTYo5fhes5um0swnKArvY/arc7KeFInfHHWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.0.2",
+        "@langchain/langgraph-sdk": "~1.9.0",
+        "@langchain/protocol": "^0.0.15",
         "@standard-schema/spec": "1.1.0",
         "uuid": "^10.0.0"
       },
@@ -2077,7 +1680,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.16",
+        "@langchain/core": "^1.1.44",
         "zod": "^3.25.32 || ^4.2.0",
         "zod-to-json-schema": "^3.x"
       },
@@ -2088,9 +1691,9 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
-      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
+      "integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
       "license": "MIT",
       "dependencies": {
         "uuid": "^10.0.0"
@@ -2099,7 +1702,21 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.0.1"
+        "@langchain/core": "^1.1.44"
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
@@ -2134,6 +1751,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -2143,28 +1761,44 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.8.tgz",
-      "integrity": "sha512-4OoqFAvPloOTZ6oPxXbJngz4FLJO8QSXb+BQV3qvNTvmfu1LQA7cCEqSNLYX9MoC340PbnDkHNgUtjajwkDHRg==",
+    "node_modules/@langchain/langgraph/node_modules/@langchain/core": {
+      "version": "1.1.46",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.46.tgz",
+      "integrity": "sha512-i8rDC83BpItxChCw4Lf+6tAr+k+OUcbirc5ZkrhI9ywYWmvxegUljLGOGYvtJNTbEAIFkhYIODPE5QRqyjF6sA==",
       "license": "MIT",
       "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.2.tgz",
+      "integrity": "sha512-1kDPjR0VH/39q2h8k0Sxi35KxOvEQPModVCepxGLlRkbZmuWUH+zfICuJd3rmD1ByeOKQBZEaB7Y+VCYmSMt1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/core": "^1.1.44",
+        "@langchain/protocol": "^0.0.15",
         "@types/json-schema": "^7.0.15",
         "p-queue": "^9.0.1",
         "p-retry": "^7.1.1",
         "uuid": "^13.0.0"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.16",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "svelte": "^4.0.0 || ^5.0.0",
         "vue": "^3.0.0"
       },
       "peerDependenciesMeta": {
-        "@langchain/core": {
-          "optional": true
-        },
         "react": {
           "optional": true
         },
@@ -2179,10 +1813,26 @@
         }
       }
     },
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
+      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -2198,20 +1848,37 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
-    "node_modules/@langchain/langgraph/node_modules/p-queue": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
-      "integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+    "node_modules/@langchain/langgraph/node_modules/langsmith": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.3.tgz",
+      "integrity": "sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^7.0.0"
+        "p-queue": "6.6.2"
       },
-      "engines": {
-        "node": ">=20"
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@langchain/langgraph/node_modules/p-retry": {
@@ -2240,6 +1907,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@langchain/langgraph/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/protocol": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
+      "integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+      "license": "MIT"
     },
     "node_modules/@lit-labs/react": {
       "version": "2.1.3",
@@ -2296,12 +1983,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
-      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
       "license": "MIT",
       "dependencies": {
-        "langium": "^4.0.0"
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -2630,15 +2317,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
-      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
-      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -2652,9 +2339,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
-      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -2668,14 +2355,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
-      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2687,14 +2371,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
-      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2706,14 +2387,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
-      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2725,14 +2403,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
-      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2744,9 +2419,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
-      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -2760,9 +2435,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
-      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -2791,13 +2466,25 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "resolved": "../../../node_modules/.pnpm/@playwright+test@1.57.0/node_modules/@playwright/test",
-      "link": true
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@preact/signals-core": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
-      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.2.tgz",
+      "integrity": "sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3521,9 +3208,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/node-fetch-server": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/node-fetch-server/-/node-fetch-server-0.13.0.tgz",
-      "integrity": "sha512-1EsNo0ZpgXu/90AWoRZf/oE3RVTUS80tiTUpt+hv5pjtAkw7icN4WskDwz/KdAw5ARbJLMhZBrO1NqThmy/McA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/node-fetch-server/-/node-fetch-server-0.13.1.tgz",
+      "integrity": "sha512-dOL+A/C84EA47gO/ps52KGrVSiYy96512rwtbXmJfWKYFm1FbrbjA3jao1hcIfao+jwVNEaZ1kTMwFjiino+HQ==",
       "license": "MIT"
     },
     "node_modules/@repeaterjs/repeater": {
@@ -3687,17 +3374,284 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@tailwindcss/postcss": {
-      "resolved": "../../../node_modules/.pnpm/@tailwindcss+postcss@4.1.18/node_modules/@tailwindcss/postcss",
-      "link": true
-    },
-    "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.23",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
-      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.23"
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "postcss": "^8.5.10",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
       },
       "funding": {
         "type": "github",
@@ -3709,9 +3663,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.23",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
-      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3981,9 +3935,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -4038,8 +3992,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "resolved": "../../../node_modules/.pnpm/@types+node@22.19.11/node_modules/@types/node",
-      "link": true
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.13",
@@ -4058,8 +4017,14 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "resolved": "../../../node_modules/.pnpm/@types+react@19.2.7/node_modules/@types/react",
-      "link": true
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -4098,9 +4063,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
     },
     "node_modules/@upsetjs/venn.js": {
@@ -4124,9 +4089,9 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
@@ -4238,18 +4203,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4272,14 +4225,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.158",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.158.tgz",
-      "integrity": "sha512-gLTp1UXFtMqKUi3XHs33K7UFglbvojkxF/aq337TxnLGOhHIW9+GyP2jwW4hYX87f1es+wId3VQoPRRu9zEStQ==",
+      "version": "6.0.177",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.177.tgz",
+      "integrity": "sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.95",
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23",
+        "@ai-sdk/gateway": "3.0.112",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
@@ -4290,9 +4243,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4320,6 +4273,16 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -4407,9 +4370,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -4420,7 +4383,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -4526,9 +4489,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4626,34 +4589,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/chevrotain": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
-      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "12.0.0",
-        "@chevrotain/gast": "12.0.0",
-        "@chevrotain/regexp-to-ast": "12.0.0",
-        "@chevrotain/types": "12.0.0",
-        "@chevrotain/utils": "12.0.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/chevrotain-allstar": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
-      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "chevrotain": "^12.0.0"
-      }
-    },
     "node_modules/clarinet": {
       "version": "0.12.6",
       "resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.6.tgz",
@@ -4699,6 +4634,21 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -4771,14 +4721,55 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "resolved": "../../../node_modules/.pnpm/concurrently@9.2.1/node_modules/concurrently",
-      "link": true
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
     },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "license": "MIT"
+    "node_modules/concurrently/node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/console-table-printer": {
       "version": "2.15.0",
@@ -4884,9 +4875,9 @@
       "license": "MIT"
     },
     "node_modules/cytoscape": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
-      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -5524,8 +5515,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5569,9 +5560,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5615,6 +5606,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -5631,6 +5629,20 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
+      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -5688,6 +5700,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -5764,23 +5796,23 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -5799,7 +5831,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -5819,12 +5851,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5876,9 +5908,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -6006,6 +6038,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6061,10 +6108,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6157,10 +6214,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -6262,9 +6326,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7145,9 +7209,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7270,6 +7334,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -7292,9 +7366,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -7366,6 +7440,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
@@ -7377,9 +7461,9 @@
       }
     },
     "node_modules/is-network-error": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
-      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -7412,10 +7496,20 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -7524,63 +7618,30 @@
       }
     },
     "node_modules/langchain": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.3.1.tgz",
-      "integrity": "sha512-tJu8Ibf3NAuDW8pMT7VIBCc96m8TymjSMqRBpQawlG8zeTGPZK5TKA5gBYRNZvrz0YkJA57O2rcjP+mIxrS0+g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.4.0.tgz",
+      "integrity": "sha512-p3H5U1vfO0T4ri/xxqI6jccRP3LYmOW6KGxaJcwI5mIGVR/G6eNhZyjSZB9d7me6J7an4Pc6zA8tH8Qa6/7xwA==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph": "^1.2.8",
+        "@langchain/langgraph": "^1.3.0",
         "@langchain/langgraph-checkpoint": "^1.0.1",
         "langsmith": ">=0.5.0 <1.0.0",
-        "uuid": "^11.1.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.39"
+        "@langchain/core": "^1.1.44"
       }
     },
-    "node_modules/langchain/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/langium": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
-      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
+    "node_modules/langchain/node_modules/langsmith": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.3.tgz",
+      "integrity": "sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/regexp-to-ast": "~12.0.0",
-        "chevrotain": "~12.0.0",
-        "chevrotain-allstar": "~0.4.1",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.1.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/langsmith": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.18.tgz",
-      "integrity": "sha512-3zuZUWffTHQ+73EAwnodADtf534VNEZUpXr9jC12qyG8/IQuJET7PRsCpTb9wX2lmBspakwLUpqpj3tNm/0bVA==",
-      "license": "MIT",
-      "dependencies": {
-        "p-queue": "6.6.2",
-        "uuid": "10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
@@ -7607,6 +7668,54 @@
         }
       }
     },
+    "node_modules/langsmith": {
+      "version": "0.3.87",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
+      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "chalk": "^4.1.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/layout-base": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
@@ -7614,10 +7723,271 @@
       "license": "MIT"
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.12.41",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
-      "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.1.tgz",
+      "integrity": "sha512-GEw0GLL7YUUA6nv21IsCvVjtI5Ejn84sjbdfQ9KxdbqEVOk1PZh7xejn01EEiniKw+dBeCfim+8MGeuvVuE2BA==",
       "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/lit": {
       "version": "3.3.2",
@@ -7710,6 +8080,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-table": {
@@ -13107,14 +13487,14 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
-      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.0",
+        "@mermaid-js/parser": "^1.1.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
         "cytoscape": "^3.33.1",
@@ -13125,14 +13505,14 @@
         "dagre-d3-es": "7.0.14",
         "dayjs": "^1.11.19",
         "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
         "katex": "^0.16.25",
         "khroma": "^2.1.0",
-        "lodash-es": "^4.17.23",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/mermaid/node_modules/marked": {
@@ -13145,19 +13525,6 @@
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/mermaid/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/methods": {
@@ -13238,6 +13605,148 @@
         "uvu": "^0.5.0"
       }
     },
+    "node_modules/micromark-extension-cjk-friendly": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-1.2.3.tgz",
+      "integrity": "sha512-gRzVLUdjXBLX6zNPSnHGDoo+ZTp5zy+MZm0g3sv+3chPXY7l9gW+DnrcHcZh/jiPR6MjPKO4AEJNp4Aw6V9z5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "micromark-extension-cjk-friendly-util": "2.1.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-gfm-strikethrough": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-gfm-strikethrough/-/micromark-extension-cjk-friendly-gfm-strikethrough-1.2.3.tgz",
+      "integrity": "sha512-gSPnxgHDDqXYOBvQRq6lerrq9mjDhdtKn+7XETuXjxWcL62yZEfUdA28Ml1I2vDIPfAOIKLa0h2XDSGkInGHFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "get-east-asian-width": "^1.3.0",
+        "micromark-extension-cjk-friendly-util": "2.1.1",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-gfm-strikethrough/node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-gfm-strikethrough/node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-gfm-strikethrough/node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-gfm-strikethrough/node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-extension-cjk-friendly-gfm-strikethrough/node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/micromark-extension-cjk-friendly-util": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-util/-/micromark-extension-cjk-friendly-util-2.1.1.tgz",
@@ -13294,6 +13803,76 @@
       "license": "MIT"
     },
     "node_modules/micromark-extension-cjk-friendly-util/node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-extension-cjk-friendly/node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly/node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly/node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-extension-cjk-friendly/node_modules/micromark-util-types": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
@@ -14736,18 +15315,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mlly": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
-      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.3"
-      }
-    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -14773,9 +15340,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -14800,12 +15367,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
-      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.15",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -14818,14 +15385,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.15",
-        "@next/swc-darwin-x64": "15.5.15",
-        "@next/swc-linux-arm64-gnu": "15.5.15",
-        "@next/swc-linux-arm64-musl": "15.5.15",
-        "@next/swc-linux-x64-gnu": "15.5.15",
-        "@next/swc-linux-x64-musl": "15.5.15",
-        "@next/swc-win32-arm64-msvc": "15.5.15",
-        "@next/swc-win32-x64-msvc": "15.5.15",
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -14971,18 +15538,18 @@
       }
     },
     "node_modules/oniguruma-parser": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
-      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
-      "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
       "license": "MIT",
       "dependencies": {
-        "oniguruma-parser": "^0.12.1",
+        "oniguruma-parser": "^0.12.2",
         "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
       }
@@ -15131,16 +15698,10 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
-    "node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "license": "MIT"
-    },
     "node_modules/phoenix": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.8.5.tgz",
-      "integrity": "sha512-Oj5nlRV/NKXkjBx8uMgCMmgMf1twd/B2qOcO30cHLH1PCGR8149o4T1lRIaqN4nq2KQJAeMqPiLdh1Asd0wQFg==",
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.8.7.tgz",
+      "integrity": "sha512-mQfiO4PNEjToj5iUfka6OjRWtCNe+0JsVrW6x+q94kPN8VX8taulJPTa4/u2ZPb2b8+hzmBAvMxQWnuTc0T4KQ==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -15220,15 +15781,36 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "license": "MIT",
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/points-on-curve": {
@@ -15248,8 +15830,33 @@
       }
     },
     "node_modules/postcss": {
-      "resolved": "../../../node_modules/.pnpm/postcss@8.5.6/node_modules/postcss",
-      "link": true
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -15327,9 +15934,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -15388,12 +15995,25 @@
       }
     },
     "node_modules/react": {
-      "resolved": "../../../node_modules/.pnpm/react@19.2.3/node_modules/react",
-      "link": true
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-dom": {
-      "resolved": "../../../node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom",
-      "link": true
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
     },
     "node_modules/react-is": {
       "version": "18.3.1",
@@ -15762,6 +16382,48 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/remark-cjk-friendly": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/remark-cjk-friendly/-/remark-cjk-friendly-1.2.3.tgz",
+      "integrity": "sha512-UvAgxwlNk+l9Oqgl/9MWK2eWRS7zgBW/nXX9AthV7nd/3lNejF138E7Xbmk9Zs4WjTJGs721r7fAEc7tNFoH7g==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-cjk-friendly": "1.2.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/remark-cjk-friendly-gfm-strikethrough": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/remark-cjk-friendly-gfm-strikethrough/-/remark-cjk-friendly-gfm-strikethrough-1.2.3.tgz",
+      "integrity": "sha512-bXfMZtsaomK6ysNN/UGRIcasQAYkC10NtPmP0oOHOV8YOhA2TXmwRXCku4qOzjIFxAPfish5+XS0eIug2PzNZA==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-cjk-friendly-gfm-strikethrough": "1.2.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
       }
     },
     "node_modules/remark-gfm": {
@@ -16525,6 +17187,16 @@
       "integrity": "sha512-152puVH0qMoRJQFnaMG+rVDdf01Jq/CaED+MBuXExurJgdbkLp0c3TIe4R12o28Klx8uyGsjvFNG05aFG69G9w==",
       "license": "Apache-2.0"
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -16672,6 +17344,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -16679,9 +17357,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -16805,6 +17483,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shiki": {
@@ -17177,58 +17868,6 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/streamdown/node_modules/micromark-extension-cjk-friendly": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-1.2.3.tgz",
-      "integrity": "sha512-gRzVLUdjXBLX6zNPSnHGDoo+ZTp5zy+MZm0g3sv+3chPXY7l9gW+DnrcHcZh/jiPR6MjPKO4AEJNp4Aw6V9z5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.1.0",
-        "micromark-extension-cjk-friendly-util": "2.1.1",
-        "micromark-util-chunked": "^2.0.1",
-        "micromark-util-resolve-all": "^2.0.1",
-        "micromark-util-symbol": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "micromark": "^4.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "micromark-util-types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/streamdown/node_modules/micromark-extension-cjk-friendly-gfm-strikethrough": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-gfm-strikethrough/-/micromark-extension-cjk-friendly-gfm-strikethrough-1.2.3.tgz",
-      "integrity": "sha512-gSPnxgHDDqXYOBvQRq6lerrq9mjDhdtKn+7XETuXjxWcL62yZEfUdA28Ml1I2vDIPfAOIKLa0h2XDSGkInGHFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.1.0",
-        "get-east-asian-width": "^1.3.0",
-        "micromark-extension-cjk-friendly-util": "2.1.1",
-        "micromark-util-character": "^2.1.1",
-        "micromark-util-chunked": "^2.0.1",
-        "micromark-util-resolve-all": "^2.0.1",
-        "micromark-util-symbol": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "micromark": "^4.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "micromark-util-types": {
-          "optional": true
-        }
       }
     },
     "node_modules/streamdown/node_modules/micromark-factory-destination": {
@@ -17610,48 +18249,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/streamdown/node_modules/remark-cjk-friendly": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/remark-cjk-friendly/-/remark-cjk-friendly-1.2.3.tgz",
-      "integrity": "sha512-UvAgxwlNk+l9Oqgl/9MWK2eWRS7zgBW/nXX9AthV7nd/3lNejF138E7Xbmk9Zs4WjTJGs721r7fAEc7tNFoH7g==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-extension-cjk-friendly": "1.2.3"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@types/mdast": "^4.0.0",
-        "unified": "^11.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/mdast": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/streamdown/node_modules/remark-cjk-friendly-gfm-strikethrough": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/remark-cjk-friendly-gfm-strikethrough/-/remark-cjk-friendly-gfm-strikethrough-1.2.3.tgz",
-      "integrity": "sha512-bXfMZtsaomK6ysNN/UGRIcasQAYkC10NtPmP0oOHOV8YOhA2TXmwRXCku4qOzjIFxAPfish5+XS0eIug2PzNZA==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-extension-cjk-friendly-gfm-strikethrough": "1.2.3"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@types/mdast": "^4.0.0",
-        "unified": "^11.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/mdast": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/streamdown/node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -17768,6 +18365,21 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -17780,6 +18392,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -17851,9 +18476,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -17869,9 +18494,9 @@
       }
     },
     "node_modules/tailwind-merge": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
-      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -17879,8 +18504,25 @@
       }
     },
     "node_modules/tailwindcss": {
-      "resolved": "../../../node_modules/.pnpm/tailwindcss@4.1.18/node_modules/tailwindcss",
-      "link": true
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/thread-stream": {
       "version": "3.1.0",
@@ -17898,9 +18540,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -17920,6 +18562,16 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -18016,19 +18668,23 @@
       }
     },
     "node_modules/typescript": {
-      "resolved": "../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript",
-      "link": true
-    },
-    "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "license": "MIT"
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -18301,9 +18957,9 @@
       }
     },
     "node_modules/use-stick-to-bottom": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-stick-to-bottom/-/use-stick-to-bottom-1.1.3.tgz",
-      "integrity": "sha512-GgRLdeGhxBxpcbrBbEIEoOKUQ9d46/eaSII+wyv1r9Du+NbCn1W/OE+VddefvRP4+5w/1kATN/6g2/BAC/yowQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/use-stick-to-bottom/-/use-stick-to-bottom-1.1.4.tgz",
+      "integrity": "sha512-2w/lydkrwhWMv1vCaEhYbzMDhgbwIodHpAHPV0/xKJErRkbjDEUe1EWmvr6Fwb+qhiERjc1EWgAEZaSaF69CpA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -18319,16 +18975,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/uvu": {
@@ -18486,55 +19142,6 @@
         "d3-timer": "^3.0.1"
       }
     },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
-      }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-      "license": "MIT"
-    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -18591,6 +19198,40 @@
       "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
       "license": "MIT"
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -18618,9 +19259,53 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/zod": {
-      "resolved": "../../../node_modules/.pnpm/zod@3.25.76/node_modules/zod",
-      "link": true
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",

--- a/showcase/integrations/ms-agent-python/package.json
+++ b/showcase/integrations/ms-agent-python/package.json
@@ -10,7 +10,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@ag-ui/client": "^0.0.43",
+    "@ag-ui/client": "^0.0.52",
     "@copilotkit/a2ui-renderer": "next",
     "@copilotkit/react-core": "next",
     "@copilotkit/runtime": "next",

--- a/showcase/integrations/ms-agent-python/requirements.txt
+++ b/showcase/integrations/ms-agent-python/requirements.txt
@@ -7,4 +7,3 @@ python-dotenv==1.0.1
 uvicorn==0.37.0
 fastapi>=0.115.0
 starlette<1.0.0
-pypdf>=4.0.0,<7.0.0

--- a/showcase/integrations/ms-agent-python/src/agent_server.py
+++ b/showcase/integrations/ms-agent-python/src/agent_server.py
@@ -11,7 +11,7 @@ import os
 
 import uvicorn
 from agent_framework import BaseChatClient
-from agent_framework.openai import OpenAIChatClient
+from agent_framework.openai import OpenAIChatClient, OpenAIChatCompletionClient
 from agent_framework_ag_ui import add_agent_framework_fastapi_endpoint
 from dotenv import load_dotenv
 from fastapi import FastAPI
@@ -51,7 +51,7 @@ def _build_chat_client(model_override: str | None = None) -> BaseChatClient:
     try:
         if bool(os.getenv("OPENAI_API_KEY")):
             return OpenAIChatClient(
-                model=model_override or os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-4o-mini"),
+                model=model_override or os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-5.2"),
                 api_key=os.getenv("OPENAI_API_KEY"),
             )
 
@@ -67,11 +67,31 @@ chat_client = _build_chat_client()
 my_agent = create_agent(chat_client)
 voice_agent = create_voice_agent(chat_client)
 agent_config_agent = create_agent_config_agent(chat_client)
-reasoning_agent = create_reasoning_agent(chat_client)
+
+# Reasoning: dedicated client carrying `reasoning={"effort","summary"}` so
+# the Responses API streams real REASONING_MESSAGE_* events. Scoped here
+# (not the shared `chat_client`) so other demos don't pay reasoning-token
+# latency on every turn.
+reasoning_chat_client = _build_chat_client(
+    os.getenv("OPENAI_REASONING_MODEL_ID", "gpt-5.2")
+)
+reasoning_agent = create_reasoning_agent(reasoning_chat_client)
 tool_rendering_reasoning_chain_agent = create_tool_rendering_reasoning_chain_agent(
     chat_client
 )
-a2ui_dynamic_agent = create_a2ui_dynamic_agent(chat_client)
+# A2UI dynamic: dedicated chat.completions client. The OUTER agent calls
+# `generate_a2ui` and produces a short summary -- gpt-5.x via the
+# Responses API silently drops function-call replay items between turns
+# (reasoning items have to be reproduced in the exact original order, and
+# MAF cannot recover them on a subsequent run), so the second turn 400s
+# with "No tool output found for function call ...". The chat.completions
+# API has no such constraint -- assistant + tool messages replay cleanly.
+# Same model (gpt-5.2), no reasoning surface needed for this agent.
+a2ui_dynamic_chat_client = OpenAIChatCompletionClient(
+    model=os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-5.2"),
+    api_key=os.getenv("OPENAI_API_KEY"),
+)
+a2ui_dynamic_agent = create_a2ui_dynamic_agent(a2ui_dynamic_chat_client)
 a2ui_fixed_agent = create_a2ui_fixed_agent(chat_client)
 open_gen_ui_agent = create_open_gen_ui_agent(chat_client)
 open_gen_ui_advanced_agent = create_open_gen_ui_advanced_agent(chat_client)
@@ -85,9 +105,10 @@ interrupt_agent = create_interrupt_agent(chat_client)
 shared_state_read_write_agent = create_shared_state_read_write_agent(chat_client)
 subagents_agent = create_subagents_agent(chat_client)
 
-# Multimodal: vision-capable; gpt-4o-mini natively handles `image` parts.
-# Scoped to its own endpoint so other demos don't silently upgrade to vision.
-multimodal_chat_client = _build_chat_client("gpt-4o-mini")
+# Multimodal: vision-capable; gpt-5.2 natively handles `image` AND `document`
+# (PDF) parts via the Responses API. Kept on its own client so the demo can
+# pin a specific vision model independently of the shared chat client.
+multimodal_chat_client = _build_chat_client()
 multimodal_agent = create_multimodal_agent(multimodal_chat_client)
 
 # Beautiful Chat: flagship polished sales dashboard demo. Combines A2UI

--- a/showcase/integrations/ms-agent-python/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/ms-agent-python/src/agents/a2ui_dynamic.py
@@ -2,21 +2,54 @@
 MS Agent Framework agent for the Declarative Generative UI (A2UI — Dynamic Schema) demo.
 
 Pattern (ported from the LangGraph reference
-`showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py`):
+``showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py``):
 
-- The agent binds an explicit `generate_a2ui` tool. When called, it invokes a
-  secondary LLM bound to `render_a2ui` (tool_choice forced) and returns the
-  resulting `a2ui_operations` container.
-- The runtime (see `src/app/api/copilotkit-declarative-gen-ui/route.ts`) uses
-  `injectA2UITool: false` because the tool binding is owned by the agent here
-  (double-injection would duplicate the tool slot).
+- The agent binds an explicit ``generate_a2ui`` tool. When called, it invokes
+  a secondary LLM with ``tool_choice`` forced to ``render_a2ui`` and returns
+  the resulting ``a2ui_operations`` container.
+- The runtime (see ``src/app/api/copilotkit-declarative-gen-ui/route.ts``)
+  uses ``injectA2UITool: false`` because the tool binding is owned by the
+  agent here (double-injection would duplicate the tool slot).
+
+Threading the registered catalog schema into the secondary call
+---------------------------------------------------------------
+The CopilotKit A2UI middleware serialises the frontend-registered catalog
+(component names + Zod prop schemas, brought in via
+``<CopilotKit a2ui={{ catalog: myCatalog }}>``) into the AG-UI request's
+``context[]`` field, with ``description`` starting with
+"A2UI Component Schema" -- see
+``node_modules/@ag-ui/a2ui-middleware/dist/index.mjs`` (``A2UI_SCHEMA_CONTEXT_DESCRIPTION``).
+
+We capture that entry at request time in ``_A2UIDynamicAgent.run()`` and
+stash it on a shared dict the ``generate_a2ui`` tool reads. Without it,
+gpt-5.x guesses prop names (e.g. emits ``children: [...]`` on ``Card``
+when the catalog defined ``child: string``, or ``status``/``delta`` on
+``StatusBadge``/``Metric`` instead of ``variant``/``trend``), which the
+A2UI renderer accepts as valid components but renders as blank slots —
+producing the "Here's a quick KPI dashboard" + blank-canvas symptom.
+
+Why the secondary call uses ``chat_client.client`` directly
+-----------------------------------------------------------
+``BaseChatClient.get_response`` runs a full function-invocation auto-loop
+when tools are passed (see ``agent_framework/_tools.py:2380``). That loop
+auto-EXECUTES the forced tool, feeds the result back to the model, and
+iterates -- which is exactly what we don't want for a one-shot structured
+output. ``response_format=PydanticModel`` is also unsuitable: A2UI
+components are arbitrary dicts and OpenAI's strict JSON schema mode
+rejects ``additionalProperties`` defaults.
+
+So we drop one layer and call the underlying ``AsyncOpenAI`` client
+directly -- but pull the configured model and api_key off the parent
+``chat_client``, so the secondary call inherits the same model, base URL,
+api_key, and any custom OpenAI configuration. This is what LangGraph
+effectively does via ``model.bind_tools(...).invoke(...)``.
 """
 
 from __future__ import annotations
 
 import json
 from textwrap import dedent
-from typing import Annotated
+from typing import Annotated, Any
 
 from agent_framework import Agent, BaseChatClient, tool
 from agent_framework_ag_ui import AgentFrameworkAgent
@@ -27,101 +60,315 @@ from tools import build_a2ui_operations_from_tool_call
 CUSTOM_CATALOG_ID = "declarative-gen-ui-catalog"
 
 
-@tool(
-    name="generate_a2ui",
-    description=(
-        "Generate dynamic A2UI components based on the conversation. "
-        "A secondary LLM designs the UI schema and data."
-    ),
-)
-def generate_a2ui(
-    context: Annotated[
-        str,
-        Field(description="Conversation context to generate UI from."),
-    ],
-) -> str:
-    """Generate dynamic A2UI dashboard from conversation context."""
-    from openai import OpenAI
+# Description prefix used by ``@ag-ui/a2ui-middleware`` when it injects the
+# catalog schema context entry. Stable across catalog edits (it's the
+# *description*, not the value). See the middleware bundle's
+# ``A2UI_SCHEMA_CONTEXT_DESCRIPTION``.
+_A2UI_SCHEMA_DESCRIPTION_PREFIX = "A2UI Component Schema"
 
-    client = OpenAI()
-    tool_schema = {
-        "type": "function",
-        "function": {
-            "name": "render_a2ui",
-            "description": "Render a dynamic A2UI v0.9 surface.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "surfaceId": {"type": "string"},
-                    "catalogId": {"type": "string"},
-                    "components": {"type": "array", "items": {"type": "object"}},
-                    "data": {"type": "object"},
+
+_GENERATE_A2UI_PROMPT_HEADER = f"""\
+You are designing a dynamic A2UI v0.9 surface. Call the `render_a2ui` tool
+with a flat component array.
+
+Hard requirements (failing any of these breaks the renderer -- be strict):
+- `catalogId` MUST be exactly: "{CUSTOM_CATALOG_ID}"
+- `surfaceId` is a short kebab-case identifier (e.g. "kpi-dashboard").
+- `components` is a FLAT (non-empty) array. Every entry MUST include both an
+  `id` (unique string) AND a `component` (string -- the catalog component
+  name). The root entry MUST have `id: "root"` AND a valid `component`
+  field -- never emit a root entry without a component type.
+- Container components reference children by id via their `children` (array
+  of strings) or `child` (single string) prop. Do NOT inline children
+  objects. Define each child as its own entry in the flat array and
+  reference its id.
+
+CRITICAL -- all properties go at the ENTRY LEVEL
+================================================
+A2UI v0.9 entries are FLAT objects. EVERY property the component takes
+(both basic primitives like Column/Row/Text AND custom catalog components
+like Card/Metric/StatusBadge/PieChart/BarChart) goes as a SIBLING of
+`id` and `component`. NEVER wrap props in a nested `"props": {{...}}`
+object. The renderer reads each declared schema field directly off the
+entry; a nested `props` wrapper makes them invisible to the binder.
+
+Right:
+  {{"id":"root","component":"Column","children":["a","b"],"justify":"start"}}
+  {{"id":"banner","component":"Text","text":"KPI Dashboard","variant":"h2"}}
+  {{"id":"m1","component":"Metric","label":"Revenue","value":"$1.2M","trend":"up"}}
+  {{"id":"b1","component":"StatusBadge","text":"On track","variant":"success"}}
+  {{"id":"c1","component":"Card","title":"Revenue","subtitle":"$1.2M","child":"m1"}}
+
+Wrong (DO NOT DO THIS):
+  {{"id":"m1","component":"Metric","props":{{"label":"Revenue", ...}}}}
+
+Use ONLY the prop names declared in the catalog schema below for each
+component. Do NOT invent prop names (no `status` if the schema declares
+`variant`; no `delta` if it declares `trend`).
+"""
+
+
+_RENDER_A2UI_TOOL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "render_a2ui",
+        "description": (
+            "Render a dynamic A2UI v0.9 surface. The `components` array "
+            "MUST be non-empty: emit at least a root component plus its "
+            "children. Empty `components` is invalid and breaks the renderer."
+        ),
+        # ``strict: false`` because A2UI components are arbitrary dicts;
+        # strict mode would require ``additionalProperties: false`` on every
+        # nested object which defeats the purpose of dynamic UI. Without this
+        # flag gpt-5.x defaults to strict and rejects ``items: {type: object}``
+        # as under-specified, returning an empty ``components: []`` array.
+        "strict": False,
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "surfaceId": {
+                    "type": "string",
+                    "description": "Short kebab-case surface identifier.",
                 },
-                "required": ["surfaceId", "catalogId", "components"],
+                "catalogId": {
+                    "type": "string",
+                    "description": "Catalog id (use the demo's CUSTOM_CATALOG_ID).",
+                },
+                "components": {
+                    "type": "array",
+                    "minItems": 1,
+                    "description": (
+                        "FLAT (non-empty) array of A2UI components. Each entry "
+                        "MUST have both an `id` and a `component` field. The "
+                        "root entry MUST have id='root'."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string"},
+                            "component": {"type": "string"},
+                            "props": {"type": "object"},
+                            "children": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "child": {"type": "string"},
+                        },
+                        "required": ["id", "component"],
+                    },
+                },
+                "data": {"type": "object"},
             },
+            "required": ["surfaceId", "catalogId", "components"],
         },
-    }
-
-    response = client.chat.completions.create(
-        model="gpt-4.1",
-        messages=[
-            {
-                "role": "system",
-                "content": (
-                    context
-                    or f"Generate a useful dashboard UI. Use catalogId='{CUSTOM_CATALOG_ID}'."
-                ),
-            },
-            {
-                "role": "user",
-                "content": "Generate a dynamic A2UI dashboard based on the conversation.",
-            },
-        ],
-        tools=[tool_schema],
-        tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
-    )
-
-    if not response.choices[0].message.tool_calls:
-        return json.dumps({"error": "LLM did not call render_a2ui"})
-
-    tool_call = response.choices[0].message.tool_calls[0]
-    args = json.loads(tool_call.function.arguments)
-    # Default the catalog to the dynamic-gen-ui catalog if the LLM omitted it.
-    args.setdefault("catalogId", CUSTOM_CATALOG_ID)
-    result = build_a2ui_operations_from_tool_call(args)
-    return json.dumps(result)
+    },
+}
 
 
 SYSTEM_PROMPT = dedent(
     """
     You are a demo assistant for Declarative Generative UI (A2UI — Dynamic
-    Schema). Whenever a response would benefit from a rich visual — a
-    dashboard, status report, KPI summary, card layout, info grid, a
-    pie/donut chart of part-of-whole breakdowns, a bar chart comparing
-    values across categories, or anything more structured than plain text —
-    call `generate_a2ui` to draw it. The registered catalog includes
-    `Card`, `StatusBadge`, `Metric`, `InfoRow`, `PrimaryButton`, `PieChart`,
-    and `BarChart` (in addition to the basic A2UI primitives). Prefer
-    `PieChart` for part-of-whole breakdowns (sales by region, traffic
-    sources, portfolio allocation) and `BarChart` for comparisons across
-    categories (quarterly revenue, headcount by team, signups per month).
-    `generate_a2ui` takes a `context` string summarising the user's request
-    and handles the rendering automatically. Keep chat replies to one short
-    sentence; let the UI do the talking.
+    Schema). Your PRIMARY behavior is to render rich UI surfaces via the
+    `generate_a2ui` tool.
+
+    Rules (strict — do not deviate):
+      1. For ANY request that mentions a dashboard, chart, KPIs, metrics,
+         status report, table, card layout, sales/revenue/signups/churn/
+         pie/bar/breakdown — you MUST call `generate_a2ui` before
+         responding with text. Do not describe the dashboard; RENDER it.
+      2. After the tool returns, send a single short sentence
+         (1 sentence max) acknowledging what was rendered.
+      3. Only respond with text alone when the user is asking a plain
+         conversational question with no UI implication.
+
+    `generate_a2ui` takes a `context` string summarising the user's
+    request and the data they want shown; it handles the rendering
+    automatically.
     """
 ).strip()
 
 
+def _reorder_tool_messages(messages: list[Any]) -> list[Any]:
+    """Move ``role=tool`` messages to immediately follow the
+    ``role=assistant`` message whose ``toolCalls`` contains a matching
+    ``id``. CopilotKit's frontend message store occasionally emits the
+    history in the order ``[user, tool, assistant(toolCalls), assistant
+    text, user]``, which violates OpenAI's "assistant with `tool_calls`
+    MUST be followed by tool messages" rule and 400s on the next turn.
+
+    Idempotent and a no-op when messages are already in the canonical
+    order.
+    """
+    if not isinstance(messages, list) or not messages:
+        return messages
+
+    # Build a map: tool_call_id -> tool message
+    tool_by_call_id: dict[str, Any] = {}
+    for m in messages:
+        if not isinstance(m, dict) or m.get("role") != "tool":
+            continue
+        tcid = m.get("toolCallId")
+        if isinstance(tcid, str):
+            tool_by_call_id[tcid] = m
+
+    if not tool_by_call_id:
+        return messages
+
+    # Walk messages, drop tool messages from their original slots, and
+    # re-attach them after their matching assistant tool_calls message.
+    result: list[Any] = []
+    consumed_tool_ids: set[str] = set()
+    for m in messages:
+        if isinstance(m, dict) and m.get("role") == "tool":
+            tcid = m.get("toolCallId")
+            if isinstance(tcid, str) and tcid in tool_by_call_id:
+                # Skip here; we'll insert it after its assistant.
+                continue
+        result.append(m)
+        if (
+            isinstance(m, dict)
+            and m.get("role") == "assistant"
+            and m.get("toolCalls")
+        ):
+            for tc in m.get("toolCalls") or []:
+                tc_id = tc.get("id") if isinstance(tc, dict) else None
+                if (
+                    isinstance(tc_id, str)
+                    and tc_id in tool_by_call_id
+                    and tc_id not in consumed_tool_ids
+                ):
+                    result.append(tool_by_call_id[tc_id])
+                    consumed_tool_ids.add(tc_id)
+
+    # Any tool messages whose matching assistant never appeared (stale or
+    # orphaned) get dropped -- they would 400 anyway, and the secondary
+    # call's prompt-driven flow doesn't depend on them.
+    return result
+
+
+def _extract_catalog_schema(input_data: dict[str, Any]) -> str | None:
+    """Pull the A2UI catalog schema JSON out of the AG-UI request context."""
+    context = input_data.get("context")
+    if not isinstance(context, list):
+        return None
+    for entry in context:
+        if not isinstance(entry, dict):
+            continue
+        description = entry.get("description")
+        if isinstance(description, str) and description.startswith(
+            _A2UI_SCHEMA_DESCRIPTION_PREFIX
+        ):
+            value = entry.get("value")
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def _make_generate_a2ui_tool(
+    chat_client: BaseChatClient, catalog_schema_holder: dict[str, str]
+):
+    """Build the ``generate_a2ui`` tool bound to ``chat_client``.
+
+    ``catalog_schema_holder`` is a single-key dict the agent's ``run()``
+    populates with the per-request A2UI catalog schema (under
+    ``"current"``). The tool reads it on each invocation so the secondary
+    LLM sees the exact catalog the frontend registered, not a stale or
+    hardcoded list.
+    """
+
+    @tool(
+        name="generate_a2ui",
+        description=(
+            "Generate dynamic A2UI components based on the conversation. "
+            "A secondary LLM designs the UI schema and data."
+        ),
+    )
+    async def generate_a2ui(
+        context: Annotated[
+            str,
+            Field(description="Conversation context to generate UI from."),
+        ],
+    ) -> str:
+        """Generate a dynamic A2UI dashboard from conversation context.
+
+        Must ALWAYS return a string -- even on internal error -- because
+        MAF's chat-completions function-invocation loop will otherwise
+        send a follow-up request with an orphan ``tool_calls`` assistant
+        message and OpenAI 400s with "An assistant message with
+        'tool_calls' must be followed by tool messages responding to
+        each 'tool_call_id'."
+        """
+        try:
+            user_request = (
+                context
+                or "Generate a useful dashboard UI from the conversation context."
+            )
+            system_parts = [_GENERATE_A2UI_PROMPT_HEADER]
+            catalog_schema = catalog_schema_holder.get("current")
+            if catalog_schema:
+                system_parts.append(
+                    "Registered catalog schema (component names + prop types -- "
+                    "use these EXACTLY):\n" + catalog_schema
+                )
+            response = await chat_client.client.chat.completions.create(
+                model=chat_client.model,
+                messages=[
+                    {"role": "system", "content": "\n\n".join(system_parts)},
+                    {"role": "user", "content": user_request},
+                ],
+                tools=[_RENDER_A2UI_TOOL_SCHEMA],
+                tool_choice={
+                    "type": "function",
+                    "function": {"name": "render_a2ui"},
+                },
+            )
+
+            tool_calls = response.choices[0].message.tool_calls or []
+            if not tool_calls:
+                return json.dumps({"error": "LLM did not call render_a2ui"})
+
+            args = json.loads(tool_calls[0].function.arguments)
+            # Pin the canonical catalog id -- the LLM has been observed
+            # hallucinating ids from sibling demos when context is sparse.
+            args["catalogId"] = CUSTOM_CATALOG_ID
+            return json.dumps(build_a2ui_operations_from_tool_call(args))
+        except Exception as exc:
+            import traceback
+
+            print(f"[a2ui_dynamic] generate_a2ui internal error: {exc!r}")
+            traceback.print_exc()
+            return json.dumps({"error": f"generate_a2ui failed: {exc!r}"})
+
+    return generate_a2ui
+
+
 def create_agent(chat_client: BaseChatClient) -> AgentFrameworkAgent:
     """Instantiate the MS-Agent-backed declarative-gen-ui agent."""
+    catalog_schema_holder: dict[str, str] = {}
+
     base_agent = Agent(
         client=chat_client,
         name="declarative_gen_ui_agent",
         instructions=SYSTEM_PROMPT,
-        tools=[generate_a2ui],
+        tools=[_make_generate_a2ui_tool(chat_client, catalog_schema_holder)],
     )
 
-    return AgentFrameworkAgent(
+    class _A2UIDynamicAgent(AgentFrameworkAgent):
+        """Capture the A2UI catalog schema from the AG-UI request context."""
+
+        async def run(self, input_data: dict[str, Any]):  # type: ignore[override]
+            schema = _extract_catalog_schema(input_data)
+            if schema:
+                catalog_schema_holder["current"] = schema
+            messages = input_data.get("messages")
+            if isinstance(messages, list):
+                reordered = _reorder_tool_messages(messages)
+                if reordered is not messages:
+                    input_data = {**input_data, "messages": reordered}
+            async for event in super().run(input_data):
+                yield event
+
+    return _A2UIDynamicAgent(
         agent=base_agent,
         name="CopilotKitMicrosoftAgentFrameworkAgent",
         description="Dynamic A2UI generator that designs rich UI surfaces on demand.",

--- a/showcase/integrations/ms-agent-python/src/agents/agent.py
+++ b/showcase/integrations/ms-agent-python/src/agents/agent.py
@@ -148,55 +148,101 @@ def search_flights(
     return json.dumps(result)
 
 
-@tool(
-    name="generate_a2ui",
-    description=(
-        "Generate dynamic A2UI components based on the conversation. "
-        "A secondary LLM designs the UI schema and data."
-    ),
-)
-def generate_a2ui(
-    context: Annotated[str, Field(description="Conversation context to generate UI from.")],
-) -> str:
-    """Generate dynamic A2UI dashboard from conversation context."""
-    from openai import OpenAI
-
-    client = OpenAI()
-    tool_schema = {
-        "type": "function",
-        "function": {
-            "name": "render_a2ui",
-            "description": "Render a dynamic A2UI v0.9 surface.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "surfaceId": {"type": "string"},
-                    "catalogId": {"type": "string"},
-                    "components": {"type": "array", "items": {"type": "object"}},
-                    "data": {"type": "object"},
+# Shared schema + secondary-call pattern. See ``a2ui_dynamic.py`` for the
+# detailed write-up of why we drop into ``chat_client.client`` directly
+# rather than going through ``BaseChatClient.get_response`` (the latter
+# triggers MAF's function-invocation auto-loop, which keeps re-executing
+# the forced tool and never returns the raw structured args).
+_RENDER_A2UI_TOOL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "render_a2ui",
+        "description": (
+            "Render a dynamic A2UI v0.9 surface. The `components` array "
+            "MUST be non-empty: emit at least a root component plus its "
+            "children."
+        ),
+        "strict": False,
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "surfaceId": {"type": "string"},
+                "catalogId": {"type": "string"},
+                "components": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string"},
+                            "component": {"type": "string"},
+                            "props": {"type": "object"},
+                            "children": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "child": {"type": "string"},
+                        },
+                        "required": ["id", "component"],
+                    },
                 },
-                "required": ["surfaceId", "catalogId", "components"],
+                "data": {"type": "object"},
             },
+            "required": ["surfaceId", "catalogId", "components"],
         },
-    }
+    },
+}
 
-    response = client.chat.completions.create(
-        model="gpt-4.1",
-        messages=[
-            {"role": "system", "content": context or "Generate a useful dashboard UI."},
-            {"role": "user", "content": "Generate a dynamic A2UI dashboard based on the conversation."},
-        ],
-        tools=[tool_schema],
-        tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
+
+_GENERATE_A2UI_PROMPT_HEADER = """\
+You are designing a dynamic A2UI v0.9 surface. Call the `render_a2ui` tool
+with a flat component array.
+
+Hard requirements (failing any of these breaks the renderer -- be strict):
+- `surfaceId` is a short kebab-case identifier (e.g. "kpi-dashboard").
+- `components` is a FLAT (non-empty) array. Every entry MUST include both
+  an `id` (unique string) AND a `component` (string -- the catalog
+  component name). The root entry MUST have `id: "root"` AND a valid
+  `component` field.
+- Container components (Row, Column, Card) reference children by id via
+  their `children` (array of strings) or `child` (single string) prop. Do
+  NOT inline children objects.
+"""
+
+
+def _make_generate_a2ui_tool(chat_client: BaseChatClient):
+    """Factory for ``generate_a2ui`` bound to the configured chat client."""
+
+    @tool(
+        name="generate_a2ui",
+        description=(
+            "Generate dynamic A2UI components based on the conversation. "
+            "A secondary LLM designs the UI schema and data."
+        ),
     )
+    async def generate_a2ui(
+        context: Annotated[str, Field(description="Conversation context to generate UI from.")],
+    ) -> str:
+        """Generate a dynamic A2UI dashboard from conversation context."""
+        user_request = context or "Generate a useful dashboard UI."
+        response = await chat_client.client.chat.completions.create(
+            model=chat_client.model,
+            messages=[
+                {"role": "system", "content": _GENERATE_A2UI_PROMPT_HEADER},
+                {"role": "user", "content": user_request},
+            ],
+            tools=[_RENDER_A2UI_TOOL_SCHEMA],
+            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
+        )
 
-    if not response.choices[0].message.tool_calls:
-        return json.dumps({"error": "LLM did not call render_a2ui"})
+        tool_calls = response.choices[0].message.tool_calls or []
+        if not tool_calls:
+            return json.dumps({"error": "LLM did not call render_a2ui"})
 
-    tool_call = response.choices[0].message.tool_calls[0]
-    args = json.loads(tool_call.function.arguments)
-    result = build_a2ui_operations_from_tool_call(args)
-    return json.dumps(result)
+        args = json.loads(tool_calls[0].function.arguments)
+        return json.dumps(build_a2ui_operations_from_tool_call(args))
+
+    return generate_a2ui
 
 
 def create_agent(chat_client: BaseChatClient) -> AgentFrameworkAgent:
@@ -237,7 +283,7 @@ def create_agent(chat_client: BaseChatClient) -> AgentFrameworkAgent:
               after that summary unless the user asks. ALWAYS send this conversational summary so the message persists.
             """.strip()
         ),
-        tools=[manage_sales_todos, get_sales_todos, get_weather, query_data, schedule_meeting, search_flights, generate_a2ui],
+        tools=[manage_sales_todos, get_sales_todos, get_weather, query_data, schedule_meeting, search_flights, _make_generate_a2ui_tool(chat_client)],
     )
 
     return AgentFrameworkAgent(

--- a/showcase/integrations/ms-agent-python/src/agents/beautiful_chat.py
+++ b/showcase/integrations/ms-agent-python/src/agents/beautiful_chat.py
@@ -157,62 +157,104 @@ def search_flights(
     return json.dumps(result)
 
 
-@tool(
-    name="generate_a2ui",
-    description=(
-        "Generate a dynamic A2UI dashboard based on the conversation. A "
-        "secondary LLM designs the UI schema and data. Use this for rich "
-        "custom dashboards (sales metrics, charts, tables, cards)."
-    ),
-)
-def generate_a2ui(
-    context: Annotated[
-        str,
-        Field(description="Conversation context to generate UI from."),
-    ],
-) -> str:
-    """Generate a dynamic A2UI dashboard from conversation context."""
-    from openai import OpenAI
-
-    client = OpenAI()
-    tool_schema = {
-        "type": "function",
-        "function": {
-            "name": "render_a2ui",
-            "description": "Render a dynamic A2UI v0.9 surface.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "surfaceId": {"type": "string"},
-                    "catalogId": {"type": "string"},
-                    "components": {"type": "array", "items": {"type": "object"}},
-                    "data": {"type": "object"},
+# Shared A2UI secondary-call schema + prompt. See ``a2ui_dynamic.py`` for
+# the detailed write-up of why we use ``chat_client.client`` directly
+# rather than ``BaseChatClient.get_response`` (the latter triggers MAF's
+# function-invocation auto-loop, which never returns raw structured args).
+_RENDER_A2UI_TOOL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "render_a2ui",
+        "description": (
+            "Render a dynamic A2UI v0.9 surface. The `components` array "
+            "MUST be non-empty: emit at least a root component plus its "
+            "children."
+        ),
+        "strict": False,
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "surfaceId": {"type": "string"},
+                "catalogId": {"type": "string"},
+                "components": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string"},
+                            "component": {"type": "string"},
+                            "props": {"type": "object"},
+                            "children": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "child": {"type": "string"},
+                        },
+                        "required": ["id", "component"],
+                    },
                 },
-                "required": ["surfaceId", "catalogId", "components"],
+                "data": {"type": "object"},
             },
+            "required": ["surfaceId", "catalogId", "components"],
         },
-    }
+    },
+}
 
-    response = client.chat.completions.create(
-        model="gpt-4.1",
-        messages=[
-            {"role": "system", "content": context or "Generate a useful dashboard UI."},
-            {
-                "role": "user",
-                "content": "Generate a dynamic A2UI dashboard based on the conversation.",
-            },
-        ],
-        tools=[tool_schema],
-        tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
+
+_GENERATE_A2UI_PROMPT_HEADER = """\
+You are designing a dynamic A2UI v0.9 surface. Call the `render_a2ui` tool
+with a flat component array.
+
+Hard requirements (failing any of these breaks the renderer -- be strict):
+- `surfaceId` is a short kebab-case identifier (e.g. "kpi-dashboard").
+- `components` is a FLAT (non-empty) array. Every entry MUST include both
+  an `id` (unique string) AND a `component` (string -- the catalog
+  component name). The root entry MUST have `id: "root"` AND a valid
+  `component` field.
+- Container components (Row, Column, Card) reference children by id via
+  their `children` (array of strings) or `child` (single string) prop. Do
+  NOT inline children objects.
+"""
+
+
+def _make_generate_a2ui_tool(chat_client: BaseChatClient):
+    """Factory for ``generate_a2ui`` bound to the configured chat client."""
+
+    @tool(
+        name="generate_a2ui",
+        description=(
+            "Generate a dynamic A2UI dashboard based on the conversation. A "
+            "secondary LLM designs the UI schema and data. Use this for rich "
+            "custom dashboards (sales metrics, charts, tables, cards)."
+        ),
     )
+    async def generate_a2ui(
+        context: Annotated[
+            str,
+            Field(description="Conversation context to generate UI from."),
+        ],
+    ) -> str:
+        """Generate a dynamic A2UI dashboard from conversation context."""
+        user_request = context or "Generate a useful dashboard UI."
+        response = await chat_client.client.chat.completions.create(
+            model=chat_client.model,
+            messages=[
+                {"role": "system", "content": _GENERATE_A2UI_PROMPT_HEADER},
+                {"role": "user", "content": user_request},
+            ],
+            tools=[_RENDER_A2UI_TOOL_SCHEMA],
+            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
+        )
 
-    if not response.choices[0].message.tool_calls:
-        return json.dumps({"error": "LLM did not call render_a2ui"})
+        tool_calls = response.choices[0].message.tool_calls or []
+        if not tool_calls:
+            return json.dumps({"error": "LLM did not call render_a2ui"})
 
-    tool_call = response.choices[0].message.tool_calls[0]
-    args = json.loads(tool_call.function.arguments)
-    result = build_a2ui_operations_from_tool_call(args)
-    return json.dumps(result)
+        args = json.loads(tool_calls[0].function.arguments)
+        return json.dumps(build_a2ui_operations_from_tool_call(args))
+
+    return generate_a2ui
 
 
 # ---------------------------------------------------------------------
@@ -256,7 +298,7 @@ def create_beautiful_chat_agent(chat_client: BaseChatClient) -> AgentFrameworkAg
         client=chat_client,
         name="beautiful_chat_agent",
         instructions=SYSTEM_PROMPT,
-        tools=[manage_todos, query_data, search_flights, generate_a2ui],
+        tools=[manage_todos, query_data, search_flights, _make_generate_a2ui_tool(chat_client)],
     )
 
     return AgentFrameworkAgent(

--- a/showcase/integrations/ms-agent-python/src/agents/multimodal_agent.py
+++ b/showcase/integrations/ms-agent-python/src/agents/multimodal_agent.py
@@ -1,42 +1,83 @@
 """
-Multimodal MS Agent Framework agent -- accepts image + document (PDF)
+Multimodal MS Agent Framework agent — accepts image + document (PDF)
 attachments.
 
-A *dedicated* vision-capable agent scoped to the `/demos/multimodal` cell.
-Other demos continue to use their own (cheaper, text-only) models via
-`agents/agent.py` -- this keeps vision cost isolated to the one demo that
-exercises it.
+A *dedicated* vision-capable agent scoped to the ``/demos/multimodal`` cell.
+Other demos continue to use their own chat clients via ``agents/agent.py``.
 
-Wire format the agent sees
-==========================
-Attachments arrive here after travelling through:
+Wire format
+===========
+Attachments arrive after travelling through:
 
-    CopilotChat  ->  AG-UI message content parts  ->  agent_framework_ag_ui
-                                                       (AG-UI -> AF adapter)
+    CopilotChat  ->  AG-UI message content parts
+                ->  agent_framework_ag_ui (AG-UI -> AF adapter)
                 ->  this agent
+                ->  agent_framework_openai (AF -> OpenAI Responses API)
 
-The deployed AG-UI adapter recognizes the legacy
-``{ type: "binary", mimeType, data | url }`` AG-UI part shape. The page at
-``src/app/demos/multimodal/page.tsx`` installs an ``onRunInitialized`` shim
-that rewrites the modern ``{ type: "image" | "document", source: {...} }``
-shape CopilotChat emits to the legacy ``binary`` shape before it hits the
-runtime. We therefore route on ``mimeType``, not the part ``type``:
+The installed ``agent_framework_ag_ui`` adapter parses the modern AG-UI
+multimodal shape natively (``{type: "image" | "document",
+source: {type, value | url, mimeType}}``) — see ``_message_adapters.py:266``.
+The ``agent_framework_openai`` client then forwards image + PDF parts to
+OpenAI as ``input_file`` / ``input_image`` content blocks — see
+``_chat_client.py:1525``. ``gpt-5.2`` accepts both natively.
 
-- ``image/*`` parts are forwarded to GPT-4o-mini unchanged (vision-native).
-- ``application/pdf`` parts are flattened to inline text via ``pypdf`` so
-  the model can read them without needing file-part support.
+Why a (tiny) subclass remains
+=============================
+The OpenAI Responses ``input_file`` schema requires a ``filename`` field
+alongside ``file_data``. CopilotChat sends the filename in ``part.metadata.
+filename``, but the upstream AG-UI adapter (``_message_adapters.py``) does
+not propagate metadata into the resulting ``Content`` object — so the
+chat-client conversion has no filename to forward and OpenAI 400s with
+"Missing required parameter: input[1].content[1]" for any document.
+
+We patch this with the smallest surgical override: walk inbound document
+parts and copy ``metadata.filename`` to ``source.filename``, then patch
+the adapter once at module load to also read ``source.filename`` into
+``Content.additional_properties["filename"]``. No PDF extraction, no
+shape rewriting, no provider-specific logic — just the one missing field.
 
 Reference:
 - showcase/integrations/langgraph-python/src/agents/multimodal_agent.py
 """
 
-import base64
-import io
 from textwrap import dedent
-from typing import Any, Optional, Tuple
+from typing import Any
 
-from agent_framework import Agent, BaseChatClient
+from agent_framework import Agent, BaseChatClient, Content
 from agent_framework_ag_ui import AgentFrameworkAgent
+
+# Patch the upstream adapter ONCE at module import: when parsing a
+# multimodal data part, propagate ``source.filename`` (or top-level
+# ``part.filename``) into ``Content.additional_properties["filename"]``
+# so the OpenAI chat-client conversion at ``_chat_client.py:1554`` finds
+# it and includes it in the ``input_file`` payload.
+import agent_framework_ag_ui._message_adapters as _ag_ui_adapters
+
+_original_parse_multimodal_media_part = _ag_ui_adapters._parse_multimodal_media_part
+
+
+def _parse_multimodal_media_part_with_filename(part: dict[str, Any]) -> Content | None:
+    content = _original_parse_multimodal_media_part(part)
+    if content is None:
+        return None
+    source = part.get("source") if isinstance(part, dict) else None
+    filename = (
+        (source.get("filename") if isinstance(source, dict) else None)
+        or (part.get("filename") if isinstance(part, dict) else None)
+        or (
+            part.get("metadata", {}).get("filename")
+            if isinstance(part, dict) and isinstance(part.get("metadata"), dict)
+            else None
+        )
+    )
+    if isinstance(filename, str) and filename:
+        props = dict(content.additional_properties or {})
+        props.setdefault("filename", filename)
+        content.additional_properties = props
+    return content
+
+
+_ag_ui_adapters._parse_multimodal_media_part = _parse_multimodal_media_part_with_filename
 
 
 SYSTEM_PROMPT = dedent(
@@ -49,176 +90,31 @@ SYSTEM_PROMPT = dedent(
 ).strip()
 
 
-def _extract_data_url_parts(url: str) -> tuple[str, str]:
-    """Split a ``data:<mime>;base64,<payload>`` URL into (mime, base64-payload).
-
-    Returns ("", url) if the input is not a data URL -- callers can fall
-    back to treating the url as a fetchable reference.
-    """
-    if not url.startswith("data:"):
-        return "", url
-    header, _, payload = url.partition(",")
-    if ":" not in header:
-        return "", payload
-    meta = header.split(":", 1)[1]
-    mime = meta.split(";", 1)[0] if ";" in meta else meta
-    return mime, payload
-
-
-def _extract_pdf_text(b64: str) -> str:
-    """Decode an inline-base64 PDF and extract its text.
-
-    Returns an empty string if decoding or extraction fails -- callers must
-    treat the extracted text as best-effort. Any exception here is logged
-    and swallowed so one malformed attachment does not tank the whole
-    user turn.
-    """
-    try:
-        raw = base64.b64decode(b64, validate=False)
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[multimodal_agent] base64 decode failed: {exc}")
-        return ""
-
-    try:
-        # Lazy import -- keeps the module importable even if pypdf is missing
-        # at dev-server boot (we only need it when a PDF actually arrives).
-        from pypdf import PdfReader  # type: ignore[import-not-found]
-    except ImportError as exc:  # pragma: no cover - defensive
-        print(
-            "[multimodal_agent] pypdf not installed -- PDF text extraction "
-            f"unavailable: {exc}",
-        )
-        return ""
-
-    try:
-        reader = PdfReader(io.BytesIO(raw))
-        pages = [page.extract_text() or "" for page in reader.pages]
-        return "\n\n".join(pages).strip()
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[multimodal_agent] pypdf extraction failed: {exc}")
-        return ""
-
-
-def _classify_attachment_part(part: Any) -> Optional[Tuple[str, str, str]]:
-    """Inspect a content part and return (kind, mime, base64_payload).
-
-    ``kind`` is one of ``"image"``, ``"pdf"``, ``"other"``. Returns ``None``
-    if the part is not an attachment we recognize.
-
-    Handles the shapes the MS-AF AG-UI adapter may surface:
-
-    - ``{"type": "image_url", "image_url": {"url": "data:..."}}``
-      (post-adapter, from the legacy-binary rewrite on the page).
-    - ``{"type": "image_url", "image_url": "data:..."}`` (older shape).
-    - ``{"type": "binary", "mimeType": "...", "data": "<base64>"}``
-      (direct legacy binary).
-    - ``{"type": "document", "source": {"type": "data",
-      "value": "<base64>", "mimeType": "application/pdf"}}`` (modern AG-UI).
-    - ``{"type": "image", "source": {...}}`` (modern AG-UI, for completeness).
-    """
-    if not isinstance(part, dict):
-        return None
-    part_type = part.get("type")
-
-    if part_type == "image_url":
-        image_url = part.get("image_url")
-        url: Optional[str] = None
-        if isinstance(image_url, str):
-            url = image_url
-        elif isinstance(image_url, dict):
-            raw_url = image_url.get("url")
-            if isinstance(raw_url, str):
-                url = raw_url
-        if not url:
-            return None
-        mime, payload = _extract_data_url_parts(url)
-        if not payload or not mime:
-            return None
-        if mime.startswith("image/"):
-            return ("image", mime, payload)
-        if "pdf" in mime.lower():
-            return ("pdf", mime, payload)
-        return ("other", mime, payload)
-
-    if part_type == "binary":
-        mime = part.get("mimeType", "")
-        data = part.get("data")
-        if not isinstance(mime, str) or not isinstance(data, str):
-            return None
-        if mime.startswith("image/"):
-            return ("image", mime, data)
-        if "pdf" in mime.lower():
-            return ("pdf", mime, data)
-        return ("other", mime, data)
-
-    if part_type in ("document", "image"):
-        source = part.get("source")
-        if not isinstance(source, dict) or source.get("type") != "data":
-            return None
-        value = source.get("value")
-        mime = source.get("mimeType", "")
-        if not isinstance(value, str) or not isinstance(mime, str):
-            return None
-        if mime.startswith("image/"):
-            return ("image", mime, value)
-        if "pdf" in mime.lower():
-            return ("pdf", mime, value)
-        return ("other", mime, value)
-
-    return None
-
-
-def _preprocess_part(part: Any) -> Any:
-    """Flatten PDF attachments to text; pass everything else through.
-
-    Images stay as-is so gpt-4o consumes them natively. PDFs become a text
-    part prefixed with ``[Attached document]``. If extraction fails we emit
-    a structured placeholder so the model can tell the user the document
-    was unreadable rather than pretending no attachment was sent.
-    """
-    classified = _classify_attachment_part(part)
-    if classified is None:
-        return part
-    kind, _mime, payload = classified
-    if kind != "pdf":
-        return part
-    text = _extract_pdf_text(payload)
-    if not text:
-        return {
-            "type": "text",
-            "text": "[Attached document: PDF could not be read.]",
-        }
-    return {"type": "text", "text": f"[Attached document]\n{text}"}
-
-
 class _MultimodalAgent(AgentFrameworkAgent):
-    """Thin wrapper that pre-processes inbound messages before each run.
-
-    We flatten `document` (PDF) content parts to text so the model can reason
-    about them even when the underlying chat client does not accept the
-    `document` content-part shape. Images are untouched.
-    """
-
-    def _flatten_messages(self, messages: Any) -> Any:
-        if not isinstance(messages, list):
-            return messages
-        rewritten: list[Any] = []
-        for message in messages:
-            if not isinstance(message, dict):
-                rewritten.append(message)
-                continue
-            content = message.get("content")
-            if not isinstance(content, list):
-                rewritten.append(message)
-                continue
-            new_parts = [_preprocess_part(part) for part in content]
-            rewritten.append({**message, "content": new_parts})
-        return rewritten
+    """Promote ``metadata.filename`` to ``source.filename`` on inbound document
+    parts so the patched adapter (above) can carry it into ``Content``."""
 
     async def run(self, input_data: dict[str, Any]):  # type: ignore[override]
         messages = input_data.get("messages")
         if isinstance(messages, list):
-            input_data = {**input_data, "messages": self._flatten_messages(messages)}
+            for message in messages:
+                if not isinstance(message, dict):
+                    continue
+                content = message.get("content")
+                if not isinstance(content, list):
+                    continue
+                for part in content:
+                    if not isinstance(part, dict):
+                        continue
+                    if part.get("type") not in ("document", "binary"):
+                        continue
+                    metadata = part.get("metadata") or {}
+                    filename = metadata.get("filename") if isinstance(metadata, dict) else None
+                    if not isinstance(filename, str) or not filename:
+                        continue
+                    source = part.get("source")
+                    if isinstance(source, dict) and "filename" not in source:
+                        source["filename"] = filename
         async for event in super().run(input_data):
             yield event
 

--- a/showcase/integrations/ms-agent-python/src/agents/reasoning_agent.py
+++ b/showcase/integrations/ms-agent-python/src/agents/reasoning_agent.py
@@ -7,89 +7,58 @@ Shared by two demos:
 
 Approach
 --------
-The LangGraph reference agent relies on AG-UI REASONING_MESSAGE_* events, which
-CopilotKit renders natively via `CopilotChatReasoningMessage`. The MS Agent
-Framework's current AG-UI bridge does not surface reasoning tokens as
-first-class REASONING_MESSAGE events, so we fall back to the closest portable
-pattern: a `think` tool.
+Routes through ``OpenAIChatClient`` (Responses API) on a reasoning-capable
+model (``gpt-5.2``) with ``reasoning={"effort":"medium","summary":"detailed"}``.
+The agent-framework AG-UI bridge converts the streamed reasoning summaries
+into first-class ``REASONING_MESSAGE_*`` events, which CopilotKit renders
+via its built-in ``CopilotChatReasoningMessage`` slot (default) or a custom
+``messageView.reasoningMessage`` slot override (custom variant).
 
-Flow:
-  1. The agent MUST call `think(thought=...)` before producing its final
-     answer. Its `thought` field contains the step-by-step reasoning.
-  2. The frontend renders the tool call with `useRenderTool("think", ...)` as
-     a visible reasoning block (custom or default style, per demo).
-  3. The agent then produces a concise final answer as a normal assistant
-     message.
+No tool plumbing required — the model emits reasoning content natively.
 """
 
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import Annotated
 
-from agent_framework import Agent, BaseChatClient, tool
+from agent_framework import Agent, BaseChatClient
 from agent_framework_ag_ui import AgentFrameworkAgent
-from pydantic import Field
-
-
-@tool(
-    name="think",
-    description=(
-        "Record a step-by-step reasoning trace that the UI will render as a "
-        "visible thinking block. Always call this tool BEFORE answering the "
-        "user's question. Use a single call per user turn."
-    ),
-)
-def think(
-    thought: Annotated[
-        str,
-        Field(
-            description=(
-                "A concise, step-by-step reasoning chain leading toward the "
-                "final answer. Write in first person (e.g., 'First I'll..., "
-                "then I'll...'). Keep it under ~5 short steps."
-            )
-        ),
-    ],
-) -> str:
-    """Accept the reasoning; the UI displays it as a thinking block."""
-    # The tool body is intentionally trivial: the useful payload is `thought`,
-    # which the frontend receives via the tool-call args (rendered live).
-    return "Reasoning recorded."
 
 
 def create_reasoning_agent(chat_client: BaseChatClient) -> AgentFrameworkAgent:
-    """Create the MS Agent Framework reasoning demo agent."""
+    """Create the MS Agent Framework reasoning demo agent.
+
+    The ``chat_client`` MUST point at a reasoning-capable model (gpt-5*,
+    o3, o4-mini, …). ``OpenAIChatClient`` (Responses API) is required —
+    ``OpenAIChatCompletionClient`` does NOT surface reasoning content
+    against vanilla OpenAI.
+    """
     base_agent = Agent(
         client=chat_client,
         name="reasoning_agent",
         instructions=dedent(
             """
-            You are a helpful assistant that shows its work.
-
-            Required workflow for EVERY user question:
-              1. Call the `think` tool exactly once with a concise,
-                 step-by-step reasoning chain describing how you will
-                 approach the answer.
-              2. After the tool call returns, produce a clear, concise
-                 final assistant message with the actual answer.
-
-            Rules:
-              - You MUST call `think` before your final answer. Never skip it.
-              - Keep the `thought` focused on reasoning, not the final answer.
-              - Keep the final answer short (1-3 short paragraphs).
-              - Do NOT repeat the reasoning in the final answer; just give
-                the user the conclusion.
-            """.strip()
-        ),
-        tools=[think],
+            You are a helpful assistant. For each user question, think
+            step-by-step about the approach, then give a clear, concise
+            final answer. Keep the final answer short (1-3 short
+            paragraphs).
+            """
+        ).strip(),
+        # Per OpenAIChatOptions (agent_framework_openai/_chat_client.py).
+        # `effort: "medium"` balances depth vs. latency; `summary: "detailed"`
+        # is required for the reasoning summary text to be visible in the
+        # stream (`"auto"` may collapse it).
+        # See: https://platform.openai.com/docs/guides/reasoning
+        default_options={
+            "reasoning": {"effort": "medium", "summary": "detailed"},
+        },
     )
 
     return AgentFrameworkAgent(
         agent=base_agent,
         name="CopilotKitMicrosoftAgentFrameworkReasoningAgent",
         description=(
-            "Demonstrates a visible reasoning chain via the `think` tool."
+            "Streams real REASONING_MESSAGE_* events via gpt-5.2 + Responses API."
         ),
         require_confirmation=False,
     )

--- a/showcase/integrations/ms-agent-python/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -1,33 +1,30 @@
 "use client";
 
-// Agentic Chat (Reasoning) — visible reasoning chain alongside the final
+// Agentic Chat (Reasoning) -- visible reasoning chain alongside the final
 // answer for the Microsoft Agent Framework backend.
 //
 // How reasoning surfaces here:
-//   - LangGraph reference relies on AG-UI REASONING_MESSAGE_* events, which
-//     CopilotKit renders via the first-class `reasoningMessage` slot on
-//     CopilotChat.
-//   - The MS Agent Framework AG-UI bridge does not currently emit those
-//     events. To provide the equivalent UX, the backend agent is instructed
-//     to call a `think(thought=...)` tool before every answer, and the
-//     frontend uses `useRenderTool` to render that tool call as a visibly
-//     tagged amber block — the same visual language as the reference.
+//   - The backend agent (src/agents/reasoning_agent.py) routes through
+//     `OpenAIChatClient` (Responses API) on `gpt-5.2` with
+//     `reasoning={"effort":"medium","summary":"detailed"}`. The
+//     agent-framework AG-UI bridge converts the streamed reasoning
+//     summary into first-class AG-UI REASONING_MESSAGE_* events.
+//   - The frontend overrides the `messageView.reasoningMessage` slot on
+//     `<CopilotChat />` with `<ReasoningBlock />` -- the same pattern the
+//     LangGraph reference uses. No tool plumbing, no `useRenderTool`.
 
-import React from "react";
 import {
   CopilotKit,
   CopilotChat,
-  useRenderTool,
+  CopilotChatReasoningMessage,
 } from "@copilotkit/react-core/v2";
-import { z } from "zod";
 import { ReasoningBlock } from "./reasoning-block";
+
+const AGENT_ID = "agentic-chat-reasoning";
 
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit
-      runtimeUrl="/api/copilotkit-reasoning"
-      agent="agentic-chat-reasoning"
-    >
+    <CopilotKit runtimeUrl="/api/copilotkit-reasoning" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />
@@ -38,22 +35,16 @@ export default function AgenticChatReasoningDemo() {
 }
 
 function Chat() {
-  // @region[reasoning-block-render]
-  useRenderTool({
-    name: "think",
-    parameters: z.object({
-      thought: z.string(),
-    }),
-    render: ({ args, status }: any) => (
-      <ReasoningBlock args={args} status={status} />
-    ),
-  });
-  // @endregion[reasoning-block-render]
-
   return (
     <CopilotChat
-      agentId="agentic-chat-reasoning"
+      agentId={AGENT_ID}
       className="h-full rounded-2xl"
+      messageView={{
+        // @region[reasoning-block-render]
+        reasoningMessage:
+          ReasoningBlock as unknown as typeof CopilotChatReasoningMessage,
+        // @endregion[reasoning-block-render]
+      }}
     />
   );
 }

--- a/showcase/integrations/ms-agent-python/src/app/demos/agentic-chat-reasoning/reasoning-block.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/agentic-chat-reasoning/reasoning-block.tsx
@@ -1,24 +1,27 @@
 "use client";
 
-// Custom reasoning block renderer for the `think` tool.
+// Custom `reasoningMessage` slot renderer.
 //
-// MS Agent Framework's AG-UI bridge doesn't currently emit
-// REASONING_MESSAGE_* events, so we surface reasoning by having the agent
-// call a `think(thought)` tool and rendering the tool call as a visible
-// amber-tagged block matching the LangGraph reference's visual language.
+// Receives the `ReasoningMessage` plus (optionally) the full message list and
+// the running state from the slot system. Renders the content inline with a
+// visibly tagged amber banner so the user can always see the agent's thinking
+// chain -- this is the focal UI of the demo.
 
 import React from "react";
+import type { ReasoningMessage, Message } from "@ag-ui/core";
 
 export function ReasoningBlock({
-  args,
-  status,
+  message,
+  messages,
+  isRunning,
 }: {
-  args: { thought?: string };
-  status?: string;
+  message: ReasoningMessage;
+  messages?: Message[];
+  isRunning?: boolean;
 }) {
-  const isStreaming = status !== "complete";
-  const thought = args?.thought ?? "";
-  const hasContent = thought.length > 0;
+  const isLatest = messages?.[messages.length - 1]?.id === message.id;
+  const isStreaming = !!(isRunning && isLatest);
+  const hasContent = !!(message.content && message.content.length > 0);
 
   return (
     <div
@@ -35,7 +38,7 @@ export function ReasoningBlock({
       </div>
       {hasContent && (
         <div className="mt-1.5 whitespace-pre-wrap italic text-[#57575B]">
-          {thought}
+          {message.content}
         </div>
       )}
     </div>

--- a/showcase/integrations/ms-agent-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/multimodal/page.tsx
@@ -10,12 +10,12 @@
  * Architecture:
  * - Dedicated runtime route at `/api/copilotkit-multimodal` (see
  *   ../../api/copilotkit-multimodal/route.ts). The vision-capable model
- *   (gpt-4o-mini) is scoped to just this demo, so other cells keep their
+ *   (gpt-5.2) is scoped to just this demo, so other cells keep their
  *   default configuration.
  * - Dedicated MS Agent Framework agent mounted at `/multimodal` on the
- *   Python agent server (src/agents/multimodal_agent.py). Images are
- *   forwarded to the model natively; PDFs are flattened to text on the
- *   Python side via `pypdf` for provider-agnostic behavior.
+ *   Python agent server (src/agents/multimodal_agent.py). Both images and
+ *   PDFs are forwarded to the Responses API natively as `input_image` /
+ *   `input_file` parts -- no client-side text extraction required.
  * - Sample files live at `/demo-files/sample.png` and `/demo-files/sample.pdf`
  *   (see `public/demo-files/`). The sample-buttons component fetches them
  *   client-side, wraps the blob in a File, and drives the same hidden
@@ -24,21 +24,11 @@
  *   code path -- whatever works for one works for both.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
-import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
-
-/**
- * Minimal structural shape of an AG-UI message. We care only about the
- * `user` branch; every other role passes through.
- */
-type AgentMessage = {
-  id?: string;
-  role: string;
-  content?: unknown;
-};
 
 /**
  * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
@@ -88,125 +78,11 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
-/**
- * Rewrites modern multimodal content parts (`type: "image" | "document" |
- * "audio" | "video"`, `source.{type,value,mimeType}`) to the legacy binary
- * shape (`type: "binary"`, `mimeType`, `data` | `url`). The deployed AG-UI
- * converter only recognizes legacy `binary` parts — modern parts are silently
- * filtered out, so without this rewrite the agent never sees the attachment.
- */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
-  const candidate = part as {
-    type?: string;
-    text?: string;
-    source?: {
-      type?: string;
-      value?: string;
-      mimeType?: string;
-    };
-  };
-  const type = candidate.type;
-  if (
-    type !== "image" &&
-    type !== "document" &&
-    type !== "audio" &&
-    type !== "video"
-  ) {
-    return part;
-  }
-  const source = candidate.source;
-  if (!source || typeof source.value !== "string") {
-    return part;
-  }
-  const mimeType = source.mimeType ?? "application/octet-stream";
-  if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
-  }
-  if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
-  }
-  return part;
-}
-
-/**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Returns the same array reference when nothing
- * changes so the subscriber can skip an unnecessary state write.
- */
-function rewriteMessagesForLegacyConverter(
-  messages: ReadonlyArray<Readonly<AgentMessage>>,
-): AgentMessage[] | null {
-  let mutated = false;
-  const next = messages.map((message) => {
-    if (message.role !== "user") return message as AgentMessage;
-    const content = message.content;
-    if (!Array.isArray(content)) return message as AgentMessage;
-    let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
-    if (!partMutated) return message as AgentMessage;
-    mutated = true;
-    return {
-      ...(message as object),
-      content: rewrittenParts,
-    } as AgentMessage;
-  });
-  return mutated ? next : null;
-}
-
-/**
- * Installs the `onRunInitialized` subscriber on the active agent so we
- * rewrite modern multimodal parts to the legacy shape the AG-UI converter
- * understands.
- */
-function LegacyConverterShim() {
-  const { agent } = useAgent({ agentId: "multimodal-demo" });
-
-  const subscriber = useMemo(
-    () => ({
-      onRunInitialized: ({
-        messages,
-      }: {
-        messages: ReadonlyArray<Readonly<AgentMessage>>;
-      }) => {
-        const rewritten = rewriteMessagesForLegacyConverter(messages);
-        if (!rewritten) return;
-        return { messages: rewritten };
-      },
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!agent) return;
-    // Structural shim shape; cast at subscribe boundary.
-    const handle = agent.subscribe(
-      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
-    );
-    return () => handle.unsubscribe();
-  }, [agent, subscriber]);
-
-  return null;
-}
-
 export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
-      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/integrations/ms-agent-python/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/reasoning-default-render/page.tsx
@@ -2,110 +2,27 @@
 
 // Reasoning (Default Render) demo.
 //
-// The LangGraph reference demonstrates CopilotKit's built-in
-// `CopilotChatReasoningMessage` slot rendering AG-UI REASONING_MESSAGE_*
-// events with zero config.
-//
-// The Microsoft Agent Framework AG-UI bridge doesn't currently emit those
-// events. To show the equivalent default experience, the backend calls a
-// `think` tool that the frontend renders with a minimal built-in-style
-// collapsible card — the closest MS Agent equivalent to the stock
-// `CopilotChatReasoningMessage` render.
+// The backend agent (src/agents/reasoning_agent.py) emits first-class
+// AG-UI REASONING_MESSAGE_* events via the Responses API on a
+// reasoning-capable model. With NO slot override, CopilotKit renders them
+// using its built-in `CopilotChatReasoningMessage` component (Thinking… /
+// Thought for X header with an expandable content region). This is the
+// zero-config path.
 
-import React, { useState } from "react";
-import {
-  CopilotKit,
-  CopilotChat,
-  useRenderTool,
-} from "@copilotkit/react-core/v2";
-import { z } from "zod";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+
+const AGENT_ID = "reasoning-default-render";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit
-      runtimeUrl="/api/copilotkit-reasoning"
-      agent="reasoning-default-render"
-    >
+    <CopilotKit runtimeUrl="/api/copilotkit-reasoning" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}
-          <Chat />
+          <CopilotChat agentId={AGENT_ID} className="h-full rounded-2xl" />
           {/* @endregion[default-reasoning-zero-config] */}
         </div>
       </div>
     </CopilotKit>
-  );
-}
-
-function Chat() {
-  useRenderTool({
-    name: "think",
-    parameters: z.object({ thought: z.string() }),
-    render: ({ args, status }: any) => (
-      <DefaultReasoningMessage thought={args?.thought ?? ""} status={status} />
-    ),
-  });
-
-  return (
-    <CopilotChat
-      agentId="reasoning-default-render"
-      className="h-full rounded-2xl"
-    />
-  );
-}
-
-// Mirrors CopilotKit's built-in CopilotChatReasoningMessage UX: a
-// collapsible "Thinking…" / "Thought for a moment" card.
-function DefaultReasoningMessage({
-  thought,
-  status,
-}: {
-  thought: string;
-  status?: string;
-}) {
-  const isStreaming = status !== "complete";
-  const [open, setOpen] = useState(isStreaming);
-  const hasContent = thought.length > 0;
-
-  return (
-    <div
-      data-testid="reasoning-default"
-      style={{
-        margin: "8px 0",
-        borderRadius: "12px",
-        border: "1px solid var(--copilot-kit-separator-color, #e5e7eb)",
-        background: "var(--copilot-kit-secondary-color, #f9fafb)",
-        padding: "8px 12px",
-        fontSize: "13px",
-      }}
-    >
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        style={{
-          all: "unset",
-          cursor: "pointer",
-          display: "flex",
-          alignItems: "center",
-          gap: "8px",
-          fontWeight: 500,
-          color: "var(--copilot-kit-muted-color, #4b5563)",
-        }}
-      >
-        <span aria-hidden>{open ? "▾" : "▸"}</span>
-        <span>{isStreaming ? "Thinking…" : "Thought for a moment"}</span>
-      </button>
-      {open && hasContent && (
-        <div
-          style={{
-            marginTop: "6px",
-            whiteSpace: "pre-wrap",
-            color: "var(--copilot-kit-muted-color, #6b7280)",
-          }}
-        >
-          {thought}
-        </div>
-      )}
-    </div>
   );
 }

--- a/showcase/integrations/ms-agent-python/tools/generate_a2ui.py
+++ b/showcase/integrations/ms-agent-python/tools/generate_a2ui.py
@@ -94,11 +94,36 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         _logger.warning("build_a2ui_operations_from_tool_call received empty components list")
     data = args.get("data")
 
+    # A2UI v0.9 nested operation shape -- ``@ag-ui/a2ui-middleware`` reads
+    # ``op.createSurface.surfaceId`` / ``op.updateComponents.surfaceId`` to
+    # group activity events by surface. A flat
+    # ``{type: "create_surface", surfaceId, ...}`` shape silently parses
+    # (the middleware's ``getOperationSurfaceId`` returns ``undefined`` and
+    # falls back to "default") and the resulting activity event never
+    # matches a registered catalog surface, leaving a blank canvas.
     ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
-        {"type": "update_components", "surfaceId": surface_id, "components": components},
+        {
+            "version": "v0.9",
+            "createSurface": {"surfaceId": surface_id, "catalogId": catalog_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {
+                "surfaceId": surface_id,
+                "components": components,
+            },
+        },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
+            }
+        )
 
     return {"a2ui_operations": ops}


### PR DESCRIPTION
## Summary

Live-implementation audit of `showcase/integrations/ms-agent-python/` against MAF **agent-framework-core 1.3.0 / agent-framework-openai 1.3.0 / agent-framework-ag-ui 1.0.0b260507** with **gpt-5.2**. Deletes obsolete workarounds where MAF supports things natively; isolates the remaining shims so the real upstream gaps are visible.

| Feature | Before | After |
|---|---|---|
| Reasoning | Fake `think(thought)` tool + custom amber-block renderer | Native `REASONING_MESSAGE_*` events via `reasoning={effort,summary}` on the Agent + `messageView.reasoningMessage` slot |
| Image multimodal | Frontend `LegacyConverterShim` rewrote modern parts → legacy `binary` | Modern AG-UI shape works end-to-end (adapter + `agent_framework_openai` already handle it) |
| PDF multimodal | 150-line `_MultimodalAgent` subclass with `pypdf` text extraction | OpenAI `input_file` natively; **30-line shim** propagates `metadata.filename` (upstream gap) |
| A2UI dynamic | Blank canvas, second-turn 400s | Renders multi-turn end-to-end (multiple stacked workarounds — see below) |

## What's in this PR

### Reasoning (`reasoning_agent.py`, frontend pages)
- Delete the no-op `think` tool. Configure `default_options={"reasoning": {"effort": "medium", "summary": "detailed"}}` on the Agent. The AG-UI bridge already emits real `REASONING_MESSAGE_*` events when the Responses API streams reasoning summaries.
- Bump `@ag-ui/client` `^0.0.43` → `^0.0.52`. The 0.0.43 bundle's discriminated-union event schema still only listed the deprecated `THINKING_TEXT_MESSAGE_*` events and rejected every `REASONING_MESSAGE_*` frame.
- `agentic-chat-reasoning/page.tsx` uses `messageView={{ reasoningMessage: ReasoningBlock }}`; `reasoning-default-render/page.tsx` is now zero-config `<CopilotChat />` with the built-in `CopilotChatReasoningMessage`.

### Multimodal (`multimodal_agent.py`, `multimodal/page.tsx`, `requirements.txt`)
- Delete the frontend `LegacyConverterShim` that rewrote modern `{type:"image"|"document", source:{...}}` parts to legacy `binary`.
- Delete the `pypdf` extraction codepath (`_extract_pdf_text`, `_classify_attachment_part`, `_preprocess_part`, `_flatten_messages`). Drop `pypdf` from `requirements.txt`.
- **Retain a 30-line `_MultimodalAgent` + adapter monkey-patch** that copies `metadata.filename` into `Content.additional_properties["filename"]` so OpenAI's `input_file` requirement is satisfied. The upstream `agent_framework_ag_ui._message_adapters._parse_multimodal_media_part` doesn't propagate that field.

### A2UI dynamic (`a2ui_dynamic.py`, `agent.py`, `beautiful_chat.py`, `tools/generate_a2ui.py`)
1. **Fix `build_a2ui_operations_from_tool_call`** to produce v0.9 nested `{createSurface:{surfaceId,catalogId}}` ops instead of flat `{type:"create_surface",surfaceId,...}`. The middleware's `getOperationSurfaceId` reads `op.createSurface.surfaceId`; the flat shape fell back to surface group `"default"` and never rendered.
2. **Secondary structured-output call** uses `chat_client.client` (underlying `AsyncOpenAI`) directly to bypass MAF's function-invocation auto-loop. `BaseChatClient.get_response` always auto-executes tools when passed; there's no one-shot raw-args primitive. Inherits api_key + model from the parent. Same pattern replaces `agent.py` and `beautiful_chat.py` raw-OpenAI bypasses.
3. **Inject the registered A2UI catalog schema** (~49 KB Zod-derived JSON) from `input_data.context[]` into the secondary call's system prompt. `_A2UIDynamicAgent.run()` captures the entry whose description starts with `"A2UI Component Schema"` and stashes it in a closure dict the tool body reads on each invocation.
4. **Switch the outer agent to `OpenAIChatCompletionClient`**. Responses API + tool calls + multi-turn 400s with *"No tool output found for function call …"* — reasoning items can't be replayed in MAF's loop reconstruction. chat.completions replays tool history cleanly.
5. **Defensive `_reorder_tool_messages` shim** in `_A2UIDynamicAgent.run()`. CopilotKit's frontend message store ships turn-1 history as `[user, tool, assistant(toolCalls), assistant, user]` on turn 2 — tool BEFORE its parent assistant — and OpenAI 400s. Walk inbound messages and re-attach `role="tool"` immediately after its matching `assistant.toolCalls[].id`.
6. **Tighten the `render_a2ui` tool schema**: `minItems: 1`, explicit `items.properties`, `strict: false`, and a verbose prompt that pins entry-level vs. nested prop placement. Without these gpt-5.x emits `components: []`.

### Model bump (`agent_server.py`, `.env` example)
- Default `OPENAI_CHAT_MODEL_ID` → `gpt-5.2` (Responses-capable reasoning model).
- Scoped clients: reasoning agent on `OpenAIChatClient` + `reasoning={...}`; A2UI dynamic on `OpenAIChatCompletionClient` (avoids reasoning replay).

## Upstream gaps (follow-up PRs)

This audit surfaced three concrete gaps. The current PR pins them with local shims; the actual fixes belong upstream:

1. **`agent_framework_ag_ui`** — propagate `part.metadata.filename` to `Content.additional_properties["filename"]` in `_parse_multimodal_media_part`. Removes the PDF subclass.
2. **`agent_framework`** — expose a one-shot "give me the raw `function_call` args without executing tools" path on `BaseChatClient.get_response` (e.g. `auto_invoke=False`), or cleanly export `RawOpenAIChatClient`. Removes the A2UI raw-SDK bypass.
3. **`@copilotkit/react-core/v2`** — stop reordering `role="tool"` messages before their `role="assistant"` parent in the frontend message store. Removes the A2UI message-reorder shim.

## Test plan

- [ ] `pnpm install` succeeds at repo root.
- [ ] In `showcase/integrations/ms-agent-python/`: `npm install` + `python -m venv .venv && .venv/Scripts/python -m pip install -r requirements.txt`.
- [ ] Set `OPENAI_API_KEY` (and optionally `OPENAI_CHAT_MODEL_ID=gpt-5.2`) in `agent/.env`.
- [ ] Start agent (`uvicorn agent_server:app --host 0.0.0.0 --port 8000 --app-dir src` with `PYTHONPATH="src;."`) and Next.js (`npx next dev`).
- [ ] `/demos/agentic-chat-reasoning` — multi-step prompt shows REASONING block + final answer.
- [ ] `/demos/reasoning-default-render` — built-in collapsible "Thinking…" block renders.
- [ ] `/demos/multimodal` — paste a real PNG and a real PDF; agent reads both natively (no pypdf).
- [ ] `/demos/declarative-gen-ui` — click "Show a KPI dashboard", then click "Pie chart — sales by region". Both surfaces render; no 400 on the second turn.