### PR TITLE
fix(react-core): wait for provider HITL responses

### DIFF
--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { AbstractAgent } from "@ag-ui/client";
+import { ToolCallStatus } from "@copilotkit/core";
 import type { FrontendTool } from "@copilotkit/core";
 import type React from "react";
 import {
@@ -464,6 +465,9 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
     openGenerativeUI?.sandboxFunctions,
     "openGenerativeUI.sandboxFunctions must be a stable array.",
   );
+  const humanInTheLoopResolversRef = useRef<
+    Map<string, (result: unknown) => void>
+  >(new Map());
 
   // Note: warnings for array identity changes are handled by useStableArrayProp
 
@@ -480,16 +484,32 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
         parameters: tool.parameters,
         followUp: tool.followUp,
         ...(tool.agentId && { agentId: tool.agentId }),
-        handler: async () => {
-          // This handler will be replaced by the hook when it runs
-          // For provider-level tools, we create a basic handler that waits for user interaction
+        handler: async (_args, context) => {
           return new Promise((resolve) => {
-            // The actual implementation will be handled by the render component
-            // This is a placeholder that the hook will override
-            console.warn(
-              `Human-in-the-loop tool '${tool.name}' called but no interactive handler is set up.`,
-            );
-            resolve(undefined);
+            const toolCallId = context?.toolCall?.id;
+            if (!toolCallId) {
+              console.warn(
+                `Human-in-the-loop tool '${tool.name}' called without a tool call id.`,
+              );
+              resolve(undefined);
+              return;
+            }
+
+            const finish = (result: unknown) => {
+              humanInTheLoopResolversRef.current.delete(toolCallId);
+              resolve(result);
+            };
+
+            humanInTheLoopResolversRef.current.set(toolCallId, finish);
+
+            if (context.signal?.aborted) {
+              finish(undefined);
+              return;
+            }
+
+            context.signal?.addEventListener("abort", () => finish(undefined), {
+              once: true,
+            });
           });
         },
       };
