### PR TITLE
fix(showcase): consolidate cell rendering into single CellModel codepath

### DIFF
--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -11,15 +11,14 @@ import { useProbes, useTriggerProbe } from "@/hooks/use-probes";
 import { mergeRowsToMap } from "@/lib/live-status";
 import { useOverlays } from "@/hooks/useOverlays";
 import { OverlayToggleBar } from "@/components/overlay-toggle-bar";
-import { ComposedCell } from "@/components/composed-cell";
+import { UnifiedCell } from "@/components/unified-cell";
+import { buildCellModel } from "@/lib/cell-model";
 import { AdaptiveStatsBar } from "@/components/adaptive-stats-bar";
 import { AdaptiveLegend } from "@/components/adaptive-legend";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { BaselineTab } from "@/components/baseline-tab";
 import type { ParityTier } from "@/components/parity-badge";
 import { getDocsStatus } from "@/lib/docs-status";
-import { deriveDepth } from "@/components/depth-utils";
-import type { CatalogCell } from "@/components/depth-utils";
 import type { DepthDistribution } from "@/components/adaptive-stats-bar";
 import catalog from "@/data/catalog.json";
 import type { CatalogData } from "@/data/catalog-types";
@@ -72,37 +71,34 @@ export default function Page() {
     selectProbe,
   } = useOverlays();
 
