### PR TITLE
Add GitHub Environment protection to publish/deploy workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -86,6 +86,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: npm
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -23,6 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: npm
     permissions:
       contents: read
       # pkg-pr-new posts snapshot comments on the PR using the workflow token

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -80,6 +80,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: npm
     permissions:
       contents: write
     steps:

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -160,6 +160,7 @@ jobs:
     if: needs.resolve-matrix.outputs.has_services == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: railway
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -40,6 +40,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: npm
     steps:
       - name: Check for existing release PR
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7


### PR DESCRIPTION
## Summary

- Add `environment:` declarations to all 5 publish/deploy jobs across CopilotKit workflows
- This enables GitHub Environment protection rules (required reviewers, deployment branch policies, wait timers) to gate package publishing and Railway deploys

### Workflows updated

| Workflow | Job | Environment |
|----------|-----|-------------|
| prerelease.yml | publish | npm |
| publish-commit.yml | build | npm |
| publish-release.yml | publish | npm |
| stable-release.yml | create-release-pr | npm |
| showcase_deploy.yml | verify | railway |

### Environments created

- `npm` - for TypeScript package publishing
- `railway` - for showcase deployment verification

### Next steps

After merging, add required reviewers to each environment via repo Settings > Environments.

## Test plan

- [ ] Verify workflow YAML is valid (no syntax errors)
- [ ] Confirm environments exist in repo settings
- [ ] Test a dry-run prerelease to verify environment gates work