### PR TITLE
fix(showcase): un-skip hitl-in-app downgrade + fix beautiful-chat networkidle

### DIFF
--- a/showcase/integrations/langgraph-python/tests/e2e/beautiful-chat.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/beautiful-chat.spec.ts
@@ -227,7 +227,6 @@ test.describe("Beautiful Chat", () => {
     page,
   }) => {
     test.setTimeout(120_000);
-    await page.waitForLoadState("networkidle");
 
     await page
       .getByRole("button", { name: "Task Manager (Shared State)" })

--- a/showcase/integrations/langgraph-python/tests/e2e/hitl-in-app.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/hitl-in-app.spec.ts
@@ -178,7 +178,7 @@ test.describe("HITL In-App (approval dialog portaled to <body>)", () => {
   });
 
   // TODO: re-enable when downgrade flow is fixed (broken upstream as of 2026-05-07)
-  test.skip("downgrade #12346 → approve/reject flow", async () => {
+  test("downgrade #12346 → approve/reject flow", async () => {
     // Intentionally skipped per spec: the downgrade pill exposes a
     // separate upstream bug (ticket-12346 surface) that is out of scope
     // for the genuine-pass rewrite. Re-enable when the upstream demo

--- a/showcase/integrations/langgraph-typescript/tests/e2e/beautiful-chat.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/beautiful-chat.spec.ts
@@ -227,7 +227,6 @@ test.describe("Beautiful Chat", () => {
     page,
   }) => {
     test.setTimeout(120_000);
-    await page.waitForLoadState("networkidle");
 
     await page
       .getByRole("button", { name: "Task Manager (Shared State)" })

--- a/showcase/integrations/langgraph-typescript/tests/e2e/hitl-in-app.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/hitl-in-app.spec.ts
@@ -178,7 +178,7 @@ test.describe("HITL In-App (approval dialog portaled to <body>)", () => {
   });
 
   // TODO: re-enable when downgrade flow is fixed (broken upstream as of 2026-05-07)
-  test.skip("downgrade #12346 → approve/reject flow", async () => {
+  test("downgrade #12346 → approve/reject flow", async () => {
     // Intentionally skipped per spec: the downgrade pill exposes a
     // separate upstream bug (ticket-12346 surface) that is out of scope
     // for the genuine-pass rewrite. Re-enable when the upstream demo


### PR DESCRIPTION
## Summary
- Un-skip hitl-in-app downgrade test — upstream bug is fixed, test passes on both LGP and LGT
- Remove `page.waitForLoadState("networkidle")` from beautiful-chat Task Manager test — persistent SSE connections prevent networkidle from ever resolving

## Test plan
- [x] 16/16 tests pass on LGP (port 3100) — hitl-in-app + beautiful-chat specs
- [x] 16/16 tests pass on LGT (port 3101)
- [x] All specs byte-identical between LGP and LGT

🤖 Generated with [Claude Code](https://claude.com/claude-code)