### PR TITLE
Docs(DeepAgents): Improved State Rendering Python Code Example

### DIFF
--- a/docs/content/docs/integrations/deepagents/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/integrations/deepagents/generative-ui/state-rendering.mdx
@@ -44,9 +44,14 @@ Use state rendering when you want to:
       <Tab value="Python">
         ```python title="agent.py"
         from copilotkit import CopilotKitState
+        from langchain.agents.middleware import AgentMiddleware
+        from typing import Any
 
         class AgentState(CopilotKitState):
             searches: list[dict]
+
+        class AgentSearchMiddleware(AgentMiddleware[AgentState, Any]):
+            state_schema = AgentState
         ```
       </Tab>
       <Tab value="TypeScript">
@@ -83,19 +88,32 @@ Use state rendering when you want to:
         from copilotkit.langgraph import copilotkit_emit_state # [!code highlight]
         from langchain_core.runnables import RunnableConfig
 
-        # Inside a custom tool or middleware hook where you have access to state and config:
-        async def emit_research_progress(state: AgentState, config: RunnableConfig):
-            state["searches"] = [
+        # Inside a custom tool or middleware hook where you have access to state and config: (right now using tool)
+        async def research(topic: str, config: RunnableConfig):
+            """Research a topic and stream progress to the UI."""
+
+            state = {"searches": [
                 {"query": "Initial research", "done": False},
                 {"query": "Retrieving sources", "done": False},
                 {"query": "Forming an answer", "done": False},
-            ]
+            ]}
             await copilotkit_emit_state(config, state) # [!code highlight]
 
             for search in state["searches"]:
                 await asyncio.sleep(1)
                 search["done"] = True
                 await copilotkit_emit_state(config, state) # [!code highlight]
+
+        agent = create_deep_agent(
+            model="openai:gpt-4o",
+            tools=[research],
+            middleware=[CopilotKitMiddleware(), AgentSearchMiddleware()],
+            system_prompt=(
+                "You are a helpful research assistant. "
+                "When the user asks to research, search, look up, or find information, "
+                "call the `research` tool."
+            ),
+        )
         ```
       </Tab>
       <Tab value="TypeScript">


### PR DESCRIPTION
## Summary
The page's Python snippet defines `emit_research_progress` as a free-floating function there's ambiguity on how to register it as a tool or in middleware, at least one example should be elaborated, we used a tool approach. A reader following the page exactly ends up with a function nobody calls. When they prompt the chat with *"add the search for cats vs dogs"*, the agent falls back to the built-in `grep` tool, searches an empty virtual filesystem, and replies *"No matches found in the files."*

## Changes
- Added `AgentSearchMiddleware` because without it, 'searches' are not received on the frontend and cannot be seen in AG-UI inspector either during tool invocation. We see the state section go empty before tool call finishes, without any viable emitted state. 

- Changed `emit_research_progress` to `research `because  `emit_research_progress` reads like internal logging code — the LLM avoids it. `research` matches what the user actually says ("research X", "research for X"). Without the rename, even after registration the agent may still skip this tool in favor of the built-in `task` or `grep`.

- Added docstring because when a plain Python function is passed to `tools=[...]`, the framework uses the docstring as the tool's description for the LLM

- Defined Agent with relevant middlewares

## Results
- Following these changes, each emitted state change event is recognized by the frontend and relevant symbols with queries are rendered on the UI while the state is visible. 