### PR TITLE
feat(dojo): promote HITL and interrupt-based HITL into Featured section

### DIFF
--- a/showcase/shell-dojo/src/app/page.tsx
+++ b/showcase/shell-dojo/src/app/page.tsx
@@ -50,6 +50,9 @@ const FEATURED_DEMO_IDS: readonly string[] = [
   "mcp-apps",
   "open-gen-ui",
   "frontend-tools",
+  "hitl-in-chat",
+  "hitl-in-app",
+  "gen-ui-interrupt",
 ];
 
 const FEATURED_CATEGORY: FeatureCategory = {

--- a/showcase/shell-dojo/src/app/page.tsx
+++ b/showcase/shell-dojo/src/app/page.tsx
@@ -58,7 +58,6 @@ const EXTRA_FEATURED_BY_INTEGRATION: Readonly<
   Record<string, readonly string[]>
 > = {
   "langgraph-python": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
-  "langgraph-typescript": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
   "langgraph-fastapi": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
   "google-adk": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
 };

--- a/showcase/shell-dojo/src/app/page.tsx
+++ b/showcase/shell-dojo/src/app/page.tsx
@@ -50,10 +50,18 @@ const FEATURED_DEMO_IDS: readonly string[] = [
   "mcp-apps",
   "open-gen-ui",
   "frontend-tools",
-  "hitl-in-chat",
-  "hitl-in-app",
-  "gen-ui-interrupt",
 ];
+
+// Per-integration extras appended after the base list above.
+// Demos that the integration hasn't wired are silently skipped.
+const EXTRA_FEATURED_BY_INTEGRATION: Readonly<
+  Record<string, readonly string[]>
+> = {
+  "langgraph-python": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
+  "langgraph-typescript": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
+  "langgraph-fastapi": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
+  "google-adk": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
+};
 
 const FEATURED_CATEGORY: FeatureCategory = {
   id: "__featured__",
@@ -79,9 +87,13 @@ function groupDemosByCategory(
   // Featured comes first. Pull each ID from the current integration's demos,
   // preserving the curated order, and silently skip any the integration hasn't
   // implemented. The same demos still appear in their real category below.
-  const featured = FEATURED_DEMO_IDS.map((id) =>
-    integration.demos.find((d) => d.id === id),
-  ).filter((d): d is Demo => !!d);
+  const featuredIds = [
+    ...FEATURED_DEMO_IDS,
+    ...(EXTRA_FEATURED_BY_INTEGRATION[integration.slug] ?? []),
+  ];
+  const featured = featuredIds
+    .map((id) => integration.demos.find((d) => d.id === id))
+    .filter((d): d is Demo => !!d);
   if (featured.length > 0) {
     groups.push({ category: FEATURED_CATEGORY, demos: featured });
   }


### PR DESCRIPTION
## Summary

- Adds per-integration `EXTRA_FEATURED_BY_INTEGRATION` map to the dojo shell
- `hitl-in-chat`, `hitl-in-app`, and `gen-ui-interrupt` appear in Featured **only** for LangGraph Python, LangGraph TypeScript, LangGraph FastAPI, and Google ADK
- All other integrations see the original 9-item Featured list — zero behavioral change
- Unsupported demos (e.g. `gen-ui-interrupt` on ADK) are silently skipped per existing filter logic

Resolves OSS-138

## Test plan

- [x] Built-in Agent: 9 Featured items (original list, no HITL) — no change from before
- [x] LangGraph Python: 12 Featured items (original 9 + 3 HITL extras)
- [x] Google ADK: 11 Featured items (original 9 + 2 HITL; `gen-ui-interrupt` correctly skipped as `not_supported`)
- [ ] Review order/placement with Atai before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)