### PR TITLE
fix(ci): correct zizmor-action input names

### DIFF
--- a/.github/workflows/security_zizmor.yml
+++ b/.github/workflows/security_zizmor.yml
@@ -52,11 +52,11 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        # `min_severity: low` blocks PRs on the broadest set of findings
+        # `min-severity: low` blocks PRs on the broadest set of findings
         # without flagging hypothetical-only `informational` notes. Drop
         # to `medium` if low-severity churn becomes a problem.
         uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727 # v0.5.4
         with:
-          min_severity: low
-          advanced_security: false
+          min-severity: low
+          advanced-security: false
           config: .github/zizmor.yml


### PR DESCRIPTION
## Summary

The zizmor-action inputs use **hyphens** (`min-severity`, `advanced-security`), not underscores. The workflow had `min_severity` and `advanced_security`, which were silently ignored by the action.

Because `advanced-security: false` was never applied, the action defaulted to SARIF upload mode, which then failed because the job only grants `contents: read` (no `security-events: write`).

## What changed

- `min_severity` -> `min-severity`
- `advanced_security` -> `advanced-security`
- Updated matching comment

## Verification

The post-job cleanup on the failing run explicitly warned:
```
Unexpected input(s) 'min_severity', 'advanced_security', valid inputs are
['inputs', 'online-audits', 'persona', 'min-severity', 'min-confidence',
'version', 'token', 'advanced-security', 'color', 'annotations', 'config',
'fail-on-no-inputs']
```