### PR TITLE
fix(ci): parametrize publish-release.yml for workflow_call (PR-A)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -143,10 +143,14 @@ jobs:
 
   publish:
     needs: build
-    # Run when build succeeded (normal flow) OR was skipped (workflow_call: caller already
-    # built and uploaded the artifact). Default `if: success()` would skip publish whenever
-    # build is skipped, silently no-op'ing the entire workflow_call invocation.
-    if: ${{ !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') }}
+    # Run when build succeeded (normal flow) OR was skipped specifically because this is a
+    # workflow_call invocation (the caller already built and uploaded the artifact). The
+    # workflow_call branch is the ONE intentional skip — other skipped paths (notably a
+    # `pull_request: closed` event where the PR was closed WITHOUT merging, which makes the
+    # build job's own merged-true guard fail and skip) must NOT trigger publish. The default
+    # `if: success()` would also skip publish on legitimate workflow_call invocations, hence
+    # the explicit allowlist below.
+    if: ${{ !cancelled() && (needs.build.result == 'success' || (needs.build.result == 'skipped' && github.event_name == 'workflow_call')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: npm
@@ -230,7 +234,7 @@ jobs:
         run: pnpm tsx "scripts/release/$PUBLISH_SCRIPT" --scope "$SCOPE"
 
       - name: Verify publish step emitted version
-        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
+        if: ${{ success() && inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
         env:
           VERSION: ${{ steps.publish.outputs.version }}
         run: |
@@ -241,13 +245,13 @@ jobs:
           echo "VERSION=$VERSION confirmed"
 
       - name: Configure git user
-        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
+        if: ${{ success() && inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
       - name: Check for pre-existing tags
-        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
+        if: ${{ success() && inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
         env:
           SCOPE: ${{ steps.meta.outputs.scope }}
           VERSION: ${{ steps.publish.outputs.version }}
@@ -263,7 +267,7 @@ jobs:
           fi
 
       - name: Create and push git tag
-        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
+        if: ${{ success() && inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
         env:
           SCOPE: ${{ steps.meta.outputs.scope }}
           VERSION: ${{ steps.publish.outputs.version }}
@@ -279,7 +283,7 @@ jobs:
         id: tag
 
       - name: Create GitHub Release
-        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
+        if: ${{ success() && inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
@@ -320,7 +324,7 @@ jobs:
             }
 
       - name: Release summary (stable)
-        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
+        if: ${{ success() && inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
         run: |
           {
             echo "## Release Published"
@@ -332,7 +336,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Prerelease summary
-        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode == 'prerelease' }}
+        if: ${{ success() && inputs.dry-run != true && steps.meta.outputs.mode == 'prerelease' }}
         run: |
           {
             echo "## Prerelease Published"
@@ -343,7 +347,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dry-run summary
-        if: ${{ inputs.dry-run == true }}
+        if: ${{ success() && inputs.dry-run == true }}
         run: |
           {
             echo "## Dry Run Completed"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -222,22 +222,36 @@ jobs:
       - name: Publish to npm
         id: publish
         if: ${{ inputs.dry-run != true }}
-        run: pnpm tsx scripts/release/${{ inputs.publish-script || 'publish-release.ts' }} --scope ${{ steps.meta.outputs.scope }}
         env:
           NODE_AUTH_TOKEN: ""
           NOTION_API_KEY: ${{ steps.meta.outputs.mode == 'stable' && secrets.NOTION_API_KEY || '' }}
+          PUBLISH_SCRIPT: ${{ inputs.publish-script || 'publish-release.ts' }}
+          SCOPE: ${{ steps.meta.outputs.scope }}
+        run: pnpm tsx "scripts/release/$PUBLISH_SCRIPT" --scope "$SCOPE"
+
+      - name: Verify publish step emitted version
+        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
+        env:
+          VERSION: ${{ steps.publish.outputs.version }}
+        run: |
+          if [ -z "$VERSION" ]; then
+            echo "::error::publish step did not emit 'version' output. This indicates the publish-release.ts script (or the configured publish-script input) did not write to GITHUB_OUTPUT. Tag/release creation would produce malformed artifacts; aborting."
+            exit 1
+          fi
+          echo "VERSION=$VERSION confirmed"
 
       - name: Configure git user
-        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
+        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
       - name: Check for pre-existing tags
-        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
+        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
+        env:
+          SCOPE: ${{ steps.meta.outputs.scope }}
+          VERSION: ${{ steps.publish.outputs.version }}
         run: |
-          SCOPE="${{ steps.meta.outputs.scope }}"
-          VERSION="${{ steps.publish.outputs.version }}"
           if [ "$SCOPE" == "monorepo" ]; then
             TAG="v${VERSION}"
           else
@@ -249,10 +263,11 @@ jobs:
           fi
 
       - name: Create and push git tag
-        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
+        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
+        env:
+          SCOPE: ${{ steps.meta.outputs.scope }}
+          VERSION: ${{ steps.publish.outputs.version }}
         run: |
-          SCOPE="${{ steps.meta.outputs.scope }}"
-          VERSION="${{ steps.publish.outputs.version }}"
           if [ "$SCOPE" == "monorepo" ]; then
             TAG="v${VERSION}"
           else
@@ -264,7 +279,7 @@ jobs:
         id: tag
 
       - name: Create GitHub Release
-        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
+        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
@@ -304,11 +319,36 @@ jobs:
               });
             }
 
-      - name: Release summary
+      - name: Release summary (stable)
+        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease' }}
         run: |
-          echo "## Release Published" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Scope:** ${{ steps.meta.outputs.scope }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Mode:** ${{ steps.meta.outputs.mode }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ steps.publish.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** ${{ steps.tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Release Published"
+            echo ""
+            echo "**Scope:** ${{ steps.meta.outputs.scope }}"
+            echo "**Mode:** ${{ steps.meta.outputs.mode }}"
+            echo "**Version:** ${{ steps.publish.outputs.version }}"
+            echo "**Tag:** ${{ steps.tag.outputs.tag }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prerelease summary
+        if: ${{ inputs.dry-run != true && steps.meta.outputs.mode == 'prerelease' }}
+        run: |
+          {
+            echo "## Prerelease Published"
+            echo ""
+            echo "**Scope:** ${{ steps.meta.outputs.scope }}"
+            echo "**Version:** ${{ steps.publish.outputs.version }}"
+            echo "**Tag:** (prerelease — no tag created)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dry-run summary
+        if: ${{ inputs.dry-run == true }}
+        run: |
+          {
+            echo "## Dry Run Completed"
+            echo ""
+            echo "**Scope:** ${{ steps.meta.outputs.scope }}"
+            echo "**Mode:** ${{ steps.meta.outputs.mode }}"
+            echo "- Publish step was skipped; no npm publish, no git tag, no GitHub Release."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,6 +25,31 @@ on:
         options:
           - monorepo
           - angular
+      dry-run:
+        description: "Dry run (skip publish step)"
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      scope:
+        required: true
+        type: string
+      mode:
+        required: false
+        type: string
+        default: stable
+      dry-run:
+        required: false
+        type: boolean
+        default: false
+      publish-script:
+        required: false
+        type: string
+        default: publish-release.ts
+    secrets:
+      NOTION_API_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -39,10 +64,14 @@ env:
 jobs:
   build:
     # Run on a merged release PR (normal flow) or a manual workflow_dispatch (escape hatch).
+    # Skipped on workflow_call: the caller's build job uploads the "workspace" artifact, so
+    # the callee's publish job downloads it directly without re-building.
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-        startsWith(github.event.pull_request.head.ref, 'release/publish/'))
+      github.event_name != 'workflow_call' && (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event.pull_request.merged == true &&
+          startsWith(github.event.pull_request.head.ref, 'release/publish/'))
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -114,6 +143,10 @@ jobs:
 
   publish:
     needs: build
+    # Run when build succeeded (normal flow) OR was skipped (workflow_call: caller already
+    # built and uploaded the artifact). Default `if: success()` would skip publish whenever
+    # build is skipped, silently no-op'ing the entire workflow_call invocation.
+    if: ${{ !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: npm
@@ -121,6 +154,37 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Determine scope and mode
+        id: meta
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          INPUT_SCOPE: ${{ inputs.scope }}
+          INPUT_MODE: ${{ inputs.mode }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          # Scope: workflow_call and workflow_dispatch both populate inputs.scope;
+          # pull_request parses scope from the release branch name.
+          if [ -n "$INPUT_SCOPE" ]; then
+            SCOPE="$INPUT_SCOPE"
+          else
+            # Branch format: release/publish/<scope>/v<version>
+            SCOPE=$(echo "$PR_HEAD_REF" | sed 's|release/publish/\([^/]*\)/v.*|\1|')
+          fi
+          if [ -z "$SCOPE" ]; then
+            echo "::error::Failed to resolve scope (event=$EVENT_NAME, input=$INPUT_SCOPE, ref=$PR_HEAD_REF)"
+            exit 1
+          fi
+          # Mode: only workflow_call carries an explicit mode; everything else is stable.
+          if [ "$EVENT_NAME" = "workflow_call" ]; then
+            MODE="${INPUT_MODE:-stable}"
+          else
+            MODE="stable"
+          fi
+          echo "scope=$SCOPE" >> "$GITHUB_OUTPUT"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "Resolved scope=$SCOPE mode=$MODE (event=$EVENT_NAME)"
+
       - name: Download workspace
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -148,21 +212,31 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Dry-run notice
+        if: ${{ inputs.dry-run == true }}
+        run: |
+          echo "## Dry Run" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "DRY RUN — skipping publish step. Scope: ${{ steps.meta.outputs.scope }}, mode: ${{ steps.meta.outputs.mode }}." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Publish to npm
         id: publish
-        run: pnpm tsx scripts/release/publish-release.ts --scope ${{ needs.build.outputs.scope }}
+        if: ${{ inputs.dry-run != true }}
+        run: pnpm tsx scripts/release/${{ inputs.publish-script || 'publish-release.ts' }} --scope ${{ steps.meta.outputs.scope }}
         env:
           NODE_AUTH_TOKEN: ""
-          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          NOTION_API_KEY: ${{ steps.meta.outputs.mode == 'stable' && secrets.NOTION_API_KEY || '' }}
 
       - name: Configure git user
+        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
       - name: Check for pre-existing tags
+        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
         run: |
-          SCOPE="${{ needs.build.outputs.scope }}"
+          SCOPE="${{ steps.meta.outputs.scope }}"
           VERSION="${{ steps.publish.outputs.version }}"
           if [ "$SCOPE" == "monorepo" ]; then
             TAG="v${VERSION}"
@@ -175,8 +249,9 @@ jobs:
           fi
 
       - name: Create and push git tag
+        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
         run: |
-          SCOPE="${{ needs.build.outputs.scope }}"
+          SCOPE="${{ steps.meta.outputs.scope }}"
           VERSION="${{ steps.publish.outputs.version }}"
           if [ "$SCOPE" == "monorepo" ]; then
             TAG="v${VERSION}"
@@ -189,10 +264,11 @@ jobs:
         id: tag
 
       - name: Create GitHub Release
+        if: ${{ steps.meta.outputs.mode != 'prerelease' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
-          RELEASE_SCOPE: ${{ needs.build.outputs.scope }}
+          RELEASE_SCOPE: ${{ steps.meta.outputs.scope }}
           RELEASE_VERSION: ${{ steps.publish.outputs.version }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -232,6 +308,7 @@ jobs:
         run: |
           echo "## Release Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Scope:** ${{ needs.build.outputs.scope }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Scope:** ${{ steps.meta.outputs.scope }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Mode:** ${{ steps.meta.outputs.mode }}" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ steps.publish.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Tag:** ${{ steps.tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Why

The `release / pre` workflow (`prerelease.yml`) has been failing with `npm ENEEDAUTH` on every run since 2026-05-15 — see e.g. run `26529550757`. Customer canary publishes are blocked.

Root cause: npm enforces **exactly one** trusted publisher per package. All 16 monorepo-scoped packages (15 `@copilotkit/*` + `@copilotkitnext/angular`) are bound to `publish-release.yml @ CopilotKit/CopilotKit`. `prerelease.yml` cannot register as a second trusted publisher and therefore cannot complete the OIDC handshake.

## Fix (sequenced)

**This PR (PR-A)** parametrizes `publish-release.yml` so it can also be invoked via `workflow_call`. A follow-up PR (PR-B) converts `prerelease.yml` into a thin caller of this workflow. Because npm OIDC's `job_workflow_ref` claim resolves to the *callee* in a reusable-workflow invocation, the existing trust record on `publish-release.yml` covers both the stable and canary publish paths — no npm UI changes, no second trusted publisher.

## What changes

- New `workflow_call:` trigger with input schema (`scope`, `mode`, `dry-run`, `publish-script`) and optional `NOTION_API_KEY` secret.
- New `dry-run` input on the existing `workflow_dispatch` trigger (enables this PR's own post-merge verification via a sacrificial release branch).
- New `meta` step in the publish job unifying scope+mode resolution across all 3 event types (`pull_request`, `workflow_dispatch`, `workflow_call`).
- Build job gated to skip on `workflow_call` (the caller provides the artifact).
- Publish job `if:` override allows skipped-`needs.build` *only* when `event_name == 'workflow_call'` (prevents phantom publish on `pull_request: closed` without merge).
- All post-publish steps gated on `success() && inputs.dry-run != true && steps.meta.outputs.mode != 'prerelease'` so tag push and GH Release are only created on a successful stable publish.
- `NOTION_API_KEY` env wiring gated on `mode == 'stable'`.
- `Release summary` split into three variants (stable / prerelease / dry-run) so the summary never lies about what actually happened.
- New `Verify publish step emitted version` guard between npm publish and tag creation.
- `inputs.publish-script` and `steps.meta.outputs.scope` passed via `env:` (defense-in-depth shell hygiene).
- Concurrency key kept static (`publish-release`) — explicit decision, documented in the spec.

## Verification plan (post-merge, before PR-B)

1. Cut a sacrificial release branch (e.g. `release/publish/monorepo/v0.0.0-test`).
2. Dispatch `publish-release.yml` via `workflow_dispatch` with `scope=monorepo`, `dry-run=true`.
3. Confirm the new gating logic, scope/mode resolution, and artifact handoff all work end-to-end without an actual npm publish (the publish step is skipped under `dry-run`). Note: `dry-run` does NOT exercise the OIDC handshake — that is verified by PR-B's first real canary.

## Test plan

- [ ] CI green on the PR.
- [ ] After merge: sacrificial-branch `workflow_dispatch` with `dry-run=true` runs cleanly and emits the "Dry Run Completed" summary.
- [ ] No regression to stable releases — verified by next real stable release using the existing `pull_request: closed` path.