### PR TITLE
fix(core): use streamed tool call args

### DIFF
--- a/.changeset/fix-tool-call-args-render.md
+++ b/.changeset/fix-tool-call-args-render.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/core": patch
+"@copilotkit/react-core": patch
+---
+
+Render server-updated tool call arguments from AG-UI TOOL_CALL_ARGS events.

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -1,12 +1,12 @@
-import {
+import type {
   AbstractAgent,
   AgentSubscriber,
-  HttpAgent,
   Message,
   RunAgentResult,
   Tool,
   ToolCall,
 } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 import { randomUUID, logger, schemaToJsonSchema } from "@copilotkit/shared";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type { CopilotKitCore, CopilotKitCoreFriendsAccess } from "./core";
@@ -67,6 +67,74 @@ interface ExecuteToolHandlerResult {
   error?: string;
   isArgumentError: boolean;
 }
+
+const serializeToolCallArguments = (args: unknown): string | undefined => {
+  if (typeof args === "string") return args;
+  if (args === undefined) return undefined;
+
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return undefined;
+  }
+};
+
+const looksLikeJsonValue = (value: string) => {
+  const trimmed = value.trim();
+  return trimmed.startsWith("{") || trimmed.startsWith("[");
+};
+
+const isCompleteJson = (value: string) => {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const updateToolCallArguments = (
+  messages: ReadonlyArray<Readonly<Message>>,
+  toolCallId: string,
+  getArgs: (currentArgs: string) => unknown,
+): Message[] | undefined => {
+  let changed = false;
+  const nextMessages = messages.map((message): Message => {
+    if (message.role !== "assistant" || !Array.isArray(message.toolCalls)) {
+      return message as Message;
+    }
+
+    let messageChanged = false;
+    const toolCalls = message.toolCalls.map((toolCall) => {
+      if (toolCall.id !== toolCallId) return toolCall;
+
+      const serializedArgs = serializeToolCallArguments(
+        getArgs(toolCall.function.arguments),
+      );
+      if (serializedArgs === undefined) return toolCall;
+      if (toolCall.function.arguments === serializedArgs) return toolCall;
+
+      messageChanged = true;
+      return {
+        ...toolCall,
+        function: {
+          ...toolCall.function,
+          arguments: serializedArgs,
+        },
+      };
+    });
+
+    if (!messageChanged) return message;
+
+    changed = true;
+    return {
+      ...message,
+      toolCalls,
+    };
+  });
+
+  return changed ? nextMessages : undefined;
+};
 
 /**
  * Handles agent execution, tool calling, and agent connectivity for CopilotKitCore.
@@ -920,6 +988,37 @@ export class RunHandler {
     };
 
     return {
+      onToolCallArgsEvent: ({ event, messages }) => {
+        const updatedMessages = updateToolCallArguments(
+          messages,
+          event.toolCallId,
+          (currentArgs) => {
+            if (
+              isCompleteJson(currentArgs) &&
+              looksLikeJsonValue(event.delta)
+            ) {
+              return event.delta;
+            }
+
+            return `${currentArgs}${event.delta}`;
+          },
+        );
+
+        if (updatedMessages) {
+          return { messages: updatedMessages, stopPropagation: true };
+        }
+      },
+      onToolCallEndEvent: ({ event, messages, toolCallArgs }) => {
+        const updatedMessages = updateToolCallArguments(
+          messages,
+          event.toolCallId,
+          () => toolCallArgs,
+        );
+
+        if (updatedMessages) {
+          return { messages: updatedMessages };
+        }
+      },
       onRunFailed: async ({ error }: { error: Error }) => {
         const code =
           error instanceof AgentThreadLockedError

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRendering.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRendering.e2e.test.tsx
@@ -6,21 +6,14 @@ import {
   useCopilotKit,
 } from "../../../providers/CopilotKitProvider";
 import { CopilotChat } from "../CopilotChat";
-import {
-  AbstractAgent,
-  EventType,
-  type BaseEvent,
-  type RunAgentInput,
-} from "@ag-ui/client";
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
 import { Observable, Subject } from "rxjs";
-import {
-  defineToolCallRenderer,
-  ReactToolCallRenderer,
-  ReactFrontendTool,
-} from "../../../types";
+import type { ReactToolCallRenderer, ReactFrontendTool } from "../../../types";
+import { defineToolCallRenderer } from "../../../types";
 import CopilotChatToolCallsView from "../CopilotChatToolCallsView";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
-import { AssistantMessage, Message, ToolMessage } from "@ag-ui/core";
+import type { AssistantMessage, Message, ToolMessage } from "@ag-ui/core";
 import { ToolCallStatus } from "@copilotkit/core";
 import { useFrontendTool } from "../../../hooks/use-frontend-tool";
 
@@ -371,6 +364,107 @@ describe("Streaming in-progress without timers", () => {
       expect(el.textContent).toContain("21");
     });
 
+    agent.emit({ type: EventType.RUN_FINISHED } as BaseEvent);
+    agent.complete();
+  });
+
+  it("renders updated args from AG-UI tool call args events", async () => {
+    const agent = new MockStepwiseAgent();
+
+    const renderToolCalls = [
+      defineToolCallRenderer({
+        name: "selectAddress",
+        args: z.object({
+          postcode: z.string().optional(),
+          addresses: z
+            .array(
+              z.object({
+                id: z.string(),
+                line1: z.string(),
+              }),
+            )
+            .optional(),
+        }),
+        render: ({ args }) => {
+          const firstAddress = args.addresses?.[0];
+
+          return (
+            <div data-testid="address-tool">
+              {args.postcode} {firstAddress?.id ?? "missing"}{" "}
+              {firstAddress?.line1 ?? ""}
+            </div>
+          );
+        },
+      }),
+    ] as unknown as ReactToolCallRenderer<unknown>[];
+
+    render(
+      <CopilotKitProvider
+        agents__unsafe_dev_only={{ default: agent }}
+        renderToolCalls={renderToolCalls}
+      >
+        <div style={{ height: 400 }}>
+          <CopilotChat />
+        </div>
+      </CopilotKitProvider>,
+    );
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "Select an address" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Select an address")).toBeDefined();
+    });
+
+    const messageId = "m_address";
+    const toolCallId = "tc_address";
+
+    agent.emit({ type: EventType.RUN_STARTED } as BaseEvent);
+    agent.emit({
+      type: EventType.TEXT_MESSAGE_CHUNK,
+      messageId,
+      delta: "Selecting address",
+    } as BaseEvent);
+    agent.emit({
+      type: EventType.TOOL_CALL_START,
+      toolCallId,
+      toolCallName: "selectAddress",
+      parentMessageId: messageId,
+    } as BaseEvent);
+    agent.emit({
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId,
+      delta: JSON.stringify({
+        postcode: "M1 1AA",
+        addresses: [{ id: "fake", line1: "Hallucinated Street" }],
+      }),
+    } as BaseEvent);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("address-tool").textContent).toContain("fake");
+    });
+
+    agent.emit({
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId,
+      delta: JSON.stringify({
+        postcode: "M1 1AA",
+        addresses: [{ id: "real", line1: "1 Piccadilly" }],
+      }),
+    } as BaseEvent);
+
+    await waitFor(() => {
+      const renderedTool = screen.getByTestId("address-tool");
+      expect(renderedTool.textContent).toContain("real");
+      expect(renderedTool.textContent).toContain("1 Piccadilly");
+      expect(renderedTool.textContent).not.toContain("fake");
+    });
+
+    agent.emit({
+      type: EventType.TOOL_CALL_END,
+      toolCallId,
+    } as BaseEvent);
     agent.emit({ type: EventType.RUN_FINISHED } as BaseEvent);
     agent.complete();
   });


### PR DESCRIPTION
Fixes #4935.

Updates AG-UI tool call arg events back into the matching tool call so renderers and tool handlers receive server-updated arguments.

Checks:
- pnpm --filter @copilotkit/core build
- pnpm --filter @copilotkit/react-core test src/v2/components/chat/__tests__/CopilotChatToolRendering.e2e.test.tsx -- --runInBand
- pnpm --filter @copilotkit/core test src/__tests__/core-run-tool.test.ts
- pnpm exec oxfmt --check .changeset/fix-tool-call-args-render.md packages/core/src/core/run-handler.ts packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRendering.e2e.test.tsx
- pnpm exec oxlint packages/core/src/core/run-handler.ts packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRendering.e2e.test.tsx
- git diff --check