### PR TITLE
Docs(deepagents): interrupt flow fixes for typescript

### DIFF
--- a/docs/content/docs/integrations/deepagents/generative-ui/your-components/interrupt-based.mdx
+++ b/docs/content/docs/integrations/deepagents/generative-ui/your-components/interrupt-based.mdx
@@ -73,15 +73,18 @@ We're going to have the agent ask us to name it, so we'll need a state property 
     <Tab value="TypeScript">
         ```ts title="agent.ts"
         import { createMiddleware } from "langchain";
-        import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+        import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
         import { z } from "zod";
+        import { StateSchema } from "@langchain/langgraph";
 
-        // Define the agent's custom state as a middleware.
+        // Define the agent's custom state and include schema in middleware.
+        const AgentStateSchema = new StateSchema({
+            agentName: zodState(z.string().optional()),
+        });
+
         export const agentNameMiddleware = createMiddleware({
             name: "AgentState",
-            stateSchema: z.object({
-                agentName: z.string().optional(),
-            }),
+            stateSchema: AgentStateSchema,
         });
 
         // createDeepAgent({ middleware: [agentNameMiddleware, copilotkitMiddleware], ... })
@@ -128,15 +131,18 @@ We're going to have the agent ask us to name it, so we'll need a state property 
             In Deep Agents TypeScript, wire the interrupt into a middleware hook rather than a custom node. The hook below runs before the model call and asks the user for a name the first time.
 
             ```ts title="agent.ts"
-            import { createMiddleware } from "langchain";
-            import { interrupt } from "@langchain/langgraph"; // [!code highlight]
+            import { createMiddleware, SystemMessage, tool } from "langchain";
+            import { interrupt,  StateSchema } from "@langchain/langgraph"; // [!code highlight]
+            import { zodState } from "@copilotkit/sdk-js/langgraph";
             import { z } from "zod";
+
+            const AgentStateSchema = new StateSchema({
+                agentName: zodState(z.string().optional()),
+            });
 
             export const agentNameMiddleware = createMiddleware({
                 name: "AgentState",
-                stateSchema: z.object({
-                    agentName: z.string().optional(),
-                }),
+                stateSchema: AgentStateSchema,
                 beforeModel: async (state) => {
                     if (!state.agentName) {
                         // Interrupt and wait for the user to respond with a name
@@ -144,6 +150,16 @@ We're going to have the agent ask us to name it, so we'll need a state property 
                         return { agentName: name };
                     }
                 },
+                wrapModelCall: async (request, handler) => {
+                const name = request.state?.agentName;
+                if (!name) return handler(request);
+                const existing = request.systemMessage?.content;
+                const baseText = typeof existing === "string" ? existing : "";
+                return handler({
+                    ...request,
+                    systemMessage: new SystemMessage(`${baseText}\n\nYour name is ${name}. Refer to yourself by this name when asked.`),
+                });
+            },
             });
             ```
         </Tab>

--- a/docs/content/docs/integrations/deepagents/human-in-the-loop/interrupt-flow.mdx
+++ b/docs/content/docs/integrations/deepagents/human-in-the-loop/interrupt-flow.mdx
@@ -73,15 +73,18 @@ We're going to have the agent ask us to name it, so we'll need a state property 
     <Tab value="TypeScript">
         ```ts title="agent.ts"
         import { createMiddleware } from "langchain";
-        import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+        import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
         import { z } from "zod";
+        import { StateSchema } from "@langchain/langgraph";
 
-        // Define the agent's custom state as a middleware.
+        // Define the agent's custom state and include schema in middleware.
+        const AgentStateSchema = new StateSchema({
+            agentName: zodState(z.string().optional()),
+        });
+
         export const agentNameMiddleware = createMiddleware({
             name: "AgentState",
-            stateSchema: z.object({
-                agentName: z.string().optional(),
-            }),
+            stateSchema: AgentStateSchema,
         });
 
         // createDeepAgent({ middleware: [agentNameMiddleware, copilotkitMiddleware], ... })
