### PR TITLE
fix(react-core): preserve generated thread tool followups

### DIFF
--- a/.changeset/ent-658-generated-thread-tool-roundtrip.md
+++ b/.changeset/ent-658-generated-thread-tool-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-core": patch
+---
+
+fix: keep SDK-generated chat threads active across frontend tool follow-up runs

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -218,9 +218,7 @@ export function CopilotChat({
 
   useEffect(() => {
     agent.threadId = resolvedThreadId;
-  }, [agent, resolvedThreadId]);
 
-  useEffect(() => {
     // When the caller hasn't picked a specific thread, resolvedThreadId is a
     // UUID minted locally (either in this CopilotChat or in a wrapping
     // ThreadsProvider). The backend has never seen it, so /connect would
@@ -239,9 +237,9 @@ export function CopilotChat({
       agent.abortController = connectAbortController;
     }
 
-    const connect = async (agent: AbstractAgent) => {
+    const connect = async (agentToConnect: AbstractAgent) => {
       try {
-        await copilotkit.connectAgent({ agent });
+        await copilotkit.connectAgent({ agent: agentToConnect });
       } catch (error) {
         // Ignore errors from aborted connections (e.g., React StrictMode cleanup)
         if (detached) return;

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -1,11 +1,12 @@
 import { useAgent } from "../../hooks/use-agent";
 import { useAttachments } from "../../hooks/use-attachments";
 import { useSuggestions } from "../../hooks/use-suggestions";
-import { CopilotChatView, CopilotChatViewProps } from "./CopilotChatView";
-import { CopilotChatInputMode } from "./CopilotChatInput";
+import type { CopilotChatViewProps } from "./CopilotChatView";
+import { CopilotChatView } from "./CopilotChatView";
+import type { CopilotChatInputMode } from "./CopilotChatInput";
+import type { CopilotChatLabels } from "../../providers/CopilotChatConfigurationProvider";
 import {
   CopilotChatConfigurationProvider,
-  CopilotChatLabels,
   useCopilotChatConfiguration,
 } from "../../providers/CopilotChatConfigurationProvider";
 import {
@@ -14,7 +15,7 @@ import {
   TranscriptionErrorCode,
 } from "@copilotkit/shared";
 import type { AttachmentsConfig, InputContent } from "@copilotkit/shared";
-import { Suggestion, CopilotKitCoreErrorCode } from "@copilotkit/core";
+import type { Suggestion, CopilotKitCoreErrorCode } from "@copilotkit/core";
 import React, {
   useCallback,
   useEffect,
@@ -27,16 +28,16 @@ import {
   useLicenseContext,
 } from "../../providers/CopilotKitProvider";
 import { InlineFeatureWarning } from "../../components/license-warning-banner";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
-import { renderSlot, useShallowStableRef, SlotValue } from "../../lib/slots";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
+import type { SlotValue } from "../../lib/slots";
+import { renderSlot, useShallowStableRef } from "../../lib/slots";
 import {
   transcribeAudio,
   TranscriptionError,
 } from "../../lib/transcription-client";
-import {
-  LastUserMessageContext,
-  type LastUserMessageState,
-} from "./last-user-message-context";
+import { LastUserMessageContext } from "./last-user-message-context";
+import type { LastUserMessageState } from "./last-user-message-context";
 
 export type CopilotChatProps = Omit<
   CopilotChatViewProps,
@@ -216,6 +217,10 @@ export function CopilotChat({
     hasExplicitThreadId && lastConnectedThreadId !== resolvedThreadId;
 
   useEffect(() => {
+    agent.threadId = resolvedThreadId;
+  }, [agent, resolvedThreadId]);
+
+  useEffect(() => {
     // When the caller hasn't picked a specific thread, resolvedThreadId is a
     // UUID minted locally (either in this CopilotChat or in a wrapping
     // ThreadsProvider). The backend has never seen it, so /connect would
@@ -233,8 +238,6 @@ export function CopilotChat({
     if (agent instanceof HttpAgent) {
       agent.abortController = connectAbortController;
     }
-
-    agent.threadId = resolvedThreadId;
 
     const connect = async (agent: AbstractAgent) => {
       try {

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -217,6 +217,8 @@ export function CopilotChat({
     hasExplicitThreadId && lastConnectedThreadId !== resolvedThreadId;
 
   useEffect(() => {
+    // Non-explicit threads skip /connect, but the first runAgent still has to
+    // ship the same SDK-generated threadId that the chat UI is rendering.
     agent.threadId = resolvedThreadId;
 
     // When the caller hasn't picked a specific thread, resolvedThreadId is a

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
@@ -2,11 +2,18 @@ import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { EMPTY, Observable } from "rxjs";
-import { EventType } from "@ag-ui/client";
+import { z } from "zod";
 import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
-import { MockStepwiseAgent } from "../../../__tests__/utils/test-helpers";
+import {
+  MockStepwiseAgent,
+  runFinishedEvent,
+  runStartedEvent,
+  textChunkEvent,
+  toolCallChunkEvent,
+} from "../../../__tests__/utils/test-helpers";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+import { useFrontendTool } from "../../../hooks/use-frontend-tool";
 import { CopilotChat } from "../CopilotChat";
 import type { ReactFrontendTool } from "../../../types";
 
@@ -49,6 +56,7 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
 
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(connectSpy).toHaveBeenCalled();
+    expect(connectSpy.mock.calls[0][0].threadId).toBe("user-thread-abc");
   });
 
   it("calls connect() when a threadId is supplied via configuration provider", async () => {
@@ -64,6 +72,7 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
 
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(connectSpy).toHaveBeenCalled();
+    expect(connectSpy.mock.calls[0][0].threadId).toBe("config-thread-xyz");
   });
 
   it("uses the SDK-generated threadId for frontend tool follow-up runs", async () => {
@@ -76,38 +85,38 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
 
         return new Observable<BaseEvent>((subscriber) => {
           queueMicrotask(() => {
-            subscriber.next({ type: EventType.RUN_STARTED } as BaseEvent);
+            subscriber.next(runStartedEvent());
             if (runNumber === 1) {
-              subscriber.next({
-                type: EventType.TEXT_MESSAGE_CHUNK,
-                messageId: "assistant-tool",
-                delta: "Calling frontend tool.",
-              } as BaseEvent);
-              subscriber.next({
-                type: EventType.TOOL_CALL_CHUNK,
-                toolCallId: "tc-sdk-generated-thread",
-                toolCallName: "testFrontendToolCalling",
-                parentMessageId: "assistant-tool",
-                delta: '{"label":"X"}',
-              } as BaseEvent);
+              subscriber.next(
+                textChunkEvent("assistant-tool", "Calling frontend tool."),
+              );
+              subscriber.next(
+                toolCallChunkEvent({
+                  parentMessageId: "assistant-tool",
+                  delta: '{"label":"X"}',
+                  toolCallId: "tc-sdk-generated-thread",
+                  toolCallName: "testFrontendToolCalling",
+                }),
+              );
             } else {
-              subscriber.next({
-                type: EventType.TEXT_MESSAGE_CHUNK,
-                messageId: "assistant-final",
-                delta: "Frontend tool finished for X.",
-              } as BaseEvent);
+              subscriber.next(
+                textChunkEvent(
+                  "assistant-final",
+                  "Frontend tool finished for X.",
+                ),
+              );
             }
-            subscriber.next({ type: EventType.RUN_FINISHED } as BaseEvent);
+            subscriber.next(runFinishedEvent());
             subscriber.complete();
           });
         });
       }
     }
 
-    const agent = new FrontendToolRoundTripAgent();
-    const frontendTools: ReactFrontendTool[] = [
-      {
+    function FrontendToolRegistration() {
+      const frontendTool: ReactFrontendTool<{ label: string }> = {
         name: "testFrontendToolCalling",
+        parameters: z.object({ label: z.string() }),
         followUp: true,
         handler: async ({ label }) => `handled ${String(label)}`,
         render: ({ args, result }) => (
@@ -115,18 +124,20 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
             {String(args.label)}:{String(result ?? "pending")}
           </div>
         ),
-      },
-    ];
+      };
+      useFrontendTool(frontendTool);
+      return null;
+    }
+
+    const agent = new FrontendToolRoundTripAgent();
 
     render(
-      <CopilotKitProvider
-        agents__unsafe_dev_only={{ default: agent }}
-        frontendTools={frontendTools}
-      >
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
         <CopilotChatConfigurationProvider
           threadId="sdk-generated-thread"
           hasExplicitThreadId={false}
         >
+          <FrontendToolRegistration />
           <CopilotChat welcomeScreen={false} />
         </CopilotChatConfigurationProvider>
       </CopilotKitProvider>,
@@ -156,9 +167,11 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
         }),
       ]),
     );
-    expect(
-      screen.getByTestId("copilot-tool-render").getAttribute("data-result"),
-    ).toBe("handled X");
+    await waitFor(() => {
+      expect(screen.getByTestId("frontend-tool-card").textContent).toBe(
+        "X:handled X",
+      );
+    });
     expect(
       agent.messages.some(
         (message) =>

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { EMPTY, Observable } from "rxjs";
-import { type BaseEvent, type RunAgentInput } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
 import { MockStepwiseAgent } from "../../../__tests__/utils/test-helpers";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
 import { CopilotChat } from "../CopilotChat";
+import type { ReactFrontendTool } from "../../../types";
 
 describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)", () => {
   function buildAgentWithConnectSpy(): {
@@ -62,5 +64,107 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
 
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(connectSpy).toHaveBeenCalled();
+  });
+
+  it("uses the SDK-generated threadId for frontend tool follow-up runs", async () => {
+    class FrontendToolRoundTripAgent extends MockStepwiseAgent {
+      runInputs: RunAgentInput[] = [];
+
+      run(input: RunAgentInput): Observable<BaseEvent> {
+        this.runInputs.push(input);
+        const runNumber = this.runInputs.length;
+
+        return new Observable<BaseEvent>((subscriber) => {
+          queueMicrotask(() => {
+            subscriber.next({ type: EventType.RUN_STARTED } as BaseEvent);
+            if (runNumber === 1) {
+              subscriber.next({
+                type: EventType.TEXT_MESSAGE_CHUNK,
+                messageId: "assistant-tool",
+                delta: "Calling frontend tool.",
+              } as BaseEvent);
+              subscriber.next({
+                type: EventType.TOOL_CALL_CHUNK,
+                toolCallId: "tc-sdk-generated-thread",
+                toolCallName: "testFrontendToolCalling",
+                parentMessageId: "assistant-tool",
+                delta: '{"label":"X"}',
+              } as BaseEvent);
+            } else {
+              subscriber.next({
+                type: EventType.TEXT_MESSAGE_CHUNK,
+                messageId: "assistant-final",
+                delta: "Frontend tool finished for X.",
+              } as BaseEvent);
+            }
+            subscriber.next({ type: EventType.RUN_FINISHED } as BaseEvent);
+            subscriber.complete();
+          });
+        });
+      }
+    }
+
+    const agent = new FrontendToolRoundTripAgent();
+    const frontendTools: ReactFrontendTool[] = [
+      {
+        name: "testFrontendToolCalling",
+        followUp: true,
+        handler: async ({ label }) => `handled ${String(label)}`,
+        render: ({ args, result }) => (
+          <div data-testid="frontend-tool-card">
+            {String(args.label)}:{String(result ?? "pending")}
+          </div>
+        ),
+      },
+    ];
+
+    render(
+      <CopilotKitProvider
+        agents__unsafe_dev_only={{ default: agent }}
+        frontendTools={frontendTools}
+      >
+        <CopilotChatConfigurationProvider
+          threadId="sdk-generated-thread"
+          hasExplicitThreadId={false}
+        >
+          <CopilotChat welcomeScreen={false} />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, {
+      target: {
+        value: "invoke testFrontendToolCalling with label X",
+      },
+    });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(agent.runInputs).toHaveLength(2);
+    });
+
+    expect(agent.runInputs.map((runInput) => runInput.threadId)).toEqual([
+      "sdk-generated-thread",
+      "sdk-generated-thread",
+    ]);
+    expect(agent.runInputs[0].messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: "invoke testFrontendToolCalling with label X",
+        }),
+      ]),
+    );
+    expect(
+      screen.getByTestId("copilot-tool-render").getAttribute("data-result"),
+    ).toBe("handled X");
+    expect(
+      agent.messages.some(
+        (message) =>
+          message.role === "assistant" &&
+          message.content === "Frontend tool finished for X.",
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -56,9 +56,11 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 const HEADER_NAME = "X-CopilotCloud-Public-Api-Key";
 const COPILOT_CLOUD_CHAT_URL = "https://api.cloud.copilotkit.ai/copilotkit/v1";
-const EMPTY_HEADERS: Record<string, string> = {};
-const EMPTY_PROPERTIES: Record<string, unknown> = {};
-const EMPTY_AGENTS: Record<string, AbstractAgent> = {};
+// Stable frozen defaults keep provider effects from re-running just because a
+// caller omitted an object prop on a rerender.
+const EMPTY_HEADERS: Readonly<Record<string, string>> = Object.freeze({});
+const EMPTY_PROPERTIES: Readonly<Record<string, unknown>> = Object.freeze({});
+const EMPTY_AGENTS: Readonly<Record<string, AbstractAgent>> = Object.freeze({});
 
 const DEFAULT_DESIGN_SKILL = `When generating UI with generateSandboxedUi, follow these design principles inspired by shadcn/ui:
 

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -4,7 +4,6 @@ import type { AbstractAgent } from "@ag-ui/client";
 import type { FrontendTool } from "@copilotkit/core";
 import type React from "react";
 import {
-  type ReactNode,
   useMemo,
   useEffect,
   useLayoutEffect,
@@ -12,23 +11,18 @@ import {
   useRef,
   useState,
 } from "react";
+import type { ReactNode } from "react";
 // Context extracted to ../context.ts for cross-platform reuse (React Native)
-import {
-  CopilotKitContext,
-  type CopilotKitContextValue,
-  LicenseContext,
-} from "../context";
+import { CopilotKitContext, LicenseContext } from "../context";
+import type { CopilotKitContextValue } from "../context";
 export type { CopilotKitContextValue } from "../context";
 export { CopilotKitContext, useLicenseContext } from "../context";
 import { z } from "zod";
 import { CopilotKitInspector } from "../components/CopilotKitInspector";
 import type { Anchor } from "@copilotkit/web-inspector";
 import { LicenseWarningBanner } from "../components/license-warning-banner";
-import {
-  createLicenseContextValue,
-  type LicenseContextValue,
-  type DebugConfig,
-} from "@copilotkit/shared";
+import { createLicenseContextValue } from "@copilotkit/shared";
+import type { LicenseContextValue, DebugConfig } from "@copilotkit/shared";
 import type { CopilotKitCoreErrorCode } from "@copilotkit/core";
 import {
   MCPAppsActivityContentSchema,
@@ -62,6 +56,9 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 const HEADER_NAME = "X-CopilotCloud-Public-Api-Key";
 const COPILOT_CLOUD_CHAT_URL = "https://api.cloud.copilotkit.ai/copilotkit/v1";
+const EMPTY_HEADERS: Record<string, string> = {};
+const EMPTY_PROPERTIES: Record<string, unknown> = {};
+const EMPTY_AGENTS: Record<string, AbstractAgent> = {};
 
 const DEFAULT_DESIGN_SKILL = `When generating UI with generateSandboxedUi, follow these design principles inspired by shadcn/ui:
 
@@ -246,14 +243,14 @@ function useStableArrayProp<T>(
 export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   children,
   runtimeUrl,
-  headers: headersProp = {},
+  headers: headersProp = EMPTY_HEADERS,
   credentials,
   publicApiKey,
   publicLicenseKey,
   licenseToken,
-  properties = {},
-  agents__unsafe_dev_only: agents = {},
-  selfManagedAgents = {},
+  properties = EMPTY_PROPERTIES,
+  agents__unsafe_dev_only: agents = EMPTY_AGENTS,
+  selfManagedAgents = EMPTY_AGENTS,
   renderToolCalls,
   renderActivityMessages,
   renderCustomMessages,

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.stability.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.stability.test.tsx
@@ -146,19 +146,26 @@ describe("CopilotKitProvider stability", () => {
   });
 
   describe("setter calls on prop changes", () => {
-    it("does not re-sync an empty local agent registry on unchanged rerenders", () => {
-      const setAgentsCalls: unknown[] = [];
+    it("preserves dynamically registered agents on unchanged rerenders", () => {
+      const setAgentsSpy = vi.fn();
       let spyAttached = false;
+      let registeredAgent: unknown;
+      let capturedInstance: CopilotKitCoreReact | null = null;
 
       function SpyAttacher() {
         const { copilotkit } = useCopilotKit();
+        capturedInstance = copilotkit;
         if (!spyAttached) {
           const original =
             copilotkit.setAgents__unsafe_dev_only.bind(copilotkit);
           copilotkit.setAgents__unsafe_dev_only = (agents) => {
-            setAgentsCalls.push(agents);
+            setAgentsSpy(agents);
             return original(agents);
           };
+          registeredAgent = copilotkit.registerProxiedAgent({
+            agentId: "registered-after-mount",
+            runtimeAgentId: "remote-agent",
+          }).agent;
           spyAttached = true;
         }
         return null;
@@ -170,7 +177,7 @@ describe("CopilotKitProvider stability", () => {
         </CopilotKitProvider>,
       );
 
-      setAgentsCalls.length = 0;
+      setAgentsSpy.mockClear();
 
       rerender(
         <CopilotKitProvider runtimeUrl="http://localhost:3000/api">
@@ -178,7 +185,10 @@ describe("CopilotKitProvider stability", () => {
         </CopilotKitProvider>,
       );
 
-      expect(setAgentsCalls).toHaveLength(0);
+      expect(setAgentsSpy).not.toHaveBeenCalled();
+      expect(capturedInstance?.getAgent("registered-after-mount")).toBe(
+        registeredAgent,
+      );
     });
 
     it("calls setTools when frontendTools change instead of recreating instance", () => {

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.stability.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.stability.test.tsx
@@ -4,12 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import type { ReactFrontendTool } from "../../types/frontend-tool";
 import type { ReactToolCallRenderer } from "../../types";
-import {
-  CopilotKitProvider,
-  useCopilotKit,
-  type CopilotKitContextValue,
-} from "../CopilotKitProvider";
-import { CopilotKitCoreReact } from "../../lib/react-core";
+import { CopilotKitProvider, useCopilotKit } from "../CopilotKitProvider";
+import type { CopilotKitContextValue } from "../CopilotKitProvider";
+import type { CopilotKitCoreReact } from "../../lib/react-core";
 import { useFrontendTool } from "../../hooks/use-frontend-tool";
 
 // Mock console methods to suppress expected warnings
@@ -149,6 +146,41 @@ describe("CopilotKitProvider stability", () => {
   });
 
   describe("setter calls on prop changes", () => {
+    it("does not re-sync an empty local agent registry on unchanged rerenders", () => {
+      const setAgentsCalls: unknown[] = [];
+      let spyAttached = false;
+
+      function SpyAttacher() {
+        const { copilotkit } = useCopilotKit();
+        if (!spyAttached) {
+          const original =
+            copilotkit.setAgents__unsafe_dev_only.bind(copilotkit);
+          copilotkit.setAgents__unsafe_dev_only = (agents) => {
+            setAgentsCalls.push(agents);
+            return original(agents);
+          };
+          spyAttached = true;
+        }
+        return null;
+      }
+
+      const { rerender } = render(
+        <CopilotKitProvider runtimeUrl="http://localhost:3000/api">
+          <SpyAttacher />
+        </CopilotKitProvider>,
+      );
+
+      setAgentsCalls.length = 0;
+
+      rerender(
+        <CopilotKitProvider runtimeUrl="http://localhost:3000/api">
+          <SpyAttacher />
+        </CopilotKitProvider>,
+      );
+
+      expect(setAgentsCalls).toHaveLength(0);
+    });
+
     it("calls setTools when frontendTools change instead of recreating instance", () => {
       const setToolsSpy = vi.fn();
       let spyAttached = false;

--- a/showcase/aimock/d6/langgraph-python/threadid-frontend-tool-roundtrip.json
+++ b/showcase/aimock/d6/langgraph-python/threadid-frontend-tool-roundtrip.json
@@ -1,0 +1,34 @@
+{
+  "_meta": {
+    "description": "ENT-658 regression fixture for langgraph-python /demos/threadid-frontend-tool-roundtrip. First turn emits a frontend tool call; follow-up turn confirms the tool result without changing threads.",
+    "created": "2026-05-27"
+  },
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "invoke testFrontendToolCalling with label X",
+        "toolCallId": "call_ent_658_test_frontend_tool_x"
+      },
+      "response": {
+        "content": "Frontend tool finished for X."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "invoke testFrontendToolCalling with label X"
+      },
+      "response": {
+        "content": "Calling frontend tool.",
+        "toolCalls": [
+          {
+            "id": "call_ent_658_test_frontend_tool_x",
+            "name": "testFrontendToolCalling",
+            "arguments": {
+              "label": "X"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/showcase/integrations/langgraph-python/qa/threadid-frontend-tool-roundtrip.md
+++ b/showcase/integrations/langgraph-python/qa/threadid-frontend-tool-roundtrip.md
@@ -16,8 +16,12 @@ thread active across a frontend tool call and follow-up run.
       `label: X` and `result: handled X`.
 - [ ] Verify the assistant reply `Frontend tool finished for X.` appears.
 - [ ] Verify the chat does not return to the empty state.
-- [ ] Check `Explicit threadId`, send the same prompt again, and verify the
-      same message/tool/reply persistence behavior.
+- [ ] Refresh the page or open a new tab, check `Explicit threadId` before
+      sending any message, send the same prompt again, and verify the same
+      message/tool/reply persistence behavior.
+- [ ] Optionally toggle `Explicit threadId` after a generated-thread
+      conversation and verify the chat switches to the explicit thread's
+      history. An empty explicit thread on first use is expected.
 
 ## Automated Coverage
 

--- a/showcase/integrations/langgraph-python/qa/threadid-frontend-tool-roundtrip.md
+++ b/showcase/integrations/langgraph-python/qa/threadid-frontend-tool-roundtrip.md
@@ -1,0 +1,27 @@
+# Thread ID Frontend Tool Round Trip
+
+## Scope
+
+Regression checklist for ENT-658: a `CopilotChat` wrapped by
+`CopilotChatConfigurationProvider` must keep its SDK-generated non-explicit
+thread active across a frontend tool call and follow-up run.
+
+## Manual QA
+
+- [ ] Navigate to `/demos/threadid-frontend-tool-roundtrip`.
+- [ ] Verify the chat input is visible and `Explicit threadId` is unchecked.
+- [ ] Send `invoke testFrontendToolCalling with label X`.
+- [ ] Verify the user message remains visible.
+- [ ] Verify the `testFrontendToolCalling` card remains visible and shows
+      `label: X` and `result: handled X`.
+- [ ] Verify the assistant reply `Frontend tool finished for X.` appears.
+- [ ] Verify the chat does not return to the empty state.
+- [ ] Check `Explicit threadId`, send the same prompt again, and verify the
+      same message/tool/reply persistence behavior.
+
+## Automated Coverage
+
+- `tests/e2e/threadid-frontend-tool-roundtrip.spec.ts` covers the demo route,
+  generated-thread default state, and explicit-thread toggle.
+- `packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx`
+  covers the SDK-generated thread handoff at the component level.

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit/route.ts
@@ -74,6 +74,7 @@ agents["subagents"] = createAgent("subagents");
 // split out of main.py so main.py stays a pure default).
 agents["agentic_chat"] = createAgent("agentic_chat");
 agents["frontend_tools"] = createAgent("frontend_tools");
+agents["threadid-frontend-tool-roundtrip"] = createAgent("frontend_tools");
 // Frontend Tools (Async) — dedicated cell demonstrating an async useFrontendTool
 // handler (simulated client-side notes DB query). Backend has no tools; the
 // frontend registers `query_notes` via useFrontendTool and the agent awaits

--- a/showcase/integrations/langgraph-python/src/app/demos/threadid-frontend-tool-roundtrip/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/threadid-frontend-tool-roundtrip/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import {
+  CopilotChat,
+  CopilotChatConfigurationProvider,
+  CopilotKit,
+  useFrontendTool,
+} from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+const AGENT_ID = "threadid-frontend-tool-roundtrip";
+
+function ThreadIdRoundTripChat() {
+  const [explicitThreadId, setExplicitThreadId] = useState(false);
+  const fixedThreadId = useMemo(() => "ent-658-explicit-thread", []);
+
+  return (
+    <div className="flex h-full flex-col bg-slate-950 text-white">
+      <div className="flex items-center justify-between gap-4 border-b border-white/10 px-6 py-4">
+        <div>
+          <h1 className="text-base font-semibold">
+            Frontend Tool Thread Round Trip
+          </h1>
+          <p
+            className="mt-1 text-sm text-slate-300"
+            data-testid="ent-658-thread-mode"
+          >
+            {explicitThreadId ? "Explicit thread" : "SDK-generated thread"}
+          </p>
+        </div>
+        <label className="flex items-center gap-3 text-sm text-slate-100">
+          <input
+            aria-label="Explicit threadId"
+            checked={explicitThreadId}
+            className="h-4 w-4 accent-cyan-400"
+            onChange={(event) => setExplicitThreadId(event.target.checked)}
+            type="checkbox"
+          />
+          Explicit threadId
+        </label>
+      </div>
+
+      <div className="min-h-0 flex-1 px-6 py-5">
+        <CopilotChatConfigurationProvider
+          key={explicitThreadId ? "explicit-thread" : "generated-thread"}
+          agentId={AGENT_ID}
+          {...(explicitThreadId
+            ? { threadId: fixedThreadId, hasExplicitThreadId: true }
+            : {})}
+        >
+          <FrontendToolRegistration />
+          <CopilotChat
+            agentId={AGENT_ID}
+            className="h-full rounded-2xl border border-white/10 bg-white text-slate-950"
+            welcomeScreen={false}
+          />
+        </CopilotChatConfigurationProvider>
+      </div>
+    </div>
+  );
+}
+
+function FrontendToolRegistration() {
+  useFrontendTool({
+    name: "testFrontendToolCalling",
+    description: "Return the label that was supplied by the user.",
+    parameters: z.object({
+      label: z.string().describe("The label to echo in the tool result."),
+    }),
+    followUp: true,
+    handler: async ({ label }) => `handled ${label}`,
+    render: ({ args, result }) => (
+      <div
+        className="rounded-xl border border-cyan-200 bg-cyan-50 px-4 py-3 text-sm text-cyan-950"
+        data-testid="ent-658-tool-card"
+      >
+        <div className="font-semibold">testFrontendToolCalling</div>
+        <div>label: {args.label}</div>
+        <div>result: {String(result ?? "pending")}</div>
+      </div>
+    ),
+  });
+
+  return null;
+}
+
+export default function ThreadIdFrontendToolRoundTripDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+      <ThreadIdRoundTripChat />
+    </CopilotKit>
+  );
+}

--- a/showcase/integrations/langgraph-python/src/app/demos/threadid-frontend-tool-roundtrip/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/threadid-frontend-tool-roundtrip/page.tsx
@@ -10,7 +10,7 @@ import {
 import { z } from "zod";
 
 const AGENT_ID = "threadid-frontend-tool-roundtrip";
-const FIXED_THREAD_ID = "ent-658-explicit-thread";
+const FIXED_THREAD_ID = "a9e7e9c4-6c72-4b8a-9d74-c5c0e05f6580";
 
 function ThreadIdRoundTripChat() {
   const [explicitThreadId, setExplicitThreadId] = useState(false);

--- a/showcase/integrations/langgraph-python/src/app/demos/threadid-frontend-tool-roundtrip/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/threadid-frontend-tool-roundtrip/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import {
   CopilotChat,
   CopilotChatConfigurationProvider,
@@ -10,10 +10,10 @@ import {
 import { z } from "zod";
 
 const AGENT_ID = "threadid-frontend-tool-roundtrip";
+const FIXED_THREAD_ID = "ent-658-explicit-thread";
 
 function ThreadIdRoundTripChat() {
   const [explicitThreadId, setExplicitThreadId] = useState(false);
-  const fixedThreadId = useMemo(() => "ent-658-explicit-thread", []);
 
   return (
     <div className="flex h-full flex-col bg-slate-950 text-white">
@@ -46,7 +46,7 @@ function ThreadIdRoundTripChat() {
           key={explicitThreadId ? "explicit-thread" : "generated-thread"}
           agentId={AGENT_ID}
           {...(explicitThreadId
-            ? { threadId: fixedThreadId, hasExplicitThreadId: true }
+            ? { threadId: FIXED_THREAD_ID, hasExplicitThreadId: true }
             : {})}
         >
           <FrontendToolRegistration />

--- a/showcase/integrations/langgraph-python/tests/e2e/threadid-frontend-tool-roundtrip.spec.ts
+++ b/showcase/integrations/langgraph-python/tests/e2e/threadid-frontend-tool-roundtrip.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+// QA reference: qa/threadid-frontend-tool-roundtrip.md
+// Demo source: src/app/demos/threadid-frontend-tool-roundtrip/page.tsx
+//
+// The source-level regression for ENT-658 lives in react-core. This smoke keeps
+// the showcase demo route and generated-thread toggle covered without depending
+// on fixture-driven tool execution in the standalone showcase package.
+
+test.describe("Thread ID frontend-tool round trip", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/threadid-frontend-tool-roundtrip");
+  });
+
+  test("page loads with generated-thread mode selected", async ({ page }) => {
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+    await expect(page.getByLabel("Explicit threadId")).not.toBeChecked();
+    await expect(page.getByTestId("ent-658-thread-mode")).toHaveText(
+      /SDK-generated thread/i,
+    );
+
+    await page.getByLabel("Explicit threadId").check();
+    await expect(page.getByTestId("ent-658-thread-mode")).toHaveText(
+      /explicit thread/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep `CopilotChat` agents aligned to SDK-generated thread IDs even when `/connect` is intentionally skipped for non-explicit threads
- stabilize `CopilotKitProvider` default object props so rerenders do not re-sync an empty local agent registry and replace the live remote/Intelligence agent mid-run
- add regression coverage for SDK-generated thread frontend-tool follow-up runs and provider empty-agent rerender stability
- add a focused langgraph-python showcase demo, aimock fixture, Playwright smoke, and QA checklist for ENT-658
- add a patch changeset for `@copilotkit/react-core`

## Testing
- `npx nx run @copilotkit/react-core:test -- src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx`
- `npx nx run @copilotkit/react-core:test -- src/v2/providers/__tests__/CopilotKitProvider.stability.test.tsx`
- Pre-commit hook passed: `pnpm run test` and `pnpm run check:packages`
- Verified exact `CopilotKit/Intelligence` repro branch `mme/threadid-repro`: unchecked `Explicit threadId`, sent `invoke testFrontendToolCalling with label X`, confirmed user message/tool card/assistant reply remain visible
- Verified the same Intelligence repro with `Explicit threadId` checked
- `pnpm exec playwright test tests/e2e/threadid-frontend-tool-roundtrip.spec.ts --project=chromium --workers=1` from `showcase/integrations/langgraph-python`

## QA Checklist
- [x] Reproduce the reset in `CopilotKit/Intelligence` branch `mme/threadid-repro` with `Explicit threadId` unchecked
- [x] Confirm generated-thread frontend-tool round-trip preserves the user message, tool card, and assistant response
- [x] Confirm explicit-thread frontend-tool round-trip still preserves the user message, tool card, and assistant response
- [x] Open `/demos/threadid-frontend-tool-roundtrip` in the langgraph-python showcase demo
- [x] Confirm `Explicit threadId` is unchecked and the chat starts in SDK-generated thread mode
- [x] Send `invoke testFrontendToolCalling with label X`
- [x] Confirm the user message remains visible
- [x] Confirm the `testFrontendToolCalling` card remains visible and shows `label: X` plus `result: handled X`
- [x] Confirm the assistant reply `Frontend tool finished for X.` appears
- [x] Confirm the chat does not return to the empty state
- [x] Repeat with `Explicit threadId` checked and confirm the explicit-thread path is unchanged

## Notes
The visible reset had two frontend-side causes. First, the chat and agent could diverge when the SDK generated the thread ID. Second, in Intelligence mode, provider rerenders could re-sync an empty local agent registry and replace the live remote agent instance mid-run, dropping the in-memory chat stream. Both fixes live in `@copilotkit/react-core`.

The Playwright file is intentionally a smoke test for the demo route/toggle. The source-level regressions live in `CopilotChat.absentThreadConnect.test.tsx` and `CopilotKitProvider.stability.test.tsx`.