### PR TITLE
fix(showcase/google-adk/voice): pin transcription baseURL to real OpenAI

### DIFF
--- a/showcase/integrations/google-adk/src/app/api/copilotkit-voice/[[...slug]]/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-voice/[[...slug]]/route.ts
@@ -29,14 +29,33 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
 const voiceDemoAgent = new HttpAgent({ url: `${AGENT_URL}/voice` });
 
+/**
+ * Transcription service wrapper that pins `baseURL` to real OpenAI (or
+ * `OPENAI_TRANSCRIPTION_BASE_URL` when explicitly set) instead of falling
+ * through to `OPENAI_BASE_URL`. In local docker / Railway preview
+ * environments `OPENAI_BASE_URL` points at aimock so LLM completions stay
+ * deterministic, but aimock's proxy mode mangles multipart audio bodies on
+ * forward — Whisper rejects with `502 Invalid file format` even when the
+ * recorded webm/opus bytes are valid. Bypassing aimock for transcription
+ * lets real Whisper see the original bytes and the demo's mic round-trip
+ * actually works. Mirrors what langgraph-python does in its voice route.
+ *
+ * The sample-audio button is the deterministic affordance (synchronous
+ * text injection); the mic is the only path that should exercise real
+ * Whisper.
+ */
 class GuardedOpenAITranscriptionService extends TranscriptionService {
   private delegate: TranscriptionServiceOpenAI | null;
 
   constructor() {
     super();
     const apiKey = process.env.OPENAI_API_KEY;
+    const baseURL =
+      process.env.OPENAI_TRANSCRIPTION_BASE_URL ?? "https://api.openai.com/v1";
     this.delegate = apiKey
-      ? new TranscriptionServiceOpenAI({ openai: new OpenAI({ apiKey }) })
+      ? new TranscriptionServiceOpenAI({
+          openai: new OpenAI({ apiKey, baseURL }),
+        })
       : null;
   }
 


### PR DESCRIPTION
## Summary

Voice mic recording on Railway prod was returning `502 Invalid file format. Supported formats: ['flac', 'm4a', 'mp3', 'mp4', 'mpeg', 'mpga', 'oga', 'ogg', 'wav', 'webm']` even though the browser was sending valid WebM Opus bytes (~40 KB `audio/webm;codecs=opus` recordings).

**Root cause:** `new OpenAI({ apiKey })` falls through to `OPENAI_BASE_URL`, which in showcase environments is set to `http://aimock:4010/v1`. Aimock's `--proxy-only` forwards unmatched requests to real OpenAI but re-encodes the multipart body in the process, corrupting the audio bytes by the time Whisper sees them. Whisper inspects the actual bytes (not just the MIME), so it rejects the mangled payload with the format error above.

**Fix:** Mirror `langgraph-python`'s voice route — pin the transcription client's `baseURL` to real OpenAI (or `OPENAI_TRANSCRIPTION_BASE_URL` when explicitly set) so the audio bypasses aimock entirely. Non-transcription paths (chat completions etc.) keep going through aimock for deterministic fixtures.

```diff
 constructor() {
   super();
   const apiKey = process.env.OPENAI_API_KEY;
+  const baseURL =
+    process.env.OPENAI_TRANSCRIPTION_BASE_URL ?? "https://api.openai.com/v1";
   this.delegate = apiKey
-    ? new TranscriptionServiceOpenAI({ openai: new OpenAI({ apiKey }) })
+    ? new TranscriptionServiceOpenAI({
+        openai: new OpenAI({ apiKey, baseURL }),
+      })
     : null;
 }
```

## Test plan

- [x] Local: mic recording at http://localhost:3103/demos/voice now transcribes the user's actual words via real Whisper instead of failing 502. Confirmed end-to-end by user.
- [ ] Manual Railway prod test after merge.

## Notes

- This was the last fix from PR #4838 that didn't make it into the squash merge (`dd43576035` only included the prior commit).
- The `packages/runtime` `audio/webm` stamping shipped in PR #4838 is still useful defensive hardening for empty-type Blobs at the server-side handler; with this route-level change those bytes never reach aimock anyway.