### PR TITLE
feat(ci): add workflow_dispatch escape hatch to release/publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,6 +4,27 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  # Escape hatch for failed releases. Covers failures BEFORE the "Publish to
+  # npm" step succeeds (build errors, infra blips, git config bugs). Does
+  # NOT cover post-npm-publish failures: if npm publish already succeeded
+  # but a later step failed, the retry will fail at "Publish to npm" with
+  # an "already published" error, and the "Check for pre-existing tags"
+  # step will also block retries where the tag was pushed. For those cases,
+  # remediate by hand using release-notes.md from the merged release PR.
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: |
+          ⚠️ MANUAL RETRIGGER — republishes from the latest commit on main,
+          bypassing the normal release-PR flow. Only use this when the
+          normal flow failed BEFORE npm publish succeeded. If npm publish
+          already happened, finish the release by hand instead — dispatching
+          here will fail at "Publish to npm" with "already published".
+        required: true
+        type: choice
+        options:
+          - monorepo
+          - angular
 
 permissions:
   contents: read
@@ -17,23 +38,28 @@ env:
 
 jobs:
   build:
-    # Only run when a release PR is merged (not just closed)
+    # Run on a merged release PR (normal flow) or a manual workflow_dispatch (escape hatch).
     if: >
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/publish/')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+        startsWith(github.event.pull_request.head.ref, 'release/publish/'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
     steps:
-      - name: Extract scope from branch
+      - name: Determine scope
         id: meta
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          INPUT_SCOPE: ${{ inputs.scope }}
         run: |
-          BRANCH="${PR_HEAD_REF}"
-          # Branch format: release/publish/<scope>/v<version>
-          SCOPE=$(echo "$BRANCH" | sed 's|release/publish/\([^/]*\)/v.*|\1|')
+          if [ -n "$INPUT_SCOPE" ]; then
+            SCOPE="$INPUT_SCOPE"
+          else
+            # Branch format: release/publish/<scope>/v<version>
+            SCOPE=$(echo "$PR_HEAD_REF" | sed 's|release/publish/\([^/]*\)/v.*|\1|')
+          fi
           echo "scope=$SCOPE" >> $GITHUB_OUTPUT
           echo "Detected scope: $SCOPE"
 


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to `.github/workflows/publish-release.yml` so the release/publish workflow can be manually retriggered against the latest commit on `main`.

This is the escape hatch for the current edge case: a release failed mid-flight, `main` already has the bumped versions, but nothing was published and the normal PR-merge trigger can't fire again without a fresh release PR.

## What this covers

✅ Failures **before** the `Publish to npm` step succeeded:
- Build errors
- Infrastructure blips (runner crash, OIDC token issue, npm registry hiccup)
- Pre-publish workflow bugs (e.g. the `git config --local` issue fixed in #4874)

## What this does NOT cover

❌ Failures **after** `Publish to npm` succeeded:
- If npm publish ran but tag push or GitHub Release creation failed, dispatching this workflow will fail at `Publish to npm` with an `already published` error.
- The `Check for pre-existing tags` step will also block retries where the tag was pushed but later steps failed.

For those cases: finish the release by hand using `release-notes.md` from the merged release PR — manually create the git tag at the publish commit and create the GitHub Release. Don't dispatch.

Both the in-file YAML comment above `workflow_dispatch:` and the dispatch form's `scope` input description spell this out so operators see it before triggering.

## Change

Minimal: 33 insertions, 7 deletions in one workflow file.

- New `workflow_dispatch` trigger with a required `scope` choice input (`monorepo` | `angular`)
- `if` condition widened to also accept `workflow_dispatch` runs
- Scope-extraction step now uses `inputs.scope` when present, falls back to the existing PR-branch parsing otherwise
- YAML comment above the trigger documents the coverage limits

The normal PR-merge trigger and the entire downstream publish pipeline are unchanged.

## Test plan

- [ ] Merge to main
- [ ] Actions → "release / publish" → "Run workflow" → pick scope → confirm publish proceeds against current main versions
- [ ] Confirm a normal release-PR merge still triggers and behaves identically
- [ ] Confirm dispatch against a state where npm publish already succeeded fails fast at "Publish to npm" (does not corrupt anything)