### PR TITLE
fix(showcase-docs/frontend-tools): Improved Code Examples

### DIFF
--- a/showcase/integrations/ag2/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/frontend-tools/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-// @region[frontend-tool]
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -20,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );
@@ -44,7 +46,6 @@ function Chat() {
     // @endregion[frontend-tool-handler]
   });
   // @endregion[frontend-tool-registration]
-  // @endregion[frontend-tool]
 
   useConfigureSuggestions({
     suggestions: [
@@ -67,7 +68,7 @@ function Chat() {
       style={{ background }}
     >
       <div className="h-full w-full max-w-4xl">
-        <CopilotChat agentId="frontend_tools" className="h-full rounded-2xl" />
+        <CopilotSidebar agentId="frontend_tools" className="h-full rounded-2xl" />
       </div>
     </div>
   );

--- a/showcase/integrations/agno/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/frontend-tools/page.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import { CopilotKit } from "@copilotkit/react-core";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
+  CopilotSidebar
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
-
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 export default function FrontendToolsDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
@@ -19,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );

--- a/showcase/integrations/built-in-agent/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/frontend-tools/page.tsx
@@ -8,16 +8,17 @@
 // tool's handler runs locally in the page on invocation. No backend
 // tool wiring required.
 
-// @region[frontend-tool]
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
   CopilotKitProvider,
   CopilotChat,
-  useFrontendTool,
   useConfigureSuggestions,
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -28,6 +29,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );
@@ -52,7 +54,6 @@ function Chat() {
     // @endregion[frontend-tool-handler]
   });
   // @endregion[frontend-tool-registration]
-  // @endregion[frontend-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -19,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/frontend-tools/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-// @region[frontend-tool]
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -20,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );
@@ -44,7 +46,6 @@ function Chat() {
     // @endregion[frontend-tool-handler]
   });
   // @endregion[frontend-tool-registration]
-  // @endregion[frontend-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/crewai-crews/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/frontend-tools/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-// @region[frontend-tool]
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -20,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );
@@ -44,7 +46,6 @@ function Chat() {
     // @endregion[frontend-tool-handler]
   });
   // @endregion[frontend-tool-registration]
-  // @endregion[frontend-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/frontend-tools/page.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
   CopilotKit,
   CopilotSidebar,
-  useFrontendTool,
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 import { Background, DEFAULT_BACKGROUND } from "./background";
 import { useFrontendToolsSuggestions } from "./suggestions";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -20,6 +22,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(DEFAULT_BACKGROUND);
 
   useFrontendTool({

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/frontend-tools/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-// @region[frontend-tool]
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -20,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );
@@ -44,7 +46,6 @@ function Chat() {
     // @endregion[frontend-tool-handler]
   });
   // @endregion[frontend-tool-registration]
-  // @endregion[frontend-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/langgraph-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/frontend-tools/page.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
   CopilotKit,
   CopilotSidebar,
-  useFrontendTool,
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 import { Background, DEFAULT_BACKGROUND } from "./background";
 import { useFrontendToolsSuggestions } from "./suggestions";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(DEFAULT_BACKGROUND);
 
   useFrontendTool({

--- a/showcase/integrations/langgraph-typescript/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/frontend-tools/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-// @region[frontend-tool]
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -20,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );
@@ -44,7 +46,6 @@ function Chat() {
     // @endregion[frontend-tool-handler]
   });
   // @endregion[frontend-tool-registration]
-  // @endregion[frontend-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/langroid/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/frontend-tools/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -19,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );

--- a/showcase/integrations/llamaindex/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/frontend-tools/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -19,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );

--- a/showcase/integrations/mastra/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/mastra/src/app/demos/frontend-tools/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import { CopilotKit } from "@copilotkit/react-core";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -19,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/frontend-tools/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -19,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );

--- a/showcase/integrations/ms-agent-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/frontend-tools/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -19,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );

--- a/showcase/integrations/pydantic-ai/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/frontend-tools/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -19,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );

--- a/showcase/integrations/spring-ai/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/frontend-tools/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -19,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );

--- a/showcase/integrations/strands/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/strands/src/app/demos/frontend-tools/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-// @region[frontend-tool]
-// @region[frontend-tool-registration]
-import React, { useState } from "react";
+import React from "react";
 import {
-  useFrontendTool,
   useConfigureSuggestions,
   CopilotChat,
 } from "@copilotkit/react-core/v2";
 import { CopilotKit } from "@copilotkit/react-core";
 import { z } from "zod";
+// @region[frontend-tool-import]
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+// @endregion[frontend-tool-import]
 
 export default function FrontendToolsDemo() {
   return (
@@ -20,6 +21,7 @@ export default function FrontendToolsDemo() {
 }
 
 function Chat() {
+  // @region[frontend-tool-registration]
   const [background, setBackground] = useState<string>(
     "var(--copilot-kit-background-color)",
   );
@@ -44,7 +46,6 @@ function Chat() {
     // @endregion[frontend-tool-handler]
   });
   // @endregion[frontend-tool-registration]
-  // @endregion[frontend-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/shell-docs/src/content/docs/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/frontend-tools.mdx
@@ -29,6 +29,11 @@ Use frontend tools when your agent needs to:
 
 Register a frontend tool with `useFrontendTool`. Give it a name, a Zod schema for parameters, and a handler. The agent can then call it like any other tool and your frontend runs it in the browser.
 
+Here are the imports you need for it
+<Snippet region="frontend-tool-import" title="frontend/src/app/page.tsx — Frontend Tool Imports" />
+
+Below is how the hook can be defined. 
+
 <Snippet region="frontend-tool-registration" title="frontend/src/app/page.tsx — useFrontendTool" />
 
 The handler receives the parsed, type-safe parameters and can do anything


### PR DESCRIPTION
## Summary
Frontend tools in documentation has two minor issues in code examples. First, there is no ending brace `}` in `function Chat().` Secondly, Only Chat Component is used, CopilotChat is not used and it can be confusing for a first time user. Therefore, fixed it to only include the needed imports, and definition of useFrontendTool() to keep the code minimal, easy to copy and integrate 

## Changes
- Moved `@region[frontend-tool-registration]` inside `function Chat()` just above const background declarations to encompass only necessary required variables used in useFrontendTool, and the hook itself

- Added `@region[frontend-tool-import]` to include imports in docs 
