### PR TITLE
fix(showcase/langgraph-typescript): align manifest and styling to langgraph-python

### DIFF
--- a/showcase/integrations/langgraph-typescript/manifest.yaml
+++ b/showcase/integrations/langgraph-typescript/manifest.yaml
@@ -29,11 +29,10 @@ not_supported_features:
 features:
   - cli-start
   - agentic-chat
-  - hitl
   - hitl-in-app
   - hitl-in-chat
-  - hitl-in-chat-booking
   - gen-ui-tool-based
+  - shared-state-read
   - shared-state-read-write
   - subagents
   - tool-rendering
@@ -78,21 +77,14 @@ demos:
       - chat-ui
     command: "npx copilotkit@latest init --framework langgraph-typescript"
   - id: agentic-chat
-    name: Agentic Chat
+    name: "Pre-Built: CopilotChat"
     description: Natural conversation with frontend tool execution
     tags:
       - chat-ui
     route: /demos/agentic-chat
     animated_preview_url:
-  - id: hitl
-    name: In-Chat Human in the Loop (Original)
-    description: User approves agent actions before execution
-    tags:
-      - interactivity
-    route: /demos/hitl
-    animated_preview_url:
   - id: hitl-in-app
-    name: In-App Human in the Loop (Frontend Tools + async HITL)
+    name: "Human in the Loop: In-app"
     description: Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision
     tags:
       - interactivity
@@ -104,7 +96,7 @@ demos:
       - src/app/demos/hitl-in-app/approval-dialog.tsx
       - src/app/api/copilotkit/route.ts
   - id: hitl-in-chat
-    name: In-Chat HITL (useHumanInTheLoop — ergonomic API)
+    name: "Human In the Loop: In-chat"
     description: Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook
     tags:
       - interactivity
@@ -115,20 +107,8 @@ demos:
       - src/app/demos/hitl-in-chat/page.tsx
       - src/app/demos/hitl-in-chat/time-picker-card.tsx
       - src/app/api/copilotkit/route.ts
-  - id: hitl-in-chat-booking
-    name: In-Chat HITL (Booking)
-    description: Time-picker card rendered inline via useHumanInTheLoop for a booking flow
-    tags:
-      - interactivity
-    route: /demos/hitl-in-chat
-    animated_preview_url:
-    highlight:
-      - src/agent/hitl-in-chat.ts
-      - src/app/demos/hitl-in-chat/page.tsx
-      - src/app/demos/hitl-in-chat/time-picker-card.tsx
-      - src/app/api/copilotkit/route.ts
   - id: tool-rendering
-    name: Tool Rendering
+    name: "Generative UI: Tool Rendering (Custom)"
     description: Backend agent tools rendered as UI components
     tags:
       - agent-capabilities
@@ -138,7 +118,7 @@ demos:
       - src/agent/tool-rendering.ts
       - src/app/demos/tool-rendering/page.tsx
   - id: gen-ui-tool-based
-    name: Tool-Based Generative UI
+    name: "Generative UI: useComponent"
     description: Agent uses tools to trigger UI generation
     tags:
       - generative-ui
@@ -148,21 +128,21 @@ demos:
       - src/app/demos/gen-ui-tool-based/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: gen-ui-agent
-    name: Agentic Generative UI
+    name: "Generative UI: Agent State"
     description: Long-running agent tasks with generated UI
     tags:
       - generative-ui
     route: /demos/gen-ui-agent
     animated_preview_url:
   - id: shared-state-streaming
-    name: State Streaming
+    name: "Shared State: Streaming"
     description: Per-token state delta streaming from agent to UI
     tags:
       - agent-state
     route: /demos/shared-state-streaming
     animated_preview_url:
   - id: shared-state-read-write
-    name: Shared State (Read + Write)
+    name: "Shared State: Read + Write"
     description: Bidirectional shared state — UI writes preferences via agent.setState; agent writes notes via a Command-returning tool
     tags:
       - agent-state
@@ -173,6 +153,18 @@ demos:
       - src/app/demos/shared-state-read-write/page.tsx
       - src/app/demos/shared-state-read-write/preferences-card.tsx
       - src/app/demos/shared-state-read-write/notes-card.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: shared-state-read
+    name: "Shared State: Read-only"
+    description: "Recipe editor publishes form state via agent.setState; the agent reads the recipe context but does not mutate it (no backend tool — neutral default agent)."
+    tags:
+      - agent-state
+    route: /demos/shared-state-read
+    animated_preview_url:
+    highlight:
+      - src/app/demos/shared-state-read/page.tsx
+      - src/app/demos/shared-state-read/recipe-card.tsx
+      - src/app/demos/shared-state-read/types.ts
       - src/app/api/copilotkit/route.ts
   - id: subagents
     name: Sub-Agents
