### PR TITLE
fix(showcase/pocketbase): register CORS via routerPre and lock down baseline.createRule

### DIFF
--- a/showcase/pocketbase/pb_hooks/main.pb.js
+++ b/showcase/pocketbase/pb_hooks/main.pb.js
@@ -24,66 +24,75 @@
 // additively. An operator can add staging / preview origins without a
 // code change; removing the prod default still requires editing this
 // file (env var cannot retire it).
-
-// Built-in prod origin baked in so a fresh Railway volume is immediately
-// reachable from the production dashboard without requiring operator
-// env-var configuration. If prod ever moves off
-// dashboard.showcase.copilotkit.ai, change this default — env var alone
-// won't retire the stale origin.
-const CORS_DEFAULT_ORIGINS = ["https://dashboard.showcase.copilotkit.ai"];
-
-function corsAllowedOrigins() {
-  const extra = ($os.getenv("PB_CORS_ORIGINS") || "")
-    .split(",")
-    .map(function (s) {
-      return s.trim();
-    })
-    .filter(function (s) {
-      return s.length > 0;
-    });
-  return CORS_DEFAULT_ORIGINS.concat(extra);
-}
-
-function originAllowed(origin, allowlist) {
-  if (!origin) return false;
-  for (let i = 0; i < allowlist.length; i++) {
-    if (allowlist[i] === origin) return true;
-  }
-  return false;
-}
-
-// Middleware registered at Pre so CORS runs before auth short-circuits
-// OPTIONS preflights. PB 0.22 exposes `e.router.use(...)` on the echo
-// router inside `onBeforeServe`; the callback receives the echo context
-// as its argument.
-onBeforeServe((e) => {
-  e.router.use((next) => {
-    return (c) => {
-      const origin = c.request().header.get("Origin");
-      const allowlist = corsAllowedOrigins();
-      if (originAllowed(origin, allowlist)) {
-        c.response().header().set("Access-Control-Allow-Origin", origin);
-        c.response().header().set("Vary", "Origin");
-        c.response()
-          .header()
-          .set(
-            "Access-Control-Allow-Methods",
-            "GET, POST, PATCH, DELETE, OPTIONS",
-          );
-        c.response()
-          .header()
-          .set(
-            "Access-Control-Allow-Headers",
-            "Content-Type, Authorization, X-Requested-With",
-          );
-        c.response().header().set("Access-Control-Max-Age", "600");
+//
+// Registration nuance: PB 0.22's JSVM excludes `onBeforeServe` from
+// auto-binding (see plugins/jsvm/binds.go v0.22.21 excludeHooks), so the
+// previous `onBeforeServe((e) => e.router.use(...))` was a silent no-op
+// that would have raised `ReferenceError: onBeforeServe is not defined`
+// at load time had PB not silently swallowed pb_hooks load errors.
+// `routerPre` is the supported module-scope binding; internally it wraps
+// `OnBeforeServe + Router.Pre`, giving the same pre-routing hook point.
+//
+// Inlining nuance: the JSVM wraps the middleware function by calling
+// `m.String()` and re-compiling it inside a fresh executor VM (see
+// `wrapMiddlewares` in plugins/jsvm/binds.go). Module-scope `const`s
+// and helper functions defined outside the middleware body are NOT in
+// that executor's scope, so referencing them from the handler throws
+// `ReferenceError` and PB returns a generic 400. The CORS helpers must
+// therefore live inside the middleware closure — duplication is the
+// price of routerPre's re-execution model. `$os.getenv` survives because
+// it's a JSVM global binding, not a module-scope identifier.
+routerPre((next) => {
+  return (c) => {
+    // Built-in prod origin baked in so a fresh Railway volume is
+    // immediately reachable from the production dashboard without
+    // requiring operator env-var configuration. If prod ever moves off
+    // dashboard.showcase.copilotkit.ai, change this default — env var
+    // alone won't retire the stale origin.
+    const CORS_DEFAULT_ORIGINS = ["https://dashboard.showcase.copilotkit.ai"];
+    const extra = ($os.getenv("PB_CORS_ORIGINS") || "")
+      .split(",")
+      .map(function (s) {
+        return s.trim();
+      })
+      .filter(function (s) {
+        return s.length > 0;
+      });
+    const allowlist = CORS_DEFAULT_ORIGINS.concat(extra);
+    const origin = c.request().header.get("Origin");
+    let allowed = false;
+    if (origin) {
+      for (let i = 0; i < allowlist.length; i++) {
+        if (allowlist[i] === origin) {
+          allowed = true;
+          break;
+        }
       }
-      // Short-circuit preflight so downstream handlers (auth, routing)
-      // don't reject OPTIONS with 401/404.
-      if (c.request().method === "OPTIONS") {
-        return c.noContent(204);
-      }
-      return next(c);
-    };
-  });
+    }
+    if (allowed) {
+      c.response().header().set("Access-Control-Allow-Origin", origin);
+      c.response().header().set("Vary", "Origin");
+      c.response()
+        .header()
+        .set(
+          "Access-Control-Allow-Methods",
+          "GET, POST, PATCH, DELETE, OPTIONS",
+        );
+      c.response()
+        .header()
+        .set(
+          "Access-Control-Allow-Headers",
+          "Content-Type, Authorization, X-Requested-With",
+        );
+      c.response().header().set("Access-Control-Max-Age", "600");
+    }
+    // Short-circuit preflight so downstream handlers (auth, routing)
+    // don't reject OPTIONS with 401/404, and so PB's own echo CORS
+    // middleware (which runs in the Use() phase, after Pre()) doesn't
+    // overwrite our Access-Control-Allow-Origin with `*`.
+    if (c.request().method === "OPTIONS") {
+      return c.noContent(204);
+    }
+    return next(c);
+  };
 });

--- a/showcase/pocketbase/pb_migrations/1779909019_baseline_createRule_lockdown.js
+++ b/showcase/pocketbase/pb_migrations/1779909019_baseline_createRule_lockdown.js
@@ -1,0 +1,42 @@
+/// <reference path="../pb_data/types.d.ts" />
+// Lock down `baseline.createRule`. The `1777700000_create_baseline.js`
+// migration shipped with `createRule: ""` — empty-string in PB rule
+// semantics means "any caller can create", which makes the collection
+// publicly writable. The dashboard never creates baseline rows from the
+// browser (status-writer + offline tooling do, both with admin auth), so
+// `null` ("only admins") is the correct lockdown.
+//
+// Down: restore the original empty-string rule for legacy compatibility,
+// matching the shape `create_baseline.js` left it in. This keeps
+// up→down→up loops idempotent.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("baseline");
+    } catch {
+      // Collection not present on this instance — nothing to lock down.
+      return;
+    }
+    if (c.createRule === null) {
+      return;
+    }
+    c.createRule = null;
+    dao.saveCollection(c);
+  },
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("baseline");
+    } catch {
+      return;
+    }
+    if (c.createRule === "") {
+      return;
+    }
+    c.createRule = "";
+    dao.saveCollection(c);
+  },
+);


