### PR TITLE
ci: add Python SDK publish-to-PyPI automation

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -58,7 +58,7 @@ on:
         default: false
         type: boolean
       python_publish:
-        description: "Force Python SDK publish (bypasses version-change detection)"
+        description: "Run the Python publish lane regardless of which files changed. Still no-ops if sdk-python's version already matches PyPI."
         required: false
         default: false
         type: boolean
@@ -428,7 +428,22 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          if git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" | grep -q '^sdk-python/pyproject.toml$'; then
+          set -euo pipefail
+          if [ -z "$PR_BASE_SHA" ]; then
+            echo "::error::PR_BASE_SHA is empty — cannot determine PR base for diff. Refusing to silently skip Python publish."
+            exit 1
+          fi
+          if [ -z "$PR_HEAD_SHA" ]; then
+            echo "::error::PR_HEAD_SHA (merge_commit_sha) is empty — GitHub may not have computed the merge commit yet. Refusing to silently skip Python publish; rerun the workflow."
+            exit 1
+          fi
+          # Capture diff FIRST so a git failure trips set -e and fails loudly,
+          # rather than producing an empty pipe that grep silently routes to
+          # "not changed" — that path masked real version bumps before.
+          CHANGED="$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA")"
+          # grep -q exits 1 on legitimate no-match; guard with `if` so set -e
+          # doesn't kill the step on that expected case.
+          if printf '%s\n' "$CHANGED" | grep -q '^sdk-python/pyproject.toml$'; then
             echo "pyproject_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "pyproject_changed=false" >> "$GITHUB_OUTPUT"
@@ -485,7 +500,7 @@ jobs:
   # until the Trusted Publisher record on pypi.org is updated to match.
   publish-python:
     needs: build-python
