### PR TITLE
feat(showcase/shell-dashboard): add iframe link preview on hover

### DIFF
--- a/showcase/shell-dashboard/package-lock.json
+++ b/showcase/shell-dashboard/package-lock.json
@@ -21,6 +21,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^5.2.0",
         "jsdom": "^29.0.2",
         "postcss": "^8.5.0",
@@ -2509,6 +2510,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/showcase/shell-dashboard/package.json
+++ b/showcase/shell-dashboard/package.json
@@ -28,6 +28,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.2.0",
     "jsdom": "^29.0.2",
     "postcss": "^8.5.0",

--- a/showcase/shell-dashboard/src/app/layout.tsx
+++ b/showcase/shell-dashboard/src/app/layout.tsx
@@ -41,7 +41,10 @@ export default function RootLayout({
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
-      <body>{children}</body>
+      <body>
+        {children}
+        <div id="link-preview-root" />
+      </body>
     </html>
   );
 }

--- a/showcase/shell-dashboard/src/components/__tests__/composed-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/composed-cell.test.tsx
@@ -2,6 +2,7 @@
  * Unit tests for ComposedCell — overlay-aware cell renderer that composes
  * different content layers based on which overlays are currently active.
  */
+import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 import { ComposedCell } from "../composed-cell";
@@ -31,6 +32,22 @@ vi.mock("@/components/cell-pieces", () => ({
       feature: { id: string };
       shellUrl: string;
     }) => <div data-testid="mock-docs-row">{feature.id}</div>,
+  ),
+}));
+
+vi.mock("@/components/link-preview", () => ({
+  LinkPreview: vi.fn(
+    ({
+      children,
+      href,
+    }: {
+      children: React.ReactNode;
+      href: string;
+    }) => (
+      <span data-testid="mock-link-preview" data-href={href}>
+        {children}
+      </span>
+    ),
   ),
 }));
 
