### PR TITLE
chore: Migrate Renovate config to extend local>CopilotKit/renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["local>CopilotKit/renovate"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>CopilotKit/renovate"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,39 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "extends": ["config:recommended"],
-  "poetry": {
-    "enabled": true
-  },
-  "pep621": {
-    "enabled": false
-  },
-  "npm": {
-    "enabled": true
-  },
-  "ignorePaths": ["node_modules"],
-  "packageRules": [
-    {
-      "description": "[All] Ignore all packages initially",
-      "enabled": false,
-      "matchPackageNames": ["*"],
-      "labels": ["dependencies"]
-    },
-    {
-      "description": "[Examples] Enable Renovate for CopilotKit packages only",
-      "enabled": true,
-      "matchFileNames": ["examples/**"],
-      "matchPackageNames": ["/^@copilotkit/", "/^copilotkit/"],
-      "labels": ["examples"],
-      "groupName": "CopilotKit Examples"
-    },
-    {
-      "description": "[@copilotkit/*] Dependencies",
-      "enabled": true,
-      "matchFileNames": ["packages/**"],
-      "matchPackageNames": ["*"],
-      "labels": ["dependencies-core"],
-      "groupName": "Core Dependencies"
-    }
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["local>CopilotKit/renovate"]
 }


### PR DESCRIPTION
Migrates this repo's Renovate configuration to extend the org-wide central config at https://github.com/CopilotKit/renovate.

Phase 1 of the migration ([Notion plan](https://www.notion.so/3613aa38185281a38863fcff2907021c)) scopes Renovate to the github-actions ecosystem only; npm/pip remain on Dependabot.

Replaces the previous renovate.json (which had `extends: config:recommended` plus a global "ignore all packages initially" rule that effectively disabled the prior Renovate install). The new config inherits from the org-wide central preset, which is scoped to github-actions for Phase 1.

Pre-existing open Renovate PRs (#4751, #3295) from the prior install can be closed separately once this lands.