### PR TITLE
fix(react-core): wrap CopilotChatInput disclaimer slot in pointer-events-auto

### DIFF
--- a/.changeset/fix-disclaimer-pointer-events.md
+++ b/.changeset/fix-disclaimer-pointer-events.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-core": patch
+---
+
+fix(react-core): wrap CopilotChatInput disclaimer slot in pointer-events-auto so interactive content (links, buttons, agent selectors) inside a custom disclaimer stays clickable. The outer container's pointer-events:none is preserved.

--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -1125,7 +1125,9 @@ export function CopilotChatInput({
       <div className="cpk:max-w-3xl cpk:mx-auto cpk:py-0 cpk:px-4 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-4 cpk:pointer-events-auto">
         {inputPill}
       </div>
-      {shouldShowDisclaimer && BoundDisclaimer}
+      {shouldShowDisclaimer && (
+        <div className="cpk:pointer-events-auto">{BoundDisclaimer}</div>
+      )}
     </div>
   );
 }

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.slots.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.slots.e2e.test.tsx
@@ -925,5 +925,34 @@ describe("CopilotChatInput Slot System E2E Tests", () => {
         expect(disclaimer.textContent).toContain("Custom Disclaimer");
       }
     });
+
+    it("should wrap disclaimer in pointer-events-auto so interactive content stays clickable", () => {
+      // Regression guard: the outer CopilotChatInput container is
+      // cpk:pointer-events-none so it doesn't block clicks on chat messages
+      // behind the absolutely-positioned input. The disclaimer slot is a
+      // sibling of the input pill wrapper and must explicitly re-enable
+      // pointer events; otherwise buttons/links rendered into the slot
+      // silently fail to receive clicks. Lock the wrapper class in so a
+      // future JSX refactor can't quietly regress it.
+      const CustomDisclaimer: React.FC<any> = () => (
+        <button data-testid="disclaimer-action">Click me</button>
+      );
+
+      const { container } = render(
+        <TestWrapper>
+          <CopilotChatInput
+            showDisclaimer={true}
+            disclaimer={CustomDisclaimer}
+          />
+        </TestWrapper>,
+      );
+
+      const action = container.querySelector(
+        '[data-testid="disclaimer-action"]',
+      );
+      expect(action).not.toBeNull();
+      const wrapper = action!.closest(".cpk\\:pointer-events-auto");
+      expect(wrapper).not.toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Why this matters

Every CopilotKit consumer that puts interactive content in the disclaimer slot below the input pill hits the same trap: buttons and links render but don't respond to clicks or hover. The cause isn't obvious from outside the framework — the outer input container is intentionally `pointer-events: none` so the absolutely-positioned input doesn't block clicks on chat messages behind it, the pill itself is re-enabled, but the disclaimer slot is a sibling that never gets re-enabled.

For a canonical starter, this is friction every customizer hits the first time they add an agent selector, model picker, or any interactive disclaimer content. They debug for 10–30 minutes, find the workaround by reading the framework source, and ship a `pointerEvents: "auto"` override they didn't need to know about.

<img width="1020" height="237" alt="image" src="https://github.com/user-attachments/assets/7c0bbd51-c46f-4781-a7c2-f537e0ddadd6" />

<img width="1438" height="695" alt="image" src="https://github.com/user-attachments/assets/bebf521e-a5fa-4207-a698-057e6f9a66e3" />


## How it's implemented

Single-file change to `packages/react-core/src/v2/components/chat/CopilotChatInput.tsx`: the disclaimer render now wraps in `<div className="cpk:pointer-events-auto">`, mirroring the existing wrap around the input pill in the same file a few lines above.

The outer container's `pointer-events: none` is unchanged — pass-through over the chat column above the input continues to work as before.

## Migration

Consumers who currently work around this by manually setting `pointerEvents: "auto"` on their disclaimer slot will see their override become a redundant no-op. No functional change for them; they can drop the override when convenient.

## Known parity gap (follow-up)

Vue counterpart `packages/vue/src/v2/components/chat/CopilotChatInput.vue`
has the same disclaimer pointer-events trap. To be addressed in a
follow-up PR — left out of this scope to keep the React fix isolated.
