### PR TITLE
feat(ci): showcase build failure observability

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -381,3 +381,73 @@ jobs:
             exit 1
           fi
           echo "Railway redeploy triggered for ${{ matrix.service.dispatch_name }}"
+
+  notify:
+    name: Notify on failure
+    needs: [build]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    timeout-minutes: 5
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+    steps:
+      - name: Slack alert
+        if: env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            { "text": ${{ toJSON(format(':x: *Showcase Build Failed*\nCommit: `{0}` by {1}\n<https://github.com/{2}/actions/runs/{3}|View run>', github.sha, github.actor, github.repository, github.run_id)) }} }
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const merged = prs.find(pr => pr.merged_at);
+            if (!merged) {
+              console.log('No merged PR found for this commit — skipping comment');
+              return;
+            }
+            const marker = '<!-- showcase-build-failure -->';
+            const body = [
+              marker,
+              `### :x: Showcase Build Failed`,
+              ``,
+              `The Docker build triggered by this PR's merge failed.`,
+              ``,
+              `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `**Commit:** \`${context.sha.slice(0, 8)}\``,
+              ``,
+              `@${merged.user?.login ?? 'unknown'} — please check the build logs and fix the issue.`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: merged.number,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: merged.number,
+                body,
+              });
+            }

--- a/.github/workflows/showcase_build_check.yml
+++ b/.github/workflows/showcase_build_check.yml
@@ -1,0 +1,228 @@
+name: "Showcase: Build Check (PR)"
+
+# Pre-merge Docker build check. Runs the same Depot Docker builds as the
+# post-merge showcase_build.yml pipeline but with push: false, so
+# Dockerfile-specific failures (missing deps that exist in the monorepo
+# but not in the isolated Docker context) are caught before merge.
+
+on:
+  pull_request:
+    paths:
+      - "showcase/**"
+
+concurrency:
+  group: showcase-build-check-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has_changes: ${{ steps.build-matrix.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shell:
+              - 'showcase/shell/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/integrations/*/manifest.yaml'
+            langgraph_python:
+              - 'showcase/integrations/langgraph-python/**'
+            mastra:
+              - 'showcase/integrations/mastra/**'
+            crewai_crews:
+              - 'showcase/integrations/crewai-crews/**'
+            pydantic_ai:
+              - 'showcase/integrations/pydantic-ai/**'
+            google_adk:
+              - 'showcase/integrations/google-adk/**'
+            ag2:
+              - 'showcase/integrations/ag2/**'
+            agno:
+              - 'showcase/integrations/agno/**'
+            llamaindex:
+              - 'showcase/integrations/llamaindex/**'
+            langgraph_fastapi:
+              - 'showcase/integrations/langgraph-fastapi/**'
+            langgraph_typescript:
+              - 'showcase/integrations/langgraph-typescript/**'
+            langroid:
+              - 'showcase/integrations/langroid/**'
+            spring_ai:
+              - 'showcase/integrations/spring-ai/**'
+            strands:
+              - 'showcase/integrations/strands/**'
+            ms_agent_python:
+              - 'showcase/integrations/ms-agent-python/**'
+            claude_sdk_typescript:
+              - 'showcase/integrations/claude-sdk-typescript/**'
+            ms_agent_dotnet:
+              - 'showcase/integrations/ms-agent-dotnet/**'
+            claude_sdk_python:
+              - 'showcase/integrations/claude-sdk-python/**'
+            built_in_agent:
+              - 'showcase/integrations/built-in-agent/**'
+            shell_dojo:
+              - 'showcase/shell-dojo/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/integrations/*/manifest.yaml'
+            shell_dashboard:
+              - 'showcase/shell-dashboard/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/integrations/*/manifest.yaml'
+            shell_docs:
+              - 'showcase/shell-docs/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/integrations/*/manifest.yaml'
+            showcase_harness:
+              - 'showcase/harness/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/integrations/*/manifest.yaml'
+            showcase_aimock:
+              - 'showcase/aimock/**'
+
+      - name: Build service matrix
+        id: build-matrix
+        run: |
+          # Mirror of the ALL_SERVICES definition from showcase_build.yml.
+          # Keep in sync — the matrix here must match the production build
+          # workflow so that every service buildable post-merge is also
+          # checked pre-merge.
+          #
+          # Fields carried over: dispatch_name, filter_key, context, image,
+          # timeout, lfs, build_args_*, dockerfile.
+          # Fields omitted (not needed for build-only): railway_id, health_path.
+          ALL_SERVICES='[
+            {"dispatch_name":"shell","filter_key":"shell","context":".","image":"showcase-shell","timeout":10,"lfs":true,"build_args_sha":"${{ github.event.pull_request.head.sha }}","build_args_branch":"${{ github.head_ref }}","dockerfile":"showcase/shell/Dockerfile"},
+            {"dispatch_name":"langgraph-python","filter_key":"langgraph_python","context":"showcase/integrations/langgraph-python","image":"showcase-langgraph-python","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"mastra","filter_key":"mastra","context":"showcase/integrations/mastra","image":"showcase-mastra","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"crewai-crews","filter_key":"crewai_crews","context":"showcase/integrations/crewai-crews","image":"showcase-crewai-crews","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"pydantic-ai","filter_key":"pydantic_ai","context":"showcase/integrations/pydantic-ai","image":"showcase-pydantic-ai","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"google-adk","filter_key":"google_adk","context":"showcase/integrations/google-adk","image":"showcase-google-adk","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"ag2","filter_key":"ag2","context":"showcase/integrations/ag2","image":"showcase-ag2","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"agno","filter_key":"agno","context":"showcase/integrations/agno","image":"showcase-agno","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"llamaindex","filter_key":"llamaindex","context":"showcase/integrations/llamaindex","image":"showcase-llamaindex","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"langgraph-fastapi","filter_key":"langgraph_fastapi","context":"showcase/integrations/langgraph-fastapi","image":"showcase-langgraph-fastapi","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"langgraph-typescript","filter_key":"langgraph_typescript","context":"showcase/integrations/langgraph-typescript","image":"showcase-langgraph-typescript","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"langroid","filter_key":"langroid","context":"showcase/integrations/langroid","image":"showcase-langroid","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"spring-ai","filter_key":"spring_ai","context":"showcase/integrations/spring-ai","image":"showcase-spring-ai","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"strands","filter_key":"strands","context":"showcase/integrations/strands","image":"showcase-strands","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"ms-agent-python","filter_key":"ms_agent_python","context":"showcase/integrations/ms-agent-python","image":"showcase-ms-agent-python","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"claude-sdk-typescript","filter_key":"claude_sdk_typescript","context":"showcase/integrations/claude-sdk-typescript","image":"showcase-claude-sdk-typescript","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"ms-agent-dotnet","filter_key":"ms_agent_dotnet","context":"showcase/integrations/ms-agent-dotnet","image":"showcase-ms-agent-dotnet","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"claude-sdk-python","filter_key":"claude_sdk_python","context":"showcase/integrations/claude-sdk-python","image":"showcase-claude-sdk-python","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"built-in-agent","filter_key":"built_in_agent","context":"showcase/integrations/built-in-agent","image":"showcase-built-in-agent","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile"},
+            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","timeout":10,"lfs":true,"build_args_sha":"${{ github.event.pull_request.head.sha }}","build_args_branch":"${{ github.head_ref }}","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_ops_url":"https://showcase-harness-production.up.railway.app","dockerfile":"showcase/shell-dashboard/Dockerfile"},
+            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","timeout":10,"lfs":true,"build_args_sha":"${{ github.event.pull_request.head.sha }}","build_args_branch":"${{ github.head_ref }}","dockerfile":"showcase/shell-docs/Dockerfile"},
+            {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/harness/Dockerfile"},
+            {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","timeout":5,"lfs":false,"build_args":"","dockerfile":"showcase/aimock/Dockerfile"}
+          ]'
+
+          CHANGES='${{ steps.filter.outputs.changes }}'
+          CHANGES="${CHANGES:-[]}"
+
+          # PR event only — filter to changed services
+          MATRIX=$(echo "$ALL_SERVICES" | jq -c --argjson changes "$CHANGES" '
+            [.[] | (.filter_key as $fk | select(
+              ($changes | index($fk) != null)
+            ))]
+          ')
+
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          if [ "$MATRIX" = "[]" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+  build-check:
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: ${{ fromJSON(matrix.service.timeout) }}
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: ${{ matrix.service.lfs }}
+
+      - name: Setup Depot
+        uses: depot/setup-action@v1
+
+      - name: Prepare build args
+        id: build-args
+        run: |
+          ARGS=""
+          if [ -n "${{ matrix.service.build_args_sha }}" ]; then
+            ARGS="COMMIT_SHA=${{ matrix.service.build_args_sha }}"
+            ARGS="${ARGS}"$'\n'"BRANCH=${{ matrix.service.build_args_branch }}"
+          fi
+          if [ -n "${{ matrix.service.build_args_pb_url }}" ]; then
+            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_POCKETBASE_URL=${{ matrix.service.build_args_pb_url }}"
+          fi
+          if [ -n "${{ matrix.service.build_args_shell_url }}" ]; then
+            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_SHELL_URL=${{ matrix.service.build_args_shell_url }}"
+          fi
+          if [ -n "${{ matrix.service.build_args_ops_url }}" ]; then
+            ARGS="${ARGS:+${ARGS}$'\n'}OPS_BASE_URL=${{ matrix.service.build_args_ops_url }}"
+          fi
+          # Use delimiter to safely pass multiline value
+          echo "args<<BUILDARGS_EOF" >> $GITHUB_OUTPUT
+          echo "$ARGS" >> $GITHUB_OUTPUT
+          echo "BUILDARGS_EOF" >> $GITHUB_OUTPUT
+
+      - name: Copy shared modules into build context
+        run: |
+          set -euo pipefail
+          CONTEXT="${{ matrix.service.context }}"
+          if [ -d "showcase/shared/python" ] && [ -d "$CONTEXT" ]; then
+            rm -rf "$CONTEXT/shared_python"
+            cp -r showcase/shared/python "$CONTEXT/shared_python"
+          fi
+          if [ -d "showcase/shared/typescript/tools" ] && [ -d "$CONTEXT" ]; then
+            rm -rf "$CONTEXT/shared_typescript"
+            mkdir -p "$CONTEXT/shared_typescript"
+            cp -r showcase/shared/typescript/tools "$CONTEXT/shared_typescript/tools"
+          fi
+
+          for link_name in tools shared-tools; do
+            link_path="$CONTEXT/$link_name"
+            if [ -L "$link_path" ]; then
+              target="$(readlink -f "$link_path")"
+              if [ -d "$target" ]; then
+                rm "$link_path"
+                cp -r "$target" "$link_path"
+              fi
+            fi
+          done
+
+      - name: Build Docker image (no push)
+        uses: depot/build-push-action@v1
+        with:
+          project: m2kw2wmmcp
+          context: ${{ matrix.service.context }}
+          file: ${{ matrix.service.dockerfile != '' && matrix.service.dockerfile || format('{0}/Dockerfile', matrix.service.context) }}
+          platforms: linux/amd64
+          push: false
+          build-args: ${{ steps.build-args.outputs.args }}

--- a/showcase/shell-docs/package-lock.json
+++ b/showcase/shell-docs/package-lock.json
@@ -25,6 +25,7 @@
         "@tailwindcss/postcss": "^4.0.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "postcss": "^8.5.0",
         "tailwindcss": "^4.0.0",
         "tsx": "^4.19.0",
@@ -1973,6 +1974,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/trusted-types": {

--- a/showcase/shell-docs/package.json
+++ b/showcase/shell-docs/package.json
@@ -27,6 +27,7 @@
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "postcss": "^8.5.0",
     "tailwindcss": "^4.0.0",
     "tsx": "^4.19.0",


### PR DESCRIPTION
## Summary

- **Fix shell-docs build**: Add missing `@types/react-dom` to devDependencies — Docker build was failing because react-dom types resolve transitively in the monorepo but not in the isolated Docker context (broke after PR #4691 merged)
- **Slack + PR comment on failure**: New `notify` job in `showcase_build.yml` posts to #oss-alerts and comments on the originating PR when a showcase Docker build fails post-merge
- **Pre-merge Docker build check**: New `showcase_build_check.yml` workflow runs the same Depot Docker build on PRs with `push: false`, catching Dockerfile-specific failures before they land on main

## Why

PR #4691 merged but never went live — the shell-docs Docker build was silently failing for 27 hours with no notification. The merge author had no way to discover this without manually checking the Actions tab.

## Test plan

- [ ] Verify shell-docs GHCR build succeeds after merge (the `@types/react-dom` fix unblocks it)
- [ ] Verify Slack notification fires on next build failure (can test with `workflow_dispatch` + intentional break)
- [ ] Verify PR comment appears on the originating PR when a build fails
- [ ] Open a test PR touching `showcase/` to confirm the pre-merge Docker build check triggers