### PR TITLE
fix(ci): unblock main format check + harden auto-commit step

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -110,7 +110,15 @@ jobs:
             if [ -n "$py_files" ]; then
               echo "$py_files" | xargs ruff format || echo "::warning::ruff format exited with error"
             fi
-            if [ -n "$(git diff --name-only)" ]; then
+            # Restrict the auto-commit to files we deliberately fed to oxfmt.
+            # `git diff` alone can also list tracked-but-gitignored paths oxfmt
+            # incidentally rewrote (e.g. fixtures under a `recorded/` ignore
+            # rule); `git add` refuses ignored paths, and that exit-1 propagates
+            # through xargs as 123 and kills the commit step.
+            git diff --name-only \
+              | grep -Fxf .pr-format-files.existing.txt \
+              > .pr-format-files.modified.txt || true
+            if [ -s .pr-format-files.modified.txt ]; then
               echo "format_fixed=true" >> $GITHUB_ENV
             fi
             # Check mode: verify everything is formatted
@@ -141,11 +149,11 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         run: |
-          if [ -z "$(git diff --name-only)" ]; then
+          if [ ! -s .pr-format-files.modified.txt ]; then
             echo "No formatting changes to commit"
             exit 0
           fi
-          git diff --name-only -z | xargs -0 git add
+          xargs -a .pr-format-files.modified.txt git add
           git commit -m "style: auto-fix formatting"
           git push
 

