### PR TITLE
fix: remove stale smoke monitor refs

### DIFF
--- a/.github/workflows/showcase_keep-alive.yml
+++ b/.github/workflows/showcase_keep-alive.yml
@@ -5,8 +5,8 @@
 # tier doesn't sleep containers, but warm-state decays over idle.
 #
 # This workflow is intentionally minimal — no Slack, no metrics, no state.
-# Observability / alerting is already handled by showcase_smoke-monitor.yml.
-# This is strictly keep-alive.
+# This is strictly keep-alive; alerting lives with the validation/deploy
+# workflows.
 
 name: "Showcase: Keep-Alive"
 

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -20,7 +20,6 @@ on:
       - "pnpm-workspace.yaml"
       - ".github/workflows/showcase_validate.yml"
       - ".github/workflows/showcase_deploy.yml"
-      - ".github/workflows/showcase_smoke-monitor.yml"
 
 # Least-privilege by default. Individual jobs/steps can widen when needed.
 permissions:


### PR DESCRIPTION
## Summary
- remove stale smoke monitor workflow reference from showcase validate push paths
- update keep-alive comment so it no longer points at the deleted workflow

## Tests
- rg "showcase_smoke-monitor|smoke-monitor" .github/workflows
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/showcase_keep-alive.yml .github/workflows/showcase_validate.yml
- git diff --check -- .github/workflows/showcase_keep-alive.yml .github/workflows/showcase_validate.yml
- pre-commit hook: lint-fix, test-and-check-packages, commitlint passed on retry