### PR TITLE
fix(showcase/ms-agent-python): close last 4 cells to 37/37 D5

### DIFF
--- a/showcase/integrations/ms-agent-python/manifest.yaml
+++ b/showcase/integrations/ms-agent-python/manifest.yaml
@@ -305,7 +305,7 @@ demos:
     highlight:
       - src/agents/interrupt_agent.py
       - src/app/demos/gen-ui-interrupt/page.tsx
-      - src/app/demos/gen-ui-interrupt/time-picker-card.tsx
+      - src/app/demos/gen-ui-interrupt/_components/time-picker-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: declarative-gen-ui
     name: Declarative Generative UI (A2UI)

--- a/showcase/integrations/ms-agent-python/package-lock.json
+++ b/showcase/integrations/ms-agent-python/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@ag-ui/client": "^0.0.53",
-        "@copilotkit/a2ui-renderer": "next",
-        "@copilotkit/react-core": "next",
-        "@copilotkit/runtime": "next",
-        "@copilotkit/voice": "next",
+        "@copilotkit/a2ui-renderer": "1.57.2",
+        "@copilotkit/react-core": "1.57.2",
+        "@copilotkit/runtime": "1.57.2",
+        "@copilotkit/voice": "1.57.2",
         "@hashbrownai/core": "0.5.0-beta.4",
         "@hashbrownai/react": "0.5.0-beta.4",
         "@json-render/core": "0.18.0",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@ag-ui/a2ui-middleware": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-middleware/-/a2ui-middleware-0.0.4.tgz",
-      "integrity": "sha512-N7goCObceqsCQgFRKBpo/X9D9Q0Jp6ALV+ier2W7WnK3sy0WfY2jAeFhqEaoZRqcNeLTKEt8sDqdtd4TGQE1+w==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-middleware/-/a2ui-middleware-0.0.5.tgz",
+      "integrity": "sha512-nhF8LBzq36BmLR1O3nStxqSpIu1+4//ttqOyQgiXUsKZK1znCyN4q4MBTARrkFa7CuFr3fcNTiZuS4V1HRUHTw==",
       "dependencies": {
         "clarinet": "^0.12.6"
       },
@@ -118,12 +118,12 @@
       }
     },
     "node_modules/@ag-ui/langgraph": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.27.tgz",
-      "integrity": "sha512-sfUG985ngG4HAGIZK04POvZVDrsI3QaeWuqJ388QgBPGg9n/oi4+vxueW7O5PIQv6uOPCLsbxf43pZZRN3zZtg==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.31.tgz",
+      "integrity": "sha512-mK24pfQZiV5SlnDLhTka+873gw7QQOAWXqqDSnwkuyoQQQFX7KC8xZR+4Da2dWqyVhbhNPx+amE16X7twS1wcg==",
       "dependencies": {
-        "@langchain/core": "^0.3.80",
-        "@langchain/langgraph-sdk": "^0.1.2",
+        "@langchain/core": "^1.1.40",
+        "@langchain/langgraph-sdk": "^1.8.8",
         "langchain": ">=1.2.0",
         "partial-json": "^0.1.7",
         "rxjs": "7.8.1"
@@ -205,13 +205,13 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex": {
-      "version": "3.0.138",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-3.0.138.tgz",
-      "integrity": "sha512-Ghjn5y7yMMPYNL+s/cuJkTd4svXQMxaiZr162UhfJIyicUKYn3EnveT+2ThL8Ty/FMdJf1IBfWf45LW67lI6yQ==",
+      "version": "3.0.139",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-3.0.139.tgz",
+      "integrity": "sha512-kWlq+YFGsZEqMWrZKRJdluOzqSQVE5QZ39EcOueNsBH301Tn2HoOVTcjcWpkpbIGmJgDB5lH6DgofD4i2kukdQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "2.0.79",
-        "@ai-sdk/google": "2.0.73",
+        "@ai-sdk/google": "2.0.74",
         "@ai-sdk/openai-compatible": "1.0.39",
         "@ai-sdk/provider": "2.0.3",
         "@ai-sdk/provider-utils": "3.0.25",
@@ -241,9 +241,9 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/google": {
-      "version": "2.0.73",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.73.tgz",
-      "integrity": "sha512-XbYFFSnr8ddK1pHNP7rALOY6s3JScRFcS6dXFFqMkK9ZY/CoGRwYHlSex7+NTcC2m1L1Y3NrfyUU7RD4jYV+ag==",
+      "version": "2.0.74",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.74.tgz",
+      "integrity": "sha512-Lhw1742RXc+4pRIvqVXa0jdl5+qdpmw8lj0lm6OchUg9rVGHzymlaxe7CDiYX5U2af4jbjKeTY22LDi3bIycgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.3",
@@ -452,9 +452,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@copilotkit/a2ui-renderer": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.55.2-next.1.tgz",
-      "integrity": "sha512-6R/a07xAUMVuLczUZEapMhHIdurbP7u18+iiKkacn7LBJZwnSDM/CwkFENVKL1TeC/k73aPHN4JYrEdbVxt6vQ==",
+      "version": "1.57.2",
+      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.57.2.tgz",
+      "integrity": "sha512-Z/cHi48YGPOL3svBppQWdJAMtXLLAVSRv+SGAwrhm5IY2VS0hUTGwLH7zACgklEBO5GZyNwssCw/VRk0QX5raA==",
       "license": "MIT",
       "dependencies": {
         "@a2ui/web_core": "0.9.0",
@@ -468,12 +468,13 @@
       }
     },
     "node_modules/@copilotkit/core": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.55.2-next.1.tgz",
-      "integrity": "sha512-z8FfUtZrO8WP2ptPvzLbwPBakooqCVZjv5bHK347CNMHQabfSXR8r+bCsnYSYj8zbc9l9e2cLRdHgADPYh5A3A==",
+      "version": "1.57.2",
+      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.57.2.tgz",
+      "integrity": "sha512-DmIJRNCtId7qtUxjhufe7e+TinbU79AEAUsW/lfEMg07OfgM9BZ8ENICQ/gm3pwoN4v1PaZ/Jns73gID20CDSg==",
       "dependencies": {
-        "@ag-ui/client": "0.0.52",
-        "@copilotkit/shared": "1.55.2-next.1",
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/shared": "1.57.2",
+        "@tanstack/pacer": "^0.20.1",
         "phoenix": "^1.8.4",
         "rxjs": "7.8.1",
         "zod-to-json-schema": "^3.24.6"
@@ -482,68 +483,24 @@
         "node": ">=18"
       }
     },
