### PR TITLE
fix(showcase/google-adk + harness): unblock D5 probes — harness fixes, ag-ui-adk 0.6.3, e2e spec parity

### DIFF
--- a/showcase/harness/src/probes/drivers/e2e-deep.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.ts
@@ -221,6 +221,16 @@ export interface E2eDeepPage extends Page {
    */
   isClosed?(): boolean;
   /**
+   * Resolve a Playwright Locator for the given CSS selector. The probe
+   * scripts use it for count-based assertions
+   * (`page.locator(sel).count()`) when polling for an expected number of
+   * elements to appear; the harness `Page.evaluate` path only supports
+   * zero-arg functions, so dynamic selectors need a Locator. Optional so
+   * test fakes can omit it; the only production probe that needs it is
+   * `d5-tool-rendering-reasoning-chain`.
+   */
+  locator?(selector: string): { count(): Promise<number> };
+  /**
    * Install a request interceptor on the underlying Playwright page.
    * Optional — only the d5-readonly-state-context probe currently uses
    * this surface. Test fakes can omit it; the probe falls back with a
@@ -426,6 +436,7 @@ const defaultLauncher: E2eDeepBrowserLauncher =
                 requestFailures: requestFailures.slice(-10),
               }),
               isClosed: () => page.isClosed(),
+              locator: (s) => page.locator(s),
               route: (url, handler) =>
                 page.route(url, handler as Parameters<typeof page.route>[1]),
               unroute: (url) => page.unroute(url),
@@ -547,6 +558,7 @@ export function createPooledE2eDeepLauncher(
                 requestFailures: requestFailures.slice(-10),
               }),
               isClosed: () => page.isClosed(),
+              locator: (s) => page.locator(s),
               route: (url, handler) =>
                 page.route(url, handler as Parameters<typeof page.route>[1]),
               unroute: (url) => page.unroute(url),

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts
@@ -48,6 +48,11 @@ const CHART_INTEGRATIONS = new Set([
   "langgraph-python",
   "ms-agent-python",
   "spring-ai",
+  // google-adk's gen-ui-tool-based page was ported from langgraph-python
+  // verbatim during the D5 parity push, so it registers
+  // `render_pie_chart` + `render_bar_chart` via `useComponent` like LGP
+  // does, not the legacy `generate_haiku` shape.
+  "google-adk",
 ]);
 
 /**

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-reasoning-chain.ts
@@ -52,14 +52,15 @@ import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 
 /** The harness `Page` interface intentionally narrows the surface to
- *  `waitForSelector` + `evaluate` (see conversation-runner.ts). At
- *  runtime the underlying object IS a real Playwright Page, so we cast
- *  to a slightly wider shape here for the multi-pill polling we need —
- *  counting elements that match a selector and short sleeps between
- *  polls. Cast scope is limited to this file. */
+ *  `waitForSelector` + `evaluate` (see conversation-runner.ts). For
+ *  count-based polling we need `Page.locator(sel).count()` — that method
+ *  is exposed by the e2e-deep wrapper (`E2eDeepPage.locator`). We cast
+ *  to a local interface so this script doesn't depend on the wider
+ *  Playwright Page type. Sleep between polls uses native `setTimeout`
+ *  rather than Playwright's `page.waitForTimeout`, which is not part of
+ *  the harness `Page` surface. */
 interface CountablePage extends Page {
   locator(selector: string): { count(): Promise<number> };
-  waitForTimeout(ms: number): Promise<void>;
 }
 
 const POLL_INTERVAL_MS = 250;
@@ -214,7 +215,7 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
       while (Date.now() - reasoningStart < REASONING_TIMEOUT_MS) {
         const count = await reasoningBlocks.count();
         if (count >= expectedReasoningCount) break;
-        await pw.waitForTimeout(POLL_INTERVAL_MS);
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
       }
       const reasoningCount = await reasoningBlocks.count();
       if (reasoningCount < expectedReasoningCount) {
@@ -239,7 +240,7 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
         while (Date.now() - cardStart < CARD_TIMEOUT_MS) {
           const count = await locator.count();
           if (count >= card.minCount) break;
-          await pw.waitForTimeout(POLL_INTERVAL_MS);
+          await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
         }
         const count = await locator.count();
         if (count < card.minCount) {

--- a/showcase/integrations/google-adk/requirements.txt
+++ b/showcase/integrations/google-adk/requirements.txt
@@ -7,4 +7,4 @@ google-adk
 # the secondary generate_a2ui planner call. Explicit pin keeps the version
 # floor independent of google-adk's transitive resolution.
 google-genai>=0.8.0
-ag-ui-adk==0.6.1
+ag-ui-adk==0.6.3

--- a/showcase/integrations/google-adk/src/agents/headless_complete_agent.py
+++ b/showcase/integrations/google-adk/src/agents/headless_complete_agent.py
@@ -1,0 +1,109 @@
+"""ADK agent backing the Headless Chat (Complete) demo.
+
+Ports the langgraph-python sibling (`src/agents/headless_complete.py`) to
+ADK: three mock backend tools (`get_weather`, `get_stock_price`,
+`get_revenue_chart`) that the per-tool renderers on the frontend
+(`useRenderTool`) match by name, plus the same system prompt routing
+rules so the LLM picks the matching tool per pill.
+
+The frontend also registers a `highlight_note` *frontend* tool via
+`useComponent`, which the LLM may emit a tool_call for; that call flows
+through the AG-UI tool surface and is executed in the browser (no
+backend Python is required for that one, so it's not in the tools list
+here — same shape as langgraph-python).
+"""
+
+from __future__ import annotations
+
+from google.adk.agents import LlmAgent
+from google.adk.tools import ToolContext
+
+from agents.shared_chat import get_model, stop_on_terminal_text
+
+
+def get_weather(tool_context: ToolContext, location: str) -> dict:
+    """Get the current weather for a given location.
+
+    Returns a mock payload with city, temperature in Fahrenheit, humidity,
+    wind speed, and conditions. Use this whenever the user asks about
+    weather anywhere.
+    """
+    return {
+        "city": location,
+        "temperature": 68,
+        "humidity": 55,
+        "wind_speed": 10,
+        "conditions": "Sunny",
+    }
+
+
+def get_stock_price(tool_context: ToolContext, ticker: str) -> dict:
+    """Get a mock current price for a stock ticker.
+
+    Returns a payload with the ticker symbol (uppercased), price in USD,
+    and percentage change for the day. Use this whenever the user asks
+    about a stock price.
+    """
+    return {
+        "ticker": ticker.upper(),
+        "price_usd": 189.42,
+        "change_pct": 1.27,
+    }
+
+
+def get_revenue_chart(tool_context: ToolContext) -> dict:
+    """Get a mock six-month revenue series for a chart visualization.
+
+    Returns a title, subtitle, and an array of {label, value} points. Use
+    this whenever the user asks for a chart, graph, or visualization of
+    revenue, sales, or other quarterly/monthly metrics.
+    """
+    return {
+        "title": "Quarterly revenue",
+        "subtitle": "Last six months · USD thousands",
+        "data": [
+            {"label": "Jan", "value": 38},
+            {"label": "Feb", "value": 47},
+            {"label": "Mar", "value": 52},
+            {"label": "Apr", "value": 49},
+            {"label": "May", "value": 63},
+            {"label": "Jun", "value": 71},
+        ],
+    }
+
+
+# System prompt mirrored from
+# `showcase/integrations/langgraph-python/src/agents/headless_complete.py`
+# so the routing heuristics are identical across showcases. Keep these in
+# sync if the LGP version evolves.
+_INSTRUCTION = (
+    "You are a helpful, concise assistant wired into a headless chat "
+    "surface that demonstrates CopilotKit's full rendering stack. Pick the "
+    "right surface for each user question and fall back to plain text when "
+    "none of the tools fit.\n\n"
+    "Routing rules:\n"
+    "  - If the user asks about weather for a place, call `get_weather` "
+    "with the location.\n"
+    "  - If the user asks about a stock or ticker (AAPL, TSLA, MSFT, ...), "
+    "call `get_stock_price` with the ticker.\n"
+    "  - If the user asks for a chart, graph, or visualization of revenue, "
+    "sales, or other metrics over time, call `get_revenue_chart`.\n"
+    "  - If the user asks you to highlight, flag, or mark a short note or "
+    "phrase, call the frontend `highlight_note` tool with the text and a "
+    "color (yellow, pink, green, or blue). Do NOT ask the user for the "
+    "color — pick a sensible one if they didn't say.\n"
+    "  - If the user asks to draw, sketch, or diagram something, use the "
+    "Excalidraw MCP tools that are available to you.\n"
+    "  - Otherwise, reply in plain text.\n\n"
+    "After a tool returns, write one short sentence summarizing the "
+    "result. Never fabricate data a tool could provide."
+)
+
+
+headless_complete_agent = LlmAgent(
+    name="HeadlessCompleteAgent",
+    model=get_model(),
+    instruction=_INSTRUCTION,
+    tools=[get_weather, get_stock_price, get_revenue_chart],
+    after_model_callback=stop_on_terminal_text,
+)

--- a/showcase/integrations/google-adk/src/agents/registry.py
+++ b/showcase/integrations/google-adk/src/agents/registry.py
@@ -67,6 +67,7 @@ from agents.readonly_state_agent_context_agent import (
 )
 from agents.beautiful_chat_agent import beautiful_chat_agent
 from agents.shared_state_read_agent import shared_state_read_agent
+from agents.headless_complete_agent import headless_complete_agent
 
 
 @dataclass
@@ -137,7 +138,7 @@ AGENT_REGISTRY: dict[str, AgentSpec] = {
     "chat-slots": AgentSpec(_simple_chat),
     "chat-customization-css": AgentSpec(_simple_chat),
     "headless-simple": AgentSpec(_simple_chat),
-    "headless_complete": AgentSpec(_simple_chat),
+    "headless_complete": AgentSpec(headless_complete_agent),
     "voice": AgentSpec(_simple_chat),
     # ----- Reasoning demos -----
     "reasoning-custom": AgentSpec(_thinking_chat),

--- a/showcase/integrations/google-adk/tests/e2e/a2ui-fixed-schema.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/a2ui-fixed-schema.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 // QA reference: qa/a2ui-fixed-schema.md
 // Demo source: src/app/demos/a2ui-fixed-schema/{page.tsx, a2ui/*}
-// Backend: src/agents/a2ui_fixed_agent.py + src/agents/a2ui_schemas/flight_schema.json
+// Backend: src/agents/a2ui_fixed.py + src/agents/a2ui_schemas/flight_schema.json
 //
 // Pattern: A2UI FIXED-schema — the component tree lives on the frontend
 // (flight_schema.json has 12 nodes: root, content, title, route, from,
@@ -13,8 +13,8 @@ import { test, expect } from "@playwright/test";
 // incoming data model.
 //
 // This is a pure-presentation demo: the "Book flight" Button is inert —
-// schema-swap-on-action will be wired up once the A2UI Python SDK exposes
-// `action_handlers=` on `a2ui.render` (see comment in a2ui_fixed_agent.py).
+// schema-swap-on-action will be wired up once the Python SDK exposes
+// `action_handlers=` on `a2ui.render` (see comment in a2ui_fixed.py).
 //
 // No data-testid anywhere in the demo. Assertions ride on:
 //   - verbatim label text hardcoded in flight_schema.json ("Flight
@@ -25,8 +25,8 @@ import { test, expect } from "@playwright/test";
 //     price, lilac #BEC2FF airline badge border, black #010507 book
 //     button background).
 //
-// On Railway, `display_flight` occasionally stalls the secondary LLM
-// stage; render budget is 90s.
+// W8-8: on Railway, `display_flight` occasionally stalls the secondary
+// LLM stage; render budget is 60s.
 
 test.describe("A2UI Fixed Schema (flight card)", () => {
   test.setTimeout(120_000);
@@ -85,12 +85,13 @@ test.describe("A2UI Fixed Schema (flight card)", () => {
       { timeout: 10_000 },
     );
 
-    // Regression guard (#4734): the deployed agent could loop `display_flight`
-    // indefinitely because the LLM couldn't tell the opaque
-    // `a2ui_operations` JSON return value was a success signal. The fix
-    // tightened the docstring + system prompt to spell out "card is rendered,
-    // do not call again". Assert that exactly ONE flight card is present
-    // after the round-trip — duplicates mean the loop re-emerged.
+    // Regression guard (#4734): on Railway the deployed agent used to loop
+    // `display_flight` indefinitely because the LLM (gpt-4o-mini) couldn't
+    // tell the opaque `a2ui.render(...)` JSON return value was a success
+    // signal. The fix tightened the docstring + system prompt to spell out
+    // "card is rendered, do not call again". Assert that exactly ONE flight
+    // card is present after the round-trip — duplicates mean the loop
+    // re-emerged.
     const flightDetailsCount = await page.getByText("Flight Details").count();
     expect(flightDetailsCount).toBe(1);
     const bookButtons = await page

--- a/showcase/integrations/google-adk/tests/e2e/agentic-chat.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/agentic-chat.spec.ts
@@ -1,73 +1,61 @@
 import { test, expect } from "@playwright/test";
 
+// Agentic Chat is the minimum-viable CopilotChat demo: a tiny page
+// that wraps `<CopilotChat>` plus three starter-prompt suggestions. The
+// contract here is "vanilla chat works end-to-end" — anything richer
+// belongs in dedicated demos (frontend-tools, tool-rendering, etc.).
 test.describe("Agentic Chat", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/demos/agentic-chat");
   });
 
-  test("page loads with chat input and background container", async ({
+  test("page loads with chat input and the three starter suggestions", async ({
     page,
   }) => {
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+    for (const title of ["Write a sonnet", "Tell me a joke", "Is 17 prime?"]) {
+      await expect(page.getByRole("button", { name: title })).toBeVisible({
+        timeout: 15000,
+      });
+    }
+  });
+
+  test("sends a typed message and gets an assistant response", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Say hello in one word.");
+    await input.press("Enter");
+
     await expect(
-      page.locator('[data-testid="background-container"]'),
-    ).toBeVisible();
+      page.locator('[data-testid="copilot-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 
-  test("background container has default background style", async ({
+  test("clicking a suggestion pill sends the message and gets a response", async ({
     page,
   }) => {
-    const bg = page.locator('[data-testid="background-container"]');
-    await expect(bg).toHaveCSS("background-color", "rgb(250, 250, 249)");
+    await page.getByRole("button", { name: "Tell me a joke" }).click();
+
+    await expect(
+      page.locator('[data-testid="copilot-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 
-  test("sends message and gets assistant response", async ({ page }) => {
+  test("multi-turn conversation maintains context", async ({ page }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Say hello");
+
+    await input.fill("My name is Alice.");
+    await input.press("Enter");
+    await expect(
+      page.locator('[data-testid="copilot-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    await input.fill("What name did I just give you?");
     await input.press("Enter");
 
-    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
-      timeout: 30000,
-    });
-  });
-
-  test("weather request renders WeatherCard with location and stats", async ({
-    page,
-  }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("What is the weather in Tokyo?");
-    await input.press("Enter");
-
-    // WeatherCard renders as a rounded-2xl div with shadow-xl and gradient background
-    const weatherCard = page.locator('[data-testid="weather-card"]').first();
-    await expect(weatherCard).toBeVisible({ timeout: 45000 });
-
-    // Verify the card has weather detail sections (Humidity, Wind, Feels Like)
-    await expect(weatherCard.getByText("Humidity")).toBeVisible({
-      timeout: 5000,
-    });
-    await expect(weatherCard.getByText("Wind")).toBeVisible({ timeout: 5000 });
-    await expect(weatherCard.getByText("Feels Like")).toBeVisible({
-      timeout: 5000,
-    });
-  });
-
-  test("background change request updates background style", async ({
-    page,
-  }) => {
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Change the background to a blue gradient");
-    await input.press("Enter");
-
-    // Wait for the agent to respond and process the tool call
-    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
-      timeout: 30000,
-    });
-
-    // The background-container style should have changed from the default #fafaf9
-    const bg = page.locator('[data-testid="background-container"]');
-    await expect(bg).not.toHaveCSS("background-color", "rgb(250, 250, 249)", {
-      timeout: 15000,
-    });
+    const responses = page.locator('[data-testid="copilot-assistant-message"]');
+    await expect(responses.nth(1)).toBeVisible({ timeout: 30000 });
+    await expect(responses.nth(1)).toContainText(/Alice/i, { timeout: 5000 });
   });
 });

--- a/showcase/integrations/google-adk/tests/e2e/auth.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/auth.spec.ts
@@ -61,9 +61,9 @@ test.describe("Authentication", () => {
     await input.fill("Hello");
     await input.press("Enter");
 
-    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
-      timeout: 30000,
-    });
+    await expect(
+      page.locator('[data-testid="copilot-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 
   test("signing out flips the banner amber and keeps the chat surface mounted", async ({
@@ -116,7 +116,9 @@ test.describe("Authentication", () => {
     await expect(errorSurface).toBeVisible({ timeout: 15000 });
     // Page chrome stays visible — no white-screen.
     await expect(page.locator('[data-testid="auth-banner"]')).toBeVisible();
-    await expect(page.locator('[data-role="assistant"]')).toHaveCount(0);
+    await expect(
+      page.locator('[data-testid="copilot-assistant-message"]'),
+    ).toHaveCount(0);
   });
 
   test("re-signing in from the amber banner clears the error and resumes chat", async ({
@@ -144,8 +146,8 @@ test.describe("Authentication", () => {
     const input = page.getByPlaceholder("Type a message");
     await input.fill("Hello again");
     await input.press("Enter");
-    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
-      timeout: 30000,
-    });
+    await expect(
+      page.locator('[data-testid="copilot-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/google-adk/tests/e2e/chat-customization-css.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/chat-customization-css.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Chat Customization (CSS)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/chat-customization-css");
+  });
+
+  test("scope wrapper and themed chat input render on load", async ({
+    page,
+  }) => {
+    // The `.chat-css-demo-scope` wrapper is where all `--copilot-kit-*` CSS
+    // variable overrides are applied. Its presence is the defining signal
+    // that theme.css is loaded and scoped correctly.
+    const scope = page.locator(".chat-css-demo-scope");
+    await expect(scope).toBeVisible();
+
+    // v2 CopilotChat exposes its input via data-testid regardless of theme
+    // overrides. Use the testid plus the default placeholder to assert the
+    // themed input mounted.
+    await expect(
+      scope.locator('[data-testid="copilot-chat-input"]'),
+    ).toBeVisible();
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+  });
+
+  test("CSS variables from theme.css resolve on the scope wrapper", async ({
+    page,
+  }) => {
+    const scope = page.locator(".chat-css-demo-scope");
+    await expect(scope).toBeVisible();
+
+    // Read the three most distinctive CSS variables straight off the scope
+    // element. If theme.css didn't load (or its `.chat-css-demo-scope`
+    // selector didn't match) these would resolve to empty strings.
+    const vars = await scope.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return {
+        primary: cs.getPropertyValue("--copilot-kit-primary-color").trim(),
+        background: cs
+          .getPropertyValue("--copilot-kit-background-color")
+          .trim(),
+        secondary: cs.getPropertyValue("--copilot-kit-secondary-color").trim(),
+      };
+    });
+
+    expect(vars.primary.toLowerCase()).toBe("#ff006e");
+    expect(vars.background.toLowerCase()).toBe("#fff8f0");
+    expect(vars.secondary.toLowerCase()).toBe("#fde047");
+  });
+
+  test("input textarea inherits Georgia serif font from theme.css", async ({
+    page,
+  }) => {
+    // theme.css sets `.copilotKitInput > textarea { font-family: "Georgia", ... }`.
+    // The default CopilotKit textarea does not set Georgia — asserting on
+    // this one computed property is a reliable theme-applied signal that
+    // doesn't collide with utility classes the way `border-style` does.
+    const textarea = page
+      .locator(".chat-css-demo-scope .copilotKitInput textarea")
+      .first();
+    await expect(textarea).toBeVisible();
+    const fontFamily = await textarea.evaluate(
+      (el) => getComputedStyle(el).fontFamily,
+    );
+    expect(fontFamily).toMatch(/Georgia/);
+  });
+
+  test("user bubble uses hot pink gradient after sending a message", async ({
+    page,
+  }) => {
+    // "hello" matches an existing aimock fixture (content response), so this
+    // exercises a full round-trip through the themed chat and lets us assert
+    // on the rendered user bubble's computed background.
+    await page.getByPlaceholder("Type a message").fill("hello");
+    await page.locator('[data-testid="copilot-send-button"]').first().click();
+
+    const userMsg = page
+      .locator('.chat-css-demo-scope [data-testid="copilot-user-message"]')
+      .first();
+    await expect(userMsg).toBeVisible({ timeout: 30000 });
+
+    // theme.css sets the user bubble background to
+    // `linear-gradient(135deg, #ff006e 0%, #c2185b 100%)`. Read the computed
+    // `background-image` directly — covers both the gradient presence and
+    // the starting color.
+    const bgImage = await userMsg.evaluate(
+      (el) => getComputedStyle(el).backgroundImage,
+    );
+    expect(bgImage).toContain("linear-gradient");
+    expect(bgImage).toContain("rgb(255, 0, 110)");
+  });
+
+  test("assistant bubble uses amber background after round-trip", async ({
+    page,
+  }) => {
+    await page.getByPlaceholder("Type a message").fill("hello");
+    await page.locator('[data-testid="copilot-send-button"]').first().click();
+
+    const assistant = page
+      .locator('.chat-css-demo-scope [data-testid="copilot-assistant-message"]')
+      .first();
+    await expect(assistant).toBeVisible({ timeout: 45000 });
+
+    // theme.css sets the assistant bubble background to `#fde047`
+    // (rgb(253, 224, 71)). The default CopilotKit assistant bubble has no
+    // background-color, so a mismatch proves the theme lost the cascade.
+    await expect(assistant).toHaveCSS("background-color", "rgb(253, 224, 71)");
+  });
+});

--- a/showcase/integrations/google-adk/tests/e2e/chat-slots.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/chat-slots.spec.ts
@@ -1,14 +1,11 @@
 import { test, expect } from "@playwright/test";
 
-// The ADK chat-slots demo wires three slot overrides:
-//   - welcomeScreen → CustomWelcomeScreen (data-testid="custom-welcome-screen")
-//   - input.disclaimer → CustomDisclaimer  (data-testid="custom-disclaimer")
-//   - messageView.assistantMessage → CustomAssistantMessage
-//     (data-testid="custom-assistant-message")
-// Each testid is the canonical signal that a slot override wired through
-// end-to-end. The neutral _simple_chat agent replies with plain text on
-// every turn (no frontend tools, no agent tools).
-const SLOT_ASSISTANT = '[data-testid="custom-assistant-message"]';
+// Each custom slot wraps the default in a `SlotMarker` that emits
+// `data-slot-label="<slot-path>"`. That attribute is the canonical
+// signal that a slot override wired through end-to-end (the welcome
+// screen + disclaimer also expose dedicated `data-testid` attributes
+// for ergonomics).
+const SLOT_LABEL_ASSISTANT = '[data-slot-label="MessageView.AssistantMessage"]';
 
 test.describe("Chat Slots", () => {
   test.beforeEach(async ({ page }) => {
@@ -16,19 +13,23 @@ test.describe("Chat Slots", () => {
   });
 
   test("custom welcome screen slot renders on first load", async ({ page }) => {
-    // The custom welcomeScreen slot replaces the default welcome. Asserting
-    // its testid catches accidental fallback to the default CopilotChat
-    // welcome.
+    // The custom welcomeScreen slot replaces the default welcome. Both its
+    // own testid and the nested welcomeMessage sub-slot's testid prove the
+    // override wired through end-to-end. Asserting both catches accidental
+    // fallback to the default CopilotChat welcome.
+    const welcome = page.locator('[data-testid="custom-welcome-screen"]');
+    await expect(welcome).toBeVisible();
+
     await expect(
-      page.locator('[data-testid="custom-welcome-screen"]'),
+      welcome.locator('[data-testid="custom-welcome-message"]'),
     ).toBeVisible();
   });
 
   test("both suggestion pills render with verbatim titles", async ({
     page,
   }) => {
-    // useConfigureSuggestions registers exactly two pills with available:
-    // "always". Both should be visible immediately on the welcome screen.
+    // useConfigureSuggestions registers exactly two pills with available: "always".
+    // Both should be visible immediately on the welcome screen.
     await expect(
       page
         .locator('[data-testid="copilot-suggestion"]')
@@ -47,17 +48,17 @@ test.describe("Chat Slots", () => {
   }) => {
     // Click the suggestion pill — this sends "Tell me a short joke." The
     // assistant responds with text (neutral agent, no tools), and its
-    // bubble must be wrapped in the CustomAssistantMessage container.
+    // bubble must be wrapped in the CustomAssistantMessage SlotMarker.
     await page
       .locator('[data-testid="copilot-suggestion"]')
       .filter({ hasText: "Tell me a joke" })
       .first()
       .click();
 
-    // The MessageView.AssistantMessage slot wraps every assistant bubble;
-    // its presence proves the slot override took effect rather than the
-    // default CopilotChatAssistantMessage rendering bare.
-    await expect(page.locator(SLOT_ASSISTANT).first()).toBeVisible({
+    // The MessageView.AssistantMessage slot-marker wraps every assistant
+    // bubble; its presence proves the slot override took effect rather
+    // than the default CopilotChatAssistantMessage rendering bare.
+    await expect(page.locator(SLOT_LABEL_ASSISTANT).first()).toBeVisible({
       timeout: 45000,
     });
   });
@@ -74,7 +75,7 @@ test.describe("Chat Slots", () => {
     await page.locator('[data-testid="copilot-send-button"]').first().click();
 
     // Assistant replies and is wrapped in the custom slot.
-    await expect(page.locator(SLOT_ASSISTANT).first()).toBeVisible({
+    await expect(page.locator(SLOT_LABEL_ASSISTANT).first()).toBeVisible({
       timeout: 45000,
     });
 
@@ -96,7 +97,7 @@ test.describe("Chat Slots", () => {
     // Turn 1
     await input.fill("Hi");
     await sendBtn().click();
-    await expect(page.locator(SLOT_ASSISTANT).first()).toBeVisible({
+    await expect(page.locator(SLOT_LABEL_ASSISTANT).first()).toBeVisible({
       timeout: 45000,
     });
 
@@ -106,7 +107,7 @@ test.describe("Chat Slots", () => {
 
     // Expect at least two custom-wrapped assistant messages.
     await expect
-      .poll(async () => await page.locator(SLOT_ASSISTANT).count(), {
+      .poll(async () => await page.locator(SLOT_LABEL_ASSISTANT).count(), {
         timeout: 45000,
       })
       .toBeGreaterThanOrEqual(2);

--- a/showcase/integrations/google-adk/tests/e2e/declarative-gen-ui.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/declarative-gen-ui.spec.ts
@@ -5,26 +5,25 @@ import { test, expect } from "@playwright/test";
 //
 // Pattern: A2UI dynamic-schema BYOC. The frontend registers a 7-component
 // catalog (Card, StatusBadge, Metric, InfoRow, PrimaryButton, PieChart,
-// BarChart) via `a2ui={{ catalog: myCatalog }}`. The Python ADK agent
-// (`src/agents/declarative_gen_ui_agent.py`) owns the `generate_a2ui` tool
-// (re-exported from `src/agents/main.py`) and emits an `a2ui_operations`
-// container with `catalogId: "declarative-gen-ui-catalog"`. The secondary
-// LLM inside `generate_a2ui` produces a JSON component tree that the A2UI
-// renderer binds to the registered React catalog.
+// BarChart) via `a2ui={{ catalog: myCatalog }}`. The Python agent
+// (`src/agents/a2ui_dynamic.py`) owns the `generate_a2ui` tool and emits an
+// `a2ui_operations` container with `catalogId: "declarative-gen-ui-catalog"`.
+// The secondary LLM inside `generate_a2ui` produces a JSON component tree
+// that the A2UI renderer binds to the registered React catalog.
 //
-// There is no `data-testid` on the catalog renderers themselves — we rely
-// on verbatim suggestion-pill text and the inline-style fingerprints
-// exported by `a2ui/renderers.tsx` (donut SVG, recharts markers, brand
-// lilac/mint palette). Because the secondary-LLM render is multi-step, the
-// surface can take 30-60s to paint — render assertions use generous
-// budgets.
+// There is no `data-testid` in the demo source. We rely on verbatim
+// suggestion-pill text and the inline-style fingerprints exported by
+// `a2ui/renderers.tsx` (donut SVG, recharts markers, lilac/mint brand
+// colours, etc.). Because the secondary-LLM render is multi-step, the
+// surface can take 30-60s to paint — all render assertions use a 60s budget.
 //
-// On Railway the `generate_a2ui` tool path can be slow / flaky — the KPI
-// and StatusReport flows occasionally exceed a 60s budget when the
-// secondary Gemini call stalls. Those two scenarios are skipped; the
-// deterministic PieChart and BarChart catalog renderers are kept as the
-// primary render-signal tests since they have the strongest visual
-// fingerprints. Un-skip when the agent deployment stabilises.
+// W8-7: on Railway (showcase-langgraph-python-production.up.railway.app),
+// the `generate_a2ui` tool path is occasionally slow / flaky — the KPI and
+// StatusReport flows can exceed a 60s budget when the secondary LLM stalls.
+// Those two scenarios are skipped; the deterministic PieChart and BarChart
+// catalog renderers are kept as the primary render-signal tests since they
+// have the strongest visual fingerprints. Un-skip when the agent deployment
+// stabilises.
 
 test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
   test.setTimeout(120_000);
@@ -63,8 +62,8 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
     page,
   }) => {
     // The custom DonutChart renderer (a2ui/renderers.tsx) builds an inline
-    // <svg> with one background <circle> + one stroked <circle> per slice,
-    // wrapped in `transform: scaleX(-1)`. The legend rows end in a
+    // <svg> with one grey background <circle> + one stroked <circle> per
+    // slice, wrapped in `transform: scaleX(-1)`. The legend rows end in a
     // percentage like "45%". This is the strongest visual fingerprint of a
     // correctly-bound catalog PieChart node.
     const suggestions = page.locator('[data-testid="copilot-suggestion"]');
@@ -73,9 +72,9 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
       .first()
       .click();
 
-    // At least background circle + 2 slice circles. 90s budget: on cold
-    // starts the secondary-LLM `generate_a2ui` pass can eat most of a
-    // minute before emitting the PieChart node.
+    // At least background circle + 2 slice circles. 90s budget: on
+    // cold starts the secondary-LLM `generate_a2ui` pass can eat most
+    // of a minute before emitting the PieChart node.
     const circles = page.locator("svg circle");
     await expect
       .poll(async () => await circles.count(), { timeout: 90_000 })
@@ -112,9 +111,12 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
       .poll(async () => await bars.count(), { timeout: 15_000 })
       .toBeGreaterThanOrEqual(2);
 
-    // Regression guard: assert no A2UI render-error banners are visible.
-    // Catches both the "Cannot create component root without a type" loop
-    // (LP #4734) and "Catalog not found" misconfigurations.
+    // Regression guard (#4734): the deployed KPI / dashboard pills used to
+    // loop with "A2UI render error: Cannot create component root without a
+    // type" because the secondary LLM's `render_a2ui` tool call was
+    // intercepted by the A2UI middleware before our defensive validation
+    // could drop malformed components. Renaming to `_design_a2ui_surface`
+    // killed the bypass; assert no A2UI render-error banners are visible.
     await expect(
       page.getByText(/Cannot create component .* without a type/i),
     ).toHaveCount(0);
@@ -130,7 +132,8 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
 
   // SKIP: KPI dashboard prompt drives `generate_a2ui` to emit a Card +
   // multiple Metric tiles. On Railway this path is the slowest of the 4
-  // pills and regularly exceeds 60s when the secondary LLM stalls.
+  // pills and regularly exceeds 60s when the secondary LLM stalls. See
+  // W8-7. Un-skip when the agent deployment stabilises.
   test.skip("KPI dashboard pill renders at least 3 Metric tiles", async ({
     page,
   }) => {
@@ -152,7 +155,7 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
   });
 
   // SKIP: StatusReport prompt expects at least one Card + StatusBadge pill.
-  // Same Railway slowness as KPI — often exceeds 60s.
+  // Same Railway slowness as KPI — often exceeds 60s. See W8-7.
   test.skip("Status report pill renders a Card with a StatusBadge pill", async ({
     page,
   }) => {

--- a/showcase/integrations/google-adk/tests/e2e/declarative-hashbrown.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/declarative-hashbrown.spec.ts
@@ -1,12 +1,8 @@
 /**
- * E2E spec for the Declarative UI: Hashbrown demo (ADK route
- * `/demos/declarative-hashbrown`). Ported from LP's
- * `declarative-hashbrown.spec.ts` so the dashboard's hashbrown row
- * exercises the same surfaces (metric-card + chart) across showcases.
- *
- * Selectors match the chart/metric components' `data-testid` hooks.
- * Streaming-friendly timeouts because hashbrown assembles UI
- * progressively from structured output.
+ * E2E spec for the Declarative UI: Hashbrown demo. Selectors match the
+ * chart/metric components' `data-testid` hooks. Covers 3 suggestion
+ * flows + page-load smoke; timeouts are streaming-friendly because
+ * hashbrown assembles UI progressively from structured output.
  */
 import { test, expect } from "@playwright/test";
 

--- a/showcase/integrations/google-adk/tests/e2e/declarative-json-render.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/declarative-json-render.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * E2E spec for the Declarative UI: json-render demo (ADK route
- * `/demos/declarative-json-render`). Ported from LP's
- * `declarative-json-render.spec.ts` so the dashboard's json-render row
- * exercises the same surfaces (json-render-root + metric-card + chart)
- * across showcases.
+ * E2E spec for the Declarative UI: json-render demo. Structurally
+ * mirrors `gen-ui-tool-based.spec.ts` so the dashboard's BYOC rows
+ * exercise the same surfaces (json-render-root + metric-card + chart).
  */
 test.describe("Declarative UI: json-render", () => {
   test.beforeEach(async ({ page }) => {

--- a/showcase/integrations/google-adk/tests/e2e/gen-ui-agent.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/gen-ui-agent.spec.ts
@@ -14,50 +14,101 @@ test.describe("Agentic Generative UI", () => {
     await input.fill("Hello");
     await input.press("Enter");
 
-    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
+    await expect(
+      page.locator('[data-testid="copilot-assistant-message"]').first(),
+    ).toBeVisible({
       timeout: 30000,
     });
   });
 
   test("message list container exists", async ({ page }) => {
-    // The custom messageView renders a container with data-testid
     await expect(
       page.locator('[data-testid="copilot-message-list"]'),
     ).toBeVisible({ timeout: 10000 });
   });
 
-  test("complex task triggers task progress tracker", async ({ page }) => {
+  // Regression: every set_steps tool call used to push a brand-new card into
+  // the chat (one card per state-changing message), so a 7-call run produced
+  // 7+ stacked duplicate cards. The fix moved the demo from
+  // `useCoAgentStateRender` (V1, per-message claiming) to V2 `useAgent` +
+  // `messageView.children`, which renders a single live-updating card. This
+  // test pins that contract — one card, regardless of how many state updates
+  // arrive during the run.
+  test("renders a single agent-state-card that updates in place", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill(
-      "Create a comprehensive dashboard showing sales metrics, revenue trends, and customer segments",
-    );
+    await input.fill("Plan a product launch for a new mobile app.");
     await input.press("Enter");
 
-    // The TaskProgress component should appear when the agent reports steps
-    const taskProgress = page.locator('[data-testid="task-progress"]');
-    await expect(taskProgress).toBeVisible({ timeout: 60000 });
+    const card = page.locator('[data-testid="agent-state-card"]');
+    await expect(card).toBeVisible({ timeout: 60000 });
 
-    // Should show a "Task Progress" heading
-    await expect(taskProgress.getByText("Task Progress")).toBeVisible();
+    // Wait for at least one step to be published, then assert there is still
+    // only one card (not one per state update).
+    await expect(
+      page.locator('[data-testid="agent-step"]').first(),
+    ).toBeVisible({ timeout: 60000 });
+    await expect(card).toHaveCount(1);
 
-    // Should show a completion counter like "X/Y Complete"
-    await expect(taskProgress.getByText(/\d+\/\d+\s*Complete/)).toBeVisible();
-
-    // Step descriptions should be visible
-    const stepTexts = page.locator('[data-testid="task-step-text"]');
-    await expect(stepTexts.first()).toBeVisible({ timeout: 5000 });
+    // Wait until the agent finishes the run, then re-assert single card.
+    // `agent.isRunning` flips to false → the card's spinner becomes a check.
+    await expect(card.locator(".animate-spin")).toHaveCount(0, {
+      timeout: 120000,
+    });
+    await expect(card).toHaveCount(1);
   });
 
-  test("task progress shows progress bar", async ({ page }) => {
+  test("eventually marks every step as completed", async ({ page }) => {
     const input = page.getByPlaceholder("Type a message");
-    await input.fill("Build a report analyzing quarterly performance data");
+    await input.fill("Plan a product launch for a new mobile app.");
     await input.press("Enter");
 
-    const taskProgress = page.locator('[data-testid="task-progress"]');
-    await expect(taskProgress).toBeVisible({ timeout: 60000 });
+    // Wait for the run to settle (no in-progress markers anywhere on the page).
+    await expect(
+      page.locator('[data-testid="agent-step"][data-status="in_progress"]'),
+    ).toHaveCount(0, { timeout: 120000 });
 
-    // The progress bar is a rounded-full div inside the tracker
-    const progressBar = taskProgress.locator(".rounded-full").first();
-    await expect(progressBar).toBeVisible();
+    const steps = page.locator('[data-testid="agent-step"]');
+    const total = await steps.count();
+    expect(total).toBeGreaterThan(0);
+
+    // Every step must end in `completed` — guards against the "step 3 stuck"
+    // regression where the agent terminated without flipping the last step.
+    const completed = page.locator(
+      '[data-testid="agent-step"][data-status="completed"]',
+    );
+    await expect(completed).toHaveCount(total);
+  });
+
+  // Regression: the aimock fixture used to emit a single set_steps tool call
+  // with all three steps already `completed`, so the card mounted in its
+  // final state with no sequential animation. The pill's whole point is the
+  // pending → in_progress → completed progression spelled out in the
+  // backend's SYSTEM_PROMPT, which requires a 7-call chain of set_steps
+  // emissions threaded via toolCallId. This test pins that we observe at
+  // least one step in `pending` state during the run — proof that the chain
+  // is starting from the all-pending leg, not short-circuiting to all-done.
+  test("steps animate through pending before completing (no fixture short-circuit)", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: /Plan a product launch/i }).click();
+
+    await expect(page.locator('[data-testid="agent-state-card"]')).toBeVisible({
+      timeout: 60000,
+    });
+
+    // At least one step must be observed in `pending` state. With the
+    // short-circuit bug the steps went straight to `completed` and this
+    // count would always be 0.
+    await expect
+      .poll(
+        () =>
+          page
+            .locator('[data-testid="agent-step"][data-status="pending"]')
+            .count(),
+        { intervals: [250], timeout: 30000 },
+      )
+      .toBeGreaterThan(0);
   });
 });

--- a/showcase/integrations/google-adk/tests/e2e/gen-ui-tool-based.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/gen-ui-tool-based.spec.ts
@@ -1,19 +1,58 @@
 import { test, expect } from "@playwright/test";
 
+// Tool-Based Generative UI demo: a centered <CopilotChat> with two
+// useComponent registrations (render_bar_chart + render_pie_chart) plus
+// three suggestion pills wired via useConfigureSuggestions. The demo
+// has no header / chrome — the chat surface IS the page.
 test.describe("Tool-Based Generative UI", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/demos/gen-ui-tool-based");
   });
 
-  test("page loads with sidebar open", async ({ page }) => {
+  test("page loads with chat composer and the three suggestion pills", async ({
+    page,
+  }) => {
     await expect(
       page.locator('textarea, [placeholder*="message"]').first(),
     ).toBeVisible({ timeout: 10000 });
+
+    for (const title of [
+      "Sales bar chart",
+      "Traffic pie chart",
+      "Market share",
+    ]) {
+      await expect(
+        page
+          .locator('[data-testid="copilot-suggestion"]')
+          .filter({ hasText: title }),
+      ).toBeVisible({ timeout: 15000 });
+    }
   });
 
-  test("sidebar header shows Sales Pipeline title", async ({ page }) => {
-    await expect(page.getByText("Sales Pipeline")).toBeVisible({
-      timeout: 10000,
+  test("pie chart request renders SVG visualization", async ({ page }) => {
+    const input = page.locator('textarea, [placeholder*="message"]').first();
+    await input.fill("Show me a pie chart of revenue by category");
+    await input.press("Enter");
+
+    // PieChart renders as Recharts SVG inside the assistant message.
+    const assistantMessage = page
+      .locator('[data-testid="copilot-assistant-message"]')
+      .first();
+    await expect(assistantMessage.locator("svg").first()).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  test("bar chart request renders SVG visualization", async ({ page }) => {
+    const input = page.locator('textarea, [placeholder*="message"]').first();
+    await input.fill("Show me a bar chart of monthly expenses");
+    await input.press("Enter");
+
+    const assistantMessage = page
+      .locator('[data-testid="copilot-assistant-message"]')
+      .first();
+    await expect(assistantMessage.locator("svg").first()).toBeVisible({
+      timeout: 60000,
     });
   });
 
@@ -22,8 +61,8 @@ test.describe("Tool-Based Generative UI", () => {
     await input.fill("Hello");
     await input.press("Enter");
 
-    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
-      timeout: 30000,
-    });
+    await expect(
+      page.locator('[data-testid="copilot-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 30000 });
   });
 });

--- a/showcase/integrations/google-adk/tests/e2e/hitl-in-app.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/hitl-in-app.spec.ts
@@ -1,13 +1,7 @@
 import { test, expect } from "@playwright/test";
 
-// In-App HITL demo — Google ADK.
-//
-// Mirrors langgraph-python/tests/e2e/hitl-in-app.spec.ts.
-//
 // QA reference: qa/hitl-in-app.md
-// Demo source: src/app/demos/hitl-in-app/{page.tsx, approval-dialog.tsx,
-//   tickets-panel.tsx, suggestions.ts}
-// Backend agent: src/agents/hitl_in_app_agent.py
+// Demo source: src/app/demos/hitl-in-app/{page.tsx, approval-dialog.tsx}
 //
 // Demo registers ONE frontend tool via `useFrontendTool`:
 // `request_user_approval(message, context?)`. The handler returns a Promise
@@ -18,8 +12,13 @@ import { test, expect } from "@playwright/test";
 //
 // Genuine assertion strategy: the deterministic aimock fixtures emit two
 // branched continuations per pill (sequenceIndex 0 = approve, 1 = reject).
-// Serial mode is load-bearing — test #1 of the pair claims sequenceIndex 0
-// (approve response) and test #2 claims sequenceIndex 1 (reject response).
+// Since the JSON fixture matcher cannot inspect tool message content, we
+// rely on test ordering (serial mode) so test #1 of the pair claims
+// sequenceIndex 0 (approve response) and test #2 claims sequenceIndex 1
+// (reject response). If the framework wired approve/reject into the same
+// payload, both branches would still receive the same fixture's response
+// — but the assertion text differs, so at least one of the two tests
+// would fail. That asymmetry is what makes the assertion genuine.
 
 test.describe("HITL In-App (approval dialog portaled to <body>)", () => {
   // Serial mode is load-bearing: aimock's `sequenceIndex` matcher counts
@@ -110,7 +109,8 @@ test.describe("HITL In-App (approval dialog portaled to <body>)", () => {
       page.locator('[data-testid="approval-dialog-overlay"]'),
     ).toHaveCount(0, { timeout: 5_000 });
 
-    // Reject branch: deterministic fixture leading phrase.
+    // Reject branch: deterministic fixture leading phrase. Substring
+    // assertion is intentional — locks the reject-branch identity.
     await expect(
       page
         .locator('[data-testid="copilot-assistant-message"]')
@@ -180,17 +180,22 @@ test.describe("HITL In-App (approval dialog portaled to <body>)", () => {
   // TODO: re-enable when downgrade flow is fixed (broken upstream as of 2026-05-07)
   test.skip("downgrade #12346 → approve/reject flow", async () => {
     // Intentionally skipped per spec: the downgrade pill exposes a
-    // separate upstream bug (ticket-12346 surface) that is out of scope.
-    // Re-enable when the upstream demo reliably emits request_user_approval
-    // for the downgrade prompt.
+    // separate upstream bug (ticket-12346 surface) that is out of scope
+    // for the genuine-pass rewrite. Re-enable when the upstream demo
+    // reliably emits request_user_approval for the downgrade prompt.
   });
 
-  // Regression: each pill must mount its OWN approval dialog when clicked
-  // back-to-back in the same chat thread. Historically a `hasToolResult`
-  // gate on the second pill's first-turn fixture caused it to be skipped
-  // after the first approval, so the agent jumped straight to the
-  // narration branch with no approval dialog. The fix chains the
-  // follow-up fixtures via the request_user_approval `toolCallId`.
+  // Regression for the aimock multi-pill bug:
+  // The refund (#12345) and escalate (#12347) fixtures used
+  // `hasToolResult: false/true` to split the request_user_approval emit
+  // from the approve/reject narration. After approving the first pill, the
+  // thread already had a tool result, so the second pill's first-turn
+  // fixture was skipped — the approve/reject branch fired immediately with
+  // no approval dialog. Fix: chain the follow-up fixtures via the
+  // request_user_approval `toolCallId`, drop `hasToolResult: false` from
+  // the tool-emitting fixture. This test approves refund #12345 then
+  // clicks escalate #12347 in the same thread and asserts the second pill
+  // mounts its own approval dialog.
   test("approve refund then click escalate — each pill mounts its own approval dialog", async ({
     page,
   }) => {

--- a/showcase/integrations/google-adk/tests/e2e/hitl-in-chat.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/hitl-in-chat.spec.ts
@@ -59,7 +59,7 @@ test.describe("HITL in chat — booking flow", () => {
     // Agent's follow-up confirmation arrives next.
     await expect(
       page
-        .locator('[data-role="assistant"]')
+        .locator('[data-testid="copilot-assistant-message"]')
         .filter({ hasText: /Booked.*Alice/i })
         .first(),
     ).toBeVisible({ timeout: 30000 });
@@ -92,7 +92,7 @@ test.describe("HITL in chat — booking flow", () => {
 
     await expect(
       page
-        .locator('[data-role="assistant"]')
+        .locator('[data-testid="copilot-assistant-message"]')
         .filter({ hasText: /Booked.*sales team/i })
         .first(),
     ).toBeVisible({ timeout: 30000 });
@@ -123,7 +123,7 @@ test.describe("HITL in chat — booking flow", () => {
     await page.locator('[data-testid="time-picker-slot"]').first().click();
     await expect(
       page
-        .locator('[data-role="assistant"]')
+        .locator('[data-testid="copilot-assistant-message"]')
         .filter({ hasText: /Booked.*Alice/i })
         .first(),
     ).toBeVisible({ timeout: 30000 });
@@ -144,7 +144,7 @@ test.describe("HITL in chat — booking flow", () => {
     await page.locator('[data-testid="time-picker-slot"]').last().click();
     await expect(
       page
-        .locator('[data-role="assistant"]')
+        .locator('[data-testid="copilot-assistant-message"]')
         .filter({ hasText: /Booked.*sales team/i })
         .first(),
     ).toBeVisible({ timeout: 30000 });

--- a/showcase/integrations/google-adk/tests/e2e/mcp-apps.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/mcp-apps.spec.ts
@@ -21,11 +21,11 @@ import { test, expect } from "@playwright/test";
 // frame and is not introspectable from Playwright's page context, so we
 // only assert presence + the sandbox contract.
 //
-// The MCP round-trip (agent → create_view → server-side resource
-// fetch → activity event) is the slowest flow in the suite, regularly
-// sitting above 60s on Railway. The end-to-end tool-driven tests are
-// skipped by default; the deterministic suggestion-pill render is the
-// stable signal.
+// W8-9: the MCP round-trip (agent → create_view → server-side resource
+// fetch → activity event) is the slowest flow in the suite on Railway,
+// regularly sitting above 60s. The end-to-end tool-driven test uses a
+// 90s budget and is kept un-skipped; the deterministic draw-prompt
+// version is covered by the suggestion pill flow.
 
 test.describe("MCP Apps (Excalidraw activity iframe)", () => {
   test.setTimeout(180_000);
@@ -57,7 +57,7 @@ test.describe("MCP Apps (Excalidraw activity iframe)", () => {
   // SKIP: on Railway the MCP round-trip (agent -> create_view ->
   // server-side resource fetch -> activity event -> iframe render)
   // regularly sits above 90s and intermittently fails to paint an
-  // iframe at all when the Excalidraw MCP server is slow.
+  // iframe at all when the Excalidraw MCP server is slow. See W8-9.
   // Un-skip when the MCP Apps middleware / Excalidraw upstream
   // stabilises on Railway.
   test.skip("Draw-a-flowchart pill renders a sandboxed activity iframe", async ({
@@ -74,7 +74,7 @@ test.describe("MCP Apps (Excalidraw activity iframe)", () => {
   });
 
   // SKIP: same root cause as the flowchart flow — the typed-prompt
-  // variant also depends on the MCP round-trip.
+  // variant also depends on the MCP round-trip. See W8-9.
   test.skip("explicit create_view prompt renders a sandboxed iframe", async ({
     page,
   }) => {

--- a/showcase/integrations/google-adk/tests/e2e/multimodal.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/multimodal.spec.ts
@@ -12,7 +12,7 @@ import type { Page } from "@playwright/test";
  * round-trip path end-to-end.
  *
  * Behavior pinned by this suite (each was an actual regression caught
- * during the multimodal port — see headers in
+ * during the multimodal rewrite — see headers in
  * sample-attachment-buttons.tsx and legacy-converter-shim.tsx):
  *
  * 1. Clicking a sample button auto-sends the canned prompt — no manual
@@ -20,14 +20,17 @@ import type { Page } from "@playwright/test";
  *    approach raced the upload state, the send got rejected, and the
  *    prompt got eaten.
  * 2. The user message keeps showing exactly ONE attachment chip after
- *    the assistant response arrives. The agent round-trip could double
- *    the attachment if both modern + legacy shapes survived in state
- *    (the page-level legacy-converter-shim deduplicates by source value).
- * 3. Sample-PDF renders as a `DocumentAttachment` chip, NOT as an
- *    `<img>` that errors with "Failed to load image".
- * 4. No "[Attached document]" bracket prefix leaks into the rendered
- *    user message (the chat UI must show the modern `document` chip
- *    only, never a flattened-text dump of the PDF body).
+ *    the assistant response arrives. The @ag-ui/langgraph round-trip
+ *    used to duplicate the attachment (modern + re-converted shape) so
+ *    the user saw two thumbnails for one file.
+ * 3. Sample-PDF specifically renders as a `DocumentAttachment` chip,
+ *    NOT as an `<img>` that errors with "Failed to load image". Earlier
+ *    the round-trip mis-tagged PDFs with `type: "image"` and forced the
+ *    image renderer.
+ * 4. The PDF flattened text doesn't bleed into the rendered user
+ *    message. Earlier `_PdfFlattenMiddleware` ran in `before_model`
+ *    and persisted the flattened "[Attached document]\n<pdf body>"
+ *    into state, which the chat UI rendered inline.
  * 5. Clicking image then PDF in the same session (and vice versa)
  *    leaves each user message with its own single, correct chip — no
  *    cross-contamination, no doubling.
@@ -108,8 +111,8 @@ test.describe("Multimodal Attachments", () => {
     await expect(userMsg).toContainText(IMAGE_PROMPT);
 
     // Exactly ONE rendered image — pin the dedupe + normalize behavior
-    // so the agent round-trip can't quietly start doubling attachments
-    // again.
+    // so the @ag-ui/langgraph round-trip can't quietly start doubling
+    // attachments again.
     await expect(userMsg.locator("img")).toHaveCount(1);
     await expect(userMsg.getByText(/Failed to load image/i)).toHaveCount(0);
 
@@ -124,21 +127,22 @@ test.describe("Multimodal Attachments", () => {
 
     await expect(userMsg).toContainText(PDF_PROMPT);
 
-    // Pinned regression: PDFs that survive a round-trip through a
-    // mis-typed converter could come back as `type: "image"` with
-    // `mimeType: application/pdf`, forcing the image renderer to fail
-    // load and show "Failed to load image" twice. The page-level dedupe
-    // + type-normalize subscriber turns them back into `document` parts
-    // so the icon-+-filename renderer fires exactly once.
+    // Pinned regression: PDFs round-tripped through @ag-ui/langgraph
+    // used to come back as `type: "image"` with `mimeType:
+    // application/pdf`, forcing the image renderer to fail load and
+    // show "Failed to load image" twice. The page-level dedupe + type-
+    // normalize subscriber turns them back into `document` parts so
+    // the icon-+-filename renderer fires exactly once.
     await expect(userMsg.getByText(/Failed to load image/i)).toHaveCount(0);
     await expect(userMsg.locator("img")).toHaveCount(0);
     // DocumentAttachment surfaces a "PDF" label via getDocumentIcon.
     await expect(userMsg.getByText(/^PDF$/)).toBeVisible();
 
-    // Pinned regression: any backend-side PDF flattening must not bleed
-    // its "[Attached document]\n<pdf body>" prefix into the rendered
-    // user message bubble (the chat UI must keep showing only the
-    // modern document chip, not the raw text dump).
+    // Pinned regression: the PDF flattened text used to bleed into the
+    // rendered user message when the Python middleware mutated state
+    // via `before_model`. Switching to `wrap_model_call` scopes the
+    // rewrite to the model request only — the bracket-tagged dump must
+    // never appear in the UI bubble.
     await expect(userMsg).not.toContainText("[Attached document]");
 
     await expect(asstMsg).toContainText(/copilotkit/i);

--- a/showcase/integrations/google-adk/tests/e2e/prebuilt-sidebar.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/prebuilt-sidebar.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pre-Built Sidebar", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/prebuilt-sidebar");
+  });
+
+  test("page loads with heading, main content, and sidebar open by default", async ({
+    page,
+  }) => {
+    // Main content heading is verbatim from the demo source and confirms the
+    // route mounted the expected page.
+    await expect(
+      page.getByRole("heading", { name: "Sidebar demo — click the launcher" }),
+    ).toBeVisible();
+
+    // defaultOpen={true} means the sidebar's chat input is mounted and
+    // visible on first paint.
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+
+    // The sidebar ships its own toggle button with a dedicated testid.
+    await expect(
+      page.locator('[data-testid="copilot-chat-toggle"]').first(),
+    ).toBeVisible();
+  });
+
+  test('"Say hi" suggestion pill renders and sends on click', async ({
+    page,
+  }) => {
+    // useConfigureSuggestions registers a single "Say hi" pill with
+    // available: "always", so it should render inside the sidebar on load.
+    const sayHiPill = page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Say hi" })
+      .first();
+    await expect(sayHiPill).toBeVisible({ timeout: 15000 });
+
+    await sayHiPill.click();
+
+    // The pill sends "Say hi!". We assert on the assistant message testid
+    // rather than response text since this demo has no frontend tools — the
+    // round-trip signal is simply "an assistant bubble appeared".
+    await expect(
+      page.locator('[data-testid="copilot-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 45000 });
+  });
+
+  test("typing a message and clicking send produces an assistant response", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Hello");
+
+    // Click the send button directly — using Enter on the textarea was
+    // intermittently dropping the submit on this deployment (the welcome
+    // screen stayed mounted with the text still in the box), so we use the
+    // stable send-button testid the v2 CopilotChatInput exposes.
+    await page.locator('[data-testid="copilot-send-button"]').first().click();
+
+    // Assistant responds — the neutral agent just chats, no tools.
+    await expect(
+      page.locator('[data-testid="copilot-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 45000 });
+  });
+
+  test("sidebar close toggles aria-hidden and the launcher re-opens it", async ({
+    page,
+  }) => {
+    const sidebar = page.locator('[data-testid="copilot-sidebar"]');
+
+    // Opens with aria-hidden="false" because of defaultOpen={true}.
+    await expect(sidebar).toHaveAttribute("aria-hidden", "false");
+
+    // CopilotSidebar renders its own close button in the modal header.
+    // Clicking the external toggle doesn't work while the sidebar is open
+    // (it intercepts pointer events on this viewport width), so we close
+    // from within.
+    await page.locator('[data-testid="copilot-close-button"]').first().click();
+
+    // The sidebar slides out via CSS transform but stays mounted. The
+    // authoritative open/closed signal is the aria-hidden attribute the
+    // component writes based on its isModalOpen state.
+    await expect(sidebar).toHaveAttribute("aria-hidden", "true", {
+      timeout: 10000,
+    });
+
+    // Re-open via the floating toggle button, now uncovered.
+    await page.locator('[data-testid="copilot-chat-toggle"]').first().click();
+    await expect(sidebar).toHaveAttribute("aria-hidden", "false", {
+      timeout: 10000,
+    });
+
+    // URL unchanged — toggling is pure client-side state.
+    await expect(page).toHaveURL(/\/demos\/prebuilt-sidebar$/);
+  });
+});

--- a/showcase/integrations/google-adk/tests/e2e/reasoning-custom.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/reasoning-custom.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "@playwright/test";
+
+// QA reference: qa/reasoning-custom.md
+// Demo source: src/app/demos/reasoning-custom/{page.tsx, reasoning-block.tsx}
+//
+// The demo mounts a custom `reasoningMessage` slot (`ReasoningBlock`) that
+// renders an amber banner with `data-testid="reasoning-block"`. The label
+// inside the banner reads "Thinking…" while the agent is streaming, then
+// flips to "Agent reasoning" once streaming settles. The backend uses
+// `deepagents.create_deep_agent` with a reasoning-capable OpenAI model
+// (`gpt-5-mini` by default, override via `OPENAI_REASONING_MODEL`) routed
+// through the Responses API so the model's chain of thought streams as
+// AG-UI REASONING_MESSAGE_* events.
+//
+// Streaming assertions exercise the aimock fixture in
+// `showcase/aimock/d5-all.json` — its `reasoning` field makes aimock emit
+// `response.reasoning_summary_text.delta` events deterministically, no
+// real LLM call required. Local stack: a "Show reasoning" suggestion pill
+// fires the same prompt, so a single click reproduces the streaming UX.
+//
+// Selectors are testid / role / stable text only. No LLM-text assertions.
+
+const REASONING_PROMPT = "show your reasoning step by step";
+
+test.describe("Reasoning: Custom", () => {
+  test.setTimeout(120_000);
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/reasoning-custom");
+  });
+
+  test("page loads with chat input", async ({ page }) => {
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+  });
+
+  test("send button is visible alongside the input", async ({ page }) => {
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+    await expect(
+      page.locator('[data-testid="copilot-send-button"]').first(),
+    ).toBeVisible();
+  });
+
+  test("typing a prompt and submitting does not crash the UI", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Say hello in one short sentence.");
+    await page.locator('[data-testid="copilot-send-button"]').first().click();
+
+    await expect(input).toHaveValue("", { timeout: 10_000 });
+  });
+
+  // --- Reasoning-block streaming coverage --------------------------------
+
+  test("reasoning prompt renders a reasoning-block before the answer", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(REASONING_PROMPT);
+    await page.locator('[data-testid="copilot-send-button"]').first().click();
+
+    const reasoningBlock = page
+      .locator('[data-testid="reasoning-block"]')
+      .first();
+    await expect(reasoningBlock).toBeVisible({ timeout: 60_000 });
+    await expect(
+      reasoningBlock.getByText("Reasoning", { exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("reasoning-block label flips from Thinking to Agent reasoning", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(REASONING_PROMPT);
+    await page.locator('[data-testid="copilot-send-button"]').first().click();
+
+    const reasoningBlock = page
+      .locator('[data-testid="reasoning-block"]')
+      .first();
+    await expect(reasoningBlock).toBeVisible({ timeout: 60_000 });
+    await expect(reasoningBlock.getByText("Agent reasoning")).toBeVisible({
+      timeout: 90_000,
+    });
+  });
+
+  test("reasoning-block accumulates italic reasoning content", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill(REASONING_PROMPT);
+    await page.locator('[data-testid="copilot-send-button"]').first().click();
+
+    const reasoningBlock = page
+      .locator('[data-testid="reasoning-block"]')
+      .first();
+    await expect(reasoningBlock).toBeVisible({ timeout: 60_000 });
+    // ReasoningBlock renders content inside a div with italic class when
+    // `message.content` is non-empty (see reasoning-block.tsx).
+    await expect(reasoningBlock.locator(".italic")).toBeVisible({
+      timeout: 45_000,
+    });
+  });
+
+  test("Show reasoning suggestion pill fires the reasoning prompt", async ({
+    page,
+  }) => {
+    // The page wires `useConfigureSuggestions` with a single "Show reasoning"
+    // pill whose message exactly matches the aimock fixture key.
+    const pill = page.getByRole("button", { name: /Show reasoning/i }).first();
+    await expect(pill).toBeVisible({ timeout: 30_000 });
+    await pill.click();
+
+    const reasoningBlock = page
+      .locator('[data-testid="reasoning-block"]')
+      .first();
+    await expect(reasoningBlock).toBeVisible({ timeout: 60_000 });
+  });
+});

--- a/showcase/integrations/google-adk/tests/e2e/shared-state-streaming.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/shared-state-streaming.spec.ts
@@ -1,113 +1,140 @@
 import { test, expect } from "@playwright/test";
 
-// State Streaming demo — Google ADK.
-//
-// Mirrors langgraph-python/tests/e2e/shared-state-streaming.spec.ts.
-//
-// Demo source: src/app/demos/shared-state-streaming/page.tsx
-// Backend agent: src/agents/shared_state_streaming_agent.py
-//
-// Per-token state-delta streaming. The agent's `write_document` tool
-// argument (`content`) is forwarded into `state.document` via
-// PredictStateMapping (+ streaming_function_call_arguments=True). On the
-// frontend, useAgent({ updates: [OnStateChanged, OnRunStatusChanged] })
-// re-renders DocumentView each time `state.document` grows and toggles
-// the "LIVE" badge while the agent is running. Through Gemini Studio
-// the per-token granularity falls back to chunk-level deltas (still
-// emits STATE_DELTA, just coarser).
-
-const PILLS = {
-  poem: "Write a short poem",
-  email: "Draft an email",
-  quantum: "Explain quantum computing",
-} as const;
-
 test.describe("State Streaming", () => {
-  test.setTimeout(120_000);
-
   test.beforeEach(async ({ page }) => {
     await page.goto("/demos/shared-state-streaming");
   });
 
-  test("page loads with document panel, sidebar, and 3 verbatim pills", async ({
-    page,
-  }) => {
-    // Document panel mounts with its testid and the empty-state hint.
-    await expect(page.getByTestId("document-view")).toBeVisible({
-      timeout: 15_000,
+  test("page loads with document editor and sidebar", async ({ page }) => {
+    // The document editor has a textarea
+    const textarea = page.locator("textarea").first();
+    await expect(textarea).toBeVisible({ timeout: 10000 });
+
+    // The sidebar should show "AI Document Editor" title
+    await expect(page.getByText("AI Document Editor")).toBeVisible({
+      timeout: 10000,
     });
-    await expect(
-      page.getByText(
-        "Ask the agent to write something — its output will stream here token by token.",
-      ),
-    ).toBeVisible();
-
-    // CopilotSidebar exposes the demo placeholder.
-    await expect(
-      page.getByPlaceholder("Ask me to write something..."),
-    ).toBeVisible({ timeout: 15_000 });
-
-    // 3 verbatim suggestion pills.
-    const suggestions = page.locator('[data-testid="copilot-suggestion"]');
-    for (const title of Object.values(PILLS)) {
-      await expect(suggestions.filter({ hasText: title }).first()).toBeVisible({
-        timeout: 15_000,
-      });
-    }
   });
 
-  test("initial state: 0 chars, no LIVE badge", async ({ page }) => {
-    await expect(page.getByTestId("document-char-count")).toHaveText(
-      "0 chars",
-      { timeout: 15_000 },
+  test("sidebar has chat input", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("document editor placeholder is visible when empty", async ({
+    page,
+  }) => {
+    await expect(page.getByText("Write whatever you want here...")).toBeVisible(
+      { timeout: 10000 },
     );
-    await expect(page.getByTestId("document-live-badge")).toHaveCount(0);
   });
 
-  test("clicking 'Write a short poem' streams document content into state", async ({
-    page,
-  }) => {
-    await page
-      .locator('[data-testid="copilot-suggestion"]')
-      .filter({ hasText: PILLS.poem })
-      .first()
-      .click();
+  test("user can type in the document editor", async ({ page }) => {
+    // The main textarea should accept text
+    const editorTextarea = page.locator("textarea.w-full").first();
+    await editorTextarea.fill("This is my test document content.");
 
-    // After streaming finishes, the document-content node must be visible
-    // and the char-count must be non-zero. We assert on the final state
-    // rather than racing the streaming ticks — both modes (per-token via
-    // Vertex AI, chunk-level via Gemini Studio) converge here.
-    const content = page.getByTestId("document-content");
-    await expect(content).toBeVisible({ timeout: 90_000 });
-
-    const text = (await content.textContent())?.trim() ?? "";
-    expect(text.length, "document should be non-empty").toBeGreaterThan(0);
-
-    // Char counter reflects the streamed content.
-    const charCountText =
-      (await page.getByTestId("document-char-count").textContent()) ?? "";
-    const m = charCountText.match(/(\d+)\s+chars/);
-    expect(
-      m,
-      `char-count display "${charCountText}" should match "N chars"`,
-    ).not.toBeNull();
-    if (m) {
-      expect(Number(m[1])).toBeGreaterThan(0);
-    }
+    await expect(editorTextarea).toHaveValue(
+      "This is my test document content.",
+    );
   });
 
-  test("clicking 'Draft an email' streams document content into state", async ({
-    page,
-  }) => {
-    await page
-      .locator('[data-testid="copilot-suggestion"]')
-      .filter({ hasText: PILLS.email })
-      .first()
-      .click();
+  test("asking agent to edit shows confirm changes modal", async ({ page }) => {
+    // Add some content to the editor
+    const editorTextarea = page.locator("textarea.w-full").first();
+    await editorTextarea.fill("Draft proposal for Q2 project.");
 
-    const content = page.getByTestId("document-content");
-    await expect(content).toBeVisible({ timeout: 90_000 });
-    const text = (await content.textContent())?.trim() ?? "";
-    expect(text.length).toBeGreaterThan(0);
+    // Ask the agent to modify via the sidebar chat
+    const chatInputs = page.locator(
+      'textarea[placeholder], [placeholder*="message"]',
+    );
+    const chatInput = chatInputs.last();
+    await chatInput.fill("Expand this into a full project proposal");
+    await chatInput.press("Enter");
+
+    // The ConfirmChanges modal should appear with accept/reject buttons
+    const confirmModal = page.locator('[data-testid="confirm-changes-modal"]');
+    await expect(confirmModal).toBeVisible({ timeout: 60000 });
+
+    // Should show the "Confirm Changes" heading
+    await expect(confirmModal.getByText("Confirm Changes")).toBeVisible();
+
+    // Should have Reject and Confirm buttons
+    await expect(page.locator('[data-testid="reject-button"]')).toBeVisible();
+    await expect(page.locator('[data-testid="confirm-button"]')).toBeVisible();
+  });
+
+  test("accepting changes updates status display", async ({ page }) => {
+    const editorTextarea = page.locator("textarea.w-full").first();
+    await editorTextarea.fill("Meeting notes from today.");
+
+    const chatInputs = page.locator(
+      'textarea[placeholder], [placeholder*="message"]',
+    );
+    const chatInput = chatInputs.last();
+    await chatInput.fill("Rewrite these notes in a more formal tone");
+    await chatInput.press("Enter");
+
+    // Wait for confirm modal
+    const confirmButton = page.locator('[data-testid="confirm-button"]');
+    await expect(confirmButton).toBeVisible({ timeout: 60000 });
+
+    // Click confirm
+    await confirmButton.click();
+
+    // The status should show "Accepted"
+    await expect(page.locator('[data-testid="status-display"]')).toHaveText(
+      "Accepted",
+    );
+  });
+
+  test("rejecting changes updates status display", async ({ page }) => {
+    const editorTextarea = page.locator("textarea.w-full").first();
+    await editorTextarea.fill("Budget report for Q3.");
+
+    const chatInputs = page.locator(
+      'textarea[placeholder], [placeholder*="message"]',
+    );
+    const chatInput = chatInputs.last();
+    await chatInput.fill("Make this more detailed with bullet points");
+    await chatInput.press("Enter");
+
+    // Wait for confirm modal
+    const rejectButton = page.locator('[data-testid="reject-button"]');
+    await expect(rejectButton).toBeVisible({ timeout: 60000 });
+
+    // Click reject
+    await rejectButton.click();
+
+    // The status should show "Rejected"
+    await expect(page.locator('[data-testid="status-display"]')).toHaveText(
+      "Rejected",
+    );
+  });
+
+  test("confirm modal shows diff of proposed changes", async ({ page }) => {
+    const editorTextarea = page.locator("textarea.w-full").first();
+    await editorTextarea.fill("Simple draft text.");
+
+    const chatInputs = page.locator(
+      'textarea[placeholder], [placeholder*="message"]',
+    );
+    const chatInput = chatInputs.last();
+    await chatInput.fill("Rewrite this as a formal letter");
+    await chatInput.press("Enter");
+
+    // Wait for confirm modal
+    const confirmModal = page.locator('[data-testid="confirm-changes-modal"]');
+    await expect(confirmModal).toBeVisible({ timeout: 60000 });
+
+    // Modal should contain the proposed new content (not empty)
+    const modalText = await confirmModal.textContent();
+    expect(modalText).toBeTruthy();
+    expect(modalText!.length).toBeGreaterThan(20);
+
+    // Both action buttons should be present
+    await expect(page.locator('[data-testid="reject-button"]')).toBeVisible();
+    await expect(page.locator('[data-testid="confirm-button"]')).toBeVisible();
   });
 });

--- a/showcase/integrations/google-adk/tests/e2e/subagents.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/subagents.spec.ts
@@ -1,23 +1,26 @@
 import { expect, Page, test } from "@playwright/test";
 
-// Sub-Agents demo — Google ADK.
-//
-// Mirrors langgraph-python/tests/e2e/subagents.spec.ts.
+// Sub-Agents demo (Phase-1D, multi-agent family).
 //
 // Demo source: src/app/demos/subagents/page.tsx
-// Backend agent: src/agents/subagents_agent.py (supervisor + 3 sub-agents)
+// Backend agent: src/agents/subagents.py (supervisor + 3 sub-agents)
+// Aimock fixtures: showcase/aimock/d5-all.json (3 pill chains)
 //
 // The supervisor delegates to research → writing → critique sub-agents.
 // Each delegation renders an inline tool-card in the chat stream via
 // `useRenderTool` plus an entry in the side-panel delegation log.
 //
 // Each test drives a verbatim suggestion-pill prompt (see
-// `src/app/demos/subagents/suggestions.ts`) end-to-end and asserts:
+// `src/app/demos/subagents/suggestions.ts`) end-to-end through the
+// fixture chain and asserts:
 //   1. all three role-scoped cards render
 //      (`[data-testid="subagent-card-<role>"]`),
 //   2. each card's `[data-testid="subagent-result"]` is non-empty AND
-//      does not echo the showcase-assistant boilerplate, and
-//   3. exactly one critic card renders per supervisor run.
+//      does not echo the showcase-assistant boilerplate (catches the
+//      previous bug where Writer/Critic cards leaked the chat
+//      welcome text), and
+//   3. exactly one critic card renders per supervisor run, with a
+//      stable `done` status (catches the previous critic-loop bug).
 
 const PILLS = {
   blog: "Write a blog post",
@@ -28,10 +31,10 @@ const PILLS = {
 const ROLES = ["researcher", "writer", "critic"] as const;
 type Role = (typeof ROLES)[number];
 
-// Boilerplate strings that would indicate the showcase assistant intro
-// leaked into a sub-agent card. Asserting these are absent guards
-// against regressions where the assistant intro overwrites real
-// sub-agent output.
+// Showcase boilerplate strings the previous wiring leaked into Writer
+// and Critic cards. Asserting these are absent guards against any
+// regression where the assistant intro overwrites real sub-agent
+// output.
 const BOILERPLATE_FRAGMENTS = [
   "Hi there! I'm your showcase assistant",
   "Here are the things I can help with",
@@ -132,11 +135,16 @@ test.describe("Sub-Agents", () => {
     }
   });
 
-  test("Summarize a topic pill produces 3 subagent cards", async ({ page }) => {
-    // ADK appends a single `completed` delegation entry per sub-agent
-    // call (no `running` placeholder), matching LP's reducer semantics.
-    // Reaching `done` on all three cards confirms the completion-only
-    // append in `subagents_agent.py` is in place.
+  test("Summarize a topic pill produces 3 subagent cards (regression: delegations reducer)", async ({
+    page,
+  }) => {
+    // This pill historically returned HTTP 400 with
+    // INVALID_CONCURRENT_GRAPH_UPDATE on the `delegations` state key
+    // because the TypedDict didn't declare a reducer. Reaching `done`
+    // on all three cards confirms the `Annotated[..., operator.add]`
+    // reducer in `subagents.py` is in place — without it the supervisor
+    // run would error out and at least one card would never reach
+    // `complete`.
     await clickPill(page, PILLS.summarize);
     await waitForAllCardsDone(page);
     for (const role of ROLES) {

--- a/showcase/integrations/google-adk/tests/e2e/voice.spec.ts
+++ b/showcase/integrations/google-adk/tests/e2e/voice.spec.ts
@@ -29,7 +29,7 @@ test.describe("Voice Input", () => {
     await expect(
       page.locator('[data-testid="voice-sample-audio-button"]'),
     ).toBeEnabled();
-    await expect(page.getByText("Play sample")).toBeVisible();
+    await expect(page.getByText("Try a sample audio")).toBeVisible();
     await expect(
       page.locator('[data-testid="copilot-chat-input"]'),
     ).toBeVisible();
@@ -62,11 +62,11 @@ test.describe("Voice Input", () => {
     await expect(sampleButton).toBeEnabled();
   });
 
-  test("sending the transcribed text produces an assistant response", async ({
+  test("sending the transcribed text produces a weather tool render", async ({
     page,
   }) => {
     // The end-to-end flow (click → run agent → first assistant chunk) can run
-    // up to ~50s on a cold ADK dev server, so override the default 30s
+    // up to ~50s on a cold langgraph dev server, so override the default 30s
     // suite timeout to give the locator's own 45s timeout headroom.
     test.setTimeout(90_000);
     const sampleButton = page.locator(
@@ -79,7 +79,7 @@ test.describe("Voice Input", () => {
     await expect(textarea).toHaveValue(/weather|tokyo/i, { timeout: 1000 });
     await sendButton.click();
 
-    // The voice-demo route reuses the neutral _simple_chat agent, which
+    // The voice-demo route reuses the neutral sample_agent graph, which
     // doesn't itself render a weather card — but if the runtime has a
     // tool-rendering configuration that handles weather, one of these will
     // be visible. The assertion is permissive: we care that *some*


### PR DESCRIPTION
## Summary

Three independent, layered fixes that came out of a focused google-adk D5 debugging session on top of the recently-merged ag-ui-adk + aimock parity work:

1. **Harness probe fixes** (`showcase/harness/...`) — `E2eDeepPage.locator` is now wired through the structurally-typed wrapper so probes that need count-based polling can use `page.locator(sel).count()` instead of erroring with "pw.locator is not a function" at runtime. Paired with a native `setTimeout` between polls in `d5-tool-rendering-reasoning-chain` (Playwright's `page.waitForTimeout` also wasn't in the wrapper surface). Added `google-adk` to `d5-gen-ui-custom`'s `CHART_INTEGRATIONS` set — google-adk's `gen-ui-tool-based` page was ported from LGP verbatim and now registers `render_pie_chart`/`render_bar_chart`, so the haiku-shape probe path no longer applies.
2. **`ag-ui-adk 0.6.1 → 0.6.3`** (`requirements.txt`) — pulls in the `FunctionResponse.name` fix ([ag-ui-protocol/ag-ui#1682](https://github.com/ag-ui-protocol/ag-ui/pull/1682)). Without it, every multi-leg D5 fixture keyed on `toolCallId` fell through to the first-leg `userMessage` matcher and looped indefinitely.
3. **E2E spec parity** (`tests/e2e/*.spec.ts`) — 16 diverged specs synced verbatim from langgraph-python plus 3 previously-missing ones (`chat-customization-css`, `prebuilt-sidebar`, `reasoning-custom`). Per-package `pnpm test:e2e` is the local dev validation loop; without parity here, tiny divergences accumulate silently until they surface as D5 regressions in CI.

## Context

These changes were extracted from a broader google-adk D5 investigation branch. Several other fixes from that session (the `@ag-ui/client 0.0.43 → 0.0.53` bump, the `stop_on_terminal_text` callback, most agent-side edits, several diverged demo pages) landed independently on `main` during the same window, so this PR carries only the work that does not overlap with those commits.

## Test plan

- [ ] CI: harness vitest + showcase package builds pass.
- [ ] Local: `./showcase/bin/showcase test google-adk:tool-rendering-reasoning-chain --d5` no longer errors with `pw.locator is not a function`; the chain advances past leg 1.
- [ ] Local: `./showcase/bin/showcase test google-adk:gen-ui-tool-based --d5` exercises the chart path (not haiku) and goes green.
- [ ] Local: `cd showcase/integrations/google-adk && pnpm test:e2e` runs the synced specs against the dev server.

Pairs with merged upstream work:
- aimock [#199](https://github.com/CopilotKit/aimock/pull/199) (egress `functionCall.id` round-trip, v1.24.1)
- ag-ui-protocol/ag-ui [#1682](https://github.com/ag-ui-protocol/ag-ui/pull/1682) (`FunctionResponse.name` correction, 0.6.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)