### PR TITLE
fix(showcase/ms-agent-python): drop trailing slash on subpath HttpAgent URLs

### DIFF
--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
@@ -25,7 +25,12 @@ import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
-const mcpAppsAgent = new HttpAgent({ url: `${AGENT_URL}/mcp-apps/` });
+// No trailing slash on the URL. FastAPI mounts this agent at `/mcp-apps`
+// exactly (via `add_agent_framework_fastapi_endpoint(path="/mcp-apps")` in
+// agent_server.py); posting to `/mcp-apps/` triggers FastAPI's
+// redirect-to-canonical 307, which kills the streaming SSE response and
+// surfaces as `fetch failed` / `INCOMPLETE_STREAM` in the runtime.
+const mcpAppsAgent = new HttpAgent({ url: `${AGENT_URL}/mcp-apps` });
 
 // headless-complete shares this runtime because its cell also exercises
 // MCP Apps activity rendering (the "Sketch a diagram" pill exercises the

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-voice/[[...slug]]/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-voice/[[...slug]]/route.ts
@@ -29,7 +29,13 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
 // Point at the tool-free /voice endpoint so aimock returns a direct text
 // response instead of a tool call that the agent can't summarize.
-const voiceDemoAgent = new HttpAgent({ url: `${AGENT_URL}/voice/` });
+//
+// No trailing slash on the URL. FastAPI mounts this agent at `/voice`
+// exactly (via `add_agent_framework_fastapi_endpoint(path="/voice")` in
+// agent_server.py); posting to `/voice/` triggers FastAPI's
+// redirect-to-canonical 307, which kills the streaming SSE response and
+// surfaces as `fetch failed` / `INCOMPLETE_STREAM` in the runtime.
+const voiceDemoAgent = new HttpAgent({ url: `${AGENT_URL}/voice` });
 
 /**
  * Transcription service wrapper that reports a clean, typed auth error when


### PR DESCRIPTION
## Summary

- The `mcp-apps` and `voice-demo` HttpAgent URLs had a trailing slash (`${AGENT_URL}/mcp-apps/`, `${AGENT_URL}/voice/`), but the FastAPI backend in `agent_server.py` mounts those agents at `/mcp-apps` and `/voice` exactly.
- Posting to the trailing-slash URL triggers FastAPI's default `redirect_slashes` 307, which drops the SSE streaming body and surfaces in the Next.js runtime as `RUN_ERROR: fetch failed (INCOMPLETE_STREAM)` for every pill on the deployed showcase.
- Removing the trailing slash from both `HttpAgent({ url })` constructors mirrors every other ms-agent-python subpath URL (`/hitl-in-app`, `/headless-complete`, `/multimodal`, `/agent-config`, …), all of which already work.

## Reproduction (live, against `showcase-ms-agent-python-production`)

```
$ curl -X POST -H 'Content-Type: application/json'     -H 'Accept: text/event-stream'     -d '{"method":"agent/run","params":{"agentId":"mcp-apps"},"body":{...}}'     https://showcase-ms-agent-python-production.up.railway.app/api/copilotkit-mcp-apps
data: {"type":"RUN_ERROR","message":"fetch failed","code":"INCOMPLETE_STREAM"}

$ curl -X POST ...     https://showcase-ms-agent-python-production.up.railway.app/api/copilotkit-voice/agent/voice-demo/run
data: {"type":"RUN_ERROR","message":"fetch failed","code":"INCOMPLETE_STREAM"}
```

The same `/api/copilotkit-mcp-apps` runtime called with `agentId: "headless-complete"` (URL `/headless-complete`, no trailing slash) returns a clean `RUN_FINISHED` stream — proving the trailing slash is the only difference.

## Test plan

- [x] Reproduced live against deployed `showcase-ms-agent-python-production`
- [x] `headless-complete` (no trailing slash, same runtime as mcp-apps) confirmed working
- [ ] After Railway redeploy: click "Draw a flowchart" and "Sketch a system diagram" pills on `/integrations/ms-agent-python/demos/mcp-apps` and the iframe renders
- [ ] After Railway redeploy: voice demo sample-audio "What is the weather in Tokyo?" returns an assistant reply