### PR TITLE
fix(shell-docs): stack sidebar under banner when banner is visible

### DIFF
--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -292,15 +292,20 @@ figure.shiki > div:first-child[class*="border-b"] {
   width: 100% !important;
 }
 
+/* Top offset stacks BrandNav (68px md / 88px xl) under the banner (54px
+ * when shown, 0px when dismissed — Banners writes the variable on <html>).
+ * Without `--fd-banner-height` in the calc, the fixed sidebar pins to
+ * 76/96px while body-flow chrome (Banner + BrandNav) shifts down past it,
+ * overlapping the nav row. */
 @media (min-width: 768px) {
   .shell-docs-sidebar {
-    top: 76px !important;
+    top: calc(76px + var(--fd-banner-height, 0px)) !important;
   }
 }
 
 @media (min-width: 1280px) {
   .shell-docs-sidebar {
-    top: 96px !important;
+    top: calc(96px + var(--fd-banner-height, 0px)) !important;
   }
 }
 


### PR DESCRIPTION
## Summary

- The DocsLayout sidebar uses `position: fixed` with hardcoded `top: 76px / 96px` (md / xl) in [showcase/shell-docs/src/app/globals.css](showcase/shell-docs/src/app/globals.css). When the rotating banner is visible, body-flow chrome (Banners + BrandNav) shifts down by the banner's height (~54px), but the fixed sidebar stays pinned — so the framework picker overlaps the BrandNav row.
- Wrap both top overrides in `calc(... + var(--fd-banner-height, 0px))` so the sidebar follows the banner's height (54px shown, 0px dismissed). `Banners` already writes that variable on `<html>`, and `MobileTopNav` already uses the same pattern.

## Before / after

Before: with banner showing, the sidebar's "framework" pill sits at viewport `top: 96px`, while BrandNav occupies 54-142px — the pill obscures the "CopilotKit DOCS" mark and nav links.
After: sidebar resolves to `top: 150px` (96+54) at xl and `top: 130px` (76+54) at md, sitting cleanly below BrandNav. Snaps back to 76 / 96px when the banner is dismissed.

## Test plan

- [x] Banner visible @ 1280px viewport — sidebar `top: 150px`, no overlap with BrandNav
- [x] Banner visible @ 1024px viewport — sidebar `top: 130px`, no overlap with BrandNav
- [x] Banner dismissed @ 1024px viewport — sidebar `top: 76px`, flush under BrandNav
- [x] Visual screenshot review in light theme across both breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)