### PR TITLE
fix(showcase/shell-dashboard): add LinkPreview to UnifiedCell

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
@@ -10,6 +10,7 @@
  *   5. Hides badges when health overlay is not active
  *   6. Hides depth chip when depth overlay is not active
  */
+import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 import { UnifiedCell } from "../unified-cell";
@@ -72,6 +73,16 @@ vi.mock("@/components/command-cell", () => ({
   CommandCell: vi.fn(({ ctx }: { ctx: CellContext }) => (
     <div data-testid="mock-command-cell">{ctx.demo.command}</div>
   )),
+}));
+
+vi.mock("@/components/link-preview", () => ({
+  LinkPreview: vi.fn(
+    ({ children, href }: { children: React.ReactNode; href: string }) => (
+      <span data-testid="mock-link-preview" data-href={href}>
+        {children}
+      </span>
+    ),
+  ),
 }));
 
 vi.mock("@/components/cell-pieces", () => ({

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -22,6 +22,7 @@ import type { Overlay } from "@/lib/overlay-types";
 import { CellDrilldown } from "@/components/cell-drilldown";
 import { CommandCell } from "@/components/command-cell";
 import { DocsRow, urlsFor } from "@/components/cell-pieces";
+import { LinkPreview } from "@/components/link-preview";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -82,24 +83,28 @@ function LinksLayer({ ctx }: { ctx: CellContext }) {
 
   return (
     <div className="flex items-center justify-center gap-1.5">
-      <a
-        href={links.demoUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="whitespace-nowrap text-[var(--accent)] hover:underline"
-      >
-        <span className="text-[var(--text-muted)]">Demo</span>{" "}
-        <span>&#8599;</span>
-      </a>
-      <a
-        href={links.codeUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="whitespace-nowrap text-[var(--accent)] hover:underline"
-      >
-        <span className="text-[var(--text-muted)]">Code</span>{" "}
-        <span>{"</>"}</span>
-      </a>
+      <LinkPreview href={links.demoUrl}>
+        <a
+          href={links.demoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="whitespace-nowrap text-[var(--accent)] hover:underline"
+        >
+          <span className="text-[var(--text-muted)]">Demo</span>{" "}
+          <span>&#8599;</span>
+        </a>
+      </LinkPreview>
+      <LinkPreview href={links.codeUrl}>
+        <a
+          href={links.codeUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="whitespace-nowrap text-[var(--accent)] hover:underline"
+        >
+          <span className="text-[var(--text-muted)]">Code</span>{" "}
+          <span>{"</>"}</span>
+        </a>
+      </LinkPreview>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- PR #4864 added LinkPreview to the deprecated `ComposedCell` but production uses `UnifiedCell`
- This adds the same `LinkPreview` wrapping to `unified-cell.tsx` so hover previews work in production

## Test plan

- [ ] 14 unified-cell tests pass with link-preview mock
- [ ] Manual verification on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)