### PR TITLE
fix(showcase/beautiful-chat): pin canvas to "beautiful-chat" agent id so shared state renders

### DIFF
--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -539,6 +539,43 @@
     },
     {
       "match": {
+        "toolCallId": "call_fp_beautiful_chat_manage_todos_001"
+      },
+      "response": {
+        "content": "Done — added three todos about learning CopilotKit to your task manager."
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_fp_beautiful_chat_enable_app_mode_001"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_beautiful_chat_manage_todos_001",
+            "name": "manage_todos",
+            "arguments": "{\"todos\":[{\"id\":\"todo-cpk-1\",\"title\":\"Read the CopilotKit docs\",\"description\":\"Start with the quickstart and explore the core hooks.\",\"emoji\":\"📚\",\"status\":\"pending\"},{\"id\":\"todo-cpk-2\",\"title\":\"Build a CopilotKit prototype\",\"description\":\"Wire up a basic chat and register a frontend tool.\",\"emoji\":\"🚀\",\"status\":\"pending\"},{\"id\":\"todo-cpk-3\",\"title\":\"Explore shared agent state\",\"description\":\"Watch the canvas re-render as the agent writes to state.\",\"emoji\":\"🎯\",\"status\":\"pending\"}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "three todos about learning CopilotKit",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_beautiful_chat_enable_app_mode_001",
+            "name": "enableAppMode",
+            "arguments": "{}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
         "userMessage": "hello"
       },
       "response": {

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -31,14 +31,7 @@ const beautifulChatAgent = new LangGraphAgent({
 });
 
 const agents: Record<string, LangGraphAgent> = {
-  // The page's <CopilotKit agent="beautiful-chat"> resolves here.
   "beautiful-chat": beautifulChatAgent,
-  // Internal components (headless-chat, example-canvas) call `useAgent()`
-  // with no args, which defaults to agentId "default". Alias to the same
-  // graph so those component hooks resolve instead of throwing
-  // "Agent 'default' not found". This matches the canonical's
-  // `agents: { default: defaultAgent }` shape.
-  default: beautifulChatAgent,
 };
 
 const runtime = new CopilotRuntime({

--- a/showcase/integrations/langgraph-python/src/app/demos/beautiful-chat/components/example-canvas/index.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/beautiful-chat/components/example-canvas/index.tsx
@@ -4,7 +4,7 @@ import { useAgent } from "@copilotkit/react-core/v2";
 import { TodoList } from "./todo-list";
 
 export function ExampleCanvas() {
-  const { agent } = useAgent();
+  const { agent } = useAgent({ agentId: "beautiful-chat" });
 
   return (
     <div className="h-full overflow-y-auto bg-[--background]">

--- a/showcase/integrations/langgraph-python/tests/e2e/beautiful-chat.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/beautiful-chat.spec.ts
@@ -212,4 +212,28 @@ test.describe("Beautiful Chat", () => {
       .poll(async () => await allCharts.count(), { timeout: 5_000 })
       .toBeLessThanOrEqual(2); // 1 pie + 1 bar = 2 charts in one dashboard
   });
+
+  test("Task Manager pill streams 3 todos into the shared-state canvas", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await page.waitForLoadState("networkidle");
+
+    await page
+      .getByRole("button", { name: "Task Manager (Shared State)" })
+      .click();
+
+    const todoColumn = page.locator('section[aria-label="To Do column"]');
+    await expect(todoColumn).toBeVisible({ timeout: 60_000 });
+
+    await expect(page.getByText("Read the CopilotKit docs")).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(page.getByText("Build a CopilotKit prototype")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByText("Explore shared agent state")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes the Task Manager (Shared State) pill in the langgraph-python `beautiful-chat` showcase, where clicking the pill flipped the canvas to App mode but the To Do column stayed empty even though the backend graph had populated `state.todos`.

**Root cause.** `<CopilotKit agent="beautiful-chat">` in [`page.tsx`](showcase/integrations/langgraph-python/src/app/demos/beautiful-chat/page.tsx) routes the chat through agent id `"beautiful-chat"`. The chat is required to be on that id so the cell's `useComponent` / `useFrontendTool` / `useDefaultRenderTool` registrations (chart, flight, dashboard pills) resolve. `ExampleCanvas`, however, called `useAgent()` with no args, which defaults to `DEFAULT_AGENT_ID` (`"default"`). The frontend's agent registry creates a separate `ProxiedCopilotRuntimeAgent` instance per id even though the route had a `default: beautifulChatAgent` alias on the backend — state-deltas from `manage_todos` landed on the chat's `"beautiful-chat"` instance and never reached the canvas's `"default"` subscription.

**Fix.** Pin the canvas to the same agent id and drop the now-unused backend alias:

- `src/app/demos/beautiful-chat/components/example-canvas/index.tsx` — `useAgent({ agentId: "beautiful-chat" })`
- `src/app/api/copilotkit-beautiful-chat/route.ts` — drop the `default: beautifulChatAgent` alias (the only consumer was the canvas's old default fallback)

Both halves now share one `ProxiedCopilotRuntimeAgent` on the frontend, so `manage_todos` state-deltas flow into `agent.state.todos` and the canvas re-renders.

**Regression coverage.**

- `tests/e2e/beautiful-chat.spec.ts` — Playwright test clicks the Task Manager pill and asserts the 3 verbatim todo titles render in the To Do column. Includes a `waitForLoadState("networkidle")` before the click so the pill-driven `runAgent` doesn't race the v1 CopilotKit context setup.
- `showcase/aimock/feature-parity.json` — 3 fixtures for the multi-turn flow (`parallel_tool_calls=False`, so each step is its own LLM call):
  1. `userMessage: "three todos about learning CopilotKit"` + `hasToolResult: false` → `enableAppMode` tool call
  2. `toolCallId: call_fp_beautiful_chat_enable_app_mode_001` → `manage_todos` tool call with three pending todos
  3. `toolCallId: call_fp_beautiful_chat_manage_todos_001` → final plain-text confirmation

Verified end-to-end against local aimock + langgraph + Next.js. With the fix the test passes in ~5s; reverting just the `useAgent` change reproduces the empty-canvas failure.

## Related PRs and Issues

- N/A

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)