### PR TITLE
fix(showcase): wire NEXT_SERVER_ACTIONS_ENCRYPTION_KEY into shell + shell-docs build pipelines

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -162,7 +162,7 @@ jobs:
           # to 200 at the other path. Misconfigured paths are a config bug to
           # fix in the matrix, not runtime behavior to hide.
           ALL_SERVICES='[
-            {"dispatch_name":"shell","filter_key":"shell","context":".","image":"showcase-shell","railway_id":"40eea0da-6071-4ea8-bdb9-39afb19225ec","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell","filter_key":"shell","context":".","image":"showcase-shell","railway_id":"40eea0da-6071-4ea8-bdb9-39afb19225ec","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","build_args_server_actions_key":"yes","dockerfile":"showcase/shell/Dockerfile","health_path":"/"},
             {"dispatch_name":"langgraph-python","filter_key":"langgraph_python","context":"showcase/integrations/langgraph-python","image":"showcase-langgraph-python","railway_id":"90d03214-4569-41b0-b4c1-6438a8a7b203","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"mastra","filter_key":"mastra","context":"showcase/integrations/mastra","image":"showcase-mastra","railway_id":"d7979eb7-2405-4aab-ad21-438f4a1b08af","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"crewai-crews","filter_key":"crewai_crews","context":"showcase/integrations/crewai-crews","image":"showcase-crewai-crews","railway_id":"0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -183,7 +183,7 @@ jobs:
             {"dispatch_name":"built-in-agent","filter_key":"built_in_agent","context":"showcase/integrations/built-in-agent","image":"showcase-built-in-agent","railway_id":"f4f8371a-bc46-45b2-b6d4-9c9af608bdbf","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},
             {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_ops_url":"https://showcase-harness-production.up.railway.app","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
-            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","build_args_analytics":"yes","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","build_args_analytics":"yes","build_args_server_actions_key":"yes","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
             {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/harness/Dockerfile","health_path":"/health"},
             {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","timeout":5,"lfs":false,"build_args":"","dockerfile":"showcase/aimock/Dockerfile","health_path":"/health"}
           ]'
@@ -333,6 +333,16 @@ jobs:
             ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_SCARF_PIXEL_ID=${{ secrets.SCARF_PIXEL_ID }}"
             ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_REO_KEY=${{ secrets.REO_PROJECT_KEY }}"
             ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID=${{ secrets.GOOGLE_ANALYTICS_TRACKING_ID }}"
+          fi
+          if [ "${{ matrix.service.build_args_server_actions_key }}" = "yes" ]; then
+            # Stable Server Action ID encryption key. Next.js 16.x
+            # re-hashes action IDs across builds; without a fixed key
+            # every Railway redeploy invalidates in-flight clients,
+            # producing "Failed to find Server Action 'x'" errors at
+            # the deploy boundary. Must reach `next build` so Next
+            # uses it to encrypt action references baked into the
+            # client bundle.
+            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}"
           fi
           # Use delimiter to safely pass multiline value
           echo "args<<BUILDARGS_EOF" >> $GITHUB_OUTPUT

--- a/showcase/shell-docs/Dockerfile
+++ b/showcase/shell-docs/Dockerfile
@@ -20,6 +20,15 @@ ARG NEXT_PUBLIC_REO_KEY
 ENV NEXT_PUBLIC_REO_KEY=${NEXT_PUBLIC_REO_KEY}
 ARG NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID
 ENV NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID=${NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID}
+# Server Action ID encryption key. Next.js 16.x re-hashes Server Action
+# IDs aggressively across builds; without a stable key every Railway
+# redeploy invalidates in-flight clients' action IDs, producing
+# "Failed to find Server Action 'x'" and "router state header could not
+# be parsed" errors at the deploy boundary. Sourced from a repo secret
+# via the GHA workflow (`showcase_build.yml` Prepare build args step).
+# See https://nextjs.org/docs/app/api-reference/file-conventions/page#encrypted-server-action-references
+ARG NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
+ENV NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${NEXT_SERVER_ACTIONS_ENCRYPTION_KEY}
 WORKDIR /app
 
 # Copy only what shell-docs + scripts need

--- a/showcase/shell-docs/Dockerfile
+++ b/showcase/shell-docs/Dockerfile
@@ -60,6 +60,14 @@ ENV NODE_ENV=production
 ENV PORT=10000
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}
 ENV NEXT_PUBLIC_BRANCH=${BRANCH}
+# Server Action encryption key MUST be readable at runtime too: Next.js
+# encrypts action references at build time but decrypts incoming Server
+# Action requests at runtime, using the same key. Declared here so the
+# runtime stage has the variable in its environment; Railway injects the
+# actual value from the service's env-var configuration at container
+# start. The value MUST match the one passed to `next build` in the
+# builder stage above, or in-flight clients break across the boundary.
+ENV NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=""
 
 COPY --from=builder /app/shell-docs/.next ./.next
 COPY --from=builder /app/shell-docs/node_modules ./node_modules

--- a/showcase/shell/Dockerfile
+++ b/showcase/shell/Dockerfile
@@ -1,6 +1,15 @@
 FROM node:20-slim AS builder
 ARG COMMIT_SHA=unknown
 ARG BRANCH=unknown
+# Server Action ID encryption key. Next.js 16.x re-hashes Server Action
+# IDs aggressively across builds; without a stable key every Railway
+# redeploy invalidates in-flight clients' action IDs, producing
+# "Failed to find Server Action 'x'" and "router state header could not
+# be parsed" errors at the deploy boundary. Sourced from a repo secret
+# via the GHA workflow (`showcase_build.yml` Prepare build args step).
+# See https://nextjs.org/docs/app/api-reference/file-conventions/page#encrypted-server-action-references
+ARG NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
+ENV NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${NEXT_SERVER_ACTIONS_ENCRYPTION_KEY}
 WORKDIR /app
 
 # Copy only what the shell + scripts need
@@ -34,6 +43,14 @@ ENV NODE_ENV=production
 ENV PORT=10000
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}
 ENV NEXT_PUBLIC_BRANCH=${BRANCH}
+# Server Action encryption key MUST be readable at runtime too: Next.js
+# encrypts action references at build time but decrypts incoming Server
+# Action requests at runtime, using the same key. Declared here so the
+# runtime stage has the variable in its environment; Railway injects the
+# actual value from the service's env-var configuration at container
+# start. The value MUST match the one passed to `next build` in the
+# builder stage above, or in-flight clients break across the boundary.
+ENV NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=""
 
 COPY --from=builder /app/shell/.next ./.next
 COPY --from=builder /app/shell/node_modules ./node_modules


### PR DESCRIPTION
## Summary

Plumb a stable Server Action encryption key through both `showcase/shell-docs/` AND `showcase/shell/` so Next.js Server Action IDs no longer change across Railway redeploys. Closes the failure class behind the "Failed to find Server Action 'x'" and "router state header could not be parsed" errors observed in Railway logs after today's three rapid shell-docs deploys.

Refs PDX-202, folds PDX-204.

## Root cause recap

Both services run Next.js 16.2.6. 16.x re-hashes Server Action IDs on every build unless `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` is set; without it, every redeploy invalidates in-flight clients' action IDs, which produces the deploy-boundary errors above. A grep of both apps' `src/` for `"use server"` returns zero hits, so the rejected RPCs are coming from Next.js framework internals (e.g. `revalidatePath` prefetch callbacks), not app code. The errors surfaced today on shell-docs because that's where deploys happened; `showcase/shell/` has the same vulnerability and is included here for that reason.

## Change shape

| File | What |
|---|---|
| `.github/workflows/showcase_build.yml` | Add `"build_args_server_actions_key":"yes"` to BOTH the `shell` and `shell-docs` matrix entries. Add a new conditional branch in the `Prepare build args` step that appends `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}` when the flag is set. |
| `showcase/shell-docs/Dockerfile` | Add `ARG NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` + `ENV NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=…` in the builder stage so `next build` reads it. Also add `ENV NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=""` (empty default) in the runner stage so the variable is declared and Railway's runtime injection overrides it. |
| `showcase/shell/Dockerfile` | Same pattern, mirrored. |

## Why ENV in both stages

Next.js uses the key at two different times:

- **Build time**: `next build` encrypts Server Action references and bakes the encrypted IDs into the client bundle. Needs the key in process.env at build.
- **Runtime**: `next start` decrypts incoming Server Action POSTs to recover the action target. Needs the same key in process.env at runtime.

If the builder stage has the value but the runner stage doesn't declare the variable, decryption falls back to a freshly-generated per-process key that doesn't match what the bundle was built with — clients break exactly the same way as without the fix. The empty default in the runner stage acts as a declaration; Railway's runtime env injection overrides it at container start.

## Required actions after merge

This PR ships the wiring but does NOT generate or commit the actual secret. Two manual steps:

1. **Generate the key** locally:
   ```
   openssl rand -base64 32
   ```

2. **Set in TWO places, with IDENTICAL values**:
   - **GitHub Actions repo secret** (build-time): Settings → Secrets and variables → Actions → New repository secret. Name `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY`, value = the openssl output.
   - **Railway env vars** for BOTH services:
     - `7badfb8d-4228-414c-9145-b4026803714f` (shell-docs)
     - `40eea0da-6071-4ea8-bdb9-39afb19225ec` (shell)
     Both get `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=<same value>`.

After both are set, trigger a fresh build (push or `workflow_dispatch`). From the next deploy onward, action IDs stay stable across builds.

Until the secret is populated, builds simply pass an empty value through, matching previous behavior.

## Test plan

- [x] Workflow YAML still parses.
- [x] No literal key value committed.
- [x] Builder + runner ENV declarations match in both Dockerfiles.
- [ ] Post-merge: configure the secret per above.
- [ ] Post-deploy: trigger a redeploy of each service. Confirm Railway logs no longer show "Failed to find Server Action 'x'" or "router state header could not be parsed" across the deploy boundary.

Reference: [Next.js encrypted action references](https://nextjs.org/docs/app/api-reference/file-conventions/page#encrypted-server-action-references).