### PR TITLE
fix(runtime): agent-defined headers take precedence over forwarded request headers

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/agent-utils.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agent-utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { configureAgentForRequest } from "../handlers/shared/agent-utils";
+import type { AbstractAgent } from "@ag-ui/client";
+import type { CopilotRuntimeLike } from "../core/runtime";
+
+function makeRuntime(overrides: Partial<CopilotRuntimeLike> = {}): CopilotRuntimeLike {
+  return {
+    agents: {},
+    ...overrides,
+  } as unknown as CopilotRuntimeLike;
+}
+
+function makeAgent(headers: Record<string, string>): AbstractAgent & { headers: Record<string, string> } {
+  return {
+    headers,
+    clone: () => makeAgent({ ...headers }),
+  } as unknown as AbstractAgent & { headers: Record<string, string> };
+}
+
+describe("configureAgentForRequest", () => {
+  it("agent-defined headers take precedence over forwarded request headers", () => {
+    const agent = makeAgent({ Authorization: "Bearer oidc-token-for-backend" });
+
+    const request = new Request("https://example.com", {
+      headers: {
+        // Browser's Authorization (e.g. IAP or user token) must not overwrite the agent's
+        authorization: "Bearer browser-token",
+        "x-custom": "from-browser",
+      },
+    });
+
+    configureAgentForRequest({
+      runtime: makeRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    expect((agent as { headers: Record<string, string> }).headers["Authorization"]).toBe(
+      "Bearer oidc-token-for-backend",
+    );
+  });
+
+  it("merges forwarded x-* headers when agent has no conflict", () => {
+    const agent = makeAgent({ Authorization: "Bearer oidc-token" });
+
+    const request = new Request("https://example.com", {
+      headers: {
+        "x-request-id": "req-123",
+        "x-trace": "trace-abc",
+      },
+    });
+
+    configureAgentForRequest({
+      runtime: makeRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    const headers = (agent as { headers: Record<string, string> }).headers;
+    expect(headers["Authorization"]).toBe("Bearer oidc-token");
+    expect(headers["x-request-id"]).toBe("req-123");
+    expect(headers["x-trace"]).toBe("trace-abc");
+  });
+});

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -88,8 +88,8 @@ export function configureAgentForRequest(params: {
 
   if (agent.headers) {
     agent.headers = {
-      ...agent.headers,
       ...extractForwardableHeaders(request),
+      ...agent.headers,
     };
   }
 }


### PR DESCRIPTION
## Problem

`configureAgentForRequest()` merges headers from the incoming browser request **after** the agent's own headers:

```typescript
agent.headers = {
  ...agent.headers,
  ...extractForwardableHeaders(request), // ← overwrites agent headers
};
```

This silently overwrites any `Authorization` header set on the agent. A common use case is service-to-service auth where the agent is configured with an OIDC token (e.g. for Google Cloud Run), but the browser's own `Authorization` header clobbers it, causing downstream 401/403 errors.

## Fix

Reverse the spread order so agent-defined headers always win:

```typescript
agent.headers = {
  ...extractForwardableHeaders(request), // browser headers as defaults
  ...agent.headers,                       // agent headers take precedence
};
```

## Tests

Added `agent-utils.test.ts` covering:
- Agent-defined `Authorization` is preserved when the browser request also has an `Authorization` header
- Non-conflicting `x-*` headers from the request are still merged in

## Notes

The caller (application code) is still responsible for stripping infrastructure-specific headers (e.g. `x-serverless-authorization` from Cloud Run) from the request before it reaches CopilotKit — that is infrastructure knowledge CopilotKit should not need to have. This fix only addresses the merge order so that explicitly-set agent headers cannot be overwritten.