### PR TITLE
fix(react-core): reserve safe-area bottom padding for in-flow CopilotChatInput

### DIFF
--- a/.changeset/fix-input-safe-area-padding.md
+++ b/.changeset/fix-input-safe-area-padding.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-core": patch
+---
+
+fix(react-core): reserve safe-area bottom padding for in-flow CopilotChatInput via new `--copilotkit-input-safe-area` CSS variable (default `12px`). Absolute-positioned and bottom-anchored modes are unchanged.

--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -1118,7 +1118,7 @@ export function CopilotChatInput({
         // must stay still when the banner is present.
         ...(positioning === "absolute" || bottomAnchored
           ? { paddingBottom: "var(--copilotkit-license-banner-offset, 0px)" }
-          : {}),
+          : { paddingBottom: "var(--copilotkit-input-safe-area, 12px)" }),
       }}
       {...props}
     >

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.bottomAnchored.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.bottomAnchored.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CopilotChatInput } from "../CopilotChatInput";
+import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+
+const TEST_THREAD_ID = "test-thread";
+
+const BANNER_OFFSET_VAR = "var(--copilotkit-license-banner-offset, 0px)";
+const SAFE_AREA_VAR = "var(--copilotkit-input-safe-area, 12px)";
+
+function renderInput(props: React.ComponentProps<typeof CopilotChatInput>) {
+  return render(
+    <CopilotChatConfigurationProvider threadId={TEST_THREAD_ID}>
+      <CopilotChatInput {...props} />
+    </CopilotChatConfigurationProvider>,
+  );
+}
+
+describe("CopilotChatInput bottom padding", () => {
+  it('reserves license-banner offset when positioning="absolute" and bottomAnchored=false', () => {
+    const { container } = renderInput({ positioning: "absolute" });
+    const outer = container.firstChild as HTMLElement;
+    expect(outer.style.paddingBottom).toBe(BANNER_OFFSET_VAR);
+  });
+
+  it('reserves license-banner offset when positioning="absolute" and bottomAnchored=true', () => {
+    const { container } = renderInput({
+      positioning: "absolute",
+      bottomAnchored: true,
+    });
+    const outer = container.firstChild as HTMLElement;
+    expect(outer.style.paddingBottom).toBe(BANNER_OFFSET_VAR);
+  });
+
+  it('reserves license-banner offset when positioning="static" and bottomAnchored=true', () => {
+    const { container } = renderInput({
+      positioning: "static",
+      bottomAnchored: true,
+    });
+    const outer = container.firstChild as HTMLElement;
+    expect(outer.style.paddingBottom).toBe(BANNER_OFFSET_VAR);
+  });
+
+  it('reserves safe-area padding when positioning="static" and bottomAnchored=false (welcome / in-flow)', () => {
+    const { container } = renderInput({ positioning: "static" });
+    const outer = container.firstChild as HTMLElement;
+    expect(outer.style.paddingBottom).toBe(SAFE_AREA_VAR);
+  });
+});


### PR DESCRIPTION
## Why this matters

Any consumer embedding `CopilotChat` in a custom column layout — anything other than the full-screen absolute-positioned default — sees the input pill butt directly against the bottom edge of its container. The framework reserves `paddingBottom` only when `positioning === "absolute"` or `bottomAnchored` is set; the in-flow static mode (welcome-screen branch, most column embeds) gets nothing.

The visual cost is small but cumulative: every embed-in-a-card pattern, every glass-card chat panel, every two-pane app layout independently re-invents the `pb-6` workaround. For a canonical starter, the framework should default to a sensible inset that survives every positioning mode.

Issue:
<img width="870" height="202" alt="image" src="https://github.com/user-attachments/assets/0c3d479b-8618-4a6b-b689-3bd9782180c7" />

<img width="870" height="1980" alt="image" src="https://github.com/user-attachments/assets/42a5728b-a151-452d-ab89-811ead0ce7cb" />


## How it's implemented

Single-file change to `packages/react-core/src/v2/components/chat/CopilotChatInput.tsx`: the existing `paddingBottom` conditional now has a static-branch arm that reserves `var(--copilotkit-input-safe-area, 12px)`. Absolute and bottom-anchored modes are unchanged — they already use `var(--copilotkit-license-banner-offset, 0px)` and lay against the viewport edge.

The new `--copilotkit-input-safe-area` CSS variable defaults to 12px (chosen to match common manual workarounds minus existing internal pill padding). Consumers in tight popovers can set it to `0px`; consumers in roomy glass cards can raise it.

## Migration

- Apps that today work around this with `className="pb-6"` on a static-positioned CopilotChatInput will see `12px + 24px = 36px` stacking. Recommend dropping the workaround.
- Apps that depended on zero bottom inset in static mode can restore by setting `--copilotkit-input-safe-area: 0px` on their app root.
- Absolute / bottom-anchored modes are untouched — no regression possible there.

## Known parity gap (follow-up)

Vue counterpart `packages/vue/src/v2/components/chat/CopilotChatInput.vue` carries the same `paddingBottom`-only-when-absolute gate, and `packages/vue/src/v2/components/chat/__tests__/CopilotChatInput.bottomAnchored.test.ts:47-53` actively asserts the broken contract (`paddingBottom === ""` for welcome static input). `packages/vue/PARITY.md:379` documents that contract.

To be addressed in a follow-up PR — left out of this scope to keep the React fix isolated. The Vue parity test will start to fail once that follow-up lands; this PR is React-only by design.
