### PR TITLE
fix(ci): exclude node_modules from prerelease workspace artifact

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -74,11 +74,24 @@ jobs:
       - name: Run tests
         run: pnpm run test
 
+      # Exclude node_modules and build caches from the artifact. Including
+      # them produces ~6M files for this monorepo, which OOMs
+      # upload-artifact's Node process at its 4GB heap limit during
+      # enumeration (each pnpm symlink resolves to a separate entry, and
+      # the action holds the full manifest in memory before streaming).
+      # The publish job runs `pnpm install --frozen-lockfile` after
+      # download to restore node_modules from pnpm-lock.yaml — mirrors
+      # publish-release.yml.
       - name: Upload workspace
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workspace
-          path: .
+          path: |
+            .
+            !**/node_modules/**
+            !**/.next/**
+            !**/.turbo/**
+            !**/.nx/**
           include-hidden-files: true
           retention-days: 1
 
@@ -106,6 +119,14 @@ jobs:
         with:
           node-version: 22.x
           registry-url: https://registry.npmjs.org
+
+      # Restore node_modules — the build job excludes them from the
+      # uploaded workspace artifact (see "Upload workspace" above). Uses
+      # pnpm-lock.yaml from the artifact, so this is a deterministic
+      # restore of exactly what the build job ran with. `pnpm tsx` in the
+      # publish step below requires tsx to be installed locally.
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Publish prerelease
         env:


### PR DESCRIPTION
## Summary

- The `release / pre` workflow has been failing on every run since commit 770759a4be ("fix(ci): separate build and publish jobs in release workflows", May 11). The `Upload workspace` step hits a JS heap OOM in `actions/upload-artifact@v7` after enumerating 5,923,811 files.
- Root cause: the build → publish handoff uses `path: .` + `include-hidden-files: true`, which packs the entire workspace **after `pnpm install`** — including every `node_modules/`, every nested `.pnpm/` store entry (symlinks materialized), `.next`, `.turbo`, `.nx` caches, plus every `examples/*/node_modules` and showcase app subtree. The action holds the full manifest in memory before streaming → ~4GB heap, OOM.
- `publish-release.yml` already encountered this and was patched: it excludes `node_modules`/`.next`/`.turbo`/`.nx` and re-runs `pnpm install --frozen-lockfile` in the publish job. This PR ports the same pattern to `prerelease.yml` — no novel design.

## Why this preserves the security split

The original 770759a4be change separated `build` and `publish` so `NPM_TOKEN` is only in the publish job's process tree, preventing token exfiltration from build-time code. That property is untouched: the artifact still carries pre-built `dist/` directories with the already-bumped versions, and the publish job still runs only the publish script. The `pnpm install --frozen-lockfile` in the publish job runs against the same `pnpm-lock.yaml` carried in the artifact — deterministic and at the same versions the build job validated.

## Test plan

- [ ] Trigger a `release / pre` run with `--dry-run=true` against this branch — expect `Upload workspace` to complete in seconds instead of OOMing after 11 minutes.
- [ ] Verify the `Publish prerelease` step still finds `tsx` and `pnpm pack` works (i.e. the added `Install Dependencies` step restores node_modules correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)