### PR TITLE
fix(showcase/ms-agent-python): drop predict_state_config from gen_ui_agent (state-patch crash)

### DIFF
--- a/showcase/integrations/ms-agent-python/src/agents/gen_ui_agent.py
+++ b/showcase/integrations/ms-agent-python/src/agents/gen_ui_agent.py
@@ -116,6 +116,21 @@ def create_gen_ui_agent(chat_client: BaseChatClient) -> AgentFrameworkAgent:
         tools=[set_steps],
     )
 
+    # NB: `predict_state_config` (predictive streaming from LLM tool-call arg
+    # deltas) is intentionally omitted. `agent_framework_ag_ui._orchestration
+    # ._predictive_state.PredictiveStateHandler` emits StateDeltaEvents using
+    # JSON Patch `op: "replace"` against `/<state_key>`. When the run starts
+    # with `current_state = {}`, the very first StateDelta tries to replace
+    # `/steps` — a path that doesn't exist — and the browser-side patch
+    # application throws `OPERATION_PATH_UNRESOLVABLE: Cannot perform the
+    # operation at a path that does not exist`. The run stream completes
+    # (RUN_FINISHED arrives), but the chat UI's run-state machine stays in
+    # "streaming" forever because the patch failure short-circuits the
+    # `complete` transition. `state_update()` inside `set_steps` already
+    # emits a full `StateSnapshotEvent` after every tool call, so the
+    # progress card still updates step-by-step; we just lose the
+    # mid-stream predictive flicker (matches beautiful_chat's manage_todos
+    # workaround for the same bug).
     return AgentFrameworkAgent(
         agent=base_agent,
         name="GenUiAgent",
@@ -124,6 +139,5 @@ def create_gen_ui_agent(chat_client: BaseChatClient) -> AgentFrameworkAgent:
             "completed via set_steps. Drives the `gen-ui-agent` demo's "
             "live progress card."
         ),
-        predict_state_config=PREDICT_STATE_CONFIG,
         require_confirmation=False,
     )


### PR DESCRIPTION
## Summary

User-reported console error on production `gen-ui-agent` (PR #4932 already deployed):

```
Failed to apply state patch:
Current state: {}
Patch operations: [{ op: "replace", path: "/steps", value: [...] }]
Error: Cannot perform the operation at a path that does not exist
name: OPERATION_PATH_UNRESOLVABLE
```

User noticed: "the stream comes in and run finished is there but it doesn't change from streaming to done and i see the square stop button to stop the stream". RUN_FINISHED arrives, but the chat UI's run-state machine stays stuck on "streaming" forever because the patch failure short-circuits the run-complete transition.

## Root cause

`agent_framework_ag_ui._orchestration._predictive_state.PredictiveStateHandler._create_delta_event` always emits `StateDeltaEvent` with JSON Patch `op: "replace"` against `/<state_key>`. JSON Patch RFC 6902 requires the target path to exist for a `replace` operation; on the first `set_steps` tool call `current_state` is `{}` and the browser-side patch application throws `OPERATION_PATH_UNRESOLVABLE`.

## Fix

Drop `predict_state_config` from `gen_ui_agent`. Same workaround `beautiful_chat` already applied (see its inline comment from a prior fix). `set_steps` already calls `state_update(state={"steps": [...]})` which emits a full `StateSnapshotEvent` after the tool runs, so the progress card still updates step-by-step. We only lose the mid-stream predictive flicker between `TOOL_CALL_ARGS` deltas and the deterministic snapshot.

## Upstream follow-up

Worth filing against `agent_framework_ag_ui` so `PredictiveStateHandler` either:
- emits `op: "add"` (RFC-6902-correct for both new and existing paths), OR
- seeds the state path before the first delta.

## Test plan

- [x] `gen-ui-agent.spec.ts` — 6/6 passing locally with the change.
- [x] Local repro of the user's error before the fix; clean console + run completes correctly after.