-    if: needs.build-python.outputs.should_publish == 'true'
+    if: ${{ !cancelled() && needs.build-python.result == 'success' && needs.build-python.outputs.should_publish == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi
@@ -498,7 +513,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
 
       - name: Install uv

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -500,7 +500,7 @@ jobs:
   # until the Trusted Publisher record on pypi.org is updated to match.
   publish-python:
     needs: build-python
-    if: ${{ !cancelled() && needs.build-python.result == 'success' && needs.build-python.outputs.should_publish == 'true' }}
+    if: ${{ !cancelled() && needs.build-python.result == 'success' && needs.build-python.outputs.should_publish == 'true' && inputs.dry-run != true }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi
@@ -527,13 +527,22 @@ jobs:
           path: sdk-python/dist
 
       - name: Publish to PyPI (OIDC trusted publishing)
-        run: uv publish --trusted-publishing always sdk-python/dist/*
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(sdk-python/dist/*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::no build artifacts in sdk-python/dist — nothing to publish"
+            exit 1
+          fi
+          uv publish --trusted-publishing always "${files[@]}"
 
       - name: Verify version is live on PyPI
         env:
           NAME: ${{ needs.build-python.outputs.name }}
           VERSION: ${{ needs.build-python.outputs.version }}
         run: |
+          set -euo pipefail
           for i in $(seq 1 18); do
             if curl -fsS "https://pypi.org/pypi/${NAME}/${VERSION}/json" >/dev/null 2>&1; then
               echo "Confirmed ${NAME}==${VERSION} on PyPI"; exit 0
@@ -541,13 +550,18 @@ jobs:
             echo "Attempt ${i}: ${NAME}==${VERSION} not visible yet; retrying in 10s..."
             sleep 10
           done
-          echo "::error::${NAME}==${VERSION} did not appear on PyPI within 180s"; exit 1
+          echo "::error::${NAME}==${VERSION} did not appear on PyPI within 180s"
+          echo "Last curl response:"
+          curl -sS "https://pypi.org/pypi/${NAME}/${VERSION}/json" 2>&1 | tail -n 5 || true
+          exit 1
 
       - name: Configure git
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git config --local url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --local url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Create and push git tag
         id: tag
@@ -555,6 +569,7 @@ jobs:
           PY_VERSION: ${{ needs.build-python.outputs.version }}
           PY_NAME: ${{ needs.build-python.outputs.name }}
         run: |
+          set -euo pipefail
           TAG="python-sdk/v${PY_VERSION}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists — skipping"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,6 +17,15 @@
 #     skips tag push + GH Release + Notion notification.
 name: release / publish
 
+# This workflow handles two independent release lanes:
+#
+# 1. npm (TypeScript) — fires on merged release/publish/* PRs or manual dispatch.
+#    Build → publish via nx release + OIDC trusted publishers.
+#
+# 2. PyPI (Python SDK) — fires on any merged PR that bumps sdk-python/pyproject.toml.
+#    Detects version change vs PyPI registry, builds with poetry, publishes with uv.
+#    Ported from ag-ui's publish-release.yml Python lane.
+
 on:
   pull_request:
     types: [closed]
@@ -45,6 +54,11 @@ on:
         default: ""
       dry-run:
         description: "Dry run (skip publish step)"
+        required: false
+        default: false
+        type: boolean
+      python_publish:
+        description: "Force Python SDK publish (bypasses version-change detection)"
         required: false
         default: false
         type: boolean
@@ -370,4 +384,210 @@ jobs:
             echo "**Scope:** ${{ steps.meta.outputs.scope }}"
             echo "**Mode:** ${{ steps.meta.outputs.mode }}"
             echo "- Publish step was skipped; no npm publish, no git tag, no GitHub Release."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ===========================================================================
+  # Python SDK publish lane
+  #
+  # Fires independently of the npm lane. Detects whether sdk-python/pyproject.toml
+  # has a version newer than what's on PyPI, builds with poetry, publishes with uv.
+  #
+  # SECURITY: Same build/publish separation as the npm lane — PYPI_API_TOKEN is
+  # only available in the publish-python job, never where poetry install runs.
+  # ===========================================================================
+
+  build-python:
+    # Fires when:
+    # 1. A PR merging to main touched sdk-python/pyproject.toml (version bump), OR
+    # 2. Manual dispatch with python_publish=true
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.python_publish == true) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      should_publish: ${{ steps.detect.outputs.should_publish }}
+      version: ${{ steps.detect.outputs.version }}
+      name: ${{ steps.detect.outputs.name }}
+    steps:
+      - name: Checkout merged main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: main
+          persist-credentials: false
+
+      # For PRs, skip early if this PR didn't touch pyproject.toml. Manual
+      # dispatch always continues (the user explicitly asked for it).
+      - name: Check if pyproject.toml changed in this PR
+        if: github.event_name == 'pull_request'
+        id: changed
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          if git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" | grep -q '^sdk-python/pyproject.toml$'; then
+            echo "pyproject_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pyproject_changed=false" >> "$GITHUB_OUTPUT"
+            echo "sdk-python/pyproject.toml not changed in this PR — skipping Python publish"
+          fi
+
+      - name: Set up Python
+        if: github.event_name == 'workflow_dispatch' || steps.changed.outputs.pyproject_changed == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Detect version change
+        if: github.event_name == 'workflow_dispatch' || steps.changed.outputs.pyproject_changed == 'true'
+        id: detect
+        run: ./scripts/release/detect-py-version-changes.sh
+
+      - name: Install Poetry
+        if: steps.detect.outputs.should_publish == 'true'
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Build Python package
+        if: steps.detect.outputs.should_publish == 'true'
+        working-directory: sdk-python
+        run: poetry build
+
+      - name: Upload Python build artifacts
+        if: steps.detect.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: py-build-artifacts
+          path: sdk-python/dist/
+          retention-days: 1
+
+      - name: Nothing to publish
+        if: steps.detect.outputs.should_publish != 'true'
+        run: |
+          {
+            echo "## Python SDK"
+            echo ""
+            echo "No version change detected — nothing to publish."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # WARNING: PyPI trusted-publisher binding pins to:
+  #   repository:    CopilotKit/CopilotKit
+  #   workflow_file: publish-release.yml
+  #   environment:   pypi
+  # Renaming this file, changing this job's `environment:` value, or moving the
+  # publish step into another workflow breaks PyPI publishing with HTTP 422
+  # until the Trusted Publisher record on pypi.org is updated to match.
+  publish-python:
+    needs: build-python
+    if: needs.build-python.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout merged main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: ">=0.8.0"
+
+      - name: Download Python build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: py-build-artifacts
+          path: sdk-python/dist
+
+      - name: Publish to PyPI (OIDC trusted publishing)
+        run: uv publish --trusted-publishing always sdk-python/dist/*
+
+      - name: Verify version is live on PyPI
+        env:
+          NAME: ${{ needs.build-python.outputs.name }}
+          VERSION: ${{ needs.build-python.outputs.version }}
+        run: |
+          for i in $(seq 1 18); do
+            if curl -fsS "https://pypi.org/pypi/${NAME}/${VERSION}/json" >/dev/null 2>&1; then
+              echo "Confirmed ${NAME}==${VERSION} on PyPI"; exit 0
+            fi
+            echo "Attempt ${i}: ${NAME}==${VERSION} not visible yet; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::${NAME}==${VERSION} did not appear on PyPI within 180s"; exit 1
+
+      - name: Configure git
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git config --local url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Create and push git tag
+        id: tag
+        env:
+          PY_VERSION: ${{ needs.build-python.outputs.version }}
+          PY_NAME: ${{ needs.build-python.outputs.name }}
+        run: |
+          TAG="python-sdk/v${PY_VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — skipping"
+          else
+            git tag -a "$TAG" -m "Release ${PY_NAME} ${PY_VERSION}"
+            git push origin "$TAG"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.build-python.outputs.version }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const tag = process.env.RELEASE_TAG;
+            const version = process.env.RELEASE_VERSION;
+            const name = `python-sdk/v${version}`;
+            const body = `Python SDK release: copilotkit ${version}\n\nhttps://pypi.org/project/copilotkit/${version}/`;
+
+            try {
+              const existing = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+              await github.rest.repos.updateRelease({
+                owner, repo,
+                release_id: existing.data.id,
+                tag_name: tag, name, body,
+                draft: false, prerelease: false,
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.repos.createRelease({
+                owner, repo,
+                tag_name: tag, name, body,
+                draft: false, prerelease: false,
+              });
+            }
+
+      - name: Release summary
+        env:
+          PY_VERSION: ${{ needs.build-python.outputs.version }}
+        run: |
+          {
+            echo "## Python SDK Published"
+            echo ""
+            echo "- \`copilotkit@${PY_VERSION}\`"
+            echo "- https://pypi.org/project/copilotkit/${PY_VERSION}/"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/release/__tests__/detect-py-version-changes.test.sh
+++ b/scripts/release/__tests__/detect-py-version-changes.test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Red-green test for detect-py-version-changes.sh using a local fixture HTTP
+# server. No network access. Requires python3 >= 3.11 (tomllib).
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="${HERE}/../detect-py-version-changes.sh"
+TMP="$(mktemp -d)"
+SRV_PID=""
+cleanup() { [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true; rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# Preflight: tomllib requires py3.11+
+python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,11) else 1)' \
+  || { echo "SKIP/FAIL: need python3 >= 3.11 for tomllib"; exit 1; }
+
+# Fake pyproject with local version 0.2.0
+mkdir -p "$TMP/pkg"
+cat > "$TMP/pkg/pyproject.toml" <<'TOML'
+[tool.poetry]
+name = "copilotkit"
+version = "0.2.0"
+TOML
+
+PORTFILE="$TMP/port"
+WWW="$TMP/www"
+
+# Start a fixture server that serves $WWW and writes its bound port to PORTFILE.
+start_server() {
+  rm -f "$PORTFILE"
+  PORTFILE="$PORTFILE" WWW="$WWW" python3 - <<'PY' &
+import os, http.server, socketserver, functools
+www = os.environ["WWW"]
+os.makedirs(www, exist_ok=True)
+handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=www)
+httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+with open(os.environ["PORTFILE"], "w") as f:
+    f.write(str(httpd.server_address[1]))
+httpd.serve_forever()
+PY
+  SRV_PID=$!
+  for _ in $(seq 1 50); do [ -s "$PORTFILE" ] && break; sleep 0.1; done
+  PORT="$(cat "$PORTFILE")"
+}
+stop_server() { kill "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true; SRV_PID=""; }
+
+serve_published() { mkdir -p "$WWW/pypi/copilotkit"; printf '{"info":{"version":"%s"}}' "$1" > "$WWW/pypi/copilotkit/json"; }
+
+run() {
+  PYPROJECT_PATH="$TMP/pkg/pyproject.toml" PYPI_BASE_URL="http://127.0.0.1:${PORT}" \
+    "$SCRIPT" 2>/dev/null | tail -n1
+}
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# Case A: published == local (0.2.0) -> should_publish=false (no-op)
+rm -rf "$WWW"; serve_published "0.2.0"; start_server
+OUT="$(run)"; echo "A: $OUT"; [ "$OUT" = "false copilotkit 0.2.0" ] || fail "no-op: got '$OUT'"
+stop_server
+
+# Case B: published < local (0.1.91 < 0.2.0) -> should_publish=true (exactly one pkg)
+rm -rf "$WWW"; serve_published "0.1.91"; start_server
+OUT="$(run)"; echo "B: $OUT"; [ "$OUT" = "true copilotkit 0.2.0" ] || fail "bump: got '$OUT'"
+stop_server
+
+# Case C: package missing (404) -> should_publish=true (NEW)
+rm -rf "$WWW"; mkdir -p "$WWW"; start_server
+OUT="$(run)"; echo "C: $OUT"; [ "$OUT" = "true copilotkit 0.2.0" ] || fail "new-pkg: got '$OUT'"
+stop_server
+
+echo "ALL PASS"

--- a/scripts/release/__tests__/detect-py-version-changes.test.sh
+++ b/scripts/release/__tests__/detect-py-version-changes.test.sh
@@ -7,6 +7,7 @@ SCRIPT="${HERE}/../detect-py-version-changes.sh"
 TMP="$(mktemp -d)"
 SRV_PID=""
 STDERR_LOG="$TMP/stderr.log"
+SRV_LOG="$TMP/server.log"
 cleanup() { [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true; rm -rf "$TMP"; }
 trap cleanup EXIT INT TERM
 
@@ -26,51 +27,104 @@ PORTFILE="$TMP/port"
 WWW="$TMP/www"
 
 # Start a fixture server that serves $WWW and writes its bound port to PORTFILE.
+# FAIL_500_PATH (optional): when set, requests with that exact path return HTTP 500
+# instead of the default SimpleHTTPRequestHandler behavior. Used by Case I (5xx).
 start_server() {
-  rm -f "$PORTFILE"
-  PORTFILE="$PORTFILE" WWW="$WWW" python3 - <<'PY' &
+  rm -f "$PORTFILE" "$SRV_LOG"
+  PORTFILE="$PORTFILE" WWW="$WWW" FAIL_500_PATH="${FAIL_500_PATH:-}" python3 - 2>"$SRV_LOG" <<'PY' &
 import os, http.server, socketserver, functools
 www = os.environ["WWW"]
 os.makedirs(www, exist_ok=True)
-handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=www)
-httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+fail_500_path = os.environ.get("FAIL_500_PATH", "")
+
+class H(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *a, **kw):
+        super().__init__(*a, directory=www, **kw)
+    def do_GET(self):
+        if fail_500_path and self.path == fail_500_path:
+            self.send_error(500, "fixture: forced 500")
+            return
+        super().do_GET()
+
+httpd = socketserver.TCPServer(("127.0.0.1", 0), H)
 with open(os.environ["PORTFILE"], "w") as f:
     f.write(str(httpd.server_address[1]))
 httpd.serve_forever()
 PY
   SRV_PID=$!
   for _ in $(seq 1 50); do [ -s "$PORTFILE" ] && break; sleep 0.1; done
+  # Liveness check: even if PORTFILE never landed, surface the server's stderr
+  # so a crashed fixture python process produces a real error instead of a
+  # vague timeout.
+  if ! kill -0 "$SRV_PID" 2>/dev/null; then
+    echo "FAIL: fixture server process died before binding" >&2
+    if [ -s "$SRV_LOG" ]; then
+      echo "--- captured server stderr ---" >&2
+      cat "$SRV_LOG" >&2
+      echo "--- end server stderr ---" >&2
+    fi
+    exit 1
+  fi
   if [ ! -s "$PORTFILE" ]; then
     echo "FAIL: fixture server failed to bind/write PORTFILE within 5s" >&2
+    if [ -s "$SRV_LOG" ]; then
+      echo "--- captured server stderr ---" >&2
+      cat "$SRV_LOG" >&2
+      echo "--- end server stderr ---" >&2
+    fi
     exit 1
   fi
   PORT="$(cat "$PORTFILE")"
 }
-stop_server() { kill "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true; SRV_PID=""; }
+stop_server() { kill "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true; SRV_PID=""; unset FAIL_500_PATH; }
 
 serve_published() {
   # Realistic PyPI-shaped response: info.version AND a releases dict (single
   # released version). Real PyPI always returns `releases`; the bare-info shape
   # was a test-only shortcut that the max-over-releases logic doesn't match.
+  # File list contains one non-yanked dict so the script's yanked filter (which
+  # excludes empty/all-yanked file lists) still counts this as a live release.
   mkdir -p "$WWW/pypi/copilotkit"
-  printf '{"info":{"version":"%s"},"releases":{"%s":[]}}' "$1" "$1" > "$WWW/pypi/copilotkit/json"
+  printf '{"info":{"version":"%s"},"releases":{"%s":[{"yanked":false}]}}' "$1" "$1" > "$WWW/pypi/copilotkit/json"
 }
 
 # Serve a fuller PyPI-shaped response: info.version + a releases dict whose keys
 # are the version strings. $1 = info.version, remaining args = release keys.
+# Each release key gets a single non-yanked file entry so it counts as live.
 serve_published_with_releases() {
   mkdir -p "$WWW/pypi/copilotkit"
   local info="$1"; shift
   local rels="" k
   for k in "$@"; do
-    [ -z "$rels" ] && rels="\"$k\":[]" || rels="$rels,\"$k\":[]"
+    [ -z "$rels" ] && rels="\"$k\":[{\"yanked\":false}]" || rels="$rels,\"$k\":[{\"yanked\":false}]"
   done
   printf '{"info":{"version":"%s"},"releases":{%s}}' "$info" "$rels" > "$WWW/pypi/copilotkit/json"
+}
+
+# Serve a custom raw JSON body at /pypi/copilotkit/json. Used by Cases G and H
+# to inject yanked file lists or omit the `releases` key entirely.
+serve_raw_json() {
+  mkdir -p "$WWW/pypi/copilotkit"
+  printf '%s' "$1" > "$WWW/pypi/copilotkit/json"
 }
 
 run() {
   PYPROJECT_PATH="$TMP/pkg/pyproject.toml" PYPI_BASE_URL="http://127.0.0.1:${PORT}" \
     "$SCRIPT" 2>"$STDERR_LOG" | tail -n1
+}
+# Run and assert non-zero exit. Captures the script's exit status BEFORE the
+# pipeline (a `| tail` rhs would mask the lhs exit code). Returns 0 if the
+# script failed as expected, non-zero otherwise. PYPROJECT path overridable
+# via $1.
+run_expect_fail() {
+  local pyproj="${1:-$TMP/pkg/pyproject.toml}"
+  set +e
+  PYPROJECT_PATH="$pyproj" PYPI_BASE_URL="http://127.0.0.1:${PORT}" \
+    "$SCRIPT" >"$TMP/stdout.log" 2>"$STDERR_LOG"
+  local ec=$?
+  set -e
+  if [ "$ec" -eq 0 ]; then return 1; fi
+  return 0
 }
 fail() {
   echo "FAIL: $1" >&2
@@ -90,9 +144,9 @@ GHO="$TMP/gho.txt"; : > "$GHO"
 OUT="$(GITHUB_OUTPUT="$GHO" PYPROJECT_PATH="$TMP/pkg/pyproject.toml" PYPI_BASE_URL="http://127.0.0.1:${PORT}" \
   "$SCRIPT" 2>"$STDERR_LOG" | tail -n1)"
 echo "A: $OUT"; [ "$OUT" = "false copilotkit 0.2.0" ] || fail "no-op: got '$OUT'"
-grep -q '^should_publish=false$' "$GHO" || fail "GITHUB_OUTPUT missing should_publish=false (got: $(cat "$GHO"))"
-grep -q '^name=copilotkit$' "$GHO" || fail "GITHUB_OUTPUT missing name=copilotkit (got: $(cat "$GHO"))"
-grep -q '^version=0.2.0$' "$GHO" || fail "GITHUB_OUTPUT missing version=0.2.0 (got: $(cat "$GHO"))"
+grep -Fxq 'should_publish=false' "$GHO" || fail "GITHUB_OUTPUT missing should_publish=false (got: $(cat "$GHO"))"
+grep -Fxq 'name=copilotkit' "$GHO" || fail "GITHUB_OUTPUT missing name=copilotkit (got: $(cat "$GHO"))"
+grep -Fxq 'version=0.2.0' "$GHO" || fail "GITHUB_OUTPUT missing version=0.2.0 (got: $(cat "$GHO"))"
 stop_server
 
 # Case B: published < local (0.1.91 < 0.2.0) -> should_publish=true (exactly one pkg)
@@ -110,6 +164,13 @@ stop_server
 # old line can produce this state. The script must compute the max over the
 # numeric-parseable releases keys, not trust info.version.
 # releases = {0.1.0, 0.2.0}, info.version=0.1.0, local=0.2.0 -> 0.2.0==0.2.0 -> false.
+# Explicitly (re)write pyproject so this case doesn't implicitly depend on
+# Case A's setup persisting through the prior cases.
+cat > "$TMP/pkg/pyproject.toml" <<'TOML'
+[tool.poetry]
+name = "copilotkit"
+version = "0.2.0"
+TOML
 rm -rf "$WWW"; serve_published_with_releases "0.1.0" "0.1.0" "0.2.0"; start_server
 OUT="$(run)"; echo "D: $OUT"; [ "$OUT" = "false copilotkit 0.2.0" ] || fail "max-over-releases: got '$OUT'"
 stop_server
@@ -129,6 +190,64 @@ serve_published_with_releases "0.2.1rc1" "0.2.0" "0.2.1rc1"; start_server
 OUT="$(PYPROJECT_PATH="$TMP/pkg2/pyproject.toml" PYPI_BASE_URL="http://127.0.0.1:${PORT}" \
   "$SCRIPT" 2>"$STDERR_LOG" | tail -n1)"
 echo "E: $OUT"; [ "$OUT" = "true copilotkit 0.2.1" ] || fail "non-numeric-released-ignored: got '$OUT'"
+stop_server
+
+# Case F (zero-pad): published has only key "0.2" (live); local pyproject "0.2.0".
+# PEP 440 treats 0.2 == 0.2.0, so should_publish must be false. Without
+# zero-padding the comparison, (0,2,0) > (0,2) would wrongly yield True and
+# trigger a duplicate-version uv publish that PyPI rejects with 400.
+cat > "$TMP/pkg/pyproject.toml" <<'TOML'
+[tool.poetry]
+name = "copilotkit"
+version = "0.2.0"
+TOML
+rm -rf "$WWW"; serve_published_with_releases "0.2" "0.2"; start_server
+OUT="$(run)"; echo "F: $OUT"; [ "$OUT" = "false copilotkit 0.2.0" ] || fail "zero-pad: got '$OUT'"
+stop_server
+
+# Case G (yanked): releases = {0.2.0:[non-yanked], 0.99.0:[yanked]}, local 0.2.1.
+# The fully-yanked 0.99.0 must be excluded when computing the published max so
+# a yanked bogus high version can't block legitimate 0.2.x bumps. Live max =
+# 0.2.0 < 0.2.1 -> should_publish=true.
+cat > "$TMP/pkg/pyproject.toml" <<'TOML'
+[tool.poetry]
+name = "copilotkit"
+version = "0.2.1"
+TOML
+rm -rf "$WWW"
+serve_raw_json '{"info":{"version":"0.2.0"},"releases":{"0.2.0":[{"yanked":false}],"0.99.0":[{"yanked":true}]}}'
+start_server
+OUT="$(run)"; echo "G: $OUT"; [ "$OUT" = "true copilotkit 0.2.1" ] || fail "yanked-excluded: got '$OUT'"
+stop_server
+
+# Case H (missing-releases fail-loud): HTTP 200 with body missing the
+# `releases` key entirely. This is a malformed/unexpected PyPI response and a
+# publish gate must NOT silently treat it as "new package" — only a genuine
+# 404 means NEW. Script must exit non-zero.
+cat > "$TMP/pkg/pyproject.toml" <<'TOML'
+[tool.poetry]
+name = "copilotkit"
+version = "0.2.0"
+TOML
+rm -rf "$WWW"
+serve_raw_json '{"info":{"version":"0.2.0"}}'
+start_server
+run_expect_fail || fail "missing-releases must fail loud (script exited 0; stdout=$(cat "$TMP/stdout.log" 2>/dev/null))"
+echo "H: non-zero exit as expected"
+stop_server
+
+# Case I (5xx coverage): server returns HTTP 500. The script already fails on
+# any unexpected non-200/404 status, so this is GREEN immediately — pure
+# coverage to lock in the 5xx-fails-loud contract.
+cat > "$TMP/pkg/pyproject.toml" <<'TOML'
+[tool.poetry]
+name = "copilotkit"
+version = "0.2.0"
+TOML
+rm -rf "$WWW"; mkdir -p "$WWW"
+FAIL_500_PATH="/pypi/copilotkit/json" start_server
+run_expect_fail || fail "5xx must fail loud (script exited 0)"
+echo "I: non-zero exit as expected"
 stop_server
 
 echo "ALL PASS"

--- a/scripts/release/__tests__/detect-py-version-changes.test.sh
+++ b/scripts/release/__tests__/detect-py-version-changes.test.sh
@@ -6,8 +6,9 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="${HERE}/../detect-py-version-changes.sh"
 TMP="$(mktemp -d)"
 SRV_PID=""
+STDERR_LOG="$TMP/stderr.log"
 cleanup() { [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true; rm -rf "$TMP"; }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
 
 # Preflight: tomllib requires py3.11+
 python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,11) else 1)' \
@@ -39,21 +40,59 @@ httpd.serve_forever()
 PY
   SRV_PID=$!
   for _ in $(seq 1 50); do [ -s "$PORTFILE" ] && break; sleep 0.1; done
+  if [ ! -s "$PORTFILE" ]; then
+    echo "FAIL: fixture server failed to bind/write PORTFILE within 5s" >&2
+    exit 1
+  fi
   PORT="$(cat "$PORTFILE")"
 }
 stop_server() { kill "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true; SRV_PID=""; }
 
-serve_published() { mkdir -p "$WWW/pypi/copilotkit"; printf '{"info":{"version":"%s"}}' "$1" > "$WWW/pypi/copilotkit/json"; }
+serve_published() {
+  # Realistic PyPI-shaped response: info.version AND a releases dict (single
+  # released version). Real PyPI always returns `releases`; the bare-info shape
+  # was a test-only shortcut that the max-over-releases logic doesn't match.
+  mkdir -p "$WWW/pypi/copilotkit"
+  printf '{"info":{"version":"%s"},"releases":{"%s":[]}}' "$1" "$1" > "$WWW/pypi/copilotkit/json"
+}
+
+# Serve a fuller PyPI-shaped response: info.version + a releases dict whose keys
+# are the version strings. $1 = info.version, remaining args = release keys.
+serve_published_with_releases() {
+  mkdir -p "$WWW/pypi/copilotkit"
+  local info="$1"; shift
+  local rels="" k
+  for k in "$@"; do
+    [ -z "$rels" ] && rels="\"$k\":[]" || rels="$rels,\"$k\":[]"
+  done
+  printf '{"info":{"version":"%s"},"releases":{%s}}' "$info" "$rels" > "$WWW/pypi/copilotkit/json"
+}
 
 run() {
   PYPROJECT_PATH="$TMP/pkg/pyproject.toml" PYPI_BASE_URL="http://127.0.0.1:${PORT}" \
-    "$SCRIPT" 2>/dev/null | tail -n1
+    "$SCRIPT" 2>"$STDERR_LOG" | tail -n1
 }
-fail() { echo "FAIL: $1" >&2; exit 1; }
+fail() {
+  echo "FAIL: $1" >&2
+  if [ -s "$STDERR_LOG" ]; then
+    echo "--- captured stderr ---" >&2
+    cat "$STDERR_LOG" >&2
+    echo "--- end stderr ---" >&2
+  fi
+  exit 1
+}
 
 # Case A: published == local (0.2.0) -> should_publish=false (no-op)
+# Also assert GITHUB_OUTPUT emission: the script must append should_publish=,
+# name=, and version= lines when GITHUB_OUTPUT is set.
 rm -rf "$WWW"; serve_published "0.2.0"; start_server
-OUT="$(run)"; echo "A: $OUT"; [ "$OUT" = "false copilotkit 0.2.0" ] || fail "no-op: got '$OUT'"
+GHO="$TMP/gho.txt"; : > "$GHO"
+OUT="$(GITHUB_OUTPUT="$GHO" PYPROJECT_PATH="$TMP/pkg/pyproject.toml" PYPI_BASE_URL="http://127.0.0.1:${PORT}" \
+  "$SCRIPT" 2>"$STDERR_LOG" | tail -n1)"
+echo "A: $OUT"; [ "$OUT" = "false copilotkit 0.2.0" ] || fail "no-op: got '$OUT'"
+grep -q '^should_publish=false$' "$GHO" || fail "GITHUB_OUTPUT missing should_publish=false (got: $(cat "$GHO"))"
+grep -q '^name=copilotkit$' "$GHO" || fail "GITHUB_OUTPUT missing name=copilotkit (got: $(cat "$GHO"))"
+grep -q '^version=0.2.0$' "$GHO" || fail "GITHUB_OUTPUT missing version=0.2.0 (got: $(cat "$GHO"))"
 stop_server
 
 # Case B: published < local (0.1.91 < 0.2.0) -> should_publish=true (exactly one pkg)
@@ -64,6 +103,32 @@ stop_server
 # Case C: package missing (404) -> should_publish=true (NEW)
 rm -rf "$WWW"; mkdir -p "$WWW"; start_server
 OUT="$(run)"; echo "C: $OUT"; [ "$OUT" = "true copilotkit 0.2.0" ] || fail "new-pkg: got '$OUT'"
+stop_server
+
+# Case D: info.version is LOWER than the true max in releases. PyPI's info.version
+# is the LATEST-UPLOADED, not the highest — an out-of-order patch upload to an
+# old line can produce this state. The script must compute the max over the
+# numeric-parseable releases keys, not trust info.version.
+# releases = {0.1.0, 0.2.0}, info.version=0.1.0, local=0.2.0 -> 0.2.0==0.2.0 -> false.
+rm -rf "$WWW"; serve_published_with_releases "0.1.0" "0.1.0" "0.2.0"; start_server
+OUT="$(run)"; echo "D: $OUT"; [ "$OUT" = "false copilotkit 0.2.0" ] || fail "max-over-releases: got '$OUT'"
+stop_server
+
+# Case E: releases contains a non-numeric prerelease key alongside numeric. The
+# script must ignore non-numeric published keys (not abort on them) and compare
+# against the numeric max. info.version is the prerelease (rc1); local is 0.2.1.
+# numeric max published = 0.2.0 < 0.2.1 -> should_publish=true.
+rm -rf "$WWW"
+mkdir -p "$TMP/pkg2"
+cat > "$TMP/pkg2/pyproject.toml" <<'TOML'
+[tool.poetry]
+name = "copilotkit"
+version = "0.2.1"
+TOML
+serve_published_with_releases "0.2.1rc1" "0.2.0" "0.2.1rc1"; start_server
+OUT="$(PYPROJECT_PATH="$TMP/pkg2/pyproject.toml" PYPI_BASE_URL="http://127.0.0.1:${PORT}" \
+  "$SCRIPT" 2>"$STDERR_LOG" | tail -n1)"
+echo "E: $OUT"; [ "$OUT" = "true copilotkit 0.2.1" ] || fail "non-numeric-released-ignored: got '$OUT'"
 stop_server
 
 echo "ALL PASS"

--- a/scripts/release/detect-py-version-changes.sh
+++ b/scripts/release/detect-py-version-changes.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Detect whether sdk-python/pyproject.toml declares a version newer than what's
+# published on PyPI. Emits GitHub Actions outputs: should_publish, name, version.
+# Also prints "<should_publish> <name> <version>" to stdout for test consumption.
+# PYPI_BASE_URL overridable for tests (default https://pypi.org). Requires py3.11+.
+set -euo pipefail
+
+PYPROJECT="${PYPROJECT_PATH:-sdk-python/pyproject.toml}"
+PYPI_BASE_URL="${PYPI_BASE_URL:-https://pypi.org}"
+
+# Parse name + version from pyproject (tomllib, py3.11+). Capture explicitly so a
+# parse failure aborts (heredoc-fed `read` would otherwise mask it under set -e).
+PYOUT="$(python3 - "$PYPROJECT" <<'PY'
+import sys, tomllib
+with open(sys.argv[1], "rb") as f:
+    data = tomllib.load(f)
+poetry = data.get("tool", {}).get("poetry", {})
+project = data.get("project", {})
+name = poetry.get("name") or project.get("name")
+version = poetry.get("version") or project.get("version")
+if not name or not version:
+    sys.exit("could not read name/version from pyproject")
+print(name)
+print(version)
+PY
+)" || { echo "ERROR: failed to parse ${PYPROJECT}" >&2; exit 1; }
+NAME="$(printf '%s\n' "$PYOUT" | sed -n 1p)"
+VERSION="$(printf '%s\n' "$PYOUT" | sed -n 2p)"
+echo "Local: ${NAME}==${VERSION}" >&2
+
+# Fetch published version, distinguishing 404 (new package) from other failures.
+RESP="$(mktemp)"; trap 'rm -f "$RESP"' EXIT
+CODE="$(curl -sS -o "$RESP" -w '%{http_code}' "${PYPI_BASE_URL}/pypi/${NAME}/json" 2>/dev/null || echo "000")"
+case "$CODE" in
+  200)
+    PUBLISHED="$(python3 -c 'import sys,json; print(json.load(open(sys.argv[1]))["info"]["version"])' "$RESP")" \
+      || { echo "ERROR: bad JSON from PyPI" >&2; exit 1; }
+    echo "Published: ${NAME}==${PUBLISHED}" >&2 ;;
+  404)
+    PUBLISHED=""; echo "Not found on PyPI — treating as NEW" >&2 ;;
+  *)
+    echo "ERROR: unexpected HTTP ${CODE} from ${PYPI_BASE_URL}/pypi/${NAME}/json" >&2; exit 1 ;;
+esac
+
+if [ -z "$PUBLISHED" ]; then
+  SHOULD_PUBLISH="true"
+else
+  # Plain X.Y.Z numeric-tuple comparison (no third-party deps). The stable lane
+  # only ships dotted-numeric versions; refuse anything non-numeric loudly.
+  SHOULD_PUBLISH="$(python3 - "$VERSION" "$PUBLISHED" <<'PY'
+import sys, re
+def parse(v):
+    if not re.fullmatch(r"\d+(\.\d+)*", v):
+        sys.exit(f"non-numeric version not supported on stable lane: {v!r}")
+    return tuple(int(x) for x in v.split("."))
+local, pub = parse(sys.argv[1]), parse(sys.argv[2])
+print("true" if local > pub else "false")
+PY
+)" || exit 1
+fi
+
+echo "should_publish=${SHOULD_PUBLISH}" >&2
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  { echo "should_publish=${SHOULD_PUBLISH}"; echo "name=${NAME}"; echo "version=${VERSION}"; } >> "$GITHUB_OUTPUT"
+fi
+echo "${SHOULD_PUBLISH} ${NAME} ${VERSION}"

--- a/scripts/release/detect-py-version-changes.sh
+++ b/scripts/release/detect-py-version-changes.sh
@@ -30,12 +30,36 @@ echo "Local: ${NAME}==${VERSION}" >&2
 
 # Fetch published version, distinguishing 404 (new package) from other failures.
 RESP="$(mktemp)"; trap 'rm -f "$RESP"' EXIT
-CODE="$(curl -sS -o "$RESP" -w '%{http_code}' "${PYPI_BASE_URL}/pypi/${NAME}/json" 2>/dev/null || echo "000")"
+CODE="$(curl -sS --max-time 30 --retry 3 --retry-connrefused -o "$RESP" -w '%{http_code}' "${PYPI_BASE_URL}/pypi/${NAME}/json" 2>/dev/null || echo "000")"
 case "$CODE" in
   200)
-    PUBLISHED="$(python3 -c 'import sys,json; print(json.load(open(sys.argv[1]))["info"]["version"])' "$RESP")" \
-      || { echo "ERROR: bad JSON from PyPI" >&2; exit 1; }
-    echo "Published: ${NAME}==${PUBLISHED}" >&2 ;;
+    # Compute the MAX numeric-parseable version from the `releases` dict (the
+    # complete set of released versions). `info.version` is the LATEST-UPLOADED,
+    # not necessarily the highest — out-of-order patch uploads to an old line
+    # can produce info.version < max(releases). Non-numeric keys (prereleases
+    # like "0.2.0rc1", dev/post tags) are filtered out, not aborted on. If no
+    # numeric keys exist, treat as empty (same as 404 -> NEW).
+    PUBLISHED="$(python3 - "$RESP" <<'PY'
+import sys, json, re
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+releases = data.get("releases") or {}
+numeric = []
+for k in releases.keys():
+    if re.fullmatch(r"\d+(\.\d+)*", k):
+        numeric.append(k)
+if not numeric:
+    print("")
+else:
+    best = max(numeric, key=lambda v: tuple(int(x) for x in v.split(".")))
+    print(best)
+PY
+)" || { echo "ERROR: bad JSON from PyPI" >&2; exit 1; }
+    if [ -z "$PUBLISHED" ]; then
+      echo "Published: ${NAME} has no numeric releases — treating as NEW" >&2
+    else
+      echo "Published: ${NAME}==${PUBLISHED}" >&2
+    fi ;;
   404)
     PUBLISHED=""; echo "Not found on PyPI — treating as NEW" >&2 ;;
   *)
@@ -46,14 +70,16 @@ if [ -z "$PUBLISHED" ]; then
   SHOULD_PUBLISH="true"
 else
   # Plain X.Y.Z numeric-tuple comparison (no third-party deps). The stable lane
-  # only ships dotted-numeric versions; refuse anything non-numeric loudly.
+  # only ships dotted-numeric LOCAL versions; refuse non-numeric LOCAL loudly.
+  # PUBLISHED is already guaranteed numeric (filtered above when computing max).
   SHOULD_PUBLISH="$(python3 - "$VERSION" "$PUBLISHED" <<'PY'
 import sys, re
-def parse(v):
+def parse_local(v):
     if not re.fullmatch(r"\d+(\.\d+)*", v):
-        sys.exit(f"non-numeric version not supported on stable lane: {v!r}")
+        sys.exit(f"non-numeric local version not supported on stable lane: {v!r}")
     return tuple(int(x) for x in v.split("."))
-local, pub = parse(sys.argv[1]), parse(sys.argv[2])
+local = parse_local(sys.argv[1])
+pub = tuple(int(x) for x in sys.argv[2].split("."))
 print("true" if local > pub else "false")
 PY
 )" || exit 1

--- a/scripts/release/detect-py-version-changes.sh
+++ b/scripts/release/detect-py-version-changes.sh
@@ -29,24 +29,39 @@ VERSION="$(printf '%s\n' "$PYOUT" | sed -n 2p)"
 echo "Local: ${NAME}==${VERSION}" >&2
 
 # Fetch published version, distinguishing 404 (new package) from other failures.
-RESP="$(mktemp)"; trap 'rm -f "$RESP"' EXIT
-CODE="$(curl -sS --max-time 30 --retry 3 --retry-connrefused -o "$RESP" -w '%{http_code}' "${PYPI_BASE_URL}/pypi/${NAME}/json" 2>/dev/null || echo "000")"
+# Capture curl stderr so transport errors (DNS/TLS/connection refused) surface to
+# the operator instead of being erased into a vague "HTTP 000".
+RESP="$(mktemp)"; CURL_ERR="$(mktemp)"; trap 'rm -f "$RESP" "$CURL_ERR"' EXIT
+CODE="$(curl -sS --max-time 30 --retry 3 --retry-all-errors --retry-connrefused -o "$RESP" -w '%{http_code}' "${PYPI_BASE_URL}/pypi/${NAME}/json" 2>"$CURL_ERR" || echo "000")"
 case "$CODE" in
   200)
     # Compute the MAX numeric-parseable version from the `releases` dict (the
     # complete set of released versions). `info.version` is the LATEST-UPLOADED,
     # not necessarily the highest — out-of-order patch uploads to an old line
     # can produce info.version < max(releases). Non-numeric keys (prereleases
-    # like "0.2.0rc1", dev/post tags) are filtered out, not aborted on. If no
-    # numeric keys exist, treat as empty (same as 404 -> NEW).
+    # like "0.2.0rc1", dev/post tags) are filtered out, not aborted on.
+    #
+    # Exclude fully-yanked releases: each release maps to a list of file dicts
+    # with a "yanked" bool. A version with an empty file list or all files
+    # yanked is NOT a live release and must be skipped — otherwise a yanked
+    # bogus high version (e.g. 0.99.0) permanently blocks legitimate bumps.
+    #
+    # If a 200 response lacks a "releases" key, FAIL LOUD: that's not a "new
+    # package" signal (only 404 is), it's malformed/unexpected JSON for a
+    # publish gate. If no live numeric release exists, treat as NEW.
     PUBLISHED="$(python3 - "$RESP" <<'PY'
 import sys, json, re
 with open(sys.argv[1]) as f:
     data = json.load(f)
-releases = data.get("releases") or {}
+if not isinstance(data, dict) or "releases" not in data or data.get("releases") is None:
+    sys.exit("missing or null 'releases' key in PyPI JSON response")
+releases = data["releases"]
 numeric = []
-for k in releases.keys():
-    if re.fullmatch(r"\d+(\.\d+)*", k):
+for k, files in releases.items():
+    if not re.fullmatch(r"\d+(\.\d+)*", k):
+        continue
+    # Live iff at least one non-yanked file exists. Empty list -> excluded.
+    if isinstance(files, list) and any(not f.get("yanked", False) for f in files):
         numeric.append(k)
 if not numeric:
     print("")
@@ -54,16 +69,26 @@ else:
     best = max(numeric, key=lambda v: tuple(int(x) for x in v.split(".")))
     print(best)
 PY
-)" || { echo "ERROR: bad JSON from PyPI" >&2; exit 1; }
+)" || { echo "ERROR: bad JSON from PyPI (or missing releases key)" >&2; exit 1; }
     if [ -z "$PUBLISHED" ]; then
-      echo "Published: ${NAME} has no numeric releases — treating as NEW" >&2
+      echo "Published: ${NAME} has no live numeric releases — treating as NEW" >&2
     else
       echo "Published: ${NAME}==${PUBLISHED}" >&2
     fi ;;
   404)
     PUBLISHED=""; echo "Not found on PyPI — treating as NEW" >&2 ;;
+  000)
+    echo "ERROR: curl transport/connection failure contacting ${PYPI_BASE_URL}/pypi/${NAME}/json (HTTP 000 = no response, not an HTTP status)" >&2
+    if [ -s "$CURL_ERR" ]; then
+      echo "--- curl stderr ---" >&2; cat "$CURL_ERR" >&2; echo "--- end curl stderr ---" >&2
+    fi
+    exit 1 ;;
   *)
-    echo "ERROR: unexpected HTTP ${CODE} from ${PYPI_BASE_URL}/pypi/${NAME}/json" >&2; exit 1 ;;
+    echo "ERROR: unexpected HTTP ${CODE} from ${PYPI_BASE_URL}/pypi/${NAME}/json" >&2
+    if [ -s "$CURL_ERR" ]; then
+      echo "--- curl stderr ---" >&2; cat "$CURL_ERR" >&2; echo "--- end curl stderr ---" >&2
+    fi
+    exit 1 ;;
 esac
 
 if [ -z "$PUBLISHED" ]; then
@@ -72,6 +97,9 @@ else
   # Plain X.Y.Z numeric-tuple comparison (no third-party deps). The stable lane
   # only ships dotted-numeric LOCAL versions; refuse non-numeric LOCAL loudly.
   # PUBLISHED is already guaranteed numeric (filtered above when computing max).
+  # Zero-pad the shorter tuple before comparing so "0.2" and "0.2.0" compare
+  # equal (PEP 440). Without padding, (0,2,0) > (0,2) wrongly yields True and
+  # triggers a duplicate-version `uv publish` that PyPI rejects with 400.
   SHOULD_PUBLISH="$(python3 - "$VERSION" "$PUBLISHED" <<'PY'
 import sys, re
 def parse_local(v):
@@ -80,6 +108,9 @@ def parse_local(v):
     return tuple(int(x) for x in v.split("."))
 local = parse_local(sys.argv[1])
 pub = tuple(int(x) for x in sys.argv[2].split("."))
+n = max(len(local), len(pub))
+local += (0,) * (n - len(local))
+pub += (0,) * (n - len(pub))
 print("true" if local > pub else "false")
 PY
 )" || exit 1


### PR DESCRIPTION
## Summary

Adds GitHub Actions automation to publish the CopilotKit Python SDK (`copilotkit` on PyPI) on release, using **PyPI OIDC Trusted Publishing** — no long-lived PyPI token is stored anywhere.

The Python lane lives inside the existing `publish-release.yml` and is fully decoupled from the npm release scopes (`release.config.json` / `publish-release.ts` are untouched).

## How it works

- **Build job (`build-python`)**: on a merged release PR, checks out `main`, detects whether `sdk-python/pyproject.toml` changed and whether its version differs from the version already on PyPI (`scripts/release/detect-py-version-changes.sh`), builds the sdist/wheel, and uploads them as an artifact.
- **Publish job (`publish-python`)**: downloads the artifact and runs `uv publish --trusted-publishing always` in the `pypi` GitHub environment with `id-token: write`. Credential isolation: only this job holds the OIDC token. It then verifies the version is live on PyPI, tags `python-sdk/vX.Y.Z`, and creates a GitHub Release.
- **Triggers**: merge of a `chore(sdk-python): release vX.Y.Z` PR (publishes only when the version actually changed) + a `workflow_dispatch` escape hatch with a `dry-run` input that builds without publishing.

## ⚠️ Required before this can publish — PyPI Trusted Publisher

A Trusted Publisher must be configured on the PyPI `copilotkit` project **before** any version bump is merged, or the first publish fails with HTTP 422. The binding must match the workflow VERBATIM:

| Field | Value |
|---|---|
| Owner | `CopilotKit` |
| Repository | `CopilotKit` |
| Workflow filename | `publish-release.yml` |
| Environment | `pypi` |

**Do NOT bump `sdk-python/pyproject.toml` until the Trusted Publisher is live.**

## Test plan

- [x] Hermetic test suite for the detection script (9 cases A–I): version equal/greater, 404 (never published), max-over-releases, non-numeric versions ignored, zero-pad equivalence (0.2 vs 0.2.0), yanked-release filtering, and fail-loud on malformed PyPI JSON / HTTP 5xx.
- [ ] `workflow_dispatch` with `dry-run: true` to exercise the build path without publishing (after merge).
- [ ] First real publish after the Trusted Publisher is configured.
