### PR TITLE
fix(shell-docs): post-cutover polish (metadata, OG, 404, pydantic-ai, v1 redirect)

### DIFF
--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -13,10 +13,18 @@ import { DocsLandingNext } from "@/components/docs-landing-next";
 import { ShellDocsLayout } from "@/components/shell-docs-layout";
 import { SidebarFrameworkSelector } from "@/components/sidebar-framework-selector";
 import { UnscopedDocsPage } from "@/components/unscoped-docs-page";
-import { buildFrameworkOnlyNav } from "@/lib/docs-render";
+import { buildFrameworkOnlyNav, loadDoc } from "@/lib/docs-render";
 import { navTreeToPageTree } from "@/lib/page-tree-bridge";
 import { getDocsFolder } from "@/lib/registry";
-import { getBaseUrl } from "@/lib/sitemap-helpers";
+import { buildDocMetadata } from "@/lib/seo-metadata";
+
+// Force dynamic rendering so unknown slugs reliably return HTTP 404
+// from `notFound()` instead of being cached as a 200 with the not-found
+// UI baked in (the search-engine-killing soft-404). The bare home page
+// and known unscoped docs are still cheap to render — they're
+// filesystem reads of MDX content — and Railway / upstream CDN caches
+// successful responses at the edge anyway.
+export const dynamic = "force-dynamic";
 
 // Soft-default framework rendered on the bare `/` URL. BIA is the
 // "Built-in Agent" path and uses `docs_mode: authored`, so its sidebar
@@ -31,18 +39,35 @@ const HOME_DEFAULT_FRAMEWORK = "built-in-agent";
 // itself canonical so search engines index every framework's quickstart
 // (etc.) at its own URL rather than collapsing them all onto the bare
 // /quickstart. Done at the page level so the metadata depends on params.
