### PR TITLE
ci(showcase): disable auto docs-sync ahead of shell-docs cutover

### DIFF
--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -1,11 +1,11 @@
 name: "Showcase: Docs Sync"
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "docs/content/docs/**"
-      - "docs/snippets/**"
+  # Auto-trigger disabled ahead of the shell-docs cutover (2026-05-19).
+  # Shell-docs is becoming the canonical authoring source; an upstream→shell
+  # sync would clobber edits made directly in showcase/shell-docs/. Re-enable
+  # only if the cutover is reverted and docs/content/docs/ becomes upstream
+  # again. Manual runs remain available via workflow_dispatch.
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Shell-docs is becoming the canonical authoring source for CopilotKit documentation on the upcoming cutover. The existing \`showcase_docs-sync.yml\` workflow auto-syncs from \`docs/content/docs/\` down to \`showcase/shell-docs/src/content/docs/\` on every push to main that touches the upstream tree — which would clobber edits made directly in \`showcase/shell-docs/\` after cutover.

This PR disables the push trigger on \`.github/workflows/showcase_docs-sync.yml\` and keeps \`workflow_dispatch\` for manual re-run if the cutover is reverted.

## Files changed

- \`.github/workflows/showcase_docs-sync.yml\` — 5 lines

## Test plan

- [ ] Confirm the workflow no longer fires on pushes to main that touch \`docs/content/docs/**\` or \`docs/snippets/**\`
- [ ] Confirm \`workflow_dispatch\` still allows manual runs from the Actions UI