@@ -226,7 +218,7 @@ demos:
       - src/app/demos/prebuilt-popup/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: chat-slots
-    name: Chat Customization (Slots)
+    name: "Chat Customization: Slots"
     description: Customize CopilotChat via its slot system
     tags:
       - chat-ui
@@ -238,7 +230,7 @@ demos:
       - src/app/demos/chat-slots/slot-wrappers.tsx
       - src/app/api/copilotkit/route.ts
   - id: chat-customization-css
-    name: Chat Customization (CSS)
+    name: "Chat Customization: CSS"
     description: Default CopilotChat re-themed via CopilotKitCSSProperties
     tags:
       - chat-ui
@@ -250,7 +242,7 @@ demos:
       - src/app/demos/chat-customization-css/theme.css
       - src/app/api/copilotkit/route.ts
   - id: headless-simple
-    name: Headless Chat (Simple)
+    name: "Headless UI: Simple"
     description: Minimal custom chat surface built on useAgent
     tags:
       - chat-ui
@@ -261,7 +253,7 @@ demos:
       - src/app/demos/headless-simple/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: headless-complete
-    name: Headless Chat (Complete)
+    name: "Headless UI: Complete"
     description: Full chat implementation built from scratch on useAgent
     tags:
       - chat-ui
@@ -294,7 +286,7 @@ demos:
       - src/app/demos/auth/demo-token.ts
       - src/app/api/copilotkit-auth/[[...slug]]/route.ts
   - id: multimodal
-    name: Multimodal Attachments
+    name: Attachments
     description: Image and PDF uploads via CopilotChat attachments, processed by a vision-capable agent
     tags:
       - chat-ui
@@ -320,21 +312,21 @@ demos:
       - src/app/demos/agent-config/config-types.ts
       - src/app/api/copilotkit-agent-config/route.ts
   - id: tool-rendering-default-catchall
-    name: Tool Rendering (Default Catch-all)
+    name: "Generative UI: Tool Rendering (Default)"
     description: Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI
     tags:
       - generative-ui
     route: /demos/tool-rendering-default-catchall
     animated_preview_url:
   - id: tool-rendering-custom-catchall
-    name: Tool Rendering (Custom Catch-all)
+    name: "Generative UI: Tool Rendering (Catch-all)"
     description: Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call
     tags:
       - generative-ui
     route: /demos/tool-rendering-custom-catchall
     animated_preview_url:
   - id: tool-rendering-reasoning-chain
-    name: Tool Rendering + Reasoning Chain (testing)
+    name: "Generative UI: Tool calls + reasoning"
     description: Sequential tool calls with reasoning tokens rendered side-by-side
     tags:
       - generative-ui
@@ -362,7 +354,7 @@ demos:
       - src/app/demos/reasoning-default/page.tsx
       - src/app/demos/reasoning-default/suggestions.ts
   - id: gen-ui-interrupt
-    name: In-Chat HITL (useInterrupt — low-level primitive)
+    name: "Human in the Loop: Interrupts"
     description: Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle
     tags:
       - generative-ui
@@ -374,7 +366,7 @@ demos:
       - src/app/demos/gen-ui-interrupt/_components/time-picker-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: interrupt-headless
-    name: Headless Interrupt (testing)
+    name: "Human in the Loop: Headless Interrupts"
     description: Resolve langgraph interrupts from a plain button grid — no chat, no useInterrupt render prop
     tags:
       - interactivity
@@ -385,7 +377,7 @@ demos:
       - src/app/demos/interrupt-headless/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: declarative-gen-ui
-    name: Declarative Generative UI (A2UI)
+    name: "Declarative UI: Dynamic A2UI"
     description: Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; backend agent owns the generate_a2ui tool
     tags:
       - generative-ui
@@ -399,7 +391,7 @@ demos:
       - src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
       - src/app/api/copilotkit-declarative-gen-ui/route.ts
   - id: a2ui-fixed-schema
-    name: Declarative Generative UI (A2UI — Fixed Schema)
+    name: "Declarative UI: Fixed A2UI"
     description: A2UI rendering against a known client-side schema
     tags:
       - generative-ui
@@ -426,7 +418,7 @@ demos:
       - src/app/demos/mcp-apps/page.tsx
       - src/app/api/copilotkit-mcp-apps/route.ts
   - id: frontend-tools
