### PR TITLE
fix(ci): convert prerelease.yml into a thin caller of publish-release.yml

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -97,6 +97,23 @@ jobs:
 
   publish:
     needs: build
+    # Reusable-workflow permissions are CAPPED by the caller's per-job
+    # permissions (GitHub Actions semantics). The callee declares
+    # `id-token: write` and `contents: write` on its publish job, but
+    # without the caller granting those here, the callee would inherit
+    # only the workflow-level default (`contents: read`) and the npm
+    # OIDC token mint would fail silently. Grant explicitly:
+    #   - id-token: write  — REQUIRED for npm OIDC trusted publisher mint
+    #   - contents: write  — callee's stable-mode tag/release path
+    #                        (gated off in prerelease mode, but matches
+    #                        the callee's declared scope so the cap
+    #                        doesn't strip it)
+    #   - actions: read    — required by actions/download-artifact in
+    #                        the reusable workflow
+    permissions:
+      contents: write
+      id-token: write
+      actions: read
     # Delegate publish to the parametrized reusable workflow. npm's OIDC
     # trust binding uses the `job_workflow_ref` claim, which for a
     # reusable workflow resolves to the callee — so the existing trust

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -97,49 +97,23 @@ jobs:
 
   publish:
     needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    environment: npm
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Download workspace
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: workspace
-
-      - name: Setup pnpm
-        # Omit `version:` so pnpm/action-setup inherits from the repo's
-        # `packageManager` field in package.json (via corepack).
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22.x
-          registry-url: https://registry.npmjs.org
-
-      # Restore node_modules — the build job excludes them from the
-      # uploaded workspace artifact (see "Upload workspace" above). Uses
-      # pnpm-lock.yaml from the artifact, so this is a deterministic
-      # restore of exactly what the build job ran with. `pnpm tsx` in the
-      # publish step below requires tsx to be installed locally.
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Publish prerelease
-        env:
-          NODE_AUTH_TOKEN: ""
-          INPUT_SCOPE: ${{ inputs.scope }}
-          INPUT_SUFFIX: ${{ inputs.suffix }}
-          INPUT_DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          ARGS="--scope $INPUT_SCOPE"
-          if [ -n "$INPUT_SUFFIX" ]; then
-            ARGS="$ARGS --suffix $INPUT_SUFFIX"
-          fi
-          if [ "$INPUT_DRY_RUN" == "true" ]; then
-            ARGS="$ARGS --dry-run"
-          fi
-          pnpm tsx scripts/release/prerelease.ts $ARGS
+    # Delegate publish to the parametrized reusable workflow. npm's OIDC
+    # trust binding uses the `job_workflow_ref` claim, which for a
+    # reusable workflow resolves to the callee — so the existing trust
+    # record on publish-release.yml @ CopilotKit/CopilotKit matches when
+    # invoked from here. No second trusted publisher required.
+    #
+    # Input-name mapping at the with: boundary: the caller's
+    # workflow_dispatch.inputs.dry_run (underscore, preserved for
+    # backwards compatibility) maps to the callee's dry-run (hyphen,
+    # matching publish-release.yml's schema). Independent keys in
+    # independent namespaces.
+    #
+    # No secrets passed: NOTION_API_KEY is not needed for prereleases;
+    # the callee declares it as optional.
+    uses: ./.github/workflows/publish-release.yml
+    with:
+      scope: ${{ inputs.scope }}
+      mode: prerelease
+      dry-run: ${{ inputs.dry_run }}
+      publish-script: prerelease.ts


### PR DESCRIPTION
## Why

Follow-up to #5063. Together they unblock customer canary publishes that have been failing with `npm ENEEDAUTH` since 2026-05-15.

#5063 parametrized `publish-release.yml` to support `workflow_call`. This PR converts `prerelease.yml`'s publish path into a thin caller of that reusable workflow. Because npm OIDC's `job_workflow_ref` claim resolves to the callee in a reusable-workflow invocation, the existing trust record on `publish-release.yml` covers both stable AND canary publishes — no second trusted-publisher record needed (npm only allows one per package).

## What changes

- `prerelease.yml`'s `build` job is preserved verbatim (checkout, install, `bump-prerelease.ts --suffix`, build, test, upload `workspace` artifact).
- The old `publish` job is replaced with `uses: ./.github/workflows/publish-release.yml` with `mode: prerelease`, `publish-script: prerelease.ts`, `scope`, `dry-run`.
- The caller's `publish` job grants explicit `permissions: { contents: write, id-token: write, actions: read }` — REQUIRED for the callee's npm OIDC mint (per GitHub Actions, caller's per-job permissions cap the callee's declared permissions).
- The caller's `workflow_dispatch.inputs.dry_run` (underscore, preserved for backwards compat) maps to the callee's `dry-run` (hyphen) at the `with:` boundary.
- No `secrets:` block — Notion not needed for prereleases; callee declares `NOTION_API_KEY` optional and gates it on `mode == 'stable'`.

## Verification plan

1. Dispatch `prerelease.yml` with `scope: monorepo`, `suffix: test-oidc-refactor`, `dry_run: true` → confirms plumbing without an actual publish.
2. Dispatch again with `dry_run: false` → first OIDC-handshake-verifying real canary.
3. `npm view @copilotkit/runtime@1.58.0-canary.test-oidc-refactor --json | jq '.dist.attestations'` → confirm provenance attestation references `publish-release.yml`.

## Test plan

- [ ] CI green.
- [ ] Post-merge: dispatch dry-run + real canary per Verification plan above.
- [ ] Confirm provenance attestations land via `npm view`.

Supersedes #5066 (closed when #5063's base branch was deleted).