### PR TITLE
fix(web-inspector): propagate auth headers from CopilotKitProvider to DevConsole Threads list

### DIFF
--- a/.changeset/fix-web-inspector-threads-auth-headers.md
+++ b/.changeset/fix-web-inspector-threads-auth-headers.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/web-inspector": patch
+---
+
+fix(web-inspector): propagate auth headers from `CopilotKitProvider` to DevConsole Threads list
+
+The DevConsole Threads list (and the underlying owned thread stores it creates) was initialized with empty headers, so requests it issued to the runtime did not include `Authorization` (or any other) headers configured on the `CopilotKitProvider`. The inspector also did not react to `onHeadersChanged`, so an async auth handshake that updated headers after mount would never reach already-owned stores. Closes #4793.

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1,6 +1,6 @@
 import { WebInspectorElement, ɵCpkThreadDetails } from "../index";
+import type { CopilotKitCore } from "@copilotkit/core";
 import {
-  CopilotKitCore,
   CopilotKitCoreRuntimeConnectionStatus,
   type CopilotKitCoreSubscriber,
 } from "@copilotkit/core";
@@ -86,39 +86,61 @@ function createMockAgent(
 
 // --- Mock core factory ---
 
+type MockCoreOptions = {
+  runtimeUrl?: string;
+  headers?: Record<string, string>;
+};
+
 type MockCore = {
   agents: Record<string, AbstractAgent>;
   context: Record<string, unknown>;
   properties: Record<string, unknown>;
   runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
+  runtimeUrl?: string;
+  headers: Record<string, string>;
   subscribe: (subscriber: CopilotKitCoreSubscriber) => {
     unsubscribe: () => void;
   };
-  getThreadStores: () => Record<string, never>;
+  getThreadStores: () => Record<string, unknown>;
   getThreadStore: (agentId: string) => undefined;
+  registerThreadStore: (agentId: string, store: unknown) => void;
+  unregisterThreadStore: (agentId: string) => void;
 };
 
-function createMockCore(initialAgents: Record<string, AbstractAgent> = {}) {
+function createMockCore(
+  initialAgents: Record<string, AbstractAgent> = {},
+  options: MockCoreOptions = {},
+) {
   const subscribers = new Set<CopilotKitCoreSubscriber>();
+  const registeredStores = new Map<string, unknown>();
   const core: MockCore = {
     agents: initialAgents,
     context: {},
     properties: {},
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
+    runtimeUrl: options.runtimeUrl,
+    headers: options.headers ?? {},
     subscribe(subscriber: CopilotKitCoreSubscriber) {
       subscribers.add(subscriber);
       return { unsubscribe: () => subscribers.delete(subscriber) };
     },
     getThreadStores() {
-      return {};
+      return Object.fromEntries(registeredStores);
     },
     getThreadStore(_agentId: string) {
       return undefined;
+    },
+    registerThreadStore(agentId: string, store: unknown) {
+      registeredStores.set(agentId, store);
+    },
+    unregisterThreadStore(agentId: string) {
+      registeredStores.delete(agentId);
     },
   };
 
   return {
     core,
+    registeredStores,
     emitAgentsChanged(nextAgents = core.agents) {
       core.agents = nextAgents;
       // CopilotKitCore is a full class — our mock only covers what the
@@ -138,6 +160,15 @@ function createMockCore(initialAgents: Record<string, AbstractAgent> = {}) {
           context: core.context as unknown as Readonly<
             Record<string, { value: string; description: string }>
           >,
+        }),
+      );
+    },
+    setHeaders(nextHeaders: Record<string, string>) {
+      core.headers = nextHeaders;
+      subscribers.forEach((subscriber) =>
+        subscriber.onHeadersChanged?.({
+          copilotkit: core as unknown as CopilotKitCore,
+          headers: core.headers,
         }),
       );
     },
@@ -259,6 +290,65 @@ describe("WebInspectorElement", () => {
 
     contextInternals.persistState();
     expect(localStorage.getItem("cpk:inspector:state")).toBeTruthy();
+  });
+
+  it("propagates core.headers to owned thread store on initial attach", async () => {
+    // Owned thread stores are created when an agent appears on a core that has
+    // a runtimeUrl. The bug (issue #4793): `ensureOwnedThreadStore` was passing
+    // `headers: {}` to `setContext`, so auth headers from `CopilotKitProvider`
+    // never reached the DevConsole Threads list fetch.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})),
+    );
+    const { agent } = createMockAgent("alpha");
+    const { core, registeredStores } = createMockCore(
+      { alpha: agent },
+      {
+        runtimeUrl: "http://example.com",
+        headers: { Authorization: "Bearer initial" },
+      },
+    );
+    const inspector = createInspectorWithCore(core);
+    await inspector.updateComplete;
+
+    expect(registeredStores.size).toBe(1);
+    const store = registeredStores.get("alpha") as {
+      getState: () => { context: { headers: Record<string, string> } | null };
+    };
+    expect(store.getState().context?.headers).toEqual({
+      Authorization: "Bearer initial",
+    });
+  });
+
+  it("propagates updated core.headers to existing owned stores on onHeadersChanged", async () => {
+    // Second half of the fix for issue #4793: when `core.setHeaders()` fires
+    // (e.g. after an async auth handshake), `attachToCore` must re-apply the
+    // new headers to every already-owned thread store via `setContext`.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})),
+    );
+    const { agent } = createMockAgent("alpha");
+    const { core, registeredStores, setHeaders } = createMockCore(
+      { alpha: agent },
+      {
+        runtimeUrl: "http://example.com",
+        headers: { Authorization: "Bearer initial" },
+      },
+    );
+    const inspector = createInspectorWithCore(core);
+    await inspector.updateComplete;
+
+    setHeaders({ Authorization: "Bearer refreshed" });
+    await inspector.updateComplete;
+
+    const store = registeredStores.get("alpha") as {
+      getState: () => { context: { headers: Record<string, string> } | null };
+    };
+    expect(store.getState().context?.headers).toEqual({
+      Authorization: "Bearer refreshed",
+    });
   });
 
   it("syncs agent state on direct setState (onStateChanged without pipeline events)", async () => {

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1,9 +1,7 @@
 import { WebInspectorElement, ɵCpkThreadDetails } from "../index";
 import type { CopilotKitCore } from "@copilotkit/core";
-import {
-  CopilotKitCoreRuntimeConnectionStatus,
-  type CopilotKitCoreSubscriber,
-} from "@copilotkit/core";
+import { CopilotKitCoreRuntimeConnectionStatus } from "@copilotkit/core";
+import type { CopilotKitCoreSubscriber } from "@copilotkit/core";
 import type { AbstractAgent, AgentSubscriber } from "@ag-ui/client";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
@@ -22,6 +20,13 @@ type InspectorContextInternals = {
   contextStore: Record<string, { description?: string; value: unknown }>;
   copyContextValue: (value: unknown, id: string) => Promise<void>;
   persistState: () => void;
+};
+
+// Owned thread stores are real `ɵThreadStore` instances created internally by
+// the inspector — the test only reads the subset of state it asserts on, so
+// a partial view avoids depending on the full `ɵThreadStore` surface.
+type RegisteredStoreView = {
+  getState: () => { context: { headers: Record<string, string> } | null };
 };
 
 // --- Mock agent factory ---
@@ -140,7 +145,12 @@ function createMockCore(
 
   return {
     core,
-    registeredStores,
+    getRegisteredStore(agentId: string): RegisteredStoreView | undefined {
+      return registeredStores.get(agentId) as RegisteredStoreView | undefined;
+    },
+    registeredStoreCount(): number {
+      return registeredStores.size;
+    },
     emitAgentsChanged(nextAgents = core.agents) {
       core.agents = nextAgents;
       // CopilotKitCore is a full class — our mock only covers what the
@@ -228,6 +238,15 @@ describe("WebInspectorElement", () => {
     // the mock requires a cast in jsdom-style test environments.
     (navigator as unknown as { clipboard: typeof mockClipboard }).clipboard =
       mockClipboard;
+
+    // Owned thread stores started by the inspector eagerly call `fetch` to
+    // populate the threads list. Stub it to a never-resolving Promise so the
+    // request starts (exercising the headers code path) but the test stays
+    // synchronous and doesn't trigger jsdom network errors.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})),
+    );
   });
 
   afterEach(() => {
@@ -297,12 +316,8 @@ describe("WebInspectorElement", () => {
     // a runtimeUrl. The bug (issue #4793): `ensureOwnedThreadStore` was passing
     // `headers: {}` to `setContext`, so auth headers from `CopilotKitProvider`
     // never reached the DevConsole Threads list fetch.
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() => new Promise(() => {})),
-    );
     const { agent } = createMockAgent("alpha");
-    const { core, registeredStores } = createMockCore(
+    const { core, getRegisteredStore, registeredStoreCount } = createMockCore(
       { alpha: agent },
       {
         runtimeUrl: "http://example.com",
@@ -312,11 +327,8 @@ describe("WebInspectorElement", () => {
     const inspector = createInspectorWithCore(core);
     await inspector.updateComplete;
 
-    expect(registeredStores.size).toBe(1);
-    const store = registeredStores.get("alpha") as {
-      getState: () => { context: { headers: Record<string, string> } | null };
-    };
-    expect(store.getState().context?.headers).toEqual({
+    expect(registeredStoreCount()).toBe(1);
+    expect(getRegisteredStore("alpha")?.getState().context?.headers).toEqual({
       Authorization: "Bearer initial",
     });
   });
@@ -325,12 +337,8 @@ describe("WebInspectorElement", () => {
     // Second half of the fix for issue #4793: when `core.setHeaders()` fires
     // (e.g. after an async auth handshake), `attachToCore` must re-apply the
     // new headers to every already-owned thread store via `setContext`.
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() => new Promise(() => {})),
-    );
     const { agent } = createMockAgent("alpha");
-    const { core, registeredStores, setHeaders } = createMockCore(
+    const { core, getRegisteredStore, setHeaders } = createMockCore(
       { alpha: agent },
       {
         runtimeUrl: "http://example.com",
@@ -343,10 +351,7 @@ describe("WebInspectorElement", () => {
     setHeaders({ Authorization: "Bearer refreshed" });
     await inspector.updateComplete;
 
-    const store = registeredStores.get("alpha") as {
-      getState: () => { context: { headers: Record<string, string> } | null };
-    };
-    expect(store.getState().context?.headers).toEqual({
+    expect(getRegisteredStore("alpha")?.getState().context?.headers).toEqual({
       Authorization: "Bearer refreshed",
     });
   });

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2590,7 +2590,7 @@ export class WebInspectorElement extends LitElement {
     store.start();
     store.setContext({
       runtimeUrl: core.runtimeUrl,
-      headers: {},
+      headers: core.headers,
       agentId,
     });
     this._ownedThreadStores.set(agentId, store);
@@ -2651,6 +2651,17 @@ export class WebInspectorElement extends LitElement {
       },
       onPropertiesChanged: ({ properties }) => {
         this.coreProperties = properties;
+        this.requestUpdate();
+      },
+      onHeadersChanged: ({ headers }) => {
+        if (!core.runtimeUrl) return;
+        for (const [agentId, store] of this._ownedThreadStores) {
+          store.setContext({
+            runtimeUrl: core.runtimeUrl,
+            headers,
+            agentId,
+          });
+        }
         this.requestUpdate();
       },
       onError: ({ code, error }) => {


### PR DESCRIPTION
## What does this PR do?

Fixes #4793: the DevConsole Threads list (and the owned thread stores it
creates) was initialized with `headers: {}`, so the runtime fetch issued
from the inspector did not include `Authorization` (or any other)
headers configured on the `CopilotKitProvider`. The inspector also did
not subscribe to `onHeadersChanged`, so an async auth handshake that
updated headers after mount would never reach already-owned stores.

Two spots in `packages/web-inspector/src/index.ts`:

1. `ensureOwnedThreadStore`: pass `core.headers` instead of `{}` when
   calling `store.setContext`.
2. `attachToCore`: add an `onHeadersChanged` subscriber that re-applies
   the new headers to every owned thread store via `setContext` and
   requests a UI update.

Test coverage in `packages/web-inspector/src/__tests__/web-inspector.spec.ts`:

- `propagates core.headers to owned thread store on initial attach`
- `propagates updated core.headers to existing owned stores on onHeadersChanged`

Scoped to `@copilotkit/web-inspector` only (patch changeset). No
bumps in `core` / `react-core` / `react-ui`.

## Related PRs and Issues

- Closes #4793

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)