-    name: Frontend Tools (In-App Actions)
+    name: "Frontend Tools: In-app Actions"
     description: Agent invokes client-side handlers registered with useFrontendTool
     tags:
       - interactivity
@@ -437,7 +429,7 @@ demos:
       - src/app/demos/frontend-tools/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: frontend-tools-async
-    name: Frontend Tools (Async)
+    name: "Frontend Tools: Async"
     description: useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result
     tags:
       - interactivity
@@ -449,7 +441,7 @@ demos:
       - src/app/demos/frontend-tools-async/notes-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: readonly-state-agent-context
-    name: Readonly State (Agent Context)
+    name: "Shared State: Frontend Context"
     description: Frontend provides read-only context to the agent via useAgentContext
     tags:
       - agent-state
@@ -460,7 +452,7 @@ demos:
       - src/app/demos/readonly-state-agent-context/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: voice
-    name: Voice Input
+    name: Voice
     description: Speech-to-text via @copilotkit/voice with a bundled sample audio button
     tags:
       - chat-ui
@@ -508,7 +500,7 @@ demos:
       - src/app/demos/declarative-json-render/suggestions.ts
       - src/app/api/copilotkit-declarative-json-render/route.ts
   - id: open-gen-ui
-    name: Fully Open-Ended Generative UI
+    name: "Open Generative UI: Default"
     description: Agent generates UI from an arbitrary component library
     tags:
       - generative-ui
@@ -519,7 +511,7 @@ demos:
       - src/app/demos/open-gen-ui/page.tsx
       - src/app/api/copilotkit-ogui/route.ts
   - id: open-gen-ui-advanced
-    name: "Open-Ended Gen UI (Advanced: with frontend function calling)"
+    name: "Open Generative UI: Custom"
     description: Agent-authored UI that can invoke frontend sandbox functions from inside the iframe
     tags:
       - generative-ui

--- a/showcase/integrations/langgraph-typescript/src/app/copilotkit-overrides.css
+++ b/showcase/integrations/langgraph-typescript/src/app/copilotkit-overrides.css
@@ -1,9 +1,0 @@
-/* CopilotKit overrides — matches Dojo styling */
-
-.copilotKitInput {
-  border-bottom-left-radius: 0.75rem;
-  border-bottom-right-radius: 0.75rem;
-  border-top-left-radius: 0.75rem;
-  border-top-right-radius: 0.75rem;
-  border: 1px solid var(--copilot-kit-separator-color) !important;
-}

