### PR TITLE
fix(showcase/langgraph-typescript): update chat-slots manifest highlight path

### DIFF
--- a/showcase/integrations/langgraph-typescript/manifest.yaml
+++ b/showcase/integrations/langgraph-typescript/manifest.yaml
@@ -235,7 +235,7 @@ demos:
     highlight:
       - src/agent/graph.ts
       - src/app/demos/chat-slots/page.tsx
-      - src/app/demos/chat-slots/custom-welcome-screen.tsx
+      - src/app/demos/chat-slots/slot-wrappers.tsx
       - src/app/api/copilotkit/route.ts
   - id: chat-customization-css
     name: Chat Customization (CSS)


### PR DESCRIPTION
Fix stale highlight path in manifest — `custom-welcome-screen.tsx` was deleted when chat-slots was aligned to LGP's SlotMarker system. Updated to `slot-wrappers.tsx`. Fixes the Showcase: Validate CI failure from PR #4879.