### PR TITLE
fix(monorepo): replace workspace deps during release bump

### DIFF
--- a/scripts/release/lib/versions.test.ts
+++ b/scripts/release/lib/versions.test.ts
@@ -192,7 +192,7 @@ describe("bumpPackages", () => {
     expect(pkg.version).toBe("1.55.3");
   });
 
-  it("preserves workspace:* protocol in dependencies", () => {
+  it("replaces workspace:* protocol dependencies for publishable packages", () => {
     bumpPackages("monorepo", "1.55.3");
 
     const pkg = JSON.parse(
@@ -201,7 +201,7 @@ describe("bumpPackages", () => {
         "utf8",
       ),
     );
-    expect(pkg.dependencies["@copilotkit/shared"]).toBe("workspace:*");
+    expect(pkg.dependencies["@copilotkit/shared"]).toBe("1.55.3");
   });
 
   it("updates exact version deps (not workspace protocol)", () => {

--- a/scripts/release/lib/versions.ts
+++ b/scripts/release/lib/versions.ts
@@ -1,11 +1,7 @@
 import fs from "fs";
 import path from "path";
-import {
-  loadConfig,
-  getScopeConfig,
-  ROOT,
-  type ReleaseScope,
-} from "./config.js";
+import { loadConfig, getScopeConfig, ROOT } from "./config.js";
+import type { ReleaseScope } from "./config.js";
 
 export type BumpLevel = "patch" | "minor" | "major";
 
@@ -47,7 +43,7 @@ export function getCurrentVersion(scope: ReleaseScope): string {
 
 export function parseSemver(version: string): SemVer {
   const match = version.match(
-    /^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z0-9.\-]+))?(?:\+(.+))?$/,
+    /^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z0-9.-]+))?(?:\+(.+))?$/,
   );
   if (!match) {
     throw new Error(`Invalid semver: ${version}`);
@@ -132,8 +128,8 @@ export function bumpPackages(
     const oldVersion = pkg.version;
     pkg.version = newVersion;
 
-    // For shared-version scopes, update internal dependency references —
-    // but only if they use exact versions, not workspace:* protocol
+    // For shared-version scopes, published package manifests must not retain
+    // workspace protocol references that downstream consumers cannot resolve.
     if (scopeConfig.sharedVersion) {
       for (const depField of [
         "dependencies",
@@ -142,8 +138,7 @@ export function bumpPackages(
       ] as const) {
         if (!pkg[depField]) continue;
         for (const depName of Object.keys(pkg[depField])) {
-          const depValue = pkg[depField][depName];
-          if (scopeNames.has(depName) && !depValue.startsWith("workspace:")) {
+          if (scopeNames.has(depName)) {
             pkg[depField][depName] = newVersion;
           }
         }


### PR DESCRIPTION
## What

- Update the shared-version release bump so internal package dependencies are rewritten to the release version even when the source manifest uses `workspace:*`.
- Update the release regression test to assert publishable package manifests do not retain workspace protocol references.

## Why

Fixes #4911. `@copilotkit/web-inspector@1.57.2` was published with `@copilotkit/core: workspace:*`, which downstream pnpm projects cannot resolve outside the CopilotKit workspace.

## Verification

- Pre-fix regression check: `pnpm exec vitest run scripts/release/lib/versions.test.ts` failed with `expected workspace:* to be 1.55.3`.
- `pnpm exec vitest run scripts/release/lib/versions.test.ts`
- `pnpm exec oxfmt --check scripts/release/lib/versions.ts scripts/release/lib/versions.test.ts`
- `pnpm exec oxlint scripts/release/lib/versions.ts scripts/release/lib/versions.test.ts`
- Pre-commit hook completed successfully, including `pnpm test` and package checks (`publint`, `attw`).