### PR TITLE
fix(shell-docs): restore navbar Cloud sign-up CTA + try_for_free_clicked tracking

### DIFF
--- a/showcase/shell-docs/src/components/brand-nav.tsx
+++ b/showcase/shell-docs/src/components/brand-nav.tsx
@@ -7,16 +7,27 @@ import { SearchTrigger } from "./search-trigger";
 import { CopilotKitMark } from "./copilotkit-mark";
 import RocketIcon from "./icons/rocket";
 import ConsoleIcon from "./icons/console";
+import CloudIcon from "./icons/cloud";
 import ExternalLinkIcon from "./icons/external-link";
 
-// LEFT cluster — Docs / Reference. Visual pattern (icon-next-to-label)
-// mirrors canonical.
+// Cloud sign-up CTA destination. UTM params let marketing attribute
+// navbar-driven sign-ups distinctly from in-content SignupLink clicks.
+const CLOUD_CTA_HREF =
+  "https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar";
+
+// LEFT cluster — Docs / Reference / Free Developer Access. Visual pattern
+// (icon-next-to-label) mirrors canonical.
 type LeftLink = {
   href: string;
   label: string;
   icon: React.ReactNode;
   target?: "_blank" | "_self";
   showExternalLinkIcon?: boolean;
+  // Free Developer Access only renders at ≥1100px (same breakpoint as the
+  // Talk-to-Engineer pill). Below that, the navbar is too crowded; the
+  // in-content `<SignupLink>` components on quickstart and feature pages
+  // carry the conversion path.
+  hideAtNarrow?: boolean;
 };
 
 const LEFT_LINKS: LeftLink[] = [
@@ -29,6 +40,14 @@ const LEFT_LINKS: LeftLink[] = [
     icon: <ConsoleIcon className="text-[var(--text-secondary)]" />,
     label: "Reference",
     href: "/reference",
+  },
+  {
+    icon: <CloudIcon className="text-[var(--text-secondary)]" />,
+    label: "Free Developer Access",
+    href: CLOUD_CTA_HREF,
+    target: "_blank",
+    showExternalLinkIcon: true,
+    hideAtNarrow: true,
   },
 ];
 
@@ -51,6 +70,10 @@ export function BrandNav(_props: BrandNavProps = {}) {
   const handleTalkToEngineersClick = () => {
     posthog?.capture("talk_to_us_clicked", { location: "docs_nav" });
     window.location.href = "https://copilotkit.ai/talk-to-an-engineer";
+  };
+
+  const handleFreeDeveloperAccessClick = () => {
+    posthog?.capture("try_for_free_clicked", { location: "docs_navbar_left" });
   };
 
   return (
@@ -83,11 +106,25 @@ export function BrandNav(_props: BrandNavProps = {}) {
                 const hideIconAtNarrow =
                   link.label === "Docs" || link.label === "Reference";
                 const isActive = activeRoute === link.href;
+                const isFreeDevAccess =
+                  link.label === "Free Developer Access";
                 return (
-                  <li key={link.href} className="relative h-full group">
+                  <li
+                    key={link.href}
+                    className={`relative h-full group ${
+                      link.hideAtNarrow
+                        ? "[@media(width<1100px)]:hidden"
+                        : ""
+                    }`}
+                  >
                     <Link
                       href={link.href}
                       target={link.target}
+                      onClick={
+                        isFreeDevAccess
+                          ? handleFreeDeveloperAccessClick
+                          : undefined
+                      }
                       className={`h-full ${
                         isActive ? "opacity-100" : "opacity-50"
                       } hover:opacity-100 transition-opacity duration-300`}

--- a/showcase/shell-docs/src/components/brand-nav.tsx
+++ b/showcase/shell-docs/src/components/brand-nav.tsx
@@ -106,15 +106,12 @@ export function BrandNav(_props: BrandNavProps = {}) {
                 const hideIconAtNarrow =
                   link.label === "Docs" || link.label === "Reference";
                 const isActive = activeRoute === link.href;
-                const isFreeDevAccess =
-                  link.label === "Free Developer Access";
+                const isFreeDevAccess = link.label === "Free Developer Access";
                 return (
                   <li
                     key={link.href}
                     className={`relative h-full group ${
-                      link.hideAtNarrow
-                        ? "[@media(width<1100px)]:hidden"
-                        : ""
+                      link.hideAtNarrow ? "[@media(width<1100px)]:hidden" : ""
                     }`}
                   >
                     <Link


### PR DESCRIPTION
## Summary

The Fumadocs chrome migration (#4898, merged 2026-05-19) slimmed `BrandNav` and dropped the "Free Developer Access" Cloud sign-up CTA from the top navigation, along with its `posthog.capture("try_for_free_clicked", { location })` instrumentation. The event still fires from the in-content `<SignupLink>` MDX component, but the three navbar `location` dimension values (`docs_navbar_left`, `docs_navbar_right`, `docs_navbar_mobile`) went silent.

This restores the **desktop left-cluster surface only**.

## What this PR does

- Adds a "Free Developer Access" entry to `LEFT_LINKS` with `CloudIcon`, external-link affordance, and `target="_blank"`.
- Destination: `https://dashboard.operations.copilotkit.ai/` with the original UTM payload (`utm_source=docs`, `utm_medium=cta`, `utm_campaign=intelligence`, `utm_content=navbar`) so marketing attribution for navbar-driven sign-ups stays distinct from in-content `SignupLink` clicks.
- Click handler fires `posthog.capture("try_for_free_clicked", { location: "docs_navbar_left" })`, matching the pre-migration event surface.
- Renders at ≥1100px only (same breakpoint as the Talk-to-Engineer pill). Below that, the navbar is too crowded and the in-content `<SignupLink>` components on quickstart and feature pages carry the conversion path.

## What this PR deliberately does NOT do

Scope is kept narrow. The Fumadocs migration also removed the GitHub icon, Discord icon, "Integrations" left-nav link, and the mobile burger drawer. Those are out of scope here.

## Independence

This PR is based on `origin/main` and is independent of #4936. `brand-nav.tsx` is byte-identical between `main` and #4936, so there will be no merge conflict regardless of merge order.

## Test plan

- [ ] Visual: load `docs.showcase.copilotkit.ai` at ≥1100px viewport. "Free Developer Access" link appears in left nav between Reference and the Talk-to-Engineer pill. Cloud icon + external-link icon render. Below 1100px, the link is hidden (matches Talk-to-Engineer breakpoint behavior).
- [ ] Functional: click the link. New tab opens to `https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar`.
- [ ] Tracking: PostHog Live Events shows a `try_for_free_clicked` event with `properties.location = "docs_navbar_left"` for the click.