### PR TITLE
fix(runtime): throw typed RetryAfterExceededError for oversized Retry-After

### DIFF
--- a/.changeset/retry-after-exceeded-error.md
+++ b/.changeset/retry-after-exceeded-error.md
@@ -1,0 +1,16 @@
+---
+"@copilotkit/runtime": patch
+---
+
+Surface 429 quota exhaustion as a typed `RetryAfterExceededError`
+
+When a 429 response carries a `Retry-After` value that exceeds
+`RETRY_CONFIG.maxRetryAfterSeconds` (60s by default), `fetchWithRetry` now
+throws a `RetryAfterExceededError` instead of a generic `Error`. The new
+class carries the parsed `retryAfterMs` and the original `response`, so
+callers can discriminate the rate-limit-quota-exhausted condition from
+ordinary fetch failures and decide whether to wait the full reset window
+or abort.
+
+Existing call sites that only catch the throw continue to work — the
+new class still extends `Error` and the message is unchanged.

--- a/packages/runtime/src/lib/runtime/__tests__/retry-utils.test.ts
+++ b/packages/runtime/src/lib/runtime/__tests__/retry-utils.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchWithRetry, parseRetryAfter, RETRY_CONFIG } from "../retry-utils";
+import {
+  fetchWithRetry,
+  parseRetryAfter,
+  RETRY_CONFIG,
+  RetryAfterExceededError,
+} from "../retry-utils";
 
 function responseWithRetryAfter(
   headerValue: string | null,
@@ -93,7 +98,7 @@ describe("fetchWithRetry Retry-After handling (#3637)", () => {
     fetchMock.mockResolvedValue(responseWithRetryAfter(String(excessive)));
 
     // The oversized-Retry-After branch throws before sleeping, and the
-    // resulting Error doesn't match any retryable pattern, so the loop
+    // resulting error doesn't match any retryable pattern, so the loop
     // breaks out without consuming the remaining attempts.
     await expect(fetchWithRetry("https://example.com", {})).rejects.toThrow(
       new RegExp(
@@ -101,6 +106,25 @@ describe("fetchWithRetry Retry-After handling (#3637)", () => {
       ),
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a RetryAfterExceededError with the parsed delay and response", async () => {
+    const excessive = RETRY_CONFIG.maxRetryAfterSeconds + 600;
+    fetchMock.mockResolvedValue(responseWithRetryAfter(String(excessive)));
+
+    // Callers handling rate-limit quota exhaustion should be able to
+    // discriminate on the error type and read the reset timing without
+    // re-parsing the original response.
+    const error = await fetchWithRetry("https://example.com", {}).catch(
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(RetryAfterExceededError);
+    const typed = error as RetryAfterExceededError;
+    expect(typed.retryAfterMs).toBe(excessive * 1000);
+    expect(typed.response).toBeInstanceOf(Response);
+    expect(typed.response.status).toBe(429);
+    expect(typed.response.headers.get("Retry-After")).toBe(String(excessive));
   });
 
   it("falls back to exponential backoff when Retry-After is missing on 429", async () => {

--- a/packages/runtime/src/lib/runtime/retry-utils.ts
+++ b/packages/runtime/src/lib/runtime/retry-utils.ts
@@ -74,6 +74,25 @@ export function calculateDelay(attempt: number): number {
   return Math.min(delay, RETRY_CONFIG.maxDelayMs);
 }
 
+/**
+ * Thrown when a 429 response asks for a Retry-After delay that exceeds
+ * `RETRY_CONFIG.maxRetryAfterSeconds`. Signals quota exhaustion (STOP)
+ * rather than a transient retryable failure, and carries the requested
+ * reset timing so callers can decide whether to wait or abort.
+ */
+export class RetryAfterExceededError extends Error {
+  constructor(
+    message: string,
+    /** Retry-After delay in milliseconds, as parsed from the response. */
+    public readonly retryAfterMs: number,
+    /** The 429 response that triggered this error. */
+    public readonly response: Response,
+  ) {
+    super(message);
+    this.name = "RetryAfterExceededError";
+  }
+}
+
 // Retry wrapper for fetch requests
 export async function fetchWithRetry(
   url: string,
@@ -99,9 +118,11 @@ export async function fetchWithRetry(
           if (retryAfterMs !== undefined) {
             const maxMs = RETRY_CONFIG.maxRetryAfterSeconds * 1000;
             if (retryAfterMs > maxMs) {
-              throw new Error(
+              throw new RetryAfterExceededError(
                 `Server requested Retry-After of ${Math.ceil(retryAfterMs / 1000)}s ` +
                   `which exceeds the maximum of ${RETRY_CONFIG.maxRetryAfterSeconds}s`,
+                retryAfterMs,
+                response,
               );
             }
             delay = retryAfterMs;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.
-->

## What does this PR do?

Closes #4772.

PR #3842 taught `fetchWithRetry` (in `packages/runtime/src/lib/runtime/retry-utils.ts`) to honor `Retry-After` on 429 responses, but capped the wait at `RETRY_CONFIG.maxRetryAfterSeconds` (60s by default). When the server requested a longer delay, the code threw a generic `Error`:

```ts
if (retryAfterMs > maxMs) {
  throw new Error(
    `Server requested Retry-After of …s which exceeds the maximum of 60s`,
  );
}
```

Callers had no good way to distinguish quota exhaustion from any other fetch failure — concurrent agent workers all hit the wall and threw indistinguishable generic errors with no programmatic access to the requested reset window.

This PR replaces the generic throw with a typed `RetryAfterExceededError` (modeled on the existing `PlatformRequestError`) that exposes the parsed `retryAfterMs` and the original 429 `Response` as `readonly` fields. The message is unchanged, so existing call sites that only catch the throw continue to work; callers that want to handle rate-limit quota exhaustion specifically can now discriminate on `instanceof RetryAfterExceededError` and decide whether to wait the full reset window or abort.

```ts
try {
  await fetchWithRetry(url, options);
} catch (err) {
  if (err instanceof RetryAfterExceededError) {
    // err.retryAfterMs, err.response are typed
    if (err.retryAfterMs < acceptableWait) {
      await sleep(err.retryAfterMs);
      // retry caller-side
    } else {
      // abort and surface to the user
    }
  }
}
```

## Related PRs and Issues

- Closes #4772
- Builds on #3842 (initial Retry-After parsing)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)