### PR TITLE
fix(showcase): include tool implementations in tool-rendering highlight

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -3055,6 +3055,7 @@
     {
       "match": {
         "userMessage": "intro call with the sales team",
+        "toolName": "book_call",
         "hasToolResult": false
       },
       "response": {
@@ -3075,6 +3076,7 @@
     {
       "match": {
         "userMessage": "1:1 with Alice",
+        "toolName": "book_call",
         "hasToolResult": false
       },
       "response": {

--- a/showcase/integrations/ag2/manifest.yaml
+++ b/showcase/integrations/ag2/manifest.yaml
@@ -140,6 +140,10 @@ demos:
     animated_preview_url:
     highlight:
       - src/agents/agent.py
+      - tools/get_weather.py
+      - tools/query_data.py
+      - tools/schedule_meeting.py
+      - tools/search_flights.py
       - src/app/demos/tool-rendering/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering-default-catchall

--- a/showcase/integrations/agno/manifest.yaml
+++ b/showcase/integrations/agno/manifest.yaml
@@ -93,6 +93,10 @@ demos:
     animated_preview_url:
     highlight:
       - src/agents/main.py
+      - tools/get_weather.py
+      - tools/query_data.py
+      - tools/schedule_meeting.py
+      - tools/search_flights.py
       - src/app/demos/tool-rendering/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: gen-ui-agent

--- a/showcase/integrations/crewai-crews/manifest.yaml
+++ b/showcase/integrations/crewai-crews/manifest.yaml
@@ -177,6 +177,10 @@ demos:
     animated_preview_url:
     highlight:
       - src/agents/tools/custom_tool.py
+      - tools/get_weather.py
+      - tools/query_data.py
+      - tools/schedule_meeting.py
+      - tools/search_flights.py
       - src/app/demos/tool-rendering/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering-default-catchall

--- a/showcase/integrations/langroid/manifest.yaml
+++ b/showcase/integrations/langroid/manifest.yaml
@@ -136,6 +136,10 @@ demos:
     animated_preview_url:
     highlight:
       - src/agents/agent.py
+      - tools/get_weather.py
+      - tools/query_data.py
+      - tools/schedule_meeting.py
+      - tools/search_flights.py
       - src/app/demos/tool-rendering/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: gen-ui-tool-based

--- a/showcase/integrations/llamaindex/manifest.yaml
+++ b/showcase/integrations/llamaindex/manifest.yaml
@@ -196,6 +196,10 @@ demos:
     animated_preview_url:
     highlight:
       - src/agents/agent.py
+      - tools/get_weather.py
+      - tools/query_data.py
+      - tools/schedule_meeting.py
+      - tools/search_flights.py
       - src/app/demos/tool-rendering/agent.py
       - src/app/demos/tool-rendering/page.tsx
       - src/app/api/copilotkit/route.ts

--- a/showcase/integrations/mastra/manifest.yaml
+++ b/showcase/integrations/mastra/manifest.yaml
@@ -121,6 +121,10 @@ demos:
     animated_preview_url:
     highlight:
       - src/mastra/tools/index.ts
+      - shared-tools/get-weather.ts
+      - shared-tools/query-data.ts
+      - shared-tools/schedule-meeting.ts
+      - shared-tools/search-flights.ts
       - src/app/demos/tool-rendering/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering-default-catchall

--- a/showcase/integrations/ms-agent-python/manifest.yaml
+++ b/showcase/integrations/ms-agent-python/manifest.yaml
@@ -205,6 +205,10 @@ demos:
     animated_preview_url:
     highlight:
       - src/agents/agent.py
+      - tools/get_weather.py
+      - tools/query_data.py
+      - tools/schedule_meeting.py
+      - tools/search_flights.py
       - src/app/demos/tool-rendering/page.tsx
   - id: gen-ui-agent
     name: Agentic Generative UI

--- a/showcase/integrations/ms-agent-python/manifest.yaml
+++ b/showcase/integrations/ms-agent-python/manifest.yaml
@@ -281,9 +281,7 @@ demos:
     highlight:
       - src/agents/agent.py
       - src/app/demos/chat-slots/page.tsx
-      - src/app/demos/chat-slots/custom-welcome-screen.tsx
-      - src/app/demos/chat-slots/custom-assistant-message.tsx
-      - src/app/demos/chat-slots/custom-disclaimer.tsx
+      - src/app/demos/chat-slots/slot-wrappers.tsx
       - src/app/api/copilotkit/route.ts
   - id: headless-simple
     name: Headless Chat (Simple)
@@ -306,8 +304,11 @@ demos:
     highlight:
       - src/agents/agent.py
       - src/app/demos/headless-complete/page.tsx
-      - src/app/demos/headless-complete/message-list.tsx
-      - src/app/demos/headless-complete/use-rendered-messages.tsx
+      - src/app/demos/headless-complete/chat/chat.tsx
+      - src/app/demos/headless-complete/hooks/use-tool-renderers.tsx
+      - src/app/demos/headless-complete/hooks/use-frontend-components.ts
+      - src/app/demos/headless-complete/hooks/use-headless-suggestions.ts
+      - src/app/demos/headless-complete/attachments/use-attachments-config.ts
       - src/app/api/copilotkit/route.ts
   - id: agentic-chat-reasoning
     name: Reasoning

--- a/showcase/integrations/pydantic-ai/manifest.yaml
+++ b/showcase/integrations/pydantic-ai/manifest.yaml
@@ -220,6 +220,10 @@ demos:
     animated_preview_url:
     highlight:
       - src/agents/agent.py
+      - tools/get_weather.py
+      - tools/query_data.py
+      - tools/schedule_meeting.py
+      - tools/search_flights.py
       - src/app/demos/tool-rendering/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering-default-catchall

--- a/showcase/integrations/strands/manifest.yaml
+++ b/showcase/integrations/strands/manifest.yaml
@@ -257,6 +257,10 @@ demos:
     animated_preview_url:
     highlight:
       - src/agents/agent.py
+      - tools/get_weather.py
+      - tools/query_data.py
+      - tools/schedule_meeting.py
+      - tools/search_flights.py
       - src/app/demos/tool-rendering/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering-default-catchall


### PR DESCRIPTION
## Summary

Original intent: make 9 integrations' Tool Rendering demos show the tool implementations they import (QA team finding).

Scope grew to also unblock the bundler from two pre-existing drift sources that landed earlier today and were silently blocking shell rebuilds.

### Commits

1. **`fix(showcase): include tool implementations in tool-rendering highlight`**
   Adds `tools/get_weather.py`, `tools/query_data.py`, `tools/schedule_meeting.py`, `tools/search_flights.py` (or the `.ts` equivalents under `shared-tools/` for mastra) to the `highlight:` array of each integration's `tool-rendering` demo. Reasoning-chain and catch-all variants intentionally left alone (reasoning-chain defines its tools inline; catch-all variants teach generic handling and would be undercut by per-tool detail).
   Integrations: `ag2`, `agno`, `crewai-crews`, `langroid`, `llamaindex`, `ms-agent-python`, `pydantic-ai`, `strands`, `mastra`.

2. **`fix(showcase/ms-agent-python): repair stale chat-slots and headless-complete highlights`**
   Two manifest entries in `ms-agent-python` pointed at filenames that no longer exist on disk after PR #4895's port. The bundler refused to build the shell once any manifest in `ms-agent-python` changed. Adopted LGP's canonical highlight pattern for both demos.

3. **`fix(showcase/aimock): scope hitl book_call fixtures to toolName`**
   Two recorded d5 fixtures matching `"1:1 with Alice"` and `"intro call with the sales team"` returned `book_call` tool calls without a `toolName` constraint. The fixture-tool-surface validator flagged ~30 violations across most integrations because `gen-ui-interrupt` and `interrupt-headless` use `schedule_meeting`, not `book_call`. Adding `toolName: "book_call"` scopes the fixtures to hitl-in-chat only.

## Why this PR grew

The QA-team finding only required commit 1. Commits 2 and 3 are pre-existing drift that surfaced because commit 1's manifest edits triggered the shell rebuild and the `validate-fixture-tool-surface` check. Both pre-existing failures had been red on main for several hours and were inherited by every PR. Fixing them inline was the only path to a green CI on this branch.

## Test plan

- [x] All 36 added `tools/` paths exist on disk.
- [x] `showcase/scripts/bundle-demo-content.ts` runs clean (697 demos bundled across all three shells).
- [x] `showcase/scripts/validate-fixture-tool-surface.ts` runs clean (367 fixtures × 622 demos, no drift).