### PR TITLE
docs(shell-docs): tighten telemetry opt-out copy + useAgent API rename

### DIFF
--- a/showcase/shell-docs/src/content/docs/(other)/telemetry/index.mdx
+++ b/showcase/shell-docs/src/content/docs/(other)/telemetry/index.mdx
@@ -13,11 +13,7 @@ We use anonymous telemetry (metadata-only) to learn how to improve CopilotKit.
 
 ## How to opt out of anonymous telemetry
 
-You can opt out of open-source telemetry in multiple ways.
-
-In CopilotRuntime, simply set `COPILOTKIT_TELEMETRY_DISABLED=true`. We also respect [Do Not Track (DNT)](https://consoledonottrack.com/).
-
-Alternatively, you can directly set the `telemetryDisabled` flag to `true` when configuring your Copilot Runtime endpoint.
+Set `COPILOTKIT_TELEMETRY_DISABLED=true` in your runtime environment. This disables telemetry for both the CopilotRuntime and the Inspector dev-console. We also respect [Do Not Track (DNT)](https://consoledonottrack.com/).
 
 ## How to adjust telemetry sample rate
 

--- a/showcase/shell-docs/src/content/snippets/use-agent.mdx
+++ b/showcase/shell-docs/src/content/snippets/use-agent.mdx
@@ -22,7 +22,7 @@
       return (
         <div>
           {/* [!code highlight:4] */}
-          <p>Agent ID: {agent.id}</p>
+          <p>Agent ID: {agent.agentId}</p>
           <p>Thread ID: {agent.threadId}</p>
           <p>Status: {agent.isRunning ? "Running" : "Idle"}</p>
           <p>Messages: {agent.messages.length}</p>
@@ -30,6 +30,13 @@
       );
     }
     ```
+
+    <Callout type="info">
+      If you are not using CopilotKit Cloud's public access/license key, pass your agentId to the `useAgent()` hook:
+      ```ts
+      const { agent } = useAgent({ agentId: "myAgent" });
+      ```
+    </Callout>
 
     The hook will throw an error if no agent is configured, so you can safely use `agent` without null checks.
 
@@ -216,7 +223,7 @@ export function EventLogger() {
     // [!code highlight:2]
     const { unsubscribe } = agent.subscribe(subscriber);
     return () => unsubscribe();
-  }, []);
+  }, [agent]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

Two surgical pickups from a closed auto-sync PR, applied directly to shell-docs (the post-cutover canonical authoring location).

**1. `telemetry/index.mdx`** — collapse three opt-out paragraphs into a single tighter sentence, and add the Inspector dev-console to the scope of what `COPILOTKIT_TELEMETRY_DISABLED` covers.

**2. `snippets/use-agent.mdx`** — three independent improvements:
- `agent.id` → `agent.agentId` (current v2 API field name).
- New `<Callout>` pointing out that `useAgent({ agentId })` is required when not using CopilotKit Cloud's public access/license key.
- `subscribe()` `useEffect` cleanup gets `[agent]` in the deps array (exhaustive-deps; prevents stale subscriber after the agent reference changes).

## What was deliberately skipped

The auto-sync also wanted to rewrite `@copilotkit/shared/v2` → `@copilotkit/shared` in `use-agent.mdx`. The `/v2` subpath was deliberately restored as the V2 canonical-form import — left alone here.

## Test plan

- [ ] CI green
- [ ] Spot-check rendered `/telemetry` page locally / on Railway preview — opt-out paragraph reads cleaner
- [ ] Spot-check rendered `/{any-framework}/use-agent` — Callout renders inside the `<Steps>` flow, `agent.agentId` displays where the Agent ID line was, dependency array shows `[agent]`