### PR TITLE
fix(core): guard proxied agent subscriptions

### DIFF
--- a/packages/core/src/__tests__/proxied-runtime-transport.test.ts
+++ b/packages/core/src/__tests__/proxied-runtime-transport.test.ts
@@ -235,6 +235,26 @@ describe("ProxiedCopilotRuntimeAgent capabilities", () => {
   });
 });
 
+describe("ProxiedCopilotRuntimeAgent subscribers", () => {
+  it("repairs missing subscriber storage before subscribing", () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "http://localhost:3000",
+      agentId: "test-agent",
+      description: "Test agent",
+    });
+
+    delete (agent as unknown as { subscribers?: unknown[] }).subscribers;
+
+    const subscription = agent.subscribe({ onRunFinalized: vi.fn() });
+
+    expect(agent.subscribers).toHaveLength(1);
+
+    subscription.unsubscribe();
+
+    expect(agent.subscribers).toHaveLength(0);
+  });
+});
+
 describe("ProxiedCopilotRuntimeAgent cloning", () => {
   const originalFetch = global.fetch;
   const runtimeUrl = "https://runtime.example/single";

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -144,6 +144,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     if (config.debug) {
       this.debug = config.debug;
     }
+    this.ensureSubscribers();
     if (this.transport === "single") {
       this.singleEndpointUrl = this.runtimeUrl;
     }
@@ -173,8 +174,19 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     return this._capabilities;
   }
 
+  private ensureSubscribers(): void {
+    if (!Array.isArray(this.subscribers)) {
+      this.subscribers = [];
+    }
+  }
+
   async getCapabilities(): Promise<AgentCapabilities> {
     return this._capabilities ?? {};
+  }
+
+  override subscribe(subscriber: AgentSubscriber): { unsubscribe: () => void } {
+    this.ensureSubscribers();
+    return super.subscribe(subscriber);
   }
 
   override async detachActiveRun(): Promise<void> {
@@ -312,6 +324,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     // Forward the proxy's subscribers to the delegate so that UI hooks
     // (e.g. useAgent's onMessagesChanged) receive real-time updates as
     // the delegate processes events during connectAgent.
+    this.ensureSubscribers();
     const forwardedSubs = this.subscribers.map((s) => delegate.subscribe(s));
 
     try {


### PR DESCRIPTION
## Summary

-> Fixes issue #5000 where provisional agents created via `useAgent()` could crash when `agent.subscribe()` was called immediately after mount.
-> The root cause was that `ProxiedCopilotRuntimeAgent.subscribe()` could access AG-UI subscriber bookkeeping before the internal `subscribers` array had been initialized. This change ensures subscriber storage is always normalized before subscriptions are forwarded, making `subscribe()` safe to call as soon as the agent instance is available.

## Changes

-> Normalize subscriber storage during `ProxiedCopilotRuntimeAgent` initialization.
-> Override `subscribe()` to defensively restore missing subscriber state before delegating to AG-UI.
-> Add guards around intelligence-mode subscriber forwarding when `this.subscribers` is undefined.
-> Add a regression test covering missing subscriber initialization and validating subscribe/unsubscribe behavior.

## Testing

-> Added regression coverage in:
`src/__tests__/proxied-runtime-transport.test.ts`

-> Verified:
    -> `@copilotkit/core:test`
    -> `@copilotkit/core:build --excludeTaskDependencies`

