### PR TITLE
fix(shell-docs): exclude deprecated tutorials from built-in-agent sidebar

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/meta.json
@@ -27,8 +27,6 @@
     "copilot-runtime", "custom-agent", "ag-ui",
     "---Premium Features---",
     "...premium",
-    "---Tutorials---",
-    "...tutorials",
     "---Troubleshooting---",
     "...troubleshooting"
   ]


### PR DESCRIPTION
## Summary

Tutorial entries appeared in the sidebar nav on every Built-in Agent docs page (e.g. `/built-in-agent/quickstart`) despite the section being deprecated. Clicks worked because the redirect catalog 301s `/{fw}/tutorials/:path*` to `/{fw}/quickstart`, but the entries should not be visible at all.

## Root cause

BIA runs in `docs_mode: "authored"`, which routes through `buildFrameworkOnlyNav` → `buildNavTree`. That code path keeps section headers and recurses through `"...folder"` spreads (unlike the generated-mode path used by langgraph/mastra/google-adk, which strips section headers via `buildFrameworkOverridesNav`).

BIA's `integrations/built-in-agent/meta.json` declared `"---Tutorials---"` + `"...tutorials"`, so the spread descended into the tutorials folder and enumerated its subfolders into the sidebar.

## Fix

Remove the two lines from BIA's parent `meta.json`:

```diff
 "---Premium Features---",
 "...premium",
-"---Tutorials---",
-"...tutorials",
 "---Troubleshooting---",
 "...troubleshooting"
```

Source MDX is preserved.

## Test plan

- [x] JSON validity confirmed via `node -e 'JSON.parse(...)'`.
- [ ] Post-deploy: confirm no `Tutorial:` entries in `/built-in-agent/quickstart` sidebar HTML.
- [ ] Post-deploy: confirm `/built-in-agent/tutorials/ai-todo-app/step-2-setup-copilotkit` still 301s to `/built-in-agent/quickstart`.