### PR TITLE
fix(shell-docs): redirect deprecated /tutorials paths

### DIFF
--- a/showcase/shell-docs/src/lib/seo-redirects.ts
+++ b/showcase/shell-docs/src/lib/seo-redirects.ts
@@ -68,6 +68,36 @@ function canonicalSlug(legacy: string): string {
   return SLUG_RENAMES[legacy] ?? legacy;
 }
 
+/**
+ * Canonical (post-cutover) framework slugs served by shell-docs. Used for
+ * wildcard rules that match the current URL surface rather than legacy
+ * upstream slugs. Keep in sync with the registry; covers generated,
+ * authored, and hidden buckets.
+ */
+const CANONICAL_FRAMEWORKS = [
+  "built-in-agent",
+  "langgraph-python",
+  "langgraph-typescript",
+  "langgraph-fastapi",
+  "google-adk",
+  "a2a",
+  "agent-spec",
+  "deepagents",
+  "mastra",
+  "crewai-crews",
+  "pydantic-ai",
+  "agno",
+  "ag2",
+  "llamaindex",
+  "strands",
+  "ms-agent-python",
+  "ms-agent-dotnet",
+  "claude-sdk-python",
+  "claude-sdk-typescript",
+  "langroid",
+  "spring-ai",
+] as const;
+
 /** Per-framework subpath renames (Category 5 in spec). Applied to ALL 13 frameworks. */
 const SUBPATH_RENAMES: { specId: string; from: string; to: string }[] = [
   { specId: "S1", from: "agentic-chat-ui", to: "prebuilt-components" },
@@ -717,6 +747,21 @@ const WILDCARD_REDIRECTS: RedirectEntry[] = [
     source: "/generative-ui-specs/:path*",
     destination: "/generative-ui/specs/:path*",
   },
+  // Tutorials deprecation: section retired post-cutover. Framework-scoped
+  // tutorial URLs redirect to that framework's quickstart; unscoped variants
+  // redirect to the docs root. Must precede the per-framework P1×/P2×
+  // catch-alls below.
+  ...CANONICAL_FRAMEWORKS.map((fw) => ({
+    id: `T1×${fw}`,
+    source: `/${fw}/tutorials/:path*`,
+    destination: `/${fw}/quickstart`,
+  })),
+  {
+    id: "T1-unscoped-wild",
+    source: "/tutorials/:path*",
+    destination: "/",
+  },
+  { id: "T1-unscoped-root", source: "/tutorials", destination: "/" },
   // Category 1: Pattern rules (bulk coverage)
   { id: "P10", source: "/reference/v1/:path*", destination: "/reference/v2" },
   {


### PR DESCRIPTION
## Summary

- Add wildcard 301 redirects for the deprecated `/tutorials/*` URL space in the shell-docs redirect catalog.
- Framework-scoped tutorial URLs redirect to that framework's `/quickstart`; unscoped variants redirect to the docs root.
- Covers all 21 canonical framework slugs (built-in-agent, langgraph-{python,typescript,fastapi}, google-adk, a2a, agent-spec, deepagents, mastra, crewai-crews, pydantic-ai, agno, ag2, llamaindex, strands, ms-agent-{python,dotnet}, claude-sdk-{python,typescript}, langroid, spring-ai).

## Why

The step-2 tutorial MDX (`tutorials/ai-todo-app/step-2-setup-copilotkit.mdx` and `tutorials/ai-powered-textarea/step-2-setup-copilotkit.mdx`) crashes during SSR for every active framework slug, returning a 21-byte `text/plain` 500 from `railway-edge`. Sibling steps (`overview`, `step-1`, `step-3`, `next-steps`) render fine. The sitemap lists ~38 of these URLs. Two of them are in the legacy sitemap as 200s.

The tutorials section is being retired, so the right operational response is a 301 to a working destination rather than a renderer fix.

## Implementation

- New `CANONICAL_FRAMEWORKS` constant alongside the existing `FRAMEWORKS` legacy-slug array.
- Generated wildcard entries `/${fw}/tutorials/:path*` → `/${fw}/quickstart` per framework.
- Two explicit entries for unscoped paths: `/tutorials/:path*` → `/` and `/tutorials` → `/`.
- Slotted in `WILDCARD_REDIRECTS` before the per-framework `P1×`/`P2×` catch-alls so the more specific tutorial rule wins.

## Test plan

- [ ] Local: `npm run dev` in `showcase/shell-docs/` and curl a sample of step-2 URLs, confirm 301 to `/{fw}/quickstart`.
- [ ] Local: `npm run typecheck` in `showcase/shell-docs/` (catalog is pure data; TypeScript catches shape drift).
- [ ] Post-deploy: re-curl the 38 step-2 URLs from the production sitemap and confirm 301 chains land on a 200.