### PR TITLE
fix(shell-docs): fix broken prebuilt-components and HITL code examples

### DIFF
--- a/showcase/scripts/verify-shell-docs.test.ts
+++ b/showcase/scripts/verify-shell-docs.test.ts
@@ -4,6 +4,7 @@ import { checkInlineDemoRefs } from "./verify-shell-docs.js";
 import { checkSnippetRegions } from "./verify-shell-docs.js";
 import { checkInternalLinks } from "./verify-shell-docs.js";
 import { checkImportPaths } from "./verify-shell-docs.js";
+import { checkComponentImports } from "./verify-shell-docs.js";
 
 describe("runBuildCheck", () => {
   it("returns a result with name, status, and messages", () => {
@@ -184,6 +185,44 @@ describe("checkImportPaths", () => {
     ];
     const existsOnDisk = (_p: string) => true;
     const result = checkImportPaths({ pages, existsOnDisk });
+    expect(result.status).toBe("pass");
+  });
+});
+
+describe("checkComponentImports", () => {
+  it("fails when a snippet component is used with props but no import", () => {
+    const pages = [
+      {
+        path: "agno/prebuilt-components.mdx",
+        body: '<PrebuiltComponents components={props.components} framework="agno" />',
+      },
+    ];
+    const result = checkComponentImports({ pages });
+    expect(result.status).toBe("fail");
+    expect(result.messages.join(" ")).toContain("PrebuiltComponents");
+  });
+
+  it("passes when a snippet component has an explicit import", () => {
+    const pages = [
+      {
+        path: "agno/prebuilt-components.mdx",
+        body:
+          'import PrebuiltComponents from "@/snippets/shared/basics/prebuilt-components.mdx";\n\n' +
+          '<PrebuiltComponents components={props.components} framework="agno" />',
+      },
+    ];
+    const result = checkComponentImports({ pages });
+    expect(result.status).toBe("pass");
+  });
+
+  it("passes when a bare component is used without props or import", () => {
+    const pages = [
+      {
+        path: "some-page.mdx",
+        body: "<PrebuiltComponents />",
+      },
+    ];
+    const result = checkComponentImports({ pages });
     expect(result.status).toBe("pass");
   });
 });

--- a/showcase/scripts/verify-shell-docs.ts
+++ b/showcase/scripts/verify-shell-docs.ts
@@ -297,57 +297,34 @@ function aliasExists(importPath: string): boolean {
   );
 }
 
-const SNIPPET_COMPONENTS = new Set([
-  "A2UI",
-  "AgUI",
-  "AGUI",
-  "CodingAgents",
-  "CommonIssues",
-  "CopilotRuntime",
-  "CustomAgent",
-  "DebugMode",
-  "DisplayOnly",
-  "ErrorDebugging",
-  "FrontendTools",
-  "FrontEndToolsImpl",
-  "GenerativeUISpecsOverview",
-  "HeadlessUI",
-  "Inspector",
-  "Interactive",
-  "MCPApps",
-  "MCPSetup",
-  "MigrateTo",
-  "MigrateTo1100",
-  "MigrateTo182",
-  "MigrateToV",
-  "MigrateToV2",
-  "Observability",
-  "ObservabilityConnectors",
-  "Overview",
-  "PrebuiltComponents",
-  "ProgrammaticControl",
-  "ReasoningMessages",
-  "SelfHosting",
-  "Slots",
-  "Threads",
-  "ToolRenderer",
-  "ToolRendering",
-  "DefaultToolRendering",
-]);
+export function loadSnippetComponentNames(): Set<string> {
+  const docsRenderPath = path.join(
+    REPO_ROOT,
+    "showcase/shell-docs/src/lib/docs-render.tsx",
+  );
+  const src = fs.readFileSync(docsRenderPath, "utf-8");
+  const mapMatch = src.match(/export const SNIPPET_MAP[^{]*\{([^}]+)\}/s);
+  if (!mapMatch)
+    throw new Error("Could not find SNIPPET_MAP in docs-render.tsx");
+  const keys = [...mapMatch[1].matchAll(/^\s*(\w+)\s*:/gm)].map((m) => m[1]);
+  return new Set(keys);
+}
 
-// Matches the same shape that inlineSnippets() in docs-render.tsx can
-// resolve at render time: <Component /> or <Component components={...} />.
-// Any snippet component usage that doesn't match this pattern AND lacks
-// an explicit import will silently render nothing.
-const INLINE_SNIPPETS_RE = /<([A-Z]\w*)\s*(?:components=\{[^}]*\}\s*)?\/>/g;
-
-// Catches snippet component usages with extra props (e.g. framework="...")
-// that the inlineSnippets regex can't handle.
 const SNIPPET_WITH_PROPS_RE = /<([A-Z]\w*)\s+[^>]*(?:>|\/>)/g;
