### PR TITLE
fix(react-core): scope [data-copilotkit] background to chat root only

### DIFF
--- a/.changeset/fix-data-copilotkit-bg-scope.md
+++ b/.changeset/fix-data-copilotkit-bg-scope.md
@@ -1,0 +1,9 @@
+---
+"@copilotkit/react-core": patch
+---
+
+fix(react-core): scope [data-copilotkit] background-color to chat root only
+
+The `data-copilotkit` attribute is applied to dozens of chat-internal nodes (assistant messages, suggestion containers, input wrappers, attachment chips) for CSS-variable scoping. The base rule painted `background-color` on all of them, which defeated any consumer wrapping the chat in a translucent surface — every internal element painted opaque `--background` over their backdrop.
+
+Split the rule: `color` stays on `[data-copilotkit]` for descendant inheritance; `background-color` moves to a new `[data-copilotkit-root]` selector that only chat root containers carry. `CopilotChatView`, `CopilotSidebarView`, and `CopilotPopupView` are tagged with the new attribute, so default-theme appearance is unchanged. Custom translucent themes no longer need per-element overrides.

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -366,6 +366,7 @@ export function CopilotChatView({
     return (
       <div
         data-copilotkit
+        data-copilotkit-root
         data-testid="copilot-chat"
         data-copilot-running={isRunning ? "true" : "false"}
         onDragOver={onDragOver}
@@ -399,6 +400,7 @@ export function CopilotChatView({
   return (
     <div
       data-copilotkit
+      data-copilotkit-root
       data-testid="copilot-chat"
       data-copilot-running={isRunning ? "true" : "false"}
       onDragOver={onDragOver}

--- a/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import CopilotChatView, {
+import type {
   CopilotChatViewProps,
   WelcomeScreenProps,
 } from "./CopilotChatView";
+import CopilotChatView from "./CopilotChatView";
 import CopilotChatToggleButton from "./CopilotChatToggleButton";
 import { CopilotModalHeader } from "./CopilotModalHeader";
 import { cn } from "../../lib/utils";
-import { renderSlot, SlotValue } from "../../lib/slots";
+import type { SlotValue } from "../../lib/slots";
+import { renderSlot } from "../../lib/slots";
 import {
   CopilotChatConfigurationProvider,
   CopilotChatDefaultLabels,
@@ -208,6 +210,7 @@ function CopilotPopupViewInternal({
   const popupContent = isRendered ? (
     <div
       data-copilotkit
+      data-copilotkit-root
       className={cn(
         "cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch",
         "cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4",

--- a/packages/react-core/src/v2/components/chat/CopilotSidebarView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotSidebarView.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 
-import CopilotChatView, {
+import type {
   CopilotChatViewProps,
   WelcomeScreenProps,
 } from "./CopilotChatView";
+import CopilotChatView from "./CopilotChatView";
 import {
   CopilotChatConfigurationProvider,
   useCopilotChatConfiguration,
@@ -11,7 +12,8 @@ import {
 import CopilotChatToggleButton from "./CopilotChatToggleButton";
 import { cn } from "../../lib/utils";
 import { CopilotModalHeader } from "./CopilotModalHeader";
-import { renderSlot, SlotValue } from "../../lib/slots";
+import type { SlotValue } from "../../lib/slots";
+import { renderSlot } from "../../lib/slots";
 
 const DEFAULT_SIDEBAR_WIDTH = 480;
 const SIDEBAR_TRANSITION_MS = 260;
@@ -158,6 +160,7 @@ function CopilotSidebarViewInternal({
       <aside
         ref={sidebarRef}
         data-copilotkit
+        data-copilotkit-root
         data-testid="copilot-sidebar"
         data-copilot-sidebar
         data-position={position}
@@ -181,7 +184,7 @@ function CopilotSidebarViewInternal({
         style={
           {
             // Use CSS custom property for responsive width
-            ["--sidebar-width" as string]: widthToCss(sidebarWidth),
+            "--sidebar-width": widthToCss(sidebarWidth),
             // Safe area insets for iOS
             paddingTop: "env(safe-area-inset-top)",
             paddingBottom: "env(safe-area-inset-bottom)",

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -138,9 +138,16 @@
   * {
     @apply cpk:border-border cpk:outline-ring/50;
   }
-  /* Apply foreground/background on CopilotKit roots (replaces body rule) */
+  /* Apply foreground on every CopilotKit-scoped node so descendants inherit
+   * the framework's text color, but paint the background only on chat root
+   * containers ([data-copilotkit-root]). Painting --background on every
+   * descendant carrying [data-copilotkit] (assistant messages, suggestion
+   * containers, input wrappers, attachment chips, etc.) defeated translucent
+   * consumer themes by stacking opaque backgrounds across the whole chat tree. */
   [data-copilotkit] {
     color: var(--foreground);
+  }
+  [data-copilotkit-root] {
     background-color: var(--background);
   }
 


### PR DESCRIPTION
## Why this matters

The framework applies `background-color: var(--background)` to every element carrying the `data-copilotkit` attribute — which today is dozens of chat-internal nodes (assistant messages, suggestion containers, input wrappers, attachment chips). The attribute exists on those descendants for CSS-variable scoping, not because each one should paint its own opaque background.

The consequence: any consumer wrapping the chat in a translucent surface — glass cards, gradient backdrops, dark overlays — sees every chat-internal element paint solid `--background` (default white) directly over their backdrop. Custom theming is silently defeated. The workaround is a per-element `background-color: transparent !important` override applied across the whole chat tree.

For a canonical starter, the framework's CSS-variable token surface should be ergonomic to override. Today it isn't — every translucent theme starts with a one-page CSS prelude before it can render correctly.

<img width="870" height="1980" alt="image" src="https://github.com/user-attachments/assets/166ee474-a05b-456d-be71-a19a6ff3ca1b" />

## How it's implemented

Two changes:

1. **Split the CSS rule** in `packages/react-core/src/v2/styles/globals.css`. The `color` declaration stays on `[data-copilotkit]` (so descendant elements inherit foreground correctly). The `background-color` declaration moves to a new `[data-copilotkit-root]` selector that only chat root containers carry.

2. **Add `data-copilotkit-root` attribute** to chat root containers — `CopilotChatView`'s outer container, `CopilotSidebar`, `CopilotPopup`, and any other top-level chat surface. Each root keeps its existing `data-copilotkit` and additionally gets the new attribute.

Default-theme appearance is unchanged (the root still paints `--background`). The cascade is also unchanged for `color`. Only the per-descendant background paint is removed.

## Migration

Apps relying on `CopilotSidebar` / `CopilotPopup` defaults: no change. Apps with custom translucent embeds: gain transparent descendants by default — exactly the theming-friendly behavior they were working around.

The rare consumer that depended on every internal node painting `--background` can restore the old behavior with a one-line override in their own CSS:
```css
[data-copilotkit] { background-color: var(--background); }
```

## Known parity gap (follow-up)

Vue and Angular packages carry the same combined CSS rule and same `data-copilotkit`-on-internal-nodes pattern:

- `packages/vue/src/styles/globals.css:142-145`
- `packages/angular/src/styles/globals.css:142-145`

To be addressed in a follow-up PR — left out of this scope to keep the React fix isolated and reviewable. Custom translucent themes will continue to need per-element overrides in Vue/Angular consumers until that lands.
