### PR TITLE
fix(showcase): un-skip declarative-gen-ui KPI + StatusReport tests

### DIFF
--- a/showcase/integrations/langgraph-python/tests/e2e/declarative-gen-ui.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/declarative-gen-ui.spec.ts
@@ -17,13 +17,11 @@ import { test, expect } from "@playwright/test";
 // colours, etc.). Because the secondary-LLM render is multi-step, the
 // surface can take 30-60s to paint — all render assertions use a 60s budget.
 //
-// W8-7: on Railway (showcase-langgraph-python-production.up.railway.app),
-// the `generate_a2ui` tool path is occasionally slow / flaky — the KPI and
-// StatusReport flows can exceed a 60s budget when the secondary LLM stalls.
-// Those two scenarios are skipped; the deterministic PieChart and BarChart
-// catalog renderers are kept as the primary render-signal tests since they
-// have the strongest visual fingerprints. Un-skip when the agent deployment
-// stabilises.
+// W8-7 (resolved): KPI and StatusReport were skipped due to Railway
+// slowness. The root cause was aimock fixtures returning content+toolCalls
+// in one response — the frontend closed the assistant turn before the A2UI
+// tool call rendered. Fixed by splitting fixtures (2436adba6); all 4 pills
+// now test reliably with aimock.
 
 test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
   test.setTimeout(120_000);
@@ -130,11 +128,7 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
       .toBeLessThanOrEqual(1);
   });
 
