### PR TITLE
feat(showcase/ms-agent-python): register reasoning-default + reasoning-custom

### DIFF
--- a/showcase/integrations/ms-agent-python/manifest.yaml
+++ b/showcase/integrations/ms-agent-python/manifest.yaml
@@ -31,6 +31,8 @@ features:
   - chat-customization-css
   - headless-simple
   - headless-complete
+  - reasoning-custom
+  - reasoning-default
   - frontend-tools
   - frontend-tools-async
   - hitl
@@ -295,6 +297,28 @@ demos:
       - src/app/demos/headless-complete/hooks/use-frontend-components.ts
       - src/app/demos/headless-complete/hooks/use-headless-suggestions.ts
       - src/app/demos/headless-complete/attachments/use-attachments-config.ts
+      - src/app/api/copilotkit/route.ts
+  - id: reasoning-default
+    name: "Reasoning: Default"
+    description: Built-in CopilotChatReasoningMessage rendering with no slot override.
+    tags:
+      - chat-ui
+    route: /demos/reasoning-default
+    highlight:
+      - src/app/demos/reasoning-default/page.tsx
+      - src/app/demos/reasoning-default/suggestions.ts
+      - src/agents/reasoning_agent.py
+  - id: reasoning-custom
+    name: "Reasoning: Custom"
+    description: Visible reasoning/thinking chain alongside the final answer
+    tags:
+      - chat-ui
+    route: /demos/reasoning-custom
+    animated_preview_url:
+    highlight:
+      - src/app/demos/reasoning-custom/page.tsx
+      - src/app/demos/reasoning-custom/reasoning-block.tsx
+      - src/agents/reasoning_agent.py
       - src/app/api/copilotkit/route.ts
   - id: gen-ui-interrupt
     name: In-Chat HITL (useInterrupt — low-level primitive)


### PR DESCRIPTION
## Summary

- The MS Agent Python integration's `reasoning-default` and `reasoning-custom` demos were already fully ported from the langgraph-python north-star — code, agent (`src/agents/reasoning_agent.py` using the OpenAI Responses API for `REASONING_MESSAGE_*` event streaming), pages, suggestion pills, e2e specs (`tests/e2e/reasoning-default.spec.ts`, `tests/e2e/reasoning-custom.spec.ts`), aimock fixtures (`showcase/aimock/d5-all.json`, `showcase/harness/fixtures/d5/reasoning-display.json`) and D5 probe mapping all exist and are byte-identical to LGP.
- The only missing piece was the `manifest.yaml` registration. Without it the cells never appeared in the showcase shell, weren't counted as features, and were skipped by D5 routing.
- This PR adds:
  - `reasoning-custom` + `reasoning-default` to the `features:` list (between `headless-complete` and `frontend-tools`, matching LGP order).
  - `demos:` entries for both, mirroring the LGP manifest verbatim.

## Verification

- `tsx showcase/scripts/generate-registry.ts` → catalog now lists both cells with `status: wired`, `max_depth: 4`, identical to LGP.
- `tsx showcase/scripts/validate-parity.ts` → `ms-agent-python   [PASS]   38   37   10   35 warn` (was 36/35; the 2 new e2e specs were already present). New warnings are the standard `no qa/...md` pattern that LGP also has for these two demos.
- `tsx showcase/scripts/validate-pins.ts` → ratchet count stays at 93 (unchanged).

## Test plan

- [x] generate-registry succeeds; catalog wired for both cells with max_depth 4
- [x] validate-parity passes
- [x] validate-pins ratchet unchanged
- [ ] Showcase shell renders `/integrations/ms-agent-python/demos/reasoning-default` and `reasoning-custom` after deploy
- [ ] D5 `reasoning-display` probe passes for ms-agent-python in CI
- [ ] e2e: `npm --prefix showcase/integrations/ms-agent-python run test:e2e -- tests/e2e/reasoning-default.spec.ts tests/e2e/reasoning-custom.spec.ts --project=chromium` (will run on next CI pipeline)