### PR TITLE
Pin aimock to 1.24.1 in doc-tests workflow

### DIFF
--- a/.github/workflows/test_integration-docs.yml
+++ b/.github/workflows/test_integration-docs.yml
@@ -54,7 +54,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Install and start aimock
         run: |
-          npm install -g @copilotkit/aimock@latest
+          npm install -g @copilotkit/aimock@1.24.1
           AIMOCK_BIN=$(npm root -g)/../bin/aimock
           echo "aimock binary: $AIMOCK_BIN"
           ls -la "$AIMOCK_BIN" || echo "binary not found at expected path"


### PR DESCRIPTION
## Summary
- Pin `@copilotkit/aimock` from `@latest` to `@1.24.1` in test_integration-docs.yml
- Prevents unexpected breakage from new aimock releases and makes CI builds reproducible

## Test plan
- Workflow-only change; the pinned version matches current latest (1.24.1)