-    "node_modules/@copilotkit/core/node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/@ag-ui/core": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.52.tgz",
-      "integrity": "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/@ag-ui/encoder": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.52.tgz",
-      "integrity": "sha512-6GVDTb1dv2rjap7VVnmXYypDutZi6nrsTcdfxoP6ryDG5ynlXtmmS+FSDAt62JbIMD5CtEE963xNCb6d1iXw9g==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/proto": "0.0.52"
-      }
-    },
-    "node_modules/@copilotkit/core/node_modules/@ag-ui/proto": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.52.tgz",
-      "integrity": "sha512-+iCGzNUNL50YIoThVmsolWPjG4MJidl+R9k8QAGVwErEfHRtQ64KFyrdpeOXNVuWtM3SViJqPSgFyv7eGVS63A==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
-      }
-    },
     "node_modules/@copilotkit/license-verifier": {
-      "version": "0.0.1-a1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.0.1-a1.tgz",
-      "integrity": "sha512-eTsupi14qPwDhpQBrFC6t4U5rxmHo9nPaHz60gOBPPCu7tTcA8GwEq5QfX/XGfmmKbCX2noL9yto1Pg0A8qQ9g=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.4.0.tgz",
+      "integrity": "sha512-axD7B767YVHGfz/nekw3wUk9GFZGIcIq2X9AZfNA0qb6GnHcB3yJ636T21LHhon5sHerxe1oOOuNYmiAUMNonQ=="
     },
     "node_modules/@copilotkit/react-core": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.55.2-next.1.tgz",
-      "integrity": "sha512-NfvHwcK3EIdPg3fjfmCuRU2/N0CcRsNkqimg5KfXDd3bvXZesjX740vw65aHqrpthI2TYZMug/G7oZ/HpgTjmA==",
+      "version": "1.57.2",
+      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.57.2.tgz",
+      "integrity": "sha512-aeJJPSaoMTOJG8WV9tiUjz1/VzotNa1MQsfuP9npBJ65hCPH2fgmKP4T95Yd5TIP6lkWFwNDoTLuGV19Mst+fQ==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.52",
-        "@ag-ui/core": "0.0.52",
-        "@copilotkit/a2ui-renderer": "1.55.2-next.1",
-        "@copilotkit/core": "1.55.2-next.1",
-        "@copilotkit/runtime-client-gql": "1.55.2-next.1",
-        "@copilotkit/shared": "1.55.2-next.1",
-        "@copilotkit/web-inspector": "1.55.2-next.1",
+        "@ag-ui/client": "0.0.53",
+        "@ag-ui/core": "0.0.53",
+        "@copilotkit/a2ui-renderer": "1.57.2",
+        "@copilotkit/core": "1.57.2",
+        "@copilotkit/runtime-client-gql": "1.57.2",
+        "@copilotkit/shared": "1.57.2",
+        "@copilotkit/web-inspector": "1.57.2",
         "@jetbrains/websandbox": "^1.1.3",
         "@lit-labs/react": "^2.0.2",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -568,50 +525,6 @@
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc",
         "zod": ">=3.0.0"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/@ag-ui/core": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.52.tgz",
-      "integrity": "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/@ag-ui/encoder": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.52.tgz",
-      "integrity": "sha512-6GVDTb1dv2rjap7VVnmXYypDutZi6nrsTcdfxoP6ryDG5ynlXtmmS+FSDAt62JbIMD5CtEE963xNCb6d1iXw9g==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/proto": "0.0.52"
-      }
-    },
-    "node_modules/@copilotkit/react-core/node_modules/@ag-ui/proto": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.52.tgz",
-      "integrity": "sha512-+iCGzNUNL50YIoThVmsolWPjG4MJidl+R9k8QAGVwErEfHRtQ64KFyrdpeOXNVuWtM3SViJqPSgFyv7eGVS63A==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
       }
     },
     "node_modules/@copilotkit/react-core/node_modules/@types/hast": {
@@ -1394,24 +1307,24 @@
       }
     },
     "node_modules/@copilotkit/runtime": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.55.2-next.1.tgz",
-      "integrity": "sha512-lCZK3wE3eaV7GJnnl+jFtCDOcOE3yAFPUh3cSK+QDfxK+RCsOVAC7fplUxbIolPngKsy//QL2UxKea7pPIKXUg==",
+      "version": "1.57.2",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.57.2.tgz",
+      "integrity": "sha512-RrG+S8NdAcqO3zCqLY/QEDbnYG1y9yssBVeshxW7TsiXZE5STFKucVlJAy5+SWMP8HCIQnhpQRqt3ZjPiGKUSQ==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/a2ui-middleware": "0.0.4",
-        "@ag-ui/client": "0.0.52",
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/langgraph": "0.0.27",
+        "@ag-ui/a2ui-middleware": "0.0.5",
+        "@ag-ui/client": "0.0.53",
+        "@ag-ui/core": "0.0.53",
+        "@ag-ui/encoder": "0.0.53",
+        "@ag-ui/langgraph": "0.0.31",
         "@ag-ui/mcp-apps-middleware": "0.0.3",
         "@ai-sdk/anthropic": "^3.0.49",
         "@ai-sdk/google": "^3.0.33",
         "@ai-sdk/google-vertex": "^3.0.97",
         "@ai-sdk/mcp": "^1.0.21",
         "@ai-sdk/openai": "^3.0.36",
-        "@copilotkit/license-verifier": "0.0.1-a1",
-        "@copilotkit/shared": "1.55.2-next.1",
+        "@copilotkit/license-verifier": "0.4.0",
+        "@copilotkit/shared": "1.57.2",
         "@graphql-yoga/plugin-defer-stream": "^3.3.1",
         "@hono/node-server": "^1.13.5",
         "@modelcontextprotocol/sdk": "^1.18.2",
@@ -1428,7 +1341,7 @@
         "graphql-scalars": "^1.23.0",
         "graphql-yoga": "^5.3.1",
         "hono": "^4.11.4",
-        "openai": "^4.85.1",
+        "openai": "^4.85.1 || >=5.0.0",
         "partial-json": "^0.1.7",
         "phoenix": "^1.8.4",
         "pino": "^9.2.0",
@@ -1449,7 +1362,8 @@
         "@langchain/langgraph-sdk": ">=0.1.2",
         "@langchain/openai": ">=0.4.2",
         "groq-sdk": ">=0.3.0 <1.0.0",
-        "langchain": ">=0.3.3"
+        "langchain": ">=0.3.3",
+        "openai": "^4.85.1 || >=5.0.0"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
@@ -1482,12 +1396,12 @@
       }
     },
     "node_modules/@copilotkit/runtime-client-gql": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.55.2-next.1.tgz",
