### PR TITLE
fix(showcase): controlled gen-UI — reliable 2nd-suggestion render + sidebar tag (OSS-137)

### DIFF
--- a/showcase/harness/fixtures/d5/gen-ui-custom.json
+++ b/showcase/harness/fixtures/d5/gen-ui-custom.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "D5 fixture for /demos/gen-ui-tool-based. Two integration families: (1) langgraph-python registers render_pie_chart via useComponent (PieChart SVG donut); (2) all other integrations register generate_haiku via useFrontendTool (HaikuCard div). Uses hasToolResult matching: aimock checks for role:tool messages in the request to disambiguate multi-turn fixtures sharing the same userMessage. Fixtures ordered by hasToolResult false→true for readability.",
+  "_comment": "D5 fixture for /demos/gen-ui-tool-based. Two integration families: (1) langgraph-python registers render_pie_chart via useComponent (PieChart SVG donut); (2) all other integrations register generate_haiku via useFrontendTool (HaikuCard div). Uses hasToolResult matching: aimock checks for role:tool messages in the request to disambiguate multi-turn fixtures sharing the same userMessage. Fixtures ordered by hasToolResult false→true for readability. The 'Sales bar chart' / 'Traffic pie chart' / 'Market share' entries mirror the suggestion chips wired in src/app/demos/gen-ui-tool-based/suggestions.ts for LGP and ADK — keep them in sync with that file so D5 covers the suggestion-click path end-to-end.",
   "fixtures": [
     {
       "match": {
@@ -23,6 +23,78 @@
       },
       "response": {
         "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Show me a bar chart of quarterly sales for Q1, Q2, Q3, Q4.",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_render_bar_chart_sales",
+            "name": "render_bar_chart",
+            "arguments": "{\"title\":\"Quarterly Sales\",\"description\":\"Illustrative quarterly sales figures\",\"data\":[{\"label\":\"Q1\",\"value\":120000},{\"label\":\"Q2\",\"value\":150000},{\"label\":\"Q3\",\"value\":175000},{\"label\":\"Q4\",\"value\":210000}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Show me a bar chart of quarterly sales for Q1, Q2, Q3, Q4.",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Bar chart rendered above — sales grew quarter over quarter, with Q4 the strongest. Values are illustrative samples."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Show me a pie chart of website traffic by source.",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_render_pie_chart_traffic",
+            "name": "render_pie_chart",
+            "arguments": "{\"title\":\"Website Traffic by Source\",\"description\":\"Illustrative traffic breakdown by acquisition channel\",\"data\":[{\"label\":\"Organic Search\",\"value\":45},{\"label\":\"Direct\",\"value\":22},{\"label\":\"Referral\",\"value\":15},{\"label\":\"Social\",\"value\":12},{\"label\":\"Paid\",\"value\":6}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Show me a pie chart of website traffic by source.",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Pie chart rendered above — Organic Search drives most traffic, with Direct and Referral following. Values are illustrative samples."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Show a pie chart of smartphone market share by brand.",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_render_pie_chart_market_share",
+            "name": "render_pie_chart",
+            "arguments": "{\"title\":\"Smartphone Market Share\",\"description\":\"Illustrative global market share by brand\",\"data\":[{\"label\":\"Apple\",\"value\":28},{\"label\":\"Samsung\",\"value\":22},{\"label\":\"Xiaomi\",\"value\":14},{\"label\":\"Oppo\",\"value\":9},{\"label\":\"Other\",\"value\":27}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Show a pie chart of smartphone market share by brand.",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Pie chart rendered above — Apple and Samsung lead, with Xiaomi and Oppo close behind. Values are illustrative samples."
       }
     },
     {

--- a/showcase/integrations/google-adk/manifest.yaml
+++ b/showcase/integrations/google-adk/manifest.yaml
@@ -199,7 +199,7 @@ demos:
     name: Tool-Based Generative UI
     description: Agent uses tools to trigger UI generation
     tags:
-      - generative-ui
+      - controlled-generative-ui
     route: /demos/gen-ui-tool-based
     animated_preview_url:
     highlight:

--- a/showcase/integrations/google-adk/src/agents/gen_ui_tool_based_agent.py
+++ b/showcase/integrations/google-adk/src/agents/gen_ui_tool_based_agent.py
@@ -18,6 +18,13 @@ _INSTRUCTION = (
     "`render_pie_chart` with a concise title, short description, and a "
     "`data` array of `{label, value}` items. Pick bar for comparisons over "
     "a small set of categories; pick pie for composition / share-of-whole.\n\n"
+    "If the user names a chart subject but does NOT supply concrete numbers "
+    "(e.g. \"show me a pie chart of website traffic by source\"), do NOT "
+    "ask them for data. Invent plausible illustrative sample values "
+    "yourself, call the appropriate `render_*` tool immediately, and "
+    "briefly note in the follow-up that the values are illustrative "
+    "samples. Always render the chart on the first turn -- never reply "
+    "with a clarifying question asking for the data.\n\n"
     "Keep chat responses brief -- let the chart do the talking."
 )
 

--- a/showcase/integrations/google-adk/src/agents/gen_ui_tool_based_agent.py
+++ b/showcase/integrations/google-adk/src/agents/gen_ui_tool_based_agent.py
@@ -19,7 +19,7 @@ _INSTRUCTION = (
     "`data` array of `{label, value}` items. Pick bar for comparisons over "
     "a small set of categories; pick pie for composition / share-of-whole.\n\n"
     "If the user names a chart subject but does NOT supply concrete numbers "
-    "(e.g. \"show me a pie chart of website traffic by source\"), do NOT "
+    '(e.g. "show me a pie chart of website traffic by source"), do NOT '
     "ask them for data. Invent plausible illustrative sample values "
     "yourself, call the appropriate `render_*` tool immediately, and "
     "briefly note in the follow-up that the values are illustrative "

--- a/showcase/integrations/langgraph-python/manifest.yaml
+++ b/showcase/integrations/langgraph-python/manifest.yaml
@@ -202,7 +202,7 @@ demos:
     name: "Generative UI: useComponent"
     description: Agent uses tools to trigger UI generation
     tags:
-      - generative-ui
+      - controlled-generative-ui
     route: /demos/gen-ui-tool-based
     animated_preview_url:
     highlight:

--- a/showcase/integrations/langgraph-python/src/agents/gen_ui_tool_based.py
+++ b/showcase/integrations/langgraph-python/src/agents/gen_ui_tool_based.py
@@ -16,6 +16,14 @@ with a concise title, short description, and a `data` array of
 `{label, value}` items. Pick bar for comparisons over a small set of
 categories; pick pie for composition / share-of-whole.
 
+If the user names a chart subject but does NOT supply concrete numbers
+(e.g. "show me a pie chart of website traffic by source"), do NOT ask
+them for data. Invent plausible illustrative sample values yourself,
+call the appropriate `render_*` tool immediately, and briefly note in
+the follow-up that the values are illustrative samples. Always render
+the chart on the first turn -- never reply with a clarifying question
+asking for the data.
+
 Keep chat responses brief -- let the chart do the talking."""
 
 graph = create_agent(

--- a/showcase/shell-dojo/src/app/page.tsx
+++ b/showcase/shell-dojo/src/app/page.tsx
@@ -45,7 +45,6 @@ const FEATURED_DEMO_IDS: readonly string[] = [
   "agentic-chat",
   "chat-customization-css",
   "headless-simple",
-  "gen-ui-tool-based",
   "declarative-gen-ui",
   "mcp-apps",
   "open-gen-ui",
@@ -54,12 +53,29 @@ const FEATURED_DEMO_IDS: readonly string[] = [
 
 // Per-integration extras appended after the base list above.
 // Demos that the integration hasn't wired are silently skipped.
+//
+// `gen-ui-tool-based` (Controlled Generative UI) is scoped here rather than
+// in the global list (OSS-137): the controlled-gen-UI product treatment
+// — reliable sample-data rendering + the "Controlled Generative UI" pill —
+// is only polished for LangGraph Python and Google ADK so far. The other
+// integrations still expose the demo in its category section; it just
+// isn't promoted into Featured until the treatment scales to them.
 const EXTRA_FEATURED_BY_INTEGRATION: Readonly<
   Record<string, readonly string[]>
 > = {
-  "langgraph-python": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
+  "langgraph-python": [
+    "gen-ui-tool-based",
+    "hitl-in-chat",
+    "hitl-in-app",
+    "gen-ui-interrupt",
+  ],
   "langgraph-fastapi": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
-  "google-adk": ["hitl-in-chat", "hitl-in-app", "gen-ui-interrupt"],
+  "google-adk": [
+    "gen-ui-tool-based",
+    "hitl-in-chat",
+    "hitl-in-app",
+    "gen-ui-interrupt",
+  ],
 };
 
 const FEATURED_CATEGORY: FeatureCategory = {


### PR DESCRIPTION
## What & why

[OSS-137](https://linear.app/copilotkit/issue/OSS-137/controlled-gen-ui-demo-optimize-2nd-suggestion-prompt-rename-sidebar) — the **Controlled Generative UI** demo (`gen-ui-tool-based`) had two issues, scoped here to **LangGraph-Python** and **Google ADK** (per the ticket; other 16 integrations roll out later).

### 1. 2nd suggestion didn't reliably render UI
The "Traffic pie chart" chip (`"Show me a pie chart of website traffic by source."`) names a subject but supplies no numbers, so the agent **asked the user for data** instead of rendering a chart.

**Fix:** a system-prompt directive (both LGP + ADK agents) instructing the agent to invent plausible illustrative sample values, call `render_*` immediately, and **never** reply with a clarifying question. The suggestion copy stays clean — behavior is carried by the system prompt, not by leaking "(use sample data)" hints into the UI.

### 2. Sidebar tag → product language
Retagged the demo from `generative-ui` → `controlled-generative-ui` (LGP + ADK), so the dojo sidebar pill reads **"Controlled Generative UI"** — the established taxonomy already used in `shared/feature-registry.json` and the dashboard catalog.

## Tests
Added D5 aimock fixture entries mirroring all three suggestion chips (bar / traffic-pie / market-share) so the suggestion-click path has deterministic coverage. The existing `"revenue by category"` probe message is **preserved**, so the [dashboard](https://dashboard.showcase.copilotkit.ai/#matrix:links,health) D5 row for the edited row stays green.

## Acceptance check
- [x] 2nd suggestion renders UI without asking for data (system-prompt directive; verified locally against the live agent)
- [x] Sidebar entry tagged "Controlled Generative UI"
- [x] Sample/hallucinated data supplied via system prompt
- [x] Scoped to LGP + ADK
- [x] Tests augmented (D5 fixtures for every chip)
- [x] D5 still shown for the edited row (probe message unchanged)

## Out of scope (left out deliberately)
`package-lock.json` churn from a local reinstall (un-pins `latest`) was **not** committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)