### PR TITLE
Wire ms-agent-harness-dotnet for deployment

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -379,7 +379,7 @@ jobs:
           done
 
       - name: Build and push
-        uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1
+        uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
         with:
           project: m2kw2wmmcp
           context: ${{ matrix.service.context }}

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -41,6 +41,7 @@ on:
           - ms-agent-python
           - claude-sdk-typescript
           - ms-agent-dotnet
+          - ms-agent-harness-dotnet
           - claude-sdk-python
           - built-in-agent
           - shell-dojo
@@ -119,6 +120,8 @@ jobs:
               - 'showcase/integrations/claude-sdk-typescript/**'
             ms_agent_dotnet:
               - 'showcase/integrations/ms-agent-dotnet/**'
+            ms_agent_harness_dotnet:
+              - 'showcase/integrations/ms-agent-harness-dotnet/**'
             claude_sdk_python:
               - 'showcase/integrations/claude-sdk-python/**'
             built_in_agent:
@@ -179,6 +182,7 @@ jobs:
             {"dispatch_name":"ms-agent-python","filter_key":"ms_agent_python","context":"showcase/integrations/ms-agent-python","image":"showcase-ms-agent-python","railway_id":"655db75a-af8d-427d-a4f9-441570ae5003","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"claude-sdk-typescript","filter_key":"claude_sdk_typescript","context":"showcase/integrations/claude-sdk-typescript","image":"showcase-claude-sdk-typescript","railway_id":"18a98727-5700-44aa-b497-b60795dbbd6a","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"ms-agent-dotnet","filter_key":"ms_agent_dotnet","context":"showcase/integrations/ms-agent-dotnet","image":"showcase-ms-agent-dotnet","railway_id":"beeb2dd6-87a4-4599-aa07-0578f7bd6519","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"ms-agent-harness-dotnet","filter_key":"ms_agent_harness_dotnet","context":"showcase/integrations/ms-agent-harness-dotnet","image":"showcase-ms-agent-harness-dotnet","railway_id":"6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"claude-sdk-python","filter_key":"claude_sdk_python","context":"showcase/integrations/claude-sdk-python","image":"showcase-claude-sdk-python","railway_id":"b122ab65-9854-4cb2-a68e-b50ff13f7481","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"built-in-agent","filter_key":"built_in_agent","context":"showcase/integrations/built-in-agent","image":"showcase-built-in-agent","railway_id":"f4f8371a-bc46-45b2-b6d4-9c9af608bdbf","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},

--- a/.github/workflows/showcase_build_check.yml
+++ b/.github/workflows/showcase_build_check.yml
@@ -73,6 +73,8 @@ jobs:
               - 'showcase/integrations/claude-sdk-typescript/**'
             ms_agent_dotnet:
               - 'showcase/integrations/ms-agent-dotnet/**'
+            ms_agent_harness_dotnet:
+              - 'showcase/integrations/ms-agent-harness-dotnet/**'
             claude_sdk_python:
               - 'showcase/integrations/claude-sdk-python/**'
             built_in_agent:
