### PR TITLE
chore(angular): relicense package as MIT

### DIFF
--- a/packages/angular/LICENSE
+++ b/packages/angular/LICENSE
@@ -1,10 +1,21 @@
-Proprietary License
+The MIT License
 
-Copyright 2025 Tawkit Inc.
+Copyright (c) Tawkit Inc.
 
-All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-This software is proprietary and confidential. 
-Unauthorized copying, modification, distribution, or use of this software, 
-via any medium, is strictly prohibited without prior written permission 
-from the copyright holder.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -2,7 +2,7 @@
   "name": "@copilotkitnext/angular",
   "version": "1.54.3",
   "description": "Angular library for CopilotKit",
-  "license": "Commercial",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/CopilotKit/CopilotKit.git",


### PR DESCRIPTION
## Summary
- Switches `packages/angular` from a proprietary "Commercial" license to MIT, aligning it with the rest of the CopilotKit packages.
- Updates `packages/angular/LICENSE` to the MIT text (Copyright (c) Tawkit Inc.) and sets `"license": "MIT"` in `packages/angular/package.json`.

## Test plan
- [ ] CI passes