### PR DESCRIPTION
## Summary

Two related fixes to `showcase/pocketbase` that share the same rebuild/deploy cycle.

### 1. CORS middleware was a silent no-op

`showcase/pocketbase/pb_hooks/main.pb.js` registered the CORS middleware via `onBeforeServe((e) => e.router.use(...))`. PB 0.22's JSVM excludes `onBeforeServe` from auto-binding — see `plugins/jsvm/binds.go` in v0.22.21 `excludeHooks`. The hook was never registered; CORS for the dashboard was effectively unwired.

The supported module-scope binding is `routerPre`, which internally wraps `OnBeforeServe + Router.Pre`. Switching to it gets the middleware actually registered.

One subtle gotcha forced an additional change: `routerPre` re-compiles the middleware function in a fresh executor VM via `m.String()` (see `wrapMiddlewares` in `binds.go`). Module-scope `const`s and helper functions defined outside the middleware body are NOT in that executor's scope — referencing them from the handler throws `ReferenceError` at request time and PB returns a generic 400. The CORS allowlist + helpers therefore had to be inlined into the middleware closure. `$os.getenv` survives because it's a JSVM global binding, not a module-scope identifier. The duplication is documented in the file.

### 2. `baseline.createRule` was publicly writable

`1777700000_create_baseline.js` shipped the `baseline` collection with `createRule: ""`. In PB rule semantics, empty-string means "any caller can create" — i.e. anyone in the world could `POST /api/collections/baseline/records` from a browser. The dashboard never creates baseline rows from the browser; status-writer + offline tooling do, both with admin auth.

Added `1779909019_baseline_createRule_lockdown.js` to set `createRule = null` (admin-only). Down restores the legacy empty-string rule for rollback compatibility.

## Local Docker verification

Built `showcase/pocketbase/Dockerfile` and ran with `PB_CORS_ORIGINS=https://example.test`:

- No `ReferenceError: onBeforeServe is not defined` (or any other) on hook load.
- `OPTIONS /api/health` from `https://example.test` → `204 No Content` + `Access-Control-Allow-Origin: https://example.test` + `Vary: Origin` + the expected methods/headers/max-age.
- `OPTIONS /api/health` from `https://evil.test` → `204 No Content` with NO `Access-Control-Allow-Origin` header.
- Migration `1779909019_baseline_createRule_lockdown.js` recorded in `_migrations`; sqlite dump confirms `baseline.createRule IS NULL`.

For the actual GET response: PB 0.22's built-in echo CORS middleware (running in the `Use()` phase, after our `Pre()`) overwrites `Access-Control-Allow-Origin` to `*`. We can't prevent this from a `Pre()` hook — but the OPTIONS short-circuit returns before that middleware runs, so preflight uses our echoed origin. The actual response getting `*` is acceptable here: the dashboard uses bearer tokens (no cookies / no `credentials: 'include'`).

## Test plan

- [ ] CI green on `showcase_build` for `showcase-pocketbase` image.
- [ ] After merge + CI build, pin Railway prod + staging `showcase-pocketbase` services to the new image digest (currently runs `:latest` — see PR comment).
- [ ] Verify dashboard at `https://dashboard.showcase.copilotkit.ai` still loads against the deployed PB (CORS now actually works end-to-end).
- [ ] Verify `POST /api/collections/baseline/records` from a non-admin caller returns 403/401 against the deployed PB.