### PR TITLE
feat: support URL input for ImageMessage

### DIFF
--- a/packages/runtime-client-gql/src/client/types.ts
+++ b/packages/runtime-client-gql/src/client/types.ts
@@ -159,6 +159,7 @@ export class ImageMessage
   bytes: ImageMessageInput["bytes"];
   role: ImageMessageInput["role"];
   parentMessageId: ImageMessageInput["parentMessageId"];
+  url: ImageMessageInput["url"];
 
   constructor(props: ImageMessageConstructorOptions) {
     super(props);

--- a/packages/runtime/src/graphql/inputs/message.input.ts
+++ b/packages/runtime/src/graphql/inputs/message.input.ts
@@ -87,6 +87,9 @@ export class ImageMessageInput {
 
   @Field(() => MessageRole)
   role: MessageRole;
+
+  @Field(() => String, { nullable: true })
+  url?: string;
 }
 
 // GraphQL does not support union types in inputs, so we need to use

--- a/packages/runtime/src/service-adapters/anthropic/utils.ts
+++ b/packages/runtime/src/service-adapters/anthropic/utils.ts
@@ -161,6 +161,21 @@ export function convertMessageToAnthropicMessage(
       };
     }
   } else if (message.isImageMessage()) {
+    if (message.url) {
+      return {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "url",
+              url: message.url,
+            },
+          },
+        ],
+      };
+    }
+
     let mediaType: "image/jpeg" | "image/png" | "image/webp" | "image/gif";
     switch (message.format) {
       case "jpeg":

--- a/packages/runtime/src/service-adapters/openai/utils.ts
+++ b/packages/runtime/src/service-adapters/openai/utils.ts
@@ -258,13 +258,16 @@ export function convertMessageToOpenAIMessage(
       content: message.content,
     } satisfies UsedMessageParams;
   } else if (message.isImageMessage()) {
+    const imageUrl = message.url
+      ? message.url
+      : `data:image/${message.format};base64,${message.bytes}`;
     return {
       role: "user",
       content: [
         {
           type: "image_url",
           image_url: {
-            url: `data:image/${message.format};base64,${message.bytes}`,
+            url: imageUrl,
           },
         },
       ],


### PR DESCRIPTION
## What does this PR do?

This PR adds support for URL input in `ImageMessage`, allowing users to pass image URLs directly instead of only base64-encoded data.

### Changes
- Add optional `url` field to `ImageMessageInput` GraphQL input type
- Add `url` property to `ImageMessage` class
- Update OpenAI and Anthropic service adapters to use URL directly when provided
- Fall back to base64 data URL when `url` is not set

### Usage
Users can now pass either:
- `bytes` + `format` for base64-encoded images (existing behavior)
- `url` for URL-based images (new)

Ref: Vercel AI SDK's convert-to-openai-chat-messages.ts

## Related PRs and Issues

- Closes #1967

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)
