### PR TITLE
fix(shell-docs): route /unselected/* to /built-in-agent/* not /

### DIFF
--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -106,13 +106,13 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
 
-      // /unselected/* tree retired. Most files were either canonical at
-      // root or duplicated content from `integrations/built-in-agent/`.
-      // Per-path redirects below handle the BIA-canonical mappings; the
-      // catch-all at the bottom funnels everything else to root (where
-      // either the canonical version now lives or the soft-default
-      // serves the right framework view).
-      { source: "/unselected", destination: "/", permanent: true },
+      // /unselected/* tree retired. Files moved to integrations/built-in-agent/
+      // (BIA replaced the old "unselected" slot as the default integration).
+      // Per-path entries below cover BIA-canonical mappings (direct moves +
+      // slug renames from SUBPATH_RENAMES in seo-redirects.ts); the catch-all
+      // at the bottom routes everything else into /built-in-agent/ to preserve
+      // SEO equity, since these legacy URLs historically served BIA content.
+      { source: "/unselected", destination: "/built-in-agent", permanent: true },
       {
         source: "/unselected/quickstart",
         destination: "/built-in-agent/quickstart",
@@ -219,12 +219,88 @@ const nextConfig: NextConfig = {
         destination: "/",
         permanent: true,
       },
-      // Catch-all: any remaining /unselected/* path lands on its
-      // canonical root equivalent (Cat A files: coding-agents,
-      // custom-look-and-feel/*, frontend-tools, etc.).
+      // Slug-rename entries (mirror SUBPATH_RENAMES in seo-redirects.ts).
+      // These MUST come before the catch-all so the rename wins. Each
+      // historical slug under /unselected/ has been renamed under
+      // /built-in-agent/; e.g. agentic-chat-ui → prebuilt-components.
+      {
+        source: "/unselected/agentic-chat-ui",
+        destination: "/built-in-agent/prebuilt-components",
+        permanent: true,
+      },
+      {
+        source: "/unselected/use-agent-hook",
+        destination: "/built-in-agent/programmatic-control",
+        permanent: true,
+      },
+      {
+        source: "/unselected/frontend-actions",
+        destination: "/built-in-agent/frontend-tools",
+        permanent: true,
+      },
+      {
+        source: "/unselected/vibe-coding-mcp",
+        destination: "/built-in-agent/coding-agents",
+        permanent: true,
+      },
+      {
+        source: "/unselected/generative-ui/agentic",
+        destination:
+          "/built-in-agent/generative-ui/your-components/display-only",
+        permanent: true,
+      },
+      {
+        source: "/unselected/generative-ui/backend-tools",
+        destination: "/built-in-agent/generative-ui/tool-rendering",
+        permanent: true,
+      },
+      {
+        source: "/unselected/generative-ui/frontend-tools",
+        destination: "/built-in-agent/frontend-tools",
+        permanent: true,
+      },
+      {
+        source: "/unselected/generative-ui/render-only",
+        destination:
+          "/built-in-agent/generative-ui/your-components/display-only",
+        permanent: true,
+      },
+      {
+        source: "/unselected/generative-ui/tool-based",
+        destination: "/built-in-agent/generative-ui/tool-rendering",
+        permanent: true,
+      },
+      {
+        source: "/unselected/custom-look-and-feel/bring-your-own-components",
+        destination: "/built-in-agent/custom-look-and-feel/slots",
+        permanent: true,
+      },
+      {
+        source: "/unselected/custom-look-and-feel/customize-built-in-ui-components",
+        destination: "/built-in-agent/custom-look-and-feel/slots",
+        permanent: true,
+      },
+      {
+        source: "/unselected/custom-look-and-feel/markdown-rendering",
+        destination: "/built-in-agent/custom-look-and-feel/slots",
+        permanent: true,
+      },
+      {
+        source: "/unselected/guide",
+        destination: "/built-in-agent/guides",
+        permanent: true,
+      },
+      {
+        source: "/unselected/mcp",
+        destination: "/built-in-agent/coding-agents",
+        permanent: true,
+      },
+      // Catch-all: route remaining /unselected/* paths into /built-in-agent/.
+      // BIA is the canonical owner of the legacy unselected/ content tree;
+      // matches P1×unselected in seo-redirects.ts.
       {
         source: "/unselected/:path*",
-        destination: "/:path*",
+        destination: "/built-in-agent/:path*",
         permanent: true,
       },
 

--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -112,7 +112,11 @@ const nextConfig: NextConfig = {
       // slug renames from SUBPATH_RENAMES in seo-redirects.ts); the catch-all
       // at the bottom routes everything else into /built-in-agent/ to preserve
       // SEO equity, since these legacy URLs historically served BIA content.
-      { source: "/unselected", destination: "/built-in-agent", permanent: true },
+      {
+        source: "/unselected",
+        destination: "/built-in-agent",
+        permanent: true,
+      },
       {
         source: "/unselected/quickstart",
         destination: "/built-in-agent/quickstart",
@@ -276,7 +280,8 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
-        source: "/unselected/custom-look-and-feel/customize-built-in-ui-components",
+        source:
+          "/unselected/custom-look-and-feel/customize-built-in-ui-components",
         destination: "/built-in-agent/custom-look-and-feel/slots",
         permanent: true,
       },


### PR DESCRIPTION
## Summary

Phase 4 validation surfaced 13 broken redirects under the `/unselected/*` tree. They were dropping users (and SEO equity from indexed legacy URLs) at the framework-agnostic root pages (e.g. `/prebuilt-components`) instead of the BIA-scoped equivalents (e.g. `/built-in-agent/prebuilt-components`).

## Root cause

`next.config.ts` `redirects()` runs at the Next.js routing layer, **before** middleware. So any rule it matches preempts the `seo-redirects.ts` catalog. The existing `/unselected/*` catch-all in `next.config.ts` stripped the prefix (`/unselected/foo` → `/foo`), regardless of what the seo-redirects catalog specified for BIA-scoped destinations.

## Changes

`showcase/shell-docs/next.config.ts`:

- `/unselected` (root): destination `/built-in-agent` (was `/`)
- `/unselected/:path*` catch-all: destination `/built-in-agent/:path*` (was `/:path*`)
- Added 14 explicit slug-rename entries above the catch-all, mirroring `SUBPATH_RENAMES` in `seo-redirects.ts` (S1–S15, minus S13 which is handled implicitly):
  - `agentic-chat-ui` → `prebuilt-components`
  - `use-agent-hook` → `programmatic-control`
  - `frontend-actions` → `frontend-tools`
  - `vibe-coding-mcp` → `coding-agents`
  - `generative-ui/{agentic,render-only}` → `generative-ui/your-components/display-only`
  - `generative-ui/{backend-tools,tool-based}` → `generative-ui/tool-rendering`
  - `generative-ui/frontend-tools` → `frontend-tools`
  - `custom-look-and-feel/{bring-your-own-components,customize-built-in-ui-components,markdown-rendering}` → `custom-look-and-feel/slots`
  - `guide` → `guides`
  - `mcp` → `coding-agents`

The pre-existing per-path entries for `/unselected/{quickstart,server-tools,mcp-servers,...}` are unchanged — they already routed correctly to `/built-in-agent/*`. Same for the `unselected/ag-ui` → `/backend/ag-ui` and `unselected/copilot-runtime` → `/backend/copilot-runtime` special cases.

## What's NOT changed (intentionally)

- `/unselected/agent-app-context` → `/` kept as-is. The comment in next.config notes "agent-app-context was concept-per-framework only; no canonical root home." Genuine product call, not a redirect bug.
- `/copilot-suggestions` → `/` and other non-`/unselected/*` catalog/next.config conflicts left alone. Those reflect deliberate product decisions ("orphaned broken stub") that the catalog hasn't caught up with — separate cleanup.

## Test plan

- [ ] Build succeeds
- [ ] After deploy, re-run Phase 4 redirect catalog probe — `unselected/*` failures should drop from 13 to 0
- [ ] Manual spot-check: `curl -sIL https://docs.showcase.copilotkit.ai/unselected/agentic-chat-ui` → final URL `/built-in-agent/prebuilt-components`, status 200
- [ ] Manual spot-check: `curl -sIL https://docs.showcase.copilotkit.ai/unselected/some-random-path` → `/built-in-agent/some-random-path` (catch-all path)