--- a/showcase/integrations/langgraph-typescript/src/app/demos/layout.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/layout.tsx
@@ -20,9 +20,6 @@ function loadDemoIndex(): Map<string, string> {
   for (const demo of manifest.demos ?? []) {
     if (demo.route) {
       const slug = demo.route.replace(/^\/demos\//, "");
-      // Last writer wins; manifest has duplicate routes (e.g., hitl-in-chat
-      // shared by hitl-in-chat and hitl-in-chat-booking). Prefer the first
-      // entry to keep titles stable.
       if (!map.has(slug)) map.set(slug, demo.name);
     }
   }

--- a/showcase/integrations/langgraph-typescript/src/app/globals.css
+++ b/showcase/integrations/langgraph-typescript/src/app/globals.css
@@ -3,11 +3,43 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-:root {
-  --copilot-kit-background-color: #f8f9fa;
-  --copilot-kit-primary-color: #0066ff;
+/* Map the CSS variables declared on :root below into Tailwind v4 theme tokens
+ * so utilities like `bg-background`, `text-foreground`, `bg-muted`,
+ * `border-border`, etc. actually generate CSS. Without this block the
+ * shadcn / AI Elements / prompt-kit primitives fall back to no styling. */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--card);
+  --color-popover-foreground: var(--card-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
 
-  --background: #f8f9fa;
+:root {
+  --copilot-kit-background-color: #ffff;
+  --copilot-kit-primary-color: #0d6e3f;
+  --copilot-kit-response-button-background-color: #f5f5f3;
+  --copilot-kit-response-button-color: #1a1a18;
+
+  --background: #ffff;
   --foreground: #1a1a18;
   --card: #ffffff;
   --card-foreground: #1a1a18;
@@ -52,10 +84,73 @@
   box-sizing: border-box;
 }
 
-body {
+html {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  min-height: 100vh;
   background: var(--background);
   color: var(--foreground);
+}
+
+/* `body` deliberately does NOT have `width: 100%`. Letting it auto-size
+ * lets <CopilotSidebar /> shrink the document via `margin-inline-end` so
+ * the sidebar pushes the page content instead of overlapping it. */
+body {
+  height: 100%;
+  overflow: hidden;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+/* When a Radix overlay (Select / Dialog / Popover) opens, react-remove-scroll
+ * adds `body[data-scroll-locked]` with `padding-right` equal to what it
+ * thinks is the scrollbar width. Because our <body> uses `margin-inline-end`
+ * to make room for <CopilotSidebar />, the lib mis-detects the sidebar
+ * width as scrollbar width and injects a matching padding-right, which
+ * shrinks the page on every dropdown open. We have no real scrollbar
+ * (`overflow: hidden` above) so the compensation is unnecessary — neutralize
+ * it here. */
+body[data-scroll-locked] {
+  padding-right: 0 !important;
+}
+
+.demo-card {
+  display: block;
+  padding: 1rem 1.125rem;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    transform 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    background 120ms ease;
+}
+
+.demo-card:hover {
+  border-color: color-mix(in oklab, var(--ring) 70%, var(--border));
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 4px 16px rgba(0, 0, 0, 0.04);
+  transform: translateY(-1px);
+  background: var(--card);
+}
+
+.demo-card:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+/* Slot Atlas: each marker shows its label only when the cursor is on THAT
+ * marker, not on a descendant. Markers nest (welcomeScreen wraps the input
+ * and suggestions, each of which is its own marker), so a plain
+ * `:hover .slot-label { opacity: 1 }` would light up every nested label as
+ * soon as the cursor entered the outermost marker. The `:not(:has(...))`
+ * predicate excludes the case where a descendant marker is also hovered. */
+.slot-marker:hover:not(:has(.slot-marker:hover)) > .slot-label {
+  opacity: 1;
 }

--- a/showcase/integrations/langgraph-typescript/src/app/layout.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import "@copilotkit/react-core/v2/styles.css";
 import "./globals.css";
-import "./copilotkit-overrides.css";
 
 export const metadata: Metadata = {
   title: "CopilotKit Showcase — LangGraph (TypeScript)",


### PR DESCRIPTION
## Summary

Brings LangGraph TypeScript showcase to parity with LangGraph Python (north-star) on both demo metadata and visual styling.

### Manifest fixes
- **Dropped phantom slugs.** `hitl-in-chat-booking` had no folder of its own and pointed to the same route as `hitl-in-chat` — two slugs rendered the same demo. `hitl` was a legacy entry Python had already removed.
- **Added missing `shared-state-read`.** The folder existed on disk with a working page; the manifest just wasn't surfacing it.
- **Renamed 23 demos** to match the canonical names in `shared/feature-registry.json` (Python already does). Examples: `"Agentic Chat"` → `"Pre-Built: CopilotChat"`, `"In-Chat HITL (useHumanInTheLoop — ergonomic API)"` → `"Human In the Loop: In-chat"`, `"Voice Input"` → `"Voice"`. Matched Python on the 3 tool-rendering variants where canonical and Python disagreed.
- Dropped the now-obsolete duplicate-routes comment in `demos/layout.tsx`.

### Styling fixes
Ported `langgraph-python/src/app/globals.css` verbatim. Notable effects:
- **Adds the `@theme inline` Tailwind v4 block** so shadcn / AI Elements / prompt-kit primitives actually pick up the design tokens. Without this they fall back to no styling.
- **Constrains `html`/`body` to 100% with `overflow: hidden`** so flex-centered chats render in the middle instead of anchored to the top — this is the visible bug that motivated the styling pass.
- **Switches the brand color** from `#0066ff` blue to `#0d6e3f` CopilotKit green and adds the response-button color tokens.
- Adds the Radix overlay scroll-lock fix, `.demo-card` utility, and `.slot-marker` Slot Atlas styling.
- Deletes `copilotkit-overrides.css` and its import — the rounded-input rule it added is already covered by the v2 core styles.

After this PR, `globals.css` is byte-identical to Python's, and the registry has zero slug or name divergence between LGT and LGP.

## Test plan
- [x] `npx tsx scripts/generate-registry.ts` regenerates clean (all 18 integrations, no schema errors).
- [x] `npx tsx scripts/validate-parity.ts` reports `[PASS]` for `langgraph-typescript`.
- [x] Registry diff vs Python: 0 slugs in TS not in PY, 0 slugs in PY not in TS, 0 name mismatches, 0 duplicate routes.
- [x] `oxfmt --check` and `oxlint` clean on touched files.
- [ ] Visual smoke after deploy: chat is vertically centered, brand color is green, shadcn primitives render styled.