+//
+// For the bare home page we hand-wire title/description so visitors and
+// social platforms see CopilotKit's positioning rather than the page's
+// own first MDX line.
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ slug?: string[] }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const slugPath = slug && slug.length > 0 ? `/${slug.join("/")}` : "";
-  return {
-    alternates: {
-      canonical: `${getBaseUrl()}${slugPath}`,
-    },
-  };
+  const slugPath = slug?.join("/") ?? "";
+  const canonicalPath = slugPath ? `/${slugPath}` : "/";
+  // Home page: brand-level title + tagline. Other unscoped slugs (e.g.
+  // /quickstart, /concepts/architecture) read frontmatter via loadDoc.
+  if (!slugPath) {
+    return buildDocMetadata({
+      title: "CopilotKit: the frontend stack for agents",
+      description:
+        "Connect any agent framework or model to your React app for chat, generative UI, canvas, and human-in-the-loop workflows.",
+      canonicalPath: "/",
+    });
+  }
+  const doc = loadDoc(slugPath);
+  return buildDocMetadata({
+    title: doc?.fm.title ?? slugPath,
+    description: doc?.fm.description,
+    canonicalPath,
+    ogPath: `/og${canonicalPath}/og.png`,
+  });
 }
 
 function DocsOverview() {

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -104,9 +104,7 @@ export async function generateMetadata({
     // tagline, falling back to the framework's index.mdx if present.
     const integration = getIntegration(framework);
     const overview = frameworkOverviews[framework];
-    const indexDoc = loadDoc(
-      `integrations/${getDocsFolder(framework)}/index`,
-    );
+    const indexDoc = loadDoc(`integrations/${getDocsFolder(framework)}/index`);
     title =
       indexDoc?.fm.title ??
       overview?.frameworkName ??

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -56,7 +56,7 @@ import {
   getIntegrations,
 } from "@/lib/registry";
 import type { Integration } from "@/lib/registry";
-import { getBaseUrl } from "@/lib/sitemap-helpers";
+import { buildDocMetadata } from "@/lib/seo-metadata";
 import { RESERVED_ROUTE_SLUGS } from "@/app/layout";
 import demoContent from "@/data/demo-content.json";
 import fs from "fs";
@@ -69,6 +69,11 @@ import path from "path";
 // UnscopedDocsPage but the canonical still points at the same URL —
 // the page's identity is defined by its URL, not the resolution
 // strategy used to render it.
+//
+// Title and description come from the resolved MDX frontmatter (with
+// the same per-framework override resolution the page render uses) so
+// every variant emits its own social card and SEO description rather
+// than inheriting the layout's generic site-wide values.
 export async function generateMetadata({
   params,
 }: {
@@ -76,11 +81,49 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { framework, slug } = await params;
   const slugTail = slug && slug.length > 0 ? `/${slug.join("/")}` : "";
-  return {
-    alternates: {
-      canonical: `${getBaseUrl()}/${framework}${slugTail}`,
-    },
-  };
+  const canonicalPath = `/${framework}${slugTail}`;
+  // Try to read frontmatter for the resolved page. Mirror the page's
+  // own content-resolution order (authored vs generated, per-framework
+  // override vs root) cheaply: best-effort only; if nothing resolves,
+  // the helper falls back to the framework slug as a humanised title.
+  let title: string | undefined;
+  let description: string | undefined;
+  const slugPath = slug?.join("/") ?? "";
+  if (slugPath) {
+    const docsFolder = getDocsFolder(framework);
+    const frameworkScopedDoc = loadDoc(
+      `integrations/${docsFolder}/${slugPath}`,
+    );
+    const doc = frameworkScopedDoc ?? loadDoc(slugPath);
+    if (doc) {
+      title = doc.fm.title;
+      description = doc.fm.description;
+    }
+  } else {
+    // Framework root — prefer the integration record's display name and
+    // tagline, falling back to the framework's index.mdx if present.
+    const integration = getIntegration(framework);
+    const overview = frameworkOverviews[framework];
+    const indexDoc = loadDoc(
+      `integrations/${getDocsFolder(framework)}/index`,
+    );
+    title =
+      indexDoc?.fm.title ??
+      overview?.frameworkName ??
+      integration?.name ??
+      framework;
+    description = indexDoc?.fm.description ?? overview?.subheader;
+  }
+  // Per-page OG route lives at /og/<slug>/og.png — see
+  // src/app/og/[...slug]/route.tsx. Each framework variant gets its own
+  // image because the slug is framework-scoped.
+  const ogPath = `/og${canonicalPath}/og.png`;
+  return buildDocMetadata({
+    title: title ?? framework,
+    description,
+    canonicalPath,
+    ogPath,
+  });
 }
 
 export async function generateStaticParams() {
@@ -89,6 +132,15 @@ export async function generateStaticParams() {
   // × ~60 doc pages, all cheap to render on demand.
   return [];
 }
+
+// Force dynamic rendering so paths NOT in generateStaticParams are
+// rendered fresh on each request. Without this, Next.js was caching
+// the rendered "404 page body" with a 200 status and `s-maxage=1y`
+// (a soft-404 that demotes the whole site in search rankings). With
+// `force-dynamic`, the runtime notFound() call sets the response
+// status to 404 every time. The data fetches here are filesystem
+// reads of MDX, so per-request rendering is cheap.
+export const dynamic = "force-dynamic";
 
 interface DemoRecord {
   regions?: Record<string, unknown>;

--- a/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
@@ -19,23 +19,78 @@ import { docsComponents } from "@/lib/mdx-registry";
 import { stripLeadingImports } from "@/lib/docs-render";
 import { transformerMeta } from "@/lib/rehype-code-meta";
 import { resolveWithinDir, safeReadFileSync } from "@/lib/safe-fs";
-import { getBaseUrl } from "@/lib/sitemap-helpers";
+import { buildDocMetadata } from "@/lib/seo-metadata";
 
 // Self-canonical for /ag-ui[/<slug>]. AG-UI pages aren't per-framework
 // but get a canonical for parity with the rest of the docs surface.
+// Title/description come from the page's MDX frontmatter so every AG-UI
+// doc emits its own social card and `<meta description>` rather than
+// inheriting the layout's generic site-wide values.
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ slug?: string[] }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const slugTail = slug && slug.length > 0 ? `/${slug.join("/")}` : "";
-  return {
-    alternates: {
-      canonical: `${getBaseUrl()}/ag-ui${slugTail}`,
-    },
-  };
+  const slugPath = slug && slug.length > 0 ? slug.join("/") : "";
+  const canonicalPath = slugPath ? `/ag-ui/${slugPath}` : "/ag-ui";
+  // Overview page (no slug): hard-code the protocol-level title rather
+  // than reading from MDX, since /ag-ui has no backing file — its body
+  // is rendered by `OverviewContent` in this same module.
+  if (!slugPath) {
+    return buildDocMetadata({
+      title: "AG-UI: the Agent-User Interaction Protocol",
+      description:
+        "AG-UI is an open protocol for connecting AI agents to frontend applications via a standard event-based interface.",
+      canonicalPath,
+    });
+  }
+  // Read frontmatter from the AG-UI MDX file. Mirror the page render's
+  // own resolution (file.mdx → folder/index.mdx) so the metadata always
+  // matches what the user sees. Use safeReadFileSync to keep the read
+  // path-traversal-guarded.
+  const mdxResolved = resolveWithinDir(CONTENT_DIR, `${slugPath}.mdx`);
+  const indexResolved = resolveWithinDir(
+    CONTENT_DIR,
+    path.join(slugPath, "index.mdx"),
+  );
+  let title: string | undefined;
+  let description: string | undefined;
+  const relPath = mdxResolved
+    ? path.relative(CONTENT_DIR, mdxResolved)
+    : indexResolved
+      ? path.relative(CONTENT_DIR, indexResolved)
+      : null;
+  if (relPath) {
+    const raw = safeReadFileSync(CONTENT_DIR, relPath);
+    if (raw !== null) {
+      try {
+        const { data } = matter(raw);
+        if (typeof data.title === "string" && data.title.length > 0) {
+          title = data.title;
+        }
+        if (
+          typeof data.description === "string" &&
+          data.description.length > 0
+        ) {
+          description = data.description;
+        }
+      } catch {
+        // Malformed frontmatter — fall back to the slug-derived title.
+      }
+    }
+  }
+  return buildDocMetadata({
+    title: title ?? titleFromSlug(slugPath),
+    description,
+    canonicalPath,
+  });
 }
+
+// Force dynamic rendering so unknown AG-UI slugs reliably return HTTP
+// 404 from `notFound()` instead of being cached as a 200 (soft-404).
+// See the matching note in the framework route.
+export const dynamic = "force-dynamic";
 
 const CONTENT_DIR = path.join(process.cwd(), "src/content/ag-ui");
 

--- a/showcase/shell-docs/src/app/layout.tsx
+++ b/showcase/shell-docs/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Plus_Jakarta_Sans } from "next/font/google";
 import Script from "next/script";
-import { Suspense } from "react";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import { AnalyticsClient } from "@/components/analytics-client";
 import { Banners } from "@/components/banners";
@@ -151,31 +150,39 @@ export default function RootLayout({
       </head>
       <body>
         <AnalyticsClient />
-        <Suspense fallback={null}>
-          <PostHogProvider>
-            <FrameworkProvider knownFrameworks={knownFrameworks}>
-              {/* RootProvider supplies Fumadocs's theme provider (next-themes)
-               * and the search-dialog context, which DocsLayout and other
-               * fumadocs-ui components read from. We keep BrandNav + Banners
-               * outside DocsLayout so chrome remains shell-docs's own. */}
-              <RootProvider theme={{ enabled: true, defaultTheme: "system" }}>
-                {/* Body is a fixed-height (100vh) flex column with hidden
-                 * overflow (see globals.css). Banner + nav sit naturally
-                 * at the top; <main> takes the remaining height and is
-                 * the horizontal flex row that hosts sidebar + the
-                 * scrolling `.docs-content-wrapper`. No sticky positioning
-                 * is needed — chrome stays put because it's outside the
-                 * scroll container. Mirrors canonical `#nd-home-layout`
-                 * (margin: 0 4px; xl: 0 8px 8px 8px). */}
-                <Banners />
-                <BrandNav />
-                <main className="flex flex-1 min-h-0 overflow-hidden mx-1 md:mx-[22px] mt-2 md:mt-6 mb-2 md:mb-3">
-                  {children}
-                </main>
-              </RootProvider>
-            </FrameworkProvider>
-          </PostHogProvider>
-        </Suspense>
+        {/* No <Suspense> wrapper around the page tree. Previously this
+         * was wrapped in a Suspense with a null fallback, which caused
+         * Next.js to start streaming the response BEFORE the page
+         * component called `notFound()`. Once bytes are in the wire,
+         * Next can't change the response status, so every unknown URL
+         * returned HTTP 200 + the not-found UI (a soft-404 that demoted
+         * the entire site in search rankings). The PostHogProvider and
+         * FrameworkProvider are client components and don't suspend
+         * during server render, so removing the boundary is safe.
+         */}
+        <PostHogProvider>
+          <FrameworkProvider knownFrameworks={knownFrameworks}>
+            {/* RootProvider supplies Fumadocs's theme provider (next-themes)
+             * and the search-dialog context, which DocsLayout and other
+             * fumadocs-ui components read from. We keep BrandNav + Banners
+             * outside DocsLayout so chrome remains shell-docs's own. */}
+            <RootProvider theme={{ enabled: true, defaultTheme: "system" }}>
+              {/* Body is a fixed-height (100vh) flex column with hidden
+               * overflow (see globals.css). Banner + nav sit naturally
+               * at the top; <main> takes the remaining height and is
+               * the horizontal flex row that hosts sidebar + the
+               * scrolling `.docs-content-wrapper`. No sticky positioning
+               * is needed — chrome stays put because it's outside the
+               * scroll container. Mirrors canonical `#nd-home-layout`
+               * (margin: 0 4px; xl: 0 8px 8px 8px). */}
+              <Banners />
+              <BrandNav />
+              <main className="flex flex-1 min-h-0 overflow-hidden mx-1 md:mx-[22px] mt-2 md:mt-6 mb-2 md:mb-3">
+                {children}
+              </main>
+            </RootProvider>
+          </FrameworkProvider>
+        </PostHogProvider>
         <div
           aria-hidden="true"
           style={{

--- a/showcase/shell-docs/src/app/not-found.tsx
+++ b/showcase/shell-docs/src/app/not-found.tsx
@@ -1,0 +1,55 @@
+// Root-level not-found page. Required by Next.js so a thrown
+// `notFound()` from any route handler yields a proper HTTP 404 response
+// (not a soft-200 with a default body). Without this file, prod was
+// returning 200 + Next's built-in "404: This page could not be found"
+// HTML; Google read every nonexistent URL as low-quality content and
+// downranked the whole site.
+//
+// Setting the explicit response status is the load-bearing piece. The
+// rendered body is intentionally minimal — docs-shell chrome already
+// wraps every page through the root layout.
+
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Page not found",
+  description: "The page you're looking for doesn't exist.",
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
+
+export default function NotFound() {
+  return (
+    <div className="flex-1 min-w-0 overflow-y-auto">
+      <div className="mx-auto max-w-2xl px-6 py-24 text-center">
+        <p className="text-xs font-mono uppercase tracking-widest text-[var(--accent)] mb-3">
+          404
+        </p>
+        <h1 className="text-3xl font-semibold text-[var(--text)] tracking-tight mb-3">
+          This page doesn't exist
+        </h1>
+        <p className="text-base text-[var(--text-secondary)] leading-relaxed mb-8">
+          The URL you followed may be out of date, or the page may have moved.
+          Try the docs home or browse from there.
+        </p>
+        <div className="flex justify-center gap-3">
+          <Link
+            href="/"
+            className="inline-flex items-center px-4 py-2 rounded-lg border border-[var(--accent)] bg-[var(--accent)] text-white text-sm font-medium hover:opacity-90 transition-opacity"
+          >
+            Go to docs home
+          </Link>
+          <Link
+            href="/reference"
+            className="inline-flex items-center px-4 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text)] text-sm font-medium hover:border-[var(--accent)] transition-colors"
+          >
+            API reference
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/shell-docs/src/app/og/[...slug]/route.tsx
+++ b/showcase/shell-docs/src/app/og/[...slug]/route.tsx
@@ -3,6 +3,7 @@ import type { NextRequest } from "next/server";
 import { notFound } from "next/navigation";
 import { ImageResponse } from "next/og";
 import { loadDoc } from "@/lib/docs-render";
+import { getDocsFolder, getIntegration } from "@/lib/registry";
 
 // Per-page Open Graph image route — emits a 1200x630-ish PNG used by
 // Twitter cards, LinkedIn previews, and Slack unfurls. Ported from
@@ -13,44 +14,15 @@ import { loadDoc } from "@/lib/docs-render";
 // Public signature is preserved: requests at `/og/<slug>/og.png` map
 // to the page at `<slug>` (the trailing `og.png` is stripped, matching
 // upstream's `generateStaticParams` which appends it).
-
-const getInter = async () => {
-  try {
-    const response = await fetch(
-      `https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfMZg.ttf`,
-      { cache: "force-cache" },
-    );
-    if (!response.ok) {
-      throw new Error(`Failed to fetch Inter font: ${response.status}`);
-    }
-    const res = await response.arrayBuffer();
-    return res;
-  } catch (error) {
-    console.error("Error fetching Inter font:", error);
-    // Return null to handle the error case in the ImageResponse
-    return null;
-  }
-};
-
-const getInterSemibold = async () => {
-  try {
-    const response = await fetch(
-      `https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuGKYMZg.ttf`,
-      { cache: "force-cache" },
-    );
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch Inter Semibold font: ${response.status}`,
-      );
-    }
-    const res = await response.arrayBuffer();
-    return res;
-  } catch (error) {
-    console.error("Error fetching Inter Semibold font:", error);
-    // Return null to handle the error case in the ImageResponse
-    return null;
-  }
-};
+//
+// Previously this route fetched Inter TTFs from fonts.gstatic.com at
+// request time and any failure (Railway egress hiccup, font URL drift,
+// cold cache) put the request into the catch block, which 307-redirected
+// to a static CDN fallback that itself was broken (25 bytes). The result
+// was zero working OG images on most pages in prod. We now skip the font
+// fetch entirely and rely on Satori's built-in default sans-serif. The
+// PNG quality is unchanged for the headings and tagline; the upside is
+// every page renders successfully without depending on external network.
 
 // In Next.js 13+ (app directory), route handlers use the following signature:
 export async function GET(
@@ -67,32 +39,24 @@ export async function GET(
     // Drop the trailing `og.png` segment to recover the actual page slug.
     const slugParts = resolvedParams.slug.slice(0, -1);
     const slugPath = slugParts.join("/");
-    const doc = slugPath ? loadDoc(slugPath) : null;
+    // Resolution mirrors the framework page route's order so that the
+    // OG image always reflects the same MDX file the user sees:
+    //   1. Direct loadDoc(slugPath) for unscoped paths (e.g. concepts/...).
+    //   2. Framework-scoped: when the first segment is a registered
+    //      integration slug, try integrations/<docsFolder>/<rest>.
+    //   3. Bare framework root (e.g. "built-in-agent") -> the file at
+    //      that name in the docs root (built-in-agent.mdx) — the
+    //      existing behavior preserved here so prior callers keep
+    //      working.
+    let doc = slugPath ? loadDoc(slugPath) : null;
+    if (!doc && slugParts.length >= 2) {
+      const [framework, ...rest] = slugParts;
+      if (getIntegration(framework)) {
+        const docsFolder = getDocsFolder(framework);
+        doc = loadDoc(`integrations/${docsFolder}/${rest.join("/")}`);
+      }
+    }
     if (!doc) notFound();
-
-    const interFont = await getInter();
-    const interSemiboldFont = await getInterSemibold();
-
-    // Define fonts array without type errors by dropping strong typing
-    const fontOptions = [];
-
-    if (interFont) {
-      fontOptions.push({
-        name: "Inter",
-        weight: 500,
-        data: interFont,
-        style: "normal",
-      });
-    }
-
-    if (interSemiboldFont) {
-      fontOptions.push({
-        name: "Inter",
-        weight: 700,
-        data: interSemiboldFont,
-        style: "normal",
-      });
-    }
 
     return new ImageResponse(
       <section
@@ -108,7 +72,7 @@ export async function GET(
           padding: "5%",
           display: "block",
           position: "relative",
-          fontFamily: "Satori",
+          fontFamily: "sans-serif",
         }}
       >
         <section style={{ display: "flex", flexDirection: "column" }}>
@@ -135,7 +99,7 @@ export async function GET(
               <p
                 style={{
                   color: "#4f46e5",
-                  fontFamily: fontOptions.length ? "Inter" : "sans-serif",
+                  fontFamily: "sans-serif",
                   fontWeight: 700,
                   margin: 0,
                   fontSize: 48,
@@ -151,7 +115,7 @@ export async function GET(
                   fontSize: 34,
                   marginBottom: 12,
                   fontWeight: 500,
-                  fontFamily: fontOptions.length ? "Inter" : "sans-serif",
+                  fontFamily: "sans-serif",
                 }}
               >
                 {doc.fm.description}
@@ -160,22 +124,18 @@ export async function GET(
           </section>
         </section>
       </section>,
-      {
-        // width: width,
-        // height: height,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        fonts: fontOptions.length ? (fontOptions as any) : undefined,
-      },
     );
   } catch (error) {
+    // Note: notFound() throws an internal Next.js redirect-like error; let
+    // it propagate so the framework returns a proper 404. Anything else is
+    // a real failure we want surfaced as a 500 with a server-side log so
+    // operators see breakage rather than silent fallback to a static PNG
+    // that may itself be broken.
+    const digest = (error as { digest?: string } | undefined)?.digest;
+    if (typeof digest === "string" && digest.startsWith("NEXT_HTTP_ERROR")) {
+      throw error;
+    }
     console.error("Error generating OG image:", error);
-    // Return a simple fallback image
-    return new Response("OG image generation failed - using fallback", {
-      status: 307,
-      headers: {
-        Location:
-          "https://cdn.copilotkit.ai/docs/copilotkit/images/og-fallback.png",
-      },
-    });
+    return new Response("OG image generation failed", { status: 500 });
   }
 }

--- a/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
@@ -27,22 +27,45 @@ import {
 } from "@/lib/reference-items";
 import { stripLeadingImports } from "@/lib/docs-render";
 import { safeReadFileSync } from "@/lib/safe-fs";
-import { getBaseUrl } from "@/lib/sitemap-helpers";
+import { buildDocMetadata } from "@/lib/seo-metadata";
 
 // Self-canonical for /reference/<slug>. Reference pages are not
 // per-framework, but we still emit a canonical so the production URL
 // is unambiguous and any future host aliases can't fragment indexing.
+// Title/description come from the page's MDX frontmatter so each API
+// reference page emits its own social card and SEO description rather
+// than inheriting the layout's generic site-wide values.
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ slug: string[] }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  return {
-    alternates: {
-      canonical: `${getBaseUrl()}/reference/${slug.join("/")}`,
-    },
-  };
+  const slugPath = slug.join("/");
+  const canonicalPath = `/reference/${slugPath}`;
+  // Read the reference MDX directly to extract frontmatter. Reuse
+  // safeReadFileSync so a crafted slug can't escape REFERENCE_CONTENT_DIR.
+  const raw = safeReadFileSync(REFERENCE_CONTENT_DIR, `${slugPath}.mdx`);
+  let title: string | undefined;
+  let description: string | undefined;
+  if (raw !== null) {
+    try {
+      const { data } = matter(raw);
+      if (typeof data.title === "string" && data.title.length > 0) {
+        title = data.title;
+      }
+      if (typeof data.description === "string" && data.description.length > 0) {
+        description = data.description;
+      }
+    } catch {
+      // Malformed frontmatter — fall back to slug-derived title.
+    }
+  }
+  return buildDocMetadata({
+    title: title ?? slug[slug.length - 1],
+    description,
+    canonicalPath,
+  });
 }
 
 // next-mdx-remote components map

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-read.mdx
@@ -78,3 +78,97 @@ state updates, you can reflect these updates natively in your application.
     app = agent.to_ag_ui(deps=StateDeps(AgentState()))
 
     if __name__ == "__main__":
+        import uvicorn
+        uvicorn.run(app, host="0.0.0.0", port=8000)
+    ```
+
+  </Step>
+  <Step>
+    ### Use the `useAgent` Hook
+    With your agent connected and running all that is left is to call the `useAgent` hook, pass the agent's name, and
+    optionally provide an initial state.
+
+    ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2"; // [!code highlight]
+
+    // Define the agent state type, should match the actual state of your agent
+    type AgentState = {
+      language: "english" | "spanish";
+    }
+
+    function YourMainContent() {
+      // [!code highlight:4]
+      const { agent } = useAgent({
+        agentId: "my_agent",
+        initialState: { language: "english" }  // optionally provide an initial state
+      });
+
+      // ...
+
+      return (
+        // style excluded for brevity
+        <div>
+          <h1>Your main content</h1>
+          {/* [!code highlight:1] */}
+          <p>Language: {agent.state?.language}</p>
+        </div>
+      );
+    }
+    ```
+
+    <Callout type="warn" title="Important">
+      The `name` parameter must exactly match the agent name you defined in your CopilotRuntime configuration (e.g., `my_agent` from the quickstart).
+    </Callout>
+
+    <Callout type="info">
+      The `agent.state` in `useAgent` is reactive and will automatically update when the agent's state changes.
+    </Callout>
+
+  </Step>
+  <Step>
+    ### Give it a try!
+    As the agent state updates, your `state` variable will automatically update with it! In this case, you'll see the
+    language set to "english" as that's the initial state we set.
+  </Step>
+</Steps>
+
+## Rendering agent state in the chat
+
+You can also render the agent's state in the chat UI. This is useful for informing the user about the agent's state in a
+more in-context way. To do this, you can use the `useAgent` hook with a `render` function.
+
+```tsx title="ui/app/page.tsx"
+import { useAgent } from "@copilotkit/react-core/v2"; // [!code highlight]
+
+// Define the agent state type, should match the actual state of your agent
+type AgentState = {
+  language: "english" | "spanish";
+};
+
+function YourMainContent() {
+  // ...
+  // [!code highlight:7]
+  useAgent({
+    agentId: "my_agent",
+    render: ({ state }) => {
+      if (!state.language) return null;
+      return <div>Language: {state.language}</div>;
+    },
+  });
+  // ...
+}
+```
+
+<Callout type="warn" title="Important">
+  The `name` parameter must exactly match the agent name you defined in your CopilotRuntime configuration (e.g., `my_agent` from the quickstart).
+</Callout>
+
+<Callout type="info">
+  The `agent.state` in `useAgent` is reactive and will automatically
+  update when the agent's state changes.
+</Callout>
+
+## Intermediately Stream and Render Agent State
+
+By default, the Pydantic AI Agent state will only update _between_ Pydantic AI Agent node transitions --
+which means state updates will be discontinuous and delayed.

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-write.mdx
@@ -78,6 +78,74 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
     app = agent.to_ag_ui(deps=StateDeps(AgentState()))
 
     if __name__ == "__main__":
+        import uvicorn
+        uvicorn.run(app, host="0.0.0.0", port=8000)
+    ```
+
+  </Step>
+  <Step>
+    ### Call `agent.setState` from the `useAgent` hook
+    `useAgent` returns an `agent` object with a `setState` method that you can use to update the agent state. Calling this
+    will update the agent state and trigger a rerender of anything that depends on the agent state.
+
+    ```tsx title="ui/app/page.tsx"
+    import { useAgent } from "@copilotkit/react-core/v2"; // [!code highlight]
+
+    // Define the agent state type, should match the actual state of your agent
+    type AgentState = {
+      language: "english" | "spanish";
+    }
+
+    // Example usage in a pseudo React component
+    function YourMainContent() {
+      const { agent } = useAgent({ // [!code highlight]
+        agentId: "my_agent",
+        initialState: { language: "english" }  // optionally provide an initial state
+      });
+
+      // ...
+
+      const toggleLanguage = () => {
+        agent.setState({ language: agent.state?.language === "english" ? "spanish" : "english" }); // [!code highlight]
+      };
+
+      // ...
+
+      return (
+        // style excluded for brevity
+        <div>
+          <h1>Your main content</h1>
+          {/* [!code highlight:2] */}
+          <p>Language: {agent.state?.language}</p>
+          <button onClick={toggleLanguage}>Toggle Language</button>
+        </div>
+      );
+    }
+    ```
+
+    <Callout type="warn" title="Important">
+      The `name` parameter must exactly match the agent name you defined in your CopilotRuntime configuration (e.g., `my_agent` from the quickstart).
+    </Callout>
+
+  </Step>
+  <Step>
+    ### Give it a try!
+    You can now use `agent.setState` to update the agent state and `agent.state` to read it. Try toggling the language button
+    and talking to your agent. You'll see the language change to match the agent's state.
+  </Step>
+</Steps>
+
+## Advanced Usage
+
+### Re-run the agent with a hint about what's changed
+
+The new agent state will be used next time the agent runs.
+If you want to re-run it manually, use `copilotkit.runAgent()`.
+
+The agent will be re-run with the latest updated state. You can also add a hint message before re-running.
+
+```tsx title="ui/app/page.tsx"
+import { useAgent, useCopilotKit } from "@copilotkit/react-core/v2";
 
 // ...
 

--- a/showcase/shell-docs/src/lib/seo-metadata.ts
+++ b/showcase/shell-docs/src/lib/seo-metadata.ts
@@ -1,0 +1,90 @@
+// Shared helper for building per-page SEO/social Metadata across the
+// four catch-all docs routes:
+//   - src/app/[[...slug]]/page.tsx
+//   - src/app/[framework]/[[...slug]]/page.tsx
+//   - src/app/ag-ui/[[...slug]]/page.tsx
+//   - src/app/reference/[...slug]/page.tsx
+//
+// Each route previously returned only `alternates.canonical`, leaving every
+// page to inherit the layout's generic title/description (identical across
+// the whole site) and emitting zero `og:*` / `twitter:*` tags. That broke
+// Slack/X/LinkedIn unfurls on every shared docs URL and harmed search
+// indexing because all 2400+ pages shared one description.
+//
+// This helper centralises title / description / canonical / openGraph /
+// twitter card so callers only have to thread frontmatter through.
+//
+// All URLs are absolute (built from `getBaseUrl()`) so social platforms,
+// which never know the site's base URL, resolve them correctly without
+// requiring `metadataBase` on the root layout.
+
+import type { Metadata } from "next";
+import { getBaseUrl } from "@/lib/sitemap-helpers";
+
+const SITE_NAME = "CopilotKit Docs";
+const DEFAULT_DESCRIPTION =
+  "Docs, live demos, and integrations for CopilotKit.";
+
+/**
+ * Inputs for building a doc page's Metadata object. Title and description
+ * come from MDX frontmatter (with sensible fallbacks for when a page omits
+ * them). `canonicalPath` is the absolute URL path of the page, starting
+ * with `/`. `ogPath` is the route that returns the page's OG PNG; when
+ * omitted, the social card falls back to a static CDN image so unfurls
+ * still render even before per-page OG images come online.
+ */
+export interface DocMetadataInput {
+  /** Page title; rendered as `<title>` and used in OG/Twitter card. */
+  title: string;
+  /** One-line description; used in `<meta description>`, OG, Twitter. */
+  description?: string;
+  /** Absolute URL path of the canonical page (e.g. `/built-in-agent/quickstart`). */
+  canonicalPath: string;
+  /**
+   * Absolute URL path of the OG image route for this page. Optional;
+   * callers without a per-page OG route should omit this and the helper
+   * substitutes the brand fallback so social unfurls still render.
+   */
+  ogPath?: string;
+}
+
+/**
+ * Build a Metadata object suitable for return from a route's
+ * `generateMetadata`. Centralises the title/description/canonical/og/
+ * twitter wiring so the four catch-all routes stay consistent and any
+ * change to social-card behaviour is a one-line edit.
+ */
+export function buildDocMetadata(input: DocMetadataInput): Metadata {
+  const base = getBaseUrl();
+  const description = input.description?.trim() || DEFAULT_DESCRIPTION;
+  const title = input.title?.trim() || SITE_NAME;
+  const canonical = `${base}${input.canonicalPath}`;
+  // Fallback brand card kept on CDN so social embeds always render even
+  // for pages without a per-page OG route or when the OG renderer fails.
+  // Keep this in sync with the OG route's own fallback path.
+  const ogImageUrl = input.ogPath
+    ? `${base}${input.ogPath}`
+    : "https://cdn.copilotkit.ai/docs/copilotkit/images/og-fallback.png";
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      siteName: SITE_NAME,
+      type: "article",
+      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogImageUrl],
+    },
+  };
+}

--- a/showcase/shell-docs/src/lib/seo-redirects.ts
+++ b/showcase/shell-docs/src/lib/seo-redirects.ts
@@ -763,7 +763,11 @@ const WILDCARD_REDIRECTS: RedirectEntry[] = [
   },
   { id: "T1-unscoped-root", source: "/tutorials", destination: "/" },
   // Category 1: Pattern rules (bulk coverage)
-  { id: "P10", source: "/reference/v1/:path*", destination: "/reference/v2" },
+  {
+    id: "P10",
+    source: "/reference/v1/:path*",
+    destination: "/reference/v2/:path*",
+  },
   {
     id: "P11",
     source: "/guides/:path*",


### PR DESCRIPTION
## Summary

Three independent regressions surfaced during Phase 6 post-cutover validation against the live docs.copilotkit.ai. Bundled together since they all live under `showcase/shell-docs/` and were verified together end-to-end.

### 1. Soft-404 returning HTTP 200 with not-found UI body

Unknown URLs returned `HTTP 200` with the Next.js "404: This page could not be found" body. Internal Next 404 markers (`NEXT_HTTP_ERROR_FALLBACK`, `<meta name="robots" content="noindex">`) were present in the body but the wire status stayed 200. Google treats this as low-quality content and demotes the entire site.

Root cause: `<Suspense fallback={null}>` in `app/layout.tsx` committed the response stream at status 200 before page-level `notFound()` could flip it.

Fix:
- Removed the layout Suspense wrapper (both PostHogProvider and FrameworkProvider are `"use client"` with no suspending APIs, so the boundary was incidental from the original telemetry port).
- Added an explicit `src/app/not-found.tsx` rendering a branded 404 page.
- Marked the three catch-all routes `dynamic = "force-dynamic"` so unknown slugs always re-evaluate at request time. Reference route stays SSG (its slugs come from `referenceStaticParams`).

Verified: `/this-clearly-does-not-exist` returns `HTTP 404`. Real pages return 200.

### 2. Per-page metadata + OG / Twitter cards

All four `generateMetadata` functions returned only `alternates.canonical`. Every page inherited the layout's generic `<meta name="description">` and emitted zero `og:*` / `twitter:*` tags. Every social share unfurled bare.

Fix: routes now build full `Metadata` via a shared `src/lib/seo-metadata.ts` helper that reads MDX frontmatter for title and description and emits openGraph + Twitter card with absolute URLs.

Bonus fix in `app/og/[...slug]/route.tsx`: the OG image route fetched Inter TTFs from `fonts.gstatic.com` on every request. Any failure (Railway egress, font URL drift) tripped the catch block, which 307'd to a 25-byte broken CDN fallback. Dropped the runtime font fetch (Satori's default sans-serif renders cleanly), broadened slug resolution to also try `integrations/<folder>/<slug>` paths, and replaced the broken-fallback redirect with a real 500 + log.

Verified locally: full og/twitter meta set on every page; `/og/built-in-agent/quickstart/og.png` and `/og/langgraph-python/quickstart/og.png` both return 1200x630 PNGs with branded backgrounds.

### 3. Pydantic-ai shared-state pages 500

`/pydantic-ai/shared-state/in-app-agent-read` and `/pydantic-ai/shared-state/in-app-agent-write` returned deterministic HTTP 500. Same paths on all other frameworks returned 200. A full sitemap crawl (2451 URLs) found these as the only 5xx on the entire site.

Root cause: both MDX files at `src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-{read,write}.mdx` were truncated/malformed during the v1→v2 content port — `read.mdx` ended mid-Python-fence with unclosed `<Step>` / `<Steps>`; `write.mdx` had a Python code fence containing JS/TSX. Pure MDX parse failure during SSR.

Fix: restored both files from the canonical legacy source under `docs/content/docs/integrations/pydantic-ai/shared-state/`, stripped leading `import` blocks per the convention used by other pydantic-ai pages (components resolve via `docsComponents` in `src/lib/mdx-registry.tsx`).

Verified locally: both URLs go 500 → 200.

### 4. `/reference/v1/:path*` redirect dropped its suffix

Catalog rule P10 redirected `/reference/v1/hooks/useCopilotChat` to a generic `/reference/v2` index instead of `/reference/v2/hooks/useCopilotChat`. Users following v1 docs links from product code messages landed on the wrong page.

Fix: one-line change in `seo-redirects.ts`: destination `/reference/v2` → `/reference/v2/:path*`. Audited all other catalog rules with `:path*` source and bare destination — remaining cases (`concepts/*` collapse, tutorials deprecation wildcards) are documented intentional wildcard-to-single-page rules, not drift.

## Test plan

- [x] `npm run typecheck`, `npm run lint`, `npm test` (32 tests pass), `npm run build` all green in `showcase/shell-docs/`.
- [x] Local prod-mode walkthrough on all four fix surfaces:
  - `/built-in-agent/quickstart` → 200 + full og/twitter meta + per-page description + branded OG PNG.
  - `/langgraph-python/voice` → 200, live demo iframe renders.
  - `/built-in-agent/garbage-page-xyz` → 404 (real status, branded 404 page).
  - `/pydantic-ai/shared-state/in-app-agent-read` → 200.
  - `/reference/v1/hooks/useCopilotChat` → 301 → `/reference/v2/hooks/useCopilotChat` → 200.
- [ ] Post-deploy: re-curl a sample of soft-404 URLs against prod and confirm wire status is `404`, not `200`.
- [ ] Post-deploy: validate a docs URL share in Slack / X to confirm OG card renders with title + description + image.