+
+// Matches the same shape that inlineSnippets() in docs-render.tsx resolves at
+// render time. Per-match check (not per-name) so a page with both <Foo /> and
+// <Foo framework="x" /> correctly flags only the latter.
+const INLINE_HANDLED_RE = /^<[A-Z]\w*\s*(?:components=\{[^}]*\}\s*)?\/>/;
 
 const MDX_IMPORT_NAME_RE = /^\s*import\s+(\w+)\s+from\s+["']@\/snippets\//gm;
 
-export function checkComponentImports(pages: PageInput[]): CheckResult {
+export function checkComponentImports({
+  pages,
+}: {
+  pages: PageInput[];
+}): CheckResult {
+  const snippetComponents = loadSnippetComponentNames();
   const failures: string[] = [];
   for (const page of pages) {
     const body = strip(page.body);
@@ -359,23 +336,15 @@ export function checkComponentImports(pages: PageInput[]): CheckResult {
       imported.add(im[1]);
     }
 
-    // Collect component usages that inlineSnippets() would handle
-    const handledByInline = new Set<string>();
-    INLINE_SNIPPETS_RE.lastIndex = 0;
-    let m: RegExpExecArray | null;
-    while ((m = INLINE_SNIPPETS_RE.exec(body)) !== null) {
-      handledByInline.add(m[1]);
-    }
-
-    // Find snippet components used with extra props
     SNIPPET_WITH_PROPS_RE.lastIndex = 0;
     const flagged = new Set<string>();
+    let m: RegExpExecArray | null;
     while ((m = SNIPPET_WITH_PROPS_RE.exec(body)) !== null) {
       const name = m[1];
       if (
-        SNIPPET_COMPONENTS.has(name) &&
+        snippetComponents.has(name) &&
         !imported.has(name) &&
-        !handledByInline.has(name) &&
+        !INLINE_HANDLED_RE.test(m[0]) &&
         !flagged.has(name)
       ) {
         flagged.add(name);
@@ -405,7 +374,7 @@ async function main() {
     checkSnippetRegions({ pages, demoContent }),
     checkInternalLinks({ pages, knownRoutes }),
     checkImportPaths({ pages, existsOnDisk: aliasExists }),
-    checkComponentImports(pages),
+    checkComponentImports({ pages }),
     runEssentialContentCheck(pages),
   ];
 

--- a/showcase/scripts/verify-shell-docs.ts
+++ b/showcase/scripts/verify-shell-docs.ts
@@ -297,6 +297,101 @@ function aliasExists(importPath: string): boolean {
   );
 }
 
+const SNIPPET_COMPONENTS = new Set([
+  "A2UI",
+  "AgUI",
+  "AGUI",
+  "CodingAgents",
+  "CommonIssues",
+  "CopilotRuntime",
+  "CustomAgent",
+  "DebugMode",
+  "DisplayOnly",
+  "ErrorDebugging",
+  "FrontendTools",
+  "FrontEndToolsImpl",
+  "GenerativeUISpecsOverview",
+  "HeadlessUI",
+  "Inspector",
+  "Interactive",
+  "MCPApps",
+  "MCPSetup",
+  "MigrateTo",
+  "MigrateTo1100",
+  "MigrateTo182",
+  "MigrateToV",
+  "MigrateToV2",
+  "Observability",
+  "ObservabilityConnectors",
+  "Overview",
+  "PrebuiltComponents",
+  "ProgrammaticControl",
+  "ReasoningMessages",
+  "SelfHosting",
+  "Slots",
+  "Threads",
+  "ToolRenderer",
+  "ToolRendering",
+  "DefaultToolRendering",
+]);
+
+// Matches the same shape that inlineSnippets() in docs-render.tsx can
+// resolve at render time: <Component /> or <Component components={...} />.
+// Any snippet component usage that doesn't match this pattern AND lacks
+// an explicit import will silently render nothing.
+const INLINE_SNIPPETS_RE = /<([A-Z]\w*)\s*(?:components=\{[^}]*\}\s*)?\/>/g;
+
+// Catches snippet component usages with extra props (e.g. framework="...")
+// that the inlineSnippets regex can't handle.
+const SNIPPET_WITH_PROPS_RE = /<([A-Z]\w*)\s+[^>]*(?:>|\/>)/g;
+
+const MDX_IMPORT_NAME_RE = /^\s*import\s+(\w+)\s+from\s+["']@\/snippets\//gm;
+
+export function checkComponentImports(pages: PageInput[]): CheckResult {
+  const failures: string[] = [];
+  for (const page of pages) {
+    const body = strip(page.body);
+
+    const imported = new Set<string>();
+    MDX_IMPORT_NAME_RE.lastIndex = 0;
+    let im: RegExpExecArray | null;
+    while ((im = MDX_IMPORT_NAME_RE.exec(page.body)) !== null) {
+      imported.add(im[1]);
+    }
+
+    // Collect component usages that inlineSnippets() would handle
+    const handledByInline = new Set<string>();
+    INLINE_SNIPPETS_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = INLINE_SNIPPETS_RE.exec(body)) !== null) {
+      handledByInline.add(m[1]);
+    }
+
+    // Find snippet components used with extra props
+    SNIPPET_WITH_PROPS_RE.lastIndex = 0;
+    const flagged = new Set<string>();
+    while ((m = SNIPPET_WITH_PROPS_RE.exec(body)) !== null) {
+      const name = m[1];
+      if (
+        SNIPPET_COMPONENTS.has(name) &&
+        !imported.has(name) &&
+        !handledByInline.has(name) &&
+        !flagged.has(name)
+      ) {
+        flagged.add(name);
+        failures.push(
+          `${page.path}: <${name}> used with props but missing snippet import`,
+        );
+      }
+    }
+  }
+  return {
+    name: "component-imports",
+    status: failures.length === 0 ? "pass" : "fail",
+    messages: failures,
+  };
+}
+
 async function main() {
   const skipBuild = process.argv.includes("--skip-build");
   const pages = loadPages();
@@ -310,6 +405,7 @@ async function main() {
     checkSnippetRegions({ pages, demoContent }),
     checkInternalLinks({ pages, knownRoutes }),
     checkImportPaths({ pages, existsOnDisk: aliasExists }),
+    checkComponentImports(pages),
     runEssentialContentCheck(pages),
   ];
 

--- a/showcase/shell-docs/src/content/docs/integrations/adk/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/human-in-the-loop.mdx
@@ -50,6 +50,8 @@ Use frontend tools when you need your agent to interact with client-side primiti
         prompts the user for approval.
 
         ```tsx title="page.tsx"
+        import { useHumanInTheLoop } from "@copilotkit/react-core/v2" // [!code highlight]
+        import { z } from "zod"
 
         export function Page() {
           // ...
@@ -57,20 +59,10 @@ Use frontend tools when you need your agent to interact with client-side primiti
           useHumanInTheLoop({
             name: "offerOptions",
             description: "Give the user a choice between two options and have them select one.",
-            parameters: [
-              {
-                name: "option_1",
-                type: "string",
-                description: "The first option",
-                required: true,
-              },
-              {
-                name: "option_2",
-                type: "string",
-                description: "The second option",
-                required: true,
-              },
-            ],
+            parameters: z.object({
+              option_1: z.string().describe("The first option"),
+              option_2: z.string().describe("The second option"),
+            }),
             render: ({ args, respond }) => {
               if (!respond) return <></>;
               return (

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/human-in-the-loop.mdx
@@ -58,6 +58,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
 
         ```tsx title="page.tsx"
         import { useHumanInTheLoop } from "@copilotkit/react-core/v2" // [!code highlight]
+        import { z } from "zod"
 
         export function Page() {
           // ...
@@ -65,20 +66,10 @@ Use frontend tools when you need your agent to interact with client-side primiti
           useHumanInTheLoop({
             name: "offerOptions",
             description: "Give the user a choice between two options and have them select one.",
-            parameters: [
-              {
-                name: "option_1",
-                type: "string",
-                description: "The first option",
-                required: true,
-              },
-              {
-                name: "option_2",
-                type: "string",
-                description: "The second option",
-                required: true,
-              },
-            ],
+            parameters: z.object({
+              option_1: z.string().describe("The first option"),
+              option_2: z.string().describe("The second option"),
+            }),
             render: ({ args, respond }) => {
               if (!respond) return <></>;
               return (

--- a/showcase/shell-docs/src/content/docs/integrations/agent-spec/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agent-spec/human-in-the-loop.mdx
@@ -64,6 +64,8 @@ Use frontend tools when you need your agent to interact with client-side primiti
         prompts the user for approval.
 
         ```tsx title="page.tsx"
+        import { useHumanInTheLoop } from "@copilotkit/react-core/v2" // [!code highlight]
+        import { z } from "zod"
 
         export function Page() {
           // ...
@@ -71,20 +73,10 @@ Use frontend tools when you need your agent to interact with client-side primiti
           useHumanInTheLoop({
             name: "offerOptions",
             description: "Give the user a choice between two options and have them select one.",
-            parameters: [
-              {
-                name: "option_1",
-                type: "string",
-                description: "The first option",
-                required: true,
-              },
-              {
-                name: "option_2",
-                type: "string",
-                description: "The second option",
-                required: true,
-              },
-            ],
+            parameters: z.object({
+              option_1: z.string().describe("The first option"),
+              option_2: z.string().describe("The second option"),
+            }),
             render: ({ args, respond }) => {
               if (!respond) return <></>;
               return (

--- a/showcase/shell-docs/src/content/docs/integrations/agno/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/human-in-the-loop.mdx
@@ -87,6 +87,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
 
         ```tsx title="page.tsx"
         import { useHumanInTheLoop } from "@copilotkit/react-core/v2" // [!code highlight]
+        import { z } from "zod"
 
         export function Page() {
           // ...
@@ -94,20 +95,10 @@ Use frontend tools when you need your agent to interact with client-side primiti
           useHumanInTheLoop({
             name: "offerOptions",
             description: "Give the user a choice between two options and have them select one.",
-            parameters: [
-              {
-                name: "option_1",
-                type: "string",
-                description: "The first option",
-                required: true,
-              },
-              {
-                name: "option_2",
-                type: "string",
-                description: "The second option",
-                required: true,
-              },
-            ],
+            parameters: z.object({
+              option_1: z.string().describe("The first option"),
+              option_2: z.string().describe("The second option"),
+            }),
             render: ({ args, respond }) => {
               if (!respond) return <></>;
               return (

--- a/showcase/shell-docs/src/content/docs/integrations/agno/prebuilt-components.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/prebuilt-components.mdx
@@ -4,4 +4,6 @@ icon: "lucide/SendHorizontal"
 description: "Drop-in chat components for your Agno agent."
 ---
 
-<SharedContent framework="agno" />
+import PrebuiltComponents from "@/snippets/shared/basics/prebuilt-components.mdx";
+
+<PrebuiltComponents components={props.components} framework="agno" />

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/prebuilt-components.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/prebuilt-components.mdx
@@ -3,4 +3,6 @@ title: "Prebuilt Components"
 icon: "lucide/SendHorizontal"
 description: "Drop-in chat components for your AWS Strands agent."
 ---
+import PrebuiltComponents from "@/snippets/shared/basics/prebuilt-components.mdx";
+
 <PrebuiltComponents components={props.components} framework="aws-strands" />

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/prebuilt-components.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/prebuilt-components.mdx
@@ -4,4 +4,6 @@ icon: "lucide/SendHorizontal"
 description: "Drop-in chat components for your CrewAI Flows agent."
 ---
 
+import PrebuiltComponents from "@/snippets/shared/basics/prebuilt-components.mdx";
+
 <PrebuiltComponents components={props.components} framework="crewai" />

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/human-in-the-loop.mdx
@@ -94,6 +94,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
 
         ```tsx title="page.tsx"
         import { useHumanInTheLoop } from "@copilotkit/react-core/v2" // [!code highlight]
+        import { z } from "zod"
 
         export function Page() {
           // ...
@@ -101,20 +102,10 @@ Use frontend tools when you need your agent to interact with client-side primiti
           useHumanInTheLoop({
             name: "offerOptions",
             description: "Give the user a choice between two options and have them select one.",
-            parameters: [
-              {
-                name: "option_1",
-                type: "string",
-                description: "The first option",
-                required: true,
-              },
-              {
-                name: "option_2",
-                type: "string",
-                description: "The second option",
-                required: true,
-              },
-            ],
+            parameters: z.object({
+              option_1: z.string().describe("The first option"),
+              option_2: z.string().describe("The second option"),
+            }),
             render: ({ args, respond }) => {
               if (!respond) return <></>;
               return (

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/prebuilt-components.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/prebuilt-components.mdx
@@ -3,4 +3,6 @@ title: "Prebuilt Components"
 icon: "lucide/SendHorizontal"
 description: "Drop-in chat components for your LlamaIndex agent."
 ---
-<PrebuiltComponents components={props.components} />
+import PrebuiltComponents from "@/snippets/shared/basics/prebuilt-components.mdx";
+
+<PrebuiltComponents components={props.components} framework="llamaindex" />

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/human-in-the-loop/tool-based.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/human-in-the-loop/tool-based.mdx
@@ -44,6 +44,7 @@ you can ensure that the agent is always making the right decisions and ultimatel
 
     ```tsx title="ui/app/page.tsx"
     import { useHumanInTheLoop } from "@copilotkit/react-core/v2" // [!code highlight]
+    import { z } from "zod"
 
     function YourMainContent() {
       // ...
@@ -51,20 +52,10 @@ you can ensure that the agent is always making the right decisions and ultimatel
       useHumanInTheLoop({
         name: "offerOptions",
         description: "Give the user a choice between two options and have them select one.",
-        parameters: [
-          {
-            name: "option_1",
-            type: "string",
-            description: "The first option",
-            required: true,
-          },
-          {
-            name: "option_2",
-            type: "string",
-            description: "The second option",
-            required: true,
-          },
-        ],
+        parameters: z.object({
+          option_1: z.string().describe("The first option"),
+          option_2: z.string().describe("The second option"),
+        }),
         render: ({ args, respond }) => {
           if (!respond) return <></>;
           return (

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop.mdx
@@ -48,6 +48,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
 
         ```tsx title="page.tsx"
         import { useHumanInTheLoop } from "@copilotkit/react-core/v2" // [!code highlight]
+        import { z } from "zod"
 
         export function Page() {
           // ...
@@ -55,14 +56,9 @@ Use frontend tools when you need your agent to interact with client-side primiti
           useHumanInTheLoop({
             name: "humanApprovedCommand",
             description: "Ask human for approval to run a command.",
-            parameters: [
-              {
-                name: "command",
-                type: "string",
-                description: "The command to run",
-                required: true,
-              },
-            ],
+            parameters: z.object({
+              command: z.string().describe("The command to run"),
+            }),
             render: ({ args, respond }) => {
               if (!respond) return <></>;
               return (

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/prebuilt-components.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/prebuilt-components.mdx
@@ -4,4 +4,6 @@ icon: "lucide/SendHorizontal"
 description: "Drop-in chat components for your Microsoft Agent Framework agent."
 ---
 
+import PrebuiltComponents from "@/snippets/shared/basics/prebuilt-components.mdx";
+
 <PrebuiltComponents components={props.components} framework="microsoft-agent-framework-dotnet" />

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/human-in-the-loop.mdx
@@ -50,6 +50,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
 
         ```tsx title="page.tsx"
         import { useHumanInTheLoop } from "@copilotkit/react-core/v2" // [!code highlight]
+        import { z } from "zod"
 
         export function Page() {
           // ...
@@ -57,20 +58,10 @@ Use frontend tools when you need your agent to interact with client-side primiti
           useHumanInTheLoop({
             name: "offerOptions",
             description: "Give the user a choice between two options and have them select one.",
-            parameters: [
-              {
-                name: "option_1",
-                type: "string",
-                description: "The first option",
-                required: true,
-              },
-              {
-                name: "option_2",
-                type: "string",
-                description: "The second option",
-                required: true,
-              },
-            ],
+            parameters: z.object({
+              option_1: z.string().describe("The first option"),
+              option_2: z.string().describe("The second option"),
+            }),
             render: ({ args, respond }) => {
               if (!respond) return <></>;
               return (

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/prebuilt-components.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/prebuilt-components.mdx
@@ -4,4 +4,6 @@ icon: "lucide/SendHorizontal"
 description: "Drop-in chat components for your Pydantic AI agent."
 ---
 
+import PrebuiltComponents from "@/snippets/shared/basics/prebuilt-components.mdx";
+
 <PrebuiltComponents components={props.components} framework="pydantic-ai" />


### PR DESCRIPTION
## Summary

- **6 prebuilt-components pages** were missing their `PrebuiltComponents` import, causing the `inlineSnippets()` regex to skip them and the `framework` prop to be dropped (iframe URLs defaulted to `langgraph` instead of the correct integration)
- **8 HITL pages** had copy-pasted code examples using the deprecated v1 `parameters: [{ name, type }]` array format instead of `parameters: z.object({...})` Zod schemas
- Added a `checkComponentImports()` validation to `verify-shell-docs.ts` to catch missing snippet imports going forward

### Affected pages

**Prebuilt-components** (missing import): agno, aws-strands, crewai-flows, llamaindex, microsoft-agent-framework, pydantic-ai

**HITL code examples** (deprecated params format): adk, ag2, agent-spec, agno, llamaindex, mastra, microsoft-agent-framework, pydantic-ai

## Test plan

- [ ] Serve shell-docs locally (`cd showcase/shell-docs && npx next dev`) and verify prebuilt-components pages render with correct iframe content
- [ ] Verify HITL pages show `parameters: z.object({...})` in code blocks
- [ ] Run `npx tsx showcase/scripts/verify-shell-docs.ts --skip-build` and confirm no component-import warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)