### PR TITLE
fix(web-inspector): shim localStorage in vitest setup for Node 25

### DIFF
--- a/packages/web-inspector/vitest.config.ts
+++ b/packages/web-inspector/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     clearMocks: true,
+    setupFiles: ["./vitest.setup.ts"],
     reporters: [["default", { summary: false }]],
     silent: true,
   },

--- a/packages/web-inspector/vitest.setup.ts
+++ b/packages/web-inspector/vitest.setup.ts
@@ -1,0 +1,76 @@
+// Node 25 ships an experimental built-in `localStorage` global (gated on the
+// `--localstorage-file` flag, but the accessor exists unconditionally). When
+// vitest boots the jsdom environment, jsdom defines its own `localStorage` on
+// the synthetic `window`, but Node's global accessor still wins on
+// `globalThis.localStorage` AND — because vitest's jsdom integration aliases
+// `window` to `globalThis` — also on `window.localStorage`. The result is that
+// `window.localStorage` resolves to Node's stub object which has no `clear`,
+// `setItem`, `removeItem`, etc., breaking every test that touches localStorage.
+//
+// This setup file installs a proper in-memory Storage implementation on both
+// `globalThis` and `window` BEFORE any test code runs. The shim is a plain
+// object (not a class) so `vi.spyOn(window.localStorage, "getItem")` works —
+// vitest needs the methods to be own properties on the spied target.
+//
+// We re-install the shim in `beforeEach` so a test that did
+// `vi.restoreAllMocks()` (which restores spied methods) still sees the shim's
+// methods, and so each test starts with a fresh empty store.
+
+import { beforeEach } from "vitest";
+
+function createStorageShim(): Storage {
+  const store = new Map<string, string>();
+  const shim = {
+    get length() {
+      return store.size;
+    },
+    key(index: number): string | null {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    getItem(key: string): string | null {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    setItem(key: string, value: string): void {
+      store.set(String(key), String(value));
+    },
+    removeItem(key: string): void {
+      store.delete(key);
+    },
+    clear(): void {
+      store.clear();
+    },
+  } as Storage;
+  return shim;
+}
+
+function installLocalStorageShim(): void {
+  const shim = createStorageShim();
+  // Override the Node 25 global accessor (and any jsdom accessor) with a
+  // plain data property pointing at our shim. `configurable: true` so a
+  // subsequent install can replace it.
+  Object.defineProperty(globalThis, "localStorage", {
+    value: shim,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+  if (typeof window !== "undefined" && window !== (globalThis as unknown)) {
+    Object.defineProperty(window, "localStorage", {
+      value: shim,
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  }
+}
+
+// Install once at module load so any top-level code in test files (e.g.
+// imports that read localStorage on init) sees the shim.
+installLocalStorageShim();
+
+// Re-install before each test so `vi.restoreAllMocks()` from a prior test
+// can't leave behind spied/replaced methods, and each test starts with an
+// empty store.
+beforeEach(() => {
+  installLocalStorageShim();
+});


### PR DESCRIPTION
## Summary

Node 25 ships an experimental built-in `localStorage` global accessor (gated on `--localstorage-file`, but the accessor exists unconditionally and the warning `\`--localstorage-file\` was provided without a valid path` surfaces in test output). On Node 25, vitest's jsdom environment ends up with `window.localStorage === globalThis.localStorage` pointing at Node's empty stub — no `clear()`, no `setItem()`, no `removeItem()`, no `getItem()`.

The fallout: all 22 telemetry tests in `packages/web-inspector` fail with `TypeError: window.localStorage.clear is not a function`, and the lefthook pre-commit hook blocks every commit repo-wide until folks pass `--no-verify`.

## Fix

Add `packages/web-inspector/vitest.setup.ts` that installs a plain in-memory `Storage` shim on both `globalThis` and `window` once at module load and again in `beforeEach`. Wire it via `setupFiles` in `vitest.config.ts`.

Plain-object shim (not a class) so `vi.spyOn(window.localStorage, "getItem")` continues to work — vitest needs the spied methods to be own properties on the target. `Object.defineProperty` with `configurable: true` so we can override Node's accessor.

## Why this approach

- (a) Setup-file shim — minimal config delta, zero source/test changes, works on both Node 20 and Node 25.
- (b) Switch to `happy-dom` — bigger blast radius, may have other behavior diffs.
- (c) `vi.stubGlobal` per test — invasive, requires touching every test.
- (d) Disable Node's experimental `localStorage` — no stable flag exists; can't rely on it.

We picked (a).

## Verification

- 22/22 failing telemetry tests now pass.
- Full `pnpm test` in `packages/web-inspector`: 29/29 pass (telemetry 22 + web-inspector spec 7).
- Lefthook pre-commit ran cleanly on this branch without `--no-verify` (test-and-check-packages 145s, commitlint OK).

## Test plan

- [x] `pnpm exec vitest run src/lib/__tests__/telemetry.test.ts` in `packages/web-inspector` — 22/22 pass on Node 25.8.0
- [x] `pnpm test` in `packages/web-inspector` — 29/29 pass
- [x] `git commit` without `--no-verify` succeeds (lefthook pre-commit + commit-msg both green)
- [ ] CI: web-inspector lane green