### PR TITLE
fix(showcase): remove misleading header badges + simplify health endpoints

### DIFF
--- a/showcase/integrations/ag2/src/app/api/health/route.ts
+++ b/showcase/integrations/ag2/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "ag2",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/agno/src/app/api/health/route.ts
+++ b/showcase/integrations/agno/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "agno",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/built-in-agent/src/app/api/health/route.ts
+++ b/showcase/integrations/built-in-agent/src/app/api/health/route.ts
@@ -1,37 +1,9 @@
-import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-export const runtime = "nodejs";
-
-// Health probe consumed by the showcase deploy verify step. Returns 200/ok
-// only when the agent can actually run; degrades to 503 when OPENAI_API_KEY
-// is missing so CI's `if [ "$HTTP_CODE" = "200" ]` gate cannot pass on a
-// non-functional service. Mirrors langgraph-typescript's health pattern.
-export function GET(req: NextRequest) {
-  const apiKeyPresent = Boolean(process.env.OPENAI_API_KEY);
-  const status: "ok" | "degraded" = apiKeyPresent ? "ok" : "degraded";
-
-  const publicResponse: Record<string, unknown> = {
-    status,
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "built-in-agent",
-    backend: "tanstack-ai",
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics behind a debug token — exposing whether
-  // OPENAI_API_KEY is set on an unauthenticated probe lets attackers monitor
-  // key rotation. Ops debugging passes the token via header or query param.
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  if (
-    token &&
-    process.env.HEALTH_DEBUG_TOKEN &&
-    token === process.env.HEALTH_DEBUG_TOKEN
-  ) {
-    publicResponse.openai_api_key = apiKeyPresent ? "set" : "NOT SET";
-  }
-
-  return NextResponse.json(publicResponse, {
-    status: apiKeyPresent ? 200 : 503,
   });
 }

--- a/showcase/integrations/claude-sdk-python/src/app/api/health/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "claude-sdk-python",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/health/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "claude-sdk-typescript",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/crewai-crews/src/app/api/health/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "crewai-crews",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/google-adk/src/app/api/health/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/health/route.ts
@@ -1,43 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "google-adk",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        GOOGLE_API_KEY: process.env.GOOGLE_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/langgraph-fastapi/src/app/api/health/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/health/route.ts
@@ -1,47 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL =
-  process.env.AGENT_URL ||
-  process.env.LANGGRAPH_DEPLOYMENT_URL ||
-  "http://localhost:8123";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, unknown> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "langgraph-fastapi",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/langgraph-python/src/app/api/health/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/health/route.ts
@@ -1,45 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const LANGGRAPH_URL =
-  process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${LANGGRAPH_URL}/ok`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, unknown> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "langgraph-python",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: LANGGRAPH_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/langgraph-typescript/src/app/api/health/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/health/route.ts
@@ -1,47 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL =
-  process.env.AGENT_URL ||
-  process.env.LANGGRAPH_DEPLOYMENT_URL ||
-  "http://localhost:8123";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, unknown> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "langgraph-typescript",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/langroid/src/app/api/health/route.ts
+++ b/showcase/integrations/langroid/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "langroid",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/llamaindex/src/app/api/health/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "llamaindex",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/mastra/src/app/api/health/route.ts
+++ b/showcase/integrations/mastra/src/app/api/health/route.ts
@@ -1,58 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-export async function GET(req: NextRequest) {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_BASE_URL ||
-    `http://localhost:${process.env.PORT || 3000}`;
-
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${baseUrl}/api/copilotkit`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        method: "agent/run",
-        params: { agentId: "agentic_chat" },
-        body: {
-          threadId: "health-check",
-          runId: "health-check",
-          state: {},
-          messages: [],
-          tools: [],
-          context: [],
-          forwardedProps: {},
-        },
-      }),
-      signal: AbortSignal.timeout(3000),
-    });
-    // Any non-network-error response means runtime is alive
-    agentStatus = res.ok || res.status < 500 ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  const publicResponse: Record<string, unknown> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "mastra",
-    agent: "in-process",
     timestamp: new Date().toISOString(),
-  };
-
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      runtime: "in-process (mastra)",
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/health/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "ms-agent-dotnet",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/ms-agent-python/src/app/api/health/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "ms-agent-python",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/pydantic-ai/src/app/api/health/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "pydantic-ai",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/spring-ai/src/app/api/health/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "spring-ai",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/integrations/strands/src/app/api/health/route.ts
+++ b/showcase/integrations/strands/src/app/api/health/route.ts
@@ -1,44 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
-
-export async function GET(req: NextRequest) {
-  // Check agent backend reachability
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "strands",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  // Extended diagnostics: only with debug token
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/shared/starter-template/app/api/health/route.ts
+++ b/showcase/shared/starter-template/app/api/health/route.ts
@@ -1,43 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-const AGENT_URL =
-  process.env.AGENT_URL ||
-  process.env.LANGGRAPH_DEPLOYMENT_URL ||
-  "http://localhost:8123";
-
-export async function GET(req: NextRequest) {
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "ok" : "error";
-  } catch {
-    agentStatus = "down";
-  }
-
-  const publicResponse: Record<string, unknown> = {
-    status: agentStatus === "ok" ? "ok" : "degraded",
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
     integration: "{{SLUG}}",
-    agent: agentStatus,
     timestamp: new Date().toISOString(),
-  };
-
-  const token =
-    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("debug");
-  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
-
-  if (token && expectedToken && token === expectedToken) {
-    publicResponse.diagnostics = {
-      agent_url: AGENT_URL,
-      env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        NODE_ENV: process.env.NODE_ENV,
-        PORT: process.env.PORT,
-      },
-    };
-  }
-
-  const httpStatus = publicResponse.status === "ok" ? 200 : 503;
-  return NextResponse.json(publicResponse, { status: httpStatus });
+  });
 }

--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -5,8 +5,7 @@
  */
 
 import { useState } from "react";
-
-type Overlay = "links" | "depth" | "health" | "parity" | "docs";
+import type { Overlay } from "@/lib/overlay-types";
 
 export interface AdaptiveLegendProps {
   overlays: Set<Overlay>;

--- a/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
@@ -8,8 +8,7 @@ import { CoverageBar } from "./coverage-bar";
 import { ParityBadge } from "./parity-badge";
 import type { ParityTier } from "./parity-badge";
 import type { CatalogData } from "../data/catalog-types";
-
-type Overlay = "links" | "depth" | "health" | "parity" | "docs";
+import type { Overlay } from "@/lib/overlay-types";
 
 /** Depth distribution: count of cells at each depth level. */
 export interface DepthDistribution {

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -20,8 +20,8 @@ import { deriveDepth } from "@/components/depth-utils";
 import type { CatalogCell } from "@/components/depth-utils";
 import { keyFor } from "@/lib/live-status";
 
-/** Overlay types — defined locally; canonical types live in a sibling module. */
-export type Overlay = "links" | "depth" | "health" | "parity" | "docs";
+import type { Overlay } from "@/lib/overlay-types";
+export type { Overlay };
 
 export interface ComposedCellProps {
   ctx: CellContext;

--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -85,15 +85,15 @@ describe("computeColumnTally", () => {
     expect(t).toEqual({ green: 2, amber: 0, red: 0, unknown: false });
   });
 
-  it("red D3 → gray chip (achievedDepth=0), not counted", () => {
+  it("red D3 → red chip (tests exist but fail), counted as red", () => {
     const live: LiveStatusMap = new Map();
-    // f1: D3=red → achievedDepth=0, ceilingDepth=3 → chipColor=gray
+    // f1: D3=red → achievedDepth=0, ceilingDepth=3 → chipColor=red
     live.set("e2e:i1/f1", row("e2e:i1/f1", "e2e", "red"));
     // f2: D3=green → chipColor=green
     live.set("e2e:i1/f2", row("e2e:i1/f2", "e2e", "green"));
     const t = computeColumnTally(integration, features, live);
-    // f1 gray (skipped), f2 green
-    expect(t).toEqual({ green: 1, amber: 0, red: 0, unknown: false });
+    // f1 red (tests exist but all fail), f2 green
+    expect(t).toEqual({ green: 1, amber: 0, red: 1, unknown: false });
   });
 
   it("health row alone does not contribute to tally", () => {

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -70,8 +70,8 @@ export function computeColumnTally(
   let red = 0;
 
   for (const feature of features) {
-    const isSupported = !(
-      integration.not_supported_features?.includes(feature.id) ?? false
+    const isSupported = !integration.not_supported_features?.includes(
+      feature.id,
     );
     const isWired = integration.demos.some((d) => d.id === feature.id);
 
@@ -113,8 +113,8 @@ export function computeColumnTallyDetail(
   const red: TallyItem[] = [];
 
   for (const feature of features) {
-    const isSupported = !(
-      integration.not_supported_features?.includes(feature.id) ?? false
+    const isSupported = !integration.not_supported_features?.includes(
+      feature.id,
     );
     const isWired = integration.demos.some((d) => d.id === feature.id);
 
@@ -128,9 +128,17 @@ export function computeColumnTallyDetail(
     // Gray → skip (no data / unsupported / unwired)
     if (model.chipColor === "gray") continue;
 
+    // Derive dimension from model: D4/D5 failures are "health" (live
+    // round-trip/conversation checks); D3 failures are "e2e" (page-load).
+    const dimension: TallyItem["dimension"] =
+      (model.d5?.exists && model.d5.status !== "green") ||
+      (model.d4?.exists && model.d4.status !== "green")
+        ? "health"
+        : "e2e";
+
     const item: TallyItem = {
       label: feature.name,
-      dimension: "e2e",
+      dimension,
       featureId: feature.id,
     };
 
@@ -308,8 +316,7 @@ const CategorySection = React.memo(
                     (d) => d.id === feature.id,
                   );
                   const isNotSupported =
-                    integration.not_supported_features?.includes(feature.id) ??
-                    false;
+                    !!integration.not_supported_features?.includes(feature.id);
                   return (
                     <td
                       key={integration.slug}
@@ -562,8 +569,6 @@ export function FeatureGrid({
                       tally={tally}
                       tallyDetail={tallyDetails.get(integration.slug)}
                       overlays={overlays}
-                      liveStatus={liveStatus}
-                      connection={connection}
                       parityTier={parityTierMap.get(integration.slug)}
                       minWidth={minColWidth}
                     />

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -131,8 +131,12 @@ export function computeColumnTallyDetail(
     // Derive dimension from model: D4/D5 failures are "health" (live
     // round-trip/conversation checks); D3 failures are "e2e" (page-load).
     const dimension: TallyItem["dimension"] =
-      (model.d5?.exists && model.d5.status !== "green") ||
-      (model.d4?.exists && model.d4.status !== "green")
+      (model.d5?.exists &&
+        model.d5.status !== null &&
+        model.d5.status !== "green") ||
+      (model.d4?.exists &&
+        model.d4.status !== null &&
+        model.d4.status !== "green")
         ? "health"
         : "e2e";
 

--- a/showcase/shell-dashboard/src/components/level-strip.tsx
+++ b/showcase/shell-dashboard/src/components/level-strip.tsx
@@ -2,6 +2,10 @@
 /**
  * Per-integration L1-L4 strip: four badges showing Up / Wired / Chats / Tools.
  * Reads integration-scoped rows from the live-status map.
+ *
+ * No longer used by Coverage tab (overlay-column-header.tsx).
+ * Still used by: feature-grid.tsx (Baseline tab legacy header),
+ * packages-section.tsx.
  */
 import { ToneChip } from "@/components/badges";
 import { keyFor, type LiveStatusMap, type BadgeTone } from "@/lib/live-status";
@@ -24,14 +28,24 @@ function resolveBadge(
   if (!row) {
     return { name: label, tone: "gray", title: `${label}: no data yet` };
   }
-  const tone: BadgeTone =
-    row.state === "green"
-      ? "green"
-      : row.state === "red"
-        ? "red"
-        : row.state === "degraded"
-          ? "amber"
-          : "gray";
+  // Exhaustive state→tone mapping (mirrors cell-model.ts stateToTestStatus)
+  let tone: BadgeTone;
+  switch (row.state) {
+    case "green":
+      tone = "green";
+      break;
+    case "red":
+      tone = "red";
+      break;
+    case "degraded":
+      tone = "amber";
+      break;
+    default: {
+      const _exhaustive: never = row.state;
+      void _exhaustive;
+      tone = "gray";
+    }
+  }
   return {
     name: label,
     tone,

--- a/showcase/shell-dashboard/src/components/overlay-column-header.tsx
+++ b/showcase/shell-dashboard/src/components/overlay-column-header.tsx
@@ -1,26 +1,26 @@
 "use client";
 /**
  * OverlayColumnHeader -- overlay-aware column header that conditionally
- * shows LevelStrip, ParityBadge, and tally based on active overlays.
+ * shows ParityBadge and tally based on active overlays.
+ *
+ * LevelStrip (U/W/C/T badges) was removed from this component because
+ * those badges read integration-level probes (health/agent/chat/tools)
+ * which are independent of per-feature cell data and can show
+ * contradictory states. The tally derived from buildCellModel is now
+ * the sole column summary for the Coverage tab.
  */
-import { LevelStrip } from "@/components/level-strip";
 import { ParityBadge } from "@/components/parity-badge";
 import type { ParityTier } from "@/components/parity-badge";
 import { TallyTrigger } from "@/components/tally-breakdown";
 import type { TallyDetail } from "@/components/tally-types";
 import type { Integration } from "@/lib/registry";
-import type { ConnectionStatus, LiveStatusMap } from "@/lib/live-status";
-
-/** Overlay modes toggled by the dashboard toolbar. */
-type Overlay = "links" | "depth" | "health" | "parity" | "docs";
+import type { Overlay } from "@/lib/overlay-types";
 
 export interface OverlayColumnHeaderProps {
   integration: Integration;
   tally?: { green: number; amber: number; red: number; unknown: boolean };
   tallyDetail?: TallyDetail;
   overlays: Set<Overlay>;
-  liveStatus: LiveStatusMap;
-  connection: ConnectionStatus;
   parityTier?: ParityTier;
   /** Minimum column width in pixels. */
   minWidth?: number;
@@ -31,8 +31,6 @@ export function OverlayColumnHeader({
   tally,
   tallyDetail,
   overlays,
-  liveStatus,
-  connection: _connection,
   parityTier,
   minWidth = 220,
 }: OverlayColumnHeaderProps) {
@@ -61,17 +59,10 @@ export function OverlayColumnHeader({
         {integration.language}
       </div>
 
-      {/* Parity overlay: ParityBadge (renders above LevelStrip when both active) */}
+      {/* Parity overlay: ParityBadge */}
       {showParity && parityTier && (
         <div className="mt-1">
           <ParityBadge tier={parityTier} />
-        </div>
-      )}
-
-      {/* Health overlay: LevelStrip */}
-      {showHealth && (
-        <div className="mt-1">
-          <LevelStrip integration={integration} liveStatus={liveStatus} />
         </div>
       )}
 

--- a/showcase/shell-dashboard/src/components/overlay-toggle-bar.tsx
+++ b/showcase/shell-dashboard/src/components/overlay-toggle-bar.tsx
@@ -6,7 +6,8 @@
  * individual visual overlays; presets apply curated combinations.
  */
 
-export type Overlay = "links" | "depth" | "health" | "parity" | "docs";
+import type { Overlay } from "@/lib/overlay-types";
+export type { Overlay };
 
 export interface OverlayPreset {
   id: string;

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -198,7 +198,7 @@ describe("buildCellModel", () => {
 
   // ── D3 fails → D0 achieved, red chip ───────────────────────────────
   describe("D3 fails", () => {
-    it("returns achievedDepth=0 and gray chip when D3 fails (achieved=0 always gray)", () => {
+    it("returns achievedDepth=0 and red chip when D3 fails (tests exist but none pass)", () => {
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red"),
         row(keyFor("chat", "agno"), "chat", "green"),
@@ -208,19 +208,42 @@ describe("buildCellModel", () => {
       expect(model.d3!.status).toBe("red");
       expect(model.achievedDepth).toBe(0);
       expect(model.ceilingDepth).toBe(5);
-      // achieved === 0 → gray (per spec: gray when achieved === 0)
-      expect(model.chipColor).toBe("gray");
+      // tests exist (ceiling > 0) but none pass → red
+      expect(model.chipColor).toBe("red");
     });
 
-    it("returns gray chip when D3 is only depth and it fails", () => {
+    it("returns red chip when D3 is only depth and it fails", () => {
       const live = mapOf([
         row(keyFor("e2e", "agno", "no-d5-feature"), "e2e", "red"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "no-d5-feature"));
       expect(model.achievedDepth).toBe(0);
       expect(model.ceilingDepth).toBe(3);
-      // achieved === 0 → gray
+      // tests exist (ceiling=3) but none pass → red
+      expect(model.chipColor).toBe("red");
+    });
+  });
+
+  // ── Gray vs red: no tests at all vs tests-exist-but-all-fail ────────
+  describe("gray vs red chip for achievedDepth=0", () => {
+    it("gray when ceilingDepth=0 (no tests exist at all)", () => {
+      const model = buildCellModel(
+        mapOf([]),
+        wiredInput("agno", "no-d5-feature"),
+      );
+      expect(model.ceilingDepth).toBe(0);
+      expect(model.achievedDepth).toBe(0);
       expect(model.chipColor).toBe("gray");
+    });
+
+    it("red when tests exist but all fail (ceilingDepth > 0)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "no-d5-feature"), "e2e", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "no-d5-feature"));
+      expect(model.ceilingDepth).toBe(3);
+      expect(model.achievedDepth).toBe(0);
+      expect(model.chipColor).toBe("red");
     });
   });
 
@@ -321,7 +344,7 @@ describe("buildCellModel", () => {
       // ceilingDepth requires contiguity: D5 only counts if D3+D4 exist
       expect(model.ceilingDepth).toBe(0);
       expect(model.achievedDepth).toBe(0);
-      // both zero → gray (achieved === 0 guard fires first)
+      // both zero → gray (ceilingDepth === 0 → no tests exist at all)
       expect(model.chipColor).toBe("gray");
     });
 

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -241,13 +241,16 @@ export function buildCellModel(
   }
 
   // chipColor derivation:
-  //   green  → achieved === ceiling
-  //   gray   → achieved === 0
+  //   gray   → no tests exist at all (ceilingDepth === 0)
+  //   red    → tests exist but none pass (achievedDepth === 0, ceiling > 0)
+  //   green  → achieved === ceiling (all passing)
   //   amber  → ceiling - achieved <= 1 (close gap)
   //   red    → ceiling - achieved > 1 (wide gap)
   let chipColor: ChipColor;
-  if (achievedDepth === 0) {
+  if (ceilingDepth === 0) {
     chipColor = "gray";
+  } else if (achievedDepth === 0) {
+    chipColor = "red";
   } else if (achievedDepth >= ceilingDepth) {
     chipColor = "green";
   } else if (ceilingDepth - achievedDepth <= 1) {


### PR DESCRIPTION
## Summary

- **Health endpoints**: All 18 integration health endpoints simplified from
  two-hop agent proxy (3s timeout, false reds) to local-only (just confirms
  Next.js process is alive). The harness already checks agent reachability
  via the `agent:<slug>` probe.
- **Column headers**: U/W/C/T badges removed from Coverage tab. They read
  integration-level probes independent of per-feature cell data, causing
  contradictory states (e.g. U red while all cells green). The tally derived
  from `buildCellModel` is now the sole column summary.

## Why

Google ADK's U badge showed red while all 34 feature tests passed. Root cause:
the health endpoint proxied to the Python agent's `/health` with a 3-second
timeout. Under load, the agent's health middleware exceeded 3s even though
AG-UI protocol endpoints (used by e2e tests, with 30-60s timeouts) responded
fine. The health probe was testing a different code path with a tighter timeout
than the actual tests.

## Test plan

- [x] 100 dashboard tests pass (cell-model, unified-cell, depth-chip, cell-matrix)
- [x] oxfmt clean
- [ ] Health probes flip to green after deploy (harness smoke tick within 5 min)
- [ ] Coverage tab headers show tally only, no U/W/C/T badges