@@ -128,21 +131,34 @@ We're going to have the agent ask us to name it, so we'll need a state property 
             In Deep Agents TypeScript, wire the interrupt into a middleware hook rather than a custom node. The hook below runs before the model call and asks the user for a name the first time.
 
             ```ts title="agent.ts"
-            import { createMiddleware } from "langchain";
-            import { interrupt } from "@langchain/langgraph"; // [!code highlight]
+            import { createMiddleware, SystemMessage, tool } from "langchain";
+            import { interrupt,  StateSchema } from "@langchain/langgraph"; // [!code highlight]
+            import { zodState } from "@copilotkit/sdk-js/langgraph";
             import { z } from "zod";
+
+            const AgentStateSchema = new StateSchema({
+                agentName: zodState(z.string().optional()),
+            });
 
             export const agentNameMiddleware = createMiddleware({
                 name: "AgentState",
-                stateSchema: z.object({
-                    agentName: z.string().optional(),
-                }),
+                stateSchema: AgentStateSchema,
                 beforeModel: async (state) => {
                     if (!state.agentName) {
                         // Interrupt and wait for the user to respond with a name
                         const name = await interrupt("Before we start, what would you like to call me?"); // [!code highlight]
                         return { agentName: name };
                     }
+                },
+                wrapModelCall: async (request, handler) => {
+                const name = request.state?.agentName;
+                if (!name) return handler(request);
+                const existing = request.systemMessage?.content;
+                const baseText = typeof existing === "string" ? existing : "";
+                return handler({
+                    ...request,
+                    systemMessage: new SystemMessage(`${baseText}\n\nYour name is ${name}. Refer to yourself by this name when asked.`),
+                });
                 },
             });
             ```


### PR DESCRIPTION
## Summary
Fixed the middleware code snippet In Typescript variant of DeepAgents to work correctly by accepting agentName.

## Issue
If we use exposeState in middleware, — `createCopilotkitMiddleware({ exposeState: ["agentName"] })` — it compiles, runs, and produces no error, but the model never sees the value. This is because The full graph state is parsed through **the calling middleware's own Zod schema** and any key not declared in that schema is stripped before `wrapModelCall` ever sees it. So when CopilotKit's `wrapModelCall` evaluates `request.state["agentName"]`, the value is `undefined` — not because state is empty in the graph, but because langchain stripped the foreign key before handing the object over. `exposeState: ["agentName"]` is iterating over an object that has already lost the key.

## Changes

1. used `zodState` imported from `"@copilotkit/sdk-js/langgraph"` because without this, custom fields are silently dropped from graph's `output_schema`. Therefore, it cannot be seen in AG-UI `STATE_SNAPSHOT` payload sent to the frontend even though the underlying thread state has the value. 

### Reference
https://github.com/CopilotKit/CopilotKit/blob/ce41ea617ed5aa3063889c2d72b32b6235054366/packages/sdk-js/src/langgraph/middleware.ts#L20-L43

2. Added 'wrapModelCall' in the middleware that **declares** `agentName` Because that middleware's schema includes `agentName`, the langchain projection keeps the key and `request.state.agentName` is populated.

## Alternative Solutions
To restore one-line parity with the Python `expose_state` shape,  (In sdk-python package), `@copilotkit/sdk-js` would need to change how its middleware obtains state inside `wrapModelCall`. There are Three viable options on the SDK side:
- **(a)** Declare a passthrough schema so foreign keys survive the langchain projection:
  ```js
  stateSchema: z.object({ copilotkit: /*...*/ }).passthrough()
  ```
- **(b)** Add a selector form so the caller — who *does* declare `agentName` — supplies the projection:
  ```ts
  createCopilotkitMiddleware({ exposeState: (state) => ({ agentName: state.agentName }) })
  ```
- **(c)** Read the unfiltered graph state via the LangGraph runtime (`runtime.getState()` or equivalent) inside `wrapModelCall`, instead of `request.state`, so the schema projection is bypassed for state-note purposes only.