### PR TITLE
fix(core): sync streamed tool call args into messages

### DIFF
--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -1,12 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { CopilotKitCore } from "../core";
-import {
-  AbstractAgent,
-  Message,
-  State,
-  RunAgentInput,
-  EventType,
-} from "@ag-ui/client";
+import type { Message, State, RunAgentInput } from "@ag-ui/client";
+import { AbstractAgent, EventType } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
 
 /**
@@ -23,7 +18,7 @@ class EventEmittingMockAgent extends AbstractAgent {
     });
   }
 
-  protected run(input: RunAgentInput): any {
+  protected run(_input: RunAgentInput): any {
     // Not used in these tests
     throw new Error("run() should not be called in these tests");
   }
@@ -175,6 +170,56 @@ class EventEmittingMockAgent extends AbstractAgent {
     }
   }
 
+  // Helper to emit tool call args event
+  public async emitToolCallArgs(
+    runId: string,
+    toolCallId: string,
+    delta: string,
+  ) {
+    const toolCall = this.findToolCall(toolCallId);
+    for (const sub of this.subscribers) {
+      if (sub.onToolCallArgsEvent) {
+        const mutation = await sub.onToolCallArgsEvent({
+          event: {
+            type: EventType.TOOL_CALL_ARGS,
+            toolCallId,
+            delta,
+          },
+          toolCallBuffer: toolCall?.function.arguments ?? "",
+          toolCallName: toolCall?.function.name ?? "",
+          partialToolCallArgs: {},
+          messages: this.messages,
+          state: this.state,
+          agent: this,
+          input: this.createRunInput(runId),
+        });
+        this.applyMutation(mutation);
+      }
+    }
+  }
+
+  // Helper to emit tool call end event
+  public async emitToolCallEnd(runId: string, toolCallId: string) {
+    const toolCall = this.findToolCall(toolCallId);
+    for (const sub of this.subscribers) {
+      if (sub.onToolCallEndEvent) {
+        const mutation = await sub.onToolCallEndEvent({
+          event: {
+            type: EventType.TOOL_CALL_END,
+            toolCallId,
+          },
+          toolCallName: toolCall?.function.name ?? "",
+          toolCallArgs: this.parseToolCallArgs(toolCall?.function.arguments),
+          messages: this.messages,
+          state: this.state,
+          agent: this,
+          input: this.createRunInput(runId),
+        });
+        this.applyMutation(mutation);
+      }
+    }
+  }
+
   // Override subscribe to track subscribers
   public override subscribe(subscriber: any) {
     this.subscribers.push(subscriber);
@@ -195,6 +240,38 @@ class EventEmittingMockAgent extends AbstractAgent {
       state: this.state,
       messages: this.messages,
     };
+  }
+
+  private findToolCall(toolCallId: string) {
+    for (const message of this.messages) {
+      if (message.role !== "assistant") continue;
+      const toolCall = message.toolCalls?.find((candidateToolCall) => {
+        return candidateToolCall.id === toolCallId;
+      });
+      if (toolCall) return toolCall;
+    }
+  }
+
+  public getToolCallArguments(toolCallId: string) {
+    return this.findToolCall(toolCallId)?.function.arguments;
+  }
+
+  private parseToolCallArgs(args?: string) {
+    if (!args) return {};
+    try {
+      return JSON.parse(args);
+    } catch {
+      return {};
+    }
+  }
+
+  private applyMutation(mutation: any) {
+    if (mutation?.messages) {
+      this.messages = mutation.messages;
+    }
+    if (mutation?.state) {
+      this.state = mutation.state;
+    }
   }
 }
 
@@ -521,6 +598,66 @@ describe("StateManager - Message Tracking", () => {
       "msg1",
     );
     expect(associatedRunId).toBe(runId);
+  });
+
+  it("should replace snapshot tool call args with streamed args", async () => {
+    const runId = "run1";
+    const message: Message = {
+      id: "msg1",
+      role: "assistant",
+      content: "",
+      toolCalls: [
+        {
+          id: "tool1",
+          type: "function",
+          function: {
+            name: "searchWeb",
+            arguments: JSON.stringify({ query: "hallucinated" }),
+          },
+        },
+      ],
+    };
+
+    await agent.emitRunStarted(runId, {});
+    await agent.emitNewMessage(runId, message);
+    await agent.emitToolCallArgs(
+      runId,
+      "tool1",
+      JSON.stringify({ query: "server enriched", limit: 3 }),
+    );
+
+    expect(agent.getToolCallArguments("tool1")).toBe(
+      JSON.stringify({ query: "server enriched", limit: 3 }),
+    );
+  });
+
+  it("should accumulate streamed args independently of existing message args", async () => {
+    const runId = "run1";
+    const message: Message = {
+      id: "msg1",
+      role: "assistant",
+      content: "",
+      toolCalls: [
+        {
+          id: "tool1",
+          type: "function",
+          function: {
+            name: "searchWeb",
+            arguments: JSON.stringify({ query: "hallucinated" }),
+          },
+        },
+      ],
+    };
+
+    await agent.emitRunStarted(runId, {});
+    await agent.emitNewMessage(runId, message);
+    await agent.emitToolCallArgs(runId, "tool1", '{"query":');
+    await agent.emitToolCallArgs(runId, "tool1", '"server enriched"}');
+    await agent.emitToolCallEnd(runId, "tool1");
+
+    expect(agent.getToolCallArguments("tool1")).toBe(
+      '{"query":"server enriched"}',
+    );
   });
 });
 

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AbstractAgent,
   Message,
   State,
@@ -6,8 +6,11 @@ import {
   StateSnapshotEvent,
   StateDeltaEvent,
   MessagesSnapshotEvent,
-  randomUUID,
+  AgentStateMutation,
+  ToolCallArgsEvent,
+  ToolCallEndEvent,
 } from "@ag-ui/client";
+import { randomUUID } from "@ag-ui/client";
 import type { CopilotKitCore } from "./core";
 
 /**
@@ -24,6 +27,9 @@ export class StateManager {
 
   // Active run tracking: `agentId:threadId` -> runId (used when messages arrive without input)
   private activeRun: Map<string, string> = new Map();
+
+  // Tool call args streamed after a snapshot are authoritative for renderers.
+  private toolCallArgsById: Map<string, string> = new Map();
 
   // Agent subscriptions for cleanup
   private agentSubscriptions: Map<string, () => void> = new Map();
@@ -117,14 +123,17 @@ export class StateManager {
         if (revoked) return;
         this.handleStateDelta(agent, event, effectiveInput(input), state);
       },
-      onMessagesSnapshotEvent: ({ event, input, messages }) => {
+      onMessagesSnapshotEvent: ({ event, input }) => {
         if (revoked) return;
-        this.handleMessagesSnapshot(
-          agent,
-          event,
-          effectiveInput(input),
-          messages,
-        );
+        this.handleMessagesSnapshot(agent, event, effectiveInput(input));
+      },
+      onToolCallArgsEvent: ({ event, messages }) => {
+        if (revoked) return;
+        return this.handleToolCallArgs(agent, event, messages);
+      },
+      onToolCallEndEvent: ({ event, messages }) => {
+        if (revoked) return;
+        return this.handleToolCallEnd(agent, event, messages);
       },
       onNewMessage: ({ message, input }) => {
         if (revoked) return;
@@ -272,7 +281,6 @@ export class StateManager {
     agent: AbstractAgent,
     event: MessagesSnapshotEvent,
     input: RunAgentInput,
-    messages: Message[],
   ): void {
     if (!agent.agentId) return;
 
@@ -312,6 +320,82 @@ export class StateManager {
 
     const { threadId, runId } = input;
     this.associateMessageWithRun(agent.agentId, threadId, message.id, runId);
+  }
+
+  /**
+   * Handle streamed tool call args.
+   */
+  private handleToolCallArgs(
+    agent: AbstractAgent,
+    event: ToolCallArgsEvent,
+    messages: ReadonlyArray<Readonly<Message>>,
+  ): AgentStateMutation | void {
+    if (!agent.agentId) return;
+
+    const key = this.toolCallArgsKey(agent, event.toolCallId);
+    const args = (this.toolCallArgsById.get(key) ?? "") + event.delta;
+    this.toolCallArgsById.set(key, args);
+
+    return this.updateToolCallArguments(messages, event.toolCallId, args);
+  }
+
+  /**
+   * Handle tool call completion.
+   */
+  private handleToolCallEnd(
+    agent: AbstractAgent,
+    event: ToolCallEndEvent,
+    messages: ReadonlyArray<Readonly<Message>>,
+  ): AgentStateMutation | void {
+    if (!agent.agentId) return;
+
+    const key = this.toolCallArgsKey(agent, event.toolCallId);
+    const args = this.toolCallArgsById.get(key);
+    this.toolCallArgsById.delete(key);
+
+    if (args === undefined) return;
+    return this.updateToolCallArguments(messages, event.toolCallId, args);
+  }
+
+  private updateToolCallArguments(
+    messages: ReadonlyArray<Readonly<Message>>,
+    toolCallId: string,
+    args: string,
+  ): AgentStateMutation | void {
+    let didUpdate = false;
+
+    const nextMessages = messages.map((message) => {
+      if (message.role !== "assistant" || !message.toolCalls) {
+        return message as Message;
+      }
+
+      const nextToolCalls = message.toolCalls.map((toolCall) => {
+        if (toolCall.id !== toolCallId) {
+          return toolCall;
+        }
+
+        didUpdate = true;
+        return {
+          ...toolCall,
+          function: {
+            ...toolCall.function,
+            arguments: args,
+          },
+        };
+      });
+
+      return {
+        ...message,
+        toolCalls: nextToolCalls,
+      };
+    });
+
+    if (!didUpdate) return;
+    return { messages: nextMessages };
+  }
+
+  private toolCallArgsKey(agent: AbstractAgent, toolCallId: string): string {
+    return `${agent.agentId ?? ""}:${agent.threadId}:${toolCallId}`;
   }
 
   /**


### PR DESCRIPTION
## What does this PR do?

Fixes #4935.

Updates CopilotKit core message state so streamed `TOOL_CALL_ARGS` are treated as the authoritative tool-call arguments for frontend rendering. This prevents `useFrontendTool` from rendering with hallucinated args from `MESSAGES_SNAPSHOT` when the backend later streams enriched tool-call args.

### Changes

-> Track streamed tool-call args in `StateManager` by agent/thread/toolCallId.
-> Return updated AG-UI message mutations from `onToolCallArgsEvent` and `onToolCallEndEvent`.
-> Preserve accumulated streamed args independently from existing snapshot args.
-> Add regression tests covering:
  -> replacement of hallucinated snapshot args
  -> multi-delta streamed args accumulation

## Related PRs and Issues

-> Fixes #4935

## Testing

->  `pnpm nx run @copilotkit/core:test -- --run src/__tests__/state-manager.test.ts`
->  `pnpm nx run @copilotkit/core:build`

Note: local monorepo-wide tests currently fail due to unrelated Vitest timeout issues in other packages.
