### PR TITLE
Add platform signup as Step 1 across integration quickstarts

### DIFF
--- a/docs/app/(home)/[[...slug]]/page.tsx
+++ b/docs/app/(home)/[[...slug]]/page.tsx
@@ -23,6 +23,7 @@ import { PropertyReference } from "@/components/react/property-reference";
 import { InsecurePasswordProtected } from "@/components/react/insecure-password-protected";
 import { LinkToCopilotCloud } from "@/components/react/link-to-copilot-cloud";
 import { OpsPlatformCTA } from "@/components/react/ops-platform-cta";
+import { SignupLink } from "@/components/react/signup-link";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 import { NavigationLink } from "@/components/react/subdocs-menu";
 import { getSnippetTOCForPage } from "@/lib/snippet-toc";
@@ -42,6 +43,7 @@ const mdxComponents = {
   InsecurePasswordProtected: InsecurePasswordProtected,
   LinkToCopilotCloud: LinkToCopilotCloud,
   OpsPlatformCTA: OpsPlatformCTA,
+  SignupLink: SignupLink,
   Accordions: Accordions,
   Accordion: Accordion,
   Tabs: Tabs,

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -377,3 +377,30 @@ h2, h3, p {
 .dark .quickstart-select-bg {
   background: linear-gradient(to right, rgba(1, 5, 7, 0.10), rgba(1, 5, 7, 0)), #111618;
 }
+
+/* Brand-tint the first Step's heading in any <Steps> block. Indigo→
+ * purple gradient text matches the CopilotKit accent (OpsPlatformCTA,
+ * nav). Subtle cue that Step 1 is the entry point — the badge itself
+ * stays in its default Fumadocs styling so the contrast comes from
+ * the heading, not chrome.
+ *
+ * `> .fd-step:first-child` (direct-child) is load-bearing: without it,
+ * `.fd-step:first-child` also matches the first inner <Step> inside
+ * each <TailoredContentOption>, so e.g. "Run our CLI" gets the
+ * gradient too. The outer Step 1 is the only direct child of the
+ * top-level .fd-steps wrapper. */
+.fd-steps > .fd-step:first-child h3 {
+  background-image: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  /* `background-clip: text` renders glyphs through a transparent fill,
+   * which uses grayscale antialiasing on macOS WebKit rather than the
+   * subpixel AA used for solid-fill text. The result is visibly
+   * lighter/smaller-looking glyphs at the same nominal font-size.
+   * Compensate by bumping weight + size so Step 1 reads as visually
+   * equal-or-larger than the adjacent solid 600/20px headings. */
+  font-weight: 700;
+  font-size: 1.375rem;
+}

--- a/docs/app/integrations/[[...slug]]/page.tsx
+++ b/docs/app/integrations/[[...slug]]/page.tsx
@@ -22,6 +22,7 @@ import { PropertyReference } from "@/components/react/property-reference";
 import { InsecurePasswordProtected } from "@/components/react/insecure-password-protected";
 import { LinkToCopilotCloud } from "@/components/react/link-to-copilot-cloud";
 import { OpsPlatformCTA } from "@/components/react/ops-platform-cta";
+import { SignupLink } from "@/components/react/signup-link";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 import { NavigationLink } from "@/components/react/subdocs-menu";
 import { getSnippetTOCForPage } from "@/lib/snippet-toc";
@@ -44,6 +45,7 @@ const mdxComponents = {
   InsecurePasswordProtected: InsecurePasswordProtected,
   LinkToCopilotCloud: LinkToCopilotCloud,
   OpsPlatformCTA: OpsPlatformCTA,
+  SignupLink: SignupLink,
   Accordions: Accordions,
   Accordion: Accordion,
   Tabs: Tabs,

--- a/docs/components/react/signup-link.tsx
+++ b/docs/components/react/signup-link.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import posthog from "posthog-js";
+import { useCallback } from "react";
+
+const DEFAULT_SIGNUP_URL = "https://dashboard.operations.copilotkit.ai/";
+
+const SIGNUP_URL =
+  process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL || DEFAULT_SIGNUP_URL;
+
+export interface SignupLinkProps {
+  /** Stable identifier for analytics, e.g. "docs_langgraph_quickstart_step1" */
+  surface: string;
+  children: React.ReactNode;
+}
+
+function buildHref(surface: string): string {
+  const url = new URL(SIGNUP_URL);
+  url.searchParams.set("utm_source", "docs");
+  url.searchParams.set("utm_medium", "cta");
+  url.searchParams.set("utm_campaign", "intelligence");
+  url.searchParams.set("utm_content", surface);
+  return url.toString();
+}
+
+export function SignupLink({ surface, children }: SignupLinkProps) {
+  const handleClick = useCallback(() => {
+    try {
+      posthog.capture("try_for_free_clicked", { location: surface });
+    } catch {
+      // PostHog may be blocked by ad blockers — never let analytics block navigation.
+    }
+  }, [surface]);
+
+  return (
+    <a
+      href={buildHref(surface)}
+      target="_blank"
+      rel="noreferrer"
+      onClick={handleClick}
+      data-cta-surface={surface}
+    >
+      {children}
+    </a>
+  );
+}

--- a/docs/components/react/tailored-content.tsx
+++ b/docs/components/react/tailored-content.tsx
@@ -165,11 +165,11 @@ function TailoredContentInner({
   };
 
   const itemCn =
-    "border p-4 rounded-md flex-1 flex md:block md:space-y-1 items-center md:items-start gap-4 cursor-pointer bg-white dark:bg-secondary relative overflow-hidden group transition-all";
+    "border p-3 pl-4 rounded-md flex-1 flex md:block md:space-y-0.5 items-center md:items-start gap-4 cursor-pointer bg-white dark:bg-secondary relative overflow-hidden group transition-all";
   const selectedCn =
-    "shadow-lg ring-1 ring-indigo-400 selected bg-gradient-to-r from-indigo-100/80 to-purple-200 dark:from-indigo-900/20 dark:to-purple-900/30";
+    "shadow-lg ring-1 ring-indigo-400 selected bg-gradient-to-r from-slate-50 to-indigo-50/30 dark:from-slate-800/40 dark:to-indigo-950/20";
   const iconCn =
-    "w-10 h-10 mb-4 top-0 transition-all opacity-20 group-[.selected]:text-indigo-500 group-[.selected]:opacity-60 dark:group-[.selected]:text-indigo-400 dark:group-[.selected]:opacity-60 dark:text-gray-400";
+    "w-8 h-8 mb-2 top-0 transition-all opacity-20 group-[.selected]:text-indigo-500 group-[.selected]:opacity-60 dark:group-[.selected]:text-indigo-400 dark:group-[.selected]:opacity-60 dark:text-gray-400";
 
   const tablistId = `tailored-content-tablist-${id}`;
   const tabId = (optId: string) => `tailored-content-tab-${id}-${optId}`;
@@ -217,7 +217,7 @@ function TailoredContentInner({
                   )}
                 </div>
                 <div>
-                  <p className="font-semibold text-lg">{option.props.title}</p>
+                  <p className="font-semibold text-base">{option.props.title}</p>
                   <p className="text-xs md:text-sm">{option.props.description}</p>
                 </div>
               </div>

--- a/docs/content/docs/integrations/a2a/quickstart.mdx
+++ b/docs/content/docs/integrations/a2a/quickstart.mdx
@@ -49,6 +49,12 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_a2a_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
         ### Clone the A2A starter template
 
         ```bash

--- a/docs/content/docs/integrations/adk/quickstart.mdx
+++ b/docs/content/docs/integrations/adk/quickstart.mdx
@@ -40,18 +40,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing ADK agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_adk_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing ADK agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -385,6 +388,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
 </Steps>
 
 ## What's next?

--- a/docs/content/docs/integrations/ag2/quickstart.mdx
+++ b/docs/content/docs/integrations/ag2/quickstart.mdx
@@ -79,6 +79,12 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_ag2_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
         ### Clone the AG2 Samples Repository
 
         ```bash

--- a/docs/content/docs/integrations/agent-spec/quickstart.mdx
+++ b/docs/content/docs/integrations/agent-spec/quickstart.mdx
@@ -26,18 +26,21 @@ import {
 ## Getting started
 
 <Steps>
-  <TailoredContent
-    className="step"
-    id="agent-spec-quickstart-path"
-    header={
-      <div>
-        <p className="text-xl font-semibold">Choose your starting point</p>
-        <p className="text-base">
-          You can either start fresh with our starter template or connect CopilotKit to an existing Agent Spec agent.
-        </p>
-      </div>
-    }
-  >
+  <Step>
+    ### Create a free account
+
+    <SignupLink surface="docs_agent_spec_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+  </Step>
+
+  <Step>
+      ### Choose your starting point
+
+      You can either start fresh with our starter template or connect CopilotKit to an existing Agent Spec agent.
+
+      <TailoredContent
+          className="step"
+          id="agent-spec-quickstart-path"
+      >
     <TailoredContentOption
       id="starter"
       title="Start from scratch"
@@ -461,6 +464,7 @@ import {
     </Step>
     </TailoredContentOption>
   </TailoredContent>
+  </Step>
 </Steps>
 
 ## Tools and tool registry

--- a/docs/content/docs/integrations/agno/quickstart.mdx
+++ b/docs/content/docs/integrations/agno/quickstart.mdx
@@ -39,18 +39,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing Agno agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_agno_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing Agno agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -324,6 +327,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/docs/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/docs/content/docs/integrations/aws-strands/quickstart.mdx
@@ -39,18 +39,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing Strands agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_aws_strands_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing Strands agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -340,6 +343,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/docs/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/docs/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -44,6 +44,12 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_built_in_agent_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
         ### Create your frontend
 
         CopilotKit works with any React-based frontend. We'll use Next.js for this example.

--- a/docs/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/docs/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -56,18 +56,21 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
 ## Getting started
 
 <Steps>
-<TailoredContent
-    className="step"
-    id="path"
-    header={
-        <div>
-            <p className="text-xl font-semibold">How do you want to get started?</p>
-            <p className="text-base">
-                Bootstrap with the new <span className="text-indigo-500 dark:text-indigo-400">CopilotKit CLI (Beta)</span> or code along with us to get started.
-            </p>
-        </div>
-    }
->
+<Step>
+    ### Create a free account
+
+    <SignupLink surface="docs_crewai_flows_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+</Step>
+
+<Step>
+    ### How do you want to get started?
+
+    Bootstrap with the new CopilotKit CLI (Beta) or code along with us to get started.
+
+    <TailoredContent
+        className="step"
+        id="path"
+    >
     {/*
     <TailoredContentOption
         id="cli"
@@ -247,6 +250,7 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
         </Step>
     </TailoredContentOption>
     </TailoredContent>
+</Step>
 
 </Steps>
 

--- a/docs/content/docs/integrations/deepagents/quickstart.mdx
+++ b/docs/content/docs/integrations/deepagents/quickstart.mdx
@@ -27,6 +27,12 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_deepagents_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
         ### Initialize your agent project
 
         <Tabs groupId="agent_language" items={['Python', 'TypeScript']} persist>

--- a/docs/content/docs/integrations/langgraph/quickstart.mdx
+++ b/docs/content/docs/integrations/langgraph/quickstart.mdx
@@ -59,18 +59,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing LangChain agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_langgraph_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing LangChain agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -502,6 +505,7 @@ Before you begin, you'll need the following:
           </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/docs/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/docs/content/docs/integrations/llamaindex/quickstart.mdx
@@ -40,18 +40,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing LlamaIndex agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_llamaindex_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing LlamaIndex agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -393,6 +396,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
 </Steps>
 
 ## What's next?

--- a/docs/content/docs/integrations/mastra/quickstart.mdx
+++ b/docs/content/docs/integrations/mastra/quickstart.mdx
@@ -51,18 +51,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing Mastra Agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_mastra_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing Mastra Agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -309,6 +312,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -32,18 +32,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing Microsoft Agent Framework agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_microsoft_agent_framework_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing Microsoft Agent Framework agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -442,6 +445,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/docs/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -40,18 +40,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing Pydantic AI agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_pydantic_ai_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing Pydantic AI agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -317,6 +320,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -347,7 +347,45 @@ samp {
 .docs-steps {
   counter-reset: docs-step;
 }
+.docs-step__badge {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-weight: 600;
+}
 .docs-step__badge::before {
   counter-increment: docs-step;
   content: counter(docs-step);
+}
+
+/* Brand-tint the first Step's heading. Indigo→purple gradient text
+ * matches the CopilotKit accent (OpsPlatformCTA, nav). Subtle cue
+ * that Step 1 is the entry point — the badge itself stays in its
+ * default styling so the contrast comes from the heading, not chrome.
+ * The :is() drops the anchor-link `#` (which uses .docs-heading-anchor). */
+.docs-steps > div:first-child h3,
+.docs-steps > div:first-child h3 > :is(:not(.docs-heading-anchor)) {
+  background-image: linear-gradient(135deg, #6366f1 0%, #a855f7 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+
+/* Mute the SignupLink color in Step 1 so it doesn't clash with the
+ * gradient heading above it. The link stays underlined for affordance,
+ * inherits hover (opacity: 0.8) from .reference-content a. */
+.docs-steps > div:first-child a[data-cta-surface] {
+  color: var(--text);
+}
+
+/* Align each Step's first heading with its number badge.
+ * `.reference-content h2/h3/h4` ship with `margin-top` (1.25–2.5rem) so
+ * the heading would otherwise float well below the absolutely-positioned
+ * `.docs-step__badge` (anchored at `top: -0.125rem`). Zero out the top
+ * margin when the heading is the first thing rendered inside a Step. */
+.docs-steps h2:first-child,
+.docs-steps h3:first-child,
+.docs-steps h4:first-child {
+  margin-top: 0;
 }

--- a/showcase/shell-docs/src/components/docs-steps.tsx
+++ b/showcase/shell-docs/src/components/docs-steps.tsx
@@ -43,22 +43,25 @@ export function Step({ title, children }: StepProps) {
         paddingBottom: "1.5rem",
       }}
     >
-      {/* numbered badge — number rendered via CSS counter (globals.css) */}
+      {/* numbered badge — number rendered via CSS counter (globals.css).
+       * Appearance (background/border/color) lives in globals.css so
+       * `.docs-steps > div:first-child .docs-step__badge` can override
+       * it for Step 1 without fighting inline-style specificity. */}
       <div
         aria-hidden
         className="docs-step__badge"
         style={{
           position: "absolute",
           left: "-2.75rem",
-          top: "-0.125rem",
+          // Badge center sits ~midway up the first heading line:
+          // h3 is 1.125rem with line-height 1.65 ≈ 29.7px → text center at
+          // ~14.85px from the Step's top. Badge is 1.5rem (24px) so its
+          // half-height is 12px; top = 14.85 − 12 ≈ 0.1875rem.
+          top: "0.1875rem",
           width: "1.5rem",
           height: "1.5rem",
           borderRadius: "999px",
-          background: "var(--bg-surface)",
-          border: "1px solid var(--border)",
-          color: "var(--text)",
           fontSize: "0.75rem",
-          fontWeight: 600,
           display: "flex",
           alignItems: "center",
           justifyContent: "center",

--- a/showcase/shell-docs/src/components/react/signup-link.tsx
+++ b/showcase/shell-docs/src/components/react/signup-link.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import posthog from "posthog-js";
+import { useCallback } from "react";
+
+const DEFAULT_SIGNUP_URL = "https://dashboard.operations.copilotkit.ai/";
+
+const SIGNUP_URL =
+  process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL || DEFAULT_SIGNUP_URL;
+
+export interface SignupLinkProps {
+  /** Stable identifier for analytics, e.g. "docs_langgraph_quickstart_step1" */
+  surface: string;
+  children: React.ReactNode;
+}
+
+function buildHref(surface: string): string {
+  const url = new URL(SIGNUP_URL);
+  url.searchParams.set("utm_source", "docs");
+  url.searchParams.set("utm_medium", "cta");
+  url.searchParams.set("utm_campaign", "intelligence");
+  url.searchParams.set("utm_content", surface);
+  return url.toString();
+}
+
+export function SignupLink({ surface, children }: SignupLinkProps) {
+  const handleClick = useCallback(() => {
+    try {
+      posthog.capture("try_for_free_clicked", { location: surface });
+    } catch {
+      // PostHog may be blocked by ad blockers — never let analytics block navigation.
+    }
+  }, [surface]);
+
+  return (
+    <a
+      href={buildHref(surface)}
+      target="_blank"
+      rel="noreferrer"
+      onClick={handleClick}
+      data-cta-surface={surface}
+    >
+      {children}
+    </a>
+  );
+}

--- a/showcase/shell-docs/src/components/react/tailored-content.tsx
+++ b/showcase/shell-docs/src/components/react/tailored-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import type { ReactNode } from "react";
 import React, {
-  ReactNode,
   Suspense,
   useCallback,
   useEffect,
@@ -217,7 +217,9 @@ function TailoredContentInner({
                   )}
                 </div>
                 <div>
-                  <p className="font-semibold text-base">{option.props.title}</p>
+                  <p className="font-semibold text-base">
+                    {option.props.title}
+                  </p>
                   <p className="text-xs md:text-sm">
                     {option.props.description}
                   </p>

--- a/showcase/shell-docs/src/components/react/tailored-content.tsx
+++ b/showcase/shell-docs/src/components/react/tailored-content.tsx
@@ -165,11 +165,11 @@ function TailoredContentInner({
   };
 
   const itemCn =
-    "border p-4 rounded-md flex-1 flex md:block md:space-y-1 items-center md:items-start gap-4 cursor-pointer bg-white dark:bg-secondary relative overflow-hidden group transition-all";
+    "border p-3 pl-4 rounded-md flex-1 flex md:block md:space-y-0.5 items-center md:items-start gap-4 cursor-pointer bg-white dark:bg-secondary relative overflow-hidden group transition-all";
   const selectedCn =
-    "shadow-lg ring-1 ring-indigo-400 selected bg-gradient-to-r from-indigo-100/80 to-purple-200 dark:from-indigo-900/20 dark:to-purple-900/30";
+    "shadow-lg ring-1 ring-indigo-400 selected bg-gradient-to-r from-slate-50 to-indigo-50/30 dark:from-slate-800/40 dark:to-indigo-950/20";
   const iconCn =
-    "w-10 h-10 mb-4 top-0 transition-all opacity-20 group-[.selected]:text-indigo-500 group-[.selected]:opacity-60 dark:group-[.selected]:text-indigo-400 dark:group-[.selected]:opacity-60 dark:text-gray-400";
+    "w-8 h-8 mb-2 top-0 transition-all opacity-20 group-[.selected]:text-indigo-500 group-[.selected]:opacity-60 dark:group-[.selected]:text-indigo-400 dark:group-[.selected]:opacity-60 dark:text-gray-400";
 
   const tablistId = `tailored-content-tablist-${id}`;
   const tabId = (optId: string) => `tailored-content-tab-${id}-${optId}`;
@@ -185,7 +185,7 @@ function TailoredContentInner({
           id={tablistId}
           role="tablist"
           aria-orientation="horizontal"
-          className="flex flex-col md:flex-row gap-3 my-2 w-full"
+          className="flex flex-col md:flex-row gap-3 mt-2 mb-6 w-full"
         >
           {options.map((option, index) => {
             const isSelected = selectedIndex === index;
@@ -217,7 +217,7 @@ function TailoredContentInner({
                   )}
                 </div>
                 <div>
-                  <p className="font-semibold text-lg">{option.props.title}</p>
+                  <p className="font-semibold text-base">{option.props.title}</p>
                   <p className="text-xs md:text-sm">
                     {option.props.description}
                   </p>

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
@@ -44,6 +44,12 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_a2a_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
         ### Clone the A2A starter template
 
         ```bash

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -26,18 +26,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing ADK agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_adk_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing ADK agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -371,6 +374,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
 </Steps>
 
 ## What's next?

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/quickstart.mdx
@@ -79,6 +79,12 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_ag2_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
         ### Clone the AG2 Samples Repository
 
         ```bash

--- a/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
@@ -20,18 +20,21 @@ hideTOC: true
 ## Getting started
 
 <Steps>
-  <TailoredContent
-    className="step"
-    id="agent-spec-quickstart-path"
-    header={
-      <div>
-        <p className="text-xl font-semibold">Choose your starting point</p>
-        <p className="text-base">
-          You can either start fresh with our starter template or connect CopilotKit to an existing Agent Spec agent.
-        </p>
-      </div>
-    }
-  >
+  <Step>
+    ### Create a free account
+
+    <SignupLink surface="docs_agent_spec_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+  </Step>
+
+  <Step>
+      ### Choose your starting point
+
+      You can either start fresh with our starter template or connect CopilotKit to an existing Agent Spec agent.
+
+      <TailoredContent
+          className="step"
+          id="agent-spec-quickstart-path"
+      >
     <TailoredContentOption
       id="starter"
       title="Start from scratch"
@@ -455,6 +458,7 @@ hideTOC: true
     </Step>
     </TailoredContentOption>
   </TailoredContent>
+  </Step>
 </Steps>
 
 ## Tools and tool registry

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -26,18 +26,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing Agno agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_agno_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing Agno agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -311,6 +314,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -26,18 +26,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing Strands agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_aws_strands_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing Strands agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -327,6 +330,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -43,6 +43,12 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_built_in_agent_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
         ### Create your frontend
 
         CopilotKit works with any React-based frontend. We'll use Next.js for this example.

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -38,18 +38,21 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
 ## Getting started
 
 <Steps>
-<TailoredContent
-    className="step"
-    id="path"
-    header={
-        <div>
-            <p className="text-xl font-semibold">How do you want to get started?</p>
-            <p className="text-base">
-                Bootstrap with the new <span className="text-indigo-500 dark:text-indigo-400">CopilotKit CLI (Beta)</span> or code along with us to get started.
-            </p>
-        </div>
-    }
->
+<Step>
+    ### Create a free account
+
+    <SignupLink surface="docs_crewai_flows_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+</Step>
+
+<Step>
+    ### How do you want to get started?
+
+    Bootstrap with the new CopilotKit CLI (Beta) or code along with us to get started.
+
+    <TailoredContent
+        className="step"
+        id="path"
+    >
     <TailoredContentOption
         id="cli"
         title="Use the CopilotKit CLI (NextJS only)"
@@ -221,6 +224,7 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
         </Step>
     </TailoredContentOption>
     </TailoredContent>
+</Step>
 
 </Steps>
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
@@ -24,6 +24,12 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_deepagents_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
         ### Initialize your agent project
 
         <Tabs groupId="agent_language" items={['Python', 'TypeScript']} persist>

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -26,18 +26,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing LangGraph agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_langgraph_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing LangGraph agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -469,6 +472,7 @@ Before you begin, you'll need the following:
           </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -26,18 +26,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing LlamaIndex agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_llamaindex_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing LlamaIndex agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -379,6 +382,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
 </Steps>
 
 ## What's next?

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -25,18 +25,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing Mastra Agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_mastra_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing Mastra Agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -283,6 +286,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -26,18 +26,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing Microsoft Agent Framework agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_microsoft_agent_framework_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing Microsoft Agent Framework agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -436,6 +439,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -26,18 +26,21 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your starting point</p>
-                <p className="text-base">
-                    You can either start fresh with our starter template or integrate CopilotKit into your existing Pydantic AI agent.
-                </p>
-            </div>
-        }
-    >
+    <Step>
+        ### Create a free account
+
+        <SignupLink surface="docs_pydantic_ai_quickstart_step1">Sign up for a free developer account</SignupLink> on our Enterprise Intelligence Platform to get a license key. You'll use it later to enable persistent threads, observability, and the inspector.
+    </Step>
+
+    <Step>
+        ### Choose your starting point
+
+        You can either start fresh with our starter template or integrate CopilotKit into your existing Pydantic AI agent.
+
+        <TailoredContent
+            className="step"
+            id="agent"
+        >
         <TailoredContentOption
             id="starter"
             title="Start from scratch"
@@ -303,6 +306,7 @@ Before you begin, you'll need the following:
             </Step>
         </TailoredContentOption>
     </TailoredContent>
+    </Step>
     <Step>
         ### 🎉 Start chatting!
 

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/react/tailored-content";
 import { FrameworkTabs } from "@/components/framework-tabs";
 import { OpsPlatformCTA } from "@/components/react/ops-platform-cta";
+import { SignupLink } from "@/components/react/signup-link";
 import { IframeSwitcher as RealIframeSwitcher } from "@/components/content";
 import { PropertyReference } from "@/components/property-reference";
 import { IntegrationGrid } from "@/components/integration-grid";
@@ -85,6 +86,7 @@ export const docsComponents = {
   Accordion,
   PropertyReference,
   OpsPlatformCTA,
+  SignupLink,
   FeatureIntegrations: ({ feature }: { feature?: string }) => {
     if (!feature) {
       warnSilentNull("FeatureIntegrations", "no `feature` prop provided");


### PR DESCRIPTION
## Summary
- Adds a "Create a free account" Step 1 to all 28 integration quickstarts (14 in `docs/`, 14 in `showcase/shell-docs/`) using a new `<SignupLink>` MDX component instrumented with the standard PostHog `try_for_free_clicked` event and per-quickstart UTM surface (`docs_<int>_quickstart_step1`). Picks up `NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL` when set, falls back to `https://dashboard.operations.copilotkit.ai/`.
- Promotes the framework picker ("Choose your starting point" / "How do you want to get started?") to its own numbered Step so it advances the counter; inner option paths render as steps 3+ instead of 2+.
- Visual polish on both surfaces: indigo→purple gradient heading on Step 1, near-grayscale option-card background, shorter cards with more left padding, shell-docs badge↔heading alignment fixes.

## Test plan
- [ ] Visit `/integrations/<int>/quickstart` on docs/ and `/<int>/quickstart` on shell-docs; Step 1 reads "Create a free account" with an inline signup link
- [ ] Hover the link — URL is `https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=docs_<int>_quickstart_step1`
- [ ] Click the link — PostHog fires `try_for_free_clicked` with `location=docs_<int>_quickstart_step1`
- [ ] Step 2 is the framework picker with its own numbered badge; inner steps continue from 3
- [ ] Selected option card uses a near-grayscale wash with the indigo ring as the "selected" indicator
- [ ] Step 1's gradient heading reads at a similar visual weight to Step 2's solid heading
- [ ] On shell-docs, number badges align vertically with their step headings