### PR TITLE
chore: align A2UI integration docs with v0.9 SDK helpers

### DIFF
--- a/docs/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
+++ b/docs/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx
@@ -58,11 +58,11 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
       ...
       ---BEGIN SINGLE_COLUMN_LIST_EXAMPLE---
       [
-        {{ "beginRendering": {{ "surfaceId": "default", "root": "root-column", "styles": {{ "primaryColor": "#FF0000", "font": "Roboto" }} }} }},
-        {{ "surfaceUpdate": {{
+        {{ "createSurface": {{ "surfaceId": "default", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json", "styles": {{ "primaryColor": "#FF0000", "font": "Roboto" }} }} }},
+        {{ "updateComponents": {{
           "surfaceId": "default",
           "components": [
-            {{ "id": "root-column", "component": {{ "Column": {{ "children": {{ "explicitList": ["title-heading", "item-list"] }} }} }} }},
+            {{ "id": "root", "component": {{ "Column": {{ "children": {{ "explicitList": ["title-heading", "item-list"] }} }} }} }},
             {{ "id": "title-heading", "component": {{ "Text": {{ "usageHint": "h1", "text": {{ "literalString": "Top Restaurants" }} }} }} }},
             {{ "id": "item-list", "component": {{ "List": {{ "direction": "vertical", "children": {{ "template": {{ "componentId": "item-card-template", "dataBinding": "/items" }} }} }} }} }},
             {{ "id": "item-card-template", "component": {{ "Card": {{ "child": "card-layout" }} }} }},
@@ -77,7 +77,7 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
             {{ "id": "book-now-text", "component": {{ "Text": {{ "text": {{ "literalString": "Book Now" }} }} }} }}
           ]
         }} }},
-        {{ "dataModelUpdate": {{
+        {{ "updateDataModel": {{
           "surfaceId": "default",
           "path": "/",
           "contents": [
@@ -109,9 +109,9 @@ Build an A2A agent, configure it to use A2UI, use the A2UI composer to generate 
     The widgets are injected into the agent's prompt, in this case using the `RESTAURANT_UI_EXAMPLES` variable.
     Widgets are defined for the agent using examples of the json arrays they should output, wrapped in a comment block.
     - A comment indicating the start of the example
-    - beginRendering: The start of the widget's rendering
-    - surfaceUpdate: An example of the json structure for the widget
-    - dataModelUpdate: an example of the data that will be used to populate the widget
+    - createSurface: Initializes the surface with its catalog (and optional styles/theme). Must come first.
+    - updateComponents: The component tree for the widget. Exactly one component must have `id: "root"`.
+    - updateDataModel: The data used to populate the widget
     - A comment indicating the end of the example
 
     In the example repo, all of the widgets are defined in a single variable int the prompt_builder.py file, but you can structure them however you like,

--- a/docs/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
+++ b/docs/content/docs/integrations/deepagents/generative-ui/a2ui/advanced.mdx
@@ -174,8 +174,8 @@ useA2UIActionHandler((action, declaredOps) => {
   if (action.name === "book_flight") {
     // Return custom operations
     return [
-      { surfaceUpdate: { surfaceId: action.surfaceId, components: mySchema } },
-      { beginRendering: { surfaceId: action.surfaceId, root: "root" } },
+      { createSurface: { surfaceId: action.surfaceId, catalogId: "https://a2ui.org/specification/v0_9/basic_catalog.json" } },
+      { updateComponents: { surfaceId: action.surfaceId, components: mySchema } },
     ];
   }
   return null; // skip — let other handlers or fallback try

--- a/docs/content/docs/integrations/deepagents/generative-ui/a2ui/dynamic-schema.mdx
+++ b/docs/content/docs/integrations/deepagents/generative-ui/a2ui/dynamic-schema.mdx
@@ -116,8 +116,8 @@ The secondary LLM's `render_a2ui` tool call streams through LangGraph as `TOOL_C
 
 1. Extracts the `components` array as it streams — waits for the full schema before rendering
 2. Extracts `surfaceId` and `root` from the partial JSON
-3. Once the schema is complete, emits `surfaceUpdate` + `beginRendering`
-4. Extracts complete `items` objects progressively and emits `dataModelUpdate` for each
+3. Once the schema is complete, emits `createSurface` + `updateComponents`
+4. Extracts complete `items` objects progressively and emits `updateDataModel` for each
 5. Cards appear one by one as data streams in
 
 ## Built-in progress indicator

--- a/docs/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
+++ b/docs/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
@@ -12,7 +12,7 @@ In the fixed-schema approach, you design the UI schema once (in a JSON file or u
 
 1. Schema is loaded from a JSON file at startup
 2. Agent tool receives data from the LLM (e.g., flight search results)
-3. Tool returns `a2ui.render()` with surfaceUpdate + dataModelUpdate + beginRendering
+3. Tool returns `a2ui.render()` with createSurface + updateComponents + updateDataModel
 4. The A2UI middleware intercepts the tool result and renders the surface
 
 ## Implementation
@@ -65,23 +65,22 @@ def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
     return a2ui.render(
         operations=[
-            a2ui.surface_update(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.data_model_update(SURFACE_ID, {"flights": flights}),
-            a2ui.begin_rendering(SURFACE_ID, "root"),
+            a2ui.create_surface(SURFACE_ID),
+            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
+            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
         ],
         action_handlers={
             # Exact match: fires when a button with action.name="book_flight" is clicked
             "book_flight": [
-                a2ui.surface_update(SURFACE_ID, BOOKED_SCHEMA),
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.update_components(SURFACE_ID, BOOKED_SCHEMA),
+                a2ui.update_data_model(SURFACE_ID, {
                     "title": "Booking Confirmed",
                     "detail": "Your flight has been booked.",
                 }),
-                a2ui.begin_rendering(SURFACE_ID, "root"),
             ],
             # Catch-all: fires for any button action without a specific match
             "*": [
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.update_data_model(SURFACE_ID, {
                     "status": "Action received",
                 }),
             ],

--- a/docs/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
+++ b/docs/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
@@ -60,21 +60,21 @@ All three approaches use the same A2UI protocol and renderer. The difference is 
 
 ## How it works
 
-Every A2UI surface is built from three operations:
+Every A2UI v0.9 surface is built from three operations:
 
-1. **`surfaceUpdate`** — defines the component tree (the schema)
-2. **`dataModelUpdate`** — provides the data that populates the components
-3. **`beginRendering`** — tells the client to start rendering
+1. **`createSurface`** — initializes the surface with its catalog (must come first)
+2. **`updateComponents`** — defines the component tree (the schema)
+3. **`updateDataModel`** — provides the data that populates the components
 
 The CopilotKit Python SDK provides helpers to build these operations:
 
 ```python
 from copilotkit import a2ui
 
-a2ui.surface_update(surface_id, components)
-a2ui.data_model_update(surface_id, {"items": data})
-a2ui.begin_rendering(surface_id, root_id)
-a2ui.render(operations)  # wraps and serializes
+a2ui.create_surface(surface_id)
+a2ui.update_components(surface_id, components)
+a2ui.update_data_model(surface_id, {"items": data})
+a2ui.render(operations)  # wraps in a2ui_operations and serializes
 ```
 
 Continue to one of the approach guides above to see the full implementation.

--- a/docs/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
+++ b/docs/content/docs/integrations/langgraph/generative-ui/a2ui/advanced.mdx
@@ -174,8 +174,8 @@ useA2UIActionHandler((action, declaredOps) => {
   if (action.name === "book_flight") {
     // Return custom operations
     return [
-      { surfaceUpdate: { surfaceId: action.surfaceId, components: mySchema } },
-      { beginRendering: { surfaceId: action.surfaceId, root: "root" } },
+      { createSurface: { surfaceId: action.surfaceId, catalogId: "https://a2ui.org/specification/v0_9/basic_catalog.json" } },
+      { updateComponents: { surfaceId: action.surfaceId, components: mySchema } },
     ];
   }
   return null; // skip — let other handlers or fallback try

--- a/docs/content/docs/integrations/langgraph/generative-ui/a2ui/dynamic-schema.mdx
+++ b/docs/content/docs/integrations/langgraph/generative-ui/a2ui/dynamic-schema.mdx
@@ -115,8 +115,8 @@ The secondary LLM's `render_a2ui` tool call streams through LangGraph as `TOOL_C
 
 1. Extracts the `components` array as it streams — waits for the full schema before rendering
 2. Extracts `surfaceId` and `root` from the partial JSON
-3. Once the schema is complete, emits `surfaceUpdate` + `beginRendering`
-4. Extracts complete `items` objects progressively and emits `dataModelUpdate` for each
+3. Once the schema is complete, emits `createSurface` + `updateComponents`
+4. Extracts complete `items` objects progressively and emits `updateDataModel` for each
 5. Cards appear one by one as data streams in
 
 ## Built-in progress indicator

--- a/docs/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
+++ b/docs/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
@@ -12,7 +12,7 @@ In the fixed-schema approach, you design the UI schema once (in a JSON file or u
 
 1. Schema is loaded from a JSON file at startup
 2. Agent tool receives data from the LLM (e.g., flight search results)
-3. Tool returns `a2ui.render()` with surfaceUpdate + dataModelUpdate + beginRendering
+3. Tool returns `a2ui.render()` with createSurface + updateComponents + updateDataModel
 4. The A2UI middleware intercepts the tool result and renders the surface
 
 ## Implementation
@@ -65,23 +65,22 @@ def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
     return a2ui.render(
         operations=[
-            a2ui.surface_update(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.data_model_update(SURFACE_ID, {"flights": flights}),
-            a2ui.begin_rendering(SURFACE_ID, "root"),
+            a2ui.create_surface(SURFACE_ID),
+            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
+            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
         ],
         action_handlers={
             # Exact match: fires when a button with action.name="book_flight" is clicked
             "book_flight": [
-                a2ui.surface_update(SURFACE_ID, BOOKED_SCHEMA),
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.update_components(SURFACE_ID, BOOKED_SCHEMA),
+                a2ui.update_data_model(SURFACE_ID, {
                     "title": "Booking Confirmed",
                     "detail": "Your flight has been booked.",
                 }),
-                a2ui.begin_rendering(SURFACE_ID, "root"),
             ],
             # Catch-all: fires for any button action without a specific match
             "*": [
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.update_data_model(SURFACE_ID, {
                     "status": "Action received",
                 }),
             ],

--- a/docs/content/docs/integrations/langgraph/generative-ui/a2ui/index.mdx
+++ b/docs/content/docs/integrations/langgraph/generative-ui/a2ui/index.mdx
@@ -60,21 +60,21 @@ All three approaches use the same A2UI protocol and renderer. The difference is 
 
 ## How it works
 
-Every A2UI surface is built from three operations:
+Every A2UI v0.9 surface is built from three operations:
 
-1. **`surfaceUpdate`** — defines the component tree (the schema)
-2. **`dataModelUpdate`** — provides the data that populates the components
-3. **`beginRendering`** — tells the client to start rendering
+1. **`createSurface`** — initializes the surface with its catalog (must come first)
+2. **`updateComponents`** — defines the component tree (the schema)
+3. **`updateDataModel`** — provides the data that populates the components
 
 The CopilotKit Python SDK provides helpers to build these operations:
 
 ```python
 from copilotkit import a2ui
 
-a2ui.surface_update(surface_id, components)
-a2ui.data_model_update(surface_id, {"items": data})
-a2ui.begin_rendering(surface_id, root_id)
-a2ui.render(operations)  # wraps and serializes
+a2ui.create_surface(surface_id)
+a2ui.update_components(surface_id, components)
+a2ui.update_data_model(surface_id, {"items": data})
+a2ui.render(operations)  # wraps in a2ui_operations and serializes
 ```
 
 Continue to one of the approach guides above to see the full implementation.


### PR DESCRIPTION
## Summary

- Aligns A2UI integration docs (DeepAgents, LangGraph, A2A) with the v0.9 helpers exported by [`sdk-python/copilotkit/a2ui.py`](https://github.com/CopilotKit/CopilotKit/blob/main/sdk-python/copilotkit/a2ui.py): `create_surface`, `update_components`, `update_data_model`.
- Updates Python helper names, wire-format op keys in prose (`surfaceUpdate` → `updateComponents`, etc.), and the TS action-handler return shapes in `advanced.mdx`. Reorders operations so `createSurface` comes first (no trailing `beginRendering`).
- A2A example: renames the root component id from `root-column` to `root` per the v0.9 catalog convention (exactly one component must have `id: "root"`).

Frontend dispatch confirmation: `packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx` (`getOperationSurfaceId`) routes only on `createSurface | updateComponents | updateDataModel | deleteSurface`, so the pre-v0.9 names in the docs would not round-trip through the runtime.

Tracks #4821 (point 1).

## Files changed

9 mdx files, +45 / −47:

- `docs/content/docs/integrations/deepagents/generative-ui/a2ui/{index,fixed-schema,dynamic-schema,advanced}.mdx`
- `docs/content/docs/integrations/langgraph/generative-ui/a2ui/{index,fixed-schema,dynamic-schema,advanced}.mdx`
- `docs/content/docs/integrations/a2a/generative-ui/declarative-a2ui.mdx`

No SDK or runtime changes.

## Out of scope (filed under #4821)

- `action_handlers=` kwarg appears in fixed-schema examples but is not yet on `a2ui.render`'s signature. Left in place — separate decision needed (SDK feature vs. doc rollback).
- No runnable DeepAgents showcase. Filed for tracking, not addressed here.

## Test plan

- [ ] Vercel preview renders all 9 pages without MDX errors
- [ ] Code snippets visually match the v0.9 SDK surface (`create_surface` / `update_components` / `update_data_model`)
- [ ] A2A example: root component id reads `"root"` (not `"root-column"`)
- [ ] `dynamic-schema.mdx` prose lists `createSurface` + `updateComponents` (not the pre-v0.9 names)