### PR TITLE
Fix rAF teardown errors in CopilotChat perf tests and lefthook script

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -37,11 +37,18 @@ pre-commit:
       # the commit.
       exclude:
         - "docs/**"
+      # Use `set --` so the staged files become positional args; this is the
+      # only shell-portable way to test "are there any" without breaking on
+      # multi-file expansion. The old `[ -n "{staged_files}" ]` form failed
+      # with `sh: 1: [: <path>: unexpected operator` because lefthook
+      # interpolates the file list as space-separated words, not a single
+      # quoted string, so [ saw 3+ args and tried to parse a binary op.
       run: |
-        if [ -n "{staged_files}" ]; then
-          pnpm exec oxlint --fix {staged_files} &&
-          pnpm exec oxfmt --write {staged_files} ;
-          ruff format {staged_files} 2>/dev/null || true
+        set -- {staged_files}
+        if [ "$#" -gt 0 ]; then
+          pnpm exec oxlint --fix "$@" &&
+          pnpm exec oxfmt --write "$@" ;
+          ruff format "$@" 2>/dev/null || true
         fi
       stage_fixed: true
     test-and-check-packages:

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatPerf.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatPerf.e2e.test.tsx
@@ -115,17 +115,58 @@ describe("CopilotChat perf — re-render regression", () => {
     renderCounts.clear();
   });
 
-  // TanStack Virtual schedules rAF callbacks for measurement. On Node 20 the
-  // jsdom timing is different — draining a fixed number of rAF rounds is not
-  // enough because the observer keeps scheduling new callbacks. When
-  // @testing-library/react's auto-cleanup unmounts the component AFTER our
-  // afterEach, any pending rAF fires against a torn-down window (null) and
-  // throws: TypeError: Cannot read properties of null ('requestAnimationFrame').
+  // @tanstack/virtual-core 3.13.18 has a latent bug: `scrollToIndex` schedules
+  // a nested rAF that calls `this.targetWindow.requestAnimationFrame(verify)`
+  // with no null-check. The virtualizer's cleanup (run on React unmount) sets
+  // `targetWindow = null`, so if the outer rAF fires after unmount, the inner
+  // schedule throws `Cannot read properties of null (reading 'requestAnimationFrame')`.
   //
-  // Fix: after draining what we can, replace rAF with a no-op so any callback
-  // scheduled during (or after) RTL cleanup is silently swallowed. Restore the
-  // real rAF at the start of the next test via beforeEach.
+  // Vitest reports this as an unhandled error and exits non-zero even though
+  // every test passes. We wrap rAF (on BOTH globalThis and window — they're
+  // separate bindings in vitest+jsdom; tanstack uses `targetWindow.rAF` which
+  // resolves to `window.rAF`) so callbacks that hit the known tanstack bug
+  // are swallowed. After each test we drain pending callbacks and replace rAF
+  // with a no-op to keep stragglers from leaking into the next test.
   const realRAF = globalThis.requestAnimationFrame;
+  const realWindowRAF =
+    typeof window !== "undefined" ? window.requestAnimationFrame : realRAF;
+
+  const isKnownTanstackTeardownError = (err: unknown): boolean => {
+    const message =
+      (err as { message?: string } | null | undefined)?.message ?? "";
+    return (
+      message.includes("Cannot read properties of null") &&
+      message.includes("requestAnimationFrame")
+    );
+  };
+
+  const wrapRAF = (real: typeof requestAnimationFrame) =>
+    ((cb: FrameRequestCallback) =>
+      real((time) => {
+        try {
+          cb(time);
+        } catch (err) {
+          if (isKnownTanstackTeardownError(err)) return;
+          throw err;
+        }
+      })) as typeof requestAnimationFrame;
+
+  const noopRAF = ((_cb: FrameRequestCallback) =>
+    0) as typeof requestAnimationFrame;
+
+  const installSafeRAF = () => {
+    globalThis.requestAnimationFrame = wrapRAF(realRAF);
+    if (typeof window !== "undefined") {
+      window.requestAnimationFrame = wrapRAF(realWindowRAF);
+    }
+  };
+
+  const installNoopRAF = () => {
+    globalThis.requestAnimationFrame = noopRAF;
+    if (typeof window !== "undefined") {
+      window.requestAnimationFrame = noopRAF;
+    }
+  };
 
   afterEach(async () => {
     // Best-effort drain of already-queued rAF callbacks.
@@ -134,13 +175,12 @@ describe("CopilotChat perf — re-render regression", () => {
       await new Promise<void>((r) => realRAF(() => r()));
     });
     // Neuter rAF so callbacks scheduled during RTL cleanup are harmless.
-    globalThis.requestAnimationFrame = ((_cb: FrameRequestCallback) =>
-      0) as typeof requestAnimationFrame;
+    installNoopRAF();
   });
 
   beforeEach(() => {
-    // Restore real rAF for the upcoming test.
-    globalThis.requestAnimationFrame = realRAF;
+    // Install the error-swallowing wrap on rAF for the upcoming test.
+    installSafeRAF();
   });
 
   it("completed messages do not re-render when a new message is added", async () => {


### PR DESCRIPTION
## What does this PR do?

This PR addresses two issues:

1. **CopilotChat perf test flakiness**: Fixes unhandled errors from `@tanstack/virtual-core` 3.13.18's `scrollToIndex` method, which schedules nested `requestAnimationFrame` callbacks without null-checking `targetWindow`. When the virtualizer unmounts and sets `targetWindow = null`, pending rAF callbacks throw "Cannot read properties of null (reading 'requestAnimationFrame')". The fix wraps both `globalThis.requestAnimationFrame` and `window.requestAnimationFrame` to catch and swallow this known tanstack teardown error while allowing other errors to propagate.

2. **Lefthook script robustness**: Fixes the pre-commit oxlint/oxfmt/ruff hook to properly handle staged files with spaces or special characters. The old `[ -n "{staged_files}" ]` check failed with "unexpected operator" errors because lefthook interpolates file lists as space-separated words. The fix uses `set --` to convert the file list into positional arguments, enabling proper shell-portable testing and quoting.

## Related PRs and Issues

- Addresses flakiness in `CopilotChat perf — re-render regression` test suite
- Improves reliability of pre-commit linting hooks

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] Changes are covered by existing test infrastructure (perf tests now pass reliably)
- [x] "Allow edits by maintainers" is checked

https://claude.ai/code/session_01MvPWxQAVmUmZRB6dTnJyjU