### PR TITLE
fix(showcase/aimock): break content+toolCalls history-split loops + scope Sales Dashboard leg-2

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -2665,10 +2665,10 @@
     {
       "match": {
         "userMessage": "intro call with the sales team",
-        "toolName": "schedule_meeting"
+        "toolName": "schedule_meeting",
+        "hasToolResult": false
       },
       "response": {
-        "content": "Sure — let me check available times.",
         "toolCalls": [
           {
             "name": "schedule_meeting",
@@ -2703,10 +2703,10 @@
     {
       "match": {
         "userMessage": "1:1 with Alice",
-        "toolName": "schedule_meeting"
+        "toolName": "schedule_meeting",
+        "hasToolResult": false
       },
       "response": {
-        "content": "Got it — pulling up next-week slots.",
         "toolCalls": [
           {
             "name": "schedule_meeting",

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -1864,11 +1864,11 @@
       }
     },
     {
+      "_comment": "frontend-tools 'Sunset' pill — 1st leg: emit change_background tool call only. NB: do NOT include `content` here. agent_framework_openai's ChatCompletions client splits an assistant message that carries BOTH `content` and `tool_calls` into two separate history entries (one with content, one with tool_calls), so on the follow-up leg aimock sees the standalone content message and re-matches THIS fixture by `userMessage` substring → another change_background tool call → infinite loop. The toolCallId-keyed follow-up fixture immediately above provides the post-tool narration text.",
       "match": {
         "userMessage": "Make the background a sunset gradient"
       },
       "response": {
-        "content": "Sunset gradient applied — warm orange-to-rose blend.",
         "toolCalls": [
           {
             "id": "call_d5_change_background_sunset",
@@ -1890,11 +1890,11 @@
       }
     },
     {
+      "_comment": "frontend-tools 'Forest' pill — 1st leg: emit change_background tool call only. See the Sunset fixture above for why we drop `content`.",
       "match": {
         "userMessage": "deep green forest gradient"
       },
       "response": {
-        "content": "Forest gradient applied — deep green hues.",
         "toolCalls": [
           {
             "id": "call_d5_change_background_forest",
@@ -1916,11 +1916,11 @@
       }
     },
     {
+      "_comment": "frontend-tools 'Cosmic' pill — 1st leg: emit change_background tool call only. See the Sunset fixture above for why we drop `content`.",
       "match": {
         "userMessage": "navy → magenta cosmic gradient"
       },
       "response": {
-        "content": "Cosmic gradient applied — navy fading to magenta.",
         "toolCalls": [
           {
             "id": "call_d5_change_background_cosmic",

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -2858,27 +2858,6 @@
     },
     {
       "match": {
-        "model": "gpt-4.1",
-        "turnIndex": 0,
-        "hasToolResult": false
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "render_a2ui",
-            "arguments": "{\"surfaceId\":\"dashboard-001\",\"catalogId\":\"copilotkit://app-dashboard-catalog\"}",
-            "id": "call_Q3rTavqr4dXJ08ne9bEesL9d"
-          }
-        ]
-      },
-      "metadata": {
-        "systemHash": "28fe3ed7",
-        "toolsHash": "2cbb50da"
-      },
-      "_comment": "Recorded fixture from d5-recorded: openai-2026-05-15T20-55-02-522Z-e88af85f.json"
-    },
-    {
-      "match": {
         "userMessage": "First use the query_data tool to fetch the financial sales data, then using A2UI, show me a sales dashboard with total revenue, new customers, and conversion rate metrics. Include a pie chart of revenue by category and a bar chart of monthly sales.",
         "model": "gpt-4o",
         "turnIndex": 2,

--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -17,11 +17,11 @@
       }
     },
     {
-      "_comment": "beautiful-chat Sales Dashboard pill — turn 1: after query_data returns, call generate_a2ui. NB: `turnIndex` is intentionally absent — turnIndex counts assistant messages globally in the thread, so when this pill fires AFTER another pill (e.g. Toggle Theme), the turnIndex is already past 1 and a `turnIndex: 1` matcher silently misses → no generate_a2ui call → the dashboard surface never renders. The `userMessage` substring + `hasToolResult: true` + `toolName: query_data` triple is already unique to this pill's leg-2 request and disambiguates from leg-1 (no tool result yet) and from later legs (toolName moves past query_data).",
+      "_comment": "beautiful-chat Sales Dashboard pill — turn 1: after query_data returns, call generate_a2ui. NB: `turnIndex` is intentionally absent — counts assistant messages thread-globally and silently misses when this pill fires after another pill. Anchored on the leg-1 query_data toolCallId so the matcher cleanly fires exactly once: on leg-3 the last tool result is from generate_a2ui (different call_id) so this fixture doesn't re-match and create a generate_a2ui loop. NB: aimock's `toolName` matcher only checks that the named tool is REGISTERED in `effective.tools`, not that the last tool result was from it — so `toolName` alone cannot disambiguate leg-2 from leg-3 here.",
       "match": {
         "userMessage": "with total revenue, new customers, and conversion rate metrics",
         "hasToolResult": true,
-        "toolName": "query_data"
+        "toolCallId": "call_fp_query_data_sales_001"
       },
       "response": {
         "toolCalls": [


### PR DESCRIPTION
## Summary

Three aimock fixture fixes that surfaced when production deployed PR #4929+#4931 and the user clicked through. All three are variants of one root cause: **agent_framework_openai's ChatCompletions client splits an assistant message that carries BOTH `content` and `toolCalls` into two separate history entries**, so on the follow-up leg the leftover content message is still in history, the original `userMessage` substring re-matches THIS fixture, and aimock re-emits the same tool call → infinite loop or duplicate render. LangGraph handles content+toolCalls atomically which is why LGP didn't hit this; the underlying agent_framework_openai behavior deserves a separate upstream issue.

### Commit 1: drop stale `render_a2ui` catchall + scope Sales Dashboard leg-2 ([d2e1cdba1](../commit/d2e1cdba1))

Two stacked issues on beautiful-chat Sales Dashboard:

- `d5-all.json` had a recorded catchall `{ model: "gpt-4.1", turnIndex: 0, hasToolResult: false }` with no `userMessage` constraint. The secondary LLM call inside `beautiful_chat.py::generate_a2ui` hits aimock with that exact shape; the catchall matched first and returned a stale `render_a2ui` tool call with `{surfaceId: "dashboard-001"}` and no `components`. `build_a2ui_operations_from_tool_call` then mounted an empty surface. Catchall predates the `render_a2ui` → `_design_a2ui_surface` rename; feature-parity.json already carries the correct fixture. Removed the catchall.
- The leg-2 fixture I added in PR #4930 used `toolName: query_data` to disambiguate from leg-3, but aimock's `toolName` matcher only checks if the tool is REGISTERED in `effective.tools` — `query_data` is always there. Re-anchored on `toolCallId: "call_fp_query_data_sales_001"` which is unique to leg-2's last tool result.

### Commit 2: frontend-tools first-leg fixtures ([ac94edaf5](../commit/ac94edaf5))

The Sunset / Forest / Cosmic `change_background` fixtures returned both `content` and `toolCalls`. agent_framework_openai split that into a standalone `content` assistant message + a separate tool_call message; the follow-up leg's `userMessage` substring still matched the same fixture → infinite `change_background` loop (visible as a chat thread growing past 30 messages while the run never ended — exactly the user-reported "infinite loop"). Dropped `content` from all three; the toolCallId-anchored follow-up fixtures already provide narration ("Done — sunset gradient is live." etc.).

### Commit 3: gen-ui-interrupt / interrupt-headless first-leg fixtures ([efa63dee8](../commit/efa63dee8))

Same shape: the two `schedule_meeting` first-leg fixtures ("intro call with the sales team", "1:1 with Alice") returned content + toolCalls. Resulted in the picker rendering twice on the gen-ui-interrupt page, matching the user-reported "renders everything twice". Dropped `content` from both, added `hasToolResult: false` as a belt-and-braces guard so they only fire on the initial leg.

## Test plan

- [x] Local repro: chat thread on `frontend-tools` Sunset pill now stabilizes at 2 assistant messages (was looping to 30+).
- [x] Local repro: gen-ui-interrupt picker mounts exactly once (was rendering twice).
- [x] Local repro: beautiful-chat Sales Dashboard pill renders the full A2UI surface with 2 recharts containers + Total Revenue / metrics (was rendering empty surface).
- [x] Full ms-agent-python e2e suite: **186 passed, 3 skipped, 0 failed**.

## Out of scope (still on the user's list, all production-only — passing locally)

- `gen-ui-agent` "stream never ends" — local direct SSE shows 7 set_steps cycles + `RUN_FINISHED` in ~60s, all 3 steps reach `completed`.
- `hitl-in-app` reject "infinite loop" — local: reject button closes modal, agent emits expected narration.
- `interrupt-headless` "still broken" — local: popup mounts in app surface after pill click.
- `hitl-in-chat` "buttons disable after first interaction" — local: 30/30 spec passes including back-to-back pill clicks.

Most likely all four were production-only because Railway aimock hadn't redeployed yet; should clear after this PR + #4931's image rebuild lands.