### PR TITLE
fix(shell-docs): remove extra bottom margin from p inside callouts

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,8 +55,6 @@ pre-commit:
       tags: test-packages
       env:
         NX_TUI: "false"
-        # @copilotkit/core:build bundles many deps inline and needs > 4 GB heap.
-        NODE_OPTIONS: "--max-old-space-size=8192"
       run: pnpm run test && pnpm run check:packages
 
     check-plugin-skills:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,6 +55,8 @@ pre-commit:
       tags: test-packages
       env:
         NX_TUI: "false"
+        # @copilotkit/core:build bundles many deps inline and needs > 4 GB heap.
+        NODE_OPTIONS: "--max-old-space-size=8192"
       run: pnpm run test && pnpm run check:packages
 
     check-plugin-skills:

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -631,6 +631,16 @@ samp {
   margin-bottom: 1rem;
 }
 
+/* prose-no-margin (used by fumadocs Callout and Table) lives in @layer utilities,
+ * which always loses to unlayered styles like .reference-content p above.
+ * Mirror its intent here at (0,2,1) specificity so the layered utility wins. */
+.reference-content .prose-no-margin > :first-child {
+  margin-top: 0;
+}
+.reference-content .prose-no-margin > :last-child {
+  margin-bottom: 0;
+}
+
 .reference-content ul,
 .reference-content ol {
   font-size: 0.9375rem;


### PR DESCRIPTION
Before:
<img width="781" height="87" alt="Screenshot 2026-05-26 at 9 35 58 AM" src="https://github.com/user-attachments/assets/547dc74b-04e7-4784-85b4-823f1adaefb4" />

After:
<img width="784" height="69" alt="Screenshot 2026-05-26 at 9 39 03 AM" src="https://github.com/user-attachments/assets/e8cf7948-a2bb-439a-90ef-9b73b40504dc" />


## Summary

- `.reference-content p { margin-bottom: 1rem }` in `globals.css` is **unlayered** CSS, so it always wins over fumadocs-ui's `prose-no-margin` utility (which lives in `@layer utilities`), causing visible extra space at the bottom of info callout boxes
- Fix mirrors `prose-no-margin`'s first/last-child intent at `(0,2,1)` specificity in `globals.css` so the margin resets actually apply

## Test plan

- [x] Open any docs page with a `<Callout>` block (e.g. a quickstart page)
- [x] Verify no extra bottom padding/margin inside the callout box
- [x] Check both light and dark mode
- [x] Check callouts with and without a `title` prop