### PR TITLE
fix(showcase/google-adk): bring final 5 demos to D5 green

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -2458,7 +2458,11 @@
                 {
                   "id": "metrics-col",
                   "component": "Column",
-                  "children": ["metric-revenue", "metric-signups", "metric-churn"],
+                  "children": [
+                    "metric-revenue",
+                    "metric-signups",
+                    "metric-churn"
+                  ],
                   "gap": 12
                 },
                 {

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -2435,7 +2435,7 @@
       }
     },
     {
-      "_comment": "render_a2ui — KPI dashboard pill. Emits Card root with three Metric children (revenue, signups, churn) so the probe sees declarative-card + declarative-metric.",
+      "_comment": "render_a2ui — KPI dashboard pill (Google-ADK secondary tool name). Card has a single `child` slot (per myDefinitions.Card.props.child: string), so we wrap the three Metrics in a basic-catalog Column to satisfy the multi-child layout.",
       "match": {
         "userMessage": "KPI dashboard",
         "toolName": "render_a2ui"
@@ -2450,39 +2450,37 @@
               "components": [
                 {
                   "id": "root",
-                  "type": "Card",
-                  "props": {
-                    "title": "KPI dashboard",
-                    "subtitle": "Last 30 days",
-                    "child": "metric-revenue"
-                  }
+                  "component": "Card",
+                  "title": "KPI dashboard",
+                  "subtitle": "Last 30 days",
+                  "child": "metrics-col"
+                },
+                {
+                  "id": "metrics-col",
+                  "component": "Column",
+                  "children": ["metric-revenue", "metric-signups", "metric-churn"],
+                  "gap": 12
                 },
                 {
                   "id": "metric-revenue",
-                  "type": "Metric",
-                  "props": {
-                    "label": "Revenue",
-                    "value": "$1.2M",
-                    "trend": "up"
-                  }
+                  "component": "Metric",
+                  "label": "Revenue",
+                  "value": "$1.2M",
+                  "trend": "up"
                 },
                 {
                   "id": "metric-signups",
-                  "type": "Metric",
-                  "props": {
-                    "label": "Signups",
-                    "value": "4,820",
-                    "trend": "up"
-                  }
+                  "component": "Metric",
+                  "label": "Signups",
+                  "value": "4,820",
+                  "trend": "up"
                 },
                 {
                   "id": "metric-churn",
-                  "type": "Metric",
-                  "props": {
-                    "label": "Churn",
-                    "value": "2.1%",
-                    "trend": "down"
-                  }
+                  "component": "Metric",
+                  "label": "Churn",
+                  "value": "2.1%",
+                  "trend": "down"
                 }
               ],
               "data": {}
@@ -2492,7 +2490,7 @@
       }
     },
     {
-      "_comment": "render_a2ui — pie-chart pill. Emits a PieChart so the probe sees declarative-pie-chart.",
+      "_comment": "render_a2ui — pie-chart pill (Google-ADK). Flat {id, component, ...props} shape.",
       "match": {
         "userMessage": "pie chart of sales by region",
         "toolName": "render_a2ui"
@@ -2507,29 +2505,15 @@
               "components": [
                 {
                   "id": "root",
-                  "type": "PieChart",
-                  "props": {
-                    "title": "Sales by region",
-                    "description": "Q4 — share of total revenue",
-                    "data": [
-                      {
-                        "label": "North America",
-                        "value": 540
-                      },
-                      {
-                        "label": "EMEA",
-                        "value": 320
-                      },
-                      {
-                        "label": "APAC",
-                        "value": 210
-                      },
-                      {
-                        "label": "LATAM",
-                        "value": 90
-                      }
-                    ]
-                  }
+                  "component": "PieChart",
+                  "title": "Sales by region",
+                  "description": "Q4 — share of total revenue",
+                  "data": [
+                    { "label": "North America", "value": 540 },
+                    { "label": "EMEA", "value": 320 },
+                    { "label": "APAC", "value": 210 },
+                    { "label": "LATAM", "value": 90 }
+                  ]
                 }
               ],
               "data": {}
@@ -2539,7 +2523,7 @@
       }
     },
     {
-      "_comment": "render_a2ui — bar-chart pill. Emits a BarChart so the probe sees declarative-bar-chart.",
+      "_comment": "render_a2ui — bar-chart pill (Google-ADK). Flat {id, component, ...props} shape.",
       "match": {
         "userMessage": "bar chart of quarterly revenue",
         "toolName": "render_a2ui"
@@ -2554,29 +2538,15 @@
               "components": [
                 {
                   "id": "root",
-                  "type": "BarChart",
-                  "props": {
-                    "title": "Quarterly revenue",
-                    "description": "FY24 — USD thousands",
-                    "data": [
-                      {
-                        "label": "Q1",
-                        "value": 820
-                      },
-                      {
-                        "label": "Q2",
-                        "value": 940
-                      },
-                      {
-                        "label": "Q3",
-                        "value": 1080
-                      },
-                      {
-                        "label": "Q4",
-                        "value": 1240
-                      }
-                    ]
-                  }
+                  "component": "BarChart",
+                  "title": "Quarterly revenue",
+                  "description": "FY24 — USD thousands",
+                  "data": [
+                    { "label": "Q1", "value": 820 },
+                    { "label": "Q2", "value": 940 },
+                    { "label": "Q3", "value": 1080 },
+                    { "label": "Q4", "value": 1240 }
+                  ]
                 }
               ],
               "data": {}
@@ -2586,7 +2556,7 @@
       }
     },
     {
-      "_comment": "render_a2ui — status-report pill. Emits a Card root containing three StatusBadge children (API/database/workers) so the probe sees declarative-card + declarative-status-badge.",
+      "_comment": "render_a2ui — status-report pill (Google-ADK). Card has single `child` slot, so wrap the three StatusBadges in a basic-catalog Column.",
       "match": {
         "userMessage": "status report on system health",
         "toolName": "render_a2ui"
@@ -2601,36 +2571,34 @@
               "components": [
                 {
                   "id": "root",
-                  "type": "Card",
-                  "props": {
-                    "title": "System health",
-                    "subtitle": "All services",
-                    "child": "status-api"
-                  }
+                  "component": "Card",
+                  "title": "System health",
+                  "subtitle": "All services",
+                  "child": "status-col"
+                },
+                {
+                  "id": "status-col",
+                  "component": "Column",
+                  "children": ["status-api", "status-db", "status-workers"],
+                  "gap": 8
                 },
                 {
                   "id": "status-api",
-                  "type": "StatusBadge",
-                  "props": {
-                    "text": "API: healthy",
-                    "variant": "success"
-                  }
+                  "component": "StatusBadge",
+                  "text": "API: healthy",
+                  "variant": "success"
                 },
                 {
                   "id": "status-db",
-                  "type": "StatusBadge",
-                  "props": {
-                    "text": "Database: healthy",
-                    "variant": "success"
-                  }
+                  "component": "StatusBadge",
+                  "text": "Database: healthy",
+                  "variant": "success"
                 },
                 {
                   "id": "status-workers",
-                  "type": "StatusBadge",
-                  "props": {
-                    "text": "Workers: degraded",
-                    "variant": "warning"
-                  }
+                  "component": "StatusBadge",
+                  "text": "Workers: degraded",
+                  "variant": "warning"
                 }
               ],
               "data": {}
@@ -2640,7 +2608,7 @@
       }
     },
     {
-      "_comment": "render_a2ui — fallback for any unmatched pill. Emits the original Card+Metric so unforeseen pills still render something deterministic instead of erroring.",
+      "_comment": "render_a2ui — fallback for any unmatched pill (Google-ADK). Single Metric child satisfies Card's single-slot schema.",
       "match": {
         "toolName": "render_a2ui"
       },
@@ -2654,21 +2622,17 @@
               "components": [
                 {
                   "id": "root",
-                  "type": "Card",
-                  "props": {
-                    "title": "Declarative Demo",
-                    "subtitle": "Catalog primitives",
-                    "child": "metric-1"
-                  }
+                  "component": "Card",
+                  "title": "Declarative Demo",
+                  "subtitle": "Catalog primitives",
+                  "child": "metric-1"
                 },
                 {
                   "id": "metric-1",
-                  "type": "Metric",
-                  "props": {
-                    "label": "Revenue",
-                    "value": "$1.2M",
-                    "trend": "up"
-                  }
+                  "component": "Metric",
+                  "label": "Revenue",
+                  "value": "$1.2M",
+                  "trend": "up"
                 }
               ],
               "data": {}

--- a/showcase/harness/fixtures/d5/gen-ui-declarative.json
+++ b/showcase/harness/fixtures/d5/gen-ui-declarative.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "D5 fixture for /demos/declarative-gen-ui. Four pill prompts (KPI dashboard / pie chart / bar chart / status report). Each produces a `generate_a2ui` tool call; the secondary LLM (also routed through aimock) returns an a2ui_operations container with the pill's expected catalog components. Under real LLM on Railway the secondary call produces richer payloads; the fixture variants here are the minimum that satisfies the per-pill testid assertions in d5-gen-ui-declarative.ts (kpi-dashboard → declarative-card+declarative-metric; pie-chart → declarative-pie-chart; bar-chart → declarative-bar-chart; status-report → declarative-status-badge+declarative-card). The render_a2ui matchers AND together (userMessage substring + toolName) so each pill emits its own catalog payload — without per-pill branching the probe goes red on the second pill (every pill would render the same Card+Metric).",
+  "_comment": "D5 fixture for /demos/declarative-gen-ui. Four pill prompts (KPI dashboard / pie chart / bar chart / status report). Each produces a `generate_a2ui` tool call; the secondary LLM (also routed through aimock) returns the structured surface payload. The match `toolName` differs between integrations: LangGraph-Python binds the secondary call to `_design_a2ui_surface`; Google-ADK binds it to `render_a2ui` (see showcase/integrations/google-adk/src/agents/main.py and showcase/integrations/langgraph-python/src/agents/a2ui_dynamic.py). Both tools take an identical `components` array shape — flat entries with `id` + `component` + catalog-specific props at top level (NOT nested under `props`, and NOT keyed as `type` — `sanitize_a2ui_components` drops entries missing `component`).",
   "fixtures": [
     {
       "match": { "userMessage": "KPI dashboard" },
@@ -30,7 +30,7 @@
       }
     },
     {
-      "_comment": "render_a2ui — KPI dashboard pill. Emits Card root with three Metric children (revenue, signups, churn) so the probe sees declarative-card + declarative-metric.",
+      "_comment": "render_a2ui — KPI dashboard pill (Google-ADK secondary tool name).",
       "match": {
         "userMessage": "KPI dashboard",
         "toolName": "render_a2ui"
@@ -45,39 +45,37 @@
               "components": [
                 {
                   "id": "root",
-                  "type": "Card",
-                  "props": {
-                    "title": "KPI dashboard",
-                    "subtitle": "Last 30 days",
-                    "child": "metric-revenue"
-                  }
+                  "component": "Card",
+                  "title": "KPI dashboard",
+                  "subtitle": "Last 30 days",
+                  "child": "metrics-col"
+                },
+                {
+                  "id": "metrics-col",
+                  "component": "Column",
+                  "children": ["metric-revenue", "metric-signups", "metric-churn"],
+                  "gap": 12
                 },
                 {
                   "id": "metric-revenue",
-                  "type": "Metric",
-                  "props": {
-                    "label": "Revenue",
-                    "value": "$1.2M",
-                    "trend": "up"
-                  }
+                  "component": "Metric",
+                  "label": "Revenue",
+                  "value": "$1.2M",
+                  "trend": "up"
                 },
                 {
                   "id": "metric-signups",
-                  "type": "Metric",
-                  "props": {
-                    "label": "Signups",
-                    "value": "4,820",
-                    "trend": "up"
-                  }
+                  "component": "Metric",
+                  "label": "Signups",
+                  "value": "4,820",
+                  "trend": "up"
                 },
                 {
                   "id": "metric-churn",
-                  "type": "Metric",
-                  "props": {
-                    "label": "Churn",
-                    "value": "2.1%",
-                    "trend": "down"
-                  }
+                  "component": "Metric",
+                  "label": "Churn",
+                  "value": "2.1%",
+                  "trend": "down"
                 }
               ],
               "data": {}
@@ -87,7 +85,62 @@
       }
     },
     {
-      "_comment": "render_a2ui — pie-chart pill. Emits a PieChart so the probe sees declarative-pie-chart.",
+      "_comment": "_design_a2ui_surface — KPI dashboard pill (LangGraph-Python secondary tool name). Card has a single `child` slot, so wrap metrics in a Column.",
+      "match": {
+        "userMessage": "KPI dashboard",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "_design_a2ui_surface",
+            "arguments": {
+              "surfaceId": "declarative-surface",
+              "catalogId": "declarative-gen-ui-catalog",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "Card",
+                  "title": "KPI dashboard",
+                  "subtitle": "Last 30 days",
+                  "child": "metrics-col"
+                },
+                {
+                  "id": "metrics-col",
+                  "component": "Column",
+                  "children": ["metric-revenue", "metric-signups", "metric-churn"],
+                  "gap": 12
+                },
+                {
+                  "id": "metric-revenue",
+                  "component": "Metric",
+                  "label": "Revenue",
+                  "value": "$1.2M",
+                  "trend": "up"
+                },
+                {
+                  "id": "metric-signups",
+                  "component": "Metric",
+                  "label": "Signups",
+                  "value": "4,820",
+                  "trend": "up"
+                },
+                {
+                  "id": "metric-churn",
+                  "component": "Metric",
+                  "label": "Churn",
+                  "value": "2.1%",
+                  "trend": "down"
+                }
+              ],
+              "data": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "render_a2ui — pie-chart pill.",
       "match": {
         "userMessage": "pie chart of sales by region",
         "toolName": "render_a2ui"
@@ -102,17 +155,15 @@
               "components": [
                 {
                   "id": "root",
-                  "type": "PieChart",
-                  "props": {
-                    "title": "Sales by region",
-                    "description": "Q4 — share of total revenue",
-                    "data": [
-                      { "label": "North America", "value": 540 },
-                      { "label": "EMEA", "value": 320 },
-                      { "label": "APAC", "value": 210 },
-                      { "label": "LATAM", "value": 90 }
-                    ]
-                  }
+                  "component": "PieChart",
+                  "title": "Sales by region",
+                  "description": "Q4 — share of total revenue",
+                  "data": [
+                    { "label": "North America", "value": 540 },
+                    { "label": "EMEA", "value": 320 },
+                    { "label": "APAC", "value": 210 },
+                    { "label": "LATAM", "value": 90 }
+                  ]
                 }
               ],
               "data": {}
@@ -122,7 +173,40 @@
       }
     },
     {
-      "_comment": "render_a2ui — bar-chart pill. Emits a BarChart so the probe sees declarative-bar-chart.",
+      "_comment": "_design_a2ui_surface — pie-chart pill (LGP variant).",
+      "match": {
+        "userMessage": "pie chart of sales by region",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "_design_a2ui_surface",
+            "arguments": {
+              "surfaceId": "declarative-surface",
+              "catalogId": "declarative-gen-ui-catalog",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "PieChart",
+                  "title": "Sales by region",
+                  "description": "Q4 — share of total revenue",
+                  "data": [
+                    { "label": "North America", "value": 540 },
+                    { "label": "EMEA", "value": 320 },
+                    { "label": "APAC", "value": 210 },
+                    { "label": "LATAM", "value": 90 }
+                  ]
+                }
+              ],
+              "data": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "render_a2ui — bar-chart pill.",
       "match": {
         "userMessage": "bar chart of quarterly revenue",
         "toolName": "render_a2ui"
@@ -137,17 +221,15 @@
               "components": [
                 {
                   "id": "root",
-                  "type": "BarChart",
-                  "props": {
-                    "title": "Quarterly revenue",
-                    "description": "FY24 — USD thousands",
-                    "data": [
-                      { "label": "Q1", "value": 820 },
-                      { "label": "Q2", "value": 940 },
-                      { "label": "Q3", "value": 1080 },
-                      { "label": "Q4", "value": 1240 }
-                    ]
-                  }
+                  "component": "BarChart",
+                  "title": "Quarterly revenue",
+                  "description": "FY24 — USD thousands",
+                  "data": [
+                    { "label": "Q1", "value": 820 },
+                    { "label": "Q2", "value": 940 },
+                    { "label": "Q3", "value": 1080 },
+                    { "label": "Q4", "value": 1240 }
+                  ]
                 }
               ],
               "data": {}
@@ -157,7 +239,40 @@
       }
     },
     {
-      "_comment": "render_a2ui — status-report pill. Emits a Card root containing three StatusBadge children (API/database/workers) so the probe sees declarative-card + declarative-status-badge.",
+      "_comment": "_design_a2ui_surface — bar-chart pill (LGP variant).",
+      "match": {
+        "userMessage": "bar chart of quarterly revenue",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "_design_a2ui_surface",
+            "arguments": {
+              "surfaceId": "declarative-surface",
+              "catalogId": "declarative-gen-ui-catalog",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "BarChart",
+                  "title": "Quarterly revenue",
+                  "description": "FY24 — USD thousands",
+                  "data": [
+                    { "label": "Q1", "value": 820 },
+                    { "label": "Q2", "value": 940 },
+                    { "label": "Q3", "value": 1080 },
+                    { "label": "Q4", "value": 1240 }
+                  ]
+                }
+              ],
+              "data": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "render_a2ui — status-report pill.",
       "match": {
         "userMessage": "status report on system health",
         "toolName": "render_a2ui"
@@ -172,27 +287,28 @@
               "components": [
                 {
                   "id": "root",
-                  "type": "Card",
-                  "props": {
-                    "title": "System health",
-                    "subtitle": "All services",
-                    "child": "status-api"
-                  }
+                  "component": "Card",
+                  "title": "System health",
+                  "subtitle": "All services",
+                  "children": ["status-api", "status-db", "status-workers"]
                 },
                 {
                   "id": "status-api",
-                  "type": "StatusBadge",
-                  "props": { "text": "API: healthy", "variant": "success" }
+                  "component": "StatusBadge",
+                  "text": "API: healthy",
+                  "variant": "success"
                 },
                 {
                   "id": "status-db",
-                  "type": "StatusBadge",
-                  "props": { "text": "Database: healthy", "variant": "success" }
+                  "component": "StatusBadge",
+                  "text": "Database: healthy",
+                  "variant": "success"
                 },
                 {
                   "id": "status-workers",
-                  "type": "StatusBadge",
-                  "props": { "text": "Workers: degraded", "variant": "warning" }
+                  "component": "StatusBadge",
+                  "text": "Workers: degraded",
+                  "variant": "warning"
                 }
               ],
               "data": {}
@@ -202,7 +318,53 @@
       }
     },
     {
-      "_comment": "render_a2ui — fallback for any unmatched pill. Emits the original Card+Metric so unforeseen pills still render something deterministic instead of erroring.",
+      "_comment": "_design_a2ui_surface — status-report pill (LGP variant).",
+      "match": {
+        "userMessage": "status report on system health",
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "_design_a2ui_surface",
+            "arguments": {
+              "surfaceId": "declarative-surface",
+              "catalogId": "declarative-gen-ui-catalog",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "Card",
+                  "title": "System health",
+                  "subtitle": "All services",
+                  "children": ["status-api", "status-db", "status-workers"]
+                },
+                {
+                  "id": "status-api",
+                  "component": "StatusBadge",
+                  "text": "API: healthy",
+                  "variant": "success"
+                },
+                {
+                  "id": "status-db",
+                  "component": "StatusBadge",
+                  "text": "Database: healthy",
+                  "variant": "success"
+                },
+                {
+                  "id": "status-workers",
+                  "component": "StatusBadge",
+                  "text": "Workers: degraded",
+                  "variant": "warning"
+                }
+              ],
+              "data": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "render_a2ui — fallback for any unmatched pill (Google-ADK).",
       "match": {
         "toolName": "render_a2ui"
       },
@@ -216,21 +378,51 @@
               "components": [
                 {
                   "id": "root",
-                  "type": "Card",
-                  "props": {
-                    "title": "Declarative Demo",
-                    "subtitle": "Catalog primitives",
-                    "child": "metric-1"
-                  }
+                  "component": "Card",
+                  "title": "Declarative Demo",
+                  "subtitle": "Catalog primitives",
+                  "children": ["metric-1"]
                 },
                 {
                   "id": "metric-1",
-                  "type": "Metric",
-                  "props": {
-                    "label": "Revenue",
-                    "value": "$1.2M",
-                    "trend": "up"
-                  }
+                  "component": "Metric",
+                  "label": "Revenue",
+                  "value": "$1.2M",
+                  "trend": "up"
+                }
+              ],
+              "data": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "_design_a2ui_surface — fallback (LGP variant).",
+      "match": {
+        "toolName": "_design_a2ui_surface"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "_design_a2ui_surface",
+            "arguments": {
+              "surfaceId": "declarative-surface",
+              "catalogId": "declarative-gen-ui-catalog",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "Card",
+                  "title": "Declarative Demo",
+                  "subtitle": "Catalog primitives",
+                  "children": ["metric-1"]
+                },
+                {
+                  "id": "metric-1",
+                  "component": "Metric",
+                  "label": "Revenue",
+                  "value": "$1.2M",
+                  "trend": "up"
                 }
               ],
               "data": {}

--- a/showcase/harness/fixtures/d5/gen-ui-declarative.json
+++ b/showcase/harness/fixtures/d5/gen-ui-declarative.json
@@ -53,7 +53,11 @@
                 {
                   "id": "metrics-col",
                   "component": "Column",
-                  "children": ["metric-revenue", "metric-signups", "metric-churn"],
+                  "children": [
+                    "metric-revenue",
+                    "metric-signups",
+                    "metric-churn"
+                  ],
                   "gap": 12
                 },
                 {
@@ -108,7 +112,11 @@
                 {
                   "id": "metrics-col",
                   "component": "Column",
-                  "children": ["metric-revenue", "metric-signups", "metric-churn"],
+                  "children": [
+                    "metric-revenue",
+                    "metric-signups",
+                    "metric-churn"
+                  ],
                   "gap": 12
                 },
                 {

--- a/showcase/integrations/google-adk/src/agents/beautiful_chat_agent.py
+++ b/showcase/integrations/google-adk/src/agents/beautiful_chat_agent.py
@@ -75,7 +75,7 @@ def _get_genai_client():
     base_url = os.environ.get("GOOGLE_GEMINI_BASE_URL")
     if base_url:
         return genai.Client(
-            http_options={"api_endpoint": base_url},
+            http_options={"base_url": base_url},
         )
     return genai.Client()
 

--- a/showcase/integrations/google-adk/src/agents/main.py
+++ b/showcase/integrations/google-adk/src/agents/main.py
@@ -72,7 +72,7 @@ def _get_genai_client():
     base_url = os.environ.get("GOOGLE_GEMINI_BASE_URL")
     if base_url:
         return genai.Client(
-            http_options={"api_endpoint": base_url},
+            http_options={"base_url": base_url},
         )
     return genai.Client()
 

--- a/showcase/integrations/google-adk/src/agents/shared_chat.py
+++ b/showcase/integrations/google-adk/src/agents/shared_chat.py
@@ -77,6 +77,28 @@ def stop_on_terminal_text(
     if getattr(llm_response, "partial", False):
         return None
 
+    # Under thinking mode (`include_thoughts=True`), Gemini emits a turn
+    # as TWO separate non-partial chunks:
+    #   1. text-only chunk: thought + reply text, `finish_reason=None`
+    #   2. function_call-only chunk: `finish_reason=FUNCTION_CALL`
+    # The callback fires on both. Without the finish_reason guard below,
+    # chunk 1's text-without-function-call shape causes premature
+    # termination — the function call in chunk 2 still streams but the
+    # agentic loop is already marked `end_invocation=True`, so the
+    # post-tool-result re-invocation that would chain to the next tool
+    # never happens (tool-rendering-reasoning-chain AAPL→MSFT regression).
+    # Only terminate when Gemini signals the turn is genuinely done with
+    # `finish_reason=STOP` (no further chunks coming). FUNCTION_CALL and
+    # None mean "more chunks are inbound" — defer.
+    finish_reason = getattr(llm_response, "finish_reason", None)
+    finish_reason_name = (
+        getattr(finish_reason, "name", None)
+        if finish_reason is not None
+        else None
+    )
+    if finish_reason_name != "STOP" and finish_reason != "STOP":
+        return None
+
     has_text = any(getattr(part, "text", None) for part in content.parts)
     has_function_call = any(
         getattr(part, "function_call", None) for part in content.parts

--- a/showcase/integrations/google-adk/src/agents/shared_chat.py
+++ b/showcase/integrations/google-adk/src/agents/shared_chat.py
@@ -92,9 +92,7 @@ def stop_on_terminal_text(
     # None mean "more chunks are inbound" — defer.
     finish_reason = getattr(llm_response, "finish_reason", None)
     finish_reason_name = (
-        getattr(finish_reason, "name", None)
-        if finish_reason is not None
-        else None
+        getattr(finish_reason, "name", None) if finish_reason is not None else None
     )
     if finish_reason_name != "STOP" and finish_reason != "STOP":
         return None

--- a/showcase/integrations/google-adk/src/agents/shared_state_streaming_agent.py
+++ b/showcase/integrations/google-adk/src/agents/shared_state_streaming_agent.py
@@ -37,15 +37,19 @@ from google.adk.tools import ToolContext
 from agents.shared_chat import get_model, stop_on_terminal_text
 
 
-def write_document(tool_context: ToolContext, content: str) -> dict:
+def write_document(tool_context: ToolContext, document: str) -> dict:
     """Write a document into shared state.
 
     Whenever the user asks you to write or draft anything (essay, poem,
     email, summary, etc.), call this tool with the full content as a
     single string. The UI renders state["document"] live as you type.
+
+    Argument name `document` mirrors langgraph-python's `write_document`
+    signature so the shared D5 fixture (`tool_argument="document"`) and
+    the LGP-aligned PredictStateMapping below stay in lock-step.
     """
-    tool_context.state["document"] = content
-    return {"status": "ok", "length": len(content)}
+    tool_context.state["document"] = document
+    return {"status": "ok", "length": len(document)}
 
 
 _INSTRUCTION = (
@@ -69,7 +73,7 @@ SHARED_STATE_STREAMING_PREDICT_STATE = [
     PredictStateMapping(
         state_key="document",
         tool="write_document",
-        tool_argument="content",
+        tool_argument="document",
         emit_confirm_tool=False,
         stream_tool_call=True,
     ),

--- a/showcase/integrations/google-adk/src/agents/subagents_agent.py
+++ b/showcase/integrations/google-adk/src/agents/subagents_agent.py
@@ -53,7 +53,7 @@ _CRITIQUE_SYSTEM = (
 def _client() -> genai.Client:
     base_url = os.environ.get("GOOGLE_GEMINI_BASE_URL")
     if base_url:
-        return genai.Client(http_options={"api_endpoint": base_url})
+        return genai.Client(http_options={"base_url": base_url})
     return genai.Client()
 
 

--- a/showcase/integrations/google-adk/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,18 +11,15 @@ import {
 import { ACTIVITIES, DemoLayout } from "./demo-layout";
 import { useReadonlyStateAgentContextSuggestions } from "./suggestions";
 
-// Agent name uses underscores because the ADK runtime mounts agents by
-// the path `${AGENT_URL}/<name>` (see src/agents/registry.py and
-// src/app/api/copilotkit/route.ts), and the registered key here is
-// `readonly_state_agent_context`.
-const AGENT_ID = "readonly_state_agent_context";
-
 export default function ReadonlyStateAgentContextDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      agent="readonly-state-agent-context"
+    >
       <DemoContent />
       <CopilotPopup
-        agentId={AGENT_ID}
+        agentId="readonly-state-agent-context"
         defaultOpen={true}
         labels={{ chatInputPlaceholder: "Ask about your context..." }}
       />


### PR DESCRIPTION
## Summary

- Final five google-adk demos that were red after PR #4826 are now D5 green: **readonly-state-context, multimodal, gen-ui-declarative, shared-state-streaming, tool-rendering-reasoning-chain** — google-adk is now 38/38 under aimock locally.
- Each demo had a distinct root cause; details in the commit body (covers agent-ID kebab/underscore mismatch, `google-genai 1.75` `HttpOptions` field rename, A2UI fixture shape regression, `write_document` param parity with LGP, and the thinking-mode `stop_on_terminal_text` premature-termination bug).
- The `stop_on_terminal_text` finish-reason guard in `shared_chat.py` applies to every ADK agent using the shared callback, so chain-aware behavior is uniform across the package.
- D5 fixtures for `gen-ui-declarative` now include both `render_a2ui` (Google-ADK) and `_design_a2ui_surface` (LangGraph-Python) variants so the same fixture serves both integrations.

## Test plan

- [x] `bin/showcase test google-adk --d5 --live` finishes green for all 38 cells (~140s) on a clean recreate; dashboard reflects results from PocketBase.
- [x] Single-cell verification for each of the 5 fixed demos via `bin/showcase test google-adk:<slug> --d5`.
- [x] Manual real-Gemini click-through (`GOOGLE_GEMINI_BASE_URL=` empty + recreate) of the five fixed demos — all behave correctly end-to-end against real Gemini.
- [ ] CI runs the full monorepo test suite (gates publish + the rest of the demos in the matrix).

## Notes

- The bundled `public/demo-files/sample.png` / `sample.pdf` for the multimodal demo are still Git-LFS-tracked. Fresh checkouts must `git lfs pull` before `bin/showcase build google-adk` so the image bakes in the real binaries instead of the LFS pointer stubs (the magic-byte check in `sample-attachment-buttons.tsx` already fails loudly on pointer content — added that as a clear error path some time back).