### PR TITLE
fix(showcase-docs): fix display-only generative UI snippets and add LangGraph backend setup

### DIFF
--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -212,11 +212,16 @@ export default async function FrameworkScopedDocsPage({
   let contentSlugPath: string = slugPath;
   let doc: ReturnType<typeof loadDoc> = null;
 
-  // `/quickstart` at the root is a routing shim — it exists only so
-  // the sidebar's Quickstart entry has a backing page. Real quickstart
-  // content lives per-framework at `integrations/<framework>/quickstart.mdx`,
-  // so for framework-scoped URLs the override always wins over the shim.
-  if (slugPath === "quickstart") {
+  // Some root pages are generic overview shims — real per-framework
+  // content lives at `integrations/<framework>/<slug>.mdx` and should
+  // always win over the root shim when an override exists.
+  // `/quickstart` was the original case; add paths here as needed.
+  const INTEGRATION_OVERRIDE_SLUGS = new Set([
+    "quickstart",
+    "generative-ui/your-components/display-only",
+  ]);
+
+  if (INTEGRATION_OVERRIDE_SLUGS.has(slugPath)) {
     const overridePath = `integrations/${docsFolder}/${slugPath}`;
     doc = loadDoc(overridePath);
     if (doc) contentSlugPath = overridePath;

--- a/showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx
@@ -16,18 +16,32 @@ Display-only generative UI lets you register React components as tools your agen
 <Tabs items={['page.tsx', 'chart.tsx']}>
   <Tab value="page.tsx">
   ```tsx
+import { useComponent } from "@copilotkit/react-core/v2"; 
+import { Chart, ChartProps } from "./chart"; // chart.tsx (see next tab)
 
-useComponent({
-name: "showChart",
-description: "Populate data and show the user a chart",
-parameters: ChartProps,
-render: Chart
-});
+function YourMainContent() {
+  useComponent({
+    name: "showChart",
+    description: "Populate data and show the user a chart",
+    parameters: ChartProps,
+    render: Chart
+  });
+  return <div>{/* ... */}</div>;
+}
 
 ````
 </Tab>
 <Tab value="chart.tsx">
 ```tsx
+import { z } from "zod";
+import {
+  ResponsiveContainer,
+  BarChart,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Bar,
+} from "recharts";
 
 export const ChartProps = z.object({
   title: z.string(),

--- a/showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx
@@ -16,7 +16,7 @@ Display-only generative UI lets you register React components as tools your agen
 <Tabs items={['page.tsx', 'chart.tsx']}>
   <Tab value="page.tsx">
   ```tsx
-import { useComponent } from "@copilotkit/react-core/v2"; 
+import { useComponent } from "@copilotkit/react-core/v2";
 import { Chart, ChartProps } from "./chart"; // chart.tsx (see next tab)
 
 function YourMainContent() {
@@ -28,11 +28,10 @@ function YourMainContent() {
   });
   return <div>{/* ... */}</div>;
 }
-
-````
-</Tab>
-<Tab value="chart.tsx">
-```tsx
+  ```
+  </Tab>
+  <Tab value="chart.tsx">
+  ```tsx
 import { z } from "zod";
 import {
   ResponsiveContainer,
@@ -61,8 +60,7 @@ export function Chart({ title, data }: z.infer<typeof ChartProps>) {
     </div>
   );
 }
-````
-
+  ```
   </Tab>
 </Tabs>
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/your-components/display-only.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/your-components/display-only.mdx
@@ -187,15 +187,15 @@ export function Chart({ title, data }: z.infer<typeof ChartProps>) {
       <TailoredContentOption
         id="prebuilt"
         title="Prebuilt agent"
-        description="I'm using a prebuilt agent like create_react_agent by LangGraph"
+        description="I'm using a prebuilt agent like create_agent by LangGraph"
       >
         <Tabs groupId="language_langgraph_agent" items={['Python', 'TypeScript']} default="Python" persist>
           <Tab value="Python">
             ```python title="agent.py"
-            from langchain.agents import create_react_agent
+            from langchain.agents import create_agent
             from copilotkit import CopilotKitMiddleware, CopilotKitState # [!code highlight]
 
-            graph = create_react_agent(
+            graph = create_agent(
                 model="openai:gpt-4o",
                 tools=[],
                 middleware=[CopilotKitMiddleware()], # [!code highlight]
@@ -221,7 +221,7 @@ export function Chart({ title, data }: z.infer<typeof ChartProps>) {
   <Step>
     ### Give it a try!
 
-    Ask your agent something that would trigger the component (e.g. "What's the weather in San Francisco?"). You should see your component rendered directly in the chat.
+    Ask your agent something that would trigger the component (e.g. "Create a bar chart showing the ratio of men to women in California."). You should see your component rendered directly in the chat.
   </Step>
 </Steps>
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/your-components/display-only.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/your-components/display-only.mdx
@@ -3,78 +3,133 @@ title: "Display-only"
 icon: "lucide/Eye"
 description: "Register React components that your agent can render in the chat."
 ---
+
 ## What is this?
 
 `useComponent` lets you register a React component as a tool your agent can invoke. When the agent calls the tool, CopilotKit renders your component directly in the chat with the tool's arguments as props.
 
 This is the simplest form of Generative UI — your agent decides when to show a component, and CopilotKit renders it. No handler logic, no user interaction required.
 
-## When should I use this?
+<Tabs items={['page.tsx', 'chart.tsx']}>
+  <Tab value="page.tsx">
+  ```tsx
+import { useComponent } from "@copilotkit/react-core/v2"; // [!code highlight]
+import { Chart, ChartProps } from "./chart"; // chart.tsx (see next tab)
 
-Use `useComponent` when you want to:
-- Display rich UI (cards, charts, tables) inline in the chat
-- Show structured data from agent responses
-- Render previews, status indicators, or visual feedback
-- Let the agent present information beyond plain text
+function YourMainContent() {
+  // [!code highlight:6]
+  useComponent({
+    name: "showChart",
+    description: "Populate data and show the user a chart",
+    parameters: ChartProps,
+    render: Chart
+  });
+  return <div>{/* ... */}</div>;
+}
+  ```
+  </Tab>
+  <Tab value="chart.tsx">
+  ```tsx
+import { z } from "zod";
+import {
+  ResponsiveContainer,
+  BarChart,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Bar,
+} from "recharts";
 
-For components that need user interaction, see [Interactive](/langgraph/generative-ui/your-components/interactive) or [Interrupt-based](/langgraph/generative-ui/your-components/interrupt-based).
+export const ChartProps = z.object({
+  title: z.string(),
+  data: z.array(z.object({ label: z.string(), value: z.number() })),
+});
 
-## Implementation
+export function Chart({ title, data }: z.infer<typeof ChartProps>) {
+  return (
+    <div>
+      <h3>{title}</h3>
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={data}>
+          <XAxis dataKey="label" /><YAxis /><Tooltip />
+          <Bar dataKey="value" fill="#6366f1" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+  ```
+  </Tab>
+</Tabs>
+
+## Backend Setup
 
 <Steps>
   <Step>
     ### Run and connect your agent
-    <RunAndConnect />
-  </Step>
-  <Step>
-    ### Register a component
 
-    Use the `useComponent` hook to register a React component. The agent will be able to call it by name, and CopilotKit will render it with the tool arguments as props.
+    You'll need to run your agent and connect it to CopilotKit before proceeding.
 
-    ```tsx title="app/page.tsx"
-    import { useComponent } from "@copilotkit/react-core/v2"; // [!code highlight]
-    import { z } from "zod";
+    If you don't already have CopilotKit and your agent connected, choose one of the following options:
 
-    const weatherSchema = z.object({
-      city: z.string().describe("City name"),
-      temperature: z.number().describe("Temperature in Fahrenheit"),
-      condition: z.string().describe("Weather condition"),
-    });
+    <Accordions>
+      <Accordion title="I already have an agent">
+        You can follow the instructions in the [quickstart](/langgraph/quickstart) guide.
+      </Accordion>
+      <Accordion title="I want to start from scratch">
+        Run the following command to create a brand new project with a pre-configured agent:
 
-    function WeatherCard({ city, temperature, condition }: z.infer<typeof weatherSchema>) {
-      return (
-        <div className="rounded-lg border p-4">
-          <h3 className="font-semibold">{city}</h3>
-          <p className="text-2xl">{temperature}°F</p>
-          <p className="text-sm text-gray-500">{condition}</p>
-        </div>
-      );
-    }
-
-    function YourMainContent() {
-      // [!code highlight:9]
-      useComponent({
-        name: "showWeather",
-        description: "Display a weather card for a city.",
-        parameters: weatherSchema,
-        render: WeatherCard,
-      });
-
-      return <div>{/* ... */}</div>;
-    }
-    ```
+        <Tabs groupId="language_langgraph_agent" items={['Python', 'TypeScript']} default="Python" persist>
+          <Tab value="Python">
+            ```bash
+            npx copilotkit@latest create -f langgraph-py
+            ```
+          </Tab>
+          <Tab value="TypeScript">
+            ```bash
+            npx copilotkit@latest create -f langgraph-js
+            ```
+          </Tab>
+        </Tabs>
+      </Accordion>
+    </Accordions>
   </Step>
   <Step>
     ### Install the CopilotKit SDK
 
-    Now, we'll need to make sure your agent can access frontend tools. In your terminal, navigate to your agent's folder and continue from there.
+    Navigate to your agent's folder and install the SDK:
 
-    <InstallSDKSnippet/>
+    <Tabs groupId="language_langgraph_agent" items={['Python', 'TypeScript']} default="Python" persist>
+      <Tab value="Python">
+        <Tabs groupId="python-pm" items={['uv', 'poetry', 'pip']} default="uv">
+          <Tab value="uv">
+            ```bash
+            uv add copilotkit
+            ```
+          </Tab>
+          <Tab value="poetry">
+            ```bash
+            poetry add copilotkit
+            ```
+          </Tab>
+          <Tab value="pip">
+            ```bash
+            pip install copilotkit --extra-index-url https://copilotkit.gateway.scarf.sh/simple/
+            ```
+          </Tab>
+        </Tabs>
+      </Tab>
+      <Tab value="TypeScript">
+        ```bash
+        npm install @copilotkit/sdk-js
+        ```
+      </Tab>
+    </Tabs>
   </Step>
   <Step>
     ### Inherit from CopilotKitState
 
-    To access the frontend tools provided by CopilotKit, inherit from `CopilotKitState` in your agent's state definition:
+    To access frontend tools from your agent, inherit from `CopilotKitState` in your agent's state definition:
 
     <Tabs groupId="language_langgraph_agent" items={['Python', 'TypeScript']} default="Python" persist>
       <Tab value="Python">
@@ -86,7 +141,7 @@ For components that need user interaction, see [Interactive](/langgraph/generati
         ```
       </Tab>
       <Tab value="TypeScript">
-        ```typescript title="agent-js/src/agent.ts"
+        ```typescript title="agent.ts"
         import { StateSchema } from "@langchain/langgraph";
         import { CopilotKitStateSchema } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
 
@@ -101,41 +156,81 @@ For components that need user interaction, see [Interactive](/langgraph/generati
   <Step>
     ### Agent calls the component
 
-    When your agent's LLM decides to use the tool, CopilotKit automatically renders your component in the chat. The tool is registered as a frontend tool that the agent can discover and call.
+    When your agent's LLM decides to use the tool, CopilotKit automatically renders your component in the chat. Make sure your agent is reading the frontend tools from state and binding them to its model:
 
-    <FrontEndToolsImpl />
+    <TailoredContent id="agent-impl">
+      <TailoredContentOption
+        id="graph"
+        title="Custom graph"
+        description="I'm using a custom graph, where I define the nodes and edges myself."
+      >
+        <Tabs groupId="language_langgraph_agent" items={['Python', 'TypeScript']} default="Python" persist>
+          <Tab value="Python">
+            ```python title="agent.py"
+            async def agent_node(state: YourAgentState, config: RunnableConfig):
+                tools = state.get("copilotkit", {}).get("actions", []) # [!code highlight]
+                model = ChatOpenAI(model="gpt-4o").bind_tools(tools)
+                # ...
+            ```
+          </Tab>
+          <Tab value="TypeScript">
+            ```typescript title="agent.ts"
+            async function agentNode(state: YourAgentState, config: RunnableConfig) {
+                const tools = state.copilotkit?.actions; // [!code highlight]
+                const model = new ChatOpenAI({ model: "gpt-4o" }).bindTools(tools);
+                // ...
+            }
+            ```
+          </Tab>
+        </Tabs>
+      </TailoredContentOption>
+      <TailoredContentOption
+        id="prebuilt"
+        title="Prebuilt agent"
+        description="I'm using a prebuilt agent like create_react_agent by LangGraph"
+      >
+        <Tabs groupId="language_langgraph_agent" items={['Python', 'TypeScript']} default="Python" persist>
+          <Tab value="Python">
+            ```python title="agent.py"
+            from langchain.agents import create_react_agent
+            from copilotkit import CopilotKitMiddleware, CopilotKitState # [!code highlight]
+
+            graph = create_react_agent(
+                model="openai:gpt-4o",
+                tools=[],
+                middleware=[CopilotKitMiddleware()], # [!code highlight]
+                state_schema=CopilotKitState # [!code highlight]
+            )
+            ```
+          </Tab>
+          <Tab value="TypeScript">
+            ```typescript title="agent.ts"
+            import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+
+            export const graph = createReactAgent({
+                model: "openai:gpt-4o",
+                tools: [],
+                middleware: [copilotkitMiddleware], // [!code highlight]
+            });
+            ```
+          </Tab>
+        </Tabs>
+      </TailoredContentOption>
+    </TailoredContent>
   </Step>
   <Step>
     ### Give it a try!
 
-    Ask your agent something that would trigger the component (e.g. "What's the weather in San Francisco?"). You should see your `WeatherCard` rendered directly in the chat.
+    Ask your agent something that would trigger the component (e.g. "What's the weather in San Francisco?"). You should see your component rendered directly in the chat.
   </Step>
 </Steps>
 
-## Without parameters
+## When should I use this?
 
-For simple components that don't need typed parameters:
+Use display-only generative UI when you want to:
 
-```tsx
-useComponent({
-  name: "showGreeting",
-  render: ({ message }: { message: string }) => (
-    <div className="rounded border p-3 bg-blue-50">
-      <p>{message}</p>
-    </div>
-  ),
-});
-```
+- Display rich UI (cards, charts, tables) inline in the chat
+- Show structured data from agent responses
+- Render previews, status indicators, or visual feedback
+- Let the agent present information beyond plain text
 
-## Scoping to an agent
-
-In multi-agent setups, scope a component to a specific agent:
-
-```tsx
-useComponent({
-  name: "renderProfile",
-  parameters: z.object({ userId: z.string() }),
-  render: ProfileCard,
-  agentId: "support-agent",
-});
-```


### PR DESCRIPTION
## Summary

Improved the **Display Components** generative UI docs in the showcase to be accurate, copy-paste ready, and properly structured per integration.

## Changes

### Routing
- Added `generative-ui/your-components/display-only` to `INTEGRATION_OVERRIDE_SLUGS` in the framework-scoped router so LangGraph users are served their own integration-specific file instead of the generic root

### LangGraph integration file (`integrations/langgraph/generative-ui/your-components/display-only.mdx`)
- Restructured page flow to match the root: code example at top → Backend Setup steps in the middle → "When should I use this?" at the bottom
- Inlined all SDK install and run-and-connect content directly (avoids broken `InstallPythonSDKSnippet` nested partial chain)
- Fixed `create_react_agent` → `create_agent` in the "Agent calls the component" step
- Updated prompt wording across backend setup steps

### Root file (`generative-ui/your-components/display-only.mdx`)
- Fixed broken code fences (4-backtick closing fence → 3) so code blocks render correctly
- Added missing `import { Chart, ChartProps } from "./chart"` to the `page.tsx` snippet so it compiles on copy-paste
- Fixed missing imports (`z` from `zod`, recharts components) in the `chart.tsx` snippet
- Removed `WhenFrameworkHas` gating — LangGraph now has its own dedicated route

## Type of Change

- [x] Bug fix (docs)
- [ ] New feature
- [ ] Breaking change

## Affected Files

- `showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx`
- `showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/your-components/display-only.mdx`
- `showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx`

## Testing

- [x] Verified `/langgraph-python/generative-ui/your-components/display-only` serves the LangGraph-specific file
- [x] Verified other frameworks (mastra, pydantic-ai) still serve the root file
- [x] Verified code blocks render correctly in the docs dev server
- [x] Verified copy-pasted snippets compile without errors in a fresh Next.js project