@@ -309,6 +326,22 @@ describe("ComposedCell", () => {
       "npx copilotkit@latest",
     );
     expect(queryByText("Demo")).not.toBeInTheDocument();
+  });
+
+  it("wraps Demo and Code links with LinkPreview", () => {
+    const ctx = makeCtx();
+    const { getAllByTestId } = render(
+      <ComposedCell ctx={ctx} overlays={overlaySet("links")} />,
+    );
+
+    const previews = getAllByTestId("mock-link-preview");
+    expect(previews).toHaveLength(2);
+    expect(previews[0].getAttribute("data-href")).toBe(
+      "https://demo.test/preview",
+    );
+    expect(previews[1].getAttribute("data-href")).toBe(
+      "https://demo.test/code",
+    );
   });
 
   it("renders empty div when only parity overlay is active", () => {

--- a/showcase/shell-dashboard/src/components/__tests__/composed-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/composed-cell.test.tsx
@@ -37,13 +37,7 @@ vi.mock("@/components/cell-pieces", () => ({
 
 vi.mock("@/components/link-preview", () => ({
   LinkPreview: vi.fn(
-    ({
-      children,
-      href,
-    }: {
-      children: React.ReactNode;
-      href: string;
-    }) => (
+    ({ children, href }: { children: React.ReactNode; href: string }) => (
       <span data-testid="mock-link-preview" data-href={href}>
         {children}
       </span>

--- a/showcase/shell-dashboard/src/components/__tests__/link-preview.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/link-preview.test.tsx
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, act, cleanup } from "@testing-library/react";
+import { LinkPreview, HOVER_DELAY_MS, DISMISS_DELAY_MS } from "../link-preview";
+
+function flushTimers() {
+  act(() => {
+    vi.runAllTimers();
+  });
+}
+
+function advanceBy(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+describe("LinkPreview", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    if (!document.getElementById("link-preview-root")) {
+      const el = document.createElement("div");
+      el.id = "link-preview-root";
+      document.body.appendChild(el);
+    }
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    const root = document.getElementById("link-preview-root");
+    if (root) root.innerHTML = "";
+  });
+
+  it("renders children (the link) immediately without a popup", () => {
+    const { getByText, queryByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <a href="https://example.com">Demo ↗</a>
+      </LinkPreview>,
+    );
+    expect(getByText("Demo ↗")).toBeInTheDocument();
+    expect(queryByTestId("link-preview-popup")).not.toBeInTheDocument();
+  });
+
+  it("shows popup after hover delay", () => {
+    const { getByTestId, queryByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo ↗</span>
+      </LinkPreview>,
+    );
+    fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
+    advanceBy(HOVER_DELAY_MS - 1);
+    expect(queryByTestId("link-preview-popup")).not.toBeInTheDocument();
+    advanceBy(1);
+    expect(queryByTestId("link-preview-popup")).toBeInTheDocument();
+  });
+
+  it("does not show popup if mouse leaves before hover delay", () => {
+    const { getByTestId, queryByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo ↗</span>
+      </LinkPreview>,
+    );
+    const wrapper = getByTestId("trigger").parentElement!;
+    fireEvent.mouseEnter(wrapper);
+    advanceBy(HOVER_DELAY_MS - 100);
+    fireEvent.mouseLeave(wrapper);
+    flushTimers();
+    expect(queryByTestId("link-preview-popup")).not.toBeInTheDocument();
+  });
+
+  it("dismisses popup after dismiss delay when mouse leaves both link and popup", () => {
+    const { getByTestId, queryByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo ↗</span>
+      </LinkPreview>,
+    );
+    fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    expect(queryByTestId("link-preview-popup")).toBeInTheDocument();
+    fireEvent.mouseLeave(getByTestId("trigger").parentElement!);
+    advanceBy(DISMISS_DELAY_MS - 1);
+    expect(queryByTestId("link-preview-popup")).toBeInTheDocument();
+    advanceBy(1);
+    expect(queryByTestId("link-preview-popup")).not.toBeInTheDocument();
+  });
+
+  it("keeps popup open when mouse moves from link into popup (bridge gap)", () => {
+    const { getByTestId, queryByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo ↗</span>
+      </LinkPreview>,
+    );
+    fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    const popup = queryByTestId("link-preview-popup")!;
+    expect(popup).toBeInTheDocument();
+    fireEvent.mouseLeave(getByTestId("trigger").parentElement!);
+    advanceBy(DISMISS_DELAY_MS / 2);
+    fireEvent.mouseEnter(popup);
+    flushTimers();
+    expect(queryByTestId("link-preview-popup")).toBeInTheDocument();
+  });
+
+  it("contains an iframe with the correct src", () => {
+    const { getByTestId } = render(
+      <LinkPreview href="https://example.com/preview">
+        <span data-testid="trigger">Demo ↗</span>
+      </LinkPreview>,
+    );
+    fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    const iframe = getByTestId("link-preview-popup").querySelector("iframe");
+    expect(iframe).toBeTruthy();
+    expect(iframe!.getAttribute("src")).toBe("https://example.com/preview");
+    expect(iframe!.style.pointerEvents).toBe("none");
+  });
+
+  it("has a transparent click overlay that opens URL in new tab", () => {
+    const windowOpen = vi.spyOn(window, "open").mockImplementation(() => null);
+    const { getByTestId } = render(
+      <LinkPreview href="https://example.com/preview">
+        <span data-testid="trigger">Demo ↗</span>
+      </LinkPreview>,
+    );
+    fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    const overlay = getByTestId("link-preview-overlay");
+    fireEvent.click(overlay);
+    expect(windowOpen).toHaveBeenCalledWith(
+      "https://example.com/preview",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    windowOpen.mockRestore();
+  });
+
+  it("dismisses popup on overlay click", () => {
+    vi.spyOn(window, "open").mockImplementation(() => null);
+    const { getByTestId, queryByTestId } = render(
+      <LinkPreview href="https://example.com/preview">
+        <span data-testid="trigger">Demo ↗</span>
+      </LinkPreview>,
+    );
+    fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    fireEvent.click(getByTestId("link-preview-overlay"));
+    expect(queryByTestId("link-preview-popup")).not.toBeInTheDocument();
+    vi.mocked(window.open).mockRestore();
+  });
+
+  it("renders popup in a portal (link-preview-root)", () => {
+    const { getByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo ↗</span>
+      </LinkPreview>,
+    );
+    fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    const portalRoot = document.getElementById("link-preview-root");
+    expect(portalRoot!.querySelector("[data-testid='link-preview-popup']")).toBeTruthy();
+  });
+
+  it("applies position-flip class when near viewport bottom", () => {
+    const { getByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo ↗</span>
+      </LinkPreview>,
+    );
+    const wrapper = getByTestId("trigger").parentElement!;
+    vi.spyOn(wrapper, "getBoundingClientRect").mockReturnValue({
+      top: 600, bottom: 620, left: 100, right: 200,
+      width: 100, height: 20, x: 100, y: 600, toJSON: () => {},
+    });
+    Object.defineProperty(window, "innerHeight", { value: 700, writable: true });
+    fireEvent.mouseEnter(wrapper);
+    advanceBy(HOVER_DELAY_MS);
+    const popup = getByTestId("link-preview-popup");
+    expect(popup.getAttribute("data-position")).toBe("above");
+  });
+
+  it("does not show popup on touch devices (hover: none)", () => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    const { getByTestId, queryByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo ↗</span>
+      </LinkPreview>,
+    );
+    const wrapper = getByTestId("trigger").parentElement!;
+    fireEvent.mouseEnter(wrapper);
+    advanceBy(HOVER_DELAY_MS + 100);
+    expect(queryByTestId("link-preview-popup")).not.toBeInTheDocument();
+  });
+});
+
+describe("LinkPreview singleton behavior", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    if (!document.getElementById("link-preview-root")) {
+      const el = document.createElement("div");
+      el.id = "link-preview-root";
+      document.body.appendChild(el);
+    }
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    const root = document.getElementById("link-preview-root");
+    if (root) root.innerHTML = "";
+  });
+
+  it("only one popup visible at a time", () => {
+    const { getAllByTestId } = render(
+      <div>
+        <LinkPreview href="https://one.com">
+          <span data-testid="trigger">Link 1</span>
+        </LinkPreview>
+        <LinkPreview href="https://two.com">
+          <span data-testid="trigger">Link 2</span>
+        </LinkPreview>
+      </div>,
+    );
+    const triggers = getAllByTestId("trigger");
+    fireEvent.mouseEnter(triggers[0].parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    const portalRoot = document.getElementById("link-preview-root")!;
+    expect(portalRoot.querySelectorAll("[data-testid='link-preview-popup']").length).toBe(1);
+    fireEvent.mouseEnter(triggers[1].parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    expect(portalRoot.querySelectorAll("[data-testid='link-preview-popup']").length).toBe(1);
+    const iframe = portalRoot.querySelector("iframe");
+    expect(iframe!.getAttribute("src")).toBe("https://two.com");
+  });
+});

--- a/showcase/shell-dashboard/src/components/__tests__/link-preview.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/link-preview.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, fireEvent, act, cleanup } from "@testing-library/react";
-import { LinkPreview, HOVER_DELAY_MS, DISMISS_DELAY_MS } from "../link-preview";
+import { LinkPreview, HOVER_DELAY_MS, DISMISS_DELAY_MS, LOAD_TIMEOUT_MS } from "../link-preview";
 
 function flushTimers() {
   act(() => {
@@ -214,6 +214,111 @@ describe("LinkPreview", () => {
     fireEvent.mouseEnter(wrapper);
     advanceBy(HOVER_DELAY_MS + 100);
     expect(queryByTestId("link-preview-popup")).not.toBeInTheDocument();
+  });
+});
+
+describe("LinkPreview load states", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    if (!document.getElementById("link-preview-root")) {
+      const el = document.createElement("div");
+      el.id = "link-preview-root";
+      document.body.appendChild(el);
+    }
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    const root = document.getElementById("link-preview-root");
+    if (root) root.innerHTML = "";
+  });
+
+  it("shows loading state initially when popup appears", () => {
+    const { getByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo</span>
+      </LinkPreview>,
+    );
+    fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    const portalRoot = document.getElementById("link-preview-root")!;
+    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeTruthy();
+  });
+
+  it("shows loaded state after iframe onLoad fires", () => {
+    const { getByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo</span>
+      </LinkPreview>,
+    );
+    fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    const portalRoot = document.getElementById("link-preview-root")!;
+    const iframe = portalRoot.querySelector("iframe")!;
+    act(() => {
+      fireEvent.load(iframe);
+    });
+    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeNull();
+    expect(iframe.style.opacity).toBe("1");
+  });
+
+  it("shows unavailable state after 8s timeout", () => {
+    const { getByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo</span>
+      </LinkPreview>,
+    );
+    fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
+    advanceBy(HOVER_DELAY_MS);
+    const portalRoot = document.getElementById("link-preview-root")!;
+    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeTruthy();
+    advanceBy(LOAD_TIMEOUT_MS);
+    expect(portalRoot.querySelector("[data-testid='link-preview-unavailable']")).toBeTruthy();
+    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeNull();
+    expect(portalRoot.textContent).toContain("Preview unavailable");
+  });
+
+  it("resets load state when popup is dismissed and reopened", () => {
+    const { getByTestId, queryByTestId } = render(
+      <LinkPreview href="https://example.com">
+        <span data-testid="trigger">Demo</span>
+      </LinkPreview>,
+    );
+    const wrapper = getByTestId("trigger").parentElement!;
+
+    // Show popup and load iframe
+    fireEvent.mouseEnter(wrapper);
+    advanceBy(HOVER_DELAY_MS);
+    const portalRoot = document.getElementById("link-preview-root")!;
+    const iframe = portalRoot.querySelector("iframe")!;
+    act(() => {
+      fireEvent.load(iframe);
+    });
+    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeNull();
+
+    // Dismiss popup
+    fireEvent.mouseLeave(wrapper);
+    advanceBy(DISMISS_DELAY_MS);
+    expect(queryByTestId("link-preview-popup")).not.toBeInTheDocument();
+
+    // Re-hover — should show loading again
+    fireEvent.mouseEnter(wrapper);
+    advanceBy(HOVER_DELAY_MS);
+    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeTruthy();
   });
 });
 

--- a/showcase/shell-dashboard/src/components/__tests__/link-preview.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/link-preview.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, fireEvent, act, cleanup } from "@testing-library/react";
-import { LinkPreview, HOVER_DELAY_MS, DISMISS_DELAY_MS, LOAD_TIMEOUT_MS } from "../link-preview";
+import {
+  LinkPreview,
+  HOVER_DELAY_MS,
+  DISMISS_DELAY_MS,
+  LOAD_TIMEOUT_MS,
+} from "../link-preview";
 
 function flushTimers() {
   act(() => {
@@ -170,7 +175,9 @@ describe("LinkPreview", () => {
     fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
     advanceBy(HOVER_DELAY_MS);
     const portalRoot = document.getElementById("link-preview-root");
-    expect(portalRoot!.querySelector("[data-testid='link-preview-popup']")).toBeTruthy();
+    expect(
+      portalRoot!.querySelector("[data-testid='link-preview-popup']"),
+    ).toBeTruthy();
   });
 
   it("applies position-flip class when near viewport bottom", () => {
@@ -181,10 +188,20 @@ describe("LinkPreview", () => {
     );
     const wrapper = getByTestId("trigger").parentElement!;
     vi.spyOn(wrapper, "getBoundingClientRect").mockReturnValue({
-      top: 600, bottom: 620, left: 100, right: 200,
-      width: 100, height: 20, x: 100, y: 600, toJSON: () => {},
+      top: 600,
+      bottom: 620,
+      left: 100,
+      right: 200,
+      width: 100,
+      height: 20,
+      x: 100,
+      y: 600,
+      toJSON: () => {},
     });
-    Object.defineProperty(window, "innerHeight", { value: 700, writable: true });
+    Object.defineProperty(window, "innerHeight", {
+      value: 700,
+      writable: true,
+    });
     fireEvent.mouseEnter(wrapper);
     advanceBy(HOVER_DELAY_MS);
     const popup = getByTestId("link-preview-popup");
@@ -256,7 +273,9 @@ describe("LinkPreview load states", () => {
     fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
     advanceBy(HOVER_DELAY_MS);
     const portalRoot = document.getElementById("link-preview-root")!;
-    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeTruthy();
+    expect(
+      portalRoot.querySelector("[data-testid='link-preview-loading']"),
+    ).toBeTruthy();
   });
 
   it("shows loaded state after iframe onLoad fires", () => {
@@ -272,7 +291,9 @@ describe("LinkPreview load states", () => {
     act(() => {
       fireEvent.load(iframe);
     });
-    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeNull();
+    expect(
+      portalRoot.querySelector("[data-testid='link-preview-loading']"),
+    ).toBeNull();
     expect(iframe.style.opacity).toBe("1");
   });
 
@@ -285,10 +306,16 @@ describe("LinkPreview load states", () => {
     fireEvent.mouseEnter(getByTestId("trigger").parentElement!);
     advanceBy(HOVER_DELAY_MS);
     const portalRoot = document.getElementById("link-preview-root")!;
-    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeTruthy();
+    expect(
+      portalRoot.querySelector("[data-testid='link-preview-loading']"),
+    ).toBeTruthy();
     advanceBy(LOAD_TIMEOUT_MS);
-    expect(portalRoot.querySelector("[data-testid='link-preview-unavailable']")).toBeTruthy();
-    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeNull();
+    expect(
+      portalRoot.querySelector("[data-testid='link-preview-unavailable']"),
+    ).toBeTruthy();
+    expect(
+      portalRoot.querySelector("[data-testid='link-preview-loading']"),
+    ).toBeNull();
     expect(portalRoot.textContent).toContain("Preview unavailable");
   });
 
@@ -308,7 +335,9 @@ describe("LinkPreview load states", () => {
     act(() => {
       fireEvent.load(iframe);
     });
-    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeNull();
+    expect(
+      portalRoot.querySelector("[data-testid='link-preview-loading']"),
+    ).toBeNull();
 
     // Dismiss popup
     fireEvent.mouseLeave(wrapper);
@@ -318,7 +347,9 @@ describe("LinkPreview load states", () => {
     // Re-hover — should show loading again
     fireEvent.mouseEnter(wrapper);
     advanceBy(HOVER_DELAY_MS);
-    expect(portalRoot.querySelector("[data-testid='link-preview-loading']")).toBeTruthy();
+    expect(
+      portalRoot.querySelector("[data-testid='link-preview-loading']"),
+    ).toBeTruthy();
   });
 });
 
@@ -367,10 +398,14 @@ describe("LinkPreview singleton behavior", () => {
     fireEvent.mouseEnter(triggers[0].parentElement!);
     advanceBy(HOVER_DELAY_MS);
     const portalRoot = document.getElementById("link-preview-root")!;
-    expect(portalRoot.querySelectorAll("[data-testid='link-preview-popup']").length).toBe(1);
+    expect(
+      portalRoot.querySelectorAll("[data-testid='link-preview-popup']").length,
+    ).toBe(1);
     fireEvent.mouseEnter(triggers[1].parentElement!);
     advanceBy(HOVER_DELAY_MS);
-    expect(portalRoot.querySelectorAll("[data-testid='link-preview-popup']").length).toBe(1);
+    expect(
+      portalRoot.querySelectorAll("[data-testid='link-preview-popup']").length,
+    ).toBe(1);
     const iframe = portalRoot.querySelector("iframe");
     expect(iframe!.getAttribute("src")).toBe("https://two.com");
   });

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -12,6 +12,7 @@ import type { CellContext } from "@/components/feature-grid";
 import { CellStatus, DocsRow, urlsFor } from "@/components/cell-pieces";
 import { CellDrilldown } from "@/components/cell-drilldown";
 import { CommandCell } from "@/components/command-cell";
+import { LinkPreview } from "@/components/link-preview";
 import { DepthChip } from "@/components/depth-chip";
 import { deriveDepth } from "@/components/depth-utils";
 import type { CatalogCell } from "@/components/depth-utils";
@@ -39,23 +40,27 @@ function LinksLayer({ ctx }: { ctx: CellContext }) {
 
   return (
     <div className="flex items-center justify-center gap-1.5">
-      <a
-        href={links.demoUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="whitespace-nowrap text-[var(--accent)] hover:underline"
-      >
-        <span className="text-[var(--text-muted)]">Demo</span> <span>↗</span>
-      </a>
-      <a
-        href={links.codeUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="whitespace-nowrap text-[var(--accent)] hover:underline"
-      >
-        <span className="text-[var(--text-muted)]">Code</span>{" "}
-        <span>{"</>"}</span>
-      </a>
+      <LinkPreview href={links.demoUrl}>
+        <a
+          href={links.demoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="whitespace-nowrap text-[var(--accent)] hover:underline"
+        >
+          <span className="text-[var(--text-muted)]">Demo</span> <span>↗</span>
+        </a>
+      </LinkPreview>
+      <LinkPreview href={links.codeUrl}>
+        <a
+          href={links.codeUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="whitespace-nowrap text-[var(--accent)] hover:underline"
+        >
+          <span className="text-[var(--text-muted)]">Code</span>{" "}
+          <span>{"</>"}</span>
+        </a>
+      </LinkPreview>
     </div>
   );
 }

--- a/showcase/shell-dashboard/src/components/link-preview.tsx
+++ b/showcase/shell-dashboard/src/components/link-preview.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import {
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+
+export const HOVER_DELAY_MS = 300;
+export const DISMISS_DELAY_MS = 200;
+
+let activeDismiss: (() => void) | null = null;
+
+function registerActive(dismiss: () => void): void {
+  if (activeDismiss && activeDismiss !== dismiss) {
+    activeDismiss();
+  }
+  activeDismiss = dismiss;
+}
+
+function unregisterActive(dismiss: () => void): void {
+  if (activeDismiss === dismiss) {
+    activeDismiss = null;
+  }
+}
+
+interface LinkPreviewProps {
+  href: string;
+  children: ReactNode;
+}
+
+export function LinkPreview({ href, children }: LinkPreviewProps) {
+  const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState<"below" | "above">("below");
+  const wrapperRef = useRef<HTMLSpanElement>(null);
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const dismiss = useCallback(() => {
+    setVisible(false);
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      dismiss();
+      unregisterActive(dismiss);
+    };
+  }, [dismiss]);
+
+  const cancelDismiss = useCallback(() => {
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+  }, []);
+
+  const startDismiss = useCallback(() => {
+    cancelDismiss();
+    dismissTimerRef.current = setTimeout(() => {
+      setVisible(false);
+      unregisterActive(dismiss);
+    }, DISMISS_DELAY_MS);
+  }, [cancelDismiss, dismiss]);
+
+  const handleMouseEnter = useCallback(() => {
+    cancelDismiss();
+    if (window.matchMedia("(hover: none)").matches) return;
+    hoverTimerRef.current = setTimeout(() => {
+      if (wrapperRef.current) {
+        const rect = wrapperRef.current.getBoundingClientRect();
+        const spaceBelow = window.innerHeight - rect.bottom;
+        setPosition(spaceBelow < 300 ? "above" : "below");
+      }
+      registerActive(dismiss);
+      setVisible(true);
+    }, HOVER_DELAY_MS);
+  }, [cancelDismiss, dismiss]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+    if (visible) {
+      startDismiss();
+    }
+  }, [visible, startDismiss]);
+
+  const handlePopupMouseEnter = useCallback(() => {
+    cancelDismiss();
+  }, [cancelDismiss]);
+
+  const handlePopupMouseLeave = useCallback(() => {
+    startDismiss();
+  }, [startDismiss]);
+
+  const handleOverlayClick = useCallback(() => {
+    window.open(href, "_blank", "noopener,noreferrer");
+    dismiss();
+    unregisterActive(dismiss);
+  }, [href, dismiss]);
+
+  function popupStyle(): React.CSSProperties {
+    if (!wrapperRef.current) return {};
+    const rect = wrapperRef.current.getBoundingClientRect();
+    const left = rect.left + rect.width / 2 - 200;
+    if (position === "above") {
+      return {
+        position: "fixed",
+        left: Math.max(4, left),
+        bottom: window.innerHeight - rect.top + 5,
+        width: 400,
+        height: 300,
+      };
+    }
+    return {
+      position: "fixed",
+      left: Math.max(4, left),
+      top: rect.bottom + 5,
+      width: 400,
+      height: 300,
+    };
+  }
+
+  const portalTarget =
+    typeof document !== "undefined"
+      ? document.getElementById("link-preview-root")
+      : null;
+
+  return (
+    <span
+      ref={wrapperRef}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      style={{ display: "inline" }}
+    >
+      {children}
+      {visible &&
+        portalTarget &&
+        createPortal(
+          <div
+            data-testid="link-preview-popup"
+            data-position={position}
+            onMouseEnter={handlePopupMouseEnter}
+            onMouseLeave={handlePopupMouseLeave}
+            className="rounded-lg border border-[var(--border)] shadow-lg overflow-hidden"
+            style={{
+              ...popupStyle(),
+              zIndex: 100,
+              backgroundColor: "var(--bg-surface)",
+            }}
+          >
+            <iframe
+              src={href}
+              title="Link preview"
+              style={{
+                width: "100%",
+                height: "100%",
+                border: "none",
+                pointerEvents: "none",
+              }}
+              sandbox="allow-scripts allow-same-origin"
+              loading="lazy"
+            />
+            <div
+              data-testid="link-preview-overlay"
+              onClick={handleOverlayClick}
+              style={{
+                position: "absolute",
+                inset: 0,
+                cursor: "pointer",
+              }}
+            />
+          </div>,
+          portalTarget,
+        )}
+    </span>
+  );
+}

--- a/showcase/shell-dashboard/src/components/link-preview.tsx
+++ b/showcase/shell-dashboard/src/components/link-preview.tsx
@@ -165,10 +165,12 @@ export function LinkPreview({ href, children }: LinkPreviewProps) {
               src={href}
               title="Link preview"
               style={{
-                width: "100%",
-                height: "100%",
+                width: 1200,
+                height: 900,
                 border: "none",
                 pointerEvents: "none",
+                transform: "scale(0.333)",
+                transformOrigin: "top left",
               }}
               sandbox="allow-scripts allow-same-origin"
               loading="lazy"

--- a/showcase/shell-dashboard/src/components/link-preview.tsx
+++ b/showcase/shell-dashboard/src/components/link-preview.tsx
@@ -11,6 +11,9 @@ import { createPortal } from "react-dom";
 
 export const HOVER_DELAY_MS = 300;
 export const DISMISS_DELAY_MS = 200;
+export const LOAD_TIMEOUT_MS = 8000;
+
+type LoadState = "loading" | "loaded" | "unavailable";
 
 let activeDismiss: (() => void) | null = null;
 
@@ -35,12 +38,15 @@ interface LinkPreviewProps {
 export function LinkPreview({ href, children }: LinkPreviewProps) {
   const [visible, setVisible] = useState(false);
   const [position, setPosition] = useState<"below" | "above">("below");
+  const [loadState, setLoadState] = useState<LoadState>("loading");
   const wrapperRef = useRef<HTMLSpanElement>(null);
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const loadTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const dismiss = useCallback(() => {
     setVisible(false);
+    setLoadState("loading");
     if (hoverTimerRef.current) {
       clearTimeout(hoverTimerRef.current);
       hoverTimerRef.current = null;
@@ -49,7 +55,28 @@ export function LinkPreview({ href, children }: LinkPreviewProps) {
       clearTimeout(dismissTimerRef.current);
       dismissTimerRef.current = null;
     }
+    if (loadTimeoutRef.current) {
+      clearTimeout(loadTimeoutRef.current);
+      loadTimeoutRef.current = null;
+    }
   }, []);
+
+  // Start the load timeout when popup becomes visible; reset when hidden
+  useEffect(() => {
+    if (visible) {
+      loadTimeoutRef.current = setTimeout(() => {
+        setLoadState((prev) => (prev === "loading" ? "unavailable" : prev));
+      }, LOAD_TIMEOUT_MS);
+    } else {
+      setLoadState("loading");
+    }
+    return () => {
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
+      }
+    };
+  }, [visible]);
 
   useEffect(() => {
     return () => {
@@ -104,6 +131,14 @@ export function LinkPreview({ href, children }: LinkPreviewProps) {
   const handlePopupMouseLeave = useCallback(() => {
     startDismiss();
   }, [startDismiss]);
+
+  const handleIframeLoad = useCallback(() => {
+    if (loadTimeoutRef.current) {
+      clearTimeout(loadTimeoutRef.current);
+      loadTimeoutRef.current = null;
+    }
+    setLoadState("loaded");
+  }, []);
 
   const handleOverlayClick = useCallback(() => {
     window.open(href, "_blank", "noopener,noreferrer");
@@ -164,6 +199,7 @@ export function LinkPreview({ href, children }: LinkPreviewProps) {
             <iframe
               src={href}
               title="Link preview"
+              onLoad={handleIframeLoad}
               style={{
                 width: 1200,
                 height: 900,
@@ -171,10 +207,56 @@ export function LinkPreview({ href, children }: LinkPreviewProps) {
                 pointerEvents: "none",
                 transform: "scale(0.333)",
                 transformOrigin: "top left",
+                opacity: loadState === "loaded" ? 1 : 0,
+                transition: "opacity 200ms ease-in",
               }}
               sandbox="allow-scripts allow-same-origin"
               loading="lazy"
             />
+            {loadState === "loading" && (
+              <div
+                data-testid="link-preview-loading"
+                style={{
+                  position: "absolute",
+                  inset: 0,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <span
+                  style={{
+                    color: "var(--text-muted)",
+                    fontSize: 13,
+                    animation: "lp-pulse 1.5s ease-in-out infinite",
+                  }}
+                >
+                  Loading preview&hellip;
+                </span>
+                <style>{`@keyframes lp-pulse { 0%,100% { opacity: .4 } 50% { opacity: 1 } }`}</style>
+              </div>
+            )}
+            {loadState === "unavailable" && (
+              <div
+                data-testid="link-preview-unavailable"
+                style={{
+                  position: "absolute",
+                  inset: 0,
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 4,
+                }}
+              >
+                <span style={{ color: "var(--text-muted)", fontSize: 13 }}>
+                  Preview unavailable
+                </span>
+                <span style={{ color: "var(--text-muted)", fontSize: 11 }}>
+                  Click to visit &rarr;
+                </span>
+              </div>
+            )}
             <div
               data-testid="link-preview-overlay"
               onClick={handleOverlayClick}


### PR DESCRIPTION
## Summary

- Adds hover-triggered iframe preview popups to Demo and Code links in the showcase dashboard grid
- Hovering a link for 300ms shows a 400×300 popup with a scaled-down (thumbnail) view of the target page
- Clicking the popup opens the URL in a new tab; moving away dismisses it after 200ms
- Includes loading state (pulsing indicator), fade-in on load, and "Preview unavailable" fallback after 8s timeout
- Only one popup visible at a time (singleton); touch devices skip previews entirely

## Test plan

- [ ] 16 unit tests covering: hover delay, dismiss timing, bridge gap, iframe src, click overlay, portal rendering, viewport flip, singleton, touch device exclusion, loading/loaded/unavailable states
- [ ] `vitest run` — 533 tests pass, 0 failures
- [ ] `tsc --noEmit` — no new type errors
- [ ] `next build` — builds successfully
- [ ] Manual smoke test: hover delay, dismiss, bridge gap, click-through, singleton, loading states all verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)