### PR TITLE
fix(showcase): move @endregion marker after Chat closing brace in reasoning demos (cherry-pick of #4858)

### DIFF
--- a/showcase/integrations/ag2/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -54,5 +54,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/agno/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -55,5 +55,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/built-in-agent/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -45,5 +45,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/claude-sdk-python/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -31,5 +31,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -40,5 +40,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/crewai-crews/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -34,5 +34,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -65,5 +65,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/langgraph-typescript/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -51,5 +51,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/langroid/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -38,5 +38,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/llamaindex/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -51,5 +51,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/mastra/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/mastra/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -37,5 +37,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -51,5 +51,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/pydantic-ai/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -48,5 +48,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/spring-ai/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -51,5 +51,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/integrations/strands/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/strands/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -51,5 +51,5 @@ function Chat() {
       }}
     />
   );
-  // @endregion[reasoning-block-render]
 }
+// @endregion[reasoning-block-render]

--- a/showcase/shell-docs/src/content/docs/generative-ui/reasoning.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/reasoning.mdx
@@ -62,7 +62,14 @@ For full control over the reasoning card, pass a component to the
 `messages` list, and `isRunning`, enough to decide whether this block is
 still streaming and whether it's the active trailing message:
 
-<Snippet region="reasoning-block-render" title="frontend/src/app/page.tsx — custom reasoning slot" />
+<Tabs items={['page.tsx', 'reasoning-block.tsx']}>
+  <Tab value="page.tsx">
+    <Snippet region="reasoning-block-render" noCaption />
+  </Tab>
+  <Tab value="reasoning-block.tsx">
+    <Snippet file="src/app/demos/agentic-chat-reasoning/reasoning-block.tsx" noCaption />
+  </Tab>
+</Tabs>
 
 The `ReasoningBlock` (imported above) renders the reasoning as an
 amber-tagged inline banner, intentionally louder than the default card


### PR DESCRIPTION
## Summary

Cherry-pick of #4858 (by @Abubakar-01) onto a maintainer-owned branch so CI can run with full token access. The original PR's CI was blocked at the Depot OIDC step because fork PRs don't receive the build tokens — the code itself is fine.

All credit to @Abubakar-01; commit authorship preserved.

## The fix

Region markers `@endregion[reasoning-block-render]` in 16 `agentic-chat-reasoning/page.tsx` demos closed **before** the enclosing `function Chat()`'s closing brace, so the rendered snippet had an unbalanced `{` and the closing `}` cut off mid-body. Moves each `@endregion` to after the function's closing brace so the snippet body is syntactically complete.

Matches the contiguous-region-wraps-imports-and-body convention established in #4829.

## Files changed

16 demo files across ag2, agno, built-in-agent, claude-sdk-python, claude-sdk-typescript, crewai-crews, google-adk, langgraph-fastapi, langgraph-python, langgraph-typescript, langroid, llamaindex, mastra, ms-agent-python, pydantic-ai, spring-ai, strands — each `src/app/demos/agentic-chat-reasoning/page.tsx` gets the same single-line marker move.

## Test plan

- [ ] Bundle regenerates clean: `pnpm tsx showcase/scripts/bundle-demo-content.ts`
- [ ] Sample 3 `reasoning-block-render` region bodies in `demo-content.json` — each should now contain a balanced `function Chat() { ... }`
- [ ] `/{framework}/generative-ui/reasoning` (or wherever the snippet is rendered) shows the full Chat function

## Original PR

Closes #4858 in favor of this maintainer-branch version. CI on fork PRs is blocked on Depot OIDC + Vercel deploy authorization, neither of which we can override per-PR.
