### PR TITLE
feat(showcase): discovery caching, auth failure alerting, and browser pool status

### DIFF
--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -1374,7 +1374,10 @@ export function createRailwayAdapter(
     { name: string; id: string }[]
   > => {
     const now = Date.now();
-    if (cachedServices && now - cachedServices.fetchedAt < SERVICE_CACHE_TTL_MS) {
+    if (
+      cachedServices &&
+      now - cachedServices.fetchedAt < SERVICE_CACHE_TTL_MS
+    ) {
       return cachedServices.data;
     }
     const data = await listServices();

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -62,6 +62,8 @@ import { BrowserPool } from "./probes/helpers/browser-pool.js";
 import { qaDriver } from "./probes/drivers/qa.js";
 import { railwayServicesSource } from "./probes/discovery/railway-services.js";
 import { pnpmPackagesDiscoverySource } from "./probes/discovery/pnpm-packages.js";
+import { withCache } from "./probes/discovery/caching-source.js";
+import { DiscoveryAuthTracker } from "./probes/discovery/auth-tracker.js";
 import { logger, reloadLogLevel } from "./logger.js";
 import { logErrorWithStack } from "./probes/loader/probe-invoker.js";
 import { makeGql } from "./probes/discovery/railway-services.js";
@@ -288,8 +290,33 @@ export async function boot(opts: BootOptions = {}): Promise<{
   try {
     await browserPool.init();
     browserPoolReady = true;
+    try {
+      await writer.write({
+        key: "system:browser-pool-degraded",
+        state: "green",
+        signal: { recovered: true, recoveredAt: new Date().toISOString() },
+        observedAt: new Date().toISOString(),
+      });
+    } catch {
+      // best-effort -- pool is healthy, status write failure is non-critical
+    }
   } catch (err) {
     logger.error("boot.browser-pool-init-failed", { error: String(err) });
+    try {
+      await writer.write({
+        key: "system:browser-pool-degraded",
+        state: "red",
+        signal: {
+          errorMessage: err instanceof Error ? err.message : String(err),
+          degradedSince: new Date().toISOString(),
+        },
+        observedAt: new Date().toISOString(),
+      });
+    } catch (writeErr) {
+      logger.warn("boot.browser-pool-status-write-failed", {
+        error: writeErr instanceof Error ? writeErr.message : String(writeErr),
+      });
+    }
   }
 
   const probeRegistry = createProbeRegistry();
@@ -298,7 +325,20 @@ export async function boot(opts: BootOptions = {}): Promise<{
     probeRegistry,
     browserPoolReady ? browserPool : undefined,
   );
-  discoveryRegistry.register(railwayServicesSource);
+  const authTracker = new DiscoveryAuthTracker({
+    threshold: 3,
+    writer,
+    logger,
+    now: () => Date.now(),
+  });
+
+  discoveryRegistry.register(
+    withCache(railwayServicesSource, {
+      ttlMs: 86_400_000,
+      logger,
+      authTracker,
+    }),
+  );
   discoveryRegistry.register(pnpmPackagesDiscoverySource);
   const probeConfigDir =
     opts.configDir !== undefined
@@ -1320,16 +1360,36 @@ export function createRailwayAdapter(
     return data.project.services.edges.map((e) => e.node);
   };
 
+  // In-memory cache for the service list so N getServiceEnv() calls
+  // within a single probe tick don't issue N redundant listServices()
+  // GraphQL round-trips. TTL of 60s ensures fresh data across ticks
+  // while collapsing intra-tick fan-out into a single fetch.
+  let cachedServices: {
+    data: { name: string; id: string }[];
+    fetchedAt: number;
+  } | null = null;
+  const SERVICE_CACHE_TTL_MS = 60_000;
+
+  const cachedListServices = async (): Promise<
+    { name: string; id: string }[]
+  > => {
+    const now = Date.now();
+    if (cachedServices && now - cachedServices.fetchedAt < SERVICE_CACHE_TTL_MS) {
+      return cachedServices.data;
+    }
+    const data = await listServices();
+    cachedServices = { data, fetchedAt: now };
+    return data;
+  };
+
   const getServiceEnv = async (
     name: string,
   ): Promise<Record<string, string | undefined>> => {
-    // No cross-tick cache: the aimock-wiring probe always calls
-    // `listServices` first (see buildCronProbeResolver), and per-tick
-    // refetch costs one GraphQL round-trip but ensures
-    // newly-renamed/added Railway services are visible without a
-    // restart. If a future caller invokes `getServiceEnv` directly
-    // without `listServices`, fetch the list here too.
-    const services = await listServices();
+    // Use the cached service list so N getServiceEnv() calls within a
+    // single probe tick share one listServices() round-trip. The cache
+    // TTL (60s) ensures cross-tick freshness while eliminating the N+1
+    // fan-out within a tick.
+    const services = await cachedListServices();
     const match = services.find((s) => s.name === name);
     if (!match) {
       throw new Error(`railway service not found: ${name}`);
@@ -1369,7 +1429,7 @@ export function createRailwayAdapter(
     return out;
   };
 
-  return { listServices, getServiceEnv };
+  return { listServices: cachedListServices, getServiceEnv };
 }
 
 // Only run boot() when executed directly (not when imported). Use fileURLToPath

--- a/showcase/harness/src/probes/discovery/auth-tracker.test.ts
+++ b/showcase/harness/src/probes/discovery/auth-tracker.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi } from "vitest";
+import { DiscoveryAuthTracker } from "./auth-tracker.js";
+import {
+  DiscoverySourceAuthError,
+  DiscoverySourceTransportError,
+} from "./errors.js";
+import type { Logger, ProbeResult, WriteOutcome } from "../../types/index.js";
+import type { StatusWriter } from "../../writers/status-writer.js";
+
+// Helpers -------------------------------------------------------------------
+
+function makeLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+function makeWriter(): StatusWriter & { writes: ProbeResult<unknown>[] } {
+  const writes: ProbeResult<unknown>[] = [];
+  return {
+    writes,
+    write: vi.fn(
+      async (result: ProbeResult<unknown>): Promise<WriteOutcome> => {
+        writes.push(result);
+        return {
+          previousState: null,
+          newState: result.state as "green" | "red" | "degraded",
+          transition: "first",
+          firstFailureAt: null,
+          failCount: 0,
+        };
+      },
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+describe("DiscoveryAuthTracker", () => {
+  it("auth failures increment counter — threshold triggers write", async () => {
+    const writer = makeWriter();
+    const tracker = new DiscoveryAuthTracker({
+      threshold: 3,
+      writer,
+      logger: makeLogger(),
+      now: () => 1000,
+    });
+
+    const err = new DiscoverySourceAuthError(
+      "railway-services",
+      "401 Unauthorized",
+    );
+
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    expect(writer.writes).toHaveLength(0);
+
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    expect(writer.writes).toHaveLength(1);
+  });
+
+  it("non-auth failures do not increment counter", async () => {
+    const writer = makeWriter();
+    const tracker = new DiscoveryAuthTracker({
+      threshold: 3,
+      writer,
+      logger: makeLogger(),
+      now: () => 1000,
+    });
+
+    const err = new DiscoverySourceTransportError(
+      "railway-services",
+      "ECONNREFUSED",
+    );
+
+    for (let i = 0; i < 5; i++) {
+      await tracker.recordFailure("railway-services", err, "serving-stale");
+    }
+
+    expect(writer.write).not.toHaveBeenCalled();
+  });
+
+  it("success resets counter", async () => {
+    const writer = makeWriter();
+    const tracker = new DiscoveryAuthTracker({
+      threshold: 3,
+      writer,
+      logger: makeLogger(),
+      now: () => 1000,
+    });
+
+    const err = new DiscoverySourceAuthError(
+      "railway-services",
+      "401 Unauthorized",
+    );
+
+    // Two auth failures (below threshold)
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+
+    // Success resets counter — isAlerting is false so no green write
+    await tracker.recordSuccess("railway-services");
+
+    // Two more auth failures (counter was reset, so still below threshold)
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+
+    // Writer should never have been called (never reached threshold)
+    expect(writer.write).not.toHaveBeenCalled();
+  });
+
+  it("threshold crossing writes system status with state red", async () => {
+    const writer = makeWriter();
+    const tracker = new DiscoveryAuthTracker({
+      threshold: 3,
+      writer,
+      logger: makeLogger(),
+      now: () => 1000,
+    });
+
+    const err = new DiscoverySourceAuthError(
+      "railway-services",
+      "401 Unauthorized",
+    );
+
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+
+    expect(writer.writes).toHaveLength(1);
+    const written = writer.writes[0]!;
+    expect(written.key).toBe("system:discovery-auth-failed");
+    expect(written.state).toBe("red");
+
+    const signal = written.signal as Record<string, unknown>;
+    expect(signal.errorMessage).toBe("401 Unauthorized");
+    expect(signal.sourceName).toBe("railway-services");
+    expect(signal.firstFailureAt).toBeTypeOf("string");
+    expect(signal.authFailuresSinceSuccess).toBe(3);
+    expect(signal.cacheStatus).toBe("serving-stale");
+  });
+
+  it("sustained alerting rate-limits writes to once per 5 minutes", async () => {
+    const writer = makeWriter();
+    let clock = 1000;
+    const tracker = new DiscoveryAuthTracker({
+      threshold: 3,
+      writer,
+      logger: makeLogger(),
+      now: () => clock,
+    });
+
+    const err = new DiscoverySourceAuthError(
+      "railway-services",
+      "401 Unauthorized",
+    );
+
+    // Failures 1-3: threshold crossed on 3rd (clock=3000)
+    clock = 1000;
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    clock = 2000;
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    clock = 3000;
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    expect(writer.writes).toHaveLength(1);
+
+    // Failure 4 at clock=4000: only 1s after threshold write — suppressed
+    clock = 4000;
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    expect(writer.writes).toHaveLength(1);
+
+    // Failure 5 at clock=60_000: still under 5 minutes — suppressed
+    clock = 60_000;
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    expect(writer.writes).toHaveLength(1);
+
+    // Failure 6 at clock=303_001: >5 min after threshold write — written
+    clock = 303_001;
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    expect(writer.writes).toHaveLength(2);
+
+    const write1 = writer.writes[0]!;
+    const write2 = writer.writes[1]!;
+
+    const signal2 = write2.signal as Record<string, unknown>;
+    expect(signal2.authFailuresSinceSuccess).toBe(6);
+
+    // Second write should have a later observedAt
+    expect(write2.observedAt > write1.observedAt).toBe(true);
+
+    // Failure 7 shortly after — suppressed again (new 5m window)
+    clock = 310_000;
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    expect(writer.writes).toHaveLength(2);
+  });
+
+  it("recovery writes green status", async () => {
+    const writer = makeWriter();
+    const tracker = new DiscoveryAuthTracker({
+      threshold: 3,
+      writer,
+      logger: makeLogger(),
+      now: () => 5000,
+    });
+
+    const err = new DiscoverySourceAuthError(
+      "railway-services",
+      "401 Unauthorized",
+    );
+
+    // Reach threshold
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    expect(writer.writes).toHaveLength(1);
+
+    // Recovery
+    await tracker.recordSuccess("railway-services");
+    expect(writer.writes).toHaveLength(2);
+
+    const recoveryWrite = writer.writes[1]!;
+    expect(recoveryWrite.key).toBe("system:discovery-auth-failed");
+    expect(recoveryWrite.state).toBe("green");
+
+    const signal = recoveryWrite.signal as Record<string, unknown>;
+    expect(signal.recovered).toBe(true);
+    expect(signal.sourceName).toBe("railway-services");
+    expect(signal.recoveredAt).toBeTypeOf("string");
+  });
+
+  it("signal includes cacheStatus", async () => {
+    // Test with serving-stale
+    const writer1 = makeWriter();
+    const tracker1 = new DiscoveryAuthTracker({
+      threshold: 3,
+      writer: writer1,
+      logger: makeLogger(),
+      now: () => 1000,
+    });
+
+    const err = new DiscoverySourceAuthError(
+      "railway-services",
+      "401 Unauthorized",
+    );
+
+    await tracker1.recordFailure("railway-services", err, "serving-stale");
+    await tracker1.recordFailure("railway-services", err, "serving-stale");
+    await tracker1.recordFailure("railway-services", err, "serving-stale");
+
+    const signal1 = writer1.writes[0]!.signal as Record<string, unknown>;
+    expect(signal1.cacheStatus).toBe("serving-stale");
+
+    // Test with no-cache
+    const writer2 = makeWriter();
+    const tracker2 = new DiscoveryAuthTracker({
+      threshold: 3,
+      writer: writer2,
+      logger: makeLogger(),
+      now: () => 1000,
+    });
+
+    await tracker2.recordFailure("railway-services", err, "no-cache");
+    await tracker2.recordFailure("railway-services", err, "no-cache");
+    await tracker2.recordFailure("railway-services", err, "no-cache");
+
+    const signal2 = writer2.writes[0]!.signal as Record<string, unknown>;
+    expect(signal2.cacheStatus).toBe("no-cache");
+  });
+
+  it("below-threshold is a no-op for writer", async () => {
+    const writer = makeWriter();
+    const tracker = new DiscoveryAuthTracker({
+      threshold: 3,
+      writer,
+      logger: makeLogger(),
+      now: () => 1000,
+    });
+
+    const err = new DiscoverySourceAuthError(
+      "railway-services",
+      "401 Unauthorized",
+    );
+
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+    await tracker.recordFailure("railway-services", err, "serving-stale");
+
+    expect(writer.write).not.toHaveBeenCalled();
+  });
+
+  it("interleaved errors — transport does not reset auth counter", async () => {
+    const writer = makeWriter();
+    const tracker = new DiscoveryAuthTracker({
+      threshold: 3,
+      writer,
+      logger: makeLogger(),
+      now: () => 1000,
+    });
+
+    const authErr = new DiscoverySourceAuthError(
+      "railway-services",
+      "401 Unauthorized",
+    );
+    const transportErr = new DiscoverySourceTransportError(
+      "railway-services",
+      "ECONNREFUSED",
+    );
+
+    // auth-fail (counter: 1)
+    await tracker.recordFailure("railway-services", authErr, "serving-stale");
+    // auth-fail (counter: 2)
+    await tracker.recordFailure("railway-services", authErr, "serving-stale");
+    // transport-fail (no-op, counter stays at 2)
+    await tracker.recordFailure(
+      "railway-services",
+      transportErr,
+      "serving-stale",
+    );
+    // auth-fail (counter: 3 — threshold crossed)
+    await tracker.recordFailure("railway-services", authErr, "serving-stale");
+
+    expect(writer.writes).toHaveLength(1);
+    const signal = writer.writes[0]!.signal as Record<string, unknown>;
+    expect(signal.authFailuresSinceSuccess).toBe(3);
+  });
+});

--- a/showcase/harness/src/probes/discovery/auth-tracker.ts
+++ b/showcase/harness/src/probes/discovery/auth-tracker.ts
@@ -1,0 +1,149 @@
+import { DiscoverySourceAuthError } from "./errors.js";
+import type { DiscoverySourceError } from "./errors.js";
+import type { StatusWriter } from "../../writers/status-writer.js";
+import type { Logger, ProbeResult } from "../../types/index.js";
+
+type DiscoveryAuthSignal =
+  | {
+      errorMessage: string;
+      sourceName: string;
+      firstFailureAt: string;
+      authFailuresSinceSuccess: number;
+      cacheStatus: "serving-stale" | "no-cache";
+    }
+  | {
+      recovered: true;
+      sourceName: string;
+      recoveredAt: string;
+    };
+
+interface SourceAuthState {
+  authFailuresSinceSuccess: number;
+  firstFailureAt: string | null;
+  lastErrorMessage: string | null;
+  isAlerting: boolean;
+  lastWriteAt: number | null;
+}
+
+export interface AuthTrackerOptions {
+  threshold: number;
+  writer: StatusWriter;
+  logger: Logger;
+  now: () => number;
+}
+
+/** Minimum interval (ms) between sustained-alerting writes to PocketBase. */
+const SUSTAINED_WRITE_INTERVAL_MS = 300_000; // 5 minutes
+
+export class DiscoveryAuthTracker {
+  private readonly opts: AuthTrackerOptions;
+  private readonly states = new Map<string, SourceAuthState>();
+
+  constructor(opts: AuthTrackerOptions) {
+    this.opts = opts;
+  }
+
+  private getState(sourceName: string): SourceAuthState {
+    let state = this.states.get(sourceName);
+    if (!state) {
+      state = {
+        authFailuresSinceSuccess: 0,
+        firstFailureAt: null,
+        lastErrorMessage: null,
+        isAlerting: false,
+        lastWriteAt: null,
+      };
+      this.states.set(sourceName, state);
+    }
+    return state;
+  }
+
+  async recordSuccess(sourceName: string): Promise<void> {
+    const state = this.getState(sourceName);
+    const wasAlerting = state.isAlerting;
+
+    state.authFailuresSinceSuccess = 0;
+    state.firstFailureAt = null;
+    state.lastErrorMessage = null;
+    state.isAlerting = false;
+
+    if (wasAlerting) {
+      const recoveredAt = new Date(this.opts.now()).toISOString();
+      const result: ProbeResult<DiscoveryAuthSignal> = {
+        key: "system:discovery-auth-failed",
+        state: "green",
+        signal: {
+          recovered: true,
+          sourceName,
+          recoveredAt,
+        },
+        observedAt: recoveredAt,
+      };
+      this.opts.logger.info("discovery.auth-tracker.recovered", {
+        sourceName,
+        recoveredAt,
+      });
+      await this.opts.writer.write(result);
+    }
+  }
+
+  async recordFailure(
+    sourceName: string,
+    error: DiscoverySourceError,
+    cacheStatus: "serving-stale" | "no-cache",
+  ): Promise<void> {
+    if (!(error instanceof DiscoverySourceAuthError)) {
+      return;
+    }
+
+    const state = this.getState(sourceName);
+    state.authFailuresSinceSuccess += 1;
+    if (state.firstFailureAt === null) {
+      state.firstFailureAt = new Date(this.opts.now()).toISOString();
+    }
+    state.lastErrorMessage = error.message;
+
+    if (state.authFailuresSinceSuccess >= this.opts.threshold) {
+      const observedAt = new Date(this.opts.now()).toISOString();
+      const result: ProbeResult<DiscoveryAuthSignal> = {
+        key: "system:discovery-auth-failed",
+        state: "red",
+        signal: {
+          errorMessage: error.message,
+          sourceName,
+          firstFailureAt: state.firstFailureAt!,
+          authFailuresSinceSuccess: state.authFailuresSinceSuccess,
+          cacheStatus,
+        },
+        observedAt,
+      };
+
+      const now = this.opts.now();
+
+      if (!state.isAlerting) {
+        state.isAlerting = true;
+        this.opts.logger.warn("discovery.auth-tracker.threshold-crossed", {
+          sourceName,
+          authFailuresSinceSuccess: state.authFailuresSinceSuccess,
+          threshold: this.opts.threshold,
+          cacheStatus,
+        });
+        state.lastWriteAt = now;
+        await this.opts.writer.write(result);
+      } else {
+        this.opts.logger.debug("discovery.auth-tracker.sustained-alert", {
+          sourceName,
+          authFailuresSinceSuccess: state.authFailuresSinceSuccess,
+          cacheStatus,
+        });
+
+        // Rate-limit sustained alerting writes: at most once per 5 minutes
+        const elapsed = now - (state.lastWriteAt ?? 0);
+        if (elapsed >= SUSTAINED_WRITE_INTERVAL_MS) {
+          state.lastWriteAt = now;
+          await this.opts.writer.write(result);
+        }
+      }
+    }
+  }
+}

--- a/showcase/harness/src/probes/discovery/caching-source.test.ts
+++ b/showcase/harness/src/probes/discovery/caching-source.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { z } from "zod";
 import { withCache, cacheKey } from "./caching-source.js";
-import {
-  DiscoverySourceAuthError,
-  DiscoverySourceError,
-} from "./errors.js";
+import { DiscoverySourceAuthError, DiscoverySourceError } from "./errors.js";
 import type { DiscoveryContext, DiscoverySource } from "../types.js";
 import type { Logger } from "../../types/index.js";
 
@@ -65,11 +62,7 @@ function makeTracker() {
   return {
     recordSuccess: vi.fn(async (_name: string) => {}),
     recordFailure: vi.fn(
-      async (
-        _name: string,
-        _error: unknown,
-        _cacheStatus: string,
-      ) => {},
+      async (_name: string, _error: unknown, _cacheStatus: string) => {},
     ),
   };
 }
@@ -262,9 +255,7 @@ describe("CachingDiscoverySource", () => {
       async (_ctx: DiscoveryContext, config: unknown) => {
         await new Promise((r) => setTimeout(r, 50));
         const cfg = config as { filter: string };
-        return cfg.filter === "a"
-          ? [{ id: "result-a" }]
-          : [{ id: "result-b" }];
+        return cfg.filter === "a" ? [{ id: "result-a" }] : [{ id: "result-b" }];
       },
     );
     const source = makeSource<{ id: string }>("test", enumerateFn);
@@ -286,21 +277,16 @@ describe("CachingDiscoverySource", () => {
 
   it("cache key isolation — different configs get separate entries", async () => {
     let callCount = 0;
-    const source = makeSource<{ id: string }>(
-      "test",
-      async (_ctx, config) => {
-        callCount++;
-        const cfg = config as { env: string };
-        if (callCount <= 2) {
-          // First two calls succeed (one per config)
-          return cfg.env === "prod"
-            ? [{ id: "prod1" }]
-            : [{ id: "stg1" }];
-        }
-        // Subsequent calls fail
-        throw new DiscoverySourceAuthError("test", "401 Unauthorized");
-      },
-    );
+    const source = makeSource<{ id: string }>("test", async (_ctx, config) => {
+      callCount++;
+      const cfg = config as { env: string };
+      if (callCount <= 2) {
+        // First two calls succeed (one per config)
+        return cfg.env === "prod" ? [{ id: "prod1" }] : [{ id: "stg1" }];
+      }
+      // Subsequent calls fail
+      throw new DiscoverySourceAuthError("test", "401 Unauthorized");
+    });
 
     const cached = withCache(source, { ttlMs: TTL });
     const ctx = makeCtx();
@@ -323,16 +309,13 @@ describe("CachingDiscoverySource", () => {
   it("stale entries evicted after 2x TTL", async () => {
     let clock = 1000;
     let shouldFail = false;
-    const source = makeSource<{ id: string }>(
-      "test",
-      async (_ctx, config) => {
-        const cfg = config as { env: string };
-        if (shouldFail) {
-          throw new DiscoverySourceAuthError("test", "gone");
-        }
-        return [{ id: cfg.env }];
-      },
-    );
+    const source = makeSource<{ id: string }>("test", async (_ctx, config) => {
+      const cfg = config as { env: string };
+      if (shouldFail) {
+        throw new DiscoverySourceAuthError("test", "gone");
+      }
+      return [{ id: cfg.env }];
+    });
 
     const cached = withCache(source, {
       ttlMs: TTL,
@@ -354,9 +337,9 @@ describe("CachingDiscoverySource", () => {
     shouldFail = true;
 
     // Config A was evicted — no stale cache to serve, so it must throw
-    await expect(
-      cached.enumerate(ctx, { env: "alpha" }),
-    ).rejects.toThrow(DiscoverySourceAuthError);
+    await expect(cached.enumerate(ctx, { env: "alpha" })).rejects.toThrow(
+      DiscoverySourceAuthError,
+    );
 
     // Config B is still fresh (just fetched) — stale serve should work
     const staleB = await cached.enumerate(ctx, { env: "bravo" });

--- a/showcase/harness/src/probes/discovery/caching-source.test.ts
+++ b/showcase/harness/src/probes/discovery/caching-source.test.ts
@@ -1,0 +1,491 @@
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+import { withCache, cacheKey } from "./caching-source.js";
+import {
+  DiscoverySourceAuthError,
+  DiscoverySourceError,
+} from "./errors.js";
+import type { DiscoveryContext, DiscoverySource } from "../types.js";
+import type { Logger } from "../../types/index.js";
+
+// Helpers -------------------------------------------------------------------
+
+/**
+ * Minimal DiscoverySource stub with a controllable enumerate function.
+ * The configSchema defaults to a passthrough object so callers that don't
+ * need schema-level assertions skip the boilerplate.
+ */
+function makeSource<T>(
+  name: string,
+  enumerateFn: (ctx: DiscoveryContext, config: unknown) => Promise<T[]>,
+): DiscoverySource<T> {
+  return {
+    name,
+    configSchema: z.object({}).passthrough(),
+    enumerate: enumerateFn,
+  };
+}
+
+/**
+ * Minimal DiscoveryContext for tests. Network access is never exercised —
+ * fetchImpl is a vi.fn() cast to satisfy the interface; the caching
+ * wrapper delegates to source.enumerate which is fully stubbed.
+ */
+function makeCtx(): DiscoveryContext {
+  return {
+    fetchImpl: vi.fn() as unknown as typeof fetch,
+    logger: makeLogger(),
+    env: {},
+  };
+}
+
+/**
+ * Minimal Logger that records calls so tests can assert on warn/info
+ * messages emitted by the caching layer.
+ */
+function makeLogger(): Logger & {
+  calls: Array<{ level: string; msg: string; meta?: Record<string, unknown> }>;
+} {
+  const calls: Array<{
+    level: string;
+    msg: string;
+    meta?: Record<string, unknown>;
+  }> = [];
+  return {
+    calls,
+    info: (msg, meta) => calls.push({ level: "info", msg, meta }),
+    warn: (msg, meta) => calls.push({ level: "warn", msg, meta }),
+    error: (msg, meta) => calls.push({ level: "error", msg, meta }),
+    debug: (msg, meta) => calls.push({ level: "debug", msg, meta }),
+  };
+}
+
+/** Minimal auth tracker stub with vi.fn() for both recording methods. */
+function makeTracker() {
+  return {
+    recordSuccess: vi.fn(async (_name: string) => {}),
+    recordFailure: vi.fn(
+      async (
+        _name: string,
+        _error: unknown,
+        _cacheStatus: string,
+      ) => {},
+    ),
+  };
+}
+
+// Tests ---------------------------------------------------------------------
+
+describe("CachingDiscoverySource", () => {
+  const TTL = 60_000;
+
+  it("success populates cache — subsequent failure serves stale", async () => {
+    let clock = 1000;
+    let callCount = 0;
+    const source = makeSource<{ id: string }>("test", async () => {
+      callCount++;
+      if (callCount === 1) return [{ id: "svc1" }];
+      throw new DiscoverySourceAuthError("test", "401 Unauthorized");
+    });
+
+    const cached = withCache(source, { ttlMs: TTL, now: () => clock });
+    const ctx = makeCtx();
+    const cfg = {};
+
+    const first = await cached.enumerate(ctx, cfg);
+    expect(first).toEqual([{ id: "svc1" }]);
+
+    const second = await cached.enumerate(ctx, cfg);
+    expect(second).toEqual([{ id: "svc1" }]);
+  });
+
+  it("failure with fresh cache serves stale results", async () => {
+    let clock = 1000;
+    let callCount = 0;
+    const source = makeSource<{ id: string }>("test", async () => {
+      callCount++;
+      if (callCount === 1) return [{ id: "svc1" }];
+      throw new DiscoverySourceAuthError("test", "401 Unauthorized");
+    });
+
+    const cached = withCache(source, {
+      ttlMs: TTL,
+      now: () => clock,
+    });
+    const ctx = makeCtx();
+    const cfg = {};
+
+    // Populate the cache
+    const first = await cached.enumerate(ctx, cfg);
+    expect(first).toEqual([{ id: "svc1" }]);
+
+    // Advance clock within TTL (30s < 60s TTL)
+    clock += 30_000;
+
+    // Failure with fresh cache should serve stale
+    const second = await cached.enumerate(ctx, cfg);
+    expect(second).toEqual([{ id: "svc1" }]);
+  });
+
+  it("failure with expired cache re-throws original error", async () => {
+    let clock = 1000;
+    let callCount = 0;
+    const source = makeSource<{ id: string }>("test", async () => {
+      callCount++;
+      if (callCount === 1) return [{ id: "svc1" }];
+      throw new DiscoverySourceAuthError("test", "401 Unauthorized");
+    });
+
+    const cached = withCache(source, {
+      ttlMs: TTL,
+      now: () => clock,
+    });
+    const ctx = makeCtx();
+    const cfg = {};
+
+    // Populate the cache
+    await cached.enumerate(ctx, cfg);
+
+    // Advance clock past TTL (60001ms > 60000ms TTL)
+    clock = 1000 + TTL + 1;
+
+    // Should re-throw because cache is expired
+    await expect(cached.enumerate(ctx, cfg)).rejects.toThrow(
+      DiscoverySourceAuthError,
+    );
+  });
+
+  it("failure with no prior cache re-throws", async () => {
+    const source = makeSource<{ id: string }>("test", async () => {
+      throw new DiscoverySourceAuthError("test", "401 Unauthorized");
+    });
+
+    const cached = withCache(source, { ttlMs: TTL });
+    const ctx = makeCtx();
+
+    await expect(cached.enumerate(ctx, {})).rejects.toThrow(
+      DiscoverySourceAuthError,
+    );
+  });
+
+  it("concurrent collapse — 3 callers, 1 upstream call", async () => {
+    const enumerateFn = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      return [{ id: "svc1" }];
+    });
+    const source = makeSource<{ id: string }>("test", enumerateFn);
+    const cached = withCache(source, { ttlMs: TTL });
+    const ctx = makeCtx();
+    const cfg = {};
+
+    const [r1, r2, r3] = await Promise.all([
+      cached.enumerate(ctx, cfg),
+      cached.enumerate(ctx, cfg),
+      cached.enumerate(ctx, cfg),
+    ]);
+
+    expect(enumerateFn).toHaveBeenCalledTimes(1);
+    expect(r1).toEqual([{ id: "svc1" }]);
+    expect(r2).toEqual([{ id: "svc1" }]);
+    expect(r3).toEqual([{ id: "svc1" }]);
+  });
+
+  it("concurrent collapse — failure path", async () => {
+    const enumerateFn = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      throw new DiscoverySourceAuthError("test", "401 Unauthorized");
+    });
+    const source = makeSource<{ id: string }>("test", enumerateFn);
+    const cached = withCache(source, { ttlMs: TTL });
+    const ctx = makeCtx();
+    const cfg = {};
+
+    const results = await Promise.allSettled([
+      cached.enumerate(ctx, cfg),
+      cached.enumerate(ctx, cfg),
+      cached.enumerate(ctx, cfg),
+    ]);
+
+    expect(enumerateFn).toHaveBeenCalledTimes(1);
+    for (const r of results) {
+      expect(r.status).toBe("rejected");
+      if (r.status === "rejected") {
+        expect(r.reason).toBeInstanceOf(DiscoverySourceAuthError);
+      }
+    }
+  });
+
+  it("calls authTracker.recordSuccess on successful enumerate", async () => {
+    const tracker = makeTracker();
+    const source = makeSource<{ id: string }>("test-source", async () => {
+      return [{ id: "a" }];
+    });
+    const cached = withCache(source, { ttlMs: TTL, authTracker: tracker });
+    const ctx = makeCtx();
+    const cfg = {};
+    await cached.enumerate(ctx, cfg);
+    expect(tracker.recordSuccess).toHaveBeenCalledWith("test-source");
+  });
+
+  it("concurrent collapse — single auth tracker call on failure", async () => {
+    const tracker = makeTracker();
+    const enumerateFn = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      throw new DiscoverySourceAuthError("test", "401 Unauthorized");
+    });
+    const source = makeSource<{ id: string }>("test", enumerateFn);
+    const cached = withCache(source, {
+      ttlMs: TTL,
+      authTracker: tracker,
+    });
+    const ctx = makeCtx();
+    const cfg = {};
+
+    // Fire 3 concurrent calls — all will reject
+    const results = await Promise.allSettled([
+      cached.enumerate(ctx, cfg),
+      cached.enumerate(ctx, cfg),
+      cached.enumerate(ctx, cfg),
+    ]);
+
+    // All should be rejected
+    for (const r of results) {
+      expect(r.status).toBe("rejected");
+    }
+
+    // Tracker should have been called exactly once, not 3 times
+    expect(tracker.recordFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("concurrent collapse — mixed configs get separate upstream calls", async () => {
+    const enumerateFn = vi.fn(
+      async (_ctx: DiscoveryContext, config: unknown) => {
+        await new Promise((r) => setTimeout(r, 50));
+        const cfg = config as { filter: string };
+        return cfg.filter === "a"
+          ? [{ id: "result-a" }]
+          : [{ id: "result-b" }];
+      },
+    );
+    const source = makeSource<{ id: string }>("test", enumerateFn);
+    const cached = withCache(source, { ttlMs: TTL });
+    const ctx = makeCtx();
+
+    const [r1, r2, r3] = await Promise.all([
+      cached.enumerate(ctx, { filter: "a" }),
+      cached.enumerate(ctx, { filter: "a" }),
+      cached.enumerate(ctx, { filter: "b" }),
+    ]);
+
+    // 2 upstream calls: one for config A, one for config B
+    expect(enumerateFn).toHaveBeenCalledTimes(2);
+    expect(r1).toEqual([{ id: "result-a" }]);
+    expect(r2).toEqual([{ id: "result-a" }]);
+    expect(r3).toEqual([{ id: "result-b" }]);
+  });
+
+  it("cache key isolation — different configs get separate entries", async () => {
+    let callCount = 0;
+    const source = makeSource<{ id: string }>(
+      "test",
+      async (_ctx, config) => {
+        callCount++;
+        const cfg = config as { env: string };
+        if (callCount <= 2) {
+          // First two calls succeed (one per config)
+          return cfg.env === "prod"
+            ? [{ id: "prod1" }]
+            : [{ id: "stg1" }];
+        }
+        // Subsequent calls fail
+        throw new DiscoverySourceAuthError("test", "401 Unauthorized");
+      },
+    );
+
+    const cached = withCache(source, { ttlMs: TTL });
+    const ctx = makeCtx();
+
+    // Populate cache for both configs
+    const prod1 = await cached.enumerate(ctx, { env: "prod" });
+    expect(prod1).toEqual([{ id: "prod1" }]);
+
+    const stg1 = await cached.enumerate(ctx, { env: "staging" });
+    expect(stg1).toEqual([{ id: "stg1" }]);
+
+    // Now source fails — cached results should be served per-config
+    const prod2 = await cached.enumerate(ctx, { env: "prod" });
+    expect(prod2).toEqual([{ id: "prod1" }]);
+
+    const stg2 = await cached.enumerate(ctx, { env: "staging" });
+    expect(stg2).toEqual([{ id: "stg1" }]);
+  });
+
+  it("stale entries evicted after 2x TTL", async () => {
+    let clock = 1000;
+    let shouldFail = false;
+    const source = makeSource<{ id: string }>(
+      "test",
+      async (_ctx, config) => {
+        const cfg = config as { env: string };
+        if (shouldFail) {
+          throw new DiscoverySourceAuthError("test", "gone");
+        }
+        return [{ id: cfg.env }];
+      },
+    );
+
+    const cached = withCache(source, {
+      ttlMs: TTL,
+      now: () => clock,
+    });
+    const ctx = makeCtx();
+
+    // Populate cache with config A at clock=1000
+    await cached.enumerate(ctx, { env: "alpha" });
+
+    // Advance clock past 2x TTL (>= 120_000ms from fetchedAt)
+    clock += TTL * 2;
+
+    // Populate cache with config B — triggers eviction sweep that
+    // removes the stale config-A entry
+    await cached.enumerate(ctx, { env: "bravo" });
+
+    // Now make the source fail for all configs
+    shouldFail = true;
+
+    // Config A was evicted — no stale cache to serve, so it must throw
+    await expect(
+      cached.enumerate(ctx, { env: "alpha" }),
+    ).rejects.toThrow(DiscoverySourceAuthError);
+
+    // Config B is still fresh (just fetched) — stale serve should work
+    const staleB = await cached.enumerate(ctx, { env: "bravo" });
+    expect(staleB).toEqual([{ id: "bravo" }]);
+  });
+
+  it("interface passthrough — name and configSchema preserved", () => {
+    const schema = z.object({ x: z.string() });
+    const source: DiscoverySource<{ id: string }> = {
+      name: "test-source",
+      configSchema: schema,
+      enumerate: async () => [],
+    };
+
+    const cached = withCache(source, { ttlMs: TTL });
+
+    expect(cached.name).toBe("test-source");
+    expect(cached.configSchema).toBe(source.configSchema);
+  });
+
+  it("non-DiscoverySourceError re-throws without serving cache", async () => {
+    let callCount = 0;
+    const source = makeSource<{ id: string }>("test", async () => {
+      callCount++;
+      if (callCount === 1) return [{ id: "svc1" }];
+      throw new Error("oops");
+    });
+
+    const cached = withCache(source, { ttlMs: TTL });
+    const ctx = makeCtx();
+    const cfg = {};
+
+    // Populate cache
+    await cached.enumerate(ctx, cfg);
+
+    // Non-DiscoverySourceError should propagate — cache is NOT served
+    await expect(cached.enumerate(ctx, cfg)).rejects.toThrow("oops");
+    await expect(cached.enumerate(ctx, cfg)).rejects.not.toBeInstanceOf(
+      DiscoverySourceError,
+    );
+  });
+
+  it("degraded warning logged on cache serve", async () => {
+    let clock = 1000;
+    let callCount = 0;
+    const customLogger = makeLogger();
+    const source = makeSource<{ id: string }>("test-src", async () => {
+      callCount++;
+      if (callCount === 1) return [{ id: "svc1" }];
+      throw new DiscoverySourceAuthError("test-src", "401 Unauthorized");
+    });
+
+    const cached = withCache(source, {
+      ttlMs: TTL,
+      logger: customLogger,
+      now: () => clock,
+    });
+    const ctx = makeCtx();
+    const cfg = { env: "prod" };
+
+    // Populate cache at clock=1000
+    await cached.enumerate(ctx, cfg);
+
+    // Advance clock within TTL
+    clock += 5000;
+
+    // Failure serves cache — should log degraded warning
+    await cached.enumerate(ctx, cfg);
+
+    const warnCall = customLogger.calls.find(
+      (c) => c.level === "warn" && c.msg === "discovery.cache.serving-stale",
+    );
+    expect(warnCall).toBeDefined();
+    expect(warnCall!.meta).toBeDefined();
+    expect(warnCall!.meta!.source).toBe("test-src");
+    expect(warnCall!.meta!.cacheKey).toBeDefined();
+    expect(warnCall!.meta!.cacheAgeMs).toBe(5000);
+    expect(warnCall!.meta!.errorClass).toBe("DiscoverySourceAuthError");
+    expect(warnCall!.meta!.errorMessage).toBe("401 Unauthorized");
+    expect(warnCall!.meta!.errorSource).toBe("test-src");
+  });
+});
+
+describe("cacheKey", () => {
+  it("produces stable output with sorted keys at every nesting level", () => {
+    const a = cacheKey({ z: 1, a: { c: 3, b: 2 } });
+    const b = cacheKey({ a: { b: 2, c: 3 }, z: 1 });
+    expect(a).toBe(b);
+  });
+
+  it("handles null/undefined/primitive config values", () => {
+    expect(cacheKey(null)).toBe("null");
+    expect(cacheKey(undefined)).toBe("null");
+    expect(cacheKey(42)).toBe("42");
+    expect(cacheKey("hello")).toBe('"hello"');
+  });
+
+  it("logs warning for non-plain objects (Map, Set, class instances)", () => {
+    const logger = makeLogger();
+
+    // Map serializes as "{}" under JSON.stringify — lossy key
+    cacheKey(new Map([["a", 1]]), logger);
+    const mapWarn = logger.calls.find(
+      (c) => c.level === "warn" && c.msg === "discovery.cache.non-plain-config",
+    );
+    expect(mapWarn).toBeDefined();
+    expect(mapWarn!.meta!.constructorName).toBe("Map");
+
+    // Set also produces "{}"
+    cacheKey(new Set([1, 2, 3]), logger);
+    const setWarn = logger.calls.filter(
+      (c) => c.level === "warn" && c.msg === "discovery.cache.non-plain-config",
+    );
+    expect(setWarn.length).toBe(2);
+    expect(setWarn[1].meta!.constructorName).toBe("Set");
+
+    // Plain objects and arrays should NOT warn
+    logger.calls.length = 0;
+    cacheKey({ a: 1 }, logger);
+    cacheKey([1, 2], logger);
+    cacheKey("str", logger);
+    cacheKey(null, logger);
+    expect(logger.calls.filter((c) => c.level === "warn")).toHaveLength(0);
+  });
+
+  it("still returns a key (does not throw) for non-plain objects", () => {
+    // Even though the key is lossy, cacheKey should not throw
+    const key = cacheKey(new Map([["a", 1]]));
+    expect(typeof key).toBe("string");
+    expect(key.length).toBeGreaterThan(0);
+  });
+});

--- a/showcase/harness/src/probes/discovery/caching-source.ts
+++ b/showcase/harness/src/probes/discovery/caching-source.ts
@@ -129,7 +129,10 @@ export function withCache<T>(
               opts.logger?.warn("discovery.cache.tracker-error", {
                 source: source.name,
                 phase: "success",
-                error: trackerErr instanceof Error ? trackerErr.message : String(trackerErr),
+                error:
+                  trackerErr instanceof Error
+                    ? trackerErr.message
+                    : String(trackerErr),
               });
             }
           }
@@ -156,7 +159,10 @@ export function withCache<T>(
               opts.logger?.warn("discovery.cache.tracker-error", {
                 source: source.name,
                 phase: "failure",
-                error: trackerErr instanceof Error ? trackerErr.message : String(trackerErr),
+                error:
+                  trackerErr instanceof Error
+                    ? trackerErr.message
+                    : String(trackerErr),
               });
             }
           }

--- a/showcase/harness/src/probes/discovery/caching-source.ts
+++ b/showcase/harness/src/probes/discovery/caching-source.ts
@@ -1,0 +1,189 @@
+import type { DiscoveryContext, DiscoverySource } from "../types.js";
+import { DiscoverySourceError } from "./errors.js";
+import type { Logger } from "../../types/index.js";
+
+/**
+ * In-memory cache entry holding the last successful enumeration results
+ * alongside a wall-clock timestamp for TTL checks.
+ */
+interface CacheEntry<T> {
+  results: T[];
+  fetchedAt: number;
+}
+
+/**
+ * Minimal interface the caching wrapper needs from the auth tracker.
+ * Defined here (rather than importing the concrete class) so the caching
+ * wrapper and the auth tracker can be developed and tested independently
+ * — the orchestrator wires them together at boot.
+ */
+export interface DiscoveryAuthTrackerLike {
+  recordSuccess(sourceName: string): Promise<void>;
+  recordFailure(
+    sourceName: string,
+    error: DiscoverySourceError,
+    cacheStatus: "serving-stale" | "no-cache",
+  ): Promise<void>;
+}
+
+interface CachingDiscoverySourceOptions {
+  ttlMs: number;
+  logger?: Logger;
+  now?: () => number;
+  authTracker?: DiscoveryAuthTrackerLike;
+}
+
+/**
+ * Stable JSON serialization with sorted object keys at every nesting
+ * level. Used to derive a cache-map key from the discovery config block
+ * so callers with semantically-identical configs always share one cache
+ * entry regardless of property-insertion order.
+ *
+ * ASSUMPTION: `config` must be a JSON-compatible value (plain objects,
+ * arrays, strings, numbers, booleans, null). Map, Set, Date, class
+ * instances, and other non-plain objects serialize as `{}` under
+ * JSON.stringify, which causes key collisions. A warning is logged if
+ * a non-plain top-level object is detected, but the lossy key is still
+ * returned so callers degrade rather than crash.
+ */
+export function cacheKey(config: unknown, logger?: Logger): string {
+  if (
+    typeof config === "object" &&
+    config !== null &&
+    !Array.isArray(config) &&
+    config.constructor !== Object
+  ) {
+    logger?.warn("discovery.cache.non-plain-config", {
+      constructorName: config.constructor?.name ?? "unknown",
+      note: "JSON.stringify produces lossy keys for non-plain objects (Map, Set, class instances); cache key may collide",
+    });
+  }
+
+  return JSON.stringify(config ?? null, (_key, value) => {
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(value).sort()) {
+        sorted[k] = value[k];
+      }
+      return sorted;
+    }
+    return value;
+  });
+}
+
+/**
+ * Wraps a `DiscoverySource` with in-memory caching, concurrent-call
+ * collapsing, and optional auth-tracker integration.
+ *
+ * Behaviour:
+ *   - On success: caches `{ results, fetchedAt }` under a stable key
+ *     derived from the config block.
+ *   - On `DiscoverySourceError` failure within TTL: serves stale results
+ *     and logs a degraded warning.
+ *   - On `DiscoverySourceError` failure past TTL / no cache: re-throws.
+ *   - On non-`DiscoverySourceError`: re-throws immediately (possible code
+ *     bug — no cache serve).
+ *   - Concurrent calls with the same config collapse into a single
+ *     upstream `enumerate` call; all joiners share the same promise.
+ */
+export function withCache<T>(
+  source: DiscoverySource<T>,
+  opts: CachingDiscoverySourceOptions,
+): DiscoverySource<T> {
+  const cache = new Map<string, CacheEntry<T>>();
+  const inflight = new Map<string, Promise<T[]>>();
+  const now = opts.now ?? (() => Date.now());
+
+  return {
+    name: source.name,
+    configSchema: source.configSchema,
+
+    enumerate(ctx: DiscoveryContext, config: unknown): Promise<T[]> {
+      const key = cacheKey(config, opts.logger);
+
+      // Concurrent collapse: if an identical call is already in flight,
+      // join it rather than issuing a second upstream request.
+      const existing = inflight.get(key);
+      if (existing) return existing;
+
+      const pipeline = (async () => {
+        try {
+          const results = await source.enumerate(ctx, config);
+          const ts = now();
+          cache.set(key, { results, fetchedAt: ts });
+
+          // Eviction sweep: remove entries that are 2x past TTL.
+          // The map is small (~10 entries per source) so a full
+          // scan after every successful set is cheap.
+          const evictionThreshold = opts.ttlMs * 2;
+          for (const [k, entry] of cache) {
+            if (ts - entry.fetchedAt >= evictionThreshold) {
+              cache.delete(k);
+            }
+          }
+
+          if (opts.authTracker) {
+            try {
+              await opts.authTracker.recordSuccess(source.name);
+            } catch (trackerErr) {
+              opts.logger?.warn("discovery.cache.tracker-error", {
+                source: source.name,
+                phase: "success",
+                error: trackerErr instanceof Error ? trackerErr.message : String(trackerErr),
+              });
+            }
+          }
+          return results;
+        } catch (err) {
+          if (!(err instanceof DiscoverySourceError)) throw err;
+
+          const ts = now();
+          const entry = cache.get(key);
+          const hasFreshCache =
+            entry != null && ts - entry.fetchedAt < opts.ttlMs;
+          const cacheStatus = hasFreshCache
+            ? ("serving-stale" as const)
+            : ("no-cache" as const);
+
+          if (opts.authTracker) {
+            try {
+              await opts.authTracker.recordFailure(
+                source.name,
+                err,
+                cacheStatus,
+              );
+            } catch (trackerErr) {
+              opts.logger?.warn("discovery.cache.tracker-error", {
+                source: source.name,
+                phase: "failure",
+                error: trackerErr instanceof Error ? trackerErr.message : String(trackerErr),
+              });
+            }
+          }
+
+          if (hasFreshCache) {
+            opts.logger?.warn("discovery.cache.serving-stale", {
+              source: source.name,
+              cacheKey: key,
+              cacheAgeMs: ts - entry!.fetchedAt,
+              errorClass: err.constructor.name,
+              errorMessage: err.message,
+              errorSource: err.source,
+            });
+            return entry!.results;
+          }
+
+          throw err;
+        }
+      })();
+
+      // Attach cleanup BEFORE storing so every consumer (including the
+      // first caller) sees the same promise that self-cleans.
+      const tracked = pipeline.finally(() => {
+        inflight.delete(key);
+      });
+      inflight.set(key, tracked);
+      return tracked;
+    },
+  };
+}

--- a/showcase/harness/src/types/index.ts
+++ b/showcase/harness/src/types/index.ts
@@ -63,6 +63,10 @@ export const DIMENSIONS = [
   // side-row dimension need closed-enum slots here.
   "e2e_parity",
   "d6",
+  // System-level dimension. The `system` dimension covers infrastructure-
+  // level signals (e.g. discovery auth status) that are not tied to any
+  // specific probe driver but need closed-enum validation in rule YAMLs.
+  "system",
 ] as const;
 export type Dimension = (typeof DIMENSIONS)[number];
 

--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -17,6 +17,7 @@ import { AdaptiveStatsBar } from "@/components/adaptive-stats-bar";
 import { AdaptiveLegend } from "@/components/adaptive-legend";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { BaselineTab } from "@/components/baseline-tab";
+import { DiscoveryAuthBanner } from "@/components/discovery-auth-banner";
 import type { ParityTier } from "@/components/parity-badge";
 import { getDocsStatus } from "@/lib/docs-status";
 import type { DepthDistribution } from "@/components/adaptive-stats-bar";
@@ -234,6 +235,8 @@ export default function Page() {
           <ThemeToggle />
         </div>
       </div>
+
+      <DiscoveryAuthBanner rows={allStatus.rows} />
 
       {activeTab === "matrix" && (
         <>

--- a/showcase/shell-dashboard/src/components/__tests__/discovery-auth-banner.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/discovery-auth-banner.test.tsx
@@ -23,13 +23,9 @@ function row(
 
 describe("DiscoveryAuthBanner", () => {
   it("renders when system row is red (discovery-auth-failed)", () => {
-    const rows: StatusRow[] = [
-      row("system:discovery-auth-failed", "red"),
-    ];
+    const rows: StatusRow[] = [row("system:discovery-auth-failed", "red")];
     render(<DiscoveryAuthBanner rows={rows} />);
-    expect(
-      screen.queryByTestId("discovery-auth-banner"),
-    ).toBeInTheDocument();
+    expect(screen.queryByTestId("discovery-auth-banner")).toBeInTheDocument();
   });
 
   it("shows cached variant when signal.cacheStatus is serving-stale", () => {
@@ -61,9 +57,7 @@ describe("DiscoveryAuthBanner", () => {
   });
 
   it("returns null when no system row is present", () => {
-    const rows: StatusRow[] = [
-      row("health:some-integration", "green"),
-    ];
+    const rows: StatusRow[] = [row("health:some-integration", "green")];
     const { container } = render(<DiscoveryAuthBanner rows={rows} />);
     expect(container.innerHTML).toBe("");
     expect(
@@ -72,9 +66,7 @@ describe("DiscoveryAuthBanner", () => {
   });
 
   it("returns null when system row state is green", () => {
-    const rows: StatusRow[] = [
-      row("system:discovery-auth-failed", "green"),
-    ];
+    const rows: StatusRow[] = [row("system:discovery-auth-failed", "green")];
     const { container } = render(<DiscoveryAuthBanner rows={rows} />);
     expect(container.innerHTML).toBe("");
     expect(
@@ -102,9 +94,7 @@ describe("DiscoveryAuthBanner", () => {
       row("system:discovery-auth-failed", "red", "unexpected string"),
     ];
     render(<DiscoveryAuthBanner rows={rows} />);
-    expect(
-      screen.queryByTestId("discovery-auth-banner"),
-    ).toBeInTheDocument();
+    expect(screen.queryByTestId("discovery-auth-banner")).toBeInTheDocument();
     // With a non-object signal, the banner should fall back to default
     // message (no-cache variant with generic source name).
     expect(
@@ -115,21 +105,15 @@ describe("DiscoveryAuthBanner", () => {
   });
 
   it("has role=alert for accessibility", () => {
-    const rows: StatusRow[] = [
-      row("system:discovery-auth-failed", "red"),
-    ];
+    const rows: StatusRow[] = [row("system:discovery-auth-failed", "red")];
     render(<DiscoveryAuthBanner rows={rows} />);
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
   it("renders browser-pool-banner when system:browser-pool-degraded row is red", () => {
-    const rows: StatusRow[] = [
-      row("system:browser-pool-degraded", "red"),
-    ];
+    const rows: StatusRow[] = [row("system:browser-pool-degraded", "red")];
     render(<DiscoveryAuthBanner rows={rows} />);
-    expect(
-      screen.queryByTestId("browser-pool-banner"),
-    ).toBeInTheDocument();
+    expect(screen.queryByTestId("browser-pool-banner")).toBeInTheDocument();
     expect(
       screen.getByText(
         "Browser pool initialization failed — e2e probes running in degraded mode with stub drivers.",
@@ -153,14 +137,10 @@ describe("DiscoveryAuthBanner", () => {
   });
 
   it("does not render browser-pool-banner when row state is green", () => {
-    const rows: StatusRow[] = [
-      row("system:browser-pool-degraded", "green"),
-    ];
+    const rows: StatusRow[] = [row("system:browser-pool-degraded", "green")];
     const { container } = render(<DiscoveryAuthBanner rows={rows} />);
     expect(container.innerHTML).toBe("");
-    expect(
-      screen.queryByTestId("browser-pool-banner"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("browser-pool-banner")).not.toBeInTheDocument();
   });
 
   it("renders both banners simultaneously when both conditions are red", () => {
@@ -174,11 +154,7 @@ describe("DiscoveryAuthBanner", () => {
       }),
     ];
     render(<DiscoveryAuthBanner rows={rows} />);
-    expect(
-      screen.queryByTestId("discovery-auth-banner"),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("browser-pool-banner"),
-    ).toBeInTheDocument();
+    expect(screen.queryByTestId("discovery-auth-banner")).toBeInTheDocument();
+    expect(screen.queryByTestId("browser-pool-banner")).toBeInTheDocument();
   });
 });

--- a/showcase/shell-dashboard/src/components/__tests__/discovery-auth-banner.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/discovery-auth-banner.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DiscoveryAuthBanner } from "../discovery-auth-banner";
+import type { StatusRow } from "@/lib/live-status";
+
+function row(
+  key: string,
+  state: StatusRow["state"],
+  signal: unknown = {},
+): StatusRow {
+  return {
+    id: `id-${key}`,
+    key,
+    dimension: key.split(":")[0] ?? "system",
+    state,
+    signal,
+    observed_at: "2026-05-14T00:00:00Z",
+    transitioned_at: "2026-05-14T00:00:00Z",
+    fail_count: 0,
+    first_failure_at: null,
+  };
+}
+
+describe("DiscoveryAuthBanner", () => {
+  it("renders when system row is red (discovery-auth-failed)", () => {
+    const rows: StatusRow[] = [
+      row("system:discovery-auth-failed", "red"),
+    ];
+    render(<DiscoveryAuthBanner rows={rows} />);
+    expect(
+      screen.queryByTestId("discovery-auth-banner"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows cached variant when signal.cacheStatus is serving-stale", () => {
+    const rows: StatusRow[] = [
+      row("system:discovery-auth-failed", "red", {
+        cacheStatus: "serving-stale",
+      }),
+    ];
+    render(<DiscoveryAuthBanner rows={rows} />);
+    expect(
+      screen.getByText(
+        "Authentication failed for discovery source — serving stale cached data. Refresh tokens to restore live updates.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows offline variant when signal.cacheStatus is no-cache", () => {
+    const rows: StatusRow[] = [
+      row("system:discovery-auth-failed", "red", {
+        cacheStatus: "no-cache",
+      }),
+    ];
+    render(<DiscoveryAuthBanner rows={rows} />);
+    expect(
+      screen.getByText(
+        "Authentication failed for discovery source — no cached data available. Discovery results may be incomplete.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("returns null when no system row is present", () => {
+    const rows: StatusRow[] = [
+      row("health:some-integration", "green"),
+    ];
+    const { container } = render(<DiscoveryAuthBanner rows={rows} />);
+    expect(container.innerHTML).toBe("");
+    expect(
+      screen.queryByTestId("discovery-auth-banner"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("returns null when system row state is green", () => {
+    const rows: StatusRow[] = [
+      row("system:discovery-auth-failed", "green"),
+    ];
+    const { container } = render(<DiscoveryAuthBanner rows={rows} />);
+    expect(container.innerHTML).toBe("");
+    expect(
+      screen.queryByTestId("discovery-auth-banner"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders sourceName from signal instead of fallback", () => {
+    const rows: StatusRow[] = [
+      row("system:discovery-auth-failed", "red", {
+        cacheStatus: "no-cache",
+        sourceName: "railway-services",
+      }),
+    ];
+    render(<DiscoveryAuthBanner rows={rows} />);
+    expect(
+      screen.getByText(
+        "Authentication failed for railway-services — no cached data available. Discovery results may be incomplete.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("banner handles non-object signal gracefully", () => {
+    const rows: StatusRow[] = [
+      row("system:discovery-auth-failed", "red", "unexpected string"),
+    ];
+    render(<DiscoveryAuthBanner rows={rows} />);
+    expect(
+      screen.queryByTestId("discovery-auth-banner"),
+    ).toBeInTheDocument();
+    // With a non-object signal, the banner should fall back to default
+    // message (no-cache variant with generic source name).
+    expect(
+      screen.getByText(
+        "Authentication failed for discovery source — no cached data available. Discovery results may be incomplete.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("has role=alert for accessibility", () => {
+    const rows: StatusRow[] = [
+      row("system:discovery-auth-failed", "red"),
+    ];
+    render(<DiscoveryAuthBanner rows={rows} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders browser-pool-banner when system:browser-pool-degraded row is red", () => {
+    const rows: StatusRow[] = [
+      row("system:browser-pool-degraded", "red"),
+    ];
+    render(<DiscoveryAuthBanner rows={rows} />);
+    expect(
+      screen.queryByTestId("browser-pool-banner"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Browser pool initialization failed — e2e probes running in degraded mode with stub drivers.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error message from signal when available", () => {
+    const rows: StatusRow[] = [
+      row("system:browser-pool-degraded", "red", {
+        errorMessage: "playwright not installed",
+        degradedSince: "2026-05-14T00:00:00Z",
+      }),
+    ];
+    render(<DiscoveryAuthBanner rows={rows} />);
+    expect(
+      screen.getByText(
+        "Browser pool initialization failed — e2e probes running in degraded mode with stub drivers. (playwright not installed)",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render browser-pool-banner when row state is green", () => {
+    const rows: StatusRow[] = [
+      row("system:browser-pool-degraded", "green"),
+    ];
+    const { container } = render(<DiscoveryAuthBanner rows={rows} />);
+    expect(container.innerHTML).toBe("");
+    expect(
+      screen.queryByTestId("browser-pool-banner"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders both banners simultaneously when both conditions are red", () => {
+    const rows: StatusRow[] = [
+      row("system:discovery-auth-failed", "red", {
+        cacheStatus: "no-cache",
+        sourceName: "railway-services",
+      }),
+      row("system:browser-pool-degraded", "red", {
+        errorMessage: "boom",
+      }),
+    ];
+    render(<DiscoveryAuthBanner rows={rows} />);
+    expect(
+      screen.queryByTestId("discovery-auth-banner"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("browser-pool-banner"),
+    ).toBeInTheDocument();
+  });
+});

--- a/showcase/shell-dashboard/src/components/discovery-auth-banner.tsx
+++ b/showcase/shell-dashboard/src/components/discovery-auth-banner.tsx
@@ -1,0 +1,76 @@
+import type { StatusRow } from "@/lib/live-status";
+
+interface DiscoveryAuthBannerProps {
+  rows: StatusRow[];
+}
+
+interface AuthSignal {
+  cacheStatus?: "serving-stale" | "no-cache";
+  sourceName?: string;
+}
+
+interface BrowserPoolSignal {
+  errorMessage?: string;
+}
+
+function isObjectSignal<T>(s: unknown): s is T {
+  return s !== null && typeof s === "object" && !Array.isArray(s);
+}
+
+export function DiscoveryAuthBanner({ rows }: DiscoveryAuthBannerProps) {
+  const authRow = rows.find(
+    (r) => r.key === "system:discovery-auth-failed" && r.state === "red",
+  );
+  const browserPoolRow = rows.find(
+    (r) => r.key === "system:browser-pool-degraded" && r.state === "red",
+  );
+  if (!authRow && !browserPoolRow) return null;
+
+  let authMessage: string | null = null;
+  if (authRow) {
+    const signal = isObjectSignal<AuthSignal>(authRow.signal)
+      ? authRow.signal
+      : null;
+    const source = signal?.sourceName ?? "discovery source";
+    if (signal?.cacheStatus === "serving-stale") {
+      authMessage = `Authentication failed for ${source} — serving stale cached data. Refresh tokens to restore live updates.`;
+    } else {
+      authMessage = `Authentication failed for ${source} — no cached data available. Discovery results may be incomplete.`;
+    }
+  }
+
+  let browserPoolMessage: string | null = null;
+  if (browserPoolRow) {
+    const signal = isObjectSignal<BrowserPoolSignal>(browserPoolRow.signal)
+      ? browserPoolRow.signal
+      : null;
+    const base =
+      "Browser pool initialization failed — e2e probes running in degraded mode with stub drivers.";
+    browserPoolMessage = signal?.errorMessage
+      ? `${base} (${signal.errorMessage})`
+      : base;
+  }
+
+  return (
+    <>
+      {authMessage && (
+        <div
+          role="alert"
+          data-testid="discovery-auth-banner"
+          className="mx-8 mb-4 flex-shrink-0 rounded-md border border-[var(--danger)] bg-[var(--bg-danger)] px-4 py-2 text-xs text-[var(--danger)]"
+        >
+          {authMessage}
+        </div>
+      )}
+      {browserPoolMessage && (
+        <div
+          role="alert"
+          data-testid="browser-pool-banner"
+          className="mx-8 mb-4 flex-shrink-0 rounded-md border border-[var(--danger)] bg-[var(--bg-danger)] px-4 py-2 text-xs text-[var(--danger)]"
+        >
+          {browserPoolMessage}
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `CachingDiscoverySource` wrapper with 24h TTL and concurrent enumeration collapsing — serves stale discovery results when Railway API is unreachable, preventing total probe blindness
- Adds `DiscoveryAuthTracker` that detects persistent auth failures (3 consecutive) and writes system status to PocketBase with rate-limited sustained alerting
- Adds `DiscoveryAuthBanner` dashboard component that surfaces auth failures and browser pool degradation above all tabs, with auto-dismiss on recovery
- Caches Railway `listServices` in the adapter (60s TTL) to eliminate N+1 GraphQL round-trips per probe tick
- Writes system status on browser pool init failure so stub-driver degradation is visible

## Why

A Railway API token expired and the showcase dashboard showed stale green data for 24+ hours with no operator-visible alert. Discovery runs from scratch every probe tick with no caching or fallback. This PR adds resilience (cache), observability (auth tracker + dashboard banner), and fixes a pre-existing silent degradation path (browser pool).

## Test plan

- [ ] 18 caching-source tests (success, failure, TTL, eviction, concurrent collapse, tracker integration)
- [ ] 9 auth-tracker tests (threshold, rate-limiting, recovery, interleaved errors)
- [ ] 12 banner tests (render variants, signal validation, accessibility, both banners simultaneously)
- [ ] Full harness suite regression check (1612/1614 pass, 2 pre-existing failures on main)
- [ ] TypeScript typecheck clean on new code