### PR TITLE
fix(ci): exclude node_modules from release artifact to avoid OOM

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -91,11 +91,21 @@ jobs:
       - name: Build packages
         run: pnpm run build
 
+      # Exclude node_modules and build caches from the artifact. Including
+      # them produces ~6.4M files for this monorepo, which OOMs
+      # upload-artifact's Node process at its 4GB heap limit during
+      # enumeration. The publish job runs `pnpm install` after download to
+      # restore node_modules from pnpm-lock.yaml.
       - name: Upload workspace
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workspace
-          path: .
+          path: |
+            .
+            !**/node_modules/**
+            !**/.next/**
+            !**/.turbo/**
+            !**/.nx/**
           include-hidden-files: true
           retention-days: 1
 
@@ -131,6 +141,13 @@ jobs:
           registry-url: https://registry.npmjs.org
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Restore node_modules — the build job excludes them from the
+      # uploaded workspace artifact (see "Upload workspace" above). Uses
+      # pnpm-lock.yaml from the artifact, so this is a deterministic
+      # restore of exactly what the build job ran with.
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Configure npm auth
         run: |


### PR DESCRIPTION
## Summary

The release/publish workflow's build job uploads the entire workspace as an artifact for the publish job to download. With `node_modules` included, this monorepo produces **~6.4M files**, which OOMs `upload-artifact`'s Node process at its 4 GB heap limit during file enumeration:

```
With the provided path, there will be 6392019 files uploaded
...
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

This was uncovered when the `workflow_dispatch` escape hatch added in #4808 was first exercised — the upload step hung for 12+ minutes and then crashed.

## Fix

1. **`Upload workspace` exclusions** — exclude `**/node_modules/**`, `**/.next/**`, `**/.turbo/**`, `**/.nx/**`. Drops the file count by orders of magnitude (almost all of those 6.4M files are pnpm's hoisted + nested `node_modules`).
2. **`Install Dependencies` in the publish job** — runs `pnpm install --frozen-lockfile` after `Download workspace`, so the publish step operates against exactly the same resolved tree the build job used (`pnpm-lock.yaml` is carried in the artifact).

The published `packages/*/dist/` outputs from the build job are unaffected by the exclusions, so npm publish still has everything it needs.

## Test plan

- [ ] Merge to main
- [ ] Dispatch `release / publish` against `monorepo` (or wait for the next merged release PR)
- [ ] Confirm `Upload workspace` and `Download workspace` both finish in seconds (not minutes), and `Install Dependencies` runs in the publish job before `Publish to npm`
- [ ] Confirm the published tarballs on npm are byte-identical to what the previous flow would have produced (same lockfile → same install → same build outputs already in the artifact)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VnqgZdq8QaS15yknCKKcff)_