### PR TITLE
fix(ci): add repository.url for OIDC provenance + publish remaining v1.57.4

### DIFF
--- a/.github/workflows/publish-remaining.yml
+++ b/.github/workflows/publish-remaining.yml
@@ -1,0 +1,71 @@
+name: release / publish-remaining-1.57.4
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+          registry-url: https://registry.npmjs.org
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Publish remaining packages
+        env:
+          NODE_AUTH_TOKEN: ""
+        run: |
+          PACKAGES=(
+            agentcore-runner
+            core
+            react-core
+            react-native
+            react-textarea
+            react-ui
+            runtime
+            runtime-client-gql
+            sdk-js
+            shared
+            sqlite-runner
+            voice
+            vue
+            web-inspector
+          )
+          for pkg in "${PACKAGES[@]}"; do
+            DIR="packages/$pkg"
+            NAME=$(jq -r '.name' "$DIR/package.json")
+            VERSION=$(jq -r '.version' "$DIR/package.json")
+            echo "=== Publishing $NAME@$VERSION ==="
+            cd "$DIR"
+            pnpm pack
+            TARBALL="${NAME//@/}"
+            TARBALL="${TARBALL////-}-${VERSION}.tgz"
+            npx --yes npm@11.15.0 publish "$TARBALL" --tag latest --access public
+            cd /home/runner/work/CopilotKit/CopilotKit
+            echo "Done: $NAME@$VERSION"
+            echo ""
+          done

--- a/packages/agentcore-runner/package.json
+++ b/packages/agentcore-runner/package.json
@@ -2,6 +2,10 @@
   "name": "@copilotkit/agentcore-runner",
   "version": "1.57.4",
   "description": "AWS Bedrock AgentCore-compatible agent runner for CopilotKit2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -40,9 +44,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/CopilotKit/CopilotKit.git"
   }
 }

--- a/packages/agentcore-runner/package.json
+++ b/packages/agentcore-runner/package.json
@@ -40,5 +40,9 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,5 +50,9 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,10 @@
   "name": "@copilotkit/core",
   "version": "1.57.4",
   "description": "Core web utilities for CopilotKit2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -50,9 +54,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/CopilotKit/CopilotKit.git"
   }
 }

--- a/packages/sqlite-runner/package.json
+++ b/packages/sqlite-runner/package.json
@@ -50,5 +50,9 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
   }
 }

--- a/packages/sqlite-runner/package.json
+++ b/packages/sqlite-runner/package.json
@@ -2,6 +2,10 @@
   "name": "@copilotkit/sqlite-runner",
   "version": "1.57.4",
   "description": "SQLite-backed agent runner for CopilotKit2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -50,9 +54,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/CopilotKit/CopilotKit.git"
   }
 }

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -2,6 +2,10 @@
   "name": "@copilotkit/voice",
   "version": "1.57.4",
   "description": "Voice services for CopilotKit (transcription, text-to-speech, etc.)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -42,9 +46,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/CopilotKit/CopilotKit.git"
   }
 }

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -42,5 +42,9 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
   }
 }

--- a/packages/web-inspector/package.json
+++ b/packages/web-inspector/package.json
@@ -2,6 +2,10 @@
   "name": "@copilotkit/web-inspector",
   "version": "1.57.4",
   "description": "Lit-based web component for the CopilotKit web inspector",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -47,9 +51,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/CopilotKit/CopilotKit.git"
   }
 }

--- a/packages/web-inspector/package.json
+++ b/packages/web-inspector/package.json
@@ -47,5 +47,9 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/CopilotKit/CopilotKit.git"
   }
 }


### PR DESCRIPTION
## Summary
- Add `repository.url` to 5 packages missing it (`agentcore-runner`, `core`, `sqlite-runner`, `voice`, `web-inspector`) — required for npm OIDC provenance verification
- One-shot `publish-remaining` workflow to publish the 14 packages that didn't make it in the first run (`a2ui-renderer` already published via OIDC successfully)

## Context
v1.57.4 OIDC publish got 1/15 packages out before failing on `agentcore-runner` with E422 (missing `repository.url`). This fixes the URLs and provides a targeted publish workflow for the remaining 14.

## Test plan
- [ ] Merge this PR
- [ ] Dispatch `release / publish-remaining-1.57.4` workflow
- [ ] Verify all 15 packages at v1.57.4 on npm with OIDC provenance
- [ ] Delete `publish-remaining.yml` after successful publish