### PR TITLE
chore(showcase): bump copilotkit to 0.1.91 in Python integrations

### DIFF
--- a/showcase/integrations/langgraph-fastapi/requirements.txt
+++ b/showcase/integrations/langgraph-fastapi/requirements.txt
@@ -1,4 +1,4 @@
-copilotkit==0.1.90
+copilotkit==0.1.91
 langchain==1.2.15
 langchain-openai==1.1.9
 langchain-anthropic==1.4.1

--- a/showcase/integrations/langgraph-python/requirements.txt
+++ b/showcase/integrations/langgraph-python/requirements.txt
@@ -1,4 +1,4 @@
-copilotkit==0.1.90
+copilotkit==0.1.91
 langchain==1.2.15
 langchain-openai==1.1.9
 langchain-anthropic==1.4.1

--- a/showcase/integrations/strands/requirements.txt
+++ b/showcase/integrations/strands/requirements.txt
@@ -2,7 +2,7 @@ ag-ui-protocol==0.1.18
 ag_ui_strands==0.1.8
 strands-agents[OpenAI]==1.18.0
 strands-agents-tools==0.2.16
-copilotkit==0.1.90
+copilotkit==0.1.91
 langchain==1.2.15
 langchain-openai==1.1.9
 openai==1.109.1

--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the sorted, deduplicated `[FAIL] ...` lines from validate-pins.ts. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the per-package e2e-spec-count floor (single source of truth consumed by both the workflow and validate-parity.ts). NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
   "validatePinsFailCount": 106,
-  "validatePinsFailHash": "1bb11204778ce4a2f42738153ded6f4f14565e4f99345bf7db485105f199e450",
+  "validatePinsFailHash": "d340cdebe623177b957b62576821b51cde7f174b6b788040d67cc87e3d20b702",
   "baselineDemoCount": 9
 }


### PR DESCRIPTION
## Summary

Bumps `copilotkit==0.1.90` → `copilotkit==0.1.91` in three showcase Python integration `requirements.txt` files:

- `showcase/integrations/langgraph-python`
- `showcase/integrations/strands`
- `showcase/integrations/langgraph-fastapi`

Picks up the forwarded-header extraction landed in #4984 and published as `copilotkit 0.1.91` on PyPI by the release in #5011.

Updates `validate-pins` ratchet hash in `showcase/scripts/fail-baseline.json` (count stays at 106, FAIL set shifted because showcase pins now diverge from Dojo on `0.1.91` vs `0.1.87`).

## Why split from the @ag-ui/langgraph pin bump

The matching `@ag-ui/langgraph` bump (`0.0.31` → `0.0.33` in `packages/runtime/package.json` and `packages/sdk-js/package.json`) waits for the ag-ui side: `publish-release.yml` is currently broken (OIDC `pull_request` vs `push` event mismatch — last 30 runs all failed). Fix is in flight in a separate session. Once `@ag-ui/langgraph 0.0.33` is live on npm, a follow-up PR will bump those two pins.

This split unblocks D6 LGP today. D6 LGT remains waiting on the ag-ui side.

## Test plan

- [ ] CI green
- [ ] After merge, showcase_build.yml redeploys langgraph-python + strands + langgraph-fastapi to Railway
- [ ] Production D6 LGP probe verifies forwarded headers reach the agent via aimock logs