### PR TITLE
fix(shell-docs): add missing @types/react-dom devDependency

### DIFF
--- a/showcase/shell-docs/package-lock.json
+++ b/showcase/shell-docs/package-lock.json
@@ -25,6 +25,7 @@
         "@tailwindcss/postcss": "^4.0.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "postcss": "^8.5.0",
         "tailwindcss": "^4.0.0",
         "tsx": "^4.19.0",
@@ -1970,9 +1971,20 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -2154,6 +2166,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/showcase/shell-docs/package.json
+++ b/showcase/shell-docs/package.json
@@ -27,6 +27,7 @@
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "postcss": "^8.5.0",
     "tailwindcss": "^4.0.0",
     "tsx": "^4.19.0",


### PR DESCRIPTION
## Summary

PR #4691 introduced `import { createPortal } from "react-dom"` in `src/components/search-trigger.tsx` but did not add `@types/react-dom` to `showcase/shell-docs/package.json`'s devDependencies. The Railway production build fails:

```
./src/components/search-trigger.tsx:4:30
Type error: Could not find a declaration file for module 'react-dom'.
  '/app/shell-docs/node_modules/react-dom/index.js' implicitly has an 'any' type.
```

Local dev was unaffected because the type was being satisfied via hoisting from a root `node_modules`. The Docker builder installs each package's deps in isolation, so the type resolution failed.

## Fix

Add `@types/react-dom: ^19.0.0` to shell-docs devDependencies (matches the existing `@types/react: ^19.0.0` constraint and resolves to the same major version as the runtime `react-dom: ^19.0.0`).

## Test plan

- [ ] Railway production build succeeds
- [ ] `npx tsc --noEmit` from `showcase/shell-docs/` returns no `react-dom` errors
- [ ] No regression in local dev