### PR TITLE
fix: reasoning-chain demo + reasoning-role message filter

### DIFF
--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/run-message-filtering.test.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/run-message-filtering.test.ts
@@ -37,14 +37,15 @@ function createAgent() {
 function withMockedParentRun(agent: LangGraphAgent) {
   const parentProto = Object.getPrototypeOf(Object.getPrototypeOf(agent));
   const calls: any[] = [];
-  const spy = vi
-    .spyOn(parentProto, "run")
-    .mockImplementation(function (this: unknown, input: unknown) {
-      calls.push(input);
-      // Return an empty Observable — none of our assertions consume it,
-      // we only care about what was passed in.
-      return of();
-    });
+  const spy = vi.spyOn(parentProto, "run").mockImplementation(function (
+    this: unknown,
+    input: unknown,
+  ) {
+    calls.push(input);
+    // Return an empty Observable — none of our assertions consume it,
+    // we only care about what was passed in.
+    return of();
+  });
   return { spy, calls };
 }
 

--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/run-message-filtering.test.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/run-message-filtering.test.ts
@@ -1,0 +1,155 @@
+import { of } from "rxjs";
+import { vi } from "vitest";
+import { LangGraphAgent } from "../agent";
+
+// REGRESSION: `@ag-ui/langgraph`'s message converter only handles
+// {user, assistant, system, tool} and throws "message role is not
+// supported." on anything else. Reasoning-stream agents (OpenAI
+// Responses API with `reasoning={summary:"detailed"}`) emit AG-UI
+// messages with `role:"reasoning"` that the AG-UI client persists in
+// the thread and replays on the NEXT turn's `input.messages` — which
+// crashes the converter before the model is called.
+//
+// CopilotKit's LangGraphAgent.run subclass strips those reasoning
+// messages from the inbound `input.messages` before delegating to
+// super. This file verifies that filter:
+//   - `role:"reasoning"` is dropped.
+//   - All other roles (user, assistant, system, tool, plus unknown
+//     roles we don't recognize) are preserved in order.
+//   - The pre-existing forwardedProps enrichment (`streamSubgraphs`)
+//     still applies.
+
+function createAgent() {
+  return new LangGraphAgent({
+    graphId: "test-graph",
+    url: "http://localhost:8000",
+  });
+}
+
+/**
+ * Mock the parent class's `run` method for a single test so we can
+ * capture the `input` it receives without actually opening a stream.
+ * The harness spies on the prototype TWO levels up because the
+ * CopilotKit `LangGraphAgent` extends `@ag-ui/langgraph`'s
+ * `LangGraphAgent`. Mirror the pattern from
+ * `dispatch-event-filtering.test.ts`'s `withMockedParentMerge`.
+ */
+function withMockedParentRun(agent: LangGraphAgent) {
+  const parentProto = Object.getPrototypeOf(Object.getPrototypeOf(agent));
+  const calls: any[] = [];
+  const spy = vi
+    .spyOn(parentProto, "run")
+    .mockImplementation(function (this: unknown, input: unknown) {
+      calls.push(input);
+      // Return an empty Observable — none of our assertions consume it,
+      // we only care about what was passed in.
+      return of();
+    });
+  return { spy, calls };
+}
+
+function makeInput(messages: Array<{ role: string; id?: string }>) {
+  return {
+    runId: "run-1",
+    threadId: "thread-1",
+    messages,
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+  } as any;
+}
+
+describe("LangGraphAgent.run reasoning-role message filtering", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("strips role:'reasoning' messages from input before delegating to super.run", () => {
+    const agent = createAgent();
+    const { calls } = withMockedParentRun(agent);
+
+    agent.run(
+      makeInput([
+        { role: "user", id: "u1" },
+        { role: "reasoning", id: "r1" },
+        { role: "assistant", id: "a1" },
+        { role: "tool", id: "t1" },
+        { role: "reasoning", id: "r2" },
+      ]),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].messages.map((m: { id: string }) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "t1",
+    ]);
+    expect(
+      calls[0].messages.some((m: { role: string }) => m.role === "reasoning"),
+    ).toBe(false);
+  });
+
+  it("preserves user/assistant/system/tool messages in their original order", () => {
+    const agent = createAgent();
+    const { calls } = withMockedParentRun(agent);
+
+    agent.run(
+      makeInput([
+        { role: "system", id: "s1" },
+        { role: "user", id: "u1" },
+        { role: "assistant", id: "a1" },
+        { role: "tool", id: "t1" },
+        { role: "user", id: "u2" },
+      ]),
+    );
+
+    expect(calls[0].messages.map((m: { id: string }) => m.id)).toEqual([
+      "s1",
+      "u1",
+      "a1",
+      "t1",
+      "u2",
+    ]);
+  });
+
+  it("tolerates an empty messages array without throwing", () => {
+    const agent = createAgent();
+    const { calls } = withMockedParentRun(agent);
+
+    agent.run(makeInput([]));
+
+    expect(calls[0].messages).toEqual([]);
+  });
+
+  it("tolerates omitted messages (defaults to empty array)", () => {
+    const agent = createAgent();
+    const { calls } = withMockedParentRun(agent);
+
+    const input = makeInput([{ role: "user", id: "u1" }]);
+    delete input.messages;
+    agent.run(input);
+
+    expect(calls[0].messages).toEqual([]);
+  });
+
+  it("preserves the pre-existing forwardedProps.streamSubgraphs default", () => {
+    const agent = createAgent();
+    const { calls } = withMockedParentRun(agent);
+
+    agent.run(makeInput([{ role: "user", id: "u1" }]));
+
+    expect(calls[0].forwardedProps).toMatchObject({ streamSubgraphs: true });
+  });
+
+  it("respects an explicit forwardedProps.streamSubgraphs=false", () => {
+    const agent = createAgent();
+    const { calls } = withMockedParentRun(agent);
+
+    const input = makeInput([{ role: "user", id: "u1" }]);
+    input.forwardedProps = { streamSubgraphs: false };
+    agent.run(input);
+
+    expect(calls[0].forwardedProps.streamSubgraphs).toBe(false);
+  });
+});

--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
@@ -1,17 +1,20 @@
-import { map, Observable } from "rxjs";
+import type { Observable } from "rxjs";
+import { map } from "rxjs";
 import { LangGraphEventTypes } from "../../../../agents/langgraph/events";
-import { BaseEvent, RawEvent } from "@ag-ui/core";
+import type { BaseEvent, RawEvent } from "@ag-ui/core";
+import type {
+  ProcessedEvents,
+  SchemaKeys,
+  StateEnrichment,
+} from "@ag-ui/langgraph";
 import {
   LangGraphAgent as AGUILangGraphAgent,
   LangGraphHttpAgent,
   type LangGraphAgentConfig,
-  ProcessedEvents,
-  SchemaKeys,
   type State,
-  StateEnrichment,
 } from "@ag-ui/langgraph";
