### PR TITLE
fix: gate thread requests on runtime capabilities

### DIFF
--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeMode,
   RuntimeLicenseStatus,
   IntelligenceRuntimeInfo,
+  ThreadEndpointRuntimeInfo,
 } from "@copilotkit/shared";
 import {
   logger,
@@ -72,6 +73,7 @@ export class AgentRegistry {
   private _audioFileTranscriptionEnabled: boolean = false;
   private _runtimeMode: RuntimeMode = RUNTIME_MODE_SSE;
   private _intelligence?: IntelligenceRuntimeInfo;
+  private _threadEndpoints?: ThreadEndpointRuntimeInfo;
   private _a2uiEnabled: boolean = false;
   private _a2uiAgents?: string[];
   private _openGenerativeUIEnabled: boolean = false;
@@ -113,6 +115,10 @@ export class AgentRegistry {
 
   get intelligence(): IntelligenceRuntimeInfo | undefined {
     return this._intelligence;
+  }
+
+  get threadEndpoints(): ThreadEndpointRuntimeInfo | undefined {
+    return this._threadEndpoints;
   }
 
   get a2uiEnabled(): boolean {
@@ -362,6 +368,7 @@ export class AgentRegistry {
       this._audioFileTranscriptionEnabled = false;
       this._runtimeMode = RUNTIME_MODE_SSE;
       this._intelligence = undefined;
+      this._threadEndpoints = undefined;
       this._a2uiEnabled = false;
       this._a2uiAgents = undefined;
       this._openGenerativeUIEnabled = false;
@@ -391,6 +398,7 @@ export class AgentRegistry {
         version: string;
         mode?: RuntimeMode;
         intelligence?: IntelligenceRuntimeInfo;
+        threadEndpoints?: ThreadEndpointRuntimeInfo;
       } = runtimeInfoResponse;
 
       const credentials = (this.core as unknown as CopilotKitCoreFriendsAccess)
@@ -450,6 +458,7 @@ export class AgentRegistry {
         runtimeInfoResponse.audioFileTranscriptionEnabled ?? false;
       this._runtimeMode = runtimeInfoResponse.mode ?? RUNTIME_MODE_SSE;
       this._intelligence = runtimeInfoResponse.intelligence;
+      this._threadEndpoints = runtimeInfoResponse.threadEndpoints;
       const a2uiInfo = runtimeInfoResponse.a2ui;
       this._a2uiEnabled =
         a2uiInfo?.enabled ?? runtimeInfoResponse.a2uiEnabled ?? false;
@@ -470,6 +479,7 @@ export class AgentRegistry {
       this._audioFileTranscriptionEnabled = false;
       this._runtimeMode = RUNTIME_MODE_SSE;
       this._intelligence = undefined;
+      this._threadEndpoints = undefined;
       this._a2uiEnabled = false;
       this._a2uiAgents = undefined;
       this._openGenerativeUIEnabled = false;

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -9,6 +9,7 @@ import type {
   RuntimeMode,
   RuntimeLicenseStatus,
   IntelligenceRuntimeInfo,
+  ThreadEndpointRuntimeInfo,
 } from "../types";
 import type {
   CopilotKitCoreAddAgentParams,
@@ -632,6 +633,10 @@ export class CopilotKitCore {
 
   get intelligence(): IntelligenceRuntimeInfo | undefined {
     return this.agentRegistry.intelligence;
+  }
+
+  get threadEndpoints(): ThreadEndpointRuntimeInfo | undefined {
+    return this.agentRegistry.threadEndpoints;
   }
 
   get a2uiEnabled(): boolean {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,8 +1,9 @@
-import { AbstractAgent, ToolCall } from "@ag-ui/client";
+import type { AbstractAgent, ToolCall } from "@ag-ui/client";
 import type {
   IntelligenceRuntimeInfo,
   RuntimeMode,
   RuntimeLicenseStatus,
+  ThreadEndpointRuntimeInfo,
 } from "@copilotkit/shared";
 import type { StandardSchemaV1 } from "@copilotkit/shared";
 
@@ -16,7 +17,12 @@ export enum ToolCallStatus {
 }
 
 export type CopilotRuntimeTransport = "rest" | "single" | "auto";
-export type { RuntimeMode, IntelligenceRuntimeInfo, RuntimeLicenseStatus };
+export type {
+  RuntimeMode,
+  IntelligenceRuntimeInfo,
+  RuntimeLicenseStatus,
+  ThreadEndpointRuntimeInfo,
+};
 
 /**
  * Context passed to a frontend tool handler

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads-provider-headers.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads-provider-headers.e2e.test.tsx
@@ -32,7 +32,16 @@ describe("useThreads provider headers", () => {
     fetchMock.mockReset();
     fetchMock.mockImplementation((url: string) => {
       if (url.endsWith("/info")) {
-        return jsonResponse({ version: "1.0.0", agents: {} });
+        return jsonResponse({
+          version: "1.0.0",
+          agents: {},
+          threadEndpoints: {
+            list: true,
+            inspect: true,
+            mutations: true,
+            realtimeMetadata: true,
+          },
+        });
       }
 
       if (url.includes("/threads?")) {

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -357,7 +357,7 @@ describe("useThreads", () => {
     );
   });
 
-  it("treats missing thread endpoint info as legacy-compatible and fetches", async () => {
+  it("does not fetch when connected runtime omits thread endpoint info", async () => {
     mockUseCopilotKit.mockReturnValue({
       copilotkit: {
         runtimeUrl: "http://localhost:4000",
@@ -370,7 +370,6 @@ describe("useThreads", () => {
         unregisterThreadStore: vi.fn(),
       },
     });
-    fetchMock.mockReturnValueOnce(jsonResponse({ threads: sampleThreads }));
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -378,10 +377,10 @@ describe("useThreads", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toBeNull();
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining("/threads?agentId=agent-1"),
-      expect.objectContaining({ method: "GET" }),
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.threads).toEqual([]);
+    expect(result.current.error?.message).toBe(
+      "Thread endpoints are not available on this CopilotKit runtime",
     );
   });
 

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -357,7 +357,7 @@ describe("useThreads", () => {
     );
   });
 
-  it("does not fetch when connected runtime omits thread endpoint info", async () => {
+  it("uses legacy thread behavior when connected runtime omits thread endpoint info", async () => {
     mockUseCopilotKit.mockReturnValue({
       copilotkit: {
         runtimeUrl: "http://localhost:4000",
@@ -370,6 +370,7 @@ describe("useThreads", () => {
         unregisterThreadStore: vi.fn(),
       },
     });
+    fetchMock.mockReturnValueOnce(jsonResponse({ threads: sampleThreads }));
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -377,11 +378,15 @@ describe("useThreads", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(result.current.threads).toEqual([]);
-    expect(result.current.error?.message).toBe(
-      "Thread endpoints are not available on this CopilotKit runtime",
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/threads?agentId=agent-1"),
+      expect.objectContaining({ method: "GET" }),
     );
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "t-2",
+      "t-1",
+    ]);
+    expect(result.current.error).toBeNull();
   });
 
   it("rejects mutations locally when the runtime reports mutations are unsupported", async () => {

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -190,12 +190,20 @@ function getMockSockets(): MockSocketLike[] {
   return phoenix.sockets;
 }
 
+const supportedThreadEndpoints = {
+  list: true,
+  inspect: true,
+  mutations: true,
+  realtimeMetadata: true,
+};
+
 function setupCopilotKit(runtimeUrl = "http://localhost:4000") {
   mockUseCopilotKit.mockReturnValue({
     copilotkit: {
       runtimeUrl,
       runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
       headers: { Authorization: "Bearer test-token" },
+      threadEndpoints: supportedThreadEndpoints,
       intelligence: {
         wsUrl: "ws://localhost:4000/client",
       },
@@ -315,6 +323,38 @@ describe("useThreads", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(result.current.error?.message).toBe("Runtime URL is not configured");
+  });
+
+  it("does not fetch when the runtime does not advertise thread endpoints", async () => {
+    mockUseCopilotKit.mockReturnValue({
+      copilotkit: {
+        runtimeUrl: "http://localhost:4000",
+        runtimeConnectionStatus:
+          CopilotKitCoreRuntimeConnectionStatus.Connected,
+        headers: { Authorization: "Bearer test-token" },
+        threadEndpoints: {
+          list: false,
+          inspect: false,
+          mutations: false,
+          realtimeMetadata: false,
+        },
+        intelligence: undefined,
+        registerThreadStore: vi.fn(),
+        unregisterThreadStore: vi.fn(),
+      },
+    });
+
+    const { result } = renderHook(() => useThreads(defaultInput));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.threads).toEqual([]);
+    expect(result.current.error?.message).toBe(
+      "Thread endpoints are not available on this CopilotKit runtime",
+    );
   });
 
   it("updates local state directly from realtime metadata events", async () => {
@@ -652,6 +692,7 @@ describe("useThreads", () => {
         runtimeConnectionStatus:
           CopilotKitCoreRuntimeConnectionStatus.Connected,
         headers: { Authorization: "Bearer test-token" },
+        threadEndpoints: supportedThreadEndpoints,
         intelligence: { wsUrl: "ws://localhost:4000/client" },
         registerThreadStore,
         unregisterThreadStore,
@@ -688,6 +729,7 @@ describe("useThreads", () => {
         runtimeConnectionStatus:
           CopilotKitCoreRuntimeConnectionStatus.Connecting,
         headers: { Authorization: "Bearer test-token" },
+        threadEndpoints: supportedThreadEndpoints,
         intelligence: undefined,
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),
@@ -728,6 +770,7 @@ describe("useThreads", () => {
         runtimeConnectionStatus:
           CopilotKitCoreRuntimeConnectionStatus.Connected,
         headers: { Authorization: "Bearer test-token" },
+        threadEndpoints: supportedThreadEndpoints,
         intelligence: { wsUrl: "ws://localhost:4000/client" },
         registerThreadStore: vi.fn(),
         unregisterThreadStore: vi.fn(),

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -357,6 +357,74 @@ describe("useThreads", () => {
     );
   });
 
+  it("treats missing thread endpoint info as legacy-compatible and fetches", async () => {
+    mockUseCopilotKit.mockReturnValue({
+      copilotkit: {
+        runtimeUrl: "http://localhost:4000",
+        runtimeConnectionStatus:
+          CopilotKitCoreRuntimeConnectionStatus.Connected,
+        headers: { Authorization: "Bearer test-token" },
+        threadEndpoints: undefined,
+        intelligence: undefined,
+        registerThreadStore: vi.fn(),
+        unregisterThreadStore: vi.fn(),
+      },
+    });
+    fetchMock.mockReturnValueOnce(jsonResponse({ threads: sampleThreads }));
+
+    const { result } = renderHook(() => useThreads(defaultInput));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/threads?agentId=agent-1"),
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("rejects mutations locally when the runtime reports mutations are unsupported", async () => {
+    mockUseCopilotKit.mockReturnValue({
+      copilotkit: {
+        runtimeUrl: "http://localhost:4000",
+        runtimeConnectionStatus:
+          CopilotKitCoreRuntimeConnectionStatus.Connected,
+        headers: { Authorization: "Bearer test-token" },
+        threadEndpoints: {
+          list: true,
+          inspect: true,
+          mutations: false,
+          realtimeMetadata: false,
+        },
+        intelligence: undefined,
+        registerThreadStore: vi.fn(),
+        unregisterThreadStore: vi.fn(),
+      },
+    });
+    fetchMock.mockReturnValueOnce(jsonResponse({ threads: sampleThreads }));
+
+    const { result } = renderHook(() => useThreads(defaultInput));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    fetchMock.mockClear();
+
+    await expect(result.current.renameThread("t-1", "Renamed")).rejects.toThrow(
+      "Thread mutations are not available on this CopilotKit runtime",
+    );
+    await expect(result.current.archiveThread("t-1")).rejects.toThrow(
+      "Thread mutations are not available on this CopilotKit runtime",
+    );
+    await expect(result.current.deleteThread("t-1")).rejects.toThrow(
+      "Thread mutations are not available on this CopilotKit runtime",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("updates local state directly from realtime metadata events", async () => {
     fetchMock
       .mockReturnValueOnce(

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -7,9 +7,8 @@ import {
   ɵselectThreadsIsLoading,
   ɵselectHasNextPage,
   ɵselectIsFetchingNextPage,
-  type ɵThreadRuntimeContext,
-  type ɵThreadStore,
 } from "@copilotkit/core";
+import type { ɵThreadRuntimeContext, ɵThreadStore } from "@copilotkit/core";
 import {
   useCallback,
   useEffect,
@@ -213,6 +212,12 @@ export function useThreads({
       ),
     );
   }, [copilotkit.headers]);
+  const runtimeStatus = copilotkit.runtimeConnectionStatus;
+  const threadEndpointsSupported = copilotkit.threadEndpoints?.list === true;
+  const threadEndpointsUnavailable =
+    !!copilotkit.runtimeUrl &&
+    runtimeStatus === CopilotKitCoreRuntimeConnectionStatus.Connected &&
+    !threadEndpointsSupported;
   const runtimeError = useMemo(() => {
     if (copilotkit.runtimeUrl) {
       return null;
@@ -220,6 +225,15 @@ export function useThreads({
 
     return new Error("Runtime URL is not configured");
   }, [copilotkit.runtimeUrl]);
+  const threadEndpointsError = useMemo(() => {
+    if (!threadEndpointsUnavailable) {
+      return null;
+    }
+
+    return new Error(
+      "Thread endpoints are not available on this CopilotKit runtime",
+    );
+  }, [threadEndpointsUnavailable]);
 
   // Tracks whether we've dispatched the first real context to the store.
   // The store itself starts with `isLoading: false`, so before we dispatch
@@ -229,10 +243,16 @@ export function useThreads({
   // the first fetch is in flight (at which point the store's own
   // isLoading takes over).
   const [hasDispatchedContext, setHasDispatchedContext] = useState(false);
-  const preConnectLoading = !!copilotkit.runtimeUrl && !hasDispatchedContext;
+  const preConnectLoading =
+    !!copilotkit.runtimeUrl &&
+    !threadEndpointsUnavailable &&
+    !hasDispatchedContext;
 
-  const isLoading = runtimeError ? false : preConnectLoading || storeIsLoading;
-  const error = runtimeError ?? storeError;
+  const isLoading =
+    runtimeError || threadEndpointsError
+      ? false
+      : preConnectLoading || storeIsLoading;
+  const error = runtimeError ?? threadEndpointsError ?? storeError;
 
   useEffect(() => {
     store.start();
@@ -252,7 +272,6 @@ export function useThreads({
   // leave the previously-dispatched context in place — any in-flight
   // realtime subscription or cached thread list stays usable while the
   // runtime recovers, and we don't re-trigger a fetch storm on transitions.
-  const runtimeStatus = copilotkit.runtimeConnectionStatus;
   useEffect(() => {
     copilotkit.registerThreadStore(agentId, store);
     return () => {
@@ -263,12 +282,19 @@ export function useThreads({
   useEffect(() => {
     if (!copilotkit.runtimeUrl) {
       store.setContext(null);
+      setHasDispatchedContext(false);
       return;
     }
 
     // Wait for /info to land so we can include `wsUrl` in the initial
     // context and avoid a redundant second list fetch.
     if (runtimeStatus !== CopilotKitCoreRuntimeConnectionStatus.Connected) {
+      return;
+    }
+
+    if (!threadEndpointsSupported) {
+      store.setContext(null);
+      setHasDispatchedContext(false);
       return;
     }
 
@@ -289,6 +315,7 @@ export function useThreads({
     runtimeStatus,
     headersKey,
     copilotkit.intelligence?.wsUrl,
+    threadEndpointsSupported,
     agentId,
     includeArchived,
     limit,

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -213,9 +213,10 @@ export function useThreads({
     );
   }, [copilotkit.headers]);
   const runtimeStatus = copilotkit.runtimeConnectionStatus;
-  const threadListEndpointSupported = copilotkit.threadEndpoints?.list === true;
+  const threadListEndpointSupported =
+    copilotkit.threadEndpoints?.list !== false;
   const threadMutationsSupported =
-    copilotkit.threadEndpoints?.mutations === true;
+    copilotkit.threadEndpoints?.mutations !== false;
   const threadEndpointsUnavailable =
     !!copilotkit.runtimeUrl &&
     runtimeStatus === CopilotKitCoreRuntimeConnectionStatus.Connected &&

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -213,10 +213,9 @@ export function useThreads({
     );
   }, [copilotkit.headers]);
   const runtimeStatus = copilotkit.runtimeConnectionStatus;
-  const threadListEndpointSupported =
-    copilotkit.threadEndpoints?.list !== false;
+  const threadListEndpointSupported = copilotkit.threadEndpoints?.list === true;
   const threadMutationsSupported =
-    copilotkit.threadEndpoints?.mutations !== false;
+    copilotkit.threadEndpoints?.mutations === true;
   const threadEndpointsUnavailable =
     !!copilotkit.runtimeUrl &&
     runtimeStatus === CopilotKitCoreRuntimeConnectionStatus.Connected &&
@@ -333,34 +332,36 @@ export function useThreads({
     limit,
   ]);
 
-  const renameThread = useCallback(
-    (threadId: string, name: string) => {
-      if (threadMutationsError) {
-        return Promise.reject(threadMutationsError);
-      }
-      return store.renameThread(threadId, name);
+  const guardMutation = useCallback(
+    <TArgs extends unknown[]>(
+      mutation: (...args: TArgs) => Promise<void>,
+    ): ((...args: TArgs) => Promise<void>) => {
+      return (...args: TArgs) => {
+        if (threadMutationsError) {
+          return Promise.reject(threadMutationsError);
+        }
+        return mutation(...args);
+      };
     },
-    [store, threadMutationsError],
+    [threadMutationsError],
   );
 
-  const archiveThread = useCallback(
-    (threadId: string) => {
-      if (threadMutationsError) {
-        return Promise.reject(threadMutationsError);
-      }
-      return store.archiveThread(threadId);
-    },
-    [store, threadMutationsError],
+  const renameThread = useMemo(
+    () =>
+      guardMutation((threadId: string, name: string) =>
+        store.renameThread(threadId, name),
+      ),
+    [store, guardMutation],
   );
 
-  const deleteThread = useCallback(
-    (threadId: string) => {
-      if (threadMutationsError) {
-        return Promise.reject(threadMutationsError);
-      }
-      return store.deleteThread(threadId);
-    },
-    [store, threadMutationsError],
+  const archiveThread = useMemo(
+    () => guardMutation((threadId: string) => store.archiveThread(threadId)),
+    [store, guardMutation],
+  );
+
+  const deleteThread = useMemo(
+    () => guardMutation((threadId: string) => store.deleteThread(threadId)),
+    [store, guardMutation],
   );
 
   const fetchMoreThreads = useCallback(() => store.fetchNextPage(), [store]);

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -213,11 +213,14 @@ export function useThreads({
     );
   }, [copilotkit.headers]);
   const runtimeStatus = copilotkit.runtimeConnectionStatus;
-  const threadEndpointsSupported = copilotkit.threadEndpoints?.list === true;
+  const threadListEndpointSupported =
+    copilotkit.threadEndpoints?.list !== false;
+  const threadMutationsSupported =
+    copilotkit.threadEndpoints?.mutations !== false;
   const threadEndpointsUnavailable =
     !!copilotkit.runtimeUrl &&
     runtimeStatus === CopilotKitCoreRuntimeConnectionStatus.Connected &&
-    !threadEndpointsSupported;
+    !threadListEndpointSupported;
   const runtimeError = useMemo(() => {
     if (copilotkit.runtimeUrl) {
       return null;
@@ -234,6 +237,15 @@ export function useThreads({
       "Thread endpoints are not available on this CopilotKit runtime",
     );
   }, [threadEndpointsUnavailable]);
+  const threadMutationsError = useMemo(() => {
+    if (threadMutationsSupported) {
+      return null;
+    }
+
+    return new Error(
+      "Thread mutations are not available on this CopilotKit runtime",
+    );
+  }, [threadMutationsSupported]);
 
   // Tracks whether we've dispatched the first real context to the store.
   // The store itself starts with `isLoading: false`, so before we dispatch
@@ -292,7 +304,7 @@ export function useThreads({
       return;
     }
 
-    if (!threadEndpointsSupported) {
+    if (!threadListEndpointSupported) {
       store.setContext(null);
       setHasDispatchedContext(false);
       return;
@@ -315,25 +327,40 @@ export function useThreads({
     runtimeStatus,
     headersKey,
     copilotkit.intelligence?.wsUrl,
-    threadEndpointsSupported,
+    threadListEndpointSupported,
     agentId,
     includeArchived,
     limit,
   ]);
 
   const renameThread = useCallback(
-    (threadId: string, name: string) => store.renameThread(threadId, name),
-    [store],
+    (threadId: string, name: string) => {
+      if (threadMutationsError) {
+        return Promise.reject(threadMutationsError);
+      }
+      return store.renameThread(threadId, name);
+    },
+    [store, threadMutationsError],
   );
 
   const archiveThread = useCallback(
-    (threadId: string) => store.archiveThread(threadId),
-    [store],
+    (threadId: string) => {
+      if (threadMutationsError) {
+        return Promise.reject(threadMutationsError);
+      }
+      return store.archiveThread(threadId);
+    },
+    [store, threadMutationsError],
   );
 
   const deleteThread = useCallback(
-    (threadId: string) => store.deleteThread(threadId),
-    [store],
+    (threadId: string) => {
+      if (threadMutationsError) {
+        return Promise.reject(threadMutationsError);
+      }
+      return store.deleteThread(threadId);
+    },
+    [store, threadMutationsError],
   );
 
   const fetchMoreThreads = useCallback(() => store.fetchNextPage(), [store]);

--- a/packages/runtime/src/v2/runtime/__tests__/fetch-handler.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/fetch-handler.test.ts
@@ -46,6 +46,12 @@ describe("createCopilotRuntimeHandler — multi-route with basePath", () => {
     const body = await response.json();
     expect(body).toHaveProperty("version");
     expect(body).toHaveProperty("agents");
+    expect(body.threadEndpoints).toMatchObject({
+      list: true,
+      inspect: true,
+      mutations: false,
+      realtimeMetadata: false,
+    });
   });
 
   it("returns 404 for paths not starting with basePath", async () => {
@@ -320,6 +326,12 @@ describe("createCopilotRuntimeHandler — single-route mode", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body).toHaveProperty("version");
+    expect(body.threadEndpoints).toMatchObject({
+      list: false,
+      inspect: false,
+      mutations: false,
+      realtimeMetadata: false,
+    });
   });
 });
 

--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -1,5 +1,7 @@
 import { handleGetRuntimeInfo } from "../handlers/get-runtime-info";
 import { CopilotRuntime } from "../core/runtime";
+import type { CopilotRuntimeLike } from "../core/runtime";
+import type { AgentRunner } from "../runner/agent-runner";
 import { TranscriptionService } from "../transcription-service/transcription-service";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { AbstractAgent } from "@ag-ui/client";
@@ -19,6 +21,32 @@ describe("handleGetRuntimeInfo", () => {
     mutations: false,
     realtimeMetadata: false,
   };
+  const createRunner = (supportsLocalThreadEndpoints = false) =>
+    ({
+      ...(supportsLocalThreadEndpoints
+        ? { ɵsupportsLocalThreadEndpoints: true }
+        : {}),
+      run: vi.fn(),
+      connect: vi.fn(),
+      isRunning: vi.fn(),
+      stop: vi.fn(),
+    }) as unknown as AgentRunner;
+  const createRuntimeLike = (
+    overrides: Partial<CopilotRuntimeLike>,
+  ): CopilotRuntimeLike =>
+    ({
+      agents: {},
+      transcriptionService: undefined,
+      beforeRequestMiddleware: undefined,
+      afterRequestMiddleware: undefined,
+      runner: createRunner(),
+      a2ui: undefined,
+      mcpApps: undefined,
+      openGenerativeUI: undefined,
+      mode: "sse",
+      debug: { enabled: false },
+      ...overrides,
+    }) as unknown as CopilotRuntimeLike;
 
   it("should return runtime info with audioFileTranscriptionEnabled=false when no transcription service", async () => {
     const runtime = new CopilotRuntime({
@@ -109,6 +137,58 @@ describe("handleGetRuntimeInfo", () => {
       a2uiEnabled: false,
       openGenerativeUIEnabled: false,
       telemetryDisabled: false,
+    });
+  });
+
+  it("detects local thread endpoints from the runner capability flag", async () => {
+    const runtime = createRuntimeLike({
+      runner: createRunner(true),
+    });
+
+    const response = await handleGetRuntimeInfo({
+      runtime,
+      request: mockRequest,
+      threadEndpointsEnabled: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.threadEndpoints).toEqual(inMemoryThreadEndpoints);
+  });
+
+  it("reports all Intelligence thread endpoints when multi-route REST endpoints are enabled", async () => {
+    const runtime = createRuntimeLike({
+      mode: "intelligence",
+      runner: createRunner(),
+      intelligence: {
+        ɵgetClientWsUrl: vi.fn(() => "wss://runtime.example/client"),
+      },
+      identifyUser: vi
+        .fn()
+        .mockResolvedValue({ id: "user-1", name: "User One" }),
+      generateThreadNames: true,
+      lockTtlSeconds: 20,
+      lockHeartbeatIntervalSeconds: 15,
+    } as Partial<CopilotRuntimeLike>);
+
+    const response = await handleGetRuntimeInfo({
+      runtime,
+      request: mockRequest,
+      threadEndpointsEnabled: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.threadEndpoints).toEqual({
+      list: true,
+      inspect: true,
+      mutations: true,
+      realtimeMetadata: true,
+    });
+    expect(data.intelligence).toEqual({
+      wsUrl: "wss://runtime.example/client",
     });
   });
 

--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -13,6 +13,12 @@ class MockTranscriptionService extends TranscriptionService {
 
 describe("handleGetRuntimeInfo", () => {
   const mockRequest = new Request("https://example.com/info");
+  const inMemoryThreadEndpoints = {
+    list: true,
+    inspect: true,
+    mutations: false,
+    realtimeMetadata: false,
+  };
 
   it("should return runtime info with audioFileTranscriptionEnabled=false when no transcription service", async () => {
     const runtime = new CopilotRuntime({
@@ -33,6 +39,7 @@ describe("handleGetRuntimeInfo", () => {
       agents: {},
       audioFileTranscriptionEnabled: false,
       mode: "sse",
+      threadEndpoints: inMemoryThreadEndpoints,
       a2uiEnabled: false,
       openGenerativeUIEnabled: false,
       telemetryDisabled: false,
@@ -59,6 +66,7 @@ describe("handleGetRuntimeInfo", () => {
       agents: {},
       audioFileTranscriptionEnabled: true,
       mode: "sse",
+      threadEndpoints: inMemoryThreadEndpoints,
       a2uiEnabled: false,
       openGenerativeUIEnabled: false,
       telemetryDisabled: false,
@@ -97,6 +105,7 @@ describe("handleGetRuntimeInfo", () => {
       },
       audioFileTranscriptionEnabled: true,
       mode: "sse",
+      threadEndpoints: inMemoryThreadEndpoints,
       a2uiEnabled: false,
       openGenerativeUIEnabled: false,
       telemetryDisabled: false,

--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -1,7 +1,11 @@
 import { handleGetRuntimeInfo } from "../handlers/get-runtime-info";
 import { CopilotRuntime } from "../core/runtime";
-import type { CopilotRuntimeLike } from "../core/runtime";
+import type {
+  CopilotIntelligenceRuntimeLike,
+  CopilotRuntimeLike,
+} from "../core/runtime";
 import type { AgentRunner } from "../runner/agent-runner";
+import { CopilotKitIntelligence } from "../intelligence-platform";
 import { TranscriptionService } from "../transcription-service/transcription-service";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { AbstractAgent } from "@ag-ui/client";
@@ -47,6 +51,30 @@ describe("handleGetRuntimeInfo", () => {
       debug: { enabled: false },
       ...overrides,
     }) as unknown as CopilotRuntimeLike;
+  const createIntelligenceRuntimeLike = (
+    overrides: Partial<CopilotIntelligenceRuntimeLike> = {},
+  ): CopilotIntelligenceRuntimeLike => ({
+    agents: {},
+    transcriptionService: undefined,
+    beforeRequestMiddleware: undefined,
+    afterRequestMiddleware: undefined,
+    runner: createRunner(),
+    a2ui: undefined,
+    mcpApps: undefined,
+    openGenerativeUI: undefined,
+    mode: "intelligence",
+    debug: { enabled: false },
+    intelligence: new CopilotKitIntelligence({
+      apiUrl: "https://runtime.example",
+      wsUrl: "wss://runtime.example",
+      apiKey: "test-key",
+    }),
+    identifyUser: vi.fn().mockResolvedValue({ id: "user-1", name: "User One" }),
+    generateThreadNames: true,
+    lockTtlSeconds: 20,
+    lockHeartbeatIntervalSeconds: 15,
+    ...overrides,
+  });
 
   it("should return runtime info with audioFileTranscriptionEnabled=false when no transcription service", async () => {
     const runtime = new CopilotRuntime({
@@ -157,20 +185,52 @@ describe("handleGetRuntimeInfo", () => {
     expect(data.threadEndpoints).toEqual(inMemoryThreadEndpoints);
   });
 
-  it("reports all Intelligence thread endpoints when multi-route REST endpoints are enabled", async () => {
+  it("reports no thread endpoints when multi-route REST endpoints are disabled", async () => {
     const runtime = createRuntimeLike({
-      mode: "intelligence",
-      runner: createRunner(),
-      intelligence: {
-        ɵgetClientWsUrl: vi.fn(() => "wss://runtime.example/client"),
-      },
-      identifyUser: vi
-        .fn()
-        .mockResolvedValue({ id: "user-1", name: "User One" }),
-      generateThreadNames: true,
-      lockTtlSeconds: 20,
-      lockHeartbeatIntervalSeconds: 15,
-    } as Partial<CopilotRuntimeLike>);
+      runner: createRunner(true),
+    });
+
+    const response = await handleGetRuntimeInfo({
+      runtime,
+      request: mockRequest,
+      threadEndpointsEnabled: false,
+    });
+
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.threadEndpoints).toEqual({
+      list: false,
+      inspect: false,
+      mutations: false,
+      realtimeMetadata: false,
+    });
+  });
+
+  it("does not advertise thread endpoints for a plain runner", async () => {
+    const runtime = createRuntimeLike({
+      runner: createRunner(false),
+    });
+
+    const response = await handleGetRuntimeInfo({
+      runtime,
+      request: mockRequest,
+      threadEndpointsEnabled: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.threadEndpoints).toEqual({
+      list: false,
+      inspect: false,
+      mutations: false,
+      realtimeMetadata: false,
+    });
+  });
+
+  it("reports all Intelligence thread endpoints when multi-route REST endpoints are enabled", async () => {
+    const runtime = createIntelligenceRuntimeLike();
 
     const response = await handleGetRuntimeInfo({
       runtime,

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -186,7 +186,9 @@ export function createCopilotRuntimeHandler(
         ) {
           request = createJsonRequest(request, methodCall.body);
         }
-        response = await dispatchRoute(runtime, request, route);
+        response = await dispatchRoute(runtime, request, route, {
+          threadEndpointsEnabled: false,
+        });
       } else {
         // Multi-route: match URL pattern
         const matched = matchRoute(path, basePath);
@@ -212,7 +214,9 @@ export function createCopilotRuntimeHandler(
         });
 
         // 6. Handler dispatch
-        response = await dispatchRoute(runtime, request, route);
+        response = await dispatchRoute(runtime, request, route, {
+          threadEndpointsEnabled: true,
+        });
       }
 
       // 7. onResponse hook
@@ -297,6 +301,7 @@ function dispatchRoute(
   runtime: CopilotRuntimeLike,
   request: Request,
   route: RouteInfo,
+  options: { threadEndpointsEnabled: boolean },
 ): Promise<Response> {
   switch (route.method) {
     case "agent/run":
@@ -319,7 +324,11 @@ function dispatchRoute(
         threadId: route.threadId,
       });
     case "info":
-      return handleGetRuntimeInfo({ runtime, request });
+      return handleGetRuntimeInfo({
+        runtime,
+        request,
+        threadEndpointsEnabled: options.threadEndpointsEnabled,
+      });
     case "transcribe":
       return handleTranscribe({ runtime, request });
     case "threads/clear":

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -9,7 +9,7 @@ import type { AgentDescription, RuntimeInfo } from "@copilotkit/shared";
 import type { RuntimeLicenseStatus } from "@copilotkit/shared";
 import { VERSION } from "../core/runtime";
 import { isTelemetryDisabled } from "../telemetry/telemetry-client";
-import { InMemoryAgentRunner } from "../runner/in-memory";
+import { supportsLocalThreadEndpoints } from "../runner/agent-runner";
 
 function resolveLicenseStatus(
   runtime: CopilotRuntimeLike,
@@ -130,7 +130,7 @@ function resolveThreadEndpointInfo(
 ): RuntimeInfo["threadEndpoints"] {
   const hasRestThreadBackend =
     isIntelligenceRuntime(runtime) ||
-    runtime.runner instanceof InMemoryAgentRunner;
+    supportsLocalThreadEndpoints(runtime.runner);
   const restEndpointsAvailable = threadEndpointsEnabled && hasRestThreadBackend;
   const managedThreadMetadata =
     threadEndpointsEnabled && isIntelligenceRuntime(runtime);

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -9,6 +9,7 @@ import type { AgentDescription, RuntimeInfo } from "@copilotkit/shared";
 import type { RuntimeLicenseStatus } from "@copilotkit/shared";
 import { VERSION } from "../core/runtime";
 import { isTelemetryDisabled } from "../telemetry/telemetry-client";
+import { InMemoryAgentRunner } from "../runner/in-memory";
 
 function resolveLicenseStatus(
   runtime: CopilotRuntimeLike,
@@ -26,11 +27,13 @@ function resolveLicenseStatus(
 interface HandleGetRuntimeInfoParameters {
   runtime: CopilotRuntimeLike;
   request: Request;
+  threadEndpointsEnabled?: boolean;
 }
 
 export async function handleGetRuntimeInfo({
   runtime,
   request,
+  threadEndpointsEnabled = true,
 }: HandleGetRuntimeInfoParameters) {
   try {
     const agents = await resolveAgents(runtime.agents, request);
@@ -71,6 +74,10 @@ export async function handleGetRuntimeInfo({
       agents: agentsDict,
       audioFileTranscriptionEnabled: !!runtime.transcriptionService,
       mode: runtime.mode,
+      threadEndpoints: resolveThreadEndpointInfo(
+        runtime,
+        threadEndpointsEnabled,
+      ),
       ...(isIntelligenceRuntime(runtime)
         ? {
             intelligence: {
@@ -115,4 +122,23 @@ export async function handleGetRuntimeInfo({
       },
     );
   }
+}
+
+function resolveThreadEndpointInfo(
+  runtime: CopilotRuntimeLike,
+  threadEndpointsEnabled: boolean,
+): RuntimeInfo["threadEndpoints"] {
+  const hasRestThreadBackend =
+    isIntelligenceRuntime(runtime) ||
+    runtime.runner instanceof InMemoryAgentRunner;
+  const restEndpointsAvailable = threadEndpointsEnabled && hasRestThreadBackend;
+  const managedThreadMetadata =
+    threadEndpointsEnabled && isIntelligenceRuntime(runtime);
+
+  return {
+    list: restEndpointsAvailable,
+    inspect: restEndpointsAvailable,
+    mutations: managedThreadMetadata,
+    realtimeMetadata: managedThreadMetadata,
+  };
 }

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -5,7 +5,11 @@ import {
   isIntelligenceRuntime,
   resolveAgents,
 } from "../core/runtime";
-import type { AgentDescription, RuntimeInfo } from "@copilotkit/shared";
+import type {
+  AgentDescription,
+  RuntimeInfo,
+  ThreadEndpointRuntimeInfo,
+} from "@copilotkit/shared";
 import type { RuntimeLicenseStatus } from "@copilotkit/shared";
 import { VERSION } from "../core/runtime";
 import { isTelemetryDisabled } from "../telemetry/telemetry-client";
@@ -127,7 +131,7 @@ export async function handleGetRuntimeInfo({
 function resolveThreadEndpointInfo(
   runtime: CopilotRuntimeLike,
   threadEndpointsEnabled: boolean,
-): RuntimeInfo["threadEndpoints"] {
+): ThreadEndpointRuntimeInfo {
   const hasRestThreadBackend =
     isIntelligenceRuntime(runtime) ||
     supportsLocalThreadEndpoints(runtime.runner);

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/threads.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/threads.ts
@@ -7,7 +7,7 @@ import { logger } from "@copilotkit/shared";
 import { errorResponse, isHandlerResponse } from "../shared/json-response";
 import { isValidIdentifier } from "../shared/intelligence-utils";
 import { resolveIntelligenceUser } from "../shared/resolve-intelligence-user";
-import { InMemoryAgentRunner } from "../../runner/in-memory";
+import { supportsLocalThreadEndpoints } from "../../runner/agent-runner";
 
 interface ThreadsHandlerParams {
   runtime: CopilotRuntimeLike;
@@ -106,7 +106,7 @@ export async function handleListThreads({
   }
 
   // Local in-memory fallback — useful for local development without Intelligence
-  if (runtime.runner instanceof InMemoryAgentRunner) {
+  if (supportsLocalThreadEndpoints(runtime.runner)) {
     const url = new URL(request.url);
     const agentId = url.searchParams.get("agentId");
     let threads = runtime.runner.listThreads();
@@ -134,7 +134,7 @@ export async function handleListThreads({
 export function handleClearThreads({
   runtime,
 }: ThreadsHandlerParams): Response {
-  if (runtime.runner instanceof InMemoryAgentRunner) {
+  if (supportsLocalThreadEndpoints(runtime.runner)) {
     runtime.runner.clearThreads();
   }
   return new Response(null, { status: 204 });
@@ -286,7 +286,7 @@ export async function handleGetThreadMessages({
   }
 
   // Local in-memory fallback — useful for local development without Intelligence
-  if (runtime.runner instanceof InMemoryAgentRunner) {
+  if (supportsLocalThreadEndpoints(runtime.runner)) {
     const messages = runtime.runner.getThreadMessages(threadId);
     // Map ag-ui Message objects to the same shape the Intelligence platform
     // returns. Switching on the discriminant `role` lets each branch read
@@ -363,7 +363,7 @@ export async function handleGetThreadEvents({
   }
 
   // Local in-memory fallback
-  if (runtime.runner instanceof InMemoryAgentRunner) {
+  if (supportsLocalThreadEndpoints(runtime.runner)) {
     try {
       const events = runtime.runner.getThreadEvents(threadId);
       return Response.json({ events });
@@ -406,7 +406,7 @@ export async function handleGetThreadState({
     }
   }
 
-  if (runtime.runner instanceof InMemoryAgentRunner) {
+  if (supportsLocalThreadEndpoints(runtime.runner)) {
     try {
       const state = runtime.runner.getThreadState(threadId);
       return Response.json({ state });

--- a/packages/runtime/src/v2/runtime/runner/agent-runner.ts
+++ b/packages/runtime/src/v2/runtime/runner/agent-runner.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   AbstractAgent,
   BaseEvent,
   Message,
   RunAgentInput,
 } from "@ag-ui/client";
-import { Observable } from "rxjs";
+import type { Observable } from "rxjs";
 
 export interface AgentRunnerRunRequest {
   threadId: string;
@@ -27,7 +27,35 @@ export interface AgentRunnerStopRequest {
   threadId: string;
 }
 
+export interface LocalThreadEndpointRecord {
+  id: string;
+  name: string | null;
+  agentId: string;
+  organizationId: string;
+  createdById: string;
+  archived: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LocalThreadEndpointRunner extends AgentRunner {
+  readonly ɵsupportsLocalThreadEndpoints: true;
+  listThreads(): LocalThreadEndpointRecord[];
+  getThreadMessages(threadId: string): Message[];
+  getThreadEvents(threadId: string): BaseEvent[];
+  getThreadState(threadId: string): Record<string, unknown> | null;
+  clearThreads(): void;
+}
+
+export function supportsLocalThreadEndpoints(
+  runner: AgentRunner,
+): runner is LocalThreadEndpointRunner {
+  return runner.ɵsupportsLocalThreadEndpoints === true;
+}
+
 export abstract class AgentRunner {
+  readonly ɵsupportsLocalThreadEndpoints?: boolean;
+
   abstract run(request: AgentRunnerRunRequest): Observable<BaseEvent>;
   abstract connect(request: AgentRunnerConnectRequest): Observable<BaseEvent>;
   abstract isRunning(request: AgentRunnerIsRunningRequest): Promise<boolean>;

--- a/packages/runtime/src/v2/runtime/runner/in-memory.ts
+++ b/packages/runtime/src/v2/runtime/runner/in-memory.ts
@@ -1,20 +1,19 @@
-import {
-  AgentRunner,
+import type {
   AgentRunnerConnectRequest,
   AgentRunnerIsRunningRequest,
   AgentRunnerRunRequest,
-  type AgentRunnerStopRequest,
 } from "./agent-runner";
-import { Observable, ReplaySubject } from "rxjs";
-import {
+import { AgentRunner, type AgentRunnerStopRequest } from "./agent-runner";
+import type { Observable } from "rxjs";
+import { ReplaySubject } from "rxjs";
+import type {
   AbstractAgent,
   BaseEvent,
-  EventType,
   Message,
   RunStartedEvent,
   StateSnapshotEvent,
-  compactEvents,
 } from "@ag-ui/client";
+import { EventType, compactEvents } from "@ag-ui/client";
 import { finalizeRunEvents } from "@copilotkit/shared";
 
 interface HistoricRun {
@@ -79,6 +78,8 @@ class InMemoryEventStore {
 const GLOBAL_STORE = new Map<string, InMemoryEventStore>();
 
 export class InMemoryAgentRunner extends AgentRunner {
+  readonly ɵsupportsLocalThreadEndpoints = true;
+
   run(request: AgentRunnerRunRequest): Observable<BaseEvent> {
     let existingStore = GLOBAL_STORE.get(request.threadId);
     if (!existingStore) {

--- a/packages/shared/src/utils/types.ts
+++ b/packages/shared/src/utils/types.ts
@@ -31,6 +31,13 @@ export interface IntelligenceRuntimeInfo {
   wsUrl: string;
 }
 
+export interface ThreadEndpointRuntimeInfo {
+  list: boolean;
+  inspect: boolean;
+  mutations: boolean;
+  realtimeMetadata: boolean;
+}
+
 export type RuntimeLicenseStatus =
   | "valid"
   | "none"
@@ -54,6 +61,7 @@ export interface RuntimeInfo {
   audioFileTranscriptionEnabled: boolean;
   mode: RuntimeMode;
   intelligence?: IntelligenceRuntimeInfo;
+  threadEndpoints?: ThreadEndpointRuntimeInfo;
   /**
    * @deprecated Use `a2ui` instead, which preserves per-agent scoping.
    * Kept for backward compatibility with older clients.

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1,9 +1,7 @@
 import { WebInspectorElement, ɵCpkThreadDetails } from "../index";
 import type { CopilotKitCore } from "@copilotkit/core";
-import {
-  CopilotKitCoreRuntimeConnectionStatus,
-  type CopilotKitCoreSubscriber,
-} from "@copilotkit/core";
+import { CopilotKitCoreRuntimeConnectionStatus } from "@copilotkit/core";
+import type { CopilotKitCoreSubscriber } from "@copilotkit/core";
 import type { AbstractAgent, AgentSubscriber } from "@ag-ui/client";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
@@ -621,6 +619,12 @@ type HeaderMockCore = {
   runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
   runtimeUrl: string;
   headers: Record<string, string>;
+  threadEndpoints: {
+    list: boolean;
+    inspect: boolean;
+    mutations: boolean;
+    realtimeMetadata: boolean;
+  };
   subscribe: (subscriber: CopilotKitCoreSubscriber) => {
     unsubscribe: () => void;
   };
@@ -642,6 +646,12 @@ function createHeaderMockCore(
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
     runtimeUrl: "http://localhost/api",
     headers,
+    threadEndpoints: {
+      list: true,
+      inspect: true,
+      mutations: true,
+      realtimeMetadata: true,
+    },
     subscribe(subscriber: CopilotKitCoreSubscriber) {
       subscribers.add(subscriber);
       return { unsubscribe: () => subscribers.delete(subscriber) };

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -1,7 +1,9 @@
 import { WebInspectorElement, ɵCpkThreadDetails } from "../index";
 import type { CopilotKitCore } from "@copilotkit/core";
-import { CopilotKitCoreRuntimeConnectionStatus } from "@copilotkit/core";
-import type { CopilotKitCoreSubscriber } from "@copilotkit/core";
+import {
+  CopilotKitCoreRuntimeConnectionStatus,
+  type CopilotKitCoreSubscriber,
+} from "@copilotkit/core";
 import type { AbstractAgent, AgentSubscriber } from "@ag-ui/client";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
@@ -306,6 +308,9 @@ describe("WebInspectorElement", () => {
 
 type ThreadDetailsInternals = {
   threadId: string | null;
+  runtimeUrl: string;
+  headers: Record<string, string>;
+  threadInspectionAvailable: boolean;
   liveMessageVersion: number;
   _conversation: Array<Record<string, unknown>>;
   _fetchedState: Record<string, unknown> | null;
@@ -318,6 +323,8 @@ type ThreadDetailsInternals = {
   _loadingState: boolean;
   _loadingEvents: boolean;
   _panelTplCache: Map<string, { key: readonly unknown[]; tpl: unknown }>;
+  fetchEvents: (threadId: string) => Promise<void>;
+  fetchState: (threadId: string) => Promise<void>;
   renderConversation: () => unknown;
   renderState: () => unknown;
   renderEvents: () => unknown;
@@ -375,6 +382,30 @@ describe("ɵCpkThreadDetails caching", () => {
     await el.updateComplete;
 
     expect(internals._panelTplCache.size).toBe(0);
+  });
+
+  it("does not fetch messages, events, or state when threadInspectionAvailable is omitted", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    try {
+      const { el, internals } = createThreadDetails();
+
+      internals.runtimeUrl = "http://localhost:4000";
+      internals.headers = { Authorization: "Bearer test-token" };
+      internals.threadId = "t1";
+      await el.updateComplete;
+
+      expect(internals.threadInspectionAvailable).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      await internals.fetchEvents("t1");
+      await internals.fetchState("t1");
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("conversation cache invalidates when _conversation is reassigned", async () => {

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -674,6 +674,7 @@ export class ɵCpkThreadDetails extends LitElement {
     thread: { attribute: false },
     runtimeUrl: { attribute: false },
     headers: { attribute: false },
+    threadInspectionAvailable: { attribute: false },
     agentStateInput: { attribute: false },
     agentEventsInput: { attribute: false },
     liveMessageVersion: { attribute: false },
@@ -701,6 +702,7 @@ export class ɵCpkThreadDetails extends LitElement {
   thread: ɵThread | null = null;
   runtimeUrl = "";
   headers: Record<string, string> = {};
+  threadInspectionAvailable = true;
   agentStateInput: Record<string, unknown> | null = null;
   agentEventsInput: ApiAgentEvent[] = [];
   /**
@@ -1456,7 +1458,7 @@ export class ɵCpkThreadDetails extends LitElement {
     threadId: string,
     silent: boolean = false,
   ): Promise<void> {
-    if (!this.runtimeUrl) {
+    if (!this.runtimeUrl || !this.threadInspectionAvailable) {
       if (!silent) this._conversation = [];
       return;
     }
@@ -1494,7 +1496,7 @@ export class ɵCpkThreadDetails extends LitElement {
 
   private async fetchEvents(threadId: string): Promise<void> {
     this._eventsNotAvailable = false;
-    if (!this.runtimeUrl) {
+    if (!this.runtimeUrl || !this.threadInspectionAvailable) {
       this._fetchedEvents = null;
       return;
     }
@@ -1541,7 +1543,7 @@ export class ɵCpkThreadDetails extends LitElement {
 
   private async fetchState(threadId: string): Promise<void> {
     this._stateNotAvailable = false;
-    if (!this.runtimeUrl) {
+    if (!this.runtimeUrl || !this.threadInspectionAvailable) {
       this._fetchedState = null;
       return;
     }
@@ -2585,12 +2587,14 @@ export class WebInspectorElement extends LitElement {
     if (this.core?.getThreadStore(agentId)) return;
     const core = this.core;
     if (!core?.runtimeUrl) return;
+    if (core.threadEndpoints?.list !== true) return;
 
     const store = ɵcreateThreadStore({ fetch: globalThis.fetch });
     store.start();
     store.setContext({
       runtimeUrl: core.runtimeUrl,
       headers: { ...core.headers },
+      wsUrl: core.intelligence?.wsUrl,
       agentId,
     });
     this._ownedThreadStores.set(agentId, store);
@@ -2657,8 +2661,12 @@ export class WebInspectorElement extends LitElement {
             maybeShowDisclosure();
           }
           this.flushPendingBannerViewed();
-          for (const agentId of this._ownedThreadStores.keys()) {
-            this.refreshOwnedThreadStore(agentId);
+          if (core.threadEndpoints?.list === true) {
+            for (const agentId of this._ownedThreadStores.keys()) {
+              this.refreshOwnedThreadStore(agentId);
+            }
+          } else {
+            this.teardownOwnedThreadStores();
           }
         } else {
           // Clear stale thread data immediately when the server goes away
@@ -5876,6 +5884,9 @@ ${argsString}</pre
                   .thread=${selectedThread}
                   .runtimeUrl=${this._core?.runtimeUrl ?? ""}
                   .headers=${this._core?.headers ?? {}}
+                  .threadInspectionAvailable=${
+                    this._core?.threadEndpoints?.inspect === true
+                  }
                   .liveMessageVersion=${
                     this.selectedThreadId
                       ? (this.liveMessageVersion.get(this.selectedThreadId) ??

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2587,7 +2587,7 @@ export class WebInspectorElement extends LitElement {
     if (this.core?.getThreadStore(agentId)) return;
     const core = this.core;
     if (!core?.runtimeUrl) return;
-    if (core.threadEndpoints?.list !== true) return;
+    if (core.threadEndpoints?.list === false) return;
 
     const store = ɵcreateThreadStore({ fetch: globalThis.fetch });
     store.start();
@@ -2661,7 +2661,7 @@ export class WebInspectorElement extends LitElement {
             maybeShowDisclosure();
           }
           this.flushPendingBannerViewed();
-          if (core.threadEndpoints?.list === true) {
+          if (core.threadEndpoints?.list !== false) {
             for (const agentId of this._ownedThreadStores.keys()) {
               this.refreshOwnedThreadStore(agentId);
             }
@@ -5885,7 +5885,7 @@ ${argsString}</pre
                   .runtimeUrl=${this._core?.runtimeUrl ?? ""}
                   .headers=${this._core?.headers ?? {}}
                   .threadInspectionAvailable=${
-                    this._core?.threadEndpoints?.inspect === true
+                    this._core?.threadEndpoints?.inspect !== false
                   }
                   .liveMessageVersion=${
                     this.selectedThreadId

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -702,7 +702,7 @@ export class ɵCpkThreadDetails extends LitElement {
   thread: ɵThread | null = null;
   runtimeUrl = "";
   headers: Record<string, string> = {};
-  threadInspectionAvailable = true;
+  threadInspectionAvailable = false;
   agentStateInput: Record<string, unknown> | null = null;
   agentEventsInput: ApiAgentEvent[] = [];
   /**

--- a/showcase/shell-docs/src/content/reference/hooks/useThreads.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useThreads.mdx
@@ -18,6 +18,8 @@ doc_type: reference
 
 Threads are sorted by most recently updated first. The hook supports cursor-based pagination when a `limit` is provided.
 
+`useThreads` only activates when the connected runtime advertises compatible REST thread endpoints. Managed Enterprise Intelligence provides those endpoints for durable thread metadata and realtime updates. Self-managed runner persistence, such as `AgentRunner`, `SqliteAgentRunner`, or a custom runner, can still persist and replay chat history, but it does not automatically provide the managed `useThreads` list/mutation/realtime contract.
+
 ## Signature
 
 ```tsx
@@ -132,6 +134,7 @@ function ThreadList() {
 ## Behavior
 
 - On mount, fetches the thread list and establishes a realtime WebSocket subscription.
+- If the runtime does not advertise thread endpoints, no `/threads` request is made and `error` explains that thread endpoints are unavailable.
 - Thread creates, renames, archives, and deletes from any client are reflected immediately without polling.
 - All mutation methods use **pessimistic updates** — the UI updates only after the server confirms the operation via WebSocket, not immediately on dispatch. Promises resolve on confirmation (15-second timeout) and reject on failure.
 - The `error` state updates with the most recent error from any operation.


### PR DESCRIPTION
## Root cause

`useThreads` and the web inspector treated a connected runtime as if thread list/inspect endpoints were always available. In non-Intelligence setups, that could trigger `/threads` and inspector requests against runtimes that did not expose compatible thread endpoints, producing noisy benign 404s.

## Behavior change

- Adds `threadEndpoints` capability metadata to runtime info and carries it through shared/core types.
- Reports thread list/inspect support only for multi-route runtimes backed by Intelligence or the local `InMemoryAgentRunner`; single-route runtime info reports thread endpoints as unavailable.
- Gates `useThreads` so it does not fetch when the runtime does not advertise thread list support, and returns an explicit unavailable-endpoints error instead.
- Gates web inspector owned thread stores and thread detail fetches on advertised list/inspect support.

## Docs

- Clarifies managed Intelligence thread metadata/history versus self-managed runner persistence.
- Documents that `AgentRunner`, `SqliteAgentRunner`, or a custom runner can persist and replay chat history, but does not automatically provide the managed `useThreads` list/mutation/realtime contract unless compatible REST thread endpoints are exposed.
- Updates inspector/event-inspector messaging to avoid implying thread browsing is Intelligence-only while still distinguishing durable managed history from local in-memory development support.

## Verification

Publish-pass checks:

- `gh --version`
- `gh auth status`
- `git diff --check`
- `git diff --cached --check`
- Commit hook ran `lint-fix` with warnings only, then package checks via Nx:
  - `nx run-many -t test --projects=packages/**`
  - `nx run-many -t publint,attw --projects=packages/**`

Implementation-agent reported checks:

- web-inspector tests passed
- core tests passed
- react-core tests passed
- runtime tests passed
- sqlite-runner tests passed
- `git diff --check` passed

Known limitation:

- Full `run-many check-types` was attempted by the implementation agent and failed due pre-existing dependency/typecheck issues and runtime OOM, not this FAC-1 change.
