### PR TITLE
fix(shell-docs): disable next/image optimizer for CDN-hosted images

### DIFF
--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -55,10 +55,20 @@ if (!process.env.NEXT_PUBLIC_SHELL_URL) {
 
 const nextConfig: NextConfig = {
   images: {
+    // Bypass the Next.js image optimizer (`/_next/image`). The optimizer
+    // requires `sharp` at runtime, which is missing from the Railway image
+    // and breaks all `<Image>` rendering site-wide. Our CDN
+    // (`cdn.copilotkit.ai`, CloudFront/S3) ignores `?fm=webp` and serves
+    // PNG regardless, so the optimizer added no format-conversion value
+    // for CDN-hosted images. With `unoptimized`, `<Image>` renders as a
+    // plain `<img>` pointing at the source URL — visually identical for
+    // users, no sharp dependency required.
+    unoptimized: true,
     // Asset CDN for framework intro-page media (banner videos, architecture
     // diagrams, supported-feature thumbnails, framework icons). Hosts every
     // image/video referenced by `src/data/frameworks/*.ts` and any future
-    // marketing surface that pulls from the shared CDN.
+    // marketing surface that pulls from the shared CDN. Kept here for
+    // documentation and to remain valid if the optimizer is re-enabled.
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## Problem

Post-cutover, every image on docs.copilotkit.ai is broken site-wide. Architecture diagrams, framework icons, banner media — all return broken-image icons.

## Root cause

Next.js's `/_next/image` optimizer is returning HTTP 400. The optimizer requires `sharp` at runtime, and `sharp` is missing from the Railway runtime image. Without it, the optimizer can't process any request and every `<Image>` tag on the site fails.

## Fix

Set `images.unoptimized: true` in `showcase/shell-docs/next.config.ts`. This bypasses the `/_next/image` route entirely — `<Image>` renders as a plain `<img>` pointing at the source URL. No sharp dependency required.

## Why this is safe (visually identical for users)

Our CDN (`cdn.copilotkit.ai`) is CloudFront sitting in front of S3. It does no format negotiation — it ignores `?fm=webp` on the query string and serves whatever bytes are stored (PNG today). The optimizer was already producing zero format-conversion gains for CDN-hosted images; it was only doing resize/quality knobs that we don't materially exercise on a docs site. End users see the same PNG bytes either way.

## Test plan

- [x] Local `npm run build` of `showcase/shell-docs` succeeds with the new config (verified)
- [ ] Post-merge: deploy lands on Railway, hit https://docs.copilotkit.ai/google-adk and verify the architecture diagram renders (no broken-image icon, no `/_next/image` 400 in Network tab)
- [ ] Spot-check the framework intro pages that reference CDN media (built-in-agent, langgraph, mastra) for visual regression

## Docker build

Skipped local Docker build for this wave-1 hotfix per the plan: this is a config-only change with no `Dockerfile` or dependency changes, so Docker behavior is unchanged. Local `next build` was sufficient to validate config syntax/semantics.

## Follow-up (wave 2, separate PR)

The optimizer's only realistic value here was bandwidth via WebP on the two 4K `gen-ui-specs-*.png` files. A separate PR will pre-bake WebP variants of those specific assets so we capture the size win without needing sharp at runtime.