### PR TITLE
fix(ci): scope git config to --local in publish-release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -122,8 +122,8 @@ jobs:
 
       - name: Configure git user
         run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
 
       - name: Check for pre-existing tags
         run: |


### PR DESCRIPTION
## Summary

- Changed `git config --global` to `git config --local` for user.email and user.name in the publish job's "Configure git user" step
- `--global` persists credentials beyond the job into the runner environment; `--local` scopes them to the checkout directory only

## Test plan

- [ ] Verify next release publish still creates and pushes git tags correctly
- [ ] Confirm no other steps in the workflow depend on global git config