### PR TITLE
fix(shell-dashboard): route dashboard docs cell to canonical docs host

### DIFF
--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -52,11 +52,12 @@ export function DocsRow({
   const shellPath = hasShellOverride
     ? (override?.shell_docs_path ?? undefined)
     : (feature.shell_docs_path ?? undefined);
-  // The shell-docs route handler resolves `/<framework>/<slug>` directly —
-  // the legacy `/<framework>/unselected/<slug>` shape was retired by the
-  // JTBD IA restructure (commit c11976819).
+  // Point at the canonical docs host directly. Pre-cutover this CNAME serves
+  // the Vercel docs site; post-cutover it serves shell-docs on Railway. Both
+  // resolve `/<framework>/<slug>` — `${shellUrl}` no longer serves /docs/**
+  // after PR #4702 moved redirect middleware to shell-docs (2026-05-08).
   const shellHref = shellPath
-    ? `${shellUrl}/${integration.slug}${shellPath}`
+    ? `https://docs.copilotkit.ai/${integration.slug}${shellPath}`
     : undefined;
   // CP5: distinguish the two "missing" sub-cases so the tooltip is honest.
   // The override shape (`og_docs_url: string | null`) lets us tell apart:


### PR DESCRIPTION
## Summary

- Shell pre-cutover fix. Flip the dashboard cell "Docs" link in `showcase/shell-dashboard/src/components/cell-pieces.tsx:59` from `${shellUrl}/${slug}${shellPath}` to `https://docs.copilotkit.ai/${slug}${shellPath}`.
- Pre-cutover this CNAME serves the Vercel docs site; post-cutover it serves shell-docs on Railway. Both resolve `/<framework>/<slug>` correctly, so the change is safe across the DNS flip window.
- Demo + Code iframe links (lines 20, 21) intentionally untouched — they iframe `/integrations/[slug]/[demo]/{preview,code}` routes that only `showcase/shell` serves today; porting those is post-cutover work.

## Why this is flip-blocking

After the `docs.copilotkit.ai` DNS flip, `${shellUrl}` (= `showcase.copilotkit.ai`) no longer serves `/docs/**` — those routes were ripped out and the redirect middleware moved to shell-docs in PR #4702 (merged 2026-05-08). Without this change, every dashboard "Docs" cell goes 404 at T-0 of the flip.

## Test plan

- [ ] CI green
- [ ] Smoke locally: `pnpm nx run @copilotkit/showcase-shell-dashboard:dev`, hover any cell's Docs link, confirm href starts with `https://docs.copilotkit.ai/`
- [ ] After merge + Railway redeploy of shell-dashboard, hit production and re-verify the href