### PR TITLE
fix(react-core): show welcome screen on empty thread regardless of threadId source

### DIFF
--- a/.changeset/welcome-screen-on-empty-thread.md
+++ b/.changeset/welcome-screen-on-empty-thread.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-core": patch
+---
+
+Show CopilotChat welcome screen on empty threads regardless of whether threadId was pre-minted. The welcome-screen gate is now purely about message emptiness.

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -94,11 +94,13 @@ export type CopilotChatViewProps = WithSlots<
      */
     isConnecting?: boolean;
     /**
-     * When `true`, the caller has explicitly picked a thread (via `threadId`
-     * prop or `CopilotChatConfigurationProvider`). Suppresses the welcome
-     * screen unconditionally — a caller-managed thread targets a specific
-     * conversation and should render its messages (or an empty panel during
-     * connect) rather than a generic "start a new chat" greeting.
+     * Indicates the caller explicitly picked a thread (via `threadId` prop or
+     * `CopilotChatConfigurationProvider`). Forwarded for compatibility with
+     * downstream consumers reading the flag; no longer gates the welcome
+     * screen, which is now driven purely by message emptiness so empty threads
+     * with a caller-minted UUID still render the welcome state. Use
+     * `welcomeScreen={false}` (or the equivalent slot value) to suppress the
+     * welcome screen explicitly.
      */
     hasExplicitThreadId?: boolean;
     /**
@@ -309,13 +311,14 @@ export function CopilotChatView({
   const isEmpty = messages.length === 0;
   // Type assertion needed because TypeScript doesn't fully propagate `| boolean` through WithSlots
   const welcomeScreenDisabled = (welcomeScreen as unknown) === false;
-  // Suppress the welcome screen (1) while the initial connect is in flight
-  // and (2) whenever the caller has picked a specific thread. The caller-
-  // managed case targets a conversation directly, so the generic welcome
-  // greeting is never the right thing to show — even for a thread that
-  // happens to have no messages yet.
+  // The welcome screen is semantically about having no messages, not about
+  // thread origin. Suppress it only while the initial connect is in flight
+  // (so a resumed thread doesn't flash the generic greeting before its
+  // bootstrap messages arrive) or when the caller explicitly disabled it.
+  // Empty threads with a caller-minted UUID (premint-on-mount, custom thread
+  // drawers, lock-recovery rotation, BFF sync) still get the welcome state.
   const shouldShowWelcomeScreen =
-    isEmpty && !welcomeScreenDisabled && !isConnecting && !hasExplicitThreadId;
+    isEmpty && !welcomeScreenDisabled && !isConnecting;
 
   if (shouldShowWelcomeScreen) {
     // Create a separate input for welcome screen with static positioning and disclaimer visible

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
@@ -42,16 +42,23 @@ function renderWithKit(ui: React.ReactNode, agent: TrackingAgent) {
 }
 
 /**
- * Regression coverage for fix/welcome-not-showing-at-all.
+ * Regression coverage for fix/welcome-not-showing-at-all and the follow-up
+ * fix that decouples welcome-screen gating from thread origin.
  *
- * The underlying bug: the v1 <CopilotKit> wrapper pipes a ThreadsProvider-
- * minted UUID through to CopilotChatConfigurationProvider as `threadId`.
- * CopilotChat previously treated any non-empty providedThreadId as "caller
- * supplied a real backend thread" and (a) fired /connect (→ 404 for an
- * auto-minted UUID) and (b) suppressed the welcome screen forever. The
- * fix threads an `hasExplicitThreadId` signal through the provider chain;
- * these tests pin the contract that /connect and welcome-screen gating
- * now follow that signal rather than `!!threadId`.
+ * History: the v1 <CopilotKit> wrapper pipes a ThreadsProvider-minted UUID
+ * through to CopilotChatConfigurationProvider as `threadId`. CopilotChat
+ * previously treated any non-empty providedThreadId as "caller supplied a
+ * real backend thread" and (a) fired /connect (→ 404 for an auto-minted UUID)
+ * and (b) suppressed the welcome screen forever. The first fix threaded an
+ * `hasExplicitThreadId` signal through the provider chain so /connect only
+ * fires for genuinely explicit threads.
+ *
+ * The follow-up: welcome-screen gating no longer keys on thread origin. Any
+ * empty thread renders the welcome state — including a caller-minted UUID
+ * (premint-on-mount is the standard pattern for apps that manage their own
+ * thread state). Welcome-screen visibility is now driven purely by message
+ * emptiness; `welcomeScreen={false}` remains the escape hatch for
+ * consumers that want to suppress it.
  */
 describe("CopilotChat welcome / connect integration", () => {
   beforeEach(() => {
@@ -96,7 +103,7 @@ describe("CopilotChat welcome / connect integration", () => {
   });
 
   describe("explicit threadId via CopilotChat prop", () => {
-    it("calls connectAgent with that threadId and suppresses the welcome screen", async () => {
+    it("calls connectAgent with that threadId; welcome screen returns once the empty thread settles", async () => {
       const agent = new TrackingAgent();
       agent.agentId = DEFAULT_AGENT_ID;
 
@@ -110,14 +117,17 @@ describe("CopilotChat welcome / connect integration", () => {
         TrackingAgent.connectCalls.some((c) => c.threadId === "real-thread"),
       ).toBe(true);
 
-      // Welcome screen is suppressed even after connect resolves, because the
-      // thread was caller-picked (hasExplicitThreadId=true).
-      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+      // Welcome-screen gating is now driven by message emptiness, not thread
+      // origin. TrackingAgent.connectAgent resolves with no messages, so once
+      // isConnecting flips back to false the welcome screen returns.
+      await waitFor(() => {
+        expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+      });
     });
   });
 
   describe("explicit threadId via wrapping CopilotChatConfigurationProvider", () => {
-    it("inherits explicitness from the provider and connects", async () => {
+    it("inherits explicitness from the provider and connects; empty thread keeps welcome state", async () => {
       const agent = new TrackingAgent();
       agent.agentId = DEFAULT_AGENT_ID;
 
@@ -135,12 +145,16 @@ describe("CopilotChat welcome / connect integration", () => {
       expect(
         TrackingAgent.connectCalls.some((c) => c.threadId === "from-config"),
       ).toBe(true);
-      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+      // The empty post-connect thread renders the welcome state. Thread
+      // origin no longer suppresses the greeting on its own.
+      await waitFor(() => {
+        expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+      });
     });
   });
 
   describe("thread switch between two explicit threads", () => {
-    it("keeps the welcome screen hidden across the switch", async () => {
+    it("hides the welcome screen during the switch but restores it when the empty target settles", async () => {
       const agent = new TrackingAgent();
       agent.agentId = DEFAULT_AGENT_ID;
 
@@ -154,9 +168,11 @@ describe("CopilotChat welcome / connect integration", () => {
           TrackingAgent.connectCalls.some((c) => c.threadId === "thread-a"),
         ).toBe(true);
       });
-      // After thread-a's connect resolves, welcome must still be hidden
-      // because the thread is caller-picked.
-      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+      // thread-a is empty after connect; welcome screen returns once the
+      // connect-in-flight gate releases.
+      await waitFor(() => {
+        expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+      });
 
       rerender(
         <CopilotKitProvider
@@ -169,7 +185,7 @@ describe("CopilotChat welcome / connect integration", () => {
       );
 
       // During the switch (lastConnected="thread-a" !== "thread-b") isConnecting
-      // is true — welcome must not flash.
+      // is true — welcome must not flash mid-switch.
       expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
 
       await waitFor(() => {
@@ -177,8 +193,11 @@ describe("CopilotChat welcome / connect integration", () => {
           TrackingAgent.connectCalls.some((c) => c.threadId === "thread-b"),
         ).toBe(true);
       });
-      // And after thread-b's connect resolves.
-      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+      // thread-b is also empty after connect; the welcome state returns
+      // once isConnecting releases.
+      await waitFor(() => {
+        expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+      });
     });
   });
 });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.connectingGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.connectingGate.test.tsx
@@ -29,17 +29,17 @@ describe("CopilotChatView connect-gating", () => {
     expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
   });
 
-  it("suppresses the welcome screen when hasExplicitThreadId=true", () => {
+  it("still shows the welcome screen on an empty thread when hasExplicitThreadId=true", () => {
     render(
       <TestWrapper>
         <CopilotChatView messages={[]} hasExplicitThreadId />
       </TestWrapper>,
     );
 
-    // A caller-managed thread (threadId prop / config provider) should never
-    // display the generic "start a new chat" welcome — even when the thread
-    // has no messages yet.
-    expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+    // The welcome screen is gated on message emptiness, not thread origin.
+    // Apps that premint a UUID on mount (custom thread drawers, lock-recovery
+    // rotation, BFF sync) must still see the welcome state on an empty thread.
+    expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
   });
 
   it("shows the welcome screen by default for a fresh empty chat", () => {

--- a/packages/react-core/src/v2/providers/__tests__/CopilotChatConfigurationProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotChatConfigurationProvider.test.tsx
@@ -553,8 +553,9 @@ describe("CopilotChatConfigurationProvider", () => {
     it("respects hasExplicitThreadId={false} even when a threadId prop is present (v1 bridge case)", () => {
       // The v1 <CopilotKit> wrapper always pipes a UUID through as `threadId`
       // (from ThreadsProvider). Without this override the provider would
-      // mis-infer the UUID as explicit, causing /connect to 404 and the
-      // welcome screen to stay hidden for fresh empty chats.
+      // mis-infer the UUID as explicit, causing /connect to 404 against a
+      // thread the backend has never seen. Welcome-screen gating no longer
+      // depends on this flag, but /connect routing still does.
       render(
         <CopilotChatConfigurationProvider
           threadId="auto-minted-uuid"


### PR DESCRIPTION
## Why this matters

Any CopilotKit consumer that mints its own `threadId` on mount — to drive a custom thread drawer, to dodge thread-locked errors on rotation, to sync with a BFF before the user types — currently lands on a half-built first-load experience: suggestion chips float at the top with no greeting, no scaffolding, no welcome state. The welcome screen is suppressed because `hasExplicitThreadId` flips true whenever a threadId prop is passed, even if the thread has zero messages.

Premint-on-mount is the standard pattern for any app doing its own thread management. For a canonical starter, gating the welcome screen on thread origin (rather than on message emptiness) means every developer doing real thread handling has to either work around the gate or accept the half-built look.

<img width="2000" height="1127" alt="image" src="https://github.com/user-attachments/assets/703ad92b-a01a-423d-896d-55543e957552" />

## How it's implemented

Single-line semantic fix in `packages/react-core/src/v2/components/chat/CopilotChatView.tsx`: the welcome-screen gate drops the `!hasExplicitThreadId` clause. The screen now renders whenever `isEmpty && !welcomeScreenDisabled && !isConnecting` — which matches what the welcome screen is actually *about*: having no messages to display, not the origin of the thread identifier.

## Migration

Consumers who relied on hiding the welcome screen for premint flows can drop their `hasExplicitThreadId={false}` workaround. Consumers who explicitly want to suppress the welcome screen should use `welcomeScreenDisabled` (or equivalent) — which has always been the right escape hatch.

Behavior changes only for the narrow case of "empty thread + explicit threadId" — every other state remains identical.

## Known parity gap (follow-up)

Vue counterpart `packages/vue/src/v2/components/chat/CopilotChatView.vue:193-199` has the identical `!props.hasExplicitThreadId` welcome-screen gate. Same bug, not fixed by this PR. To be addressed in a follow-up — kept out of this scope to keep the React fix isolated and reviewable.
