### PR TITLE
fix(ci): scope app token permissions in eval workflows

### DIFF
--- a/.github/workflows/showcase_eval.yml
+++ b/.github/workflows/showcase_eval.yml
@@ -554,6 +554,7 @@ jobs:
         with:
           app-id: 1108748
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          permission-checks: write
 
       - name: Update Check Run with results
         if: needs.dispatch-gate.outputs.check_run_id != ''

--- a/.github/workflows/showcase_eval_check.yml
+++ b/.github/workflows/showcase_eval_check.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           app-id: 1108748
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          permission-checks: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Create Check Run
         id: check-run


### PR DESCRIPTION
## Summary

Fixes 5 zizmor `github-app` findings across `showcase_eval.yml` and `showcase_eval_check.yml`.

Both workflows use `actions/create-github-app-token` without explicit `permission-*` inputs, causing the generated token to inherit **all** installation permissions instead of only what the downstream steps need.

## Changes

**`showcase_eval.yml`** (post-result job) — token used for `checks.update()`:
- Added `permission-checks: write`

**`showcase_eval_check.yml`** (create-check job) — token used for `checks.create()`, `issues.listComments/createComment/updateComment`:
- Added `permission-checks: write`
- Added `permission-issues: write`
- Added `permission-pull-requests: write`

## Test plan

- [ ] `showcase_eval_check.yml` is currently gated by `if: false` so no runtime impact
- [ ] `showcase_eval.yml` post-result job: trigger via `/eval` comment on a test PR and verify the Check Run updates correctly
- [ ] Confirm zizmor no longer flags these files for `github-app`