### PR TITLE
Add top-level permissions to 4 workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,6 +20,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - "packages/**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: publish-release
   cancel-in-progress: false

--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -8,6 +8,9 @@ on:
       - "docs/snippets/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: showcase-docs-sync
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` at the top level of prerelease.yml, publish-commit.yml, publish-release.yml, and showcase_docs-sync.yml
- All four workflows already have job-level permissions blocks; the top-level block constrains the default token scope for any future jobs that might be added without explicit permissions

## Test plan
- [ ] Verify prerelease workflow_dispatch still works
- [ ] Verify publish-commit still posts snapshot comments (job-level `pull-requests: write` preserved)
- [ ] Verify publish-release still reads content on PR merge
- [ ] Verify showcase docs-sync still creates PRs (job-level `contents: write` + `pull-requests: write` preserved)