### PR TITLE
Docs(DeepAgents): State Rendering - Typescript Improvements

### DIFF
--- a/docs/content/docs/integrations/deepagents/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/integrations/deepagents/generative-ui/state-rendering.mdx
@@ -54,15 +54,22 @@ Use state rendering when you want to:
         import { createMiddleware } from "langchain";
         import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
         import { z } from "zod";
+        import { zodState } from "@copilotkit/sdk-js/langgraph";
+        import { StateSchema } from "@langchain/langgraph";
+
+        // Define the agent's custom state and include schema in middleware.
+        const AgentStateSchema = new StateSchema({
+            searches: zodState(
+                            z.array(z.object({
+                                query: z.string(),
+                                done: z.boolean(),
+                            })).default([]),
+                        ),
+        });
 
         export const searchesStateMiddleware = createMiddleware({
             name: "AgentState",
-            stateSchema: z.object({
-                searches: z.array(z.object({
-                    query: z.string(),
-                    done: z.boolean(),
-                })).default([]),
-            }),
+            stateSchema: AgentStateSchema,
         });
 
         // Compose with copilotkitMiddleware when constructing the agent:
@@ -101,22 +108,46 @@ Use state rendering when you want to:
       <Tab value="TypeScript">
         ```ts title="agent.ts"
         import { copilotkitEmitState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+        import { createDeepAgent } from "deepagents";
+        import { createMiddleware, tool } from "langchain";
+        import { z } from "zod";
+        import { zodState } from "@copilotkit/sdk-js/langgraph";
+        import { getConfig } from "@langchain/langgraph";
+
 
         // Inside a custom tool or middleware hook where you have config/state:
-        async function emitResearchProgress(state: any, config: any) {
-            state.searches = [
-                { query: "Initial research", done: false },
-                { query: "Retrieving sources", done: false },
-                { query: "Forming an answer", done: false },
-            ];
-            await copilotkitEmitState(config, state); // [!code highlight]
-
+        const research = tool(
+        async ({ topic: _topic }) => {
+            const config = getConfig();
+            const state = {
+                searches: [
+                    { query: "Initial research", done: false },
+                    { query: "Retrieving sources", done: false },
+                    { query: "Forming an answer", done: false },
+                ],
+            };
+            await copilotkitEmitState(config, state);
             for (const search of state.searches) {
                 await new Promise((resolve) => setTimeout(resolve, 1000));
                 search.done = true;
-                await copilotkitEmitState(config, state); // [!code highlight]
+                await copilotkitEmitState(config, state);
             }
-        }
+            },
+            {
+                name: "research",
+                description: "Research a topic and stream progress to the UI.",
+                schema: z.object({
+                    topic: z.string().describe("The topic to research"),
+                }),
+            }
+        );
+
+        export const agent = createDeepAgent({
+            model: "openai:gpt-4o",
+            tools: [research],
+            middleware: [copilotkitMiddleware, searchesStateMiddleware],
+            systemPrompt: "You are a helpful research assistant. "
+        });
         ```
       </Tab>
     </Tabs>


### PR DESCRIPTION
## Summary
The page's typescript snippet defines `emitResearchProgress` as a free-floating function there's ambiguity on how to register it as a tool or in middleware, at least one example should be elaborated, we used a tool approach. A reader following the page exactly ends up with a function nobody calls. When they prompt the chat with *"add the search for cats vs dogs"*, the agent falls back to the built-in `grep` tool, searches an empty virtual filesystem, and replies *"No matches found in the files."*

## Changes
- Added `searchesStateMiddleware` because without it, 'searches' are not received on the frontend and cannot be seen in AG-UI inspector either during tool invocation. We see the state section go empty before tool call finishes, without any viable emitted state. used zodState() so 'searches' can be seen by AG-UI and STATE_SNAPSHOT

- Changed `emitResearchProgress` to `research` for better readability and tool call invocation  

- Defined Agent with relevant middlewares

## Results
- Following these changes, each emitted state change event is recognized by the frontend and relevant symbols with queries are rendered on the UI while the state is visible. 