### PR TITLE
fix(ci): remove Claude settings and MCP config from checked-out PR code before running Claude

### DIFF
--- a/.github/workflows/social_copy-generator.yml
+++ b/.github/workflows/social_copy-generator.yml
@@ -204,6 +204,10 @@ jobs:
         if: steps.verify.outputs.should_run == 'true'
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Remove untrusted Claude settings
+        if: steps.verify.outputs.should_run == 'true'
+        run: rm -f .claude/settings.json
+
       - name: Write prompt file
         if: steps.verify.outputs.should_run == 'true'
         env:

--- a/.github/workflows/social_copy-generator.yml
+++ b/.github/workflows/social_copy-generator.yml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Remove repository Claude settings
         if: steps.verify.outputs.should_run == 'true'
-        run: rm -f .claude/settings.json .claude/settings.local.json
+        run: rm -f .claude/settings.json .claude/settings.local.json .mcp.json
 
       - name: Get PR diff
         if: steps.verify.outputs.should_run == 'true'

--- a/.github/workflows/social_copy-generator.yml
+++ b/.github/workflows/social_copy-generator.yml
@@ -176,6 +176,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Remove repository Claude settings
+        if: steps.verify.outputs.should_run == 'true'
+        run: rm -f .claude/settings.json .claude/settings.local.json
+
       - name: Get PR diff
         if: steps.verify.outputs.should_run == 'true'
         id: diff
@@ -203,10 +207,6 @@ jobs:
       - name: Install Claude Code
         if: steps.verify.outputs.should_run == 'true'
         run: npm install -g @anthropic-ai/claude-code
-
-      - name: Remove untrusted Claude settings
-        if: steps.verify.outputs.should_run == 'true'
-        run: rm -f .claude/settings.json
 
       - name: Write prompt file
         if: steps.verify.outputs.should_run == 'true'


### PR DESCRIPTION
## Summary

- Removes three project-level Claude Code config files from the checked-out PR code immediately after checkout, before any other step runs
- Closes three pre-model-load code execution vectors that a malicious PR could exploit when a maintainer triggers the social copy generator

## What's removed and why

| File | Vector |
|------|--------|
| `.claude/settings.json` | `SessionStart` hooks execute as shell commands before the model loads |
| `.claude/settings.local.json` | Same hook vector — gitignored but can be force-committed to a branch |
| `.mcp.json` | MCP servers are launched as subprocesses before the model loads in non-`--bare` mode |

All three fire before the model processes any prompt, so `--allowedTools` restrictions don't protect against them.

## Context

The social copy generator checks out the PR's HEAD SHA and then runs `claude -p` with `ANTHROPIC_API_KEY` in scope. An existing write-access permission gate (a maintainer must manually check a checkbox to trigger generation) limits who can pull the trigger — but doesn't prevent a social-engineering attack where a seemingly legitimate PR contains a malicious config file.

The step is placed immediately after `actions/checkout` so nothing in the checked-out workspace can influence Claude Code before the sanitization runs.

## Test plan

- [ ] Trigger the social copy generator on a normal PR and confirm it still produces output