-      "integrity": "sha512-7Rjw2uW09zIcwAw3vyalxjaYbV03OVbtnLAlbXpw2sLjs/FHRpsjIl1Bpv6KCcBt0sTC5rDrVNe+tyzVVCHO0A==",
+      "version": "1.57.2",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.57.2.tgz",
+      "integrity": "sha512-XMeO5HFSriT1AHH6tBbZAudqHI0fnVymqhbnGVogEZyMSdNrF17JmRDVyF/54gOKleyAAHguXcOtAom4sKPMzA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "1.55.2-next.1",
+        "@copilotkit/shared": "1.57.2",
         "@urql/core": "^5.0.3",
         "untruncate-json": "^0.0.1",
         "urql": "^4.1.0"
@@ -1495,108 +1409,6 @@
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc"
       }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/@ag-ui/client/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/@ag-ui/core": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.52.tgz",
-      "integrity": "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/@ag-ui/encoder": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.52.tgz",
-      "integrity": "sha512-6GVDTb1dv2rjap7VVnmXYypDutZi6nrsTcdfxoP6ryDG5ynlXtmmS+FSDAt62JbIMD5CtEE963xNCb6d1iXw9g==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/proto": "0.0.52"
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/@ag-ui/proto": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.52.tgz",
-      "integrity": "sha512-+iCGzNUNL50YIoThVmsolWPjG4MJidl+R9k8QAGVwErEfHRtQ64KFyrdpeOXNVuWtM3SViJqPSgFyv7eGVS63A==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/@copilotkit/runtime/node_modules/uuid": {
       "version": "10.0.0",
@@ -1613,13 +1425,13 @@
       }
     },
     "node_modules/@copilotkit/shared": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.55.2-next.1.tgz",
-      "integrity": "sha512-B96UNONgbJLL+pJr3smNkmFtaVMLQJLjjHmHQ7hprMVvwC5kjOxRC1HobhcrM/rwlspd/QPAYH6vKNzhir11jA==",
+      "version": "1.57.2",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.57.2.tgz",
+      "integrity": "sha512-htPcMVg56HSYpVovMJ5SBpqIFxFYVGDhhjwnhA+etq/mZU9L1LCWv8I1utwLQ654S8KdZPiP2EWOfHtskwiyaA==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.52",
-        "@copilotkit/license-verifier": "0.0.1-a1",
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/license-verifier": "0.4.0",
         "@segment/analytics-node": "^2.1.2",
         "@standard-schema/spec": "^1.0.0",
         "chalk": "4.1.2",
@@ -1633,56 +1445,12 @@
         "@ag-ui/core": ">=0.0.48"
       }
     },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/core": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.52.tgz",
-      "integrity": "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/encoder": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.52.tgz",
-      "integrity": "sha512-6GVDTb1dv2rjap7VVnmXYypDutZi6nrsTcdfxoP6ryDG5ynlXtmmS+FSDAt62JbIMD5CtEE963xNCb6d1iXw9g==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/proto": "0.0.52"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/@ag-ui/proto": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.52.tgz",
-      "integrity": "sha512-+iCGzNUNL50YIoThVmsolWPjG4MJidl+R9k8QAGVwErEfHRtQ64KFyrdpeOXNVuWtM3SViJqPSgFyv7eGVS63A==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
-      }
-    },
     "node_modules/@copilotkit/voice": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/voice/-/voice-1.55.2-next.1.tgz",
-      "integrity": "sha512-hhRDrUjrBkVKcr/qLLnHOUKQYp76a7PlIgEvDBlJi0lp20RtKG0U1YKaBN4er3KMf1R64VLyP5qaXbId7EHHOQ==",
+      "version": "1.57.2",
+      "resolved": "https://registry.npmjs.org/@copilotkit/voice/-/voice-1.57.2.tgz",
+      "integrity": "sha512-jb9h00KC0jPZuLb2i0Vfw9IiP5b5n+emD71MzDyKii2rq7IN1CiCJ6OUKpGWG6JAKLDzmd97Fimhtxane4zhBQ==",
       "dependencies": {
-        "@copilotkit/runtime": "1.55.2-next.1",
+        "@copilotkit/runtime": "1.57.2",
         "openai": "^5.9.0"
       },
       "engines": {
@@ -1690,62 +1458,18 @@
       }
     },
     "node_modules/@copilotkit/web-inspector": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.55.2-next.1.tgz",
-      "integrity": "sha512-gWZaSVEORqN3yavjK5987NYMiUuDseIk+W5ahcneKXQFZb7QRptU354AwXBpvPdZ5pVAXIht9xK3aUhivmfzrQ==",
+      "version": "1.57.2",
+      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.57.2.tgz",
+      "integrity": "sha512-4ojfC9e272t1Q1uocqGCFva6PmG4ou2q139QsazTlWj7ULZmYANwaNbbnuF8p0pJEraswMoif30s+Cs3X9mgjQ==",
       "dependencies": {
-        "@ag-ui/client": "0.0.52",
-        "@copilotkit/core": "1.55.2-next.1",
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/core": "workspace:*",
         "lit": "^3.2.0",
         "lucide": "^0.525.0",
         "marked": "^12.0.2"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/core": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.52.tgz",
-      "integrity": "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/encoder": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.52.tgz",
-      "integrity": "sha512-6GVDTb1dv2rjap7VVnmXYypDutZi6nrsTcdfxoP6ryDG5ynlXtmmS+FSDAt62JbIMD5CtEE963xNCb6d1iXw9g==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/proto": "0.0.52"
-      }
-    },
-    "node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/proto": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.52.tgz",
-      "integrity": "sha512-+iCGzNUNL50YIoThVmsolWPjG4MJidl+R9k8QAGVwErEfHRtQ64KFyrdpeOXNVuWtM3SViJqPSgFyv7eGVS63A==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -2649,40 +2373,21 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "0.3.80",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
-      "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
+      "version": "1.1.47",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.47.tgz",
+      "integrity": "sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
+        "@standard-schema/spec": "^1.1.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.67",
+        "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "zod": "^3.25.32",
-        "zod-to-json-schema": "^3.22.3"
+        "zod": "^3.25.76 || ^4"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">=20"
       }
     },
     "node_modules/@langchain/langgraph": {
@@ -2741,48 +2446,6 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.1.10.tgz",
-      "integrity": "sha512-9srSCb2bSvcvehMgjA2sMMwX0o1VUgPN6ghwm5Fwc9JGAKsQa6n1S4eCwy1h4abuYxwajH5n3spBw+4I2WYbgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^9.0.0"
-      },
-      "peerDependencies": {
-        "@langchain/core": ">=0.2.31 <0.4.0 || ^1.0.0-alpha",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@langchain/core": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.4.tgz",
       "integrity": "sha512-hhASJGKa2MDJDtDkuIFdWGysMTog/HkYe0r6B6Gn1XqsURWnF7FIFl9diITAPOv1tB8YpyjnbpsBj/NkT5d+jQ==",
@@ -2816,26 +2479,13 @@
         }
       }
     },