-  // Build a cell-lookup map: integration slug + feature id -> CatalogCell
-  const cellLookup = useMemo(() => {
-    const map = new Map<string, CatalogCell>();
-    for (const cell of catalogData.cells) {
-      if (cell.feature !== null) {
-        map.set(`${cell.integration}:${cell.feature}`, cell);
-      }
-    }
-    return map;
-  }, []);
-
-  // Compute health stats using the SAME color logic as the depth chips.
-  // A cell's chip color depends on achieved vs maxPossible (from deriveDepth),
-  // so the stats bar matches what's visually displayed in the table.
+  // Compute health stats using buildCellModel — single source of truth for
+  // chip color, so the stats bar matches what's visually displayed in the table.
   const healthStats = useMemo(() => {
     let green = 0;
     let amber = 0;
     let red = 0;
     for (const cell of catalogData.cells) {
       if (cell.status !== "wired" || cell.feature === null) continue;
-      const result = deriveDepth(cell as CatalogCell, liveStatus);
-      if (result.unsupported) continue;
-      const { achieved, maxPossible } = result;
-      if (achieved === 0) {
-        green++; // D0 = no probe data yet, not a failure
-      } else if (achieved >= maxPossible) {
-        green++; // At ceiling — same as green chip
-      } else if (maxPossible - achieved <= 2) {
-        amber++; // 1-2 below max — same as amber chip
-      } else {
-        red++; // 3+ below max — same as red chip
+      // "wired" status implies supported — no need to check unsupported here
+      const model = buildCellModel(liveStatus, {
+        slug: cell.integration,
+        featureId: cell.feature,
+        isSupported: true,
+        isWired: true,
+      });
+      switch (model.chipColor) {
+        case "green":
+          green++;
+          break;
+        case "amber":
+          amber++;
+          break;
+        case "red":
+          red++;
+          break;
+        case "gray":
+          green++;
+          break; // no data yet, not a failure
       }
     }
     return { green, amber, red };
@@ -161,25 +157,37 @@ export default function Page() {
     };
     for (const cell of catalogData.cells) {
       if (cell.status !== "wired" || cell.feature === null) continue;
-      const result = deriveDepth(cell, liveStatus);
-      if (result.unsupported) continue;
-      const key = `d${result.achieved}` as keyof DepthDistribution;
+      // "wired" status implies supported — no need to check unsupported here
+      const model = buildCellModel(liveStatus, {
+        slug: cell.integration,
+        featureId: cell.feature,
+        isSupported: true,
+        isWired: true,
+      });
+      const key = `d${model.achievedDepth}` as keyof DepthDistribution;
       dist[key]++;
     }
     return dist;
   }, [liveStatus]);
 
-  // renderCell callback wrapping ComposedCell
+  // renderCell callback wrapping UnifiedCell + buildCellModel.
+  // buildCellModel is the single source of truth for cell state — it handles
+  // not-supported features, ceiling detection, and chip color derivation.
   const renderCell = useCallback(
     (ctx: CellContext) => {
-      const catalogCell = cellLookup.get(
-        `${ctx.integration.slug}:${ctx.feature.id}`,
+      const isSupported = !(
+        ctx.integration.not_supported_features?.includes(ctx.feature.id) ??
+        false
       );
-      return (
-        <ComposedCell ctx={ctx} overlays={overlays} catalogCell={catalogCell} />
-      );
+      const model = buildCellModel(ctx.liveStatus, {
+        slug: ctx.integration.slug,
+        featureId: ctx.feature.id,
+        isSupported,
+        isWired: true, // renderCell only called when demo exists
+      });
+      return <UnifiedCell ctx={ctx} model={model} overlays={overlays} />;
     },
-    [overlays, cellLookup],
+    [overlays],
   );
 
   return (

--- a/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
@@ -286,8 +286,19 @@ describe("CellMatrix", () => {
   });
 
   it("filters to rows with regressions when filter=regressions", () => {
-    // lgp/agentic-chat has D5 mapping → maxPossible=5, achieved=2 → regression
-    // lgp/no-d5-feature has NO D5 mapping → maxPossible=4, achieved=4 → no regression
+    // Uses buildCellModel D3/D4/D5 depth model (not the old D0-D6 ladder).
+    //
+    // lgp/agentic-chat: e2e row GREEN (D3 passes), chat row GREEN (D4 passes),
+    //   but "agentic-chat" has a CATALOG_TO_D5_KEY mapping so ceiling=5.
+    //   No D5 PB rows → D5 status=null → achieved=4 < ceiling=5 → REGRESSION.
+    //
+    // lgp/no-d5-feature: e2e row GREEN (D3 passes), chat row GREEN (D4 passes),
+    //   "no-d5-feature" has NO CATALOG_TO_D5_KEY mapping → ceiling=4.
+    //   achieved=4 === ceiling=4 → NOT a regression.
+    const regressFeatures = [
+      { id: "agentic-chat", name: "Agentic Chat", category: "chat-ui" },
+      { id: "no-d5-feature", name: "No D5 Feature", category: "platform" },
+    ];
     const regressCells: CatalogCell[] = [
       {
         id: "lgp/agentic-chat",
@@ -313,8 +324,7 @@ describe("CellMatrix", () => {
       },
     ];
     const live = mapOf([
-      row("health:lgp", "health", "green"),
-      row("agent:lgp", "agent", "green"),
+      row("e2e:lgp/agentic-chat", "e2e", "green"),
       row("e2e:lgp/no-d5-feature", "e2e", "green"),
       row("chat:lgp", "chat", "green"),
     ]);
@@ -325,7 +335,7 @@ describe("CellMatrix", () => {
       <CellMatrix
         cells={regressCells}
         categories={categories}
-        features={features}
+        features={regressFeatures}
         integrations={oneIntegration}
         liveStatus={live}
         defaultOpenCategories={new Set(["chat-ui", "platform"])}
@@ -333,9 +343,9 @@ describe("CellMatrix", () => {
         referenceSlug="lgp"
       />,
     );
-    // agentic-chat has regression (achieved=2 < maxPossible=5) → visible
+    // agentic-chat: achieved=4 < ceiling=5 → regression → visible
     expect(queryByText("Agentic Chat")).not.toBeNull();
-    // no-d5-feature at ceiling (achieved=4 === maxPossible=4) → hidden
+    // no-d5-feature: achieved=4 === ceiling=4 → at ceiling → hidden
     expect(queryByText("No D5 Feature")).toBeNull();
   });
 

--- a/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
-import { DepthChip, depthColorClass } from "../depth-chip";
+import { DepthChip, depthColorClass, chipColorToClass } from "../depth-chip";
 
 describe("DepthChip", () => {
   it.each([0, 1, 2, 3, 4, 5, 6])(
@@ -257,5 +257,87 @@ describe("depthColorClass (direct)", () => {
   // Additional: D1 with maxDepth=6 → red (5 below)
   it("depthColorClass(1, 6) → red", () => {
     expect(depthColorClass(1, false, 6)).toContain("danger");
+  });
+});
+
+describe("DepthChip with chipColor prop", () => {
+  it("renders green when chipColor='green' regardless of depth", () => {
+    const { getByTestId } = render(
+      <DepthChip depth={3} status="wired" chipColor="green" />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("emerald");
+  });
+
+  it("renders amber when chipColor='amber'", () => {
+    const { getByTestId } = render(
+      <DepthChip depth={4} status="wired" chipColor="amber" />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("amber");
+  });
+
+  it("renders red when chipColor='red'", () => {
+    const { getByTestId } = render(
+      <DepthChip depth={3} status="wired" chipColor="red" />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("danger");
+  });
+
+  it("renders gray when chipColor='gray'", () => {
+    const { getByTestId } = render(
+      <DepthChip depth={0} status="wired" chipColor="gray" />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("text-muted");
+  });
+
+  it("chipColor takes precedence over maxDepth when both provided", () => {
+    // maxDepth=5 with depth=4 would normally be amber, but chipColor overrides
+    const { getByTestId } = render(
+      <DepthChip depth={4} status="wired" maxDepth={5} chipColor="green" />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("emerald");
+  });
+
+  it("falls back to depthColorClass when chipColor not provided", () => {
+    // Backwards compat: D5 with no chipColor should still be green via fallback
+    const { getByTestId } = render(<DepthChip depth={5} status="wired" />);
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("emerald");
+  });
+
+  it("regression overrides chipColor='green' with danger", () => {
+    const { getByTestId } = render(
+      <DepthChip depth={5} status="wired" chipColor="green" regression />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.className).toContain("danger");
+  });
+});
+
+describe("chipColorToClass (direct)", () => {
+  it("green → emerald class", () => {
+    expect(chipColorToClass("green")).toContain("emerald");
+  });
+
+  it("amber → amber class", () => {
+    expect(chipColorToClass("amber")).toContain("amber");
+  });
+
+  it("red → danger class", () => {
+    expect(chipColorToClass("red")).toContain("danger");
+  });
+
+  it("gray → text-muted class", () => {
+    expect(chipColorToClass("gray")).toContain("text-muted");
+  });
+
+  it("regression overrides any color to danger", () => {
+    expect(chipColorToClass("green", true)).toContain("danger");
+    expect(chipColorToClass("amber", true)).toContain("danger");
+    expect(chipColorToClass("gray", true)).toContain("danger");
   });
 });

--- a/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
@@ -1,0 +1,432 @@
+/**
+ * Unit tests for UnifiedCell -- single rendering codepath for Coverage-tab
+ * cells that consumes a pre-computed CellModel.
+ *
+ * Verifies:
+ *   1. Unsupported cells render only the ban icon (Bug 3 regression guard)
+ *   2. Supported cells render depth chip with correct chipColor
+ *   3. Only shows badges for test levels that exist
+ *   4. Shows all three badges when all levels exist
+ *   5. Hides badges when health overlay is not active
+ *   6. Hides depth chip when depth overlay is not active
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { UnifiedCell } from "../unified-cell";
+import type { UnifiedCellProps } from "../unified-cell";
+import type { CellContext } from "@/components/feature-grid";
+import type { CellModel, TestLevel, ChipColor } from "@/lib/cell-model";
+import type { Overlay } from "@/lib/overlay-types";
+import type { LiveStatusMap } from "@/lib/live-status";
+
+// ---------------------------------------------------------------------------
+// Mocks -- isolate UnifiedCell's rendering logic from child components
+// ---------------------------------------------------------------------------
+
+vi.mock("@/components/depth-chip", () => ({
+  DepthChip: vi.fn(
+    ({
+      depth,
+      chipColor,
+    }: {
+      depth: number;
+      status: string;
+      chipColor?: string;
+    }) => (
+      <span data-testid="mock-depth-chip" data-chip-color={chipColor ?? ""}>
+        D{depth}
+      </span>
+    ),
+  ),
+}));
+
+vi.mock("@/components/badges", () => ({
+  Badge: vi.fn(
+    ({
+      name,
+      state,
+    }: {
+      name: string;
+      state: { tone: string; label: string };
+      title?: string;
+    }) => (
+      <span data-testid={`mock-badge-${name}`} data-tone={state.tone}>
+        {name} {state.label}
+      </span>
+    ),
+  ),
+  FlashOnChange: vi.fn(
+    ({ children }: { children: React.ReactNode; tone: string }) => (
+      <span data-testid="mock-flash">{children}</span>
+    ),
+  ),
+}));
+
+vi.mock("@/components/cell-drilldown", () => ({
+  CellDrilldown: vi.fn(() => (
+    <div data-testid="mock-cell-drilldown">drilldown</div>
+  )),
+}));
+
+vi.mock("@/components/command-cell", () => ({
+  CommandCell: vi.fn(({ ctx }: { ctx: CellContext }) => (
+    <div data-testid="mock-command-cell">{ctx.demo.command}</div>
+  )),
+}));
+
+vi.mock("@/components/cell-pieces", () => ({
+  urlsFor: vi.fn(() => ({
+    demoUrl: "https://demo.test/preview",
+    codeUrl: "https://demo.test/code",
+    hostedUrl: "https://hosted.test",
+  })),
+  DocsRow: vi.fn(
+    ({
+      feature,
+    }: {
+      integration: unknown;
+      feature: { id: string };
+      shellUrl: string;
+    }) => <div data-testid="mock-docs-row">{feature.id}</div>,
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const emptyLiveStatus: LiveStatusMap = new Map();
+
+function makeCtx(overrides?: Partial<CellContext>): CellContext {
+  return {
+    integration: {
+      name: "Next.js",
+      slug: "next",
+      category: "framework",
+      language: "TypeScript",
+      description: "Next.js integration",
+      repo: "https://github.com/test/next",
+      backend_url: "https://next.test",
+      deployed: true,
+      features: ["agentic-chat"],
+      demos: [
+        {
+          id: "agentic-chat",
+          name: "Agentic Chat",
+          description: "AI chat",
+          tags: [],
+          route: "/chat",
+        },
+      ],
+    },
+    feature: {
+      id: "agentic-chat",
+      name: "Agentic Chat",
+      category: "chat-ui",
+      description: "AI chat feature",
+      kind: "primary",
+    },
+    demo: {
+      id: "agentic-chat",
+      name: "Agentic Chat",
+      description: "AI chat",
+      tags: [],
+      route: "/chat",
+    },
+    hostedUrl: "https://next.test/chat",
+    shellUrl: "http://localhost:3000",
+    liveStatus: emptyLiveStatus,
+    connection: "live",
+    ...overrides,
+  };
+}
+
+function makeLevel(
+  exists: boolean,
+  status: "green" | "red" | "amber" | null = null,
+): TestLevel {
+  return { exists, status, row: null };
+}
+
+function makeModel(overrides?: Partial<CellModel>): CellModel {
+  return {
+    supported: true,
+    d3: makeLevel(true, "green"),
+    d4: makeLevel(true, "green"),
+    d5: makeLevel(true, "green"),
+    achievedDepth: 5,
+    ceilingDepth: 5,
+    chipColor: "green",
+    isRegression: false,
+    ...overrides,
+  };
+}
+
+function overlaySet(...overlays: Overlay[]): Set<Overlay> {
+  return new Set(overlays);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("UnifiedCell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Test 1: Unsupported cell renders only ban icon (Bug 3) ────────
+  describe("unsupported cells", () => {
+    it("renders only the ban icon with no badges and no depth chip", () => {
+      const ctx = makeCtx();
+      const model = makeModel({ supported: false });
+      const { getByTestId, queryByTestId, queryAllByTestId } = render(
+        <UnifiedCell
+          ctx={ctx}
+          model={model}
+          overlays={overlaySet("links", "depth", "health", "docs")}
+        />,
+      );
+
+      // Unsupported marker present
+      expect(getByTestId("unified-cell-unsupported")).toBeInTheDocument();
+
+      // No depth chip rendered
+      expect(queryByTestId("mock-depth-chip")).not.toBeInTheDocument();
+
+      // No badges rendered
+      expect(queryByTestId("mock-badge-API")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
+
+      // No layer divs rendered
+      expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
+      expect(queryByTestId("health-layer")).not.toBeInTheDocument();
+      expect(queryByTestId("docs-layer")).not.toBeInTheDocument();
+    });
+
+    it("renders ban icon even when all overlays are active", () => {
+      const ctx = makeCtx();
+      const model = makeModel({
+        supported: false,
+        d3: null,
+        d4: null,
+        d5: null,
+        achievedDepth: 0,
+        ceilingDepth: 0,
+        chipColor: "gray",
+      });
+      const { getByTestId, queryByTestId } = render(
+        <UnifiedCell
+          ctx={ctx}
+          model={model}
+          overlays={overlaySet("links", "depth", "health", "docs", "parity")}
+        />,
+      );
+
+      expect(getByTestId("unified-cell-unsupported")).toBeInTheDocument();
+      expect(queryByTestId("unified-cell")).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Test 2: Depth chip uses pre-computed chipColor ────────────────
+  describe("depth chip rendering", () => {
+    it("renders depth chip with correct chipColor from model", () => {
+      const ctx = makeCtx();
+      const model = makeModel({ chipColor: "amber", achievedDepth: 4 });
+      const { getByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("depth")} />,
+      );
+
+      const chip = getByTestId("mock-depth-chip");
+      expect(chip).toBeInTheDocument();
+      expect(chip.getAttribute("data-chip-color")).toBe("amber");
+      expect(chip.textContent).toBe("D4");
+    });
+
+    it("renders depth chip as green when model says green", () => {
+      const ctx = makeCtx();
+      const model = makeModel({ chipColor: "green", achievedDepth: 5 });
+      const { getByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("depth")} />,
+      );
+
+      const chip = getByTestId("mock-depth-chip");
+      expect(chip.getAttribute("data-chip-color")).toBe("green");
+    });
+
+    it("renders depth chip as red when model says red", () => {
+      const ctx = makeCtx();
+      const model = makeModel({ chipColor: "red", achievedDepth: 3 });
+      const { getByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("depth")} />,
+      );
+
+      const chip = getByTestId("mock-depth-chip");
+      expect(chip.getAttribute("data-chip-color")).toBe("red");
+    });
+  });
+
+  // ── Test 3: Only shows badges for test levels that exist ──────────
+  describe("badge existence filtering", () => {
+    it("shows API badge when D3 exists but hides RT badge when D4 is missing", () => {
+      const ctx = makeCtx();
+      const model = makeModel({
+        d3: makeLevel(true, "green"),
+        d4: makeLevel(false), // D4 missing -- no RT badge
+        d5: makeLevel(true, "red"),
+      });
+      const { getByTestId, queryByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
+      );
+
+      // API badge present (D3 exists)
+      expect(getByTestId("mock-badge-API")).toBeInTheDocument();
+      // RT badge absent (D4 does not exist)
+      expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
+      // CV badge present (D5 exists)
+      expect(getByTestId("mock-badge-CV")).toBeInTheDocument();
+    });
+
+    it("hides all badges when no test levels exist", () => {
+      const ctx = makeCtx();
+      const model = makeModel({
+        d3: makeLevel(false),
+        d4: makeLevel(false),
+        d5: makeLevel(false),
+      });
+      const { queryByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
+      );
+
+      expect(queryByTestId("mock-badge-API")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
+    });
+
+    it("hides badge when level is null", () => {
+      const ctx = makeCtx();
+      const model = makeModel({
+        d3: null,
+        d4: makeLevel(true, "green"),
+        d5: null,
+      });
+      const { getByTestId, queryByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
+      );
+
+      expect(queryByTestId("mock-badge-API")).not.toBeInTheDocument();
+      expect(getByTestId("mock-badge-RT")).toBeInTheDocument();
+      expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Test 4: Shows all three badges when all levels exist ──────────
+  describe("all badges visible", () => {
+    it("shows API, RT, and CV badges when all three levels exist", () => {
+      const ctx = makeCtx();
+      const model = makeModel({
+        d3: makeLevel(true, "green"),
+        d4: makeLevel(true, "amber"),
+        d5: makeLevel(true, "red"),
+      });
+      const { getByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
+      );
+
+      const apiBadge = getByTestId("mock-badge-API");
+      expect(apiBadge).toBeInTheDocument();
+      expect(apiBadge.getAttribute("data-tone")).toBe("green");
+
+      const rtBadge = getByTestId("mock-badge-RT");
+      expect(rtBadge).toBeInTheDocument();
+      expect(rtBadge.getAttribute("data-tone")).toBe("amber");
+
+      const cvBadge = getByTestId("mock-badge-CV");
+      expect(cvBadge).toBeInTheDocument();
+      expect(cvBadge.getAttribute("data-tone")).toBe("red");
+    });
+  });
+
+  // ── Test 5: Hides badges when health overlay is not active ────────
+  describe("overlay gating", () => {
+    it("hides health badges when health overlay is off", () => {
+      const ctx = makeCtx();
+      const model = makeModel(); // all levels exist
+      const { queryByTestId } = render(
+        <UnifiedCell
+          ctx={ctx}
+          model={model}
+          overlays={overlaySet("links", "depth")} // health NOT in set
+        />,
+      );
+
+      expect(queryByTestId("health-layer")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-API")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
+    });
+
+    // ── Test 6: Hides depth chip when depth overlay is not active ───
+    it("hides depth chip when depth overlay is off", () => {
+      const ctx = makeCtx();
+      const model = makeModel();
+      const { queryByTestId } = render(
+        <UnifiedCell
+          ctx={ctx}
+          model={model}
+          overlays={overlaySet("links", "health")} // depth NOT in set
+        />,
+      );
+
+      expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-depth-chip")).not.toBeInTheDocument();
+    });
+
+    it("renders empty when only parity overlay active", () => {
+      const ctx = makeCtx();
+      const model = makeModel();
+      const { getByTestId, queryByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("parity")} />,
+      );
+
+      expect(getByTestId("unified-cell-empty")).toBeInTheDocument();
+      expect(queryByTestId("unified-cell")).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Additional coverage ───────────────────────────────────────────
+  describe("badge tone mapping", () => {
+    it("maps green status to green tone with check mark", () => {
+      const ctx = makeCtx();
+      const model = makeModel({
+        d3: makeLevel(true, "green"),
+        d4: makeLevel(false),
+        d5: makeLevel(false),
+      });
+      const { getByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
+      );
+
+      const badge = getByTestId("mock-badge-API");
+      expect(badge.getAttribute("data-tone")).toBe("green");
+      expect(badge.textContent).toContain("✓");
+    });
+
+    it("maps null status to gray tone with question mark", () => {
+      const ctx = makeCtx();
+      const model = makeModel({
+        d3: makeLevel(true, null), // exists but no status yet
+        d4: makeLevel(false),
+        d5: makeLevel(false),
+      });
+      const { getByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
+      );
+
+      const badge = getByTestId("mock-badge-API");
+      expect(badge.getAttribute("data-tone")).toBe("gray");
+      expect(badge.textContent).toContain("?");
+    });
+  });
+});

--- a/showcase/shell-dashboard/src/components/cell-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/cell-matrix.tsx
@@ -15,8 +15,8 @@ import { DepthChip } from "./depth-chip";
 import { CellDrilldown } from "./cell-drilldown";
 import { IntegrationHeader } from "./integration-header";
 import { useCollapsible, CategoryHeaderRow } from "./collapsible-category";
-import { deriveDepth } from "./depth-utils";
-import type { CatalogCell, DepthResult } from "./depth-utils";
+import { buildCellModel } from "@/lib/cell-model";
+import type { CatalogCell } from "./depth-utils";
 import type { ParityTier } from "./parity-badge";
 import type { FilterMode } from "./filter-chips";
 import { resolveCell } from "@/lib/live-status";
@@ -143,15 +143,14 @@ function CategorySection({
             </td>
             {visibleIntegrations.map((int) => {
               const cell = cellIndex.get(`${int.slug}/${feature.id}`);
-              const depth: DepthResult = cell
-                ? deriveDepth(cell, liveStatus)
-                : {
-                    achieved: 0,
-                    maxPossible: 0,
-                    isRegression: false,
-                    unsupported: false,
-                  };
-              const cellStatus = depth.unsupported
+              const isNotSupported = cell?.status === "unsupported";
+              const model = buildCellModel(liveStatus, {
+                slug: int.slug,
+                featureId: feature.id,
+                isSupported: !isNotSupported,
+                isWired: cell?.status === "wired" || cell?.status === "stub",
+              });
+              const cellStatus = !model.supported
                 ? "unsupported"
                 : (cell?.status ?? "unshipped");
 
@@ -180,9 +179,9 @@ function CategorySection({
                     }
                   >
                     <DepthChip
-                      depth={depth.achieved}
+                      depth={model.achievedDepth as 0 | 1 | 2 | 3 | 4 | 5 | 6}
                       status={cellStatus}
-                      maxDepth={depth.maxPossible}
+                      chipColor={model.chipColor}
                     />
                   </button>
                   {isSelected && (
@@ -309,8 +308,16 @@ export function CellMatrix({
       return visibleIntegrations.some((int) => {
         const cell = cellIndex.get(`${int.slug}/${featureId}`);
         if (!cell) return false;
-        const depth = deriveDepth(cell, liveStatus);
-        return depth.isRegression;
+        const isNotSupported = cell.status === "unsupported";
+        const model = buildCellModel(liveStatus, {
+          slug: int.slug,
+          featureId,
+          isSupported: !isNotSupported,
+          isWired: cell.status === "wired" || cell.status === "stub",
+        });
+        return (
+          model.ceilingDepth > 0 && model.achievedDepth < model.ceilingDepth
+        );
       });
     }
     return true;

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -1,5 +1,8 @@
 "use client";
 /**
+ * @deprecated Use UnifiedCell from @/components/unified-cell instead.
+ * Retained for backwards compatibility during transition.
+ *
  * ComposedCell — overlay-aware cell renderer.
  *
  * Composes different content layers (Links, Depth, Health, Docs) based on

--- a/showcase/shell-dashboard/src/components/depth-chip.tsx
+++ b/showcase/shell-dashboard/src/components/depth-chip.tsx
@@ -27,6 +27,12 @@ export interface DepthChipProps {
    * go to D4 show green at D4 instead of the old hardcoded amber.
    */
   maxDepth?: number;
+  /**
+   * Pre-computed color override. When provided, bypasses the internal
+   * `depthColorClass()` derivation entirely. Useful when the caller has
+   * already determined the correct color (e.g. green when achieved == ceiling).
+   */
+  chipColor?: "green" | "amber" | "red" | "gray";
 }
 
 /**
@@ -58,11 +64,33 @@ export function depthColorClass(
   return "bg-[var(--danger)] text-white";
 }
 
+/**
+ * Map a pre-computed chip color to the corresponding CSS class string.
+ * Regression always wins (renders danger red).
+ */
+export function chipColorToClass(
+  color: "green" | "amber" | "red" | "gray",
+  regression?: boolean,
+): string {
+  if (regression) return "bg-[var(--danger)] text-white";
+  switch (color) {
+    case "green":
+      return "bg-emerald-600 text-white";
+    case "amber":
+      return "bg-[var(--amber)] text-white";
+    case "red":
+      return "bg-[var(--danger)] text-white";
+    case "gray":
+      return "bg-[var(--text-muted)]/20 text-[var(--text-muted)]";
+  }
+}
+
 export function DepthChip({
   depth,
   status,
   regression,
   maxDepth,
+  chipColor,
 }: DepthChipProps) {
   if (status === "unshipped") {
     return (
@@ -93,7 +121,9 @@ export function DepthChip({
     );
   }
 
-  const colorClass = depthColorClass(depth, regression, maxDepth);
+  const colorClass = chipColor
+    ? chipColorToClass(chipColor, regression)
+    : depthColorClass(depth, regression, maxDepth);
 
   return (
     <span

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -1,4 +1,7 @@
 /**
+ * @deprecated deriveDepth() has been replaced by buildCellModel() in @/lib/cell-model.ts.
+ * CatalogCell type is still used by cell-matrix.tsx and other consumers.
+ *
  * Pure depth-derivation utility for the D0-D6 depth ladder.
  *
  * Walks D0 through D6 checking PocketBase live-status rows:

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -16,7 +16,7 @@ import type { ConnectionStatus, LiveStatusMap } from "@/lib/live-status";
 import { LevelStrip } from "@/components/level-strip";
 import { OverlayColumnHeader } from "@/components/overlay-column-header";
 import { RefDepthHeader, RefDepthCell } from "@/components/ref-depth-column";
-import { deriveDepth } from "@/components/depth-utils";
+import { buildCellModel } from "@/lib/cell-model";
 import type { CatalogCell } from "@/components/depth-utils";
 import type { Overlay } from "@/lib/overlay-types";
 import type { ParityTier } from "@/components/parity-badge";
@@ -271,8 +271,14 @@ const CategorySection = React.memo(
             const refCell = showRefDepth
               ? refCellsByFeature.get(feature.id)
               : undefined;
-            const refDepth = refCell
-              ? deriveDepth(refCell, liveStatus)
+            const refModel = refCell
+              ? buildCellModel(liveStatus, {
+                  slug: refCell.integration,
+                  featureId: refCell.feature ?? feature.id,
+                  isSupported: refCell.status !== "unsupported",
+                  isWired:
+                    refCell.status === "wired" || refCell.status === "stub",
+                })
               : undefined;
             return (
               <tr
@@ -306,13 +312,13 @@ const CategorySection = React.memo(
                   </div>
                 </td>
                 {showRefDepth &&
-                  (refCell && refDepth && !docsOnly ? (
+                  (refCell && refModel && !docsOnly ? (
                     <RefDepthCell
-                      depth={refDepth.achieved}
+                      depth={refModel.achievedDepth}
                       status={
-                        refDepth.unsupported ? "unsupported" : refCell.status
+                        !refModel.supported ? "unsupported" : refCell.status
                       }
-                      maxDepth={refDepth.maxPossible}
+                      maxDepth={refModel.ceilingDepth}
                     />
                   ) : (
                     <td

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -1,0 +1,301 @@
+"use client";
+/**
+ * UnifiedCell -- single rendering codepath for Coverage-tab cells.
+ *
+ * Consumes a pre-computed `CellModel` and renders:
+ *   - Unsupported cells: only a ban icon, no badges, no depth chip (Bug 3 fix)
+ *   - Supported cells: depth chip (with pre-computed chipColor) + test badges
+ *     only for levels where `exists === true`
+ *
+ * Replaces ComposedCell's independent DepthLayer/HealthLayer that don't
+ * cross-check support status or test-level existence.
+ */
+
+import { memo, useState, useEffect, useRef, useCallback } from "react";
+import type { CellContext } from "@/components/feature-grid";
+import type { CellModel, TestLevel } from "@/lib/cell-model";
+import { DepthChip } from "@/components/depth-chip";
+import { Badge, FlashOnChange } from "@/components/badges";
+import type { BadgeTone } from "@/lib/live-status";
+import { keyFor, CATALOG_TO_D5_KEY } from "@/lib/live-status";
+import type { Overlay } from "@/lib/overlay-types";
+import { CellDrilldown } from "@/components/cell-drilldown";
+import { CommandCell } from "@/components/command-cell";
+import { DocsRow, urlsFor } from "@/components/cell-pieces";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface UnifiedCellProps {
+  ctx: CellContext;
+  model: CellModel;
+  overlays: Set<Overlay>;
+}
+
+// ---------------------------------------------------------------------------
+// TestBadge helper
+// ---------------------------------------------------------------------------
+
+function TestBadge({ name, level }: { name: string; level: TestLevel | null }) {
+  if (!level || !level.exists) return null;
+
+  const tone: BadgeTone =
+    level.status === "green"
+      ? "green"
+      : level.status === "red"
+        ? "red"
+        : level.status === "amber"
+          ? "amber"
+          : "gray";
+
+  const label =
+    level.status === "green"
+      ? "✓"
+      : level.status === "red"
+        ? "✗"
+        : level.status === "amber"
+          ? "~"
+          : "?";
+
+  return (
+    <FlashOnChange tone={tone}>
+      <Badge
+        name={name}
+        state={{ tone, label }}
+        title={`${name}: ${level.status ?? "pending"}`}
+      />
+    </FlashOnChange>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Layer renderers
+// ---------------------------------------------------------------------------
+
+function LinksLayer({ ctx }: { ctx: CellContext }) {
+  if (ctx.demo.command) {
+    return <CommandCell ctx={ctx} />;
+  }
+
+  const links = urlsFor(ctx);
+
+  return (
+    <div className="flex items-center justify-center gap-1.5">
+      <a
+        href={links.demoUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="whitespace-nowrap text-[var(--accent)] hover:underline"
+      >
+        <span className="text-[var(--text-muted)]">Demo</span>{" "}
+        <span>&#8599;</span>
+      </a>
+      <a
+        href={links.codeUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="whitespace-nowrap text-[var(--accent)] hover:underline"
+      >
+        <span className="text-[var(--text-muted)]">Code</span>{" "}
+        <span>{"</>"}</span>
+      </a>
+    </div>
+  );
+}
+
+function DepthLayer({ ctx, model }: { ctx: CellContext; model: CellModel }) {
+  const [drilldownOpen, setDrilldownOpen] = useState<boolean>(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const closeDrilldown = useCallback(() => setDrilldownOpen(false), []);
+
+  // Close drilldown on click-outside
+  useEffect(() => {
+    if (!drilldownOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setDrilldownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [drilldownOpen]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex items-center gap-1 relative"
+      data-testid="depth-layer"
+    >
+      <button
+        type="button"
+        data-testid={`depth-btn-${ctx.integration.slug}-${ctx.feature.id}`}
+        className="cursor-pointer bg-transparent border-none p-0"
+        onClick={() => setDrilldownOpen((prev) => !prev)}
+      >
+        <DepthChip
+          chipColor={model.chipColor}
+          depth={model.achievedDepth}
+          status="wired"
+        />
+      </button>
+      {drilldownOpen && (
+        <CellDrilldown
+          slug={ctx.integration.slug}
+          featureId={ctx.feature.id}
+          integrationName={ctx.integration.name}
+          featureName={ctx.feature.name}
+          liveStatus={ctx.liveStatus}
+          connection={ctx.connection}
+          onClose={closeDrilldown}
+        />
+      )}
+    </div>
+  );
+}
+
+function HealthLayer({ model }: { model: CellModel }) {
+  return (
+    <div
+      data-testid="health-layer"
+      className="flex items-center justify-center gap-2.5"
+    >
+      <TestBadge name="API" level={model.d3} />
+      <TestBadge name="RT" level={model.d4} />
+      <TestBadge name="CV" level={model.d5} />
+    </div>
+  );
+}
+
+function DocsLayer({ ctx }: { ctx: CellContext }) {
+  return (
+    <div data-testid="docs-layer">
+      <DocsRow
+        integration={ctx.integration}
+        feature={ctx.feature}
+        shellUrl={ctx.shellUrl}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// UnifiedCell
+// ---------------------------------------------------------------------------
+
+function UnifiedCellInner({ ctx, model, overlays }: UnifiedCellProps) {
+  // ── Unsupported cell: ban icon only (Bug 3 fix) ─────────────────────
+  if (!model.supported) {
+    return (
+      <div data-testid="unified-cell-unsupported" className="text-center">
+        <span
+          className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-base border border-slate-500/40 bg-slate-500/10 text-slate-400"
+          title="Not supported by this framework"
+        >
+          &#128683;
+        </span>
+      </div>
+    );
+  }
+
+  const isDocsOnly = ctx.feature.kind === "docs-only";
+  const isTesting = ctx.feature.kind === "testing";
+  const hasLinks = overlays.has("links");
+  const hasDepth = overlays.has("depth");
+  const hasHealth = overlays.has("health");
+  const hasDocs = overlays.has("docs");
+
+  // docs-only features: only links and docs layers, no depth or health.
+  if (isDocsOnly) {
+    const hasDocsOnlyContent = hasLinks || hasDocs;
+    if (!hasDocsOnlyContent) {
+      return <div data-testid="unified-cell-empty" />;
+    }
+    return (
+      <div
+        data-testid="unified-cell"
+        className="flex flex-col items-center gap-0.5 text-[11px] opacity-60"
+      >
+        {hasLinks && <LinksLayer ctx={ctx} />}
+        {hasDocs && <DocsLayer ctx={ctx} />}
+      </div>
+    );
+  }
+
+  // Check if any layer will produce content
+  const hasContent = hasLinks || hasDepth || hasHealth || hasDocs;
+
+  if (!hasContent) {
+    return <div data-testid="unified-cell-empty" />;
+  }
+
+  return (
+    <div
+      data-testid="unified-cell"
+      className={`flex flex-col items-center gap-0.5 text-[11px] ${isTesting ? "opacity-60" : ""}`}
+    >
+      {hasLinks && <LinksLayer ctx={ctx} />}
+      {hasDepth && <DepthLayer ctx={ctx} model={model} />}
+      {hasHealth && !ctx.demo.command && <HealthLayer model={model} />}
+      {hasDocs && <DocsLayer ctx={ctx} />}
+    </div>
+  );
+}
+
+/**
+ * Custom equality check for UnifiedCell. Skipping a cell render when its
+ * underlying inputs are unchanged is the difference between a single PB SSE
+ * delta re-rendering 1 cell vs. all ~720 cells in the matrix.
+ */
+function arePropsEqual(
+  prev: UnifiedCellProps,
+  next: UnifiedCellProps,
+): boolean {
+  if (prev.overlays !== next.overlays) return false;
+  if (prev.model !== next.model) return false;
+
+  const p = prev.ctx;
+  const n = next.ctx;
+  if (
+    p.connection !== n.connection ||
+    p.hostedUrl !== n.hostedUrl ||
+    p.shellUrl !== n.shellUrl ||
+    p.integration !== n.integration ||
+    p.feature !== n.feature ||
+    p.demo !== n.demo
+  ) {
+    return false;
+  }
+
+  if (p.liveStatus === n.liveStatus) return true;
+
+  // Map identity changed -- verify only the rows this cell reads.
+  const slug = p.integration.slug;
+  const featureId = p.feature.id;
+  const directKeys = [
+    keyFor("e2e", slug, featureId),
+    keyFor("chat", slug),
+    keyFor("tools", slug),
+  ];
+
+  // Add D5 sub-keys from CATALOG_TO_D5_KEY
+  const d5Keys = CATALOG_TO_D5_KEY[featureId];
+  if (d5Keys && d5Keys.length > 0) {
+    for (const d5Key of d5Keys) {
+      directKeys.push(keyFor("d5", slug, d5Key));
+    }
+  } else {
+    directKeys.push(keyFor("d5", slug, featureId));
+  }
+
+  for (const k of directKeys) {
+    if (prev.ctx.liveStatus.get(k) !== next.ctx.liveStatus.get(k)) return false;
+  }
+  return true;
+}
+
+export const UnifiedCell = memo(UnifiedCellInner, arePropsEqual);

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect } from "vitest";
+import { buildCellModel } from "../cell-model";
+import type { CellModel, CellModelInput } from "../cell-model";
+import type { LiveStatusMap, StatusRow, State } from "../live-status";
+import { keyFor } from "../live-status";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function row(
+  key: string,
+  dimension: string,
+  state: State,
+  overrides: Partial<StatusRow> = {},
+): StatusRow {
+  return {
+    id: `id-${key}`,
+    key,
+    dimension,
+    state,
+    signal: {},
+    observed_at: "2026-04-20T00:00:00Z",
+    transitioned_at: "2026-04-20T00:00:00Z",
+    fail_count: state === "red" ? 1 : 0,
+    first_failure_at: state === "red" ? "2026-04-20T00:00:00Z" : null,
+    ...overrides,
+  };
+}
+
+function mapOf(rows: StatusRow[]): LiveStatusMap {
+  const m: LiveStatusMap = new Map();
+  for (const r of rows) m.set(r.key, r);
+  return m;
+}
+
+function wiredInput(
+  slug: string,
+  featureId: string,
+  overrides: Partial<CellModelInput> = {},
+): CellModelInput {
+  return {
+    slug,
+    featureId,
+    isSupported: true,
+    isWired: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildCellModel", () => {
+  // ── Bug 3 regression: unsupported cell ──────────────────────────────
+  describe("unsupported cell (Bug 3 regression)", () => {
+    it("returns gray chip with all null levels", () => {
+      const live = mapOf([]);
+      const input: CellModelInput = {
+        slug: "agno",
+        featureId: "agentic-chat",
+        isSupported: false,
+        isWired: false,
+      };
+      const model = buildCellModel(live, input);
+      expect(model.supported).toBe(false);
+      expect(model.d3).toBeNull();
+      expect(model.d4).toBeNull();
+      expect(model.d5).toBeNull();
+      expect(model.achievedDepth).toBe(0);
+      expect(model.ceilingDepth).toBe(0);
+      expect(model.chipColor).toBe("gray");
+      expect(model.isRegression).toBe(false);
+    });
+
+    it("ignores live data for unsupported cells", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+      ]);
+      const model = buildCellModel(live, {
+        slug: "agno",
+        featureId: "agentic-chat",
+        isSupported: false,
+        isWired: true,
+      });
+      expect(model.supported).toBe(false);
+      expect(model.chipColor).toBe("gray");
+    });
+  });
+
+  // ── Not-wired cell ──────────────────────────────────────────────────
+  describe("not-wired cell", () => {
+    it("returns gray chip with exists=false on all levels", () => {
+      const model = buildCellModel(mapOf([]), {
+        slug: "agno",
+        featureId: "agentic-chat",
+        isSupported: true,
+        isWired: false,
+      });
+      expect(model.supported).toBe(true);
+      expect(model.d3).toEqual({ exists: false, status: null, row: null });
+      expect(model.d4).toEqual({ exists: false, status: null, row: null });
+      expect(model.d5).toEqual({ exists: false, status: null, row: null });
+      expect(model.achievedDepth).toBe(0);
+      expect(model.ceilingDepth).toBe(0);
+      expect(model.chipColor).toBe("gray");
+    });
+  });
+
+  // ── Bug 1 regression: D3 passing without health row ─────────────────
+  describe("D3 passing without health row (Bug 1 regression)", () => {
+    it("returns achievedDepth=3 when only D3 passes (no D5 mapping)", () => {
+      // Use a featureId with no CATALOG_TO_D5_KEY mapping so ceiling=3
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "no-d5-feature"), "e2e", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "no-d5-feature"));
+      expect(model.d3!.exists).toBe(true);
+      expect(model.d3!.status).toBe("green");
+      expect(model.achievedDepth).toBe(3);
+      expect(model.ceilingDepth).toBe(3);
+      expect(model.chipColor).toBe("green");
+    });
+
+    it("returns achievedDepth=3 when D3 passes and D5 exists but has no data", () => {
+      // agentic-chat IS in CATALOG_TO_D5_KEY → D5 exists=true, status=null
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d3!.exists).toBe(true);
+      expect(model.d3!.status).toBe("green");
+      expect(model.d5!.exists).toBe(true);
+      expect(model.d5!.status).toBeNull();
+      expect(model.achievedDepth).toBe(3);
+      // ceilingDepth requires contiguity: D4 doesn't exist → stops at 3
+      expect(model.ceilingDepth).toBe(3);
+      // achieved === ceiling → green
+      expect(model.chipColor).toBe("green");
+    });
+  });
+
+  // ── Bug 2 regression: D3+D4 pass, no D5 → green chip ───────────────
+  describe("D3+D4 pass, no D5 exists (Bug 2 regression)", () => {
+    it("returns green chip when achieved === ceiling", () => {
+      // Use a featureId that has no CATALOG_TO_D5_KEY mapping
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "no-d5-feature"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "no-d5-feature"));
+      expect(model.d3!.exists).toBe(true);
+      expect(model.d3!.status).toBe("green");
+      expect(model.d4!.exists).toBe(true);
+      expect(model.d4!.status).toBe("green");
+      expect(model.d5!.exists).toBe(false);
+      expect(model.achievedDepth).toBe(4);
+      expect(model.ceilingDepth).toBe(4);
+      expect(model.chipColor).toBe("green");
+    });
+  });
+
+  // ── D3+D4 pass, D5 exists but fails → amber chip ───────────────────
+  describe("D3+D4 pass, D5 exists but fails", () => {
+    it("returns amber chip (ceiling - achieved = 1)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d3!.status).toBe("green");
+      expect(model.d4!.status).toBe("green");
+      expect(model.d5!.exists).toBe(true);
+      expect(model.d5!.status).toBe("red");
+      expect(model.achievedDepth).toBe(4);
+      expect(model.ceilingDepth).toBe(5);
+      expect(model.chipColor).toBe("amber");
+    });
+  });
+
+  // ── All three pass → D5 green ───────────────────────────────────────
+  describe("all three depths pass", () => {
+    it("returns green chip at D5", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.achievedDepth).toBe(5);
+      expect(model.ceilingDepth).toBe(5);
+      expect(model.chipColor).toBe("green");
+    });
+  });
+
+  // ── D3 fails → D0 achieved, red chip ───────────────────────────────
+  describe("D3 fails", () => {
+    it("returns achievedDepth=0 and gray chip when D3 fails (achieved=0 always gray)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d3!.status).toBe("red");
+      expect(model.achievedDepth).toBe(0);
+      expect(model.ceilingDepth).toBe(5);
+      // achieved === 0 → gray (per spec: gray when achieved === 0)
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("returns gray chip when D3 is only depth and it fails", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "no-d5-feature"), "e2e", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "no-d5-feature"));
+      expect(model.achievedDepth).toBe(0);
+      expect(model.ceilingDepth).toBe(3);
+      // achieved === 0 → gray
+      expect(model.chipColor).toBe("gray");
+    });
+  });
+
+  // ── D4 via tools instead of chat ────────────────────────────────────
+  describe("D4 via tools row", () => {
+    it("resolves D4 from tools:<slug> when chat is absent", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("tools", "agno"), "tools", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d4!.exists).toBe(true);
+      expect(model.d4!.status).toBe("green");
+      expect(model.d4!.row!.dimension).toBe("tools");
+      expect(model.achievedDepth).toBe(4);
+    });
+
+    it("worst-state wins when both chat and tools exist", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("tools", "agno"), "tools", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d4!.exists).toBe(true);
+      expect(model.d4!.status).toBe("red");
+      expect(model.d4!.row!.dimension).toBe("tools");
+    });
+  });
+
+  // ── D5 multi-key (CATALOG_TO_D5_KEY has multiple sub-keys) ──────────
+  describe("D5 multi-key worst-state", () => {
+    it("picks worst state across multiple D5 sub-keys", () => {
+      // beautiful-chat maps to 5 sub-keys
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "beautiful-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-toggle-theme"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-pie-chart"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-bar-chart"), "d5", "red"),
+        row(
+          keyFor("d5", "agno", "beautiful-chat-search-flights"),
+          "d5",
+          "green",
+        ),
+        row(
+          keyFor("d5", "agno", "beautiful-chat-schedule-meeting"),
+          "d5",
+          "green",
+        ),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
+      expect(model.d5!.exists).toBe(true);
+      expect(model.d5!.status).toBe("red");
+      // D5 is red → achievedDepth stops at D4
+      expect(model.achievedDepth).toBe(4);
+      expect(model.ceilingDepth).toBe(5);
+      expect(model.chipColor).toBe("amber");
+    });
+
+    it("returns green when all D5 sub-keys pass", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "beautiful-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-toggle-theme"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-pie-chart"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-bar-chart"), "d5", "green"),
+        row(
+          keyFor("d5", "agno", "beautiful-chat-search-flights"),
+          "d5",
+          "green",
+        ),
+        row(
+          keyFor("d5", "agno", "beautiful-chat-schedule-meeting"),
+          "d5",
+          "green",
+        ),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
+      expect(model.d5!.status).toBe("green");
+      expect(model.achievedDepth).toBe(5);
+      expect(model.chipColor).toBe("green");
+    });
+  });
+
+  // ── No live data at all → D0 gray ──────────────────────────────────
+  describe("no live data", () => {
+    it("returns gray chip with achievedDepth=0 and ceilingDepth=0", () => {
+      const model = buildCellModel(
+        mapOf([]),
+        wiredInput("agno", "agentic-chat"),
+      );
+      expect(model.d3!.exists).toBe(false);
+      expect(model.d4!.exists).toBe(false);
+      // agentic-chat IS in CATALOG_TO_D5_KEY, so exists=true but status=null
+      expect(model.d5!.exists).toBe(true);
+      expect(model.d5!.status).toBeNull();
+      // ceilingDepth requires contiguity: D5 only counts if D3+D4 exist
+      expect(model.ceilingDepth).toBe(0);
+      expect(model.achievedDepth).toBe(0);
+      // both zero → gray (achieved === 0 guard fires first)
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("returns ceilingDepth=0 when no tests exist at all", () => {
+      const model = buildCellModel(
+        mapOf([]),
+        wiredInput("agno", "no-d5-feature"),
+      );
+      expect(model.ceilingDepth).toBe(0);
+      expect(model.chipColor).toBe("gray");
+    });
+  });
+
+  // ── Degraded state maps to amber ───────────────────────────────────
+  describe("degraded state → amber", () => {
+    it("maps degraded D3 to amber status", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "degraded"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d3!.status).toBe("amber");
+    });
+
+    it("maps degraded D4 to amber status", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "degraded"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d4!.status).toBe("amber");
+    });
+
+    it("degraded D3 breaks contiguous chain (achievedDepth=0)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "degraded"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.achievedDepth).toBe(0);
+    });
+  });
+
+  // ── Edge: D3 exists but no status row (no data yet) ─────────────────
+  describe("D3 exists in map but D4/D5 do not", () => {
+    it("ceilingDepth reflects only existing levels", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "no-d5-feature"), "e2e", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "no-d5-feature"));
+      expect(model.ceilingDepth).toBe(3);
+      expect(model.achievedDepth).toBe(3);
+      expect(model.chipColor).toBe("green");
+    });
+  });
+
+  // ── Contiguous chain breaks at D4 ──────────────────────────────────
+  describe("contiguous chain breaks at D4", () => {
+    it("D3 green, D4 red, D5 green → achievedDepth=3", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "red"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.achievedDepth).toBe(3);
+      expect(model.ceilingDepth).toBe(5);
+      // ceiling - achieved = 2 > 1 → red
+      expect(model.chipColor).toBe("red");
+    });
+  });
+
+  // ── isRegression is always false (stub for future) ─────────────────
+  describe("isRegression", () => {
+    it("is always false in current implementation", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.isRegression).toBe(false);
+    });
+  });
+});

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -1,0 +1,269 @@
+/**
+ * CellModel — single source of truth for Coverage-tab cell rendering.
+ *
+ * Replaces scattered inline derivation logic with one pure function
+ * (`buildCellModel`) that computes every value a cell needs to render:
+ * per-depth test levels, achieved/ceiling depths, chip color, and
+ * regression flag.
+ */
+
+import type { LiveStatusMap, StatusRow, State } from "./live-status";
+import { keyFor, CATALOG_TO_D5_KEY } from "./live-status";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TestStatus = "green" | "red" | "amber" | null;
+export type ChipColor = "green" | "amber" | "red" | "gray";
+
+export interface TestLevel {
+  exists: boolean;
+  status: TestStatus;
+  row: StatusRow | null;
+}
+
+export interface CellModel {
+  supported: boolean;
+  d3: TestLevel | null;
+  d4: TestLevel | null;
+  d5: TestLevel | null;
+  achievedDepth: 0 | 3 | 4 | 5;
+  ceilingDepth: 0 | 3 | 4 | 5;
+  chipColor: ChipColor;
+  isRegression: boolean;
+}
+
+export interface CellModelInput {
+  slug: string;
+  featureId: string;
+  isSupported: boolean;
+  isWired: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Map PocketBase State → TestStatus. */
+function stateToTestStatus(state: State): TestStatus {
+  switch (state) {
+    case "green":
+      return "green";
+    case "red":
+      return "red";
+    case "degraded":
+      return "amber";
+    default: {
+      const _exhaustive: never = state;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
+
+/** Rank for worst-state comparison: higher = worse. */
+const STATE_RANK: Readonly<Record<State, number>> = {
+  red: 3,
+  degraded: 2,
+  green: 1,
+};
+
+/**
+ * Resolve the D4 (real-time) test level for `slug`.
+ *
+ * D4 checks both `chat:<slug>` and `tools:<slug>`. When both exist the
+ * worst-state wins — a green chat + red tools yields red D4, not green.
+ */
+function resolveD4(live: LiveStatusMap, slug: string): TestLevel {
+  const chatRow = live.get(keyFor("chat", slug)) ?? null;
+  const toolsRow = live.get(keyFor("tools", slug)) ?? null;
+
+  if (!chatRow && !toolsRow) {
+    return { exists: false, status: null, row: null };
+  }
+
+  // Pick the worst row when both exist.
+  let winner: StatusRow;
+  if (chatRow && toolsRow) {
+    winner =
+      STATE_RANK[toolsRow.state] > STATE_RANK[chatRow.state]
+        ? toolsRow
+        : chatRow;
+  } else {
+    winner = (chatRow ?? toolsRow)!;
+  }
+
+  return {
+    exists: true,
+    status: stateToTestStatus(winner.state),
+    row: winner,
+  };
+}
+
+/**
+ * Resolve the D5 (conversation verification) test level for
+ * `(slug, featureId)`.
+ *
+ * Uses `CATALOG_TO_D5_KEY` to map catalog feature IDs to D5 PB row key
+ * suffixes. When multiple sub-keys exist (e.g. `beautiful-chat` fans out
+ * to 5 pills), worst-state wins.
+ */
+function resolveD5(
+  live: LiveStatusMap,
+  slug: string,
+  featureId: string,
+): TestLevel {
+  const d5Keys = CATALOG_TO_D5_KEY[featureId];
+
+  // No mapping and no fallback row → test doesn't exist for this feature.
+  if (!d5Keys || d5Keys.length === 0) {
+    return { exists: false, status: null, row: null };
+  }
+
+  let worst: StatusRow | null = null;
+  for (const d5Key of d5Keys) {
+    const row = live.get(keyFor("d5", slug, d5Key)) ?? null;
+    if (!row) continue;
+    if (!worst || STATE_RANK[row.state] > STATE_RANK[worst.state]) {
+      worst = row;
+    }
+  }
+
+  if (!worst) {
+    // Keys are mapped but no rows emitted yet — test exists but has no
+    // data. Treat as exists=true so ceilingDepth reflects it.
+    return { exists: true, status: null, row: null };
+  }
+
+  return {
+    exists: true,
+    status: stateToTestStatus(worst.state),
+    row: worst,
+  };
+}
+
+/**
+ * Resolve the D3 (API / e2e) test level for `(slug, featureId)`.
+ */
+function resolveD3(
+  live: LiveStatusMap,
+  slug: string,
+  featureId: string,
+): TestLevel {
+  const row = live.get(keyFor("e2e", slug, featureId)) ?? null;
+  if (!row) {
+    return { exists: false, status: null, row: null };
+  }
+  return {
+    exists: true,
+    status: stateToTestStatus(row.state),
+    row,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+const NOT_WIRED_LEVEL: TestLevel = { exists: false, status: null, row: null };
+
+const UNSUPPORTED: CellModel = {
+  supported: false,
+  d3: null,
+  d4: null,
+  d5: null,
+  achievedDepth: 0,
+  ceilingDepth: 0,
+  chipColor: "gray",
+  isRegression: false,
+};
+
+/**
+ * Build the complete cell model for a single (integration, feature) pair.
+ *
+ * This is the ONLY function that should derive cell rendering state —
+ * every Coverage-tab component should call this instead of doing inline
+ * resolution.
+ */
+export function buildCellModel(
+  live: LiveStatusMap,
+  input: CellModelInput,
+): CellModel {
+  const { slug, featureId, isSupported, isWired } = input;
+
+  // ── Unsupported cell ──────────────────────────────────────────────
+  if (!isSupported) {
+    return UNSUPPORTED;
+  }
+
+  // ── Not wired (supported but no test harness configured) ──────────
+  if (!isWired) {
+    return {
+      supported: true,
+      d3: NOT_WIRED_LEVEL,
+      d4: NOT_WIRED_LEVEL,
+      d5: NOT_WIRED_LEVEL,
+      achievedDepth: 0,
+      ceilingDepth: 0,
+      chipColor: "gray",
+      isRegression: false,
+    };
+  }
+
+  // ── Wired + supported: resolve each depth independently ───────────
+  const d3 = resolveD3(live, slug, featureId);
+  const d4 = resolveD4(live, slug);
+  const d5 = resolveD5(live, slug, featureId);
+
+  // ceilingDepth: highest CONTIGUOUS depth where a test EXISTS.
+  // D4 only counts if D3 exists; D5 only counts if D4 counts.
+  let ceilingDepth: 0 | 3 | 4 | 5 = 0;
+  if (d3.exists) {
+    ceilingDepth = 3;
+    if (d4.exists) {
+      ceilingDepth = 4;
+      if (d5.exists) ceilingDepth = 5;
+    }
+  }
+
+  // achievedDepth: highest CONTIGUOUS passing depth.
+  // D3 must pass before D4 counts, D4 must pass before D5 counts.
+  let achievedDepth: 0 | 3 | 4 | 5 = 0;
+  if (d3.status === "green") {
+    achievedDepth = 3;
+    if (d4.status === "green") {
+      achievedDepth = 4;
+      if (d5.status === "green") {
+        achievedDepth = 5;
+      }
+    }
+  }
+
+  // chipColor derivation:
+  //   green  → achieved === ceiling
+  //   gray   → achieved === 0
+  //   amber  → ceiling - achieved <= 1 (close gap)
+  //   red    → ceiling - achieved > 1 (wide gap)
+  let chipColor: ChipColor;
+  if (achievedDepth === 0) {
+    chipColor = "gray";
+  } else if (achievedDepth >= ceilingDepth) {
+    chipColor = "green";
+  } else if (ceilingDepth - achievedDepth <= 1) {
+    chipColor = "amber";
+  } else {
+    chipColor = "red";
+  }
+
+  return {
+    supported: true,
+    d3,
+    d4,
+    d5,
+    achievedDepth,
+    ceilingDepth,
+    chipColor,
+    isRegression: false,
+  };
+}


### PR DESCRIPTION
## Summary

Consolidates all Coverage-tab cell rendering into a single codepath driven by `CellModel` — a unified type that captures support status + D3/D4/D5 test existence and status. Replaces the fragmented multi-codepath architecture where `deriveDepth()`, `resolveCell()`, `ComposedCell`, `DepthLayer`, and `HealthLayer` each independently resolved different aspects of cell state.

**Fixes three dashboard rendering bugs:**
- **D0 despite passing tests** — old depth ladder required `health:<slug>` green before checking e2e; new model resolves D3 directly from `e2e:<slug>/<feature>`
- **Yellow D4 at ceiling** — old `depthColorClass()` hardcoded D4 as blue/accent with no ceiling concept; new model computes chip color relative to ceiling (green when achieved == ceiling)
- **No-entry icon alongside test badges** — old `DepthLayer`/`HealthLayer` rendered independently without cross-checking support status; new `UnifiedCell` short-circuits on unsupported

## Changes

- **`cell-model.ts`** — New `CellModel` type and `buildCellModel()` function. Single derivation: resolves D3 (e2e), D4 (chat/tools worst-state), D5 (CATALOG_TO_D5_KEY multi-key worst-state). Computes contiguous ceiling depth and chip color relative to ceiling.
- **`unified-cell.tsx`** — New `UnifiedCell` component consuming `CellModel`. Unsupported = no-entry only. Badges only for existing test levels. `arePropsEqual` synced with `buildCellModel` reads.
- **`depth-chip.tsx`** — Added `chipColor` prop for pre-computed color override (green/amber/red/gray).
- **`page.tsx`** — Replaced `ComposedCell` with `UnifiedCell`, `deriveDepth` with `buildCellModel` in healthStats/depthDistribution.
- **`feature-grid.tsx`** — Ref-depth column migrated to `buildCellModel`.
- **`cell-matrix.tsx`** — Baseline tab migrated from `deriveDepth` to `buildCellModel`.
- **`composed-cell.tsx` / `depth-utils.ts`** — Deprecated.

## Test plan

- [x] 22 unit tests for `buildCellModel` covering all bug regressions, D4 worst-state, D5 multi-key, contiguous chain, degraded mapping
- [x] 14 unit tests for `UnifiedCell` covering unsupported guard, badge existence, overlay gating, chipColor passthrough
- [x] 12 existing `DepthChip` tests + 12 new `chipColor` tests (52 total)
- [x] 12 `CellMatrix` tests updated for D3/D4/D5 model
- [x] 100 tests pass, 0 fail
- [x] 7-agent CR converged in 2 rounds (3 bucket-a fixes in round 1, 0 in confirmation)