### PR TITLE
fix: replace workspace:* with actual semver during release bump

### DIFF
--- a/scripts/release/lib/versions.ts
+++ b/scripts/release/lib/versions.ts
@@ -142,8 +142,7 @@ export function bumpPackages(
       ] as const) {
         if (!pkg[depField]) continue;
         for (const depName of Object.keys(pkg[depField])) {
-          const depValue = pkg[depField][depName];
-          if (scopeNames.has(depName) && !depValue.startsWith("workspace:")) {
+          if (scopeNames.has(depName)) {
             pkg[depField][depName] = newVersion;
           }
         }


### PR DESCRIPTION
## Fix: replace workspace:* with actual semver during release bump

**Issue:** #4911

### Root Cause

In `scripts/release/lib/versions.ts`, the `bumpPackages` function explicitly skips updating dependencies that use the `workspace:*` protocol:

```typescript
if (scopeNames.has(depName) && !depValue.startsWith("workspace:")) {
  pkg[depField][depName] = newVersion;
}
```

For sharedVersion scopes (e.g., `monorepo` scope which includes `@copilotkit/web-inspector`), this means `@copilotkit/core: workspace:*` was published as-is to npm in version 1.57.2. Downstream consumers not in a CopilotKit monorepo cannot resolve `workspace:*`, causing `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`.

### Fix

Remove the `!depValue.startsWith("workspace:")` check so workspace:* references are replaced with the actual release version alongside other internal dependency types:

```typescript
if (scopeNames.has(depName)) {
  pkg[depField][depName] = newVersion;
}
```

This ensures `package.json` files committed to the repository contain valid semver, not `workspace:*`, before they reach the npm registry.

### Verification

- `packages/web-inspector/package.json` in the 1.57.2 tag confirmed to contain `"@copilotkit/core": "workspace:*"` in its dependencies
- Fix was verified by the CopilotKit support bot (copilotkit-support-bot)