-    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@langchain/langgraph/node_modules/eventemitter3": {
+    "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
-    "node_modules/@langchain/langgraph/node_modules/p-queue": {
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
       "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
@@ -2851,22 +2501,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/langgraph/node_modules/p-retry": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
-      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
-      "license": "MIT",
-      "dependencies": {
-        "is-network-error": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@langchain/langgraph/node_modules/p-timeout": {
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
       "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
@@ -2876,6 +2511,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@langchain/langgraph/node_modules/uuid": {
@@ -3456,7 +3104,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0"
@@ -5176,9 +4824,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/node-fetch-server": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/node-fetch-server/-/node-fetch-server-0.13.1.tgz",
-      "integrity": "sha512-dOL+A/C84EA47gO/ps52KGrVSiYy96512rwtbXmJfWKYFm1FbrbjA3jao1hcIfao+jwVNEaZ1kTMwFjiino+HQ==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/node-fetch-server/-/node-fetch-server-0.13.2.tgz",
+      "integrity": "sha512-gPux086JQjK3PmYWe75unUXKRMsJjdxKs+lW46gg2B/vvSPRRoOdWriVUPktIXYd1Uglq1PTjGW/fWPuslSfag==",
       "license": "MIT"
     },
     "node_modules/@repeaterjs/repeater": {
@@ -5547,72 +5195,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -5661,6 +5243,39 @@
         "tailwindcss": "4.3.0"
       }
     },
+    "node_modules/@tanstack/devtools-event-client": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.4.3.tgz",
+      "integrity": "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==",
+      "license": "MIT",
+      "bin": {
+        "intent": "bin/intent.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/pacer": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/pacer/-/pacer-0.20.1.tgz",
+      "integrity": "sha512-ZNQ1bIL6eUXVKdic0tiImvBVkWrg/IoSK6VIacTrO3d3HAGnd70qFJNJagR/YOJIOw4EKGWnodwpYZkN1pWuVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/devtools-event-client": "^0.4.3",
+        "@tanstack/store": "^0.9.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.13.24",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
@@ -5676,6 +5291,16 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
+      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/virtual-core": {
@@ -6016,16 +5641,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
-      }
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -6033,20 +5648,13 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -6228,18 +5836,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/ai": {
       "version": "6.0.185",
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.185.tgz",
@@ -6302,12 +5898,15 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -6329,12 +5928,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
@@ -6492,18 +6085,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
@@ -6548,21 +6129,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -6699,18 +6265,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -6785,15 +6339,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/console-table-printer": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
-      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
-      "license": "MIT",
-      "dependencies": {
-        "simple-wcswidth": "^1.1.2"
       }
     },
     "node_modules/content-disposition": {
@@ -7453,15 +6998,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -7488,15 +7024,6 @@
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -7698,21 +7225,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7962,15 +7474,6 @@
         "node": "^12.20 || >= 14.13"
       }
     },
-    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -7987,41 +7490,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -8319,21 +7787,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -8701,15 +8154,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9043,7 +8487,7 @@
         "@langchain/core": "^1.1.47"
       }
     },
-    "node_modules/langchain/node_modules/langsmith": {
+    "node_modules/langsmith": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.1.tgz",
       "integrity": "sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==",
@@ -9074,54 +8518,6 @@
         "ws": {
           "optional": true
         }
-      }
-    },
-    "node_modules/langsmith": {
-      "version": "0.3.87",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
-      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "*",
-        "@opentelemetry/exporter-trace-otlp-proto": "*",
-        "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/langsmith/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/layout-base": {
@@ -10964,16 +10360,18 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
       "license": "MIT",
       "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
+        "is-network-error": "^1.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
@@ -11154,7 +10552,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -11173,7 +10571,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -11928,15 +11326,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/robust-predicates": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
@@ -12307,12 +11696,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT"
     },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
@@ -13095,12 +12478,12 @@
       }
     },
     "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -13156,22 +12539,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/showcase/integrations/ms-agent-python/package.json
+++ b/showcase/integrations/ms-agent-python/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@ag-ui/client": "^0.0.53",
-    "@copilotkit/a2ui-renderer": "next",
-    "@copilotkit/react-core": "next",
-    "@copilotkit/runtime": "next",
-    "@copilotkit/voice": "next",
+    "@copilotkit/a2ui-renderer": "1.57.2",
+    "@copilotkit/react-core": "1.57.2",
+    "@copilotkit/runtime": "1.57.2",
+    "@copilotkit/voice": "1.57.2",
     "@hashbrownai/core": "0.5.0-beta.4",
     "@hashbrownai/react": "0.5.0-beta.4",
     "@json-render/core": "0.18.0",
@@ -45,5 +45,15 @@
     "postcss": "^8.5.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "@copilotkit/web-inspector": {
+      "@copilotkit/core": "1.57.2"
+    }
+  },
+  "pnpm": {
+    "overrides": {
+      "@copilotkit/web-inspector>@copilotkit/core": "1.57.2"
+    }
   }
 }

--- a/showcase/integrations/ms-agent-python/src/agents/multimodal_agent.py
+++ b/showcase/integrations/ms-agent-python/src/agents/multimodal_agent.py
@@ -33,9 +33,15 @@ Reference:
 import base64
 import io
 from textwrap import dedent
-from typing import Any, Optional, Tuple
+from typing import Any
 
-from agent_framework import Agent, BaseChatClient
+from agent_framework import (
+    Agent,
+    BaseChatClient,
+    ChatContext,
+    ChatMiddleware,
+    Content,
+)
 from agent_framework_ag_ui import AgentFrameworkAgent
 
 
