### PR TITLE
fix(showcase/google-adk/beautiful-chat): wire calculator click handlers via addEventListener

### DIFF
--- a/showcase/integrations/google-adk/src/agents/beautiful_chat_agent.py
+++ b/showcase/integrations/google-adk/src/agents/beautiful_chat_agent.py
@@ -428,6 +428,25 @@ _INSTRUCTION = """
           benefits from a live, interactive UI — calculators, color pickers,
           quizzes, etc. Keep the chat reply to one short sentence; the rendered
           widget is the real output.
+
+          Sandbox iframe restrictions (CRITICAL — these are silently enforced by
+          the browser, so the LLM has to know):
+          - The iframe runs with `sandbox="allow-scripts"` ONLY. `<form>` and
+            `<button type="submit">` are blocked BEFORE any onsubmit handler
+            runs — never use a form for interactivity.
+          - Use plain `<button type="button">` elements and wire them with
+            `addEventListener('click', ...)`. Do the same for keyboard input:
+            attach a `keydown` listener that checks `e.key === 'Enter'` and
+            calls your handler directly instead of wrapping inputs in a form.
+          - All click/keypress handlers must live inside a `<script>` tag in
+            the generated `html` (the iframe runs the html plus a small
+            postMessage shim). Top-level expressions are fine; no `fetch`,
+            no `localStorage`, no `document.cookie`.
+          - For calculators: render `<button type="button" data-key="7">7</button>`
+            etc. and a single `document.addEventListener('click', e => { ... })`
+            that reads `e.target.dataset.key` and updates an output `<div>`.
+            Wire the metric-shortcut buttons the same way; reading their
+            `data-value` to push the numeric value into the display.
         - A2UI actions: when you see a log_a2ui_event result (e.g. "view_details"),
           respond with a brief confirmation. The UI already updated on the frontend.
         - Meeting scheduling is handled entirely on the frontend via the


### PR DESCRIPTION
## Summary

The Beautiful Chat **Calculator App (Open Generative UI)** pill rendered the layout but no button responded to clicks.

**Root cause:** Gemini's default emit for the calculator widget wrapped buttons in `<form>` with `type="submit"` for click handling. The iframe runs with `sandbox="allow-scripts"` ONLY, so the browser silently blocks form submission before any onsubmit / click handler fires. The buttons drew, nothing happened on click — exactly the "white empty / dead UI" the user reported in prod.

**Fix:** Expand the `generateSandboxedUi` guidance in `beautiful_chat_agent.py`'s `_INSTRUCTION` with the same sandbox-iframe contract `_OPEN_GEN_UI_ADVANCED_INSTRUCTION` already spells out:

- Forms and submit-type buttons are blocked silently — never use them.
- Use `<button type="button" data-key="…">` plus a single delegated `document.addEventListener('click', e => …)` that reads `e.target.dataset.key` / `data-value`. Keyboard input via a `keydown` listener checking `e.key === 'Enter'`.
- All handler code in a `<script>` tag inside `html`.
- For calculators specifically: each digit/operator button carries `data-key`, each metric-shortcut button carries `data-value`, one delegated click handler updates the display.

## Test plan

- [x] Local browser: Calculator pill in Beautiful Chat now produces a widget whose number / operator / metric-shortcut buttons all respond to clicks; matches the LangGraph-Python output.
- [ ] Manual Railway prod check after merge.

## Notes

- The instruction nudge for `generateSandboxedUi` itself shipped in #4837. This PR is purely about teaching Gemini the sandbox-iframe restrictions so the generated HTML stays interactive.