### PR TITLE
fix(showcase/shared-state): Added missing useAgent imports

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/adk/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/shared-state/in-app-agent-read.mdx
@@ -100,7 +100,7 @@ state updates, you can reflect these updates natively in your application.
     optionally provide an initial state.
 
     ```tsx title="ui/app/page.tsx"
-
+    import { useAgent } from "@copilotkit/react-core/v2";
     // Define the agent state type, should match the actual state of your agent
     type AgentState = {
       language: "english" | "spanish";
@@ -148,6 +148,8 @@ You can also render the agent's state in the chat UI. This is useful for informi
 more in-context way. To do this, you can use the `useAgent` hook with a `render` function.
 
 ```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2";
+
 // Define the agent state type, should match the actual state of your agent
 type AgentState = {
   language: "english" | "spanish";

--- a/showcase/shell-docs/src/content/docs/integrations/adk/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/shared-state/in-app-agent-write.mdx
@@ -100,6 +100,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
     will update the agent state and trigger a rerender of anything that depends on the agent state.
 
     ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2";
 
     // Define the agent state type, should match the actual state of your agent
     type AgentState = {
@@ -155,6 +156,8 @@ If you want to re-run it manually, use `copilotkit.runAgent()`.
 The agent will be re-run with the latest updated state. You can also add a hint message before re-running.
 
 ```tsx title="ui/app/page.tsx"
+
+import { useAgent } from "@copilotkit/react-core/v2";
 
 // ...
 

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/shared-state/in-app-agent-read.mdx
@@ -84,6 +84,7 @@ state updates, you can reflect these updates natively in your application.
     optionally provide an initial state.
 
     ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2";
 
     // Define the agent state type to match your Strands agent
     type AgentState = {
@@ -131,6 +132,8 @@ You can also render the agent state in the chat UI. This is useful for informing
 more in-context way. To do this, you can use the `useAgent` hook with a `render` function.
 
 ```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2";
+
 // Define the agent state type, should match the actual state of your agent
 type AgentState = {
   language: "english" | "spanish";

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/shared-state/in-app-agent-write.mdx
@@ -83,7 +83,8 @@ You can use this when you want to provide user input or control to your agent's 
     use `agent.setState` to update the agent state.
 
     ```tsx title="ui/app/page.tsx"
-
+    import { useAgent } from "@copilotkit/react-core/v2";
+    
     // Define the agent state type to match your Strands agent
     type AgentState = {
       language: "english" | "spanish";

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/shared-state/in-app-agent-read.mdx
@@ -66,6 +66,7 @@ state updates, you can reflect these updates natively in your application.
     optionally provide an initial state.
 
     ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2";
 
     // Define the agent state type, should match the actual state of your agent
     type AgentState = {
@@ -109,6 +110,8 @@ You can also render the agent's state in the chat UI. This is useful for informi
 more in-context way. To do this, you can use the `useAgent` hook with a `render` function.
 
 ```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2";
+
 // Define the agent state type, should match the actual state of your agent
 type AgentState = {
   language: "english" | "spanish";

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/shared-state/in-app-agent-write.mdx
@@ -64,6 +64,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
     will update the agent state and trigger a rerender of anything that depends on the agent state.
 
     ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2";
 
     // Define the agent state type, should match the actual state of your agent
     type AgentState = {
@@ -115,6 +116,7 @@ If you want to re-run it manually, use `copilotkit.runAgent()`.
 The agent will be re-run with the latest updated state. You can also add a hint message before re-running.
 
 ```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2";
 
 // ...
 

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/in-app-agent-read.mdx
@@ -89,7 +89,7 @@ state updates, you can reflect these updates natively in your application.
 
     ```tsx title="ui/app/page.tsx"
     "use client";
-
+    import { useAgent } from "@copilotkit/react-core/v2";
 
     // Define the agent state type, should match the actual state of your agent
     type AgentState = {
@@ -138,6 +138,8 @@ You can also render the agent's state in the chat UI. This is useful for informi
 more in-context way. To do this, you can use the `useAgent` hook with a `render` function.
 
 ```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2";
+
 // Define the agent state type, should match the actual state of your agent
 type AgentState = {
   language: "english" | "spanish";

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/in-app-agent-write.mdx
@@ -88,7 +88,7 @@ You can use this when you want to provide user input or control to your agent's 
 
     ```tsx title="ui/app/page.tsx"
     "use client";
-
+    import { useAgent } from "@copilotkit/react-core/v2";
 
     // Define the agent state type, should match the actual state of your agent
     type AgentState = {
@@ -148,6 +148,7 @@ If you want to re-run it manually, use `copilotkit.runAgent()`.
 The agent will be re-run with the latest updated state. You can also add a hint message before re-running.
 
 ```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2";
 
 // ...
 

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-read.mdx
@@ -90,6 +90,7 @@ state updates, you can reflect these updates natively in your application.
     optionally provide an initial state.
 
     ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2";
 
     function YourMainContent() {
       // [!code highlight:5]
@@ -129,6 +130,8 @@ You can also render the working memory in the chat UI. This is useful for inform
 more in-context way. To do this, you can use the `useAgent` hook with a `render` function.
 
 ```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2";
+
 // Define the agent state type, should match the actual state of your agent
 type AgentState = {
   language: "english" | "spanish";

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-write.mdx
@@ -89,6 +89,7 @@ You can use this when you want to provide user input or control to your agent's 
     use `agent.setState` to update the agent state.
 
     ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2"; 
 
     function YourMainContent() {
       // [!code highlight:5]

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/shared-state/in-app-agent-read.mdx
@@ -151,6 +151,7 @@ state updates, you can reflect these updates natively in your application.
     optionally provide an initial state.
 
     ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2";
 
     // Define the agent state type, should match the actual state of your agent
     type AgentState = {
@@ -204,6 +205,8 @@ You can also render the agent's state in the chat UI. This is useful for informi
 more in-context way. To do this, you can use the `useAgent` hook with a `render` function.
 
 ```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2";
+
 // Define the agent state type, should match the actual state of your agent
 type AgentState = {
   language: "english" | "spanish";

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-read.mdx
@@ -89,6 +89,7 @@ state updates, you can reflect these updates natively in your application.
     optionally provide an initial state.
 
     ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2";
 
     // Define the agent state type, should match the actual state of your agent
     type AgentState = {
@@ -137,6 +138,8 @@ You can also render the agent's state in the chat UI. This is useful for informi
 more in-context way. To do this, you can use the `useAgent` hook with a `render` function.
 
 ```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2";
+
 // Define the agent state type, should match the actual state of your agent
 type AgentState = {
   language: "english" | "spanish";

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-write.mdx
@@ -89,6 +89,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
     will update the agent state and trigger a rerender of anything that depends on the agent state.
 
     ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2";
 
     // Define the agent state type, should match the actual state of your agent
     type AgentState = {
@@ -144,6 +145,7 @@ If you want to re-run it manually, use `copilotkit.runAgent()`.
 The agent will be re-run with the latest updated state. You can also add a hint message before re-running.
 
 ```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2";
 
 // ...
 


### PR DESCRIPTION
## Summary
`useAgent` import is missing in code snippets of 'Shared State' Section of some frameworks. Added it where it was needed for the code to work

## Changes
- **Google ADK** 
    Reading Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
    Writing  Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
- **Mastra**
    Reading Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
    Writing  Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
- **CrewAI (Crews)**
    Reading Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
    Writing  Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
- **PydanticAI**
    Reading Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
    Writing  Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
- **LlamaIndex**
    Reading Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
    Writing  Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
- **AWS Strands**
    Reading Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
    Writing  Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`
- **MS Agent Framework** 
    Reading Agent State Code Example: Added `import { useAgent } from "@copilotkit/react-core/v2";`