### PR TITLE
chore: add .claude/launch.json with dev configs for showcase shells and stack

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,70 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "showcase",
+      "runtimeExecutable": "showcase/bin/showcase",
+      "runtimeArgs": ["up"]
+    },
+    {
+      "name": "shell",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "showcase/shell", "run", "dev"],
+      "port": 3000
+    },
+    {
+      "name": "shell (with local demos)",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-c",
+        "SHOWCASE_LOCAL=1 npm --prefix showcase/shell run dev"
+      ],
+      "port": 3000
+    },
+    {
+      "name": "shell-dojo",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "showcase/shell-dojo", "run", "dev"],
+      "port": 3001
+    },
+    {
+      "name": "shell-dojo (with local demos)",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-c",
+        "SHOWCASE_LOCAL=1 npm --prefix showcase/shell-dojo run dev"
+      ],
+      "port": 3001
+    },
+    {
+      "name": "shell-dashboard",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "showcase/shell-dashboard", "run", "dev"],
+      "port": 3002
+    },
+    {
+      "name": "shell-dashboard (with local demos)",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-c",
+        "SHOWCASE_LOCAL=1 npm --prefix showcase/shell-dashboard run dev"
+      ],
+      "port": 3002
+    },
+    {
+      "name": "shell-docs",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "showcase/shell-docs", "run", "dev"],
+      "port": 3003
+    },
+    {
+      "name": "shell-docs (with local demos)",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-c",
+        "SHOWCASE_LOCAL=1 npm --prefix showcase/shell-docs run dev"
+      ],
+      "port": 3003
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds [`.claude/launch.json`](.claude/launch.json) so Claude Code's `/run` flow can boot any of the showcase surfaces by name.

### Configs

| Name | What it does |
|---|---|
| `showcase` | `showcase/bin/showcase up` — backend infra stack (aimock, pocketbase, dashboard). |
| `shell` / `shell (with local demos)` | `npm --prefix showcase/shell run dev`, optionally with `SHOWCASE_LOCAL=1` to iframe local containers (port 3000) |
| `shell-dojo` / `shell-dojo (with local demos)` | Same shape (port 3001) |
| `shell-dashboard` / `shell-dashboard (with local demos)` | Same shape (port 3002) |
| `shell-docs` / `shell-docs (with local demos)` | Same shape (port 3003) |

### Why two variants per shell

Each Next.js shell iframes the integration backends. By default they point at Railway URLs. With `SHOWCASE_LOCAL=1`, they swap in `localhost:<port>` from `showcase/shared/local-ports.json` — which is what you want when `showcase up <slug>` is running locally. The `(with local demos)` variants pre-set that env var so you don't have to remember.

## Test plan

- [ ] `showcase` boots the infra containers
- [ ] Each shell variant binds to its declared port
- [ ] `(with local demos)` variants point shell iframes at `localhost:<port>` from `shared/local-ports.json`