@@ -47,22 +53,6 @@ SYSTEM_PROMPT = dedent(
     normally. Keep responses concise (1-3 sentences) unless asked to go deep.
     """
 ).strip()
-
-
-def _extract_data_url_parts(url: str) -> tuple[str, str]:
-    """Split a ``data:<mime>;base64,<payload>`` URL into (mime, base64-payload).
-
-    Returns ("", url) if the input is not a data URL -- callers can fall
-    back to treating the url as a fetchable reference.
-    """
-    if not url.startswith("data:"):
-        return "", url
-    header, _, payload = url.partition(",")
-    if ":" not in header:
-        return "", payload
-    meta = header.split(":", 1)[1]
-    mime = meta.split(";", 1)[0] if ";" in meta else meta
-    return mime, payload
 
 
 def _extract_pdf_text(b64: str) -> str:
@@ -99,128 +89,81 @@ def _extract_pdf_text(b64: str) -> str:
         return ""
 
 
-def _classify_attachment_part(part: Any) -> Optional[Tuple[str, str, str]]:
-    """Inspect a content part and return (kind, mime, base64_payload).
+def _content_pdf_payload(content: Content) -> tuple[str, str] | None:
+    """If a Content holds an inline PDF, return ``(base64_payload, mime_type)``.
 
-    ``kind`` is one of ``"image"``, ``"pdf"``, ``"other"``. Returns ``None``
-    if the part is not an attachment we recognize.
-
-    Handles the shapes the MS-AF AG-UI adapter may surface:
-
-    - ``{"type": "image_url", "image_url": {"url": "data:..."}}``
-      (post-adapter, from the legacy-binary rewrite on the page).
-    - ``{"type": "image_url", "image_url": "data:..."}`` (older shape).
-    - ``{"type": "binary", "mimeType": "...", "data": "<base64>"}``
-      (direct legacy binary).
-    - ``{"type": "document", "source": {"type": "data",
-      "value": "<base64>", "mimeType": "application/pdf"}}`` (modern AG-UI).
-    - ``{"type": "image", "source": {...}}`` (modern AG-UI, for completeness).
+    Returns ``None`` for any other content type, including PDFs delivered via
+    ``ag-ui://binary/<id>`` or external HTTPS URLs — those cannot be inlined
+    without a separate fetch and are left for the chat client to handle.
     """
-    if not isinstance(part, dict):
+    media_type = (content.media_type or "").lower()
+    if "pdf" not in media_type:
         return None
-    part_type = part.get("type")
-
-    if part_type == "image_url":
-        image_url = part.get("image_url")
-        url: Optional[str] = None
-        if isinstance(image_url, str):
-            url = image_url
-        elif isinstance(image_url, dict):
-            raw_url = image_url.get("url")
-            if isinstance(raw_url, str):
-                url = raw_url
-        if not url:
-            return None
-        mime, payload = _extract_data_url_parts(url)
-        if not payload or not mime:
-            return None
-        if mime.startswith("image/"):
-            return ("image", mime, payload)
-        if "pdf" in mime.lower():
-            return ("pdf", mime, payload)
-        return ("other", mime, payload)
-
-    if part_type == "binary":
-        mime = part.get("mimeType", "")
-        data = part.get("data")
-        if not isinstance(mime, str) or not isinstance(data, str):
-            return None
-        if mime.startswith("image/"):
-            return ("image", mime, data)
-        if "pdf" in mime.lower():
-            return ("pdf", mime, data)
-        return ("other", mime, data)
-
-    if part_type in ("document", "image"):
-        source = part.get("source")
-        if not isinstance(source, dict) or source.get("type") != "data":
-            return None
-        value = source.get("value")
-        mime = source.get("mimeType", "")
-        if not isinstance(value, str) or not isinstance(mime, str):
-            return None
-        if mime.startswith("image/"):
-            return ("image", mime, value)
-        if "pdf" in mime.lower():
-            return ("pdf", mime, value)
-        return ("other", mime, value)
-
-    return None
+    uri = content.uri or ""
+    if not uri.startswith("data:"):
+        return None
+    _, _, payload = uri.partition(",")
+    if not payload:
+        return None
+    return payload, media_type or "application/pdf"
 
 
-def _preprocess_part(part: Any) -> Any:
-    """Flatten PDF attachments to text; pass everything else through.
+class _PdfFlattenChatMiddleware(ChatMiddleware):
+    """Flatten inline PDF content parts to text for the model call only.
 
-    Images stay as-is so gpt-4o consumes them natively. PDFs become a text
-    part prefixed with ``[Attached document]``. If extraction fails we emit
-    a structured placeholder so the model can tell the user the document
-    was unreadable rather than pretending no attachment was sent.
-    """
-    classified = _classify_attachment_part(part)
-    if classified is None:
-        return part
-    kind, _mime, payload = classified
-    if kind != "pdf":
-        return part
-    text = _extract_pdf_text(payload)
-    if not text:
-        return {
-            "type": "text",
-            "text": "[Attached document: PDF could not be read.]",
-        }
-    return {"type": "text", "text": f"[Attached document]\n{text}"}
+    Scoping the rewrite to ``ChatMiddleware.process`` (LGP's equivalent of
+    ``wrap_model_call``) is what keeps the flattened ``[Attached document]\\n``
+    dump from leaking back into the AG-UI ``MESSAGES_SNAPSHOT``: the agent's
+    canonical message state stays intact, the chat client sees the text-only
+    version, and the user's chat bubble keeps showing the original PDF chip
+    instead of the raw PDF body.
 
-
-class _MultimodalAgent(AgentFrameworkAgent):
-    """Thin wrapper that pre-processes inbound messages before each run.
-
-    We flatten `document` (PDF) content parts to text so the model can reason
-    about them even when the underlying chat client does not accept the
-    `document` content-part shape. Images are untouched.
+    Originally the multimodal agent mutated ``input_data["messages"]`` inside
+    an ``AgentFrameworkAgent.run`` override, but that mutation flows into the
+    outbound snapshot serializer (``agent_framework_ag_ui._message_adapters
+    ._normalize_snapshot_content``) which then bleeds the flattened text into
+    every subsequent chat-bubble render. Restoring the original ``contents``
+    after ``call_next`` is the discipline that prevents that bleed.
     """
 
-    def _flatten_messages(self, messages: Any) -> Any:
-        if not isinstance(messages, list):
-            return messages
-        rewritten: list[Any] = []
+    async def process(
+        self,
+        context: ChatContext,
+        call_next: Any,
+    ) -> None:
+        messages = context.messages or []
+        snapshots: list[tuple[Any, list[Content] | None]] = []
         for message in messages:
-            if not isinstance(message, dict):
-                rewritten.append(message)
+            contents = getattr(message, "contents", None)
+            if not contents:
                 continue
-            content = message.get("content")
-            if not isinstance(content, list):
-                rewritten.append(message)
-                continue
-            new_parts = [_preprocess_part(part) for part in content]
-            rewritten.append({**message, "content": new_parts})
-        return rewritten
+            rewritten: list[Content] = []
+            mutated = False
+            for content in contents:
+                pdf = _content_pdf_payload(content)
+                if pdf is None:
+                    rewritten.append(content)
+                    continue
+                payload, _ = pdf
+                text = _extract_pdf_text(payload)
+                replacement = Content.from_text(
+                    text=(
+                        f"[Attached document]\n{text}"
+                        if text
+                        else "[Attached document]\n(unable to extract text)"
+                    )
+                )
+                rewritten.append(replacement)
+                mutated = True
+            if mutated:
+                snapshots.append((message, list(contents)))
+                message.contents = rewritten  # type: ignore[attr-defined]
 
-    async def run(self, input_data: dict[str, Any]):  # type: ignore[override]
-        messages = input_data.get("messages")
-        if isinstance(messages, list):
-            input_data = {**input_data, "messages": self._flatten_messages(messages)}
-        async for event in super().run(input_data):
-            yield event
+        try:
+            await call_next()
+        finally:
+            for message, original in snapshots:
+                message.contents = original  # type: ignore[attr-defined]
 
 
 def create_multimodal_agent(chat_client: BaseChatClient) -> AgentFrameworkAgent:
@@ -230,9 +173,10 @@ def create_multimodal_agent(chat_client: BaseChatClient) -> AgentFrameworkAgent:
         name="multimodal_agent",
         instructions=SYSTEM_PROMPT,
         tools=[],
+        middleware=[_PdfFlattenChatMiddleware()],
     )
 
-    return _MultimodalAgent(
+    return AgentFrameworkAgent(
         agent=base_agent,
         name="CopilotKitMicrosoftAgentFrameworkMultimodalAgent",
         description=(

--- a/showcase/integrations/ms-agent-python/src/agents/tool_rendering_reasoning_chain_agent.py
+++ b/showcase/integrations/ms-agent-python/src/agents/tool_rendering_reasoning_chain_agent.py
@@ -200,15 +200,48 @@ SYSTEM_PROMPT = dedent(
 ).strip()
 
 
+def _build_reasoning_chain_chat_client() -> BaseChatClient:
+    """Build a Responses-API chat client for reasoning-token streaming.
+
+    Mirrors ``reasoning_agent.py::_build_reasoning_chat_client`` — the model
+    env var defaults to ``OPENAI_REASONING_MODEL`` and then the canonical
+    ``gpt-5.4`` so the fixture's ``response.reasoning_summary_text.delta``
+    events surface as AG-UI ``REASONING_MESSAGE_*`` events.
+    """
+    return OpenAIChatClient(
+        model=os.environ.get("OPENAI_REASONING_MODEL", "gpt-5.4"),
+        api_key=os.environ.get("OPENAI_API_KEY"),
+    )
+
+
 def create_tool_rendering_reasoning_chain_agent(
-    chat_client: BaseChatClient,
+    _chat_client_ignored: BaseChatClient,
 ) -> AgentFrameworkAgent:
-    """Instantiate the tool-rendering reasoning-chain demo agent."""
+    """Instantiate the tool-rendering reasoning-chain demo agent.
+
+    The shared ChatCompletions client from ``agent_server.py`` is intentionally
+    ignored — this cell needs the OpenAI Responses API specifically so the
+    fixture's per-leg ``reasoning`` summaries surface as AG-UI
+    ``REASONING_MESSAGE_*`` events (mirrors ``reasoning_agent.py`` and the
+    LGP reference's ``use_responses_api=True`` config). ChatCompletions emits
+    reasoning as ``protected_data`` only — no visible text reaches the
+    ``<CopilotChatReasoningMessage>`` slot, which is the whole point of this
+    cell vs the plain ``tool-rendering`` demo.
+    """
     base_agent = Agent(
-        client=chat_client,
+        client=_build_reasoning_chain_chat_client(),
         name="tool_rendering_reasoning_chain_agent",
         instructions=SYSTEM_PROMPT,
         tools=[get_weather, search_flights, get_stock_price, roll_d20, roll_dice],
+        # Disable server-side conversation storage so the OpenAI Responses
+        # client sends the full message history (including the original
+        # user prompt) on every leg of a tool-rendering chain instead of
+        # compressing prior context behind ``previous_response_id``. aimock
+        # is stateless and cannot resolve that ID, so chain-leg fixtures
+        # keyed on ``userMessage`` would otherwise miss and the chain would
+        # fall through to the real-OpenAI proxy with a ``ChatClientException``.
+        # Same pattern as ``shared_state_read_write_agent.py``.
+        default_options={"store": False},
     )
 
     return AgentFrameworkAgent(

--- a/showcase/integrations/ms-agent-python/src/app/demos/multimodal/legacy-converter-shim.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/multimodal/legacy-converter-shim.tsx
@@ -189,6 +189,60 @@ function normalizePartType(type: string, mimeType: string | undefined): string {
   return "document";
 }
 
+/**
+ * Upgrade a legacy `{ type: "binary", mimeType, data | url }` part to the
+ * modern `{ type: "image" | "document" | ..., source: { type, value, mimeType } }`
+ * shape. Returns `null` when the part is not a legacy binary or lacks the
+ * fields needed to produce a renderable modern part.
+ *
+ * Why: `agent_framework_ag_ui._normalize_snapshot_content` rewrites every
+ * multimodal part on the outbound MESSAGES_SNAPSHOT to the legacy `binary`
+ * shape (see `_message_adapters.py::_legacy_binary_part`). The chat
+ * user-message renderer's `getMediaParts` only renders modern
+ * `image|audio|video|document` parts — `binary` parts are invisible. Without
+ * this upgrade, the very first user message loses its attachment chip the
+ * moment a second turn's snapshot replaces conversation state, which is the
+ * exact failure mode covered by the back-to-back specs.
+ */
+function modernPartFromLegacyBinary(part: unknown): unknown | null {
+  if (!part || typeof part !== "object") return null;
+  const p = part as {
+    type?: string;
+    mimeType?: string;
+    data?: string;
+    url?: string;
+    id?: string;
+  };
+  if (p.type !== "binary") return null;
+  const mimeType = p.mimeType ?? "application/octet-stream";
+  const modernType = mimeType.startsWith("image/")
+    ? "image"
+    : mimeType.startsWith("audio/")
+      ? "audio"
+      : mimeType.startsWith("video/")
+        ? "video"
+        : "document";
+  if (typeof p.data === "string" && p.data.length > 0) {
+    return {
+      type: modernType,
+      source: { type: "data", value: p.data, mimeType },
+    };
+  }
+  if (typeof p.url === "string" && p.url.length > 0) {
+    return {
+      type: modernType,
+      source: { type: "url", url: p.url, mimeType },
+    };
+  }
+  if (typeof p.id === "string" && p.id.length > 0) {
+    return {
+      type: modernType,
+      source: { type: "id", id: p.id, mimeType },
+    };
+  }
+  return null;
+}
+
 function dedupeUserMessageMedia(
   messages: ReadonlyArray<Readonly<AgentMessage>>,
 ): AgentMessage[] | null {
@@ -200,10 +254,20 @@ function dedupeUserMessageMedia(
     const seen = new Set<string>();
     const kept: unknown[] = [];
     let partMutated = false;
-    for (const part of content) {
-      if (!part || typeof part !== "object") {
-        kept.push(part);
+    for (const rawPart of content) {
+      if (!rawPart || typeof rawPart !== "object") {
+        kept.push(rawPart);
         continue;
+      }
+      // Upgrade legacy `{ type: "binary" }` parts to the modern
+      // `{ type: "image|document|..." , source: { ... } }` shape that the
+      // chat user-message renderer actually renders. We do this BEFORE the
+      // media-vs-non-media branch so an upgraded part flows through the
+      // same dedupe + type-normalize path as a natively-modern part.
+      const upgraded = modernPartFromLegacyBinary(rawPart);
+      const part = upgraded ?? rawPart;
+      if (upgraded) {
+        partMutated = true;
       }
       const p = part as {
         type?: string;

--- a/showcase/integrations/ms-agent-python/tests/e2e/beautiful-chat.spec.ts
+++ b/showcase/integrations/ms-agent-python/tests/e2e/beautiful-chat.spec.ts
@@ -227,7 +227,6 @@ test.describe("Beautiful Chat", () => {
     page,
   }) => {
     test.setTimeout(120_000);
-    await page.waitForLoadState("networkidle");
 
     await page
       .getByRole("button", { name: "Task Manager (Shared State)" })

--- a/showcase/integrations/ms-agent-python/tests/e2e/declarative-gen-ui.spec.ts
+++ b/showcase/integrations/ms-agent-python/tests/e2e/declarative-gen-ui.spec.ts
@@ -17,13 +17,11 @@ import { test, expect } from "@playwright/test";
 // colours, etc.). Because the secondary-LLM render is multi-step, the
 // surface can take 30-60s to paint — all render assertions use a 60s budget.
 //
-// W8-7: on Railway (showcase-langgraph-python-production.up.railway.app),
-// the `generate_a2ui` tool path is occasionally slow / flaky — the KPI and
-// StatusReport flows can exceed a 60s budget when the secondary LLM stalls.
-// Those two scenarios are skipped; the deterministic PieChart and BarChart
-// catalog renderers are kept as the primary render-signal tests since they
-// have the strongest visual fingerprints. Un-skip when the agent deployment
-// stabilises.
+// W8-7 (resolved): KPI and StatusReport were skipped due to Railway
+// slowness. The root cause was aimock fixtures returning content+toolCalls
+// in one response — the frontend closed the assistant turn before the A2UI
+// tool call rendered. Fixed by splitting fixtures (2436adba6); all 4 pills
+// now test reliably with aimock.
 
 test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
   test.setTimeout(120_000);
@@ -130,11 +128,7 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
       .toBeLessThanOrEqual(1);
   });
 
-  // SKIP: KPI dashboard prompt drives `generate_a2ui` to emit a Card +
-  // multiple Metric tiles. On Railway this path is the slowest of the 4
-  // pills and regularly exceeds 60s when the secondary LLM stalls. See
-  // W8-7. Un-skip when the agent deployment stabilises.
-  test.skip("KPI dashboard pill renders at least 3 Metric tiles", async ({
+  test("KPI dashboard pill renders at least 3 Metric tiles", async ({
     page,
   }) => {
     const suggestions = page.locator('[data-testid="copilot-suggestion"]');
@@ -143,30 +137,22 @@ test.describe("Declarative Generative UI (A2UI dynamic schema)", () => {
       .first()
       .click();
 
-    // Each Metric renders an uppercase label with `letterSpacing: 0.12em`
-    // above a large number. The label styling is the stable fingerprint;
-    // the text content itself is model-generated and not asserted.
-    const metricLabels = page.locator(
-      'div[style*="letter-spacing: 0.12em"], div[style*="letterSpacing: 0.12em"]',
-    );
+    // Each Metric renderer emits `data-testid="declarative-metric"`.
+    // The component tree is: label (uppercase) + value + optional trend arrow.
+    const metrics = page.locator('[data-testid="declarative-metric"]');
     await expect
-      .poll(async () => await metricLabels.count(), { timeout: 90_000 })
+      .poll(async () => await metrics.count(), { timeout: 90_000 })
       .toBeGreaterThanOrEqual(3);
   });
 
-  // SKIP: StatusReport prompt expects at least one Card + StatusBadge pill.
-  // Same Railway slowness as KPI — often exceeds 60s. See W8-7.
-  test.skip("Status report pill renders a Card with a StatusBadge pill", async ({
+  test("Status report pill renders a Card with a StatusBadge pill", async ({
     page,
   }) => {
     const suggestions = page.locator('[data-testid="copilot-suggestion"]');
     await suggestions.filter({ hasText: "Status report" }).first().click();
 
-    // StatusBadge style: `borderRadius: 999` (pill), uppercase + 0.1em
-    // letter-spacing. This combo is unique to the badge renderer.
-    const badges = page.locator(
-      'span[style*="border-radius: 999"][style*="letter-spacing: 0.1em"], span[style*="borderRadius: 999"][style*="letterSpacing: 0.1em"]',
-    );
+    // StatusBadge renderer emits `data-testid="declarative-status-badge"`.
+    const badges = page.locator('[data-testid="declarative-status-badge"]');
     await expect
       .poll(async () => await badges.count(), { timeout: 90_000 })
       .toBeGreaterThanOrEqual(1);

--- a/showcase/integrations/ms-agent-python/tools/generate_a2ui.py
+++ b/showcase/integrations/ms-agent-python/tools/generate_a2ui.py
@@ -89,6 +89,14 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
     """Build a2ui_operations dict from the secondary LLM's tool call args.
 
     Call this after the framework wrapper extracts the tool call arguments.
+
+    The returned operations use the A2UI v0.9 NESTED shape (mirroring
+    `copilotkit.a2ui.create_surface` / `update_components` / `update_data_model`
+    from langgraph-python). The `@ag-ui/a2ui-middleware` extracts the
+    surfaceId via `op.createSurface?.surfaceId ?? op.updateComponents?.surfaceId
+    ?? ...` — a flat `{"type": "create_surface", "surfaceId": ...}` shape leaves
+    every op under a "default" surface and the renderer never binds to the
+    registered catalog.
     """
     surface_id = args.get("surfaceId", "dynamic-surface")
     catalog_id = args.get("catalogId", CUSTOM_CATALOG_ID)
@@ -99,15 +107,32 @@ def build_a2ui_operations_from_tool_call(args: dict[str, Any]) -> dict[str, Any]
         )
     data = args.get("data")
 
-    ops = [
-        {"type": "create_surface", "surfaceId": surface_id, "catalogId": catalog_id},
+    ops: list[dict[str, Any]] = [
         {
-            "type": "update_components",
-            "surfaceId": surface_id,
-            "components": components,
+            "version": "v0.9",
+            "createSurface": {
+                "surfaceId": surface_id,
+                "catalogId": catalog_id,
+            },
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {
+                "surfaceId": surface_id,
+                "components": components,
+            },
         },
     ]
     if data:
-        ops.append({"type": "update_data_model", "surfaceId": surface_id, "data": data})
+        ops.append(
+            {
+                "version": "v0.9",
+                "updateDataModel": {
+                    "surfaceId": surface_id,
+                    "path": "/",
+                    "value": data,
+                },
+            }
+        )
 
     return {"a2ui_operations": ops}

--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the sorted, deduplicated `[FAIL] ...` lines from validate-pins.ts. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the per-package e2e-spec-count floor (single source of truth consumed by both the workflow and validate-parity.ts). NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
-  "validatePinsFailCount": 95,
-  "validatePinsFailHash": "aa4054dde11d45c281c49c3cbd3bd2d5cf958407a0d06ee2643aaa55fb777c82",
+  "validatePinsFailCount": 93,
+  "validatePinsFailHash": "d3eb381d559a514cd00f7b3a5377488a144cf5c1c652beafd287e52d269628bf",
   "baselineDemoCount": 9
 }


### PR DESCRIPTION
## Summary

- Closes the 4 broken/partial cells from PR #4924's [33/37 sweep](https://github.com/CopilotKit/CopilotKit/pull/4924): `declarative-gen-ui`, `multimodal`, `tool-rendering-default-catchall`, `tool-rendering-reasoning-chain` — all now match the LGP gold standard.
- Also drops a spurious `waitForLoadState("networkidle")` in `beautiful-chat` Task Manager test that LGP's identical spec doesn't have (MAF's persistent SSE never reaches idle).
- Full ms-agent-python e2e suite: **181 passed, 5 skipped, 1 timing flake (passes on retry), 0 hard failures across 37 cells**.

### Root causes + fixes (one commit per cell)

1. **declarative-gen-ui** (1d40071d8) — `tools/generate_a2ui.py` emitted FLAT ops (`{type: "create_surface", ...}`) but `@ag-ui/a2ui-middleware` extracts surfaceId from v0.9 NESTED shape (`op.createSurface?.surfaceId ?? op.updateComponents?.surfaceId ?? ...`). Rewrote the builder to nested. Also pinned `@copilotkit/*` `next` → `1.57.2` (matches LGP) with the `@copilotkit/web-inspector → @copilotkit/core` overrides workaround for the broken published 1.57.2 web-inspector manifest. Synced spec from LGP to un-skip KPI + Status report.

2. **multimodal** (9e7fd9b0b) — three stacked causes: (a) Git LFS pointer files for `sample.png` / `sample.pdf` weren't pulled (resolved out-of-band via `git lfs pull`). (b) Old `_MultimodalAgent.run` override mutated `input_data["messages"]` with PDF-flattened text before `super().run()`; `agent_framework_ag_ui._normalize_snapshot_content` then bled that flattened text into the outbound MESSAGES_SNAPSHOT, dumping the PDF body into the user chat bubble. Replaced with a `_PdfFlattenChatMiddleware(ChatMiddleware)` scoped to `process()` (LGP's `wrap_model_call` equivalent). (c) `agent_framework_ag_ui._legacy_binary_part` rewrites every multimodal part to legacy `{type:"binary"}` on outbound snapshots; the chat user-message renderer only renders modern `image|audio|video|document`. Added a `modernPartFromLegacyBinary` upgrade step in `legacy-converter-shim.tsx::dedupeUserMessageMedia` that rebuilds inbound `binary` parts as modern shape by mimeType.

3. **tool-rendering-reasoning-chain** (c745ce0b8) — two stacked causes: (a) Agent was on shared `OpenAIChatCompletionClient`; that path emits reasoning content as `Content.from_text_reasoning(protected_data=...)` only — no `text` field — so `<CopilotChatReasoningMessage>` had nothing to render. Switched to `OpenAIChatClient` (Responses API), mirroring `reasoning_agent.py`. (b) Once on Responses API the SDK compressed prior context behind `previous_response_id` and only sent NEW items per leg; aimock is stateless, so chain-leg fixtures keyed on `userMessage` couldn't match — chain fell through to real-OpenAI proxy with `ChatClientException`. Added `default_options={"store": False}` so the SDK inlines full message history per leg (same workaround as `shared_state_read_write_agent.py`, matches LangChain's wire shape). `tool-rendering-default-catchall` went green from the same diff — was bleeding REASONING events into the default-renderer cell.

4. **beautiful-chat Task Manager** (6b4a3fa43) — dropped spurious `waitForLoadState("networkidle")` that LGP's spec doesn't have. MAF's persistent SSE never reaches idle, so the wait timed out at 120s before the actual click→todos flow could run.

### Open follow-ups (not in this PR)

- Upstream aimock PR: `previous_response_id` resolution so userMessage matchers work without per-agent `store=False` workarounds. Also need to land the `hasToolResult` last-user-only scan that's currently `docker cp`'d on every aimock recreate.
- Upstream agent_framework_openai issue: ChatCompletions path stores reasoning as `protected_data` only — should also populate `text` so reasoning UI works without forcing every agent onto Responses API.

## Test plan

- [x] `BASE_URL=http://localhost:3114 ./node_modules/.bin/playwright test declarative-gen-ui.spec.ts` → 6/6
- [x] `BASE_URL=http://localhost:3114 ./node_modules/.bin/playwright test multimodal.spec.ts` → 5/5
- [x] `BASE_URL=http://localhost:3114 ./node_modules/.bin/playwright test tool-rendering-default-catchall.spec.ts` → 7/7
- [x] `BASE_URL=http://localhost:3114 ./node_modules/.bin/playwright test tool-rendering-reasoning-chain.spec.ts` → 5/5
- [x] `BASE_URL=http://localhost:3114 ./node_modules/.bin/playwright test beautiful-chat.spec.ts` → 8/8
- [x] Full ms-agent-python e2e suite (`workers=4`): 181 passed, 5 skipped, 1 multimodal back-to-back timing flake (passes on retry)
- [x] User-verified each cell in the browser (declarative-gen-ui, multimodal, tool-rendering-reasoning-chain, beautiful-chat Task Manager)