### PR TITLE
fix(skills): mark showcase-demo-debugging as internal

### DIFF
--- a/.claude/skills/showcase-demo-debugging/SKILL.md
+++ b/.claude/skills/showcase-demo-debugging/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: showcase-demo-debugging
 description: Build, debug, and regression-test CopilotKit showcase demos. Use when working under showcase/, creating new showcase demos/items/cells/pills, implementing showcase features, investigating showcase demo bugs, D5/e2e-deep failures, aimock fixture gaps, direct-LLM versus aimock behavior, recording fixtures, testing every demo pill/cell, verifying repeated and interleaved suggestion-pill fixture stability, enforcing langgraph-python 1:1 parity, or migrating a demo to the v2 CopilotKit showcase flow.
+metadata:
+  internal: true
 ---
 
 # Showcase Demo Work


### PR DESCRIPTION
## Summary

Adds `metadata.internal: true` to `.claude/skills/showcase-demo-debugging/SKILL.md` so it is hidden from `npx skills add CopilotKit/CopilotKit` public installs.

## Why

`showcase-demo-debugging` is a contributor-only skill (for working on showcase demos, fixtures, and CI regressions). It has no value to a user building a CopilotKit app, but was showing up in the install summary. This brings it in line with `git-hooks` and `copilotkit-demo-parity` which were fixed the same way in PR #4937.

## Change

```yaml
metadata:
  internal: true
```

One field, same pattern as #4937.