### PR TITLE
chore(showcase): bump @ag-ui/langgraph to 0.0.33 in langgraph-typescript overrides

### DIFF
--- a/showcase/integrations/langgraph-typescript/package-lock.json
+++ b/showcase/integrations/langgraph-typescript/package-lock.json
@@ -8,13 +8,13 @@
       "name": "@copilotkit/showcase-langgraph-typescript",
       "version": "0.1.0",
       "dependencies": {
-        "@copilotkit/a2ui-renderer": "1.57.2",
-        "@copilotkit/react-core": "1.57.2",
-        "@copilotkit/react-ui": "1.57.2",
-        "@copilotkit/runtime": "1.57.2",
-        "@copilotkit/sdk-js": "1.57.2",
-        "@copilotkit/shared": "1.57.2",
-        "@copilotkit/voice": "1.57.2",
+        "@copilotkit/a2ui-renderer": "latest",
+        "@copilotkit/react-core": "latest",
+        "@copilotkit/react-ui": "latest",
+        "@copilotkit/runtime": "latest",
+        "@copilotkit/sdk-js": "latest",
+        "@copilotkit/shared": "latest",
+        "@copilotkit/voice": "latest",
         "@hashbrownai/core": "0.5.0-beta.4",
         "@hashbrownai/react": "0.5.0-beta.4",
         "@json-render/core": "0.18.0",
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@ag-ui/langgraph": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.32.tgz",
-      "integrity": "sha512-fKf4mjlWWhyRy7EhCSgdXt9srXk/RjXcMxUlTxRi4fTcgZLGp6RSqGDaWzFz/0VwKx8WBI5YNDV7d4r88zPz+Q==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.33.tgz",
+      "integrity": "sha512-pK1sJzuwz7KDk9f3aXsuYGlHDemvnGmsWnDTNEDqjBxin0wacVjJtwUKUGGB+rCWmWXq80T0SUzk7Mlckl7eXg==",
       "dependencies": {
         "@langchain/core": "^1.1.40",
         "@langchain/langgraph-sdk": "^1.8.8",
@@ -3268,7 +3268,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0"
@@ -5929,7 +5929,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7859,7 +7858,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11080,7 +11078,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -11099,7 +11097,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -12822,7 +12820,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/showcase/integrations/langgraph-typescript/package.json
+++ b/showcase/integrations/langgraph-typescript/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.7.0"
   },
   "overrides": {
-    "@ag-ui/langgraph": "0.0.32",
+    "@ag-ui/langgraph": "0.0.33",
     "@copilotkit/web-inspector": {
       "@copilotkit/core": "latest"
     }

--- a/showcase/integrations/langgraph-typescript/src/agent/package-lock.json
+++ b/showcase/integrations/langgraph-typescript/src/agent/package-lock.json
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@ag-ui/langgraph": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.32.tgz",
-      "integrity": "sha512-fKf4mjlWWhyRy7EhCSgdXt9srXk/RjXcMxUlTxRi4fTcgZLGp6RSqGDaWzFz/0VwKx8WBI5YNDV7d4r88zPz+Q==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.33.tgz",
+      "integrity": "sha512-pK1sJzuwz7KDk9f3aXsuYGlHDemvnGmsWnDTNEDqjBxin0wacVjJtwUKUGGB+rCWmWXq80T0SUzk7Mlckl7eXg==",
       "dependencies": {
         "@langchain/core": "^1.1.40",
         "@langchain/langgraph-sdk": "^1.8.8",
@@ -1418,6 +1418,64 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",

--- a/showcase/integrations/langgraph-typescript/src/agent/package.json
+++ b/showcase/integrations/langgraph-typescript/src/agent/package.json
@@ -23,6 +23,6 @@
     "@types/node": "^22.9.0"
   },
   "overrides": {
-    "@ag-ui/langgraph": "0.0.32"
+    "@ag-ui/langgraph": "0.0.33"
   }
 }


### PR DESCRIPTION
## Summary

Bumps two showcase-level `@ag-ui/langgraph` override pins from `0.0.32` to `0.0.33`:
- `showcase/integrations/langgraph-typescript/package.json`
- `showcase/integrations/langgraph-typescript/src/agent/package.json`

Regenerates both `package-lock.json` files.

## Why this is needed (after R3b already shipped)

R3b (#5015) bumped `packages/runtime` and `packages/sdk-js` to consume `@ag-ui/langgraph@0.0.33`. But the langgraph-typescript showcase integration pins `@ag-ui/langgraph` directly in its own `package.json` files via `overrides`, which overrides whatever the runtime transitively pulls. Without this PR, the LGT Docker image bakes 0.0.32 and the D6 LGT probe stays RED.

This is the final ag-ui-side bump needed to complete the LGT header-forwarding chain end-to-end.

## What's in @ag-ui/langgraph 0.0.33

(Same as documented in #5015.) Per-request `onRequest` hook, prepareStream configurable+context partition fix for langgraph-api 0.7+, mergeConfigs context_schema allowlist.

## Test plan

- [ ] CI green
- [ ] After merge, `showcase_build.yml` auto-fires (path filter `showcase/**` matches)
- [ ] langgraph-typescript Docker image rebuilds + pushes to GHCR
- [ ] Railway redeploys langgraph-typescript service
- [ ] D6 LGT probe flips GREEN