### PR TITLE
fix(runtime): close header propagation gap for LangGraphAgent

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agent-utils-header-forwarding.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import { configureAgentForRequest } from "../handlers/shared/agent-utils";
+import type { AbstractAgent } from "@ag-ui/client";
+import type { CopilotRuntimeLike } from "../core/runtime";
+
+/**
+ * Minimal agent stub that satisfies the MiddlewareCapableAgent shape
+ * used inside configureAgentForRequest.
+ */
+function createMockAgent(headers?: Record<string, string>): AbstractAgent {
+  return {
+    headers,
+    // configureAgentForRequest checks `typeof agent.use === "function"`
+    use: () => {},
+  } as unknown as AbstractAgent;
+}
+
+function createMockRuntime(): CopilotRuntimeLike {
+  return {
+    agents: Promise.resolve({}),
+  } as unknown as CopilotRuntimeLike;
+}
+
+function createRequest(headers: Record<string, string>): Request {
+  return new Request("https://example.com/agent/test-agent/run", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("configureAgentForRequest – header forwarding", () => {
+  it("forwards x-aimock-context when agent.headers is undefined (default LangGraphAgent)", () => {
+    const agent = createMockAgent(/* headers = undefined */);
+    const request = createRequest({
+      "Content-Type": "application/json",
+      "x-aimock-context": "langgraph-python",
+    });
+
+    configureAgentForRequest({
+      runtime: createMockRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    // The core regression: before the fix, agent.headers stayed undefined
+    // because the old `if (agent.headers)` guard skipped the assignment.
+    expect((agent as any).headers).toBeDefined();
+    expect((agent as any).headers["x-aimock-context"]).toBe("langgraph-python");
+  });
+
+  it("forwards x-test-id when agent.headers is undefined", () => {
+    const agent = createMockAgent();
+    const request = createRequest({
+      "Content-Type": "application/json",
+      "x-test-id": "run-42",
+    });
+
+    configureAgentForRequest({
+      runtime: createMockRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    expect((agent as any).headers["x-test-id"]).toBe("run-42");
+  });
+
+  it("merges forwardable headers with pre-existing agent.headers", () => {
+    const agent = createMockAgent({
+      "x-existing": "keep-me",
+      authorization: "Bearer original-token",
+    });
+    const request = createRequest({
+      "Content-Type": "application/json",
+      "x-aimock-context": "langgraph-python",
+      "x-test-id": "run-99",
+    });
+
+    configureAgentForRequest({
+      runtime: createMockRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    const headers = (agent as any).headers as Record<string, string>;
+
+    // Pre-existing headers preserved
+    expect(headers["x-existing"]).toBe("keep-me");
+    expect(headers["authorization"]).toBe("Bearer original-token");
+
+    // Forwardable headers merged in
+    expect(headers["x-aimock-context"]).toBe("langgraph-python");
+    expect(headers["x-test-id"]).toBe("run-99");
+  });
+
+  it("request forwardable headers override matching pre-existing agent headers", () => {
+    const agent = createMockAgent({
+      "x-aimock-context": "old-context",
+    });
+    const request = createRequest({
+      "x-aimock-context": "new-context",
+    });
+
+    configureAgentForRequest({
+      runtime: createMockRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    // The spread order is { ...agent.headers, ...extracted } so request wins
+    expect((agent as any).headers["x-aimock-context"]).toBe("new-context");
+  });
+
+  it("does NOT forward non-forwardable headers like content-type or origin", () => {
+    const agent = createMockAgent();
+    const request = createRequest({
+      "Content-Type": "application/json",
+      Origin: "http://localhost:3000",
+      "User-Agent": "test-runner",
+      Cookie: "session=abc",
+      Host: "example.com",
+      Accept: "text/event-stream",
+      // Only this one should come through
+      "x-aimock-context": "langgraph-python",
+    });
+
+    configureAgentForRequest({
+      runtime: createMockRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    const headers = (agent as any).headers as Record<string, string>;
+
+    // Non-forwardable headers must NOT be present
+    expect(headers["content-type"]).toBeUndefined();
+    expect(headers["origin"]).toBeUndefined();
+    expect(headers["user-agent"]).toBeUndefined();
+    expect(headers["cookie"]).toBeUndefined();
+    expect(headers["host"]).toBeUndefined();
+    expect(headers["accept"]).toBeUndefined();
+
+    // The x- header IS forwarded
+    expect(headers["x-aimock-context"]).toBe("langgraph-python");
+  });
+
+  it("authorization header IS forwarded (it is in the allowlist)", () => {
+    const agent = createMockAgent();
+    const request = createRequest({
+      Authorization: "Bearer secret-token",
+      "Content-Type": "application/json",
+    });
+
+    configureAgentForRequest({
+      runtime: createMockRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    const headers = (agent as any).headers as Record<string, string>;
+    expect(headers["authorization"]).toBe("Bearer secret-token");
+    expect(headers["content-type"]).toBeUndefined();
+  });
+
+  it("results in empty headers object when request has no forwardable headers and agent.headers is undefined", () => {
+    const agent = createMockAgent();
+    const request = createRequest({
+      "Content-Type": "application/json",
+      Origin: "http://localhost",
+    });
+
+    configureAgentForRequest({
+      runtime: createMockRuntime(),
+      request,
+      agentId: "test-agent",
+      agent,
+    });
+
+    // Even with no forwardable headers, agent.headers should be set (not undefined)
+    expect((agent as any).headers).toBeDefined();
+    expect((agent as any).headers).toEqual({});
+  });
+});

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -86,12 +86,10 @@ export function configureAgentForRequest(params: {
     }
   }
 
-  if (agent.headers) {
-    agent.headers = {
-      ...agent.headers,
-      ...extractForwardableHeaders(request),
-    };
-  }
+  agent.headers = {
+    ...agent.headers,
+    ...extractForwardableHeaders(request),
+  };
 }
 
 export async function parseRunRequest(

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -27,7 +27,27 @@ from langchain.agents.middleware import (
 )
 from langgraph.runtime import Runtime
 
+from .header_propagation import install_httpx_hook
 from .langgraph import CopilotKitProperties
+
+# Track which httpx clients already have the header-propagation hook installed
+# (by object id) so we never double-install on repeated model calls.
+_hooked_clients: set[int] = set()
+
+
+def _ensure_httpx_hook(model: Any) -> None:
+    """Install the header-propagation httpx hook on a LangChain chat model's
+    underlying HTTP client(s), if present.  No-op for models that don't expose
+    an httpx transport (e.g. non-OpenAI/Anthropic providers).
+    """
+    for attr in ("client", "async_client"):
+        client = getattr(model, attr, None)
+        if client is None:
+            continue
+        cid = id(client)
+        if cid not in _hooked_clients:
+            install_httpx_hook(client)
+            _hooked_clients.add(cid)
 
 
 class StateSchema(AgentState):
@@ -152,6 +172,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         request: ModelRequest,
         handler: Callable[[ModelRequest], ModelResponse],
     ) -> ModelResponse:
+        _ensure_httpx_hook(request.model)
         request = self._apply_state_note(request)
         frontend_tools = request.state.get("copilotkit", {}).get("actions", [])
 
@@ -340,6 +361,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
+        _ensure_httpx_hook(request.model)
         self._fix_messages_for_bedrock(request.messages)
         request = self._apply_state_note(request)
 


### PR DESCRIPTION
## Summary
- Fix `if (agent.headers)` guard in `agent-utils.ts` that silently dropped forwarded headers when `agent.headers` was `undefined` (default for `LangGraphAgent`)
- Wire `install_httpx_hook` in Python SDK `CopilotKitMiddleware` so forwarded x-* headers propagate to outgoing LLM API calls via httpx event hooks
- Add 7 regression tests proving the fix (red-green verified: 5 fail before, 7 pass after)

## Context
PR #4773 built the header propagation infrastructure but documented this gap as "out of scope." The `extractForwardableHeaders()` mechanism works correctly — the bug was that it was never called for agents with no pre-configured headers.

This blocks D6 showcase fixture isolation which relies on `X-AIMock-Context` reaching aimock.

## Test plan
- [x] 7 new unit tests in `agent-utils-header-forwarding.test.ts`
- [x] Red-green verified: 5 tests fail with `if (agent.headers)` guard, all 7 pass without
- [x] All 1483 existing runtime tests pass
- [ ] E2E: showcase D5 validation with match.context fixtures after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)