@@ -133,6 +135,7 @@ jobs:
             {"dispatch_name":"ms-agent-python","filter_key":"ms_agent_python","context":"showcase/integrations/ms-agent-python","image":"showcase-ms-agent-python","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
             {"dispatch_name":"claude-sdk-typescript","filter_key":"claude_sdk_typescript","context":"showcase/integrations/claude-sdk-typescript","image":"showcase-claude-sdk-typescript","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
             {"dispatch_name":"ms-agent-dotnet","filter_key":"ms_agent_dotnet","context":"showcase/integrations/ms-agent-dotnet","image":"showcase-ms-agent-dotnet","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
+            {"dispatch_name":"ms-agent-harness-dotnet","filter_key":"ms_agent_harness_dotnet","context":"showcase/integrations/ms-agent-harness-dotnet","image":"showcase-ms-agent-harness-dotnet","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
             {"dispatch_name":"claude-sdk-python","filter_key":"claude_sdk_python","context":"showcase/integrations/claude-sdk-python","image":"showcase-claude-sdk-python","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
             {"dispatch_name":"built-in-agent","filter_key":"built_in_agent","context":"showcase/integrations/built-in-agent","image":"showcase-built-in-agent","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
             {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile"},

--- a/.github/workflows/showcase_build_check.yml
+++ b/.github/workflows/showcase_build_check.yml
@@ -239,7 +239,7 @@ jobs:
           done
 
       - name: Build Docker image (no push)
-        uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1
+        uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
         with:
           project: m2kw2wmmcp
           context: ${{ matrix.service.context }}

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -41,6 +41,7 @@ on:
           - ms-agent-python
           - claude-sdk-typescript
           - ms-agent-dotnet
+          - ms-agent-harness-dotnet
           - claude-sdk-python
           - built-in-agent
           - shell-dojo
@@ -110,6 +111,7 @@ jobs:
             {"dispatch_name":"ms-agent-python","railway_id":"655db75a-af8d-427d-a4f9-441570ae5003","health_path":"/api/health"},
             {"dispatch_name":"claude-sdk-typescript","railway_id":"18a98727-5700-44aa-b497-b60795dbbd6a","health_path":"/api/health"},
             {"dispatch_name":"ms-agent-dotnet","railway_id":"beeb2dd6-87a4-4599-aa07-0578f7bd6519","health_path":"/api/health"},
+            {"dispatch_name":"ms-agent-harness-dotnet","railway_id":"6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37","health_path":"/api/health"},
             {"dispatch_name":"claude-sdk-python","railway_id":"b122ab65-9854-4cb2-a68e-b50ff13f7481","health_path":"/api/health"},
             {"dispatch_name":"built-in-agent","railway_id":"f4f8371a-bc46-45b2-b6d4-9c9af608bdbf","health_path":"/api/health"},
             {"dispatch_name":"shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","health_path":"/"},

--- a/.github/workflows/showcase_keep-alive.yml
+++ b/.github/workflows/showcase_keep-alive.yml
@@ -44,6 +44,7 @@ jobs:
           - llamaindex
           - mastra
           - ms-agent-dotnet
+          - ms-agent-harness-dotnet
           - ms-agent-python
           - pydantic-ai
           - spring-ai

--- a/showcase/integrations/ms-agent-harness-dotnet/manifest.yaml
+++ b/showcase/integrations/ms-agent-harness-dotnet/manifest.yaml
@@ -10,7 +10,7 @@ partner_docs: https://docs.copilotkit.ai/microsoft-agent-framework
 repo: https://github.com/CopilotKit/CopilotKit/tree/main/showcase/integrations/ms-agent-harness-dotnet
 copilotkit_version: 2.0.0
 backend_url: https://showcase-ms-agent-harness-dotnet-production.up.railway.app
-deployed: false
+deployed: true
 docs_mode: generated
 sort_order: 165
 generative_ui:


### PR DESCRIPTION
## Summary

Brings the Microsoft Agent Harness (.NET) integration live on the showcase Railway project. Integration code itself landed in #4982; this PR is the deployment wiring.

### What this does

- **Railway service created** (`showcase-ms-agent-harness-dotnet`, id `6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37`) on the showcase project (`6f8c6bff-a80d-4f8f-b78d-50b32bcf4479`, production env `b14919f4-6417-429f-848d-c6ae2201e04f`) with:
  - Public domain `showcase-ms-agent-harness-dotnet-production.up.railway.app` (matches `manifest.yaml` `backend_url`)
  - Image source `ghcr.io/copilotkit/showcase-ms-agent-harness-dotnet:latest`
  - Healthcheck `/api/health`, restart policy `ON_FAILURE`
  - 10 env vars cloned from the sibling `showcase-ms-agent-dotnet` service (`AIMOCK_URL`, `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `GOOGLE_API_KEY`, `GOOGLE_GEMINI_BASE_URL`, `GitHubToken`, `NODE_ENV`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `PORT`)
- **`.github/workflows/showcase_build.yml`** — three matching matrix changes (sibling-mirrored):
  - `workflow_dispatch.inputs.service.options`: add `ms-agent-harness-dotnet`
  - `detect-changes.steps.filter.with.filters`: add `ms_agent_harness_dotnet` watching `showcase/integrations/ms-agent-harness-dotnet/**`
  - `ALL_SERVICES` JSON: add an entry mirroring the `ms-agent-dotnet` sibling (context, image name, railway_id, timeout 15, health_path `/api/health`)
- **`showcase/integrations/ms-agent-harness-dotnet/manifest.yaml`** — flip `deployed: false` -> `deployed: true` so the dashboard surfaces the integration

### Railway mutations executed (audit trail)

```
serviceCreate(name="showcase-ms-agent-harness-dotnet")        -> id 6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37
serviceDomainCreate                                            -> showcase-ms-agent-harness-dotnet-production.up.railway.app
variableCollectionUpsert (10 vars cloned from sibling)         -> true
serviceInstanceUpdate(source=ghcr.io/.../latest, healthcheck=/api/health, restartPolicy=ON_FAILURE) -> true
```

## Test plan

- [ ] CI: `Showcase: Build & Push` runs, builds and pushes `ghcr.io/copilotkit/showcase-ms-agent-harness-dotnet:latest`
- [ ] Build matrix includes `ms-agent-harness-dotnet` (proves filter + ALL_SERVICES wiring is honored)
- [ ] Railway redeploys the service from the new GHCR image (post-merge)
- [ ] `https://showcase-ms-agent-harness-dotnet-production.up.railway.app/api/health` returns 200 (post-deploy)
- [ ] Dashboard surfaces the integration (post-`deployed: true`)