### PR TITLE
fix(ci): unblock main formatter + harden auto-commit step

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -145,7 +145,13 @@ jobs:
             echo "No formatting changes to commit"
             exit 0
           fi
-          git diff --name-only -z | xargs -0 git add
+          # Stage only the files the formatter was scoped to operate on.
+          # Piping `git diff --name-only` into `git add` is unsafe: if a
+          # tracked-but-gitignored path shows up in the diff, `git add`
+          # aborts the whole step and the auto-fix push never lands —
+          # leaving formatting violations on the PR branch and (post-
+          # merge) on main.
+          xargs -a .pr-format-files.existing.txt git add --
           git commit -m "style: auto-fix formatting"
           git push
 

--- a/showcase/integrations/langgraph-python/tests/e2e/chat-customization-css.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/chat-customization-css.spec.ts
@@ -81,10 +81,7 @@ test.describe("Chat Customization (CSS)", () => {
     // `background: transparent` and styles the inner bg-muted child with
     // `var(--halcyon-paper-elevated)` (#fbf8f2) plus a 2px ember left border.
     // Assert the outer wrapper is transparent.
-    await expect(userMsg).toHaveCSS(
-      "background-color",
-      "rgba(0, 0, 0, 0)",
-    );
+    await expect(userMsg).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   });
 
   test("assistant bubble uses transparent background after round-trip", async ({
@@ -102,9 +99,6 @@ test.describe("Chat Customization (CSS)", () => {
     // `background: transparent` — editorial serif text with no bubble, just
     // an ember left-rule via ::before. The default CopilotKit assistant has
     // a visible background, so transparent proves the theme won the cascade.
-    await expect(assistant).toHaveCSS(
-      "background-color",
-      "rgba(0, 0, 0, 0)",
-    );
+    await expect(assistant).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   });
 });

--- a/showcase/integrations/langgraph-python/tests/e2e/prebuilt-popup.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/prebuilt-popup.spec.ts
@@ -76,7 +76,9 @@ test.describe("Pre-Built Popup", () => {
     // Playwright's pointer-based click, so use a JS-level .click() that
     // bypasses the overlay (same pattern as _genuine-shared.ts:clickByJs).
     await page.evaluate(() => {
-      const btn = document.querySelector('[data-testid="copilot-close-button"]');
+      const btn = document.querySelector(
+        '[data-testid="copilot-close-button"]',
+      );
       if (btn) (btn as HTMLElement).click();
     });
     await expect(popup).toBeHidden({ timeout: 10000 });

--- a/showcase/integrations/langgraph-python/tests/e2e/prebuilt-sidebar.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/prebuilt-sidebar.spec.ts
@@ -79,7 +79,9 @@ test.describe("Pre-Built Sidebar", () => {
     // JS-level .click() that bypasses the overlay (same pattern as the
     // harness probes in _genuine-shared.ts:clickByJs).
     await page.evaluate(() => {
-      const btn = document.querySelector('[data-testid="copilot-close-button"]');
+      const btn = document.querySelector(
+        '[data-testid="copilot-close-button"]',
+      );
       if (btn) (btn as HTMLElement).click();
     });
 

--- a/showcase/integrations/langgraph-typescript/package.json
+++ b/showcase/integrations/langgraph-typescript/package.json
@@ -32,19 +32,16 @@
     "langchain": "1.3.4",
     "lucide-react": "^0.460.0",
     "next": "^15.5.15",
-    "radix-ui": "^1.4.3",
-    "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1",
     "openai": "^5.9.0",
     "pdf-parse": "^1.1.1",
+    "radix-ui": "^1.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-markdown": "^10.1.0",
     "recharts": "^2.15.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.5",
     "zod": "^3.24.0"
-  },
-  "overrides": {
-    "@ag-ui/langgraph": "0.0.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",
@@ -56,5 +53,8 @@
     "postcss": "^8.5.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "@ag-ui/langgraph": "0.0.32"
   }
 }

--- a/showcase/integrations/langgraph-typescript/src/agent/gen-ui-agent.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/gen-ui-agent.ts
@@ -15,7 +15,11 @@ import { z } from "zod";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { tool } from "@langchain/core/tools";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
-import { AIMessage, SystemMessage, ToolMessage } from "@langchain/core/messages";
+import {
+  AIMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
 import type { ToolRunnableConfig } from "@langchain/core/tools";
 import {
   Annotation,
@@ -48,7 +52,7 @@ const AgentStateAnnotation = Annotation.Root({
   ...CopilotKitStateAnnotation.spec,
   // Last-write-wins reducer: each set_steps call replaces the full list.
   steps: Annotation<Step[]>({
-    reducer: (_prev, next) => (next != null ? next : _prev ?? []),
+    reducer: (_prev, next) => (next != null ? next : (_prev ?? [])),
     default: () => [],
   }),
 });

--- a/showcase/integrations/langgraph-typescript/src/agent/package.json
+++ b/showcase/integrations/langgraph-typescript/src/agent/package.json
@@ -19,10 +19,10 @@
     "typescript": "^5.6.3",
     "zod": "^3.23.8"
   },
-  "overrides": {
-    "@ag-ui/langgraph": "0.0.32"
-  },
   "devDependencies": {
     "@types/node": "^22.9.0"
+  },
+  "overrides": {
+    "@ag-ui/langgraph": "0.0.32"
   }
 }

--- a/showcase/integrations/langgraph-typescript/src/agent/shared-state-streaming.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/shared-state-streaming.ts
@@ -19,7 +19,11 @@ import { z } from "zod";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { tool } from "@langchain/core/tools";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
-import { AIMessage, SystemMessage, ToolMessage } from "@langchain/core/messages";
+import {
+  AIMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
 import type { ToolRunnableConfig } from "@langchain/core/tools";
 import {
   Annotation,

--- a/showcase/integrations/langgraph-typescript/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/beautiful-chat/page.tsx
@@ -59,7 +59,10 @@ function HomePage() {
   return (
     <ExampleLayout
       chatContent={
-        <CopilotChat attachments={{ enabled: true }} input={{ disclaimer: () => null, className: "pb-6" }} />
+        <CopilotChat
+          attachments={{ enabled: true }}
+          input={{ disclaimer: () => null, className: "pb-6" }}
+        />
       }
       appContent={<ExampleCanvas />}
     />

--- a/showcase/integrations/langgraph-typescript/src/app/demos/declarative-json-render/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/declarative-json-render/page.tsx
@@ -27,7 +27,10 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-declarative-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-declarative-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/integrations/langgraph-typescript/tests/e2e/chat-customization-css.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/chat-customization-css.spec.ts
@@ -81,10 +81,7 @@ test.describe("Chat Customization (CSS)", () => {
     // `background: transparent` and styles the inner bg-muted child with
     // `var(--halcyon-paper-elevated)` (#fbf8f2) plus a 2px ember left border.
     // Assert the outer wrapper is transparent.
-    await expect(userMsg).toHaveCSS(
-      "background-color",
-      "rgba(0, 0, 0, 0)",
-    );
+    await expect(userMsg).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   });
 
   test("assistant bubble uses transparent background after round-trip", async ({
@@ -102,9 +99,6 @@ test.describe("Chat Customization (CSS)", () => {
     // `background: transparent` — editorial serif text with no bubble, just
     // an ember left-rule via ::before. The default CopilotKit assistant has
     // a visible background, so transparent proves the theme won the cascade.
-    await expect(assistant).toHaveCSS(
-      "background-color",
-      "rgba(0, 0, 0, 0)",
-    );
+    await expect(assistant).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   });
 });

--- a/showcase/integrations/langgraph-typescript/tests/e2e/prebuilt-popup.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/prebuilt-popup.spec.ts
@@ -76,7 +76,9 @@ test.describe("Pre-Built Popup", () => {
     // Playwright's pointer-based click, so use a JS-level .click() that
     // bypasses the overlay (same pattern as _genuine-shared.ts:clickByJs).
     await page.evaluate(() => {
-      const btn = document.querySelector('[data-testid="copilot-close-button"]');
+      const btn = document.querySelector(
+        '[data-testid="copilot-close-button"]',
+      );
       if (btn) (btn as HTMLElement).click();
     });
     await expect(popup).toBeHidden({ timeout: 10000 });

--- a/showcase/integrations/langgraph-typescript/tests/e2e/prebuilt-sidebar.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/prebuilt-sidebar.spec.ts
@@ -79,7 +79,9 @@ test.describe("Pre-Built Sidebar", () => {
     // JS-level .click() that bypasses the overlay (same pattern as the
     // harness probes in _genuine-shared.ts:clickByJs).
     await page.evaluate(() => {
-      const btn = document.querySelector('[data-testid="copilot-close-button"]');
+      const btn = document.querySelector(
+        '[data-testid="copilot-close-button"]',
+      );
       if (btn) (btn as HTMLElement).click();
     });
 


### PR DESCRIPTION
## Summary

Main has been red on `static / quality → format` since 2026-05-18 14:24Z. The first red push was the merge of PR #4879, and every push since has stayed red on the same 12 unformatted files under `showcase/integrations/{langgraph-python,langgraph-typescript}`.

This PR does two things:

1. **Unblocks main** — runs `oxfmt --write` against the 12 files the push-scope check is failing on. Pure formatting (key reordering, line wrapping); no behavior changes.

2. **Hardens the format job's auto-commit step** — `Commit formatting fixes` previously fed `git diff --name-only` into `git add`. If a tracked-but-gitignored path showed up in the diff, `git add` refused it and the whole step aborted (exit 123), so the auto-fix commit never reached the PR branch. That's how #4879 was merged with 12 unformatted files: the PR's `oxfmt --write` had fixed them, but the auto-commit blew up on `showcase/aimock/d5-recorded/recorded` and the fixes were never pushed back.

The step now stages only paths from `.pr-format-files.existing.txt` — the same scoped list the formatter operates on — so unrelated working-tree diffs can no longer poison the commit.

## Verification

- `oxfmt --check .` passes on this branch (9152 files).
- After merge, the next `static / quality` push run on main should go green.

## Follow-ups (out of scope)

- Make `format` a required status check on main so a red format job blocks merge.
- Decide whether `showcase/aimock/d5-recorded/recorded` should be untracked or its ignore rule adjusted.