### PR TITLE
fix(showcase): resync scripts lockfile after aimock 1.26.1 bump

### DIFF
--- a/showcase/scripts/package-lock.json
+++ b/showcase/scripts/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@copilotkit/showcase-scripts",
       "dependencies": {
-        "@copilotkit/aimock": "latest",
+        "@copilotkit/aimock": "1.26.1",
         "@playwright/test": "^1.59.1",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@copilotkit/aimock": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/@copilotkit/aimock/-/aimock-1.16.4.tgz",
-      "integrity": "sha512-DA9WjJWpi2Yh36ltsnfMycj+BbifSS9G0pyHw0JjQZQPm41+FziGIdl2gusBtwYebStypQ4v9Jj2rjqjJqqtvQ==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/aimock/-/aimock-1.26.1.tgz",
+      "integrity": "sha512-bxnXdd4yFVKdbLvXmlcrgXQprimtXeg5SrmZMYvw2BFhfhAwGJmaVhCSv/9gSHUn+m3mxgrRlwJeok7o9Z2Bsw==",
       "license": "MIT",
       "bin": {
         "aimock": "dist/aimock-cli.js",


### PR DESCRIPTION
## Summary

- PR #4956 bumped `@copilotkit/aimock` in `showcase/scripts/package.json` from `"latest"` to `"1.26.1"` but did not regenerate `package-lock.json` (still pinned to `1.16.4`).
- The `npm ci` step inside `showcase/scripts/` fails on an out-of-sync lockfile (`EUSAGE` / "lock file's @copilotkit/aimock@1.16.4 does not satisfy @copilotkit/aimock@1.26.1"), which broke the **Showcase: Build & Push** workflow on `main` for the `showcase-harness` and `shell-dashboard` images. Failed run: https://github.com/CopilotKit/CopilotKit/actions/runs/26225644680
- Regenerated `showcase/scripts/package-lock.json` via `npm install --package-lock-only` so the lock now pins `@copilotkit/aimock@1.26.1`.

## Test plan

- [x] `npm ci` succeeds in `showcase/scripts/` against the regenerated lockfile
- [x] `node node_modules/tsx/dist/cli.mjs generate-registry.ts` runs cleanly (this is the next Dockerfile step that was masked by the silent `npm ci` failure)
- [ ] CI: Showcase: Build & Push succeeds for `showcase-harness` and `shell-dashboard`