@@ -497,10 +517,34 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
 
       // Add the render component to renderToolCalls
       if (tool.render) {
+        const RenderComponent: ReactToolCallRenderer<unknown>["render"] = (
+          props,
+        ) => {
+          const ToolComponent = tool.render;
+          const respond =
+            props.status === ToolCallStatus.Executing
+              ? async (result: unknown) => {
+                  humanInTheLoopResolversRef.current.get(props.toolCallId)?.(
+                    result,
+                  );
+                }
+              : undefined;
+
+          const enhancedProps = {
+            ...props,
+            name: tool.name,
+            description: tool.description || "",
+            agentId: tool.agentId,
+            respond,
+          } as React.ComponentProps<typeof ToolComponent>;
+
+          return <ToolComponent {...enhancedProps} />;
+        };
+
         processedRenderToolCalls.push({
           name: tool.name,
           args: tool.parameters,
-          render: tool.render as React.ComponentType<any>,
+          render: RenderComponent,
           ...(tool.agentId && { agentId: tool.agentId }),
         });
       }

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -485,7 +485,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
         followUp: tool.followUp,
         ...(tool.agentId && { agentId: tool.agentId }),
         handler: async (_args, context) => {
-          return new Promise((resolve) => {
+          return new Promise((resolve, reject) => {
             const toolCallId = context?.toolCall?.id;
             if (!toolCallId) {
               console.warn(
@@ -495,21 +495,28 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
               return;
             }
 
+            const signal = context.signal;
+            const abort = () => {
+              humanInTheLoopResolversRef.current.delete(toolCallId);
+              reject(new Error("Human-in-the-loop interaction aborted"));
+            };
+            const cleanup = () => {
+              signal?.removeEventListener("abort", abort);
+            };
             const finish = (result: unknown) => {
+              cleanup();
               humanInTheLoopResolversRef.current.delete(toolCallId);
               resolve(result);
             };
 
             humanInTheLoopResolversRef.current.set(toolCallId, finish);
 
-            if (context.signal?.aborted) {
-              finish(undefined);
+            if (signal?.aborted) {
+              abort();
               return;
             }
 
-            context.signal?.addEventListener("abort", () => finish(undefined), {
-              once: true,
-            });
+            signal?.addEventListener("abort", abort, { once: true });
           });
         },
       };

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -1,7 +1,14 @@
-import { render, renderHook, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
+import { ToolCallStatus } from "@copilotkit/core";
 import type { ReactFrontendTool } from "../../types/frontend-tool";
 import type { ReactHumanInTheLoop } from "../../types/human-in-the-loop";
 import { HttpAgent } from "@ag-ui/client";
@@ -225,11 +232,18 @@ describe("CopilotKitProvider", () => {
         (rc) => rc.name === "approvalTool",
       );
       expect(approvalTool).toBeDefined();
-      expect(approvalTool?.render).toBe(TestComponent);
+      expect(approvalTool?.render).toBeDefined();
     });
 
-    it("creates placeholder handlers for humanInTheLoop tools", async () => {
-      const TestComponent: React.FC<any> = () => <div>Test</div>;
+    it("waits for humanInTheLoop renderers to respond", async () => {
+      const TestComponent: React.FC<any> = ({ respond }) => (
+        <button
+          data-testid="hitl-respond"
+          onClick={() => respond?.({ approved: true })}
+        >
+          Respond
+        </button>
+      );
       const humanInTheLoopTools: ReactHumanInTheLoop[] = [
         {
           name: "interactiveTool",
@@ -254,19 +268,43 @@ describe("CopilotKitProvider", () => {
       })?.handler;
       expect(handler).toBeDefined();
 
-      // Call the handler and check for warning
-      const handlerPromise = handler!({ data: "test" }, {} as any);
-
-      await waitFor(() => {
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-          expect.stringContaining(
-            "Human-in-the-loop tool 'interactiveTool' called",
-          ),
-        );
+      let settled = false;
+      const handlerPromise = handler!({ data: "test" }, {
+        toolCall: {
+          id: "tool-call-1",
+          type: "function",
+          function: {
+            name: "interactiveTool",
+            arguments: JSON.stringify({ data: "test" }),
+          },
+        },
+      } as any).then((value) => {
+        settled = true;
+        return value;
       });
 
-      const result2 = await handlerPromise;
-      expect(result2).toBeUndefined();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      const renderToolCall = result.current.copilotkit.renderToolCalls.find(
+        (rc) => rc.name === "interactiveTool",
+      );
+      expect(renderToolCall).toBeDefined();
+
+      const Renderer = renderToolCall!.render;
+      render(
+        <Renderer
+          name="interactiveTool"
+          toolCallId="tool-call-1"
+          args={{ data: "test" }}
+          status={ToolCallStatus.Executing}
+          result={undefined}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("hitl-respond"));
+
+      await expect(handlerPromise).resolves.toEqual({ approved: true });
     });
 
     it("warns when humanInTheLoop prop changes", async () => {

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -9,10 +9,19 @@ import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { ToolCallStatus } from "@copilotkit/core";
+import { CopilotChat } from "../../components/chat/CopilotChat";
 import type { ReactFrontendTool } from "../../types/frontend-tool";
 import type { ReactHumanInTheLoop } from "../../types/human-in-the-loop";
 import { HttpAgent } from "@ag-ui/client";
 import { CopilotKitProvider, useCopilotKit } from "../CopilotKitProvider";
+import {
+  MockStepwiseAgent,
+  renderWithCopilotKit,
+  runFinishedEvent,
+  runStartedEvent,
+  testId,
+  toolCallChunkEvent,
+} from "../../__tests__/utils/test-helpers";
 
 // Mock console methods
 const originalConsoleError = console.error;
@@ -305,6 +314,112 @@ describe("CopilotKitProvider", () => {
       fireEvent.click(screen.getByTestId("hitl-respond"));
 
       await expect(handlerPromise).resolves.toEqual({ approved: true });
+    });
+
+    it("rejects a pending humanInTheLoop handler when the run is aborted", async () => {
+      const humanInTheLoopTools: ReactHumanInTheLoop[] = [
+        {
+          name: "interactiveTool",
+          description: "Interactive tool",
+          render: () => <div>Interactive tool</div>,
+        },
+      ];
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider humanInTheLoop={humanInTheLoopTools}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+      const controller = new AbortController();
+      const handler = result.current.copilotkit.getTool({
+        toolName: "interactiveTool",
+      })?.handler;
+
+      const handlerPromise = handler!({} as Record<string, unknown>, {
+        toolCall: {
+          id: "tool-call-abort",
+          type: "function",
+          function: { name: "interactiveTool", arguments: "{}" },
+        },
+        signal: controller.signal,
+      } as any);
+
+      controller.abort();
+
+      await expect(handlerPromise).rejects.toThrow(
+        "Human-in-the-loop interaction aborted",
+      );
+    });
+
+    it("keeps a provider HITL UI interactive after the multi-route run finishes", async () => {
+      const agent = new MockStepwiseAgent();
+      const humanInTheLoopTools: ReactHumanInTheLoop<{ action: string }>[] = [
+        {
+          name: "approvalTool",
+          description: "Requires approval",
+          parameters: z.object({ action: z.string() }),
+          render: ({ args, status, respond }) => (
+            <div data-testid="provider-hitl-tool">
+              <span data-testid="provider-hitl-status">{status}</span>
+              <span data-testid="provider-hitl-action">{args.action ?? ""}</span>
+              {respond && (
+                <button
+                  data-testid="provider-hitl-respond"
+                  onClick={() => void respond({ approved: true })}
+                >
+                  Approve
+                </button>
+              )}
+            </div>
+          ),
+        },
+      ];
+
+      renderWithCopilotKit({
+        agent,
+        humanInTheLoop: humanInTheLoopTools,
+        children: <CopilotChat welcomeScreen={false} />,
+      });
+
+      const input = await screen.findByRole("textbox");
+      fireEvent.change(input, { target: { value: "Request approval" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Request approval")).toBeDefined();
+      });
+
+      const toolCallId = testId("provider-hitl");
+      agent.emit(runStartedEvent());
+      agent.emit(
+        toolCallChunkEvent({
+          toolCallId,
+          toolCallName: "approvalTool",
+          parentMessageId: testId("message"),
+          delta: JSON.stringify({ action: "delete" }),
+        }),
+      );
+      agent.emit(runFinishedEvent());
+      agent.complete();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("provider-hitl-status").textContent).toBe(
+          ToolCallStatus.Executing,
+        );
+        expect(screen.getByTestId("provider-hitl-action").textContent).toBe(
+          "delete",
+        );
+        expect(screen.getByTestId("provider-hitl-respond")).toBeDefined();
+      });
+
+      fireEvent.click(screen.getByTestId("provider-hitl-respond"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("provider-hitl-status").textContent).toBe(
+          ToolCallStatus.Complete,
+        );
+      });
     });
 
     it("warns when humanInTheLoop prop changes", async () => {

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -594,7 +594,7 @@ describe("CopilotKitProvider", () => {
       expect(directRenderTool).toBeDefined();
 
       expect(frontendRenderTool?.render).toBe(TestComponent1);
-      expect(humanRenderTool?.render).toBe(TestComponent2);
+      expect(humanRenderTool?.render).toBeDefined();
       expect(directRenderTool?.render).toBe(TestComponent3);
     });
   });


### PR DESCRIPTION
## What does this PR do?

Fixes provider-level `humanInTheLoop` tools so they properly wait for user interaction before resolving under the default multi-route transport.

Previously, provider-registered HITL tools used a placeholder handler that resolved immediately with `undefined`. In REST/multi-route flows, this caused the HITL UI to briefly render and disappear before `respond()` was invoked.

This PR introduces proper pending resolver handling for provider-level HITL flows and ensures tool execution only resolves after the user responds.

## Related PRs and Issues

-> Fixes #4953

## Changes

-> Store pending provider-level HITL resolvers by `toolCall.id`
-> Pass a functional `respond` callback to HITL renderers while the tool call is executing
-> Resolve the matching pending HITL handler only after the user responds
-> Handle aborted HITL tool calls by resolving and cleaning up pending resolvers
-> Update provider HITL tests to cover wait-until-respond behavior
-> Adjust wildcard/provider test assertions for wrapped HITL renderers

## Testing

```bash
node ..\..\node_modules\vitest\vitest.mjs run src/v2/providers/__tests__/CopilotKitProvider.test.tsx src/v2/providers/__tests__/CopilotKitProvider.wildcard.test.tsx
```

## Notes

-> Full pre-commit lint passed for the changed files
-> Repo-wide pre-commit tests were not fully clean locally due to unrelated/flaky failures in:

  -> `A2UIMessageRenderer.test.tsx`
  -> `@copilotkit/sqlite-runner:test`

