### PR TITLE
fix(showcase/aimock): drop turnIndex from Sales Dashboard leg-2 fixture

### DIFF
--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -17,11 +17,11 @@
       }
     },
     {
-      "_comment": "beautiful-chat Sales Dashboard pill — turn 1: after query_data returns, call generate_a2ui.",
+      "_comment": "beautiful-chat Sales Dashboard pill — turn 1: after query_data returns, call generate_a2ui. NB: `turnIndex` is intentionally absent — turnIndex counts assistant messages globally in the thread, so when this pill fires AFTER another pill (e.g. Toggle Theme), the turnIndex is already past 1 and a `turnIndex: 1` matcher silently misses → no generate_a2ui call → the dashboard surface never renders. The `userMessage` substring + `hasToolResult: true` + `toolName: query_data` triple is already unique to this pill's leg-2 request and disambiguates from leg-1 (no tool result yet) and from later legs (toolName moves past query_data).",
       "match": {
         "userMessage": "with total revenue, new customers, and conversion rate metrics",
         "hasToolResult": true,
-        "turnIndex": 1
+        "toolName": "query_data"
       },
       "response": {
         "toolCalls": [

--- a/showcase/integrations/ms-agent-python/tests/e2e/beautiful-chat.spec.ts
+++ b/showcase/integrations/ms-agent-python/tests/e2e/beautiful-chat.spec.ts
@@ -245,4 +245,51 @@ test.describe("Beautiful Chat", () => {
       timeout: 5_000,
     });
   });
+
+  test("Sales Dashboard pill after another pill — A2UI surface still mounts (turnIndex regression)", async ({
+    page,
+  }) => {
+    // Regression guard: the Sales Dashboard fixture chain used to gate the
+    // leg-2 `generate_a2ui` call on `turnIndex: 1`. That fixture matcher
+    // counts assistant messages in the WHOLE thread, so clicking ANY pill
+    // before Sales Dashboard pushed the count past 1 → the matcher silently
+    // missed → `generate_a2ui` never fired → no A2UI surface rendered (only
+    // the toolCallId-keyed final-narration fixture's text appeared). Replaced
+    // with a `userMessage` + `hasToolResult: true` + `toolName: query_data`
+    // triple in feature-parity.json so the matcher is order-independent.
+    // See showcase/RUNBOOK.md "Do not use `turnIndex` in new fixtures."
+    test.setTimeout(180_000);
+
+    // Click a cheap first pill to advance turnIndex past 1.
+    await page
+      .getByRole("button", { name: "Toggle Theme (Frontend Tools)" })
+      .click();
+    await expect(
+      page.locator('[data-testid="copilot-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Now click Sales Dashboard. With the turnIndex fix in place, the A2UI
+    // surface must still mount. Without the fix, only the final narration
+    // text appears and no surface element is in the DOM.
+    await page
+      .getByRole("button", { name: "Sales Dashboard (A2UI Dynamic)" })
+      .click();
+
+    // Surface mount signal: A2UI activity renderer drops a
+    // `[data-surface-id]` (or sibling) attribute somewhere in the DOM tree
+    // for any rendered surface.
+    const surface = page
+      .locator(
+        '[data-surface-id], [data-a2ui-surface], [data-testid*="surface"]',
+      )
+      .first();
+    await expect(surface).toBeVisible({ timeout: 120_000 });
+
+    // Narration text should also appear (this used to pass on its own and
+    // mask the broken surface — keep it asserted alongside the surface
+    // check so the test catches both modes).
+    await expect(page.getByText(/Total Revenue/i).first()).toBeVisible({
+      timeout: 5_000,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Sequential follow-up to PR #4929. User-reported regression surfaced on production after #4929 merged: clicking **any** pill in beautiful-chat before Sales Dashboard makes the A2UI dashboard surface fail to render — only the toolCallId-keyed final-narration text "Here's your sales dashboard…" appears, masking the broken surface.

## Root cause

The `feature-parity.json` leg-2 fixture for the Sales Dashboard pill gated the `generate_a2ui` tool call on `turnIndex: 1`. `turnIndex` counts assistant messages in the WHOLE thread, not within the current pill — so any prior pill (e.g. Toggle Theme) pushed the count past 1, the matcher silently missed, `generate_a2ui` never fired, and the dashboard surface never rendered.

The showcase RUNBOOK already calls this out: **"Do not use `turnIndex` in new fixtures."**

## Fix

Replaced `turnIndex: 1` with `toolName: "query_data"` in the leg-2 matcher. The `userMessage` substring + `hasToolResult: true` + `toolName: query_data` triple is order-independent and still unique to this pill's leg-2 request:
- leg-1: `hasToolResult: false` (no tool result yet) → different fixture matches
- leg-2: model still has `query_data` in tools — only this leg
- later legs: `query_data` no longer in tools — `toolName` matcher skips

## Test plan

- [x] Added regression e2e (`beautiful-chat.spec.ts:249`): clicks Toggle Theme first, then Sales Dashboard, asserts the A2UI surface mounts. Catches the exact failure mode user reported on production.
- [x] Existing `Sales Dashboard pill renders A2UI dashboard surface` test (clicked alone) still passes.
- [x] Full beautiful-chat suite (9 tests) green: page-load, all-pills, Toggle Theme, Pie Chart, Bar Chart, Search Flights, Sales Dashboard alone, Sales Dashboard after another pill (new), Task Manager.