### PR TITLE
fix(core): preserve frontend tool round-trip messages

### DIFF
--- a/examples/v2/react/demo/src/app/page.tsx
+++ b/examples/v2/react/demo/src/app/page.tsx
@@ -165,7 +165,6 @@ function Chat({
       name: z.string(),
     }),
     handler: async ({ name }) => {
-      alert(`Hello ${name}`);
       return `Hello ${name}`;
     },
   });

--- a/packages/core/src/core/__tests__/run-handler-snapshot-suppression.test.ts
+++ b/packages/core/src/core/__tests__/run-handler-snapshot-suppression.test.ts
@@ -1,0 +1,151 @@
+import { EventType } from "@ag-ui/client";
+import type {
+  AbstractAgent,
+  AgentSubscriber,
+  Message,
+  RunAgentInput,
+} from "@ag-ui/client";
+import { describe, expect, it } from "vitest";
+import { CopilotKitCore } from "../core";
+import { RunHandler } from "../run-handler";
+
+type MessagesSnapshotArgs = Parameters<
+  NonNullable<AgentSubscriber["onMessagesSnapshotEvent"]>
+>[0];
+
+const userMessage = {
+  id: "user-message",
+  role: "user",
+  content: "hello",
+} as Message;
+
+const assistantMessage = {
+  id: "assistant-message",
+  role: "assistant",
+  content: "hi",
+} as Message;
+
+const toolMessage = {
+  id: "tool-message",
+  role: "tool",
+  toolCallId: "tool-call",
+  content: "tool result",
+} as Message;
+
+class SnapshotEmittingAgent {
+  agentId = "snapshot-agent";
+  threadId = "snapshot-thread";
+  messages: Message[];
+  state: Record<string, unknown> = {};
+  snapshotResult: unknown;
+
+  constructor(
+    private readonly inputMessages: Message[],
+    private readonly snapshotMessages: Message[],
+    agentMessages: Message[],
+  ) {
+    this.messages = agentMessages;
+  }
+
+  abortRun() {}
+
+  async detachActiveRun() {}
+
+  setMessages(messages: Message[]) {
+    this.messages = messages;
+  }
+
+  setState(state: Record<string, unknown>) {
+    this.state = state;
+  }
+
+  subscribe() {
+    return { unsubscribe() {} };
+  }
+
+  async runAgent(_params: unknown, subscriber?: AgentSubscriber) {
+    const args = {
+      event: {
+        type: EventType.MESSAGES_SNAPSHOT,
+        messages: this.snapshotMessages,
+      },
+      input: {
+        messages: this.inputMessages,
+      } as RunAgentInput,
+      messages: this.messages,
+      state: this.state,
+      agent: this as unknown as AbstractAgent,
+    } as MessagesSnapshotArgs;
+
+    this.snapshotResult = await subscriber?.onMessagesSnapshotEvent?.(args);
+    return { newMessages: [] };
+  }
+}
+
+function createRunHandler(): RunHandler {
+  return new RunHandler(new CopilotKitCore({}));
+}
+
+async function runSnapshotCase({
+  inputMessages,
+  snapshotMessages,
+  agentMessages,
+}: {
+  inputMessages: Message[];
+  snapshotMessages: Message[];
+  agentMessages: Message[];
+}) {
+  const agent = new SnapshotEmittingAgent(
+    inputMessages,
+    snapshotMessages,
+    agentMessages,
+  );
+
+  await createRunHandler().runAgent({
+    agent: agent as unknown as AbstractAgent,
+  });
+
+  return agent.snapshotResult;
+}
+
+describe("RunHandler frontend-tool snapshot suppression", () => {
+  it("suppresses transient empty snapshots during frontend-tool follow-up runs", async () => {
+    await expect(
+      runSnapshotCase({
+        inputMessages: [userMessage, assistantMessage, toolMessage],
+        snapshotMessages: [],
+        agentMessages: [userMessage, assistantMessage, toolMessage],
+      }),
+    ).resolves.toEqual({ stopPropagation: true });
+  });
+
+  it("does not suppress empty snapshots without tool results in the run input", async () => {
+    await expect(
+      runSnapshotCase({
+        inputMessages: [userMessage],
+        snapshotMessages: [],
+        agentMessages: [userMessage],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not suppress empty snapshots when the agent has no mounted messages", async () => {
+    await expect(
+      runSnapshotCase({
+        inputMessages: [userMessage, toolMessage],
+        snapshotMessages: [],
+        agentMessages: [],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not suppress non-empty snapshots during frontend-tool follow-up runs", async () => {
+    await expect(
+      runSnapshotCase({
+        inputMessages: [userMessage, toolMessage],
+        snapshotMessages: [assistantMessage],
+        agentMessages: [userMessage, toolMessage],
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -239,7 +239,7 @@ export class AgentRegistry {
       runtimeUrl: this._runtimeUrl,
       agentId,
       runtimeAgentId,
-      transport: this._runtimeTransport,
+      transport: this.runtimeTransport,
       credentials: friends.credentials,
       // If runtime info has already synced, mirror its mode/intelligence so
       // the proxy doesn't have to re-resolve. Otherwise stay "pending" until
@@ -394,7 +394,7 @@ export class AgentRegistry {
               runtimeUrl: this.runtimeUrl,
               agentId: id, // Runtime agents always have their ID set correctly
               description: description,
-              transport: this._runtimeTransport,
+              transport: this.runtimeTransport,
               credentials,
               runtimeMode: runtimeInfoResponse.mode ?? RUNTIME_MODE_SSE,
               intelligence: runtimeInfoResponse.intelligence,
@@ -517,7 +517,8 @@ export class AgentRegistry {
 
   /**
    * Auto-detect transport by trying REST first, then falling back to single-endpoint.
-   * Updates `_runtimeTransport` to the detected value so subsequent requests use it directly.
+   * Caches the resolved transport separately from the requested mode so provider
+   * prop syncs of `auto` do not look like transport changes.
    */
   private async fetchRuntimeInfoAutoDetect(
     headers: Record<string, string>,

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -108,6 +108,7 @@ export class RunHandler {
    * inspector and intermittent "Message not found" toasts.
    */
   private _lastConnectedThreadId: string | null = null;
+  private _connectSequence = 0;
 
   constructor(private core: CopilotKitCore) {}
 
@@ -213,8 +214,10 @@ export class RunHandler {
     agent,
   }: CopilotKitCoreConnectAgentParams): Promise<RunAgentResult> {
     try {
+      const connectSequence = ++this._connectSequence;
       const incomingThreadId = agent.threadId ?? null;
-      const isFreshRestore = incomingThreadId !== this._lastConnectedThreadId;
+      const previousConnectedThreadId = this._lastConnectedThreadId;
+      const isFreshRestore = incomingThreadId !== previousConnectedThreadId;
       this._lastConnectedThreadId = incomingThreadId;
 
       // Detach any active run before connecting to avoid previous runs
@@ -222,6 +225,10 @@ export class RunHandler {
       // churn re-connects need the previous socket torn down before a new
       // one can open.
       await agent.detachActiveRun();
+
+      if (connectSequence !== this._connectSequence) {
+        return { result: undefined, newMessages: [] };
+      }
 
       // State reset + replay-cursor clear are gated on actually moving
       // to a different thread. On same-thread churn, the local
@@ -276,7 +283,7 @@ export class RunHandler {
           context,
         });
       }
-      return { newMessages: [] };
+      return { result: undefined, newMessages: [] };
     }
   }
 
@@ -363,7 +370,7 @@ export class RunHandler {
         code: CopilotKitCoreErrorCode.AGENT_RUN_FAILED,
         context,
       });
-      return { newMessages: [] };
+      return { result: undefined, newMessages: [] };
     } finally {
       this._runDepth--;
       // Restore original abortRun when the entire chain (including

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -1,12 +1,12 @@
-import {
+import type {
   AbstractAgent,
   AgentSubscriber,
-  HttpAgent,
   Message,
   RunAgentResult,
   Tool,
   ToolCall,
 } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 import { randomUUID, logger, schemaToJsonSchema } from "@copilotkit/shared";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type { CopilotKitCore, CopilotKitCoreFriendsAccess } from "./core";
@@ -920,6 +920,22 @@ export class RunHandler {
     };
 
     return {
+      onMessagesSnapshotEvent: ({ event, input }) => {
+        const isEmptySnapshot = event.messages.length === 0;
+        const hasToolResultInRunInput = input.messages.some(
+          (message) => message.role === "tool",
+        );
+
+        // During frontend-tool follow-ups, a transient empty snapshot can arrive
+        // before the model response. Letting it propagate collapses the chat.
+        if (
+          isEmptySnapshot &&
+          hasToolResultInRunInput &&
+          agent.messages.length > 0
+        ) {
+          return { stopPropagation: true };
+        }
+      },
       onRunFailed: async ({ error }: { error: Error }) => {
         const code =
           error instanceof AgentThreadLockedError

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -252,7 +252,7 @@ export class RunHandler {
           tools: this.buildFrontendTools(agent.agentId),
           context: Object.values(this._internal.context),
         },
-        this.createAgentErrorSubscriber(agent),
+        this.createAgentRunSubscriber(agent),
       );
 
       return this.processAgentResult({ runAgentResult, agent });
@@ -348,7 +348,7 @@ export class RunHandler {
           tools: this.buildFrontendTools(agent.agentId),
           context: Object.values(this._internal.context),
         },
-        this.createAgentErrorSubscriber(agent),
+        this.createAgentRunSubscriber(agent),
       );
       return await this.processAgentResult({ runAgentResult, agent });
     } catch (error) {
@@ -900,9 +900,9 @@ export class RunHandler {
   }
 
   /**
-   * Create an agent error subscriber
+   * Create an agent run subscriber
    */
-  private createAgentErrorSubscriber(agent: AbstractAgent): AgentSubscriber {
+  private createAgentRunSubscriber(agent: AbstractAgent): AgentSubscriber {
     const emitAgentError = async (
       error: Error,
       code: CopilotKitCoreErrorCode,
@@ -921,18 +921,7 @@ export class RunHandler {
 
     return {
       onMessagesSnapshotEvent: ({ event, input }) => {
-        const isEmptySnapshot = event.messages.length === 0;
-        const hasToolResultInRunInput = input.messages.some(
-          (message) => message.role === "tool",
-        );
-
-        // During frontend-tool follow-ups, a transient empty snapshot can arrive
-        // before the model response. Letting it propagate collapses the chat.
-        if (
-          isEmptySnapshot &&
-          hasToolResultInRunInput &&
-          agent.messages.length > 0
-        ) {
+        if (isTransientEmptyFollowUpSnapshot(event, input, agent)) {
           return { stopPropagation: true };
         }
       },
@@ -976,6 +965,25 @@ export class RunHandler {
       },
     };
   }
+}
+
+function isTransientEmptyFollowUpSnapshot(
+  event: { messages: Message[] },
+  input: { messages: Message[] },
+  agent: Pick<AbstractAgent, "messages">,
+): boolean {
+  const isEmptySnapshot = event.messages.length === 0;
+  const hasToolResultInRunInput = input.messages.some(
+    (message) => message.role === "tool",
+  );
+
+  // The subscriber runs after CopilotKit's state-manager subscriber but before
+  // AG-UI's built-in message replacement. Empty snapshots are harmless to the
+  // state manager, and stopping propagation here prevents the built-in replace
+  // from collapsing the chat between a frontend-tool result and its follow-up.
+  return (
+    isEmptySnapshot && hasToolResultInRunInput && agent.messages.length > 0
+  );
 }
 
 /**

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -229,6 +229,7 @@ export function CopilotChat({
   useEffect(() => {
     // Non-explicit threads skip /connect, but the first runAgent still has to
     // ship the same SDK-generated threadId that the chat UI is rendering.
+    const previousThreadId = agent.threadId ?? null;
     agent.threadId = resolvedThreadId;
 
     // When the caller hasn't picked a specific thread, resolvedThreadId is a
@@ -236,7 +237,13 @@ export function CopilotChat({
     // ThreadsProvider). The backend has never seen it, so /connect would
     // always 404 — skip the call. A real thread is only created once the
     // user runs the agent for the first time.
-    if (!hasExplicitThreadId) return;
+    if (!hasExplicitThreadId) {
+      if (previousThreadId && previousThreadId !== resolvedThreadId) {
+        agent.setMessages([]);
+        agent.setState({});
+      }
+      return;
+    }
 
     let detached = false;
 

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -379,6 +379,15 @@ export type CopilotChatMessageViewProps = Omit<
 // worth it and the simpler flat render is faster.
 const VIRTUALIZE_THRESHOLD = 50;
 
+function isDefaultRenderableMessage(message: Message): boolean {
+  return (
+    message.role === "assistant" ||
+    message.role === "user" ||
+    message.role === "activity" ||
+    message.role === "reasoning"
+  );
+}
+
 export function CopilotChatMessageView({
   messages = [],
   assistantMessage,
@@ -506,14 +515,21 @@ export function CopilotChatMessageView({
   // Virtualize only when we have a scroll element and enough messages. The
   // `children` render prop delegates layout to the caller, so we keep
   // messageElements flat for that case.
+  const virtualizedMessages = useMemo(
+    () =>
+      renderCustomMessage
+        ? deduplicatedMessages
+        : deduplicatedMessages.filter(isDefaultRenderableMessage),
+    [deduplicatedMessages, renderCustomMessage],
+  );
   const shouldVirtualize =
     !!scrollElement &&
     !children &&
-    deduplicatedMessages.length > VIRTUALIZE_THRESHOLD;
+    virtualizedMessages.length > VIRTUALIZE_THRESHOLD;
 
   const virtualizer = useVirtualizer({
     // count=0 disables the virtualizer without changing hook call order.
-    count: shouldVirtualize ? deduplicatedMessages.length : 0,
+    count: shouldVirtualize ? virtualizedMessages.length : 0,
     getScrollElement: () => scrollElement,
     // Conservative height estimate. Items are measured by ResizeObserver after
     // first render so the estimate only affects the initial total height.
@@ -526,15 +542,15 @@ export function CopilotChatMessageView({
   });
 
   // Scroll to the bottom when virtual mode first activates or the thread changes
-  // (detected by the first message ID changing). For streaming new messages,
+  // (detected by the first renderable message ID changing). For streaming new messages,
   // use-stick-to-bottom handles auto-scroll via content height growth detection
   // on the virtualizer's total-size div — same as the flat path. Adding
-  // deduplicatedMessages.length here would forcibly yank the user to the bottom
+  // virtualizedMessages.length here would forcibly yank the user to the bottom
   // on every streaming chunk even if they've scrolled up to read history.
-  const firstMessageId = deduplicatedMessages[0]?.id;
+  const firstMessageId = virtualizedMessages[0]?.id;
   useLayoutEffect(() => {
-    if (!shouldVirtualize || !deduplicatedMessages.length) return;
-    virtualizer.scrollToIndex(deduplicatedMessages.length - 1, {
+    if (!shouldVirtualize || !virtualizedMessages.length) return;
+    virtualizer.scrollToIndex(virtualizedMessages.length - 1, {
       align: "end",
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -682,7 +698,7 @@ export function CopilotChatMessageView({
           style={{ height: virtualizer.getTotalSize(), position: "relative" }}
         >
           {virtualizer.getVirtualItems().map((virtualItem) => {
-            const message = deduplicatedMessages[virtualItem.index]!;
+            const message = virtualizedMessages[virtualItem.index]!;
             return (
               <div
                 key={message.id}

--- a/packages/react-core/src/v2/components/chat/CopilotChatToolCallsView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatToolCallsView.tsx
@@ -1,5 +1,10 @@
 import { useRenderToolCall } from "../../hooks";
-import type { AssistantMessage, Message, ToolMessage } from "@ag-ui/core";
+import type {
+  AssistantMessage,
+  Message,
+  ToolCall,
+  ToolMessage,
+} from "@ag-ui/core";
 import React from "react";
 
 export type CopilotChatToolCallsViewProps = {
@@ -19,7 +24,7 @@ export function CopilotChatToolCallsView({
 
   return (
     <>
-      {message.toolCalls.map((toolCall) => {
+      {deduplicateToolCalls(message.toolCalls).map((toolCall) => {
         const toolMessage = messages.find(
           (m) => m.role === "tool" && m.toolCallId === toolCall.id,
         ) as ToolMessage | undefined;
@@ -38,3 +43,13 @@ export function CopilotChatToolCallsView({
 }
 
 export default CopilotChatToolCallsView;
+
+function deduplicateToolCalls(toolCalls: ToolCall[]): ToolCall[] {
+  const uniqueToolCalls = new Map<string, ToolCall>();
+
+  for (const toolCall of toolCalls) {
+    uniqueToolCalls.set(toolCall.id, toolCall);
+  }
+
+  return [...uniqueToolCalls.values()];
+}

--- a/packages/react-core/src/v2/components/chat/CopilotChatToolCallsView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatToolCallsView.tsx
@@ -48,8 +48,24 @@ function deduplicateToolCalls(toolCalls: ToolCall[]): ToolCall[] {
   const uniqueToolCalls = new Map<string, ToolCall>();
 
   for (const toolCall of toolCalls) {
-    uniqueToolCalls.set(toolCall.id, toolCall);
+    const existingToolCall = uniqueToolCalls.get(toolCall.id);
+    if (
+      !existingToolCall ||
+      isMoreCompleteToolCall(toolCall, existingToolCall)
+    ) {
+      uniqueToolCalls.set(toolCall.id, toolCall);
+    }
   }
 
   return [...uniqueToolCalls.values()];
+}
+
+function isMoreCompleteToolCall(
+  nextToolCall: ToolCall,
+  currentToolCall: ToolCall,
+): boolean {
+  return (
+    nextToolCall.function.arguments.trim().length >
+    currentToolCall.function.arguments.trim().length
+  );
 }

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
@@ -76,7 +76,9 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
     expect(connectSpy).toHaveBeenCalled();
     expect(connectSpy.mock.calls[0][0].threadId).toBe("config-thread-xyz");
   });
+});
 
+describe("CopilotChat frontend tool round trips without explicit threadId (ENT-314)", () => {
   it("uses the SDK-generated threadId for frontend tool follow-up runs", async () => {
     class FrontendToolRoundTripAgent extends MockStepwiseAgent {
       runInputs: RunAgentInput[] = [];
@@ -182,7 +184,9 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
       ),
     ).toBe(true);
   });
+});
 
+describe("CopilotChat frontend tool round trips with explicit threadId (ENT-657)", () => {
   it("keeps explicit-thread messages mounted through frontend tool follow-up runs", async () => {
     class FrontendToolRoundTripAgent extends MockStepwiseAgent {
       runInputs: RunAgentInput[] = [];
@@ -230,10 +234,10 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
         name: "testFrontendToolCalling",
         parameters: z.object({ label: z.string() }),
         followUp: true,
-        handler: async ({ label }) => `handled ${String(label)}`,
+        handler: async ({ label }) => `handled ${label}`,
         render: ({ args, result }) => (
           <div data-testid="frontend-tool-card">
-            {String(args.label)}:{String(result ?? "pending")}
+            {args.label}:{result ?? "pending"}
           </div>
         ),
       };

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { EMPTY, Observable } from "rxjs";
 import { z } from "zod";
+import { EventType } from "@ag-ui/client";
 import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
 import {
   MockStepwiseAgent,
@@ -15,6 +16,7 @@ import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
 import { useFrontendTool } from "../../../hooks/use-frontend-tool";
 import { CopilotChat } from "../CopilotChat";
+import type { CopilotChatMessageViewProps } from "../CopilotChatMessageView";
 import type { ReactFrontendTool } from "../../../types";
 
 describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)", () => {
@@ -179,5 +181,121 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
           message.content === "Frontend tool finished for X.",
       ),
     ).toBe(true);
+  });
+
+  it("keeps explicit-thread messages mounted through frontend tool follow-up runs", async () => {
+    class FrontendToolRoundTripAgent extends MockStepwiseAgent {
+      runInputs: RunAgentInput[] = [];
+
+      run(input: RunAgentInput): Observable<BaseEvent> {
+        this.runInputs.push(input);
+        const runNumber = this.runInputs.length;
+
+        return new Observable<BaseEvent>((subscriber) => {
+          queueMicrotask(() => {
+            subscriber.next(runStartedEvent());
+            if (runNumber === 1) {
+              subscriber.next(
+                textChunkEvent("assistant-tool", "Calling frontend tool."),
+              );
+              subscriber.next(
+                toolCallChunkEvent({
+                  parentMessageId: "assistant-tool",
+                  delta: '{"label":"X"}',
+                  toolCallId: "tc-explicit-thread",
+                  toolCallName: "testFrontendToolCalling",
+                }),
+              );
+            } else {
+              subscriber.next({
+                type: EventType.MESSAGES_SNAPSHOT,
+                messages: [],
+              } as BaseEvent);
+              subscriber.next(
+                textChunkEvent(
+                  "assistant-final",
+                  "Frontend tool finished for X.",
+                ),
+              );
+            }
+            subscriber.next(runFinishedEvent());
+            subscriber.complete();
+          });
+        });
+      }
+    }
+
+    function FrontendToolRegistration() {
+      const frontendTool: ReactFrontendTool<{ label: string }> = {
+        name: "testFrontendToolCalling",
+        parameters: z.object({ label: z.string() }),
+        followUp: true,
+        handler: async ({ label }) => `handled ${String(label)}`,
+        render: ({ args, result }) => (
+          <div data-testid="frontend-tool-card">
+            {String(args.label)}:{String(result ?? "pending")}
+          </div>
+        ),
+      };
+      useFrontendTool(frontendTool);
+      return null;
+    }
+
+    const messageCounts: number[] = [];
+    function MessageCountProbe({ messages }: CopilotChatMessageViewProps) {
+      messageCounts.push(messages?.length ?? 0);
+      return (
+        <div data-testid="message-count">{String(messages?.length ?? 0)}</div>
+      );
+    }
+
+    const agent = new FrontendToolRoundTripAgent();
+
+    render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <FrontendToolRegistration />
+        <div style={{ height: 400 }}>
+          <CopilotChat
+            welcomeScreen={false}
+            threadId="explicit-thread"
+            messageView={MessageCountProbe}
+          />
+        </div>
+      </CopilotKitProvider>,
+    );
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, {
+      target: {
+        value: "invoke testFrontendToolCalling with label X",
+      },
+    });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(agent.runInputs).toHaveLength(2);
+    });
+
+    expect(agent.runInputs.map((runInput) => runInput.threadId)).toEqual([
+      "explicit-thread",
+      "explicit-thread",
+    ]);
+
+    expect(
+      agent.messages.some(
+        (message) => message.role === "tool" && message.content === "handled X",
+      ),
+    ).toBe(true);
+    expect(
+      agent.messages.some(
+        (message) =>
+          message.role === "assistant" &&
+          message.content === "Frontend tool finished for X.",
+      ),
+    ).toBe(true);
+
+    const firstNonEmptyRender = messageCounts.findIndex((count) => count > 0);
+    expect(firstNonEmptyRender).toBeGreaterThanOrEqual(0);
+    expect(messageCounts.slice(firstNonEmptyRender)).not.toContain(0);
   });
 });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
@@ -187,6 +187,148 @@ describe("CopilotChat frontend tool round trips without explicit threadId (ENT-3
 });
 
 describe("CopilotChat frontend tool round trips with explicit threadId (ENT-657)", () => {
+  class ThreadSwitchAgent extends MockStepwiseAgent {
+    connectInputs: RunAgentInput[] = [];
+    runInputs: RunAgentInput[] = [];
+
+    connect(input: RunAgentInput): Observable<BaseEvent> {
+      this.connectInputs.push(input);
+      return EMPTY;
+    }
+
+    run(input: RunAgentInput): Observable<BaseEvent> {
+      this.runInputs.push(input);
+      return new Observable<BaseEvent>((subscriber) => {
+        queueMicrotask(() => {
+          subscriber.next(runStartedEvent());
+          subscriber.next(textChunkEvent("thread-a-response", "Hello Alice"));
+          subscriber.next(runFinishedEvent());
+          subscriber.complete();
+        });
+      });
+    }
+  }
+
+  function createMessageCountProbe(messageCounts: number[]) {
+    function MessageCountProbe({ messages }: CopilotChatMessageViewProps) {
+      messageCounts.push(messages?.length ?? 0);
+      return (
+        <div data-testid="thread-message-count">
+          {String(messages?.length ?? 0)}
+        </div>
+      );
+    }
+    return MessageCountProbe;
+  }
+
+  function ThreadedChat({
+    MessageCountProbe,
+    threadId,
+  }: {
+    MessageCountProbe: React.ComponentType<CopilotChatMessageViewProps>;
+    threadId?: string;
+  }) {
+    return (
+      <CopilotChatConfigurationProvider
+        threadId={threadId}
+        hasExplicitThreadId={threadId !== undefined}
+      >
+        <CopilotChat
+          key={threadId ?? "stateless"}
+          welcomeScreen={false}
+          messageView={MessageCountProbe}
+          threadId={threadId}
+        />
+      </CopilotChatConfigurationProvider>
+    );
+  }
+
+  async function sendThreadAMessage(agent: ThreadSwitchAgent) {
+    await waitFor(() => {
+      expect(agent.connectInputs.map((input) => input.threadId)).toContain(
+        "thread-a",
+      );
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, {
+      target: {
+        value: "Call the sayHello frontend tool with name Alice",
+      },
+    });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-message-count").textContent).toBe("2");
+    });
+  }
+
+  it("does not leak explicit-thread history into stateless mode", async () => {
+    const agent = new ThreadSwitchAgent();
+    const messageCounts: number[] = [];
+    const MessageCountProbe = createMessageCountProbe(messageCounts);
+    const { rerender } = render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <ThreadedChat
+          MessageCountProbe={MessageCountProbe}
+          threadId="thread-a"
+        />
+      </CopilotKitProvider>,
+    );
+
+    await sendThreadAMessage(agent);
+
+    rerender(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <ThreadedChat MessageCountProbe={MessageCountProbe} />
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-message-count").textContent).toBe("0");
+    });
+    expect(
+      messageCounts.slice(messageCounts.findIndex((count) => count > 0)),
+    ).toContain(0);
+  });
+
+  it("does not leak explicit-thread history into another explicit thread", async () => {
+    const agent = new ThreadSwitchAgent();
+    const messageCounts: number[] = [];
+    const MessageCountProbe = createMessageCountProbe(messageCounts);
+    const { rerender } = render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <ThreadedChat
+          MessageCountProbe={MessageCountProbe}
+          threadId="thread-a"
+        />
+      </CopilotKitProvider>,
+    );
+
+    await sendThreadAMessage(agent);
+
+    rerender(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <ThreadedChat
+          MessageCountProbe={MessageCountProbe}
+          threadId="thread-b"
+        />
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      expect(agent.connectInputs.map((input) => input.threadId)).toContain(
+        "thread-b",
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-message-count").textContent).toBe("0");
+    });
+    expect(
+      messageCounts.slice(messageCounts.findIndex((count) => count > 0)),
+    ).toContain(0);
+  });
+
   it("keeps explicit-thread messages mounted through frontend tool follow-up runs", async () => {
     class FrontendToolRoundTripAgent extends MockStepwiseAgent {
       runInputs: RunAgentInput[] = [];

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatPerf.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatPerf.e2e.test.tsx
@@ -13,7 +13,7 @@ import { CopilotChat } from "../CopilotChat";
 import { CopilotChatAssistantMessage } from "../CopilotChatAssistantMessage";
 import CopilotChatMessageView from "../CopilotChatMessageView";
 import { ScrollElementContext } from "../scroll-element-context";
-import type { Message } from "@ag-ui/core";
+import type { Message, ToolMessage } from "@ag-ui/core";
 
 // ---------------------------------------------------------------------------
 // Spy component — must be module-level so its reference is stable across
@@ -94,6 +94,33 @@ async function emitBatch(agent: MockStepwiseAgent, n: number) {
     },
     { timeout: 10_000 },
   );
+}
+
+function createMeasuredScrollElement() {
+  // Create a fake scroll element that passes two jsdom guards:
+  // 1. clientHeight > 0 — our guard in CopilotChatMessageView
+  // 2. getBoundingClientRect().height > 0 — TanStack Virtual calls this
+  //    immediately in observeElementRect() to set the viewport size. Without
+  //    this, it overrides initialRect with { height: 0 } and renders no items.
+  const fakeScrollEl = document.createElement("div");
+  Object.defineProperty(fakeScrollEl, "clientHeight", {
+    get: () => 600,
+    configurable: true,
+  });
+  fakeScrollEl.getBoundingClientRect = () =>
+    ({
+      height: 600,
+      width: 800,
+      top: 0,
+      left: 0,
+      bottom: 600,
+      right: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+
+  return fakeScrollEl;
 }
 
 // ---------------------------------------------------------------------------
@@ -241,28 +268,7 @@ describe("CopilotChat perf — re-render regression", () => {
   it("virtual path: renders only a window of messages above VIRTUALIZE_THRESHOLD", async () => {
     const TOTAL = 60; // above VIRTUALIZE_THRESHOLD (50)
 
-    // Create a fake scroll element that passes two jsdom guards:
-    // 1. clientHeight > 0 — our guard in CopilotChatMessageView
-    // 2. getBoundingClientRect().height > 0 — TanStack Virtual calls this
-    //    immediately in observeElementRect() to set the viewport size. Without
-    //    this, it overrides initialRect with { height: 0 } and renders no items.
-    const fakeScrollEl = document.createElement("div");
-    Object.defineProperty(fakeScrollEl, "clientHeight", {
-      get: () => 600,
-      configurable: true,
-    });
-    fakeScrollEl.getBoundingClientRect = () =>
-      ({
-        height: 600,
-        width: 800,
-        top: 0,
-        left: 0,
-        bottom: 600,
-        right: 800,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      }) as DOMRect;
+    const fakeScrollEl = createMeasuredScrollElement();
 
     const messages: Message[] = Array.from({ length: TOTAL }, (_, i) => ({
       id: `virt-msg-${i}`,
@@ -298,6 +304,54 @@ describe("CopilotChat perf — re-render regression", () => {
     // Drain pending animation frames before unmounting. TanStack Virtual
     // schedules rAF callbacks for measurement; if they fire after jsdom tears
     // down (window === null) they produce a spurious uncaught exception.
+    await act(async () => {
+      await new Promise<void>((r) => requestAnimationFrame(() => r()));
+      await new Promise<void>((r) => requestAnimationFrame(() => r()));
+    });
+    unmount();
+  });
+
+  it("virtual path: excludes non-rendered tool messages from default height estimation", async () => {
+    const RENDERED_TOTAL = 60;
+    const fakeScrollEl = createMeasuredScrollElement();
+    const messages: Message[] = Array.from(
+      { length: RENDERED_TOTAL },
+      (_, i) => {
+        const assistantMessage: Message = {
+          id: `assistant-${i}`,
+          role: "assistant" as const,
+          content: `Message ${i}`,
+        };
+        const toolMessage: ToolMessage = {
+          id: `tool-${i}`,
+          role: "tool",
+          content: `Result ${i}`,
+          toolCallId: `tc-${i}`,
+        };
+        return [assistantMessage, toolMessage];
+      },
+    ).flat();
+
+    const { unmount } = renderWithCopilotKit({
+      children: (
+        <ScrollElementContext.Provider value={fakeScrollEl}>
+          <div style={{ height: 600 }}>
+            <CopilotChatMessageView messages={messages} />
+          </div>
+        </ScrollElementContext.Provider>
+      ),
+    });
+
+    await waitFor(() => {
+      const virtualContainer = document.querySelector<HTMLElement>(
+        '[data-testid="copilot-message-list"] > div[style*="position: relative"]',
+      );
+      expect(virtualContainer).not.toBeNull();
+      const virtualHeight = Number.parseInt(virtualContainer!.style.height, 10);
+      expect(virtualHeight).toBeLessThanOrEqual(RENDERED_TOTAL * 100);
+      expect(virtualHeight).toBeGreaterThan(0);
+    });
+
     await act(async () => {
       await new Promise<void>((r) => requestAnimationFrame(() => r()));
       await new Promise<void>((r) => requestAnimationFrame(() => r()));

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRendering.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatToolRendering.e2e.test.tsx
@@ -1,28 +1,19 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { z } from "zod";
-import {
-  CopilotKitProvider,
-  useCopilotKit,
-} from "../../../providers/CopilotKitProvider";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChat } from "../CopilotChat";
-import {
-  AbstractAgent,
-  EventType,
-  type BaseEvent,
-  type RunAgentInput,
-} from "@ag-ui/client";
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
 import { Observable, Subject } from "rxjs";
-import {
-  defineToolCallRenderer,
-  ReactToolCallRenderer,
-  ReactFrontendTool,
-} from "../../../types";
-import CopilotChatToolCallsView from "../CopilotChatToolCallsView";
+import type { ReactToolCallRenderer, ReactFrontendTool } from "../../../types";
+import { defineToolCallRenderer } from "../../../types";
+import { CopilotChatToolCallsView } from "../CopilotChatToolCallsView";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
-import { AssistantMessage, Message, ToolMessage } from "@ag-ui/core";
+import type { AssistantMessage, Message, ToolMessage } from "@ag-ui/core";
 import { ToolCallStatus } from "@copilotkit/core";
 import { useFrontendTool } from "../../../hooks/use-frontend-tool";
+import { vi } from "vitest";
 
 // A minimal mock agent that streams a tool call and a result
 class MockStreamingAgent extends AbstractAgent {
@@ -133,13 +124,7 @@ describe("CopilotChat tool rendering with mock agent", () => {
 });
 
 describe("Tool render status narrowing", () => {
-  function renderStatusWithProvider({
-    isRunning,
-    withResult,
-  }: {
-    isRunning: boolean;
-    withResult: boolean;
-  }) {
+  function renderStatusWithProvider({ withResult }: { withResult: boolean }) {
     const renderToolCalls = [
       defineToolCallRenderer({
         name: "getWeather",
@@ -206,14 +191,14 @@ describe("Tool render status narrowing", () => {
   }
 
   it("renders InProgress when running and no result", async () => {
-    renderStatusWithProvider({ isRunning: true, withResult: false });
+    renderStatusWithProvider({ withResult: false });
     const el = await screen.findByTestId("status");
     expect(el.textContent).toMatch(/INPROGRESS/);
     expect(el.textContent).toMatch(/Berlin/);
   });
 
   it("renders Complete with result when tool message exists", async () => {
-    renderStatusWithProvider({ isRunning: false, withResult: true });
+    renderStatusWithProvider({ withResult: true });
     const el = await screen.findByTestId("status");
     expect(el.textContent).toMatch(/COMPLETE/);
     expect(el.textContent).toMatch(/Berlin/);
@@ -221,10 +206,54 @@ describe("Tool render status narrowing", () => {
   });
 
   it("renders InProgress when not running and no tool result", async () => {
-    renderStatusWithProvider({ isRunning: false, withResult: false });
+    renderStatusWithProvider({ withResult: false });
     const el = await screen.findByTestId("status");
     expect(el.textContent).toMatch(/INPROGRESS/);
     expect(el.textContent).toMatch(/Berlin/);
+  });
+
+  it("renders duplicate tool call ids once", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const renderToolCalls = [
+      defineToolCallRenderer({
+        name: "getWeather",
+        args: z.object({ city: z.string().optional() }),
+        render: ({ args }) => (
+          <div data-testid="status">WEATHER {String(args.city ?? "")}</div>
+        ),
+      }),
+    ] as unknown as ReactToolCallRenderer<unknown>[];
+    const duplicateToolCall = {
+      id: "tc_status_1",
+      type: "function" as const,
+      function: { name: "getWeather", arguments: '{"city":"Berlin"}' },
+    };
+    const assistantMessage: AssistantMessage = {
+      id: "a1",
+      role: "assistant",
+      content: "",
+      toolCalls: [duplicateToolCall, duplicateToolCall],
+    };
+
+    render(
+      <CopilotKitProvider renderToolCalls={renderToolCalls}>
+        <CopilotChatConfigurationProvider
+          agentId="default"
+          threadId="test-thread"
+        >
+          <CopilotChatToolCallsView message={assistantMessage} messages={[]} />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    expect(await screen.findAllByTestId("status")).toHaveLength(1);
+    const duplicateKeyWarnings = consoleSpy.mock.calls.filter(
+      (call) =>
+        typeof call[0] === "string" &&
+        call[0].includes("Encountered two children with the same key"),
+    );
+    expect(duplicateKeyWarnings).toHaveLength(0);
+    consoleSpy.mockRestore();
   });
 });
 

--- a/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
@@ -1,6 +1,6 @@
 import { useCopilotChatConfiguration, useCopilotKit } from "../providers";
-import { ReactCustomMessageRendererPosition } from "../types/react-custom-message-renderer";
-import { Message } from "@ag-ui/core";
+import type { ReactCustomMessageRendererPosition } from "../types/react-custom-message-renderer";
+import type { Message } from "@ag-ui/core";
 
 interface UseRenderCustomMessagesParams {
   message: Message;
@@ -29,10 +29,11 @@ export function useRenderCustomMessages() {
       return aHasAgent ? -1 : 1;
     });
 
+  if (!customMessageRenderers.length) {
+    return null;
+  }
+
   return function (params: UseRenderCustomMessagesParams) {
-    if (!customMessageRenderers.length) {
-      return null;
-    }
     const { message, position } = params;
     const resolvedRunId =
       copilotkit.getRunIdForMessage(agentId, threadId, message.id) ??


### PR DESCRIPTION
## Summary
- suppress transient empty message snapshots during frontend tool follow-up runs so the chat does not collapse and redraw
- dedupe repeated tool-call ids in the chat tool-call renderer to avoid duplicate React keys during repeated tool round trips
- add focused core coverage for the snapshot-suppression guard positive and negative paths
- add regression coverage for explicit-thread frontend tool round trips
- assert explicit thread IDs are preserved for prop/config thread connection paths

## Verification
- `NX_TUI=false pnpm nx run @copilotkit/core:test --skip-nx-cache -- src/core/__tests__/run-handler-snapshot-suppression.test.ts`
- `NX_TUI=false pnpm nx run @copilotkit/react-core:test --skip-nx-cache -- src/v2/components/chat/__tests__/CopilotChatToolRendering.e2e.test.tsx`
- `NX_TUI=false pnpm nx run @copilotkit/react-core:test --skip-nx-cache -- src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx`
- `NX_TUI=false pnpm nx run @copilotkit/core:test --skip-nx-cache -- src/__tests__/core-connect-thread-switch.test.ts`
- lefthook pre-commit: `pnpm run test` and `pnpm run check:packages`