### PR TITLE
fix(ci): limit devops-bot token exposure in capture-previews

### DIFF
--- a/.github/workflows/showcase_capture-previews.yml
+++ b/.github/workflows/showcase_capture-previews.yml
@@ -61,13 +61,13 @@ jobs:
           app-id: "1108748"
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
 
-      # persist-credentials required: subsequent "Commit registry updates" step uses git push (via devops-bot app token)
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           lfs: true
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Ensure preview release exists
         env:
@@ -142,14 +142,16 @@ jobs:
             npx tsx showcase/scripts/capture-previews.ts "${ARGS[@]}" || true
           fi
 
-      - name: Commit registry updates
+      - name: Configure git for push
         run: |
-          # Commit as the devops-bot installation. The `<app-id>+<slug>[bot]`
-          # email is the conventional GitHub App noreply form; paired with
-          # the app-token used for checkout, the push lands on protected
-          # main via the bot's PROTECT_OUR_MAIN bypass.
           git config user.name "devops-bot[bot]"
           git config user.email "1108748+devops-bot[bot]@users.noreply.github.com"
+          git config --local url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Commit registry updates
+        run: |
           cd showcase/shell/src/data
           if git diff --quiet registry.json; then
             echo "No registry changes"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -87,7 +87,6 @@ rules:
       # branch. Origin URL is overridden with the devops-bot app token,
       # but the default checkout credential must persist past checkout.
       - showcase_docs-sync.yml
-      # showcase_capture-previews.yml: commits regenerated registry
-      # entries to main via the devops-bot app token (PROTECT_OUR_MAIN
-      # bypass actor).
-      - showcase_capture-previews.yml
+      # showcase_capture-previews.yml: now uses persist-credentials: false
+      # and injects credentials only before push via insteadOf — no
+      # longer needs an artipacked suppression.


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to checkout so the devops-bot app token
  (which bypasses branch protection) is not left in `.git/config` for ~30
  minutes while ffmpeg, Playwright, and npm packages install
- Inject credentials via `git config insteadOf` only in the new
  "Configure git for push" step, immediately before the commit/push step
- Remove the now-unnecessary `artipacked` suppression for
  `showcase_capture-previews.yml` from `.github/zizmor.yml`

## Why
A compromised dependency installed during the ~30-minute window could
exfiltrate the persisted devops-bot token from `.git/config` and push
directly to main, bypassing branch protection.

## Test plan
- [ ] Trigger capture-previews workflow manually and verify registry
  commit + push still succeeds
- [ ] Verify zizmor CI passes (no new artipacked findings)