### PR TITLE
fix(showcase, runtime): subagents fixtures, voice mic format, fine-grained shared-state gating

### DIFF
--- a/packages/runtime/src/v2/runtime/handlers/handle-transcribe.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-transcribe.ts
@@ -87,7 +87,7 @@ async function extractAudioFromFormData(
   request: Request,
 ): Promise<{ file: File } | { error: Response }> {
   const formData = await request.formData();
-  const audioFile = formData.get("audio") as File | null;
+  let audioFile = formData.get("audio") as File | null;
 
   if (!audioFile || !(audioFile instanceof File)) {
     const err = TranscriptionErrors.invalidRequest(
@@ -102,6 +102,19 @@ async function extractAudioFromFormData(
       VALID_AUDIO_TYPES,
     );
     return { error: createErrorResponse(err) };
+  }
+
+  // Browser MediaRecorder Blobs often arrive at the server with their
+  // `type` field empty (and `application/octet-stream` is also accepted by
+  // isValidAudioType for compatibility). OpenAI Whisper rejects files
+  // without a recognizable MIME / extension with a 502 "Invalid file
+  // format" — even though the bytes themselves are valid WebM Opus.
+  // Stamp `audio/webm` (the standard MediaRecorder default in Chromium /
+  // Firefox / Safari) so Whisper can pick the right decoder.
+  if (!audioFile.type || audioFile.type === "application/octet-stream") {
+    audioFile = new File([audioFile], audioFile.name || "recording.webm", {
+      type: "audio/webm",
+    });
   }
 
   return { file: audioFile };

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -1280,20 +1280,26 @@
       }
     },
     {
-      "_comment": "shared-state-read-write Greet me pill. Gated by systemMessage substring 'tone: casual' (the canonical default tone from INITIAL_PREFERENCES). If the user changes tone in the Preferences panel, the agent's system prompt loses 'tone: casual' and this fixture stops matching — aimock --proxy-only falls through to the real model so the response reflects the actual preferences.",
+      "_comment": "shared-state-read-write — Greet pill. systemMessage array gate (all-present substring match) fires ONLY when every preference is at its INITIAL_PREFERENCES default. (1) 'preferences:\\n- Preferred tone: casual\\n' breaks if name is set (Name line inserts) or tone changes. (2) '- Preferred language: English\\nTailor every response' breaks if language changes or interests are added (Interests line inserts between language and Tailor). Any state change → fixture skips → aimock --provider-gemini proxies to real Gemini for a personalised reply. Mirrors feature-parity.json so both fixture files agree.",
       "match": {
         "userMessage": "Say hi and introduce yourself",
-        "systemMessage": "tone: casual"
+        "systemMessage": [
+          "preferences:\n- Preferred tone: casual\n",
+          "- Preferred language: English\nTailor every response"
+        ]
       },
       "response": {
         "content": "Hi — I'm your shared-state co-pilot. Your Preferences panel (name, tone, language, interests) is fed to me on every turn, and I jot notes back into the Agent Scratch Pad via set_notes so the UI re-renders. Try setting your name or asking me to remember something."
       }
     },
     {
-      "_comment": "shared-state-read-write Plan a weekend pill. Same default-state gating as Greet pill.",
+      "_comment": "shared-state-read-write — Plan-a-weekend pill. Same all-defaults gate as the Greet pill.",
       "match": {
         "userMessage": "weekend plan based on my interests",
-        "systemMessage": "tone: casual"
+        "systemMessage": [
+          "preferences:\n- Preferred tone: casual\n",
+          "- Preferred language: English\nTailor every response"
+        ]
       },
       "response": {
         "content": "A weekend tailored to your interests panel: if you haven't picked any yet, try Cooking + Travel for a market-and-day-trip combo, or Tech + Books for a maker session and a long reading afternoon. Add interests in the Preferences panel and re-ask for a more specific plan."

--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -336,6 +336,287 @@
       }
     },
     {
+      "_comment": "shared-state-read-write — Greet pill. systemMessage array gate (all-present substring match) fires ONLY when every preference is at its INITIAL_PREFERENCES default. (1) 'preferences:\\n- Preferred tone: casual\\n' breaks if name is set (Name line inserts) or tone changes. (2) '- Preferred language: English\\nTailor every response' breaks if language changes or interests are added (Interests line inserts between language and Tailor). Any state change → fixture skips → aimock --provider-gemini proxies to real Gemini for a personalised reply.",
+      "match": {
+        "userMessage": "Say hi and introduce yourself.",
+        "systemMessage": [
+          "preferences:\n- Preferred tone: casual\n",
+          "- Preferred language: English\nTailor every response"
+        ]
+      },
+      "response": {
+        "content": "Hi — I'm your shared-state co-pilot. Your Preferences panel (name, tone, language, interests) is fed to me on every turn, and I jot notes back into the Agent Scratch Pad via set_notes so the UI re-renders. Try setting your name or asking me to remember something."
+      }
+    },
+    {
+      "_comment": "shared-state-read-write — Plan-a-weekend pill. Same default-state gate as the Greet pill.",
+      "match": {
+        "userMessage": "Suggest a weekend plan based on my interests.",
+        "systemMessage": [
+          "preferences:\n- Preferred tone: casual\n",
+          "- Preferred language: English\nTailor every response"
+        ]
+      },
+      "response": {
+        "content": "A weekend tailored to your interests panel: if you haven't picked any yet, try Cooking + Travel for a market-and-day-trip combo, or Tech + Books for a maker session and a long reading afternoon. Add interests in the Preferences panel and re-ask for a more specific plan."
+      }
+    },
+    {
+      "_comment": "Subagents pill 1 — 'Write a blog post' / cold exposure training. Drives supervisor → research_agent → writing_agent → critique_agent → final reply, plus three nested sub-agent turns. Mirrors d5-all.json content so production aimock (which loads feature-parity.json + d5-all.json) serves the same chain regardless of which file wins first-match.",
+      "match": {
+        "userMessage": "Produce a short blog post about the benefits of cold exposure training",
+        "hasToolResult": false,
+        "toolName": "research_agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_subagents_p1_research_001",
+            "name": "research_agent",
+            "arguments": "{\"task\":\"Cold exposure training key facts\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Nested: research sub-agent returns deterministic facts about cold exposure training.",
+      "match": {
+        "userMessage": "Cold exposure training key facts"
+      },
+      "response": {
+        "content": "- Brief cold immersion (cold showers, ice baths) triggers a sympathetic-nervous-system response that releases noradrenaline\n- Repeated exposure is associated with improved self-reported mood and stress tolerance\n- Activates brown adipose tissue, modestly increasing basal metabolic rate\n- May reduce post-exercise muscle soreness when used as a recovery modality\n- Health risk for people with cardiovascular conditions; sessions should be short (1-3 minutes) and supervised at first"
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Produce a short blog post about the benefits of cold exposure training",
+        "turnIndex": 1,
+        "toolName": "writing_agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_subagents_p1_writing_001",
+            "name": "writing_agent",
+            "arguments": "{\"task\":\"Short blog-post paragraph on the benefits of cold exposure training, grounded in the research facts.\\n\\nFacts:\\n- Brief cold immersion triggers a noradrenaline release\\n- Repeated exposure improves self-reported mood and stress tolerance\\n- Activates brown adipose tissue, modestly raises basal metabolic rate\\n- May reduce post-exercise muscle soreness\\n- Cardiovascular risk; keep early sessions short and supervised\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Nested: writing sub-agent returns deterministic prose for cold exposure.",
+      "match": {
+        "userMessage": "Short blog-post paragraph on the benefits of cold exposure training"
+      },
+      "response": {
+        "content": "Cold exposure training — short, deliberate plunges into cold water or showers — has earned a foothold in modern recovery routines for reasons grounded in physiology rather than folklore. Each immersion produces a measurable surge of noradrenaline, the same chemistry that underpins the lift practitioners report in mood and focus afterward; with repetition, that response is associated with greater day-to-day stress tolerance. Cold also activates brown adipose tissue and can blunt post-exercise soreness, making it a low-cost adjunct for active people. The honest caveat is cardiovascular risk: keep early sessions to one to three minutes, and if you have a heart condition, get a green light before you start."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Produce a short blog post about the benefits of cold exposure training",
+        "turnIndex": 2,
+        "toolName": "critique_agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_subagents_p1_critique_001",
+            "name": "critique_agent",
+            "arguments": "{\"task\":\"Critique the cold-exposure blog draft. Draft: Cold exposure training — short, deliberate plunges into cold water or showers — has earned a foothold in modern recovery routines for reasons grounded in physiology rather than folklore. Each immersion produces a measurable surge of noradrenaline...\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Nested: critique sub-agent returns deterministic critique of cold-exposure draft.",
+      "match": {
+        "userMessage": "Critique the cold-exposure blog draft"
+      },
+      "response": {
+        "content": "1. The phrase 'measurable surge of noradrenaline' should cite a study or rough magnitude — without a number, the claim reads as marketing rather than evidence.\n2. 'Modern recovery routines' is filler; lead with the physiological mechanism instead and let the cultural framing follow.\n3. The cardiovascular caveat is buried at the end. Move it earlier or make it a standalone closing line so a reader who skims still sees it."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Produce a short blog post about the benefits of cold exposure training",
+        "turnIndex": 3
+      },
+      "response": {
+        "content": "Here is the polished blog post on cold exposure training, after research → drafting → critique:\n\nCold exposure training — short, deliberate plunges into cold water or showers — produces a measurable noradrenaline surge that practitioners feel as a mood and focus lift; repeated exposure is associated with greater stress tolerance, brown-adipose activation, and reduced post-exercise soreness. Keep early sessions to one to three minutes, and if you have a cardiovascular condition, clear it with a clinician first."
+      }
+    },
+    {
+      "_comment": "Subagents pill 2 — 'Explain a topic' / LLM tool calling.",
+      "match": {
+        "userMessage": "Explain how large language models handle tool calling",
+        "hasToolResult": false,
+        "toolName": "research_agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_subagents_p2_research_001",
+            "name": "research_agent",
+            "arguments": "{\"task\":\"How LLMs handle tool calling\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Nested: research sub-agent for LLM tool calling.",
+      "match": {
+        "userMessage": "How LLMs handle tool calling"
+      },
+      "response": {
+        "content": "- The model is shown a tool schema (name, description, JSON-schema parameters) inside the system or developer prompt at request time\n- During decoding, instead of emitting natural-language text, the model emits a structured tool_call block (function name + JSON-encoded arguments)\n- The application runs the tool, packages the result into a tool message, and resends the full conversation so the model can continue\n- Modern decoders use constrained decoding or grammars to keep the arguments syntactically valid JSON\n- The model decides on tool use turn-by-turn — there is no out-of-band channel; tool calls are just a different message role in the same chat thread"
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Explain how large language models handle tool calling",
+        "turnIndex": 1,
+        "toolName": "writing_agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_subagents_p2_writing_001",
+            "name": "writing_agent",
+            "arguments": "{\"task\":\"One-paragraph explanation of how LLMs handle tool calling, grounded in the research.\\n\\nFacts:\\n- Tool schemas (name, description, JSON-schema params) are passed in the prompt\\n- Models emit a structured tool_call block instead of text\\n- Application runs the tool and replays the result as a tool message\\n- Constrained decoding keeps arguments valid JSON\\n- Tool use is decided turn-by-turn in the same chat thread\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Nested: writing sub-agent for LLM tool calling.",
+      "match": {
+        "userMessage": "One-paragraph explanation of how LLMs handle tool calling"
+      },
+      "response": {
+        "content": "Large language models handle tool calling by treating tools as a structured extension of the chat protocol rather than a separate channel. At request time the application supplies each tool's name, description, and JSON-schema parameters in the prompt; during decoding the model can emit a tool_call block — a function name plus JSON-encoded arguments — instead of plain text, with constrained decoding keeping the arguments syntactically valid. The application then executes the tool and replays the result back as a tool-role message, and the model continues the conversation from there. The decision to call a tool is made turn-by-turn, so a single user request can fan out into a chain of tool calls that the model orchestrates as it reads each result."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Explain how large language models handle tool calling",
+        "turnIndex": 2,
+        "toolName": "critique_agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_subagents_p2_critique_001",
+            "name": "critique_agent",
+            "arguments": "{\"task\":\"Critique the LLM tool-calling explanation draft. Draft: Large language models handle tool calling by treating tools as a structured extension of the chat protocol rather than a separate channel. At request time the application supplies each tool's name, description, and JSON-schema parameters in the prompt...\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Nested: critique sub-agent for LLM tool calling.",
+      "match": {
+        "userMessage": "Critique the LLM tool-calling explanation draft"
+      },
+      "response": {
+        "content": "1. The opening contrast 'rather than a separate channel' assumes the reader already knows what a 'separate channel' would mean — either drop the contrast or give a one-clause example (e.g., 'rather than a side API the model talks to in parallel').\n2. 'Constrained decoding keeping the arguments syntactically valid' is technically correct but vague; mention that this is what makes the JSON parseable on the application side.\n3. The final sentence introduces multi-tool chains without saying who controls the loop — clarify that the application is the runtime that decides whether to keep going, not the model itself."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Explain how large language models handle tool calling",
+        "turnIndex": 3
+      },
+      "response": {
+        "content": "Here is the explanation of LLM tool calling, after research → drafting → critique:\n\nLLMs treat tool calling as part of the chat protocol: each tool's name, description, and JSON-schema parameters are passed in the prompt, and during decoding the model can emit a structured tool_call block (function name + JSON arguments) instead of plain text. The application — not the model — runs the tool, returns the result as a tool-role message, and decides whether to keep looping. Constrained decoding keeps the arguments valid JSON the application can parse, and the model orchestrates multi-step chains turn-by-turn from inside the same conversation."
+      }
+    },
+    {
+      "_comment": "Subagents pill 3 — 'Summarize a topic' / reusable rockets.",
+      "match": {
+        "userMessage": "Summarize the current state of reusable rockets",
+        "hasToolResult": false,
+        "toolName": "research_agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_subagents_p3_research_001",
+            "name": "research_agent",
+            "arguments": "{\"task\":\"Current state of reusable rockets\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Nested: research sub-agent for reusable rockets.",
+      "match": {
+        "userMessage": "Current state of reusable rockets"
+      },
+      "response": {
+        "content": "- SpaceX Falcon 9 routinely lands and re-flies first stages; individual boosters have flown more than 20 missions each\n- Falcon Heavy reuses both side boosters; the center core has been recovered on a subset of flights\n- Rocket Lab's Electron has demonstrated mid-air booster catch but routine reuse is still in development\n- SpaceX Starship is targeting full reuse of both stages; orbital test flights are ongoing as of 2024-2025\n- Reuse is the dominant lever on launch cost: Falcon 9 list pricing is set well below expendable competitors largely because of stage recovery"
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Summarize the current state of reusable rockets",
+        "turnIndex": 1,
+        "toolName": "writing_agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_subagents_p3_writing_001",
+            "name": "writing_agent",
+            "arguments": "{\"task\":\"One polished paragraph summarizing the current state of reusable rockets, grounded in the research.\\n\\nFacts:\\n- Falcon 9 first stages routinely re-fly, some 20+ flights\\n- Falcon Heavy reuses side boosters; center core recovered sometimes\\n- Rocket Lab Electron demonstrating mid-air catch, reuse still in development\\n- SpaceX Starship targeting full reuse of both stages, in flight test\\n- Reuse drives launch cost downward\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Nested: writing sub-agent for reusable rockets.",
+      "match": {
+        "userMessage": "One polished paragraph summarizing the current state of reusable rockets"
+      },
+      "response": {
+        "content": "Reusable rockets have shifted from a research goal to the default cost lever in commercial spaceflight. SpaceX's Falcon 9 routinely lands and re-flies its first stage — individual boosters have now flown twenty-plus missions — and Falcon Heavy reuses both side boosters with intermittent recovery of the center core. Smaller-class operators like Rocket Lab have demonstrated mid-air booster catch but have not yet made reuse routine, while SpaceX's Starship is in active flight testing toward full two-stage reuse. The economic consequence is already visible: Falcon 9 list pricing sits well below expendable competitors precisely because the dominant cost — building a fresh first stage every flight — has been amortized across many missions."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Summarize the current state of reusable rockets",
+        "turnIndex": 2,
+        "toolName": "critique_agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_fp_subagents_p3_critique_001",
+            "name": "critique_agent",
+            "arguments": "{\"task\":\"Critique the reusable rockets summary draft. Draft: Reusable rockets have shifted from a research goal to the default cost lever in commercial spaceflight. SpaceX's Falcon 9 routinely lands and re-flies its first stage — individual boosters have now flown twenty-plus missions...\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Nested: critique sub-agent for reusable rockets.",
+      "match": {
+        "userMessage": "Critique the reusable rockets summary draft"
+      },
+      "response": {
+        "content": "1. 'Default cost lever' is jargon that pre-supposes the reader already accepts the framing — open instead with the concrete result (Falcon 9 reflight count) and let the framing emerge.\n2. The Starship sentence is hedged ('in active flight testing toward full reuse') in a way that obscures the actual milestone reached as of writing — name the latest test outcome or drop the clause.\n3. The closing economic claim asserts pricing is 'well below expendable competitors' without a reference price; one number (e.g., $/kg-to-LEO) would land the point much harder than the qualitative claim alone."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Summarize the current state of reusable rockets",
+        "turnIndex": 3
+      },
+      "response": {
+        "content": "Here is the polished summary on reusable rockets, after research → drafting → critique:\n\nReusable rockets are now mainstream in commercial spaceflight. SpaceX's Falcon 9 lands and re-flies its first stage routinely — individual boosters have flown twenty-plus missions — and Falcon Heavy reuses both side boosters. Rocket Lab has demonstrated mid-air Electron booster catch but reuse is not yet routine, while SpaceX Starship is in active orbital flight testing with full two-stage reuse as the target. The economic impact is already priced in: Falcon 9 sits well below expendable competitors per kilogram to low Earth orbit because amortizing a recovered first stage across many missions removes the largest single cost from the launch."
+      }
+    },
+    {
       "match": {
         "userMessage": "weather",
         "hasToolResult": false
@@ -675,46 +956,6 @@
     },
     {
       "match": {
-        "userMessage": "plan"
-      },
-      "response": {
-        "content": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
-      }
-    },
-    {
-      "match": {
-        "userMessage": "steps"
-      },
-      "response": {
-        "content": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
-      }
-    },
-    {
-      "match": {
-        "userMessage": "mars"
-      },
-      "response": {
-        "content": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
-      }
-    },
-    {
-      "match": {
-        "userMessage": "dashboard"
-      },
-      "response": {
-        "content": "Working on your request. Step 1: Gathering data... Step 2: Analyzing results... Step 3: Generating report. Done!"
-      }
-    },
-    {
-      "match": {
-        "userMessage": "report"
-      },
-      "response": {
-        "content": "Working on your request. Step 1: Gathering data... Step 2: Analyzing results... Step 3: Generating report. Done!"
-      }
-    },
-    {
-      "match": {
         "userMessage": "summarize"
       },
       "response": {
@@ -848,17 +1089,9 @@
       }
     },
     {
-      "_comment": "Generic 'alice' / 'Alice' greeting fixture for the showcase-assistant 'Hi I'm Alice' flow. The Schedule-1:1 pill is fully matched above (with stable toolCallId + hasToolResult gating) so it doesn't fall through here.",
+      "_comment": "Scoped 'Alice' greeting fixture for the showcase-assistant 'Hi, my name is Alice' / introduction flow. Anchored on the longer phrase so it doesn't substring-match the hitl-in-chat 'Schedule a 1:1 with Alice' pill or other prompts that merely mention Alice.",
       "match": {
-        "userMessage": "alice"
-      },
-      "response": {
-        "content": "Nice to meet you, Alice! I see you're in Tokyo -- wonderful city. How can I help you today? I can check the weather, look up flights, manage your sales pipeline, or help with other tasks."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Alice"
+        "userMessage": "Hi, my name is Alice"
       },
       "response": {
         "content": "Nice to meet you, Alice! I see you're in Tokyo -- wonderful city. How can I help you today? I can check the weather, look up flights, manage your sales pipeline, or help with other tasks."


### PR DESCRIPTION
## Summary

Three follow-ups on top of PR #4837. (My second commit on that branch — the one that removed the bare `plan`/`steps`/`mars`/`dashboard`/`report`/`alice`/`Alice` substring catch-alls — didn't survive the squash merge, so the catch-alls are back on main and still hijacking demos.)

**Fixes:**

- **packages/runtime: stamp `audio/webm` on empty-type Blobs in the transcription handler.** Browser MediaRecorder writes audio as webm/opus but the Blob's `type` is often empty by the time it hits the server. OpenAI Whisper then rejects with `502 Invalid file format`. Reconstructing the File with explicit `audio/webm` + `.webm` filename fallback makes Whisper accept the bytes. Monorepo-wide — applies to every integration using `/api/copilotkit-voice/transcribe`.

- **showcase/aimock/feature-parity.json: port 12 subagents fixtures from `d5-all.json`** so the three pills (cold-exposure blog, LLM tool-calling explanation, reusable-rockets summary) get deterministic content in production. `d5-all.json` already has the full research → writing → critique chain with substantive content; feature-parity only had the single LP remote-work pill. Verbatim port — no fabricated text. Net result: no more `[sub-agent error] the writing agent…` on the demo.

- **showcase/aimock both files: replace the `tone: casual` shared-state-rw gate with a true all-defaults `match.systemMessage` array.** The previous single-substring gate only caught tone changes — name / language / interests changes still hit the canned fixture. Replaced with a two-element array gate (aimock supports all-present substring matching, verified in `/app/dist/router.js`):
  - `preferences:\n- Preferred tone: casual\n` — breaks if name is set (Name line inserts between signature and tone) or tone changes.
  - `- Preferred language: English\nTailor every response` — breaks if language changes or interests are added (Interests line inserts between language and Tailor).
  With `--provider-gemini` already wired in local + Railway prod, any state change now proxies to real Gemini and returns a personalised reply.

- **feature-parity.json: re-remove the bare `plan` / `steps` / `mars` / `dashboard` / `report` / `alice` / `Alice` substring catch-alls** (lost in the #4837 squash). Replace the alice pair with a single scoped `Hi, my name is Alice` fixture for the showcase-assistant intro flow.

## Test plan

- [x] `bin/showcase test google-adk --d5` → 38/38 green, 165s.
- [x] Paired curl on shared-state-rw:
  - Default state → canned fixture (`"Hi — I'm your shared-state co-pilot…"`)
  - `name=alem` → real Gemini (`"Hi there! …"`)
  - `interests=[Cooking, Travel]` weekend pill → real Gemini (`"Hey there! Since you're into cooking and travel, how about a weekend plan that combines both?"`)
- [x] Validate JSON on both fixture files.
- [ ] **Manual Railway prod test** after merge — please drive shared-state-rw with state changes, subagents pills, voice mic, and hitl-in-app downgrade-#12346 to confirm the prod-only manifestations are gone.

## Notes

- Production aimock fetches `feature-parity.json` from GitHub raw at boot (per `RAILWAY.md`), so once this merges Railway picks up the new fixtures without rebuilding the image.
- The `packages/runtime` handle-transcribe change needs the runtime package to be rebuilt + published for production to receive the fix — that's a separate deploy step depending on how the integrations consume `@copilotkit/runtime`.