-  // SKIP: KPI dashboard prompt drives `generate_a2ui` to emit a Card +
-  // multiple Metric tiles. On Railway this path is the slowest of the 4
-  // pills and regularly exceeds 60s when the secondary LLM stalls. See
-  // W8-7. Un-skip when the agent deployment stabilises.
-  test.skip("KPI dashboard pill renders at least 3 Metric tiles", async ({
+  test("KPI dashboard pill renders at least 3 Metric tiles", async ({
     page,
   }) => {
     const suggestions = page.locator('[data-testid="copilot-suggestion"]');
@@ -143,30 +137,22 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
       .first()
       .click();
 
-    // Each Metric renders an uppercase label with `letterSpacing: 0.12em`
-    // above a large number. The label styling is the stable fingerprint;
-    // the text content itself is model-generated and not asserted.
-    const metricLabels = page.locator(
-      'div[style*="letter-spacing: 0.12em"], div[style*="letterSpacing: 0.12em"]',
-    );
+    // Each Metric renderer emits `data-testid="declarative-metric"`.
+    // The component tree is: label (uppercase) + value + optional trend arrow.
+    const metrics = page.locator('[data-testid="declarative-metric"]');
     await expect
-      .poll(async () => await metricLabels.count(), { timeout: 90_000 })
+      .poll(async () => await metrics.count(), { timeout: 90_000 })
       .toBeGreaterThanOrEqual(3);
   });
 
-  // SKIP: StatusReport prompt expects at least one Card + StatusBadge pill.
-  // Same Railway slowness as KPI — often exceeds 60s. See W8-7.
-  test.skip("Status report pill renders a Card with a StatusBadge pill", async ({
+  test("Status report pill renders a Card with a StatusBadge pill", async ({
     page,
   }) => {
     const suggestions = page.locator('[data-testid="copilot-suggestion"]');
     await suggestions.filter({ hasText: "Status report" }).first().click();
 
-    // StatusBadge style: `borderRadius: 999` (pill), uppercase + 0.1em
-    // letter-spacing. This combo is unique to the badge renderer.
-    const badges = page.locator(
-      'span[style*="border-radius: 999"][style*="letter-spacing: 0.1em"], span[style*="borderRadius: 999"][style*="letterSpacing: 0.1em"]',
-    );
+    // StatusBadge renderer emits `data-testid="declarative-status-badge"`.
+    const badges = page.locator('[data-testid="declarative-status-badge"]');
     await expect
       .poll(async () => await badges.count(), { timeout: 90_000 })
       .toBeGreaterThanOrEqual(1);

--- a/showcase/integrations/langgraph-typescript/tests/e2e/declarative-gen-ui.spec.ts
+++ b/showcase/integrations/langgraph-typescript/tests/e2e/declarative-gen-ui.spec.ts
@@ -17,13 +17,11 @@ import { test, expect } from "@playwright/test";
 // colours, etc.). Because the secondary-LLM render is multi-step, the
 // surface can take 30-60s to paint — all render assertions use a 60s budget.
 //
-// W8-7: on Railway (showcase-langgraph-python-production.up.railway.app),
-// the `generate_a2ui` tool path is occasionally slow / flaky — the KPI and
-// StatusReport flows can exceed a 60s budget when the secondary LLM stalls.
-// Those two scenarios are skipped; the deterministic PieChart and BarChart
-// catalog renderers are kept as the primary render-signal tests since they
-// have the strongest visual fingerprints. Un-skip when the agent deployment
-// stabilises.
+// W8-7 (resolved): KPI and StatusReport were skipped due to Railway
+// slowness. The root cause was aimock fixtures returning content+toolCalls
+// in one response — the frontend closed the assistant turn before the A2UI
+// tool call rendered. Fixed by splitting fixtures (2436adba6); all 4 pills
+// now test reliably with aimock.
 
 test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
   test.setTimeout(120_000);
@@ -130,11 +128,7 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
       .toBeLessThanOrEqual(1);
   });
 
-  // SKIP: KPI dashboard prompt drives `generate_a2ui` to emit a Card +
-  // multiple Metric tiles. On Railway this path is the slowest of the 4
-  // pills and regularly exceeds 60s when the secondary LLM stalls. See
-  // W8-7. Un-skip when the agent deployment stabilises.
-  test.skip("KPI dashboard pill renders at least 3 Metric tiles", async ({
+  test("KPI dashboard pill renders at least 3 Metric tiles", async ({
     page,
   }) => {
     const suggestions = page.locator('[data-testid="copilot-suggestion"]');
@@ -143,30 +137,22 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
       .first()
       .click();
 
-    // Each Metric renders an uppercase label with `letterSpacing: 0.12em`
-    // above a large number. The label styling is the stable fingerprint;
-    // the text content itself is model-generated and not asserted.
-    const metricLabels = page.locator(
-      'div[style*="letter-spacing: 0.12em"], div[style*="letterSpacing: 0.12em"]',
-    );
+    // Each Metric renderer emits `data-testid="declarative-metric"`.
+    // The component tree is: label (uppercase) + value + optional trend arrow.
+    const metrics = page.locator('[data-testid="declarative-metric"]');
     await expect
-      .poll(async () => await metricLabels.count(), { timeout: 90_000 })
+      .poll(async () => await metrics.count(), { timeout: 90_000 })
       .toBeGreaterThanOrEqual(3);
   });
 
-  // SKIP: StatusReport prompt expects at least one Card + StatusBadge pill.
-  // Same Railway slowness as KPI — often exceeds 60s. See W8-7.
-  test.skip("Status report pill renders a Card with a StatusBadge pill", async ({
+  test("Status report pill renders a Card with a StatusBadge pill", async ({
     page,
   }) => {
     const suggestions = page.locator('[data-testid="copilot-suggestion"]');
     await suggestions.filter({ hasText: "Status report" }).first().click();
 
-    // StatusBadge style: `borderRadius: 999` (pill), uppercase + 0.1em
-    // letter-spacing. This combo is unique to the badge renderer.
-    const badges = page.locator(
-      'span[style*="border-radius: 999"][style*="letter-spacing: 0.1em"], span[style*="borderRadius: 999"][style*="letterSpacing: 0.1em"]',
-    );
+    // StatusBadge renderer emits `data-testid="declarative-status-badge"`.
+    const badges = page.locator('[data-testid="declarative-status-badge"]');
     await expect
       .poll(async () => await badges.count(), { timeout: 90_000 })
       .toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
## Summary
- Un-skip KPI dashboard and Status report tests in declarative-gen-ui
- Fix CSS selector mismatch: tests used inline-style selectors but components use Tailwind classes
- Switch to existing `data-testid` attributes (`declarative-metric`, `declarative-status-badge`)

## Root cause
Tests were skipped citing "Railway slowness" (W8-7) but the real issue was CSS selector mismatch — inline-style queries never matched Tailwind-rendered components.

## Test plan
- [x] 6/6 declarative-gen-ui tests pass on LGP (port 3100)
- [x] 6/6 pass on LGT (port 3101)
- [x] Specs byte-identical between LGP and LGT

🤖 Generated with [Claude Code](https://claude.com/claude-code)