### PR TITLE
ci(format): really fix the gitignored-path auto-commit poison

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -89,6 +89,15 @@ jobs:
           while IFS= read -r f; do
             [ -n "$f" ] && [ -f "$f" ] && printf '%s\n' "$f" >> .pr-format-files.existing.txt
           done < .pr-format-files.txt
+          # Drop tracked-but-gitignored paths (e.g. fixtures under a
+          # `recorded/` rule). Without this, oxfmt would rewrite them and
+          # the auto-commit step's `git add` would refuse the ignored
+          # path, killing the whole step and leaving the PR unfixed.
+          if [ -s .pr-format-files.existing.txt ]; then
+            git ls-files -i -c --exclude-standard > .pr-format-files.ignored.txt
+            grep -vxFf .pr-format-files.ignored.txt .pr-format-files.existing.txt > .pr-format-files.scoped.txt || true
+            mv .pr-format-files.scoped.txt .pr-format-files.existing.txt
+          fi
           count=$(wc -l < .pr-format-files.existing.txt | tr -d ' ')
           echo "count=$count" >> "$GITHUB_OUTPUT"
           echo "PR-changed format candidates: $count"


### PR DESCRIPTION
## Summary

Follow-up to #4901. That PR unblocked main with the 12-file format fix, but the workflow change it shipped doesn't actually fix the underlying bug — the auto-commit step is still poisoned the moment any tracked-but-gitignored path lands in a PR's diff.

This PR does the real fix and proves it on real CI.

## Why #4901's workflow change wasn't enough

`xargs -a .pr-format-files.existing.txt git add --` stages files from the same list oxfmt was scoped to. But the collection step picks up tracked-but-gitignored paths (e.g. `showcase/aimock/d5-recorded/recorded/openai-*.json` — they match `*.json`, are tracked, but sit under a `recorded/` ignore rule). Those paths end up in `.pr-format-files.existing.txt`, oxfmt rewrites them, `git add` still refuses them with the "ignored by one of your .gitignore files" warning and `exit 1`, and the step still aborts. Same failure mode as #4879.

## The real fix

Filter `.pr-format-files.existing.txt` against `git ls-files -i -c --exclude-standard` — the authoritative list of tracked-but-ignored paths — in the collection step. Three effects:

1. oxfmt no longer rewrites scratch files (correct semantic: `recorded/` is recording-session scratch per its own .gitignore comment).
2. `git diff --name-only` after the formatter run won't contain any ignored paths attributable to oxfmt.
3. The auto-commit's `git add` only sees non-ignored paths, can't choke.

## Verification

**Local** (already done in the working branch):

| Setup | git add behavior |
|---|---|
| Pipe ignored fixture path → git add | `exit 1`, "ignored by .gitignore" |
| Pipe mixed list (fixture + real source) → git add | `exit 1`, only real source actually stages, but exit 1 still kills `set -e` step |
| Filter the list first via `ls-files -i -c`, then git add | `exit 0`, only real source stages, no warning |

**Real CI** (this PR):

The second commit deliberately steps on both halves of the failure mode:
- A `recorded/openai-*.json` fixture is dirty in the PR diff (tracked-but-ignored path).
- One source file (`prebuilt-popup.spec.ts`) is reverted to its pre-#4901 unformatted state (forces oxfmt to do real work and the auto-commit path to run).

Without the filter, the format job would die at `git add` exactly the way #4879 did. With the filter, the source file gets auto-fixed and the auto-commit lands cleanly.

## Merge plan

If CI is green, drop the `test:` commit (and the auto-fix commit it triggers) with `git reset --hard <fix-sha>` and force-push so only the workflow change lands on main.