### PR TITLE
fix(react-core): reserve scrollbar gutter on chat scroll container

### DIFF
--- a/.changeset/fix-scrollbar-gutter.md
+++ b/.changeset/fix-scrollbar-gutter.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-core": patch
+---
+
+Reserve scrollbar gutter on CopilotChat scroll container via `scrollbar-gutter: stable`, so the always-visible scrollbar no longer overlaps the absolutely-positioned input pill in narrow layouts.

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -471,6 +471,7 @@ export namespace CopilotChatView {
       <ScrollElementContext.Provider value={scrollEl}>
         <>
           <StickToBottom.Content
+            data-copilotkit-scroll-container
             className="cpk:overflow-y-auto cpk:overflow-x-hidden"
             style={{ flex: "1 1 0%", minHeight: 0 }}
           >
@@ -560,6 +561,7 @@ export namespace CopilotChatView {
         >
           <div
             ref={nonAutoScrollRefCallback}
+            data-copilotkit-scroll-container
             className="cpk:flex-1 cpk:min-h-0 cpk:overflow-y-auto cpk:overflow-x-hidden"
             {...props}
           >
@@ -685,7 +687,10 @@ export namespace CopilotChatView {
 
     if (!hasMounted) {
       return (
-        <div className="cpk:h-full cpk:max-h-full cpk:flex cpk:flex-col cpk:min-h-0 cpk:overflow-y-auto cpk:overflow-x-hidden">
+        <div
+          data-copilotkit-scroll-container
+          className="cpk:h-full cpk:max-h-full cpk:flex cpk:flex-col cpk:min-h-0 cpk:overflow-y-auto cpk:overflow-x-hidden"
+        >
           <div className="cpk:px-4 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6">
             {children}
           </div>
@@ -702,6 +707,7 @@ export namespace CopilotChatView {
         <ScrollElementContext.Provider value={nonAutoScrollEl}>
           <div
             ref={nonAutoScrollRefCallback}
+            data-copilotkit-scroll-container
             className={cn(
               "cpk:h-full cpk:max-h-full cpk:flex cpk:flex-col cpk:min-h-0 cpk:overflow-y-auto cpk:overflow-x-hidden cpk:relative",
               className,

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -201,6 +201,14 @@
   scrollbar-color: oklch(0.5 0 0) transparent;
 }
 
+/* Reserve scrollbar gutter on chat scroll containers so the always-visible
+ * scrollbar can't cut through the absolutely-positioned input pill in narrow
+ * layouts. `stable` keeps the gutter reserved whether or not the scrollbar is
+ * currently visible, so content doesn't reflow when overflow toggles. */
+[data-copilotkit] [data-copilotkit-scroll-container] {
+  scrollbar-gutter: stable;
+}
+
 [data-copilotkit] .prose input[type="checkbox"] {
   appearance: none;
   background-color: #fff;


### PR DESCRIPTION
## Why this matters

In narrow chat layouts — sidebar panels, drawer chats, two-pane apps with a chat column under ~500px — the framework's always-visible 6px scrollbar runs directly through the bottom-right corner of the absolutely-positioned input pill. The scrollbar thumb and the pill's rounded edge occupy the same pixels.

It's a small visual defect with a large reach: any consumer who embeds the chat in anything narrower than a typical full-page layout sees it. For a canonical starter, this is one of the first polish papercuts a developer notices when they move beyond the full-screen demo.

(not the error but the overlap)

<img width="822" height="354" alt="image" src="https://github.com/user-attachments/assets/3976b6ff-377e-4351-9cb7-0649e6a7a007" />


## How it's implemented

Single-line CSS rule in `packages/react-core/src/v2/styles/globals.css`: `scrollbar-gutter: stable` on the chat scroll container, scoped to a new `data-copilotkit-scroll-container` attribute. The attribute is added to the four scroll surfaces inside `CopilotChatView.tsx`'s `ScrollView` (the `StickToBottom.Content` pin-to-bottom case, the pin-to-send wrapper, the pre-mount fallback, and the `none` mode wrapper) so the rule reaches every autoScroll mode.

`scrollbar-gutter: stable` is the modern CSS primitive for exactly this case — it reserves space for the scrollbar whether the bar is currently visible or not. No JS, no WeakMap-of-timers, no opt-in flag. Works across Chromium, Firefox, and Safari (16.4+).

Scrollbar appearance (width, color, thumb style) is unchanged. Only the gutter reservation is new.

Note: `scrollbar-gutter: stable` reserves the gutter whether or not the scrollbar is currently visible. In wide layouts, this means a ~6px right-side inset is now reserved on the chat scroll container even when no scrollbar would render. Visually negligible in the default theme; consumers who explicitly want zero gutter can override with `scrollbar-gutter: auto`.

## Migration

Pure addition with no opt-out required for the default case. Apps that explicitly want zero gutter reservation (rare — would mean they want the overlap) can override locally with `scrollbar-gutter: auto` on `[data-copilotkit-scroll-container]`.

## Known parity gap (follow-up)

Vue/Angular counterparts have the same scrollbar-overlap risk in narrow chat layouts — both use `overflow-y-scroll` on the chat scroll container with an absolutely-positioned input pill, and neither `globals.css` reserves a gutter. To be addressed in a follow-up PR — left out of this scope to keep the React fix isolated. Confirmed:

- `packages/vue/src/v2/components/chat/CopilotChatView.vue` (scroll container line 589, absolute input wrapper line 694)
- `packages/angular/src/lib/components/chat/copilot-chat-view-scroll-view.ts` (scroll containers lines 51, 64, 134)
- `packages/angular/src/lib/components/chat/copilot-chat-view-input-container.ts` (absolute input wrapper line 76)
- `packages/vue/src/styles/globals.css` and `packages/angular/src/styles/globals.css` (neither sets `scrollbar-gutter`)