--- a/showcase/integrations/langgraph-python/tests/e2e/chat-customization-css.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/chat-customization-css.spec.ts
@@ -81,10 +81,7 @@ test.describe("Chat Customization (CSS)", () => {
     // `background: transparent` and styles the inner bg-muted child with
     // `var(--halcyon-paper-elevated)` (#fbf8f2) plus a 2px ember left border.
     // Assert the outer wrapper is transparent.
-    await expect(userMsg).toHaveCSS(
-      "background-color",
-      "rgba(0, 0, 0, 0)",
-    );
+    await expect(userMsg).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   });
 
   test("assistant bubble uses transparent background after round-trip", async ({
@@ -102,9 +99,6 @@ test.describe("Chat Customization (CSS)", () => {
     // `background: transparent` — editorial serif text with no bubble, just
     // an ember left-rule via ::before. The default CopilotKit assistant has
     // a visible background, so transparent proves the theme won the cascade.
-    await expect(assistant).toHaveCSS(
-      "background-color",
-      "rgba(0, 0, 0, 0)",
-    );
+    await expect(assistant).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   });
 });

--- a/showcase/integrations/langgraph-python/tests/e2e/prebuilt-popup.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/prebuilt-popup.spec.ts
@@ -76,7 +76,9 @@ test.describe("Pre-Built Popup", () => {
     // Playwright's pointer-based click, so use a JS-level .click() that
     // bypasses the overlay (same pattern as _genuine-shared.ts:clickByJs).
     await page.evaluate(() => {
-      const btn = document.querySelector('[data-testid="copilot-close-button"]');
+      const btn = document.querySelector(
+        '[data-testid="copilot-close-button"]',
+      );
       if (btn) (btn as HTMLElement).click();
     });
     await expect(popup).toBeHidden({ timeout: 10000 });

--- a/showcase/integrations/langgraph-python/tests/e2e/prebuilt-sidebar.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/prebuilt-sidebar.spec.ts
@@ -79,7 +79,9 @@ test.describe("Pre-Built Sidebar", () => {
     // JS-level .click() that bypasses the overlay (same pattern as the
     // harness probes in _genuine-shared.ts:clickByJs).
     await page.evaluate(() => {
-      const btn = document.querySelector('[data-testid="copilot-close-button"]');
+      const btn = document.querySelector(
+        '[data-testid="copilot-close-button"]',
+      );
       if (btn) (btn as HTMLElement).click();
     });
 

--- a/showcase/integrations/langgraph-typescript/package.json
+++ b/showcase/integrations/langgraph-typescript/package.json
@@ -32,19 +32,16 @@
     "langchain": "1.3.4",
     "lucide-react": "^0.460.0",
     "next": "^15.5.15",
-    "radix-ui": "^1.4.3",
-    "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1",
     "openai": "^5.9.0",
     "pdf-parse": "^1.1.1",
+    "radix-ui": "^1.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-markdown": "^10.1.0",
     "recharts": "^2.15.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.5",
     "zod": "^3.24.0"
-  },
-  "overrides": {
-    "@ag-ui/langgraph": "0.0.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",
@@ -56,5 +53,8 @@
     "postcss": "^8.5.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "@ag-ui/langgraph": "0.0.32"
   }
 }

--- a/showcase/integrations/langgraph-typescript/src/agent/gen-ui-agent.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/gen-ui-agent.ts
@@ -15,7 +15,11 @@ import { z } from "zod";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { tool } from "@langchain/core/tools";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
-import { AIMessage, SystemMessage, ToolMessage } from "@langchain/core/messages";
+import {
+  AIMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
 import type { ToolRunnableConfig } from "@langchain/core/tools";
 import {
   Annotation,
@@ -48,7 +52,7 @@ const AgentStateAnnotation = Annotation.Root({
   ...CopilotKitStateAnnotation.spec,
   // Last-write-wins reducer: each set_steps call replaces the full list.
   steps: Annotation<Step[]>({
-    reducer: (_prev, next) => (next != null ? next : _prev ?? []),
+    reducer: (_prev, next) => (next != null ? next : (_prev ?? [])),
     default: () => [],
   }),
 });

--- a/showcase/integrations/langgraph-typescript/src/agent/package.json
+++ b/showcase/integrations/langgraph-typescript/src/agent/package.json
@@ -19,10 +19,10 @@
     "typescript": "^5.6.3",
     "zod": "^3.23.8"
   },
-  "overrides": {
-    "@ag-ui/langgraph": "0.0.32"
-  },
   "devDependencies": {
     "@types/node": "^22.9.0"
+  },
+  "overrides": {
+    "@ag-ui/langgraph": "0.0.32"
   }
 }

--- a/showcase/integrations/langgraph-typescript/src/agent/shared-state-streaming.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/shared-state-streaming.ts
@@ -19,7 +19,11 @@ import { z } from "zod";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { tool } from "@langchain/core/tools";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
-import { AIMessage, SystemMessage, ToolMessage } from "@langchain/core/messages";
+import {
+  AIMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
 import type { ToolRunnableConfig } from "@langchain/core/tools";
 import {
   Annotation,

--- a/showcase/integrations/langgraph-typescript/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/beautiful-chat/page.tsx
@@ -59,7 +59,10 @@ function HomePage() {
   return (
     <ExampleLayout
       chatContent={
-        <CopilotChat attachments={{ enabled: true }} input={{ disclaimer: () => null, className: "pb-6" }} />
+        <CopilotChat
+          attachments={{ enabled: true }}
+          input={{ disclaimer: () => null, className: "pb-6" }}
+        />
       }
       appContent={<ExampleCanvas />}
     />

--- a/showcase/integrations/langgraph-typescript/src/app/demos/declarative-json-render/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/declarative-json-render/page.tsx
@@ -27,7 +27,10 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-declarative-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-declarative-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/integrations/langgraph-typescript/tests/e2e/chat-customization-css.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/chat-customization-css.spec.ts
@@ -81,10 +81,7 @@ test.describe("Chat Customization (CSS)", () => {
     // `background: transparent` and styles the inner bg-muted child with
     // `var(--halcyon-paper-elevated)` (#fbf8f2) plus a 2px ember left border.
     // Assert the outer wrapper is transparent.
-    await expect(userMsg).toHaveCSS(
-      "background-color",
-      "rgba(0, 0, 0, 0)",
-    );
+    await expect(userMsg).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   });
 
   test("assistant bubble uses transparent background after round-trip", async ({
@@ -102,9 +99,6 @@ test.describe("Chat Customization (CSS)", () => {
     // `background: transparent` — editorial serif text with no bubble, just
     // an ember left-rule via ::before. The default CopilotKit assistant has
     // a visible background, so transparent proves the theme won the cascade.
-    await expect(assistant).toHaveCSS(
-      "background-color",
-      "rgba(0, 0, 0, 0)",
-    );
+    await expect(assistant).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   });
 });

--- a/showcase/integrations/langgraph-typescript/tests/e2e/prebuilt-popup.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/prebuilt-popup.spec.ts
@@ -76,7 +76,9 @@ test.describe("Pre-Built Popup", () => {
     // Playwright's pointer-based click, so use a JS-level .click() that
     // bypasses the overlay (same pattern as _genuine-shared.ts:clickByJs).
     await page.evaluate(() => {
-      const btn = document.querySelector('[data-testid="copilot-close-button"]');
+      const btn = document.querySelector(
+        '[data-testid="copilot-close-button"]',
+      );
       if (btn) (btn as HTMLElement).click();
     });
     await expect(popup).toBeHidden({ timeout: 10000 });

--- a/showcase/integrations/langgraph-typescript/tests/e2e/prebuilt-sidebar.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/prebuilt-sidebar.spec.ts
@@ -79,7 +79,9 @@ test.describe("Pre-Built Sidebar", () => {
     // JS-level .click() that bypasses the overlay (same pattern as the
     // harness probes in _genuine-shared.ts:clickByJs).
     await page.evaluate(() => {
-      const btn = document.querySelector('[data-testid="copilot-close-button"]');
+      const btn = document.querySelector(
+        '[data-testid="copilot-close-button"]',
+      );
       if (btn) (btn as HTMLElement).click();
     });
 


### PR DESCRIPTION
## Summary

Main's `static / quality / format` job has been red since [run 26053174160](https://github.com/CopilotKit/CopilotKit/actions/runs/26053174160) because `oxfmt --check .` (push mode, whole-tree) found drift in 12 files under `showcase/integrations/langgraph-{python,typescript}/`. This PR scrubs the drift and fixes the workflow bug that let it land in the first place.

- **`style(showcase)`** — re-run `oxfmt --write` on the 12 affected files.
- **`fix(ci)`** — restrict the format job's auto-commit step to files that were in the PR's target list, instead of `git diff --name-only` over the whole tree.

## Root cause

PR #4879's format-job run executed `oxfmt --write` against 271 PR-changed files, including 9 tracked-but-gitignored `recorded/openai-*.json` fixtures sitting under a `recorded/` rule in `showcase/aimock/d5-recorded/.gitignore`. After oxfmt rewrote them, the commit step did:

```bash
git diff --name-only -z | xargs -0 git add
```

`git add` refuses paths covered by `.gitignore` (exit 1), `xargs` translated that into exit 123, and `bash -e` aborted the step before `git commit` / `git push` ran. All the legitimate format fixes — including for the 12 source files in this PR — got thrown away. The PR was merged anyway and the drift sat on main until the next push-mode check caught it.

## Fix

In `.github/workflows/static_quality.yml`, the commit step now intersects `git diff --name-only` with `.pr-format-files.existing.txt` (the canonical PR-changed file list) before staging. Files oxfmt touched outside that target list — gitignored fixtures, scratch — are no longer fed to `git add`.

## Test plan

- [ ] CI's format job goes green on this PR (validates the scrub).
- [ ] CI's format job goes green on `main` after merge (validates the unblock).
- [ ] Future PRs that include gitignored paths in their diff don't kill the auto-commit (validates the harden — will get organic coverage as PRs land).