### PR TITLE
fix(ci): scope devops-bot app token permissions

### DIFF
--- a/.github/workflows/showcase_capture-previews.yml
+++ b/.github/workflows/showcase_capture-previews.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           app-id: "1108748"
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -81,6 +81,8 @@ jobs:
         with:
           app-id: 1108748
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       # Create PR. For action=auto_push (no review items) the PR is
       # auto-merged via the devops bot (bypasses branch protection). For


### PR DESCRIPTION
Last 2 zizmor github-app findings — devops-bot tokens in capture-previews and docs-sync need scoped permissions.

- **capture-previews**: token used for checkout + git push to main → `permission-contents: write`
- **docs-sync**: token used for git push + PR create/list/merge → `permission-contents: write` + `permission-pull-requests: write`