### PR TITLE
fix(lefthook): exclude package.json from oxlint/oxfmt

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -29,7 +29,15 @@ pre-commit:
       # still invokes this hook with an empty expansion, and oxlint/oxfmt
       # would default to operating on the current directory, defeating the
       # scoping entirely. stage_fixed re-stages whatever the hooks modify.
-      glob: "*.{js,jsx,ts,tsx,mjs,cjs,json,jsonc,json5,md,css,yml,yaml,html,vue,py}"
+      # Intentionally excludes json/jsonc/json5: oxfmt --write rewrites JSON
+      # files into JSON5 syntax (4-space indent, trailing commas, compact
+      # objects) when invoked via lefthook with staged file paths. The result
+      # is invalid strict JSON that pnpm rejects with ERR_PNPM_JSON_PARSE,
+      # blocking every commit that touches a package.json (see PRs #5054,
+      # #5055). JSON formatting is owned by pnpm/manual editing; oxfmt has
+      # no per-file knobs to keep package.json valid, so the only safe fix
+      # is to keep .json* out of this hook entirely.
+      glob: "*.{js,jsx,ts,tsx,mjs,cjs,md,css,yml,yaml,html,vue,py}"
       # Mirror the ignorePatterns in .oxlintrc.json / .oxfmtrc.json at the
       # hook layer. Without this, a docs-only commit expands {staged_files}
       # to a single docs/** path; oxlint silently processes 0 files, then


### PR DESCRIPTION
## Summary

Removes `json`, `jsonc`, `json5` from the `lint-fix` pre-commit hook's glob in `lefthook.yml`. These extensions caused `oxfmt --write` to rewrite `package.json` files into invalid JSON5 syntax, breaking every commit that touched a `package.json` until the hook was bypassed.

## The bug

When `package.json` is staged and the `lint-fix` hook runs `oxlint --fix` + `oxfmt --write` over `{staged_files}`, oxfmt rewrites the file into:

- 4-space indent (instead of 2)
- Trailing commas after the last key in every object
- Compact single-line objects (e.g. `"publishConfig": {"access": "public"}`)

The result is **invalid strict JSON**. `pnpm install` then fails with:

```
ERR_PNPM_JSON_PARSE  Unexpected token } in JSON at line 8 column 5
```

This blocks the commit because lefthook re-stages the mangled file (`stage_fixed: true`), and any downstream tooling that calls `pnpm install` (sync-lockfile, CI, etc.) rejects it.

### Reproduction

With the buggy glob in place:

1. Edit any `package.json` (e.g. add a key)
2. `git add packages/<pkg>/package.json`
3. `lefthook run pre-commit --command lint-fix`
4. oxfmt logs `1 file reformatted`
5. `node -e "JSON.parse(require('fs').readFileSync('packages/<pkg>/package.json','utf8'))"` throws `SyntaxError: Expected double-quoted property name in JSON`

PRs #5054 and #5055 both shipped with `LEFTHOOK_EXCLUDE=lint-fix` to work around this.

## The fix

Drop `json,jsonc,json5` from the `lint-fix` glob. JSON formatting in this repo is owned by `pnpm` (writes strict 2-space JSON during lockfile sync) and manual editing — neither produces JSON5. oxfmt 0.36 exposes no per-file knobs (`printWidth`, `proseWrap`, `ignorePatterns` only) to keep `package.json` valid output, so excluding `.json*` at the hook layer is the minimal correct fix.

After the fix:

- JSON-only staged sets cause lefthook to skip `lint-fix` (`no files for inspection`) instead of mangling the file
- TS/JS/MD/CSS/YAML/etc. continue to flow through `oxlint --fix` + `oxfmt --write` unchanged
- `oxlint --fix` was a no-op on JSON anyway (`0 files`), so removing it costs nothing

A future oxfmt release that ships a configurable JSON formatter can re-add these extensions; left a comment in `lefthook.yml` explaining the rationale.

## Verification

Reproduced the bug locally with PR #5055's `packages/voice/package.json` edit, then applied this fix and re-ran the same flow:

- **Before fix**: oxfmt mangled the file → `JSON.parse` threw at line 8 col 5
- **After fix**: lefthook skipped `lint-fix`, file remained valid strict JSON
- **TS edit smoke test**: editing a `.ts` file in `packages/voice/src/` still triggers `lint-fix` and runs cleanly through oxlint+oxfmt

This commit itself was created without `LEFTHOOK_EXCLUDE` — the full pre-commit chain (`check-binaries`, `lint-fix`, `test-and-check-packages`, `commitlint`) ran green because `lefthook.yml` is not JSON.

## Related

- PR #5054 (`chore(deps): bump @ag-ui/langgraph to 0.0.34`) — bypassed via `LEFTHOOK_EXCLUDE=lint-fix`
- PR #5055 (`chore(voice): move @copilotkit/runtime from dependencies to peerDependencies`) — bypassed via `LEFTHOOK_EXCLUDE=lint-fix`, called out the bug in the PR description

## Test plan

- [ ] CI green
- [ ] Future PRs touching `package.json` no longer need `LEFTHOOK_EXCLUDE=lint-fix`