### PR TITLE
fix(web-inspector): pass auth headers to thread store

### DIFF
--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2590,7 +2590,7 @@ export class WebInspectorElement extends LitElement {
     store.start();
     store.setContext({
       runtimeUrl: core.runtimeUrl,
-      headers: {},
+      headers: { ...core.headers },
       agentId,
     });
     this._ownedThreadStores.set(agentId, store);


### PR DESCRIPTION
Fixes #4793 

## Summary
Fixes DevConsole Threads tab authentication failure by ensuring headers are properly propagated from CopilotKitProvider to the thread store context.

## Problem
The Threads tab in the DevConsole (Web Inspector) failed to authenticate when runtime authentication was enabled. Authentication headers were not propagated from `CopilotKitProvider` to the thread store context in the `ensureOwnedThreadStore()` method (line 2593).

## Solution
Modified the thread store context initialization to propagate authentication headers from `CopilotKitCore`:

\`\`\`typescript
// Before
store.setContext({
  runtimeUrl: core.runtimeUrl,
  headers: {},  // ❌ Headers not propagated
  agentId,
});

// After  
store.setContext({
  runtimeUrl: core.runtimeUrl,
  headers: { ...core.headers },  // ✅ Headers properly propagated
  agentId,
});
\`\`\`

This aligns with the established pattern in `useThreads` hook (`packages/react-core/src/v2/hooks/use-threads.tsx:277`), ensuring authenticated runtimes behave consistently across the Web Inspector and hooks APIs.

## Root Cause Analysis
- **File**: `packages/web-inspector/src/index.ts`
- **Line**: 2593
- **Method**: `ensureOwnedThreadStore()`
- **Issue**: Thread store context initialized with empty headers object instead of propagating from `core.headers`
- **Impact**: Thread list requests bypassed authentication, causing failures when runtime auth is enabled

## Security & Consistency
This ensures authenticated runtimes behave consistently across the Web Inspector and hooks APIs, maintaining the same security posture throughout the CopilotKit core.

## Testing
- ✅ All existing tests pass (29 tests in web-inspector package)
- ✅ Build completes successfully  
- ✅ Lint and type-check pass
- ✅ Pre-commit hooks pass
- ✅ Implementation matches `useThreads` hook pattern

## Files Changed
- `packages/web-inspector/src/index.ts` (1 insertion, 1 deletion)