-import { Message as LangGraphMessage } from "@langchain/langgraph-sdk/dist/types.messages";
-import { ThreadState } from "@langchain/langgraph-sdk";
+import type { Message as LangGraphMessage } from "@langchain/langgraph-sdk/dist/types.messages";
+import type { ThreadState } from "@langchain/langgraph-sdk";
 
 interface CopilotKitStateEnrichment {
   copilotkit: {
@@ -20,15 +23,16 @@ interface CopilotKitStateEnrichment {
   };
 }
 
-import { RunAgentInput, EventType, CustomEvent } from "@ag-ui/client";
+import type { RunAgentInput, CustomEvent } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
 
 // Import and re-export from separate file to maintain API compatibility
-import {
-  CustomEventNames,
+import type {
   TextMessageEvents,
   ToolCallEvents,
   PredictStateTool,
 } from "./consts";
+import { CustomEventNames } from "./consts";
 export { CustomEventNames };
 
 export class LangGraphAgent extends AGUILangGraphAgent {
@@ -154,8 +158,18 @@ export class LangGraphAgent extends AGUILangGraphAgent {
 
   // @ts-ignore
   run(input: RunAgentInput): Observable<BaseEvent> {
+    // @ag-ui/langgraph's message converter throws "message role is not
+    // supported." on any role it doesn't enumerate (user|assistant|system|tool).
+    // Reasoning-stream agents (e.g. OpenAI Responses API with reasoning summaries)
+    // emit AG-UI messages with role:"reasoning" that the client then replays on
+    // subsequent turns; without this filter the second turn crashes before the
+    // model is ever called.
+    const messages = (input.messages ?? []).filter(
+      (m: { role?: string }) => m?.role !== "reasoning",
+    );
     const enrichedInput = {
       ...input,
+      messages,
       forwardedProps: {
         ...input.forwardedProps,
         streamSubgraphs: input.forwardedProps?.streamSubgraphs ?? true,

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -11,6 +11,141 @@
       }
     },
     {
+      "_comment": "tool-rendering-reasoning-chain pill 1 (stocks) — final narration after the MSFT tool result lands. Specific toolCallId so this matches BEFORE the first-leg fixture below despite the same userMessage substring. Source: showcase/harness/fixtures/d5/tool-rendering-reasoning-chain.json.",
+      "match": {
+        "userMessage": "Compare AAPL and MSFT stocks",
+        "toolCallId": "call_rc_stock_msft_001"
+      },
+      "response": {
+        "content": "AAPL is at $338.37 (-2.96% on the day) while MSFT is at $412.18 (+1.08%). MSFT is outpacing AAPL by roughly 4 points today — strong day for MSFT, rough one for AAPL."
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 1 (stocks) — second leg: after get_stock_price(AAPL) returns, chain to MSFT for the comparison.",
+      "match": {
+        "userMessage": "Compare AAPL and MSFT stocks",
+        "toolCallId": "call_rc_stock_aapl_001"
+      },
+      "response": {
+        "reasoning": "AAPL quote is in hand. The user explicitly asked to compare AAPL with MSFT, so I'll fetch MSFT next and then summarize the side-by-side.",
+        "content": "Now pulling MSFT to complete the comparison.",
+        "toolCalls": [
+          {
+            "id": "call_rc_stock_msft_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"MSFT\",\"price_usd\":412.18,\"change_pct\":1.08}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 1 (stocks) — first leg: emit get_stock_price(AAPL). The `Compare AAPL and MSFT stocks` substring is unique to this demo's pill prompt — other integrations' reasoning-chain demos still send the older `How is AAPL doing?` prompt — so we don't need a tool-name gate and the fixture stays scoped to langgraph-python without affecting fleet-wide aimock traffic. MUST appear before the bare 'AAPL' fixtures later in this file.",
+      "match": {
+        "userMessage": "Compare AAPL and MSFT stocks"
+      },
+      "response": {
+        "reasoning": "The user asked to compare AAPL and MSFT. I'll fetch AAPL first, then MSFT, then summarize the deltas in a single sentence so the comparison is the punchline.",
+        "content": "Pulling the AAPL quote first.",
+        "toolCalls": [
+          {
+            "id": "call_rc_stock_aapl_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 2 (dice) — final narration after the d6 contrast roll lands. userMessage is the LANGGRAPH-PYTHON-UNIQUE tail of the pill prompt ('compare it to a smaller one'); other integrations' reasoning-chain demos still send the older 'Roll a 20-sided die for me.' (no period-after-die substring match against 'Roll a 20-sided die.') which lacks this suffix — so this fixture stays scoped to this demo and does NOT hijack the older 5x roll_d20 fixtures further down in this file.",
+      "match": {
+        "userMessage": "compare it to a smaller one",
+        "toolCallId": "call_rc_dice_d6_001"
+      },
+      "response": {
+        "content": "The d20 came up 14, and a d6 for contrast landed on 4 — the d20's range is much wider, which is the whole point of the comparison."
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 2 (dice) — second leg: after roll_dice(sides=20) returns, chain a smaller die for contrast.",
+      "match": {
+        "userMessage": "compare it to a smaller one",
+        "toolCallId": "call_rc_dice_d20_001"
+      },
+      "response": {
+        "reasoning": "Got the d20 result. The user explicitly asked to compare it to a smaller die — a d6 is a natural choice because its 1-6 range is what most people picture when they think 'die'. Rolling that next.",
+        "content": "Now rolling a d6 for contrast.",
+        "toolCalls": [
+          {
+            "id": "call_rc_dice_d6_001",
+            "name": "roll_dice",
+            "arguments": "{\"sides\":6}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 2 (dice) — first leg: emit roll_dice(sides=20). Unique substring 'compare it to a smaller one' keeps us scoped to this demo (other integrations' dice pills still send 'Roll a 20-sided die for me.' and fall through to the older 5x roll_d20 fixtures further down). NB: aimock's `toolName` gate is a tool-LIST gate, not a tool-CALL gate; we don't use it here because the reasoning-chain agents across the fleet all register `roll_dice`, so a `toolName: roll_dice` claim would NOT have distinguished this demo from the others.",
+      "match": {
+        "userMessage": "compare it to a smaller one"
+      },
+      "response": {
+        "reasoning": "The user asked for a d20 roll and wants to compare it against a smaller die. I'll roll the d20 first, then chain a smaller die so the contrast in possible-value ranges is concrete and observable.",
+        "content": "Rolling the d20 now.",
+        "toolCalls": [
+          {
+            "id": "call_rc_dice_d20_001",
+            "name": "roll_dice",
+            "arguments": "{\"sides\":20}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 3 (flights + destination weather) — final narration after get_weather(JFK) lands. userMessage is the LANGGRAPH-PYTHON-UNIQUE tail 'show me the weather there'; the basic tool-rendering demos AND every other integration's reasoning-chain demo still send 'Find flights from SFO to JFK.' (no destination-weather request) which lacks this substring, so this fixture stays scoped to this demo without affecting fleet-wide aimock traffic.",
+      "match": {
+        "userMessage": "show me the weather there",
+        "toolCallId": "call_rc_weather_jfk_001"
+      },
+      "response": {
+        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289). JFK is currently 68°F and sunny — easy travel weather on the receiving end."
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 3 (flights + destination weather) — second leg: after search_flights(SFO,JFK) returns, chain to destination weather.",
+      "match": {
+        "userMessage": "show me the weather there",
+        "toolCallId": "call_rc_flights_jfk_001"
+      },
+      "response": {
+        "reasoning": "Flights are in hand. The user explicitly asked for the destination weather as part of the request, so pulling JFK weather next to round out the trip plan.",
+        "content": "Pulling JFK weather to round out the trip plan.",
+        "toolCalls": [
+          {
+            "id": "call_rc_weather_jfk_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"JFK\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-reasoning-chain pill 3 (flights + destination weather) — first leg: emit search_flights(SFO,JFK). The 'show me the weather there' substring is unique to this demo's pill, so the basic tool-rendering demo's bare 'Find flights from SFO to JFK.' prompt (and the equivalent prompts in other integrations' reasoning-chain demos that have not yet been ported to the chained phrasing) flow through to the basic single-tool flights fixture later in the file.",
+      "match": {
+        "userMessage": "show me the weather there"
+      },
+      "response": {
+        "reasoning": "The user wants flights from SFO to JFK AND the destination weather. I'll call search_flights first, then chain get_weather on JFK so they have flight options and arrival conditions in one reply.",
+        "content": "Searching SFO→JFK flights.",
+        "toolCalls": [
+          {
+            "id": "call_rc_flights_jfk_001",
+            "name": "search_flights",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\"}"
+          }
+        ]
+      }
+    },
+    {
       "_comment": "headless-simple pill 1: locks the deterministic greeting leading phrase. The reply is intentionally NON-boilerplate (i.e. NOT the showcase-assistant catch-all 'I can help you with weather lookups...') so the headless-simple spec's HELLO_LEADING assertion fails when fixture priority misroutes this prompt to the catch-all.",
       "match": {
         "userMessage": "Say hello in one short sentence"

--- a/showcase/harness/fixtures/d5/tool-rendering-reasoning-chain.json
+++ b/showcase/harness/fixtures/d5/tool-rendering-reasoning-chain.json
@@ -1,52 +1,135 @@
 {
-  "_comment": "D5 fixture for /demos/tool-rendering-reasoning-chain (LangGraph Python). The demo composes a reasoningMessage slot (<ReasoningBlock data-testid=\"reasoning-block\">) with per-tool renderers (WeatherCard / FlightListCard). Two chip prompts probed: 'What's the weather in Tokyo?' (Turn 1) and 'Find flights from SFO to JFK.' (Turn 2). Each pill is a 2-leg flow: first leg emits the tool call (get_weather / search_flights), a `reasoning` field, AND a non-empty `content` field. The non-empty `content` is load-bearing: aimock's Responses-API dispatch routes tool-call-only responses (no `content`) through `buildToolCallResponse`, which silently drops the `reasoning` payload. Adding a `content` string shifts dispatch to `buildContentWithToolCallsResponse`, which emits the reasoning_summary events the v2 <ReasoningBlock> needs to mount. SFO/JFK (Turn 2) deliberately uses `toolCallId` matching for its second leg and omits `hasToolResult` from its first leg — `hasToolResult` is broken for the second turn of a multi-turn flow because Turn 1's tool result is still in the conversation, so a `hasToolResult: false` first-leg fixture would not match Turn 2's first leg and the matcher would fall through to the `hasToolResult: true` second-leg fixture, returning narration without the tool call and breaking the FlightListCard assertion. With `toolCallId` matching, the second-leg fixture only matches when the LAST conversation message is the tool result for that specific call_id, so it cannot accidentally swallow first-leg requests. The second-leg fixture must come BEFORE the first-leg in this file because the matcher is first-match-wins. Tokyo (Turn 1) keeps the simpler `hasToolResult` pattern because it has no prior turns. The agent uses `init_chat_model(... use_responses_api=True, reasoning={effort:'medium', summary:'detailed'})` — Responses-API mode delivers reasoning summaries alongside tool calls. Mirrored verbatim into showcase/aimock/d5-all.json so re-bundling stays consistent.",
+  "_comment": "D5 fixture for /demos/tool-rendering-reasoning-chain (LangGraph Python). The demo composes a reasoningMessage slot (<ReasoningBlock data-testid=\"reasoning-block\">) with per-tool renderers (WeatherCard / FlightListCard / catchall for stocks & dice). Three pills, all CHAINED — each user prompt drives two tool calls in succession before a final narration. Each first-leg fixture is gated on a `userMessage` substring that ONLY appears in this demo's pill prompts ('Compare AAPL and MSFT stocks for me', 'compare it to a smaller one', 'show me the weather there'). That keeps these fixtures from cross-contaminating the other 14+ integrations whose reasoning-chain demos share `showcase-aimock` on Railway and use overlapping prompts like 'Roll a 20-sided die for me.' or 'Find flights from SFO to JFK.' — those substrings would have been hijacked if we relied on `toolName: roll_dice` alone, because most reasoning-chain agents across the fleet also register `roll_dice`. For multi-pill safety in a single thread each follow-up leg is keyed on the prior step's `toolCallId`; the matcher checks `messages[last].tool_call_id`, which is stable regardless of how many prior pills left tool history in the thread. Ordering within each pill is final-content → second-leg → first-leg (first-match-wins) so the toolCallId-specific fixtures win before the bare first-leg can re-emit. Non-empty `content` is load-bearing on tool-emitting fixtures: aimock's Responses-API dispatch routes tool-call-only responses (no `content`) through `buildToolCallResponse`, which silently drops the `reasoning` payload, and the v2 <ReasoningBlock> never mounts. Mirrored verbatim into showcase/aimock/d5-all.json so re-bundling stays consistent.",
   "fixtures": [
     {
+      "_comment": "Pill 1 (stocks) — final narration after the MSFT tool result lands. Specific toolCallId so this matches BEFORE the first-leg fixture below despite the same userMessage substring.",
       "match": {
-        "userMessage": "weather in Tokyo",
-        "hasToolResult": false,
-        "toolName": "get_weather"
+        "userMessage": "Compare AAPL and MSFT stocks",
+        "toolCallId": "call_rc_stock_msft_001"
       },
       "response": {
-        "reasoning": "The user asked about Tokyo weather. I'll call get_weather with location='Tokyo' to get the current conditions.",
-        "content": "Looking up the weather in Tokyo for you.",
+        "content": "AAPL is at $338.37 (-2.96% on the day) while MSFT is at $412.18 (+1.08%). MSFT is outpacing AAPL by roughly 4 points today — strong day for MSFT, rough one for AAPL."
+      }
+    },
+    {
+      "_comment": "Pill 1 (stocks) — second leg: after get_stock_price(AAPL) returns, chain to MSFT for the comparison.",
+      "match": {
+        "userMessage": "Compare AAPL and MSFT stocks",
+        "toolCallId": "call_rc_stock_aapl_001"
+      },
+      "response": {
+        "reasoning": "AAPL quote is in hand. The user explicitly asked to compare AAPL with MSFT, so I'll fetch MSFT next and then summarize the side-by-side.",
+        "content": "Now pulling MSFT to complete the comparison.",
         "toolCalls": [
           {
-            "id": "call_d5_get_weather_001",
-            "name": "get_weather",
-            "arguments": "{\"location\":\"Tokyo\"}"
+            "id": "call_rc_stock_msft_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"MSFT\",\"price_usd\":412.18,\"change_pct\":1.08}"
           }
         ]
       }
     },
     {
+      "_comment": "Pill 1 (stocks) — first leg: emit get_stock_price(AAPL). The `Compare AAPL and MSFT stocks` substring is unique to this demo's pill — other integrations' reasoning-chain demos still ship the older `How is AAPL doing?` prompt — so we don't need an additional tool-name gate.",
       "match": {
-        "userMessage": "weather in Tokyo",
-        "hasToolResult": true
+        "userMessage": "Compare AAPL and MSFT stocks"
       },
       "response": {
-        "content": "Tokyo is 22°C and partly cloudy."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Find flights from SFO to JFK.",
-        "toolCallId": "call_tr_flights_sfo_jfk_001"
-      },
-      "response": {
-        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Find flights from SFO to JFK."
-      },
-      "response": {
-        "reasoning": "The user wants flights from SFO to JFK. I'll call search_flights with those airports to look up options.",
-        "content": "Searching for flights from SFO to JFK.",
+        "reasoning": "The user asked to compare AAPL and MSFT. I'll fetch AAPL first, then MSFT, then summarize the deltas in a single sentence so the comparison is the punchline.",
+        "content": "Pulling the AAPL quote first.",
         "toolCalls": [
           {
-            "id": "call_tr_flights_sfo_jfk_001",
+            "id": "call_rc_stock_aapl_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Pill 2 (dice) — final narration after the d6 contrast roll lands. userMessage is the LANGGRAPH-PYTHON-UNIQUE tail of the pill prompt ('compare it to a smaller one'); other integrations' dice pills (e.g. agno, ms-agent-python) still send the older 'Roll a 20-sided die for me.' which does NOT contain this substring, so this fixture stays scoped to this demo without needing a fragile tool-name gate.",
+      "match": {
+        "userMessage": "compare it to a smaller one",
+        "toolCallId": "call_rc_dice_d6_001"
+      },
+      "response": {
+        "content": "The d20 came up 14, and a d6 for contrast landed on 4 — the d20's range is much wider, which is the whole point of the comparison."
+      }
+    },
+    {
+      "_comment": "Pill 2 (dice) — second leg: after roll_dice(sides=20) returns, chain a smaller die for contrast.",
+      "match": {
+        "userMessage": "compare it to a smaller one",
+        "toolCallId": "call_rc_dice_d20_001"
+      },
+      "response": {
+        "reasoning": "Got the d20 result. The user explicitly asked to compare it to a smaller die — a d6 is a natural choice because its 1-6 range is what most people picture when they think 'die'. Rolling that next.",
+        "content": "Now rolling a d6 for contrast.",
+        "toolCalls": [
+          {
+            "id": "call_rc_dice_d6_001",
+            "name": "roll_dice",
+            "arguments": "{\"sides\":6}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Pill 2 (dice) — first leg: emit roll_dice(sides=20). Unique substring keeps us scoped to this demo (other integrations send the bare 'Roll a 20-sided die for me.' which falls through to the older 5x roll_d20 fixtures further down in d5-all.json).",
+      "match": {
+        "userMessage": "compare it to a smaller one"
+      },
+      "response": {
+        "reasoning": "The user asked for a d20 roll and wants to compare it against a smaller die. I'll roll the d20 first, then chain a smaller die so the contrast in possible-value ranges is concrete and observable.",
+        "content": "Rolling the d20 now.",
+        "toolCalls": [
+          {
+            "id": "call_rc_dice_d20_001",
+            "name": "roll_dice",
+            "arguments": "{\"sides\":20}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Pill 3 (flights + destination weather) — final narration after get_weather(JFK) lands. userMessage is the LANGGRAPH-PYTHON-UNIQUE tail of the pill prompt ('show me the weather there'); the basic tool-rendering demos AND the other integrations' reasoning-chain demos still send 'Find flights from SFO to JFK.' which lacks this substring, so this fixture stays scoped to this demo.",
+      "match": {
+        "userMessage": "show me the weather there",
+        "toolCallId": "call_rc_weather_jfk_001"
+      },
+      "response": {
+        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289). JFK is currently 68°F and sunny — easy travel weather on the receiving end."
+      }
+    },
+    {
+      "_comment": "Pill 3 (flights + destination weather) — second leg: after search_flights(SFO,JFK) returns, chain to destination weather.",
+      "match": {
+        "userMessage": "show me the weather there",
+        "toolCallId": "call_rc_flights_jfk_001"
+      },
+      "response": {
+        "reasoning": "Flights are in hand. The user explicitly asked for the destination weather as part of the request, so pulling JFK weather next to round out the trip plan.",
+        "content": "Pulling JFK weather to round out the trip plan.",
+        "toolCalls": [
+          {
+            "id": "call_rc_weather_jfk_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"JFK\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Pill 3 (flights + destination weather) — first leg: emit search_flights(SFO,JFK). The unique 'show me the weather there' substring keeps this fixture from absorbing the basic tool-rendering demo's bare 'Find flights from SFO to JFK.' prompt (and the equivalent prompt in other integrations' reasoning-chain demos that have not yet been ported to the chained phrasing).",
+      "match": {
+        "userMessage": "show me the weather there"
+      },
+      "response": {
+        "reasoning": "The user wants flights from SFO to JFK AND the destination weather. I'll call search_flights first, then chain get_weather on JFK so they have flight options and arrival conditions in one reply.",
+        "content": "Searching SFO→JFK flights.",
+        "toolCalls": [
+          {
+            "id": "call_rc_flights_jfk_001",
             "name": "search_flights",
             "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\"}"
           }

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
@@ -10,55 +10,127 @@
  *      `messageView.reasoningMessage` slot
  *      (`<ReasoningBlock data-testid="reasoning-block">`).
  *   2. Per-tool renderers wired through `useRenderTool`:
- *        get_weather    → <WeatherCard />
- *        search_flights → <FlightListCard />
- *        get_stock_price / roll_dice → <CustomCatchallRenderer />
+ *        get_weather    → <WeatherCard data-testid="weather-card" />
+ *        search_flights → <FlightListCard data-testid="flight-list-card" />
+ *        get_stock_price / roll_dice → <CustomCatchallRenderer
+ *          data-testid="custom-catchall-card" data-tool-name="..." />
  *
- * Single-turn flow (chip-driven):
- *   "Find flights from SFO to JFK and show me the weather there."
- *     → reasoning-block + FlightListCard + WeatherCard.
- *   This pill is CHAINED (search_flights → get_weather(JFK)) so a single
- *   turn exercises BOTH per-tool renderers — covering all the wiring the
- *   previous two-turn Tokyo+SFO script covered, at half the wall-clock.
- *   Asserts ALL THREE testids mount (reasoning-block, flight-list-card,
- *   weather-card), plus assistant transcript mentions "sfo".
+ * Three-turn flow in ONE thread (chip-driven). Each pill drives a
+ * CHAINED two-tool flow with reasoning summaries between iterations:
  *
- * The reasoning-block assertion is what makes this probe distinct from
- * `tool-rendering` (no reasoning slot) and from `reasoning-display`
- * (no per-tool renderers). A regression that drops the reasoning slot
- * OR the tool-renderer wiring OR the chained-tool-call behavior is
- * caught here. The catchall variants (dice / stocks) are covered
- * separately by `tool-rendering-custom-catchall`.
+ *   1. "Compare AAPL and MSFT stocks for me."
+ *      → get_stock_price(AAPL) → get_stock_price(MSFT) → comparison.
+ *      Asserts reasoning-block + 2 custom-catchall-card[tool=get_stock_price].
+ *   2. "Roll a 20-sided die for me and compare it to a smaller one."
+ *      → roll_dice(sides=20) → roll_dice(sides=6) → contrast narration.
+ *      Asserts reasoning-block + 2 custom-catchall-card[tool=roll_dice].
+ *   3. "Find flights from SFO to JFK and show me the weather there."
+ *      → search_flights(SFO,JFK) → get_weather(JFK) → trip-plan narration.
+ *      Asserts reasoning-block + flight-list-card + weather-card.
+ *
+ * The three-turns-in-one-thread shape is load-bearing: it's the
+ * regression guard for the AG-UI reasoning-role message bug. Without
+ * the `LangGraphAgent.run` reasoning-role filter (in
+ * @copilotkit/runtime), the SECOND turn used to crash before the model
+ * was called because @ag-ui/langgraph's message converter throws on
+ * `role:"reasoning"` messages the client replayed from turn 1. If that
+ * filter regresses, turn 2 fails here with INCOMPLETE_STREAM.
+ *
+ * The reasoning-block assertion on every turn is the second regression
+ * guard: it catches a drop of the reasoning slot wiring OR a model
+ * config drift back to `summary:"auto"` that silently skips summaries.
+ * The catchall card[tool=...] assertions catch the CustomCatchallRenderer
+ * regressing, plus the fixture chain advancing fully (not stopping at
+ * the first tool call).
+ *
+ * If you reduce the per-turn count, you LOSE multi-pill safety coverage.
+ * Keep three turns.
  */
 
 import { registerD5Script } from "../helpers/d5-registry.js";
 import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 
+/** The harness `Page` interface intentionally narrows the surface to
+ *  `waitForSelector` + `evaluate` (see conversation-runner.ts). At
+ *  runtime the underlying object IS a real Playwright Page, so we cast
+ *  to a slightly wider shape here for the multi-pill polling we need —
+ *  counting elements that match a selector and short sleeps between
+ *  polls. Cast scope is limited to this file. */
+interface CountablePage extends Page {
+  locator(selector: string): { count(): Promise<number> };
+  waitForTimeout(ms: number): Promise<void>;
+}
+
+const POLL_INTERVAL_MS = 250;
+
+interface CardSelector {
+  /** Card `data-testid`. Custom-catchall cards share one testid across
+   *  every catchall-rendered tool — combine with `toolName` to scope to
+   *  a specific tool. */
+  testId: string;
+  /** When set, restrict the selector to cards whose `data-tool-name`
+   *  matches. Required for `custom-catchall-card` because both stocks
+   *  AND dice render through it; omitted for branded per-tool cards
+   *  (`flight-list-card`, `weather-card`) where the testid is unique. */
+  toolName?: string;
+  /** Minimum visible count for this card group in this turn. `1` for the
+   *  branded per-tool cards (one flight list per turn). `2` for the
+   *  catchall cards because each pill chains a pair of calls (AAPL+MSFT,
+   *  d20+d6). */
+  minCount: number;
+}
+
 interface PillExpectation {
   /** Chip prompt — MUST mirror `tool-rendering-reasoning-chain/page.tsx`
    *  suggestion-chip messages verbatim so aimock's `userMessage`
    *  substring matcher selects the right canned response. */
   prompt: string;
-  /** Per-tool card testids to wait for. Chained pills emit multiple tool
-   *  calls in succession, so this is a list — the assertion succeeds only
-   *  if EVERY listed testid mounts within `CARD_TIMEOUT_MS`. */
-  cardTestIds: readonly string[];
-  /** Lowercase substrings the assistant transcript must contain. */
+  /** Card groups expected in this turn. Each entry has a minimum count
+   *  so chained pills can require BOTH tool calls' cards before the
+   *  turn is considered passing. */
+  cards: readonly CardSelector[];
+  /** Lowercase substrings the assistant transcript must contain. The
+   *  transcript is the cumulative across-turns view, so each turn's
+   *  expected substring should be unique to its narration. */
   textTokens: readonly string[];
-  /** Per-turn budget — agent reasoning + tool call + render. */
+  /** Per-turn budget — agent reasoning + 2 chained tool calls + render. */
   responseTimeoutMs: number;
 }
 
 const TURN_EXPECTATIONS: readonly PillExpectation[] = [
   {
-    // Pill 3 in page.tsx — chained flights + destination weather.
-    // Exercises BOTH per-tool renderers (FlightListCard + WeatherCard) in
-    // a single turn, so this one prompt covers the full per-tool wiring.
+    // Pill 1 — chained stocks comparison (AAPL → MSFT).
+    prompt: "Compare AAPL and MSFT stocks for me.",
+    cards: [
+      {
+        testId: "custom-catchall-card",
+        toolName: "get_stock_price",
+        minCount: 2,
+      },
+    ],
+    textTokens: ["aapl", "msft"],
+    responseTimeoutMs: 90_000,
+  },
+  {
+    // Pill 2 — chained dice contrast (d20 → d6).
+    prompt: "Roll a 20-sided die for me and compare it to a smaller one.",
+    cards: [
+      { testId: "custom-catchall-card", toolName: "roll_dice", minCount: 2 },
+    ],
+    textTokens: ["d20"],
+    responseTimeoutMs: 90_000,
+  },
+  {
+    // Pill 3 — chained flights + destination weather (SFO→JFK + JFK).
+    // Exercises BOTH branded per-tool renderers in one turn.
     prompt: "Find flights from SFO to JFK and show me the weather there.",
-    cardTestIds: ["flight-list-card", "weather-card"],
-    textTokens: ["sfo"],
-    responseTimeoutMs: 60_000,
+    cards: [
+      { testId: "flight-list-card", minCount: 1 },
+      { testId: "weather-card", minCount: 1 },
+    ],
+    textTokens: ["sfo", "jfk"],
+    responseTimeoutMs: 90_000,
   },
 ];
 
@@ -111,54 +183,78 @@ function assertContainsAll(
   }
 }
 
+/** Builds the CSS selector for a card group. `data-tool-name` lets us
+ *  scope catchall cards to a specific tool — without it, the catchall
+ *  testid matches BOTH the prior turn's stock cards AND the current
+ *  turn's dice cards in a multi-pill thread. */
+function cardSelector(card: CardSelector): string {
+  const base = `[data-testid="${card.testId}"]`;
+  return card.toolName
+    ? `${base}[data-tool-name="${card.toolName}"]`
+    : base;
+}
+
 export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
   return TURN_EXPECTATIONS.map((exp, idx) => ({
     input: exp.prompt,
     responseTimeoutMs: exp.responseTimeoutMs,
     assertions: async (page) => {
       const tag = `tool-rendering-reasoning-chain turn ${idx + 1}`;
+      const pw = page as CountablePage;
 
-      // 1. Wait for the reasoning-block to mount. The agent's reasoning
-      //    chain is the distinguishing signal vs the plain tool-rendering
-      //    probe — if this never mounts, the reasoning slot wiring
-      //    regressed.
-      try {
-        await page.waitForSelector(
-          `[data-testid="${REASONING_BLOCK_TESTID}"]`,
-          {
-            state: "visible",
-            timeout: REASONING_TIMEOUT_MS,
-          },
-        );
-      } catch {
+      // 1. Reasoning-block count must INCREASE this turn vs the prior
+      //    turn. A simple "visible" wait isn't enough on turn 2/3 — the
+      //    block from turn 1 is still in the DOM. Counting catches a
+      //    regression where the agent stops emitting reasoning summaries
+      //    on follow-up turns (e.g. `summary:"auto"` drift) even though
+      //    the FIRST turn renders fine.
+      const reasoningBlocks = pw.locator(
+        `[data-testid="${REASONING_BLOCK_TESTID}"]`,
+      );
+      const expectedReasoningCount = idx + 1;
+      const reasoningStart = Date.now();
+      while (Date.now() - reasoningStart < REASONING_TIMEOUT_MS) {
+        const count = await reasoningBlocks.count();
+        if (count >= expectedReasoningCount) break;
+        await pw.waitForTimeout(POLL_INTERVAL_MS);
+      }
+      const reasoningCount = await reasoningBlocks.count();
+      if (reasoningCount < expectedReasoningCount) {
         throw new Error(
-          `${tag}: expected [data-testid="${REASONING_BLOCK_TESTID}"] to mount within ${REASONING_TIMEOUT_MS}ms — reasoningMessage slot may be unwired or agent's reasoning tokens never streamed`,
+          `${tag}: expected at least ${expectedReasoningCount} [data-testid="${REASONING_BLOCK_TESTID}"] mounts within ${REASONING_TIMEOUT_MS}ms but saw ${reasoningCount} — reasoningMessage slot may be unwired, or the agent stopped emitting reasoning summaries on this turn`,
         );
       }
 
-      // 2. Wait for every per-tool card to mount. Chained pills emit
-      //    multiple tool calls in one turn — each must land its dedicated
-      //    renderer (NOT the catchall fallback). Asserting all of them
-      //    catches the case where the second tool call regresses while
-      //    the first still works.
-      for (const cardTestId of exp.cardTestIds) {
-        try {
-          await page.waitForSelector(`[data-testid="${cardTestId}"]`, {
-            state: "visible",
-            timeout: CARD_TIMEOUT_MS,
-          });
-        } catch {
+      // 2. Each card group's minimum count must be reached. Counting
+      //    rather than "visible" catches:
+      //      a. chain stopping after the first tool call (only 1 card
+      //         where we expect 2 — the second-leg fixture didn't fire);
+      //      b. on multi-pill turns, regression in toolCallId-keyed
+      //         follow-up fixtures (the chain would silently degrade to
+      //         single-tool again).
+      //    Catchall cards accumulate across turns; the per-turn minimum
+      //    here is the delta we need to see by end of this turn.
+      for (const card of exp.cards) {
+        const sel = cardSelector(card);
+        const locator = pw.locator(sel);
+        const cardStart = Date.now();
+        while (Date.now() - cardStart < CARD_TIMEOUT_MS) {
+          const count = await locator.count();
+          if (count >= card.minCount) break;
+          await pw.waitForTimeout(POLL_INTERVAL_MS);
+        }
+        const count = await locator.count();
+        if (count < card.minCount) {
           throw new Error(
-            `${tag}: expected [data-testid="${cardTestId}"] to mount within ${CARD_TIMEOUT_MS}ms — tool result may not have landed or the per-tool renderer wiring drifted`,
+            `${tag}: expected at least ${card.minCount} ${sel} within ${CARD_TIMEOUT_MS}ms but saw ${count} — tool chain may have stopped at the first call, or the per-tool renderer wiring drifted`,
           );
         }
       }
 
-      // 3. Verify the assistant transcript references the right context
-      //    (e.g. "sfo" for the SFO→JFK chain). The card mounting alone
-      //    proves wiring; the text token catches the case where a stale
-      //    fixture from a prior turn satisfies the testid wait but
-      //    contains the wrong route.
+      // 3. Verify the assistant transcript contains this turn's unique
+      //    tokens. The card mounting alone proves wiring; the text token
+      //    catches the case where a stale fixture from a prior turn
+      //    satisfies the testid wait but contains the wrong content.
       const text = await readAssistantTranscript(page);
       console.debug(`[d5-tool-rendering-reasoning-chain] ${tag} text`, {
         text: text.slice(0, 300),

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
@@ -189,9 +189,7 @@ function assertContainsAll(
  *  turn's dice cards in a multi-pill thread. */
 function cardSelector(card: CardSelector): string {
   const base = `[data-testid="${card.testId}"]`;
-  return card.toolName
-    ? `${base}[data-tool-name="${card.toolName}"]`
-    : base;
+  return card.toolName ? `${base}[data-tool-name="${card.toolName}"]` : base;
 }
 
 export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
@@ -4,34 +4,31 @@
  * Drives `/demos/tool-rendering-reasoning-chain`. The demo composes
  * two patterns into one chat surface:
  *
- *   1. Reasoning tokens streamed by `init_chat_model("openai:gpt-5-mini",
- *      use_responses_api=True, reasoning={"effort":"low"})` and rendered
- *      via a custom `messageView.reasoningMessage` slot
+ *   1. Reasoning tokens streamed by `init_chat_model("openai:gpt-5.4",
+ *      use_responses_api=True, reasoning={"effort":"medium",
+ *      "summary":"detailed"})` and rendered via a custom
+ *      `messageView.reasoningMessage` slot
  *      (`<ReasoningBlock data-testid="reasoning-block">`).
  *   2. Per-tool renderers wired through `useRenderTool`:
  *        get_weather    → <WeatherCard />
  *        search_flights → <FlightListCard />
  *        get_stock_price / roll_dice → <CustomCatchallRenderer />
  *
- * Two-turn flow (chip-driven):
- *   1. "What's the weather in Tokyo?" → reasoning-block + WeatherCard.
- *      Asserts BOTH the reasoning-block testid AND the weather-card
- *      testid mount, plus assistant transcript mentions "tokyo".
- *   2. "Find flights from SFO to JFK." → reasoning-block + FlightListCard.
- *      Asserts BOTH the reasoning-block testid AND the flight-list-card
- *      testid mount, plus assistant transcript mentions a flight token
- *      ("flight" / "sfo" / "jfk").
- *
- * Two pills (vs all four — dice / AAPL) keep wall-clock under the
- * default per-feature ceiling; the two we pick are the ones with
- * deterministic per-tool renderers (WeatherCard + FlightListCard), so
- * the assertion ladder stays sharp. The catchall variants (dice / AAPL)
- * are covered separately by `tool-rendering-custom-catchall`.
+ * Single-turn flow (chip-driven):
+ *   "Find flights from SFO to JFK and show me the weather there."
+ *     → reasoning-block + FlightListCard + WeatherCard.
+ *   This pill is CHAINED (search_flights → get_weather(JFK)) so a single
+ *   turn exercises BOTH per-tool renderers — covering all the wiring the
+ *   previous two-turn Tokyo+SFO script covered, at half the wall-clock.
+ *   Asserts ALL THREE testids mount (reasoning-block, flight-list-card,
+ *   weather-card), plus assistant transcript mentions "sfo".
  *
  * The reasoning-block assertion is what makes this probe distinct from
  * `tool-rendering` (no reasoning slot) and from `reasoning-display`
  * (no per-tool renderers). A regression that drops the reasoning slot
- * OR the tool renderer wiring is caught here.
+ * OR the tool-renderer wiring OR the chained-tool-call behavior is
+ * caught here. The catchall variants (dice / stocks) are covered
+ * separately by `tool-rendering-custom-catchall`.
  */
 
 import { registerD5Script } from "../helpers/d5-registry.js";
@@ -43,9 +40,10 @@ interface PillExpectation {
    *  suggestion-chip messages verbatim so aimock's `userMessage`
    *  substring matcher selects the right canned response. */
   prompt: string;
-  /** Per-tool card testid to wait for (after the agent's tool result
-   *  lands). */
-  cardTestId: string;
+  /** Per-tool card testids to wait for. Chained pills emit multiple tool
+   *  calls in succession, so this is a list — the assertion succeeds only
+   *  if EVERY listed testid mounts within `CARD_TIMEOUT_MS`. */
+  cardTestIds: readonly string[];
   /** Lowercase substrings the assistant transcript must contain. */
   textTokens: readonly string[];
   /** Per-turn budget — agent reasoning + tool call + render. */
@@ -54,14 +52,11 @@ interface PillExpectation {
 
 const TURN_EXPECTATIONS: readonly PillExpectation[] = [
   {
-    prompt: "What's the weather in Tokyo?",
-    cardTestId: "weather-card",
-    textTokens: ["tokyo"],
-    responseTimeoutMs: 60_000,
-  },
-  {
-    prompt: "Find flights from SFO to JFK.",
-    cardTestId: "flight-list-card",
+    // Pill 3 in page.tsx — chained flights + destination weather.
+    // Exercises BOTH per-tool renderers (FlightListCard + WeatherCard) in
+    // a single turn, so this one prompt covers the full per-tool wiring.
+    prompt: "Find flights from SFO to JFK and show me the weather there.",
+    cardTestIds: ["flight-list-card", "weather-card"],
     textTokens: ["sfo"],
     responseTimeoutMs: 60_000,
   },
@@ -141,25 +136,29 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
         );
       }
 
-      // 2. Wait for the per-tool card to mount. This proves the tool
-      //    call landed AND the per-tool renderer fired (NOT the
-      //    catchall fallback).
-      try {
-        await page.waitForSelector(`[data-testid="${exp.cardTestId}"]`, {
-          state: "visible",
-          timeout: CARD_TIMEOUT_MS,
-        });
-      } catch {
-        throw new Error(
-          `${tag}: expected [data-testid="${exp.cardTestId}"] to mount within ${CARD_TIMEOUT_MS}ms — tool result may not have landed or the per-tool renderer wiring drifted`,
-        );
+      // 2. Wait for every per-tool card to mount. Chained pills emit
+      //    multiple tool calls in one turn — each must land its dedicated
+      //    renderer (NOT the catchall fallback). Asserting all of them
+      //    catches the case where the second tool call regresses while
+      //    the first still works.
+      for (const cardTestId of exp.cardTestIds) {
+        try {
+          await page.waitForSelector(`[data-testid="${cardTestId}"]`, {
+            state: "visible",
+            timeout: CARD_TIMEOUT_MS,
+          });
+        } catch {
+          throw new Error(
+            `${tag}: expected [data-testid="${cardTestId}"] to mount within ${CARD_TIMEOUT_MS}ms — tool result may not have landed or the per-tool renderer wiring drifted`,
+          );
+        }
       }
 
       // 3. Verify the assistant transcript references the right context
-      //    (tokyo for weather, sfo for flights). The card mounting alone
+      //    (e.g. "sfo" for the SFO→JFK chain). The card mounting alone
       //    proves wiring; the text token catches the case where a stale
       //    fixture from a prior turn satisfies the testid wait but
-      //    contains the wrong city/route.
+      //    contains the wrong route.
       const text = await readAssistantTranscript(page);
       console.debug(`[d5-tool-rendering-reasoning-chain] ${tag} text`, {
         text: text.slice(0, 300),

--- a/showcase/integrations/langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py
@@ -42,12 +42,31 @@ def search_flights(origin: str, destination: str) -> dict:
 
 
 @tool
-def get_stock_price(ticker: str) -> dict:
-    """Get a mock current price for a stock ticker."""
+def get_stock_price(
+    ticker: str,
+    price_usd: float | None = None,
+    change_pct: float | None = None,
+) -> dict:
+    """Get a mock current price for a stock ticker.
+
+    The optional `price_usd` and `change_pct` arguments let the LLM (or
+    aimock fixture) script a deterministic ticker quote for testing —
+    when supplied, the tool echoes them back verbatim. Mirrors the
+    basic tool-rendering agent's signature so the aimock fixtures shared
+    across both demos can script chained AAPL/MSFT comparisons.
+    """
     return {
         "ticker": ticker.upper(),
-        "price_usd": round(100 + randint(0, 400) + randint(0, 99) / 100, 2),
-        "change_pct": round(choice([-1, 1]) * (randint(0, 300) / 100), 2),
+        "price_usd": (
+            round(float(price_usd), 2)
+            if price_usd is not None
+            else round(100 + randint(0, 400) + randint(0, 99) / 100, 2)
+        ),
+        "change_pct": (
+            round(float(change_pct), 2)
+            if change_pct is not None
+            else round(choice([-1, 1]) * (randint(0, 300) / 100), 2)
+        ),
     }
 
 

--- a/showcase/integrations/langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py
@@ -58,8 +58,27 @@ def roll_dice(sides: int = 6) -> dict:
 
 
 SYSTEM_PROMPT = (
-    "You are a travel & lifestyle concierge. When a user asks a question, "
-    "reason step-by-step and call 2+ tools in succession when relevant."
+    "You are a helpful travel & lifestyle concierge with mock tools for "
+    "weather, flights, stock prices, and dice rolls — they all return "
+    "fake data, so call them liberally.\n\n"
+    "Your habit is to CHAIN tools when one answer naturally invites "
+    "another. For a single user question, call at least TWO tools in "
+    "succession when the topic allows, then compose your final reply. "
+    "Default chains:\n"
+    "  - 'What's the weather in <city>?' -> call get_weather(<city>), "
+    "then call search_flights(origin='SFO', destination=<city>) so the "
+    "user also sees how to get there.\n"
+    "  - 'How is <ticker> doing?' -> call get_stock_price(<ticker>), "
+    "then call get_stock_price on a comparable ticker (e.g. 'MSFT' or "
+    "'GOOGL') so the user can compare.\n"
+    "  - 'Roll a 20-sided die' -> call roll_dice(sides=20), then call "
+    "roll_dice again with a different number of sides so the user sees "
+    "a contrast.\n"
+    "  - 'Find flights from <a> to <b>' -> call search_flights(a, b), "
+    "then call get_weather(<b>) for the destination.\n\n"
+    "Only skip chaining when the user has clearly asked for a single, "
+    "atomic answer and more tool calls would feel intrusive. Never "
+    "fabricate data that a tool could provide."
 )
 
 REASONING_MODEL = os.environ.get("OPENAI_REASONING_MODEL", "gpt-5.4")

--- a/showcase/integrations/langgraph-python/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -123,14 +123,16 @@ function Chat() {
   useConfigureSuggestions({
     suggestions: [
       {
-        title: "Weather + flights to Tokyo",
-        message: "What's the weather in Tokyo?",
+        title: "Compare two stocks",
+        message: "Compare AAPL and MSFT stocks for me.",
       },
-      { title: "Compare two stocks", message: "How is AAPL doing?" },
-      { title: "Chain of dice rolls", message: "Roll a 20-sided die for me." },
+      {
+        title: "Chain of dice rolls",
+        message: "Roll a 20-sided die for me and compare it to a smaller one.",
+      },
       {
         title: "Flights + destination weather",
-        message: "Find flights from SFO to JFK.",
+        message: "Find flights from SFO to JFK and show me the weather there.",
       },
     ],
     available: "always",

--- a/showcase/integrations/langgraph-python/tests/e2e/tool-rendering-reasoning-chain.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/tool-rendering-reasoning-chain.spec.ts
@@ -1,0 +1,249 @@
+import { test, expect } from "@playwright/test";
+
+// QA reference: qa/tool-rendering-reasoning-chain.md
+// Demo source: src/app/demos/tool-rendering-reasoning-chain/page.tsx
+//
+// The reasoning-chain cell composes two patterns into one chat surface:
+//   - Reasoning-summary streaming (OpenAI Responses API, `reasoning={
+//     "effort":"medium","summary":"detailed"}`) rendered through a
+//     `messageView.reasoningMessage` slot (<ReasoningBlock>).
+//   - Per-tool renderers wired via `useRenderTool` for `get_weather` and
+//     `search_flights`, plus a `useDefaultRenderTool` catchall that
+//     paints `get_stock_price` and `roll_dice`.
+//
+// Every pill drives a CHAINED two-tool flow:
+//   - Stocks: get_stock_price(AAPL) → get_stock_price(MSFT) → comparison.
+//   - Dice: roll_dice(sides=20) → roll_dice(sides=6) → contrast.
+//   - Flights+weather: search_flights(SFO,JFK) → get_weather(JFK) → plan.
+//
+// Aimock fixtures live in showcase/aimock/d5-all.json (and the matching
+// harness source at showcase/harness/fixtures/d5/tool-rendering-
+// reasoning-chain.json) and pin every pill to a deterministic two-leg
+// chain. The sequential-pills test is the regression guard for the
+// AG-UI reasoning-role message bug in @copilotkit/runtime — without
+// `LangGraphAgent.run`'s reasoning-role filter, clicking a second pill
+// in the same thread used to crash with INCOMPLETE_STREAM because
+// @ag-ui/langgraph's message converter throws on `role:"reasoning"`.
+
+const SUGGESTION_TIMEOUT = 15_000;
+const TOOL_TIMEOUT = 60_000;
+const REASONING_TIMEOUT = 30_000;
+
+const PILLS = [
+  "Compare two stocks",
+  "Chain of dice rolls",
+  "Flights + destination weather",
+] as const;
+
+test.describe("Tool Rendering — Reasoning Chain", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/tool-rendering-reasoning-chain");
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible({
+      timeout: SUGGESTION_TIMEOUT,
+    });
+  });
+
+  test("page loads with composer and 3 suggestion pills", async ({ page }) => {
+    const suggestions = page.locator('[data-testid="copilot-suggestion"]');
+    for (const title of PILLS) {
+      await expect(suggestions.filter({ hasText: title }).first()).toBeVisible({
+        timeout: SUGGESTION_TIMEOUT,
+      });
+    }
+
+    // Sanity: no per-tool cards mounted before any pill click.
+    await expect(page.locator('[data-testid="weather-card"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="flight-list-card"]')).toHaveCount(
+      0,
+    );
+    await expect(page.locator('[data-testid="custom-catchall-card"]')).toHaveCount(
+      0,
+    );
+    await expect(page.locator('[data-testid="reasoning-block"]')).toHaveCount(
+      0,
+    );
+  });
+
+  test("Compare two stocks pill chains AAPL → MSFT through the catchall renderer", async ({
+    page,
+  }) => {
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Compare two stocks" })
+      .first()
+      .click();
+
+    // Both legs of the chain mount via the catchall renderer — scoped
+    // by `data-tool-name` so we'd notice if a future per-tool stock
+    // renderer landed and only one card rendered.
+    const stockCards = page.locator(
+      '[data-testid="custom-catchall-card"][data-tool-name="get_stock_price"]',
+    );
+    await expect
+      .poll(async () => stockCards.count(), { timeout: TOOL_TIMEOUT })
+      .toBe(2);
+
+    // Reasoning slot mounts at least once — proves the agent's
+    // reasoning summaries reached the messageView slot, which is the
+    // whole reason this cell exists vs the plain tool-rendering demo.
+    await expect(
+      page.locator('[data-testid="reasoning-block"]').first(),
+    ).toBeVisible({ timeout: REASONING_TIMEOUT });
+
+    // Narration text comes from the fixture final-content leg.
+    await expect(page.getByText("AAPL is at")).toBeVisible({
+      timeout: TOOL_TIMEOUT,
+    });
+    await expect(page.getByText("MSFT is at")).toBeVisible({
+      timeout: TOOL_TIMEOUT,
+    });
+  });
+
+  test("Chain of dice rolls pill chains d20 → d6 through the catchall renderer", async ({
+    page,
+  }) => {
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Chain of dice rolls" })
+      .first()
+      .click();
+
+    const diceCards = page.locator(
+      '[data-testid="custom-catchall-card"][data-tool-name="roll_dice"]',
+    );
+    await expect
+      .poll(async () => diceCards.count(), { timeout: TOOL_TIMEOUT })
+      .toBe(2);
+
+    await expect(
+      page.locator('[data-testid="reasoning-block"]').first(),
+    ).toBeVisible({ timeout: REASONING_TIMEOUT });
+
+    // Final narration mentions both dice + the contrast framing.
+    await expect(page.getByText(/d20 came up/i)).toBeVisible({
+      timeout: TOOL_TIMEOUT,
+    });
+  });
+
+  test("Flights + destination weather pill chains search_flights → get_weather through branded per-tool renderers", async ({
+    page,
+  }) => {
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Flights + destination weather" })
+      .first()
+      .click();
+
+    // Flights card uses its branded renderer (not the catchall).
+    const flights = page.locator('[data-testid="flight-list-card"]').first();
+    await expect(flights).toBeVisible({ timeout: TOOL_TIMEOUT });
+    await expect(flights.locator('[data-testid="flight-origin"]')).toContainText(
+      "SFO",
+      { timeout: TOOL_TIMEOUT },
+    );
+    await expect(
+      flights.locator('[data-testid="flight-destination"]'),
+    ).toContainText("JFK", { timeout: TOOL_TIMEOUT });
+
+    // Destination weather card uses its branded renderer.
+    const weather = page.locator('[data-testid="weather-card"]').first();
+    await expect(weather).toBeVisible({ timeout: TOOL_TIMEOUT });
+    await expect(weather.locator('[data-testid="weather-city"]')).toContainText(
+      "JFK",
+      { timeout: TOOL_TIMEOUT },
+    );
+
+    await expect(
+      page.locator('[data-testid="reasoning-block"]').first(),
+    ).toBeVisible({ timeout: REASONING_TIMEOUT });
+
+    // Catchall renderer must NOT mount for these tools — both have
+    // per-tool registrations.
+    await expect(
+      page.locator('[data-testid="custom-catchall-card"]'),
+    ).toHaveCount(0);
+  });
+
+  // REGRESSION for the AG-UI reasoning-role message bug:
+  //   `@ag-ui/langgraph`'s message converter throws "message role is
+  //   not supported." on any role outside {user,assistant,system,tool}.
+  //   Reasoning-stream agents emit `role:"reasoning"` messages that the
+  //   AG-UI client replays on subsequent turns. Without the
+  //   reasoning-role filter in @copilotkit/runtime's LangGraphAgent.run
+  //   subclass, the SECOND pill click crashes before the model is
+  //   called and the user sees a runtime error toast.
+  //
+  // This test clicks all three pills sequentially in ONE thread and
+  // asserts the full chain renders for each — proving cross-turn safety.
+  // It also catches a regression in any of:
+  //   - The fixture toolCallId chains (degrading multi-pill to single
+  //     tool calls).
+  //   - The reasoning summary emission on follow-up turns.
+  //   - Per-tool renderer state isolation between turns.
+  test("sequential pills in one thread render full chains + reasoning blocks for each", async ({
+    page,
+  }) => {
+    // Three sequential pills × 2-tool chains × LLM-mock latency easily
+    // exceeds Playwright's 30s default. Match the budget the
+    // tool-rendering-default-catchall multi-pill regression uses.
+    test.setTimeout(240_000);
+
+    const reasoningBlocks = page.locator('[data-testid="reasoning-block"]');
+
+    // Pill 1 — stocks chain.
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Compare two stocks" })
+      .first()
+      .click();
+    const stockCards = page.locator(
+      '[data-testid="custom-catchall-card"][data-tool-name="get_stock_price"]',
+    );
+    await expect
+      .poll(async () => stockCards.count(), { timeout: TOOL_TIMEOUT })
+      .toBe(2);
+    await expect
+      .poll(async () => reasoningBlocks.count(), { timeout: REASONING_TIMEOUT })
+      .toBeGreaterThanOrEqual(1);
+
+    // Pill 2 — dice chain. The KEY assertion: this used to crash with
+    // INCOMPLETE_STREAM before the reasoning-role filter landed.
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Chain of dice rolls" })
+      .first()
+      .click();
+    const diceCards = page.locator(
+      '[data-testid="custom-catchall-card"][data-tool-name="roll_dice"]',
+    );
+    await expect
+      .poll(async () => diceCards.count(), { timeout: TOOL_TIMEOUT })
+      .toBe(2);
+    // Reasoning blocks should have INCREASED — proves the second turn
+    // produced fresh reasoning, not just reusing turn 1's block.
+    await expect
+      .poll(async () => reasoningBlocks.count(), { timeout: REASONING_TIMEOUT })
+      .toBeGreaterThanOrEqual(2);
+
+    // Pill 3 — flights + destination weather. Final regression hop.
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Flights + destination weather" })
+      .first()
+      .click();
+    await expect(
+      page.locator('[data-testid="flight-list-card"]').first(),
+    ).toBeVisible({ timeout: TOOL_TIMEOUT });
+    await expect(
+      page.locator('[data-testid="weather-card"]').first(),
+    ).toBeVisible({ timeout: TOOL_TIMEOUT });
+    await expect
+      .poll(async () => reasoningBlocks.count(), { timeout: REASONING_TIMEOUT })
+      .toBeGreaterThanOrEqual(3);
+
+    // Final sanity: card counts for the prior turns survived (no
+    // unmounts mid-thread).
+    await expect(stockCards).toHaveCount(2);
+    await expect(diceCards).toHaveCount(2);
+  });
+});

--- a/showcase/integrations/langgraph-python/tests/e2e/tool-rendering-reasoning-chain.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/tool-rendering-reasoning-chain.spec.ts
@@ -56,9 +56,9 @@ test.describe("Tool Rendering — Reasoning Chain", () => {
     await expect(page.locator('[data-testid="flight-list-card"]')).toHaveCount(
       0,
     );
-    await expect(page.locator('[data-testid="custom-catchall-card"]')).toHaveCount(
-      0,
-    );
+    await expect(
+      page.locator('[data-testid="custom-catchall-card"]'),
+    ).toHaveCount(0);
     await expect(page.locator('[data-testid="reasoning-block"]')).toHaveCount(
       0,
     );
@@ -137,10 +137,9 @@ test.describe("Tool Rendering — Reasoning Chain", () => {
     // Flights card uses its branded renderer (not the catchall).
     const flights = page.locator('[data-testid="flight-list-card"]').first();
     await expect(flights).toBeVisible({ timeout: TOOL_TIMEOUT });
-    await expect(flights.locator('[data-testid="flight-origin"]')).toContainText(
-      "SFO",
-      { timeout: TOOL_TIMEOUT },
-    );
+    await expect(
+      flights.locator('[data-testid="flight-origin"]'),
+    ).toContainText("SFO", { timeout: TOOL_TIMEOUT });
     await expect(
       flights.locator('[data-testid="flight-destination"]'),
     ).toContainText("JFK", { timeout: TOOL_TIMEOUT });


### PR DESCRIPTION
## Summary

- **Runtime bug fix:** `LangGraphAgent.run` now strips `role: "reasoning"` messages from `input.messages` before forwarding to `@ag-ui/langgraph`'s message converter. Without this, the second turn of any thread containing reasoning summaries (OpenAI Responses API + `reasoning={summary:"detailed"}`) crashes with `"message role is not supported."` before the model is ever called.
- **Showcase polish:** the `tool-rendering-reasoning-chain` demo previously promised chained tool calls in its pill titles but delivered single tools — fixed by rewording the pill prompts to pre-disclose the chain, replacing the soft system prompt with concrete per-pill chain examples (matching the langgraph-typescript `tool-rendering` agent pattern), and adding 9 chained aimock fixtures.

## What was broken

In `/demos/tool-rendering-reasoning-chain`, clicking a second pill in the same thread produced:

```
Error: message role is not supported.
  Code: agent_run_error_event
  runtimeErrorCode: INCOMPLETE_STREAM
```

Root cause: `@ag-ui/langgraph` ships a message converter that throws on any role outside `{user, assistant, system, tool}`. Reasoning-stream agents emit AG-UI `role:"reasoning"` messages during a turn; the AG-UI client persists them in the thread and replays them on the next request; the converter crashes before the model is called.

Separately, even when a single pill click succeeded, the agent was emitting only ONE tool call — the pill titles ("Weather + flights to Tokyo", "Compare two stocks", "Chain of dice rolls", "Flights + destination weather") all promised chains but neither the system prompt nor the aimock fixtures supported them.

## The fix

### `packages/runtime` (commit 1)

Single 4-line filter in `LangGraphAgent.run`. Only the *inbound* message list is filtered — the outbound event stream still carries reasoning summaries to the client, so the `<ReasoningBlock>` slot continues to render on the active turn. See the in-file comment for the AG-UI converter reference.

### `showcase/integrations/langgraph-python` (commit 2)

- **System prompt** rewritten with per-pill chain instructions (mirrors the langgraph-typescript `tool-rendering.ts` pattern).
- **Pill messages** reworded to pre-disclose the chain so the model commits to a follow-up call:
  - `"Compare AAPL and MSFT stocks for me."`
  - `"Roll a 20-sided die for me and compare it to a smaller one."`
  - `"Find flights from SFO to JFK and show me the weather there."`
  - Dropped the redundant "Weather + flights to Tokyo" pill (it was the SFO/JFK chain in reverse).
- **9 aimock fixtures** (3 per pill: `final-content → second-leg → first-leg`, ordered by `toolCallId` specificity). Each fixture is scoped by a langgraph-python-UNIQUE `userMessage` substring tail — `"Compare AAPL and MSFT stocks"`, `"compare it to a smaller one"`, `"show me the weather there"` — none of which appear in any other integration's pill prompts. So the fixtures do not cross-contaminate the other 14+ reasoning-chain demos sharing the Railway `showcase-aimock` service.
- **Harness probe** collapsed from two single-tool turns to one chained turn that asserts BOTH per-tool renderers (`FlightListCard` + `WeatherCard`) mount — same coverage as before at half the wall-clock, AND it actually exercises the chained-tool path.

## Why not gate on `toolName: "roll_dice"`?

Initial attempt used `toolName: "roll_dice"` as the differentiator between this demo and the basic `tool-rendering` demo. Code review caught that aimock's `toolName` matcher is a tool-LIST gate (checks the request's available-tools list), not a tool-CALL gate, and most reasoning-chain agents across the fleet (agno, built-in-agent, claude-sdk-python, ms-agent-python, pydantic-ai, langgraph-fastapi, …) also register `roll_dice`. The gate would NOT have isolated this demo on the shared Railway `showcase-aimock`. Scoping by unique prompt-tail substring is both cheaper and more reliable.

## Out of scope (deliberate)

- The other 17 integrations' `tool-rendering-reasoning-chain/page.tsx` still ship the older pill prompts and the soft system prompt. Same fix applies; not bundled here to keep the diff reviewable.
- Pre-existing typecheck errors in `packages/runtime/src/index.ts` (missing `@copilotkit/license-verifier` exports) and decorator errors in `src/graphql/inputs/message.input.ts` exist on `main` and are not touched here.

## Test plan

- [x] Local manual verification against real OpenAI (gpt-5.4, Responses API) — multi-pill thread no longer crashes; each pill produces 2 sequential tool calls and a final summary.
- [x] JSON validation: both `d5-all.json` and the harness fixture file parse.
- [x] Typecheck on touched files clean (`packages/runtime`, `showcase/harness`).
- [x] Lefthook pre-commit gates green on both commits.
- [ ] CI runs the updated harness probe against the canonical Docker stack.