### PR TITLE
fix(ci): limit credential exposure in format job

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -35,10 +35,10 @@ jobs:
       contents: write
 
     steps:
-      # persist-credentials required: subsequent "Commit formatting fixes" step pushes auto-formatting commits via GITHUB_TOKEN
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
           # Full history so we can diff HEAD against the current base branch
@@ -123,6 +123,18 @@ jobs:
             ruff format --check .
           fi
 
+      - name: Configure git for push
+        if: >-
+          env.format_fixed == 'true' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Commit formatting fixes
         if: >-
           env.format_fixed == 'true' &&
@@ -133,8 +145,6 @@ jobs:
             echo "No formatting changes to commit"
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git diff --name-only -z | xargs -0 git add
           git commit -m "style: auto-fix formatting"
           git push

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -63,10 +63,14 @@ rules:
   # `artipacked` flags `actions/checkout` calls that leave the default
   # GITHUB_TOKEN persisted in the local git config. Every other checkout
   # in the repo sets `persist-credentials: false`. The suppressions below
-  # are the four workflows that legitimately need the persisted token to
-  # push back to the repo (release tagging, auto-formatting, docs sync,
-  # PR comment from pkg-pr-new). Each call site carries a `persist-
-  # credentials required:` comment immediately above it.
+  # are the workflows that legitimately need the persisted token to push
+  # back to the repo (release tagging, docs sync, PR comment from
+  # pkg-pr-new). Each call site carries a `persist-credentials required:`
+  # comment immediately above it.
+  #
+  # static_quality.yml was removed: its format job now uses
+  # persist-credentials: false and injects credentials via insteadOf
+  # only before the push step.
   artipacked:
     ignore:
       # Release workflows that push tags / branches via GITHUB_TOKEN.
@@ -80,9 +84,6 @@ rules:
       # pkg-pr-new posts snapshot comments on the PR using the repo token
       # — credentials must remain persisted for the action to authenticate.
       - publish-commit.yml
-      # static_quality.yml's `format` job pushes auto-formatting fixes
-      # back to the PR branch when the formatter modifies files.
-      - static_quality.yml
       # showcase_docs-sync.yml: opens a docs-sync PR by pushing a new
       # branch. Origin URL is overridden with the devops-bot app token,
       # but the default checkout credential must persist past checkout.


### PR DESCRIPTION
## Summary

The format job in `static_quality.yml` installs third-party tools (ruff from PyPI, oxfmt from npm) with a write-scoped GITHUB_TOKEN persisted in `.git/config` for the entire job duration. A compromised tool version could exfiltrate the token.

- Add `persist-credentials: false` to the checkout step so the token is not baked into `.git/config`
- Inject git credentials via `url.insteadOf` only immediately before the push step (new "Configure git for push" step)
- Credential exposure window drops from full job duration to seconds
- Remove the `artipacked` suppression for `static_quality.yml` in `.github/zizmor.yml` since the finding no longer applies

## Test plan

- [ ] CI passes on this PR (format job still auto-fixes and pushes when formatting changes are needed)
- [ ] zizmor no longer reports an artipacked finding for static_quality.yml