### PR TITLE
fix(ci): configure git credentials in publish job for tag push

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -79,6 +79,10 @@ jobs:
         with:
           name: workspace
 
+      - name: Configure git credentials
+        run: |
+          git config --local url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
Same fix as CopilotKit/aimock#188 — the build/publish split passes the workspace via artifact but the credential helper doesn't survive. Adds url.insteadOf to inject GITHUB_TOKEN.