### PR TITLE
fix(ci): persist-credentials: false on docs-sync and stable-release

### DIFF
--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -23,12 +23,11 @@ jobs:
       SHOWCASE_BRANCH: main
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
     steps:
-      # persist-credentials required: subsequent "Create PR for docs sync" step
-      # uses git push (origin URL is overridden to use the devops-bot token).
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.SHOWCASE_BRANCH }}
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -62,12 +62,12 @@ jobs:
               );
             }
 
-      # persist-credentials required: release workflow pushes the release branch via GITHUB_TOKEN
       - name: Checkout Repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup pnpm
         # Omit `version:` so pnpm/action-setup inherits from the repo's

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -76,17 +76,12 @@ rules:
       # publish job downloads the artifact and sets up its own git auth via
       # `git config insteadOf`.
       - prerelease.yml
-      - stable-release.yml
       # pkg-pr-new posts snapshot comments on the PR using the repo token
       # — credentials must remain persisted for the action to authenticate.
       - publish-commit.yml
       # static_quality.yml's `format` job pushes auto-formatting fixes
       # back to the PR branch when the formatter modifies files.
       - static_quality.yml
-      # showcase_docs-sync.yml: opens a docs-sync PR by pushing a new
-      # branch. Origin URL is overridden with the devops-bot app token,
-      # but the default checkout credential must persist past checkout.
-      - showcase_docs-sync.yml
       # showcase_capture-previews.yml: commits regenerated registry
       # entries to main via the devops-bot app token (PROTECT_OUR_MAIN
       # bypass actor).


### PR DESCRIPTION
## Summary
- showcase_docs-sync.yml: add persist-credentials: false (already uses explicit remote URL override for push via devops-bot app token)
- stable-release.yml: add persist-credentials: false (peter-evans/create-pull-request manages own credentials via token input)
- .github/zizmor.yml: remove artipacked suppressions for both files since they now use persist-credentials: false