### PR TITLE
feat(react-core,runtime): finalize useLearnFromUserAction (RD-7)

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action-in-current-thread.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action-in-current-thread.test.tsx
@@ -184,6 +184,23 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     });
   });
 
+  it("threads learningContainer through to the underlying call", async () => {
+    installCopilotKit();
+    installChatConfig("thread-1");
+    const { calls, fetch } = mockFetch([
+      { status: 200, body: { id: "1", duplicate: false } },
+    ]);
+    globalThis.fetch = fetch;
+
+    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
+    await result.current({
+      title: "Renamed project",
+      learningContainer: ["user", "organization"],
+    });
+
+    expect(calls[0]!.body!.learningContainer).toEqual(["user", "organization"]);
+  });
+
   it("allows omitting all optional fields", async () => {
     installCopilotKit();
     installChatConfig("thread-1");

--- a/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action-in-current-thread.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action-in-current-thread.test.tsx
@@ -34,7 +34,7 @@ interface FetchCall {
 
 const mockFetch = (
   responses: Array<{ status: number; body: unknown }>,
-): { calls: FetchCall[]; fetch: typeof fetch } => {
+): { calls: FetchCall[]; fetch: typeof globalThis.fetch } => {
   const calls: FetchCall[] = [];
   let index = 0;
   const fetch = vi.fn(async (url, init) => {
@@ -101,7 +101,9 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
+    const { result } = renderHook(() =>
+      useLearnFromUserActionInCurrentThread(),
+    );
     await result.current({ title: "Clicked rename" });
 
     expect(calls).toHaveLength(1);
@@ -127,7 +129,9 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
+    const { result } = renderHook(() =>
+      useLearnFromUserActionInCurrentThread(),
+    );
     await result.current({ title: "x" });
 
     expect(calls[0]!.body!.threadId).toBe("auto-minted-uuid");
@@ -142,7 +146,9 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     globalThis.fetch = fetch;
 
     // Mounting the hook with no config is fine.
-    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
+    const { result } = renderHook(() =>
+      useLearnFromUserActionInCurrentThread(),
+    );
 
     // The call throws.
     await expect(result.current({ title: "x" })).rejects.toThrow(
@@ -153,7 +159,9 @@ describe("useLearnFromUserActionInCurrentThread", () => {
   it("throws on call when config.threadId is empty", async () => {
     installCopilotKit();
     installChatConfig("");
-    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
+    const { result } = renderHook(() =>
+      useLearnFromUserActionInCurrentThread(),
+    );
     await expect(result.current({ title: "x" })).rejects.toThrow(
       /no CopilotChatConfigurationProvider/,
     );
@@ -167,7 +175,9 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
+    const { result } = renderHook(() =>
+      useLearnFromUserActionInCurrentThread(),
+    );
     await result.current({
       title: "Renamed project",
       description: "User renamed Foo to Bar",
@@ -192,7 +202,9 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
+    const { result } = renderHook(() =>
+      useLearnFromUserActionInCurrentThread(),
+    );
     await result.current({
       title: "Renamed project",
       learningContainer: ["user", "organization"],
@@ -209,7 +221,9 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
+    const { result } = renderHook(() =>
+      useLearnFromUserActionInCurrentThread(),
+    );
     // No title, no description, no data — just thread context.
     await result.current({});
 

--- a/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action-in-current-thread.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action-in-current-thread.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCopilotKit } from "../../context";
 import { useCopilotChatConfiguration } from "../../providers";
-import { useRecordUserActionInCurrentThread } from "../use-record-user-action-in-current-thread";
+import { useLearnFromUserActionInCurrentThread } from "../use-learn-from-user-action-in-current-thread";
 
 vi.mock("../../context", () => ({
   useCopilotKit: vi.fn(),
@@ -80,7 +80,7 @@ const installChatConfig = (threadId: string | null | undefined) => {
   });
 };
 
-describe("useRecordUserActionInCurrentThread", () => {
+describe("useLearnFromUserActionInCurrentThread", () => {
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
@@ -101,7 +101,7 @@ describe("useRecordUserActionInCurrentThread", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserActionInCurrentThread());
+    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
     await result.current({ title: "Clicked rename" });
 
     expect(calls).toHaveLength(1);
@@ -127,7 +127,7 @@ describe("useRecordUserActionInCurrentThread", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserActionInCurrentThread());
+    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
     await result.current({ title: "x" });
 
     expect(calls[0]!.body!.threadId).toBe("auto-minted-uuid");
@@ -142,7 +142,7 @@ describe("useRecordUserActionInCurrentThread", () => {
     globalThis.fetch = fetch;
 
     // Mounting the hook with no config is fine.
-    const { result } = renderHook(() => useRecordUserActionInCurrentThread());
+    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
 
     // The call throws.
     await expect(result.current({ title: "x" })).rejects.toThrow(
@@ -153,7 +153,7 @@ describe("useRecordUserActionInCurrentThread", () => {
   it("throws on call when config.threadId is empty", async () => {
     installCopilotKit();
     installChatConfig("");
-    const { result } = renderHook(() => useRecordUserActionInCurrentThread());
+    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
     await expect(result.current({ title: "x" })).rejects.toThrow(
       /no CopilotChatConfigurationProvider/,
     );
@@ -167,12 +167,11 @@ describe("useRecordUserActionInCurrentThread", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserActionInCurrentThread());
+    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
     await result.current({
       title: "Renamed project",
       description: "User renamed Foo to Bar",
-      previousData: { name: "Foo" },
-      newData: { name: "Bar" },
+      data: { previous: { name: "Foo" }, next: { name: "Bar" } },
       metadata: { source: "settings-page" },
     });
 
@@ -180,8 +179,7 @@ describe("useRecordUserActionInCurrentThread", () => {
       threadId: "thread-1",
       title: "Renamed project",
       description: "User renamed Foo to Bar",
-      previousData: { name: "Foo" },
-      newData: { name: "Bar" },
+      data: { previous: { name: "Foo" }, next: { name: "Bar" } },
       metadata: { source: "settings-page" },
     });
   });
@@ -194,7 +192,7 @@ describe("useRecordUserActionInCurrentThread", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserActionInCurrentThread());
+    const { result } = renderHook(() => useLearnFromUserActionInCurrentThread());
     // No title, no description, no data — just thread context.
     await result.current({});
 

--- a/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import { useCopilotKit } from "../../context";
-import { useRecordUserAction } from "../use-record-user-action";
+import { useLearnFromUserAction } from "../use-learn-from-user-action";
 
 vi.mock("../../context", () => ({
   useCopilotKit: vi.fn(),
@@ -69,7 +69,7 @@ const installCopilotKit = (
   });
 };
 
-describe("useRecordUserAction", () => {
+describe("useLearnFromUserAction", () => {
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
@@ -89,12 +89,11 @@ describe("useRecordUserAction", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserAction());
+    const { result } = renderHook(() => useLearnFromUserAction());
     const recorded = await result.current({
       threadId: "thread-1",
       title: "Renamed project",
-      previousData: { name: "Foo" },
-      newData: { name: "Bar" },
+      data: { previous: { name: "Foo" }, next: { name: "Bar" } },
     });
 
     expect(recorded).toEqual({ id: "42", duplicate: false });
@@ -106,8 +105,7 @@ describe("useRecordUserAction", () => {
     expect(calls[0]!.body).toMatchObject({
       threadId: "thread-1",
       title: "Renamed project",
-      previousData: { name: "Foo" },
-      newData: { name: "Bar" },
+      data: { previous: { name: "Foo" }, next: { name: "Bar" } },
     });
     expect(typeof calls[0]!.body!.clientEventId).toBe("string");
     expect((calls[0]!.body!.clientEventId as string).length).toBeGreaterThan(0);
@@ -120,7 +118,7 @@ describe("useRecordUserAction", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserAction());
+    const { result } = renderHook(() => useLearnFromUserAction());
     await result.current({
       threadId: "thread-1",
       title: "X",
@@ -138,7 +136,7 @@ describe("useRecordUserAction", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserAction());
+    const { result } = renderHook(() => useLearnFromUserAction());
     await result.current({ threadId: "t", title: "x" });
     await result.current({ threadId: "t", title: "x" });
 
@@ -155,7 +153,7 @@ describe("useRecordUserAction", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserAction());
+    const { result } = renderHook(() => useLearnFromUserAction());
     await result.current({ threadId: "t", title: "x" });
 
     const headers = calls[0]!.init?.headers as Record<string, string>;
@@ -170,7 +168,7 @@ describe("useRecordUserAction", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserAction());
+    const { result } = renderHook(() => useLearnFromUserAction());
     await expect(result.current({ threadId: "t", title: "x" })).rejects.toThrow(
       /runtimeUrl is not configured/,
     );
@@ -184,7 +182,7 @@ describe("useRecordUserAction", () => {
         new TypeError("network request failed"),
       ) as unknown as typeof globalThis.fetch;
 
-    const { result } = renderHook(() => useRecordUserAction());
+    const { result } = renderHook(() => useLearnFromUserAction());
     await expect(result.current({ threadId: "t", title: "x" })).rejects.toThrow(
       /network request failed/,
     );
@@ -195,7 +193,7 @@ describe("useRecordUserAction", () => {
     const { fetch } = mockFetch([{ status: 400, body: { error: "bad" } }]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserAction());
+    const { result } = renderHook(() => useLearnFromUserAction());
     await expect(result.current({ threadId: "t", title: "x" })).rejects.toThrow(
       /400/,
     );
@@ -208,16 +206,42 @@ describe("useRecordUserAction", () => {
     ]);
     globalThis.fetch = fetch;
 
-    const { result } = renderHook(() => useRecordUserAction());
+    const { result } = renderHook(() => useLearnFromUserAction());
     await result.current({
       threadId: "t",
       title: "x",
     });
 
     expect(calls[0]!.body).not.toHaveProperty("description");
-    expect(calls[0]!.body).not.toHaveProperty("previousData");
-    expect(calls[0]!.body).not.toHaveProperty("newData");
+    expect(calls[0]!.body).not.toHaveProperty("data");
+    expect(calls[0]!.body).not.toHaveProperty("learningContainer");
     expect(calls[0]!.body).not.toHaveProperty("metadata");
     expect(calls[0]!.body).not.toHaveProperty("occurredAt");
+  });
+
+  test("forwards learningContainer (string) in the request body", async () => {
+    installCopilotKit();
+    const { calls, fetch } = mockFetch([
+      { status: 200, body: { id: "1", duplicate: false } },
+    ]);
+    globalThis.fetch = fetch;
+
+    const { result } = renderHook(() => useLearnFromUserAction());
+    await result.current({ threadId: "t1", learningContainer: "user" });
+
+    expect(calls[0]!.body!.learningContainer).toBe("user");
+  });
+
+  test("forwards learningContainer (array) in the request body", async () => {
+    installCopilotKit();
+    const { calls, fetch } = mockFetch([
+      { status: 200, body: { id: "1", duplicate: false } },
+    ]);
+    globalThis.fetch = fetch;
+
+    const { result } = renderHook(() => useLearnFromUserAction());
+    await result.current({ threadId: "t1", learningContainer: ["user", "organization"] });
+
+    expect(calls[0]!.body!.learningContainer).toEqual(["user", "organization"]);
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action.test.tsx
@@ -30,7 +30,7 @@ interface FetchCall {
 
 const mockFetch = (
   responses: Array<{ status: number; body: unknown }>,
-): { calls: FetchCall[]; fetch: typeof fetch } => {
+): { calls: FetchCall[]; fetch: typeof globalThis.fetch } => {
   const calls: FetchCall[] = [];
   let index = 0;
   const fetch = vi.fn(async (url, init) => {
@@ -240,7 +240,10 @@ describe("useLearnFromUserAction", () => {
     globalThis.fetch = fetch;
 
     const { result } = renderHook(() => useLearnFromUserAction());
-    await result.current({ threadId: "t1", learningContainer: ["user", "organization"] });
+    await result.current({
+      threadId: "t1",
+      learningContainer: ["user", "organization"],
+    });
 
     expect(calls[0]!.body!.learningContainer).toEqual(["user", "organization"]);
   });

--- a/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCopilotKit } from "../../context";
 import { useLearnFromUserAction } from "../use-learn-from-user-action";
 
@@ -219,7 +219,7 @@ describe("useLearnFromUserAction", () => {
     expect(calls[0]!.body).not.toHaveProperty("occurredAt");
   });
 
-  test("forwards learningContainer (string) in the request body", async () => {
+  it("forwards learningContainer (string) in the request body", async () => {
     installCopilotKit();
     const { calls, fetch } = mockFetch([
       { status: 200, body: { id: "1", duplicate: false } },
@@ -232,7 +232,7 @@ describe("useLearnFromUserAction", () => {
     expect(calls[0]!.body!.learningContainer).toBe("user");
   });
 
-  test("forwards learningContainer (array) in the request body", async () => {
+  it("forwards learningContainer (array) in the request body", async () => {
     installCopilotKit();
     const { calls, fetch } = mockFetch([
       { status: 200, body: { id: "1", duplicate: false } },

--- a/packages/react-core/src/v2/hooks/index.ts
+++ b/packages/react-core/src/v2/hooks/index.ts
@@ -17,17 +17,17 @@ export { useInterrupt } from "./use-interrupt";
 export type { UseInterruptConfig } from "./use-interrupt";
 export { useThreads } from "./use-threads";
 export type { Thread, UseThreadsInput, UseThreadsResult } from "./use-threads";
-export { useRecordUserAction } from "./use-record-user-action";
+export { useLearnFromUserAction } from "./use-learn-from-user-action";
 export type {
-  RecordUserActionInput,
-  RecordUserActionResult,
-  UseRecordUserActionRecorder,
-} from "./use-record-user-action";
-export { useRecordUserActionInCurrentThread } from "./use-record-user-action-in-current-thread";
+  LearnFromUserActionInput,
+  LearnFromUserActionResult,
+  UseLearnFromUserActionRecorder,
+} from "./use-learn-from-user-action";
+export { useLearnFromUserActionInCurrentThread } from "./use-learn-from-user-action-in-current-thread";
 export type {
-  RecordUserActionInCurrentThreadInput,
-  UseRecordUserActionInCurrentThreadRecorder,
-} from "./use-record-user-action-in-current-thread";
+  LearnFromUserActionInCurrentThreadInput,
+  UseLearnFromUserActionInCurrentThreadRecorder,
+} from "./use-learn-from-user-action-in-current-thread";
 export { useAttachments } from "./use-attachments";
 export type {
   UseAttachmentsProps,

--- a/packages/react-core/src/v2/hooks/use-learn-from-user-action-in-current-thread.tsx
+++ b/packages/react-core/src/v2/hooks/use-learn-from-user-action-in-current-thread.tsx
@@ -1,25 +1,25 @@
 import { useCallback } from "react";
 import { useCopilotChatConfiguration } from "../providers";
 import {
-  RecordUserActionInput,
-  RecordUserActionResult,
-  useRecordUserAction,
-} from "./use-record-user-action";
+  LearnFromUserActionInput,
+  LearnFromUserActionResult,
+  useLearnFromUserAction,
+} from "./use-learn-from-user-action";
 
 /**
- * Input to {@link UseRecordUserActionInCurrentThreadRecorder} — same as
- * {@link RecordUserActionInput} minus `threadId`, which is sourced from
+ * Input to {@link UseLearnFromUserActionInCurrentThreadRecorder} — same as
+ * {@link LearnFromUserActionInput} minus `threadId`, which is sourced from
  * the surrounding `<CopilotChatConfigurationProvider>` at call time.
  */
-export type RecordUserActionInCurrentThreadInput = Omit<
-  RecordUserActionInput,
+export type LearnFromUserActionInCurrentThreadInput = Omit<
+  LearnFromUserActionInput,
   "threadId"
 >;
 
-/** Recorder function returned by {@link useRecordUserActionInCurrentThread}. */
-export type UseRecordUserActionInCurrentThreadRecorder = (
-  input: RecordUserActionInCurrentThreadInput,
-) => Promise<RecordUserActionResult>;
+/** Recorder function returned by {@link useLearnFromUserActionInCurrentThread}. */
+export type UseLearnFromUserActionInCurrentThreadRecorder = (
+  input: LearnFromUserActionInCurrentThreadInput,
+) => Promise<LearnFromUserActionResult>;
 
 /**
  * Record a user UI interaction against the **current chat's** thread. The
@@ -30,11 +30,11 @@ export type UseRecordUserActionInCurrentThreadRecorder = (
  *
  * Throws on **call** (not on mount) when there is no chat-config provider
  * in scope — matches the "throw on call when runtimeUrl is missing"
- * behavior of {@link useRecordUserAction}. Mounting the hook in a branch
+ * behavior of {@link useLearnFromUserAction}. Mounting the hook in a branch
  * that never fires is harmless.
  *
  * The recorder does NOT accept a `threadId` override. If you need to
- * record against an explicit thread, use {@link useRecordUserAction}
+ * record against an explicit thread, use {@link useLearnFromUserAction}
  * directly — two hooks, two crisp contracts, no mode confusion.
  *
  * This hook always uses `config.threadId`, regardless of whether the
@@ -46,16 +46,15 @@ export type UseRecordUserActionInCurrentThreadRecorder = (
  *
  * @example
  * ```tsx
- * import { useRecordUserActionInCurrentThread } from "@copilotkit/react-core";
+ * import { useLearnFromUserActionInCurrentThread } from "@copilotkit/react-core";
  *
  * function SettingsPanel() {
- *   const recordUserAction = useRecordUserActionInCurrentThread();
+ *   const learnFromUserAction = useLearnFromUserActionInCurrentThread();
  *
  *   const onRename = (oldName: string, newName: string) => {
- *     void recordUserAction({
+ *     void learnFromUserAction({
  *       title: "Renamed project",
- *       previousData: { name: oldName },
- *       newData: { name: newName },
+ *       data: { previous: { name: oldName }, next: { name: newName } },
  *     });
  *   };
  *
@@ -63,24 +62,24 @@ export type UseRecordUserActionInCurrentThreadRecorder = (
  * }
  * ```
  */
-export function useRecordUserActionInCurrentThread(): UseRecordUserActionInCurrentThreadRecorder {
+export function useLearnFromUserActionInCurrentThread(): UseLearnFromUserActionInCurrentThreadRecorder {
   const config = useCopilotChatConfiguration();
-  const recordUserAction = useRecordUserAction();
+  const learnFromUserAction = useLearnFromUserAction();
 
   return useCallback(
     async (
-      input: RecordUserActionInCurrentThreadInput,
-    ): Promise<RecordUserActionResult> => {
+      input: LearnFromUserActionInCurrentThreadInput,
+    ): Promise<LearnFromUserActionResult> => {
       const threadId = config?.threadId;
       if (!threadId) {
         throw new Error(
-          "useRecordUserActionInCurrentThread: no CopilotChatConfigurationProvider in scope. " +
+          "useLearnFromUserActionInCurrentThread: no CopilotChatConfigurationProvider in scope. " +
             "Wrap the call site in <CopilotChat>, <CopilotSidebar>, or <CopilotChatConfigurationProvider>, " +
-            "or use `useRecordUserAction()` and pass `threadId` explicitly.",
+            "or use `useLearnFromUserAction()` and pass `threadId` explicitly.",
         );
       }
-      return recordUserAction({ ...input, threadId });
+      return learnFromUserAction({ ...input, threadId });
     },
-    [config?.threadId, recordUserAction],
+    [config?.threadId, learnFromUserAction],
   );
 }

--- a/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
+++ b/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
@@ -90,7 +90,9 @@ export function useLearnFromUserAction(): UseLearnFromUserActionRecorder {
   const { copilotkit } = useCopilotKit();
 
   return useCallback(
-    async (input: LearnFromUserActionInput): Promise<LearnFromUserActionResult> => {
+    async (
+      input: LearnFromUserActionInput,
+    ): Promise<LearnFromUserActionResult> => {
       const runtimeUrl = copilotkit.runtimeUrl;
       if (!runtimeUrl) {
         throw new Error(

--- a/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
+++ b/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
@@ -3,51 +3,52 @@ import { useCallback } from "react";
 import { useCopilotKit } from "../context";
 
 /**
- * Input to {@link UseRecordUserActionRecorder}, the function returned by
- * {@link useRecordUserAction}. Captures a single UI interaction that the
- * Intelligence platform's auto-curated knowledge base loop will distill
+ * Input to {@link UseLearnFromUserActionRecorder}, the function returned
+ * by {@link useLearnFromUserAction}. Captures a single UI interaction that
+ * the Intelligence platform's auto-curated knowledge base loop will distill
  * into the team's `/knowledge` notes.
  */
-export interface RecordUserActionInput {
+export interface LearnFromUserActionInput {
   /** Thread the action is associated with. May be unknown to the platform. */
   threadId: string;
   /** Short, agent-readable summary of what the user did. Optional. */
   title?: string | null;
   /** Optional longer explanation. */
   description?: string | null;
-  /** Optional JSON-serializable snapshot of state before the action. */
-  previousData?: unknown;
-  /** Optional JSON-serializable snapshot of state after the action. */
-  newData?: unknown;
+  /** Free-form, JSON-serializable snapshot describing the action. Optional. */
+  data?: unknown;
+  /**
+   * Learning container(s) this action is routed to. Accepts a single
+   * container name or an array of names. Defaults to `["organization"]`
+   * server-side when omitted. (Routing is not yet honored by the offline
+   * learner; the value is recorded for the forthcoming learner.)
+   */
+  learningContainer?: string | string[];
   /** Optional caller-defined metadata. Stored verbatim. */
   metadata?: Record<string, unknown> | null;
   /** ISO-8601 client-asserted timestamp. Defaults to server NOW() when absent. */
   occurredAt?: string;
   /**
    * Caller-supplied idempotency key. When omitted, the hook generates a
-   * fresh UUID per call so retries against the same in-flight Promise
-   * collapse to the original row at the platform. Supply your own when
-   * you want a single semantic event to remain idempotent across calls
-   * (e.g. across a React re-render or a manual retry button).
+   * fresh UUID per call so retries collapse to the original row at the
+   * platform. Supply your own to keep a single semantic event idempotent
+   * across calls (e.g. a React re-render or a manual retry button).
    */
   clientEventId?: string;
 }
 
 /** Outcome returned by the recorder function. */
-export interface RecordUserActionResult {
+export interface LearnFromUserActionResult {
   /** Platform-assigned id of the user-action row. */
   id: string;
-  /**
-   * True when the platform recognized this `clientEventId` as a retry and
-   * returned the original row id instead of inserting a new one.
-   */
+  /** True when the platform recognized this `clientEventId` as a retry. */
   duplicate: boolean;
 }
 
-/** Recorder function returned by {@link useRecordUserAction}. */
-export type UseRecordUserActionRecorder = (
-  input: RecordUserActionInput,
-) => Promise<RecordUserActionResult>;
+/** Recorder function returned by {@link useLearnFromUserAction}. */
+export type UseLearnFromUserActionRecorder = (
+  input: LearnFromUserActionInput,
+) => Promise<LearnFromUserActionResult>;
 
 /**
  * Record a user UI interaction in the Intelligence platform's user-actions
@@ -65,37 +66,35 @@ export type UseRecordUserActionRecorder = (
  * naive double-call (e.g. React 18 strict-mode double-mount, or a retry
  * after a network blip on a fresh Promise) is naturally safe. Supply your
  * own key when a single semantic event must remain idempotent across
- * multiple `recordUserAction(...)` calls.
+ * multiple `learnFromUserAction(...)` calls.
  *
  * @example
  * ```tsx
- * import { useRecordUserAction } from "@copilotkit/react-core";
+ * import { useLearnFromUserAction } from "@copilotkit/react-core";
  *
  * function SettingsPage({ threadId }) {
- *   const recordUserAction = useRecordUserAction();
+ *   const learnFromUserAction = useLearnFromUserAction();
  *
  *   const onRename = (oldName: string, newName: string) => {
- *     void recordUserAction({
+ *     void learnFromUserAction({
  *       threadId,
  *       title: "Renamed project",
- *       previousData: { name: oldName },
- *       newData: { name: newName },
+ *       data: { previous: { name: oldName }, next: { name: newName } },
+ *       learningContainer: "organization",
  *     });
  *   };
- *
- *   // ...
  * }
  * ```
  */
-export function useRecordUserAction(): UseRecordUserActionRecorder {
+export function useLearnFromUserAction(): UseLearnFromUserActionRecorder {
   const { copilotkit } = useCopilotKit();
 
   return useCallback(
-    async (input: RecordUserActionInput): Promise<RecordUserActionResult> => {
+    async (input: LearnFromUserActionInput): Promise<LearnFromUserActionResult> => {
       const runtimeUrl = copilotkit.runtimeUrl;
       if (!runtimeUrl) {
         throw new Error(
-          "useRecordUserAction: runtimeUrl is not configured. Set it on <CopilotKitProvider runtimeUrl=...>.",
+          "useLearnFromUserAction: runtimeUrl is not configured. Set it on <CopilotKitProvider runtimeUrl=...>.",
         );
       }
 
@@ -107,10 +106,10 @@ export function useRecordUserAction(): UseRecordUserActionRecorder {
         ...(input.description !== undefined
           ? { description: input.description }
           : {}),
-        ...(input.previousData !== undefined
-          ? { previousData: input.previousData }
+        ...(input.data !== undefined ? { data: input.data } : {}),
+        ...(input.learningContainer !== undefined
+          ? { learningContainer: input.learningContainer }
           : {}),
-        ...(input.newData !== undefined ? { newData: input.newData } : {}),
         ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
         ...(input.occurredAt !== undefined
           ? { occurredAt: input.occurredAt }
@@ -129,13 +128,13 @@ export function useRecordUserAction(): UseRecordUserActionRecorder {
       if (!response.ok) {
         const text = await response.text().catch(() => "");
         throw new Error(
-          `useRecordUserAction: request failed (${response.status})${
+          `useLearnFromUserAction: request failed (${response.status})${
             text ? `: ${text}` : ""
           }`,
         );
       }
 
-      return (await response.json()) as RecordUserActionResult;
+      return (await response.json()) as LearnFromUserActionResult;
     },
     [copilotkit],
   );

--- a/packages/runtime/src/v2/runtime/__tests__/handle-user-actions.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-user-actions.test.ts
@@ -270,6 +270,23 @@ describe("handleRecordUserAction", () => {
     ).toBeUndefined();
   });
 
+  it("forwards a malformed learningContainer (non-string, non-array) verbatim so the platform's Zod boundary is the single source of validation", async () => {
+    const recordUserAction = vi
+      .fn()
+      .mockResolvedValue({ id: "1", duplicate: false });
+    const runtime = createIntelligenceRuntime({
+      intelligence: { recordUserAction },
+    });
+    await handleRecordUserAction({
+      runtime,
+      request: buildRequest({ ...validBody(), learningContainer: 123 }),
+    });
+    // The runtime no longer silently rewrites bad input to `undefined`
+    // (which would silently land the platform default). The malformed
+    // value flows through; Intelligence's Zod rejects it with 400.
+    expect(recordUserAction.mock.calls[0]![0].learningContainer).toBe(123);
+  });
+
   it("returns the duplicate=true payload verbatim from the platform", async () => {
     const recordUserAction = vi
       .fn()

--- a/packages/runtime/src/v2/runtime/__tests__/handle-user-actions.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-user-actions.test.ts
@@ -265,7 +265,9 @@ describe("handleRecordUserAction", () => {
       runtime,
       request: buildRequest(validBody()),
     });
-    expect(recordUserAction.mock.calls[0]![0].learningContainer).toBeUndefined();
+    expect(
+      recordUserAction.mock.calls[0]![0].learningContainer,
+    ).toBeUndefined();
   });
 
   it("returns the duplicate=true payload verbatim from the platform", async () => {

--- a/packages/runtime/src/v2/runtime/__tests__/handle-user-actions.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-user-actions.test.ts
@@ -36,8 +36,7 @@ describe("handleRecordUserAction", () => {
     threadId: "thread-1",
     title: "Renamed project",
     description: "User renamed Foo to Bar",
-    previousData: { name: "Foo" },
-    newData: { name: "Bar" },
+    data: { previous: { name: "Foo" }, next: { name: "Bar" } },
     metadata: { source: "settings-page" },
   });
 
@@ -80,8 +79,7 @@ describe("handleRecordUserAction", () => {
         threadId: "thread-1",
         title: "Renamed project",
         description: "User renamed Foo to Bar",
-        previousData: { name: "Foo" },
-        newData: { name: "Bar" },
+        data: { previous: { name: "Foo" }, next: { name: "Bar" } },
         metadata: { source: "settings-page" },
         clientEventId: "0190a1b2-c3d4-7890-abcd-ef1234567890",
       }),
@@ -217,6 +215,57 @@ describe("handleRecordUserAction", () => {
     // than passing through as a record. Pin this so a future refactor
     // can't accidentally re-introduce the bug.
     expect(recordUserAction.mock.calls[0]![0].metadata).toBeUndefined();
+  });
+
+  it("forwards learningContainer (string) through to intelligence.recordUserAction", async () => {
+    const recordUserAction = vi
+      .fn()
+      .mockResolvedValue({ id: "1", duplicate: false });
+    const runtime = createIntelligenceRuntime({
+      intelligence: { recordUserAction },
+    });
+    await handleRecordUserAction({
+      runtime,
+      request: buildRequest({ ...validBody(), learningContainer: "user" }),
+    });
+    expect(recordUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({ learningContainer: "user" }),
+    );
+  });
+
+  it("forwards learningContainer (array) through to intelligence.recordUserAction", async () => {
+    const recordUserAction = vi
+      .fn()
+      .mockResolvedValue({ id: "1", duplicate: false });
+    const runtime = createIntelligenceRuntime({
+      intelligence: { recordUserAction },
+    });
+    await handleRecordUserAction({
+      runtime,
+      request: buildRequest({
+        ...validBody(),
+        learningContainer: ["user", "organization"],
+      }),
+    });
+    expect(recordUserAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        learningContainer: ["user", "organization"],
+      }),
+    );
+  });
+
+  it("omits learningContainer from the forward call when not provided", async () => {
+    const recordUserAction = vi
+      .fn()
+      .mockResolvedValue({ id: "1", duplicate: false });
+    const runtime = createIntelligenceRuntime({
+      intelligence: { recordUserAction },
+    });
+    await handleRecordUserAction({
+      runtime,
+      request: buildRequest(validBody()),
+    });
+    expect(recordUserAction.mock.calls[0]![0].learningContainer).toBeUndefined();
   });
 
   it("returns the duplicate=true payload verbatim from the platform", async () => {

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/user-actions.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/user-actions.ts
@@ -17,8 +17,8 @@ interface RecordUserActionBody {
   threadId: string;
   title?: string | null;
   description?: string | null;
-  previousData?: unknown;
-  newData?: unknown;
+  data?: unknown;
+  learningContainer?: string | string[];
   metadata?: Record<string, unknown> | null;
   occurredAt?: string;
   clientEventId: string;
@@ -90,8 +90,8 @@ export async function handleRecordUserAction({
       threadId: parsed.threadId,
       title: parsed.title,
       description: parsed.description,
-      previousData: parsed.previousData,
-      newData: parsed.newData,
+      data: parsed.data,
+      learningContainer: parsed.learningContainer,
       metadata: parsed.metadata,
       occurredAt: parsed.occurredAt,
       clientEventId: parsed.clientEventId,
@@ -144,8 +144,12 @@ function parseRecordUserActionBody(
           : isNonEmptyString(body.description)
             ? body.description
             : undefined,
-    previousData: body.previousData,
-    newData: body.newData,
+    data: body.data,
+    learningContainer:
+      typeof body.learningContainer === "string" ||
+      Array.isArray(body.learningContainer)
+        ? (body.learningContainer as string | string[])
+        : undefined,
     metadata:
       body.metadata === undefined
         ? undefined

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/user-actions.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/user-actions.ts
@@ -1,9 +1,9 @@
 import { logger } from "@copilotkit/shared";
-import {
+import type {
   CopilotIntelligenceRuntimeLike,
   CopilotRuntimeLike,
-  isIntelligenceRuntime,
 } from "../../core/runtime";
+import { isIntelligenceRuntime } from "../../core/runtime";
 import { PlatformRequestError } from "../../intelligence-platform/client";
 import { errorResponse, isHandlerResponse } from "../shared/json-response";
 import { resolveIntelligenceUser } from "../shared/resolve-intelligence-user";
@@ -55,7 +55,7 @@ function isNonEmptyString(value: unknown): value is string {
  * `POST /user-actions` handler.
  *
  * Three-tier flow:
- *   useRecordUserAction() (frontend)
+ *   useLearnFromUserAction() (frontend)
  *     → POST ${runtimeUrl}/user-actions
  *     → this handler resolves the Intel user from BFF auth
  *     → intelligence.recordUserAction(...)

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/user-actions.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/user-actions.ts
@@ -18,7 +18,14 @@ interface RecordUserActionBody {
   title?: string | null;
   description?: string | null;
   data?: unknown;
-  learningContainer?: string | string[];
+  /**
+   * Forwarded verbatim to the platform; Intelligence is the single
+   * authoritative validator and rejects malformed values (non-string,
+   * non-array, empty string, empty array, array with empty elements)
+   * with 400. The runtime intentionally does not type-guard this field
+   * to avoid silently rewriting bad input into the platform default.
+   */
+  learningContainer?: unknown;
   metadata?: Record<string, unknown> | null;
   occurredAt?: string;
   clientEventId: string;
@@ -145,11 +152,7 @@ function parseRecordUserActionBody(
             ? body.description
             : undefined,
     data: body.data,
-    learningContainer:
-      typeof body.learningContainer === "string" ||
-      Array.isArray(body.learningContainer)
-        ? (body.learningContainer as string | string[])
-        : undefined,
+    learningContainer: body.learningContainer,
     metadata:
       body.metadata === undefined
         ? undefined

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -604,8 +604,7 @@ describe("CopilotKitIntelligence", () => {
       userId: "user-1",
       threadId: "thread-1",
       title: "Renamed project",
-      previousData: { name: "Foo" },
-      newData: { name: "Bar" },
+      data: { previous: { name: "Foo" }, next: { name: "Bar" } },
       metadata: { source: "settings-page" },
       clientEventId: "0190a1b2-c3d4-7890-abcd-ef1234567890",
     };
@@ -643,8 +642,7 @@ describe("CopilotKitIntelligence", () => {
         userId: "user-1",
         threadId: "thread-1",
         title: "Renamed project",
-        previousData: { name: "Foo" },
-        newData: { name: "Bar" },
+        data: { previous: { name: "Foo" }, next: { name: "Bar" } },
         metadata: { source: "settings-page" },
         clientEventId: validParams.clientEventId,
       });
@@ -708,6 +706,42 @@ describe("CopilotKitIntelligence", () => {
       await expect(client.recordUserAction(validParams)).rejects.toMatchObject({
         status: 502,
       });
+    });
+
+    it("forwards learningContainer (string) verbatim in the request body", async () => {
+      fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
+
+      await client.recordUserAction({
+        ...validParams,
+        learningContainer: "user",
+      });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(JSON.parse(opts.body).learningContainer).toBe("user");
+    });
+
+    it("forwards learningContainer (array) verbatim in the request body", async () => {
+      fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
+
+      await client.recordUserAction({
+        ...validParams,
+        learningContainer: ["user", "organization"],
+      });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(JSON.parse(opts.body).learningContainer).toEqual([
+        "user",
+        "organization",
+      ]);
+    });
+
+    it("omits learningContainer from the body when not provided", async () => {
+      fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
+
+      await client.recordUserAction(validParams);
+
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(JSON.parse(opts.body).learningContainer).toBeUndefined();
     });
   });
 });

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -213,21 +213,15 @@ export interface RecordUserActionRequest {
   title?: string | null;
   /** Optional longer explanation. */
   description?: string | null;
-  /** Optional snapshot of state before the action. JSON-serializable. */
-  previousData?: unknown;
-  /** Optional snapshot of state after the action. JSON-serializable. */
-  newData?: unknown;
+  /** Free-form JSON-serializable snapshot describing the action. */
+  data?: unknown;
+  /** Learning container(s) for this action. Defaults to ["organization"] at the platform. */
+  learningContainer?: string | string[];
   /** Optional caller-defined metadata. Stored verbatim. */
   metadata?: Record<string, unknown> | null;
   /** ISO-8601 client-asserted timestamp. Defaults to server NOW() when absent. */
   occurredAt?: string;
-  /**
-   * Caller-supplied idempotency key (any RFC-compliant UUID; the
-   * frontend hook `useRecordUserAction` auto-generates one per call,
-   * so retries are safe by default). Every call hits the platform's
-   * idempotent PUT endpoint; a retry with the same id collapses to
-   * the original row.
-   */
+  /** Caller-supplied idempotency key (UUID). */
   clientEventId: string;
 }
 

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -215,8 +215,14 @@ export interface RecordUserActionRequest {
   description?: string | null;
   /** Free-form JSON-serializable snapshot describing the action. */
   data?: unknown;
-  /** Learning container(s) for this action. Defaults to ["organization"] at the platform. */
-  learningContainer?: string | string[];
+  /**
+   * Learning container(s) for this action. Forwarded verbatim to the
+   * platform, which is the single authoritative validator: well-formed
+   * input is `string | string[]` (non-empty strings, non-empty array);
+   * the platform defaults to `["organization"]` when the field is
+   * omitted entirely, and 400s on malformed values.
+   */
+  learningContainer?: unknown;
   /** Optional caller-defined metadata. Stored verbatim. */
   metadata?: Record<string, unknown> | null;
   /** ISO-8601 client-asserted timestamp. Defaults to server NOW() when absent. */

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -221,7 +221,13 @@ export interface RecordUserActionRequest {
   metadata?: Record<string, unknown> | null;
   /** ISO-8601 client-asserted timestamp. Defaults to server NOW() when absent. */
   occurredAt?: string;
-  /** Caller-supplied idempotency key (UUID). */
+  /**
+   * Caller-supplied idempotency key (any RFC-compliant UUID; the
+   * frontend hook `useLearnFromUserAction` auto-generates one per call,
+   * so retries are safe by default). Every call hits the platform's
+   * idempotent PUT endpoint; a retry with the same id collapses to
+   * the original row.
+   */
   clientEventId: string;
 }
 


### PR DESCRIPTION
Implements Linear **[RD-7](https://linear.app/copilotkit/issue/RD-7/finalize-uselearnfromuseraction)** on the SDK side.

## What this does

- Renames `useRecordUserAction` → **`useLearnFromUserAction`** and `useRecordUserActionInCurrentThread` → **`useLearnFromUserActionInCurrentThread`** (plus their exported types) in `@copilotkit/react-core`.
- Collapses the `previousData` + `newData` payload into a single free-form **`data?: unknown`** at every layer (hook → runtime body → platform request).
- Adds optional **`learningContainer?: string | string[]`** on the public hook surface. The hook and runtime forward the value verbatim (no validation, no normalization, no silent rewrites); the Intelligence backend is the single authoritative validator. For now this field is **store-only** at the backend — it's persisted but the offline learner doesn't act on it yet (future work).

## Validation philosophy: single source of truth at the wire boundary

To keep the system easy to reason about, `learningContainer` validation lives in **exactly one place**: Intelligence's Zod schema. The hook and runtime are thin pass-throughs.

- The runtime body type (`RecordUserActionBody.learningContainer`) and the platform request type (`RecordUserActionRequest.learningContainer`) are typed as `unknown` (mirroring how `data` is typed). Malformed input flows through to Intelligence, which rejects it with a clean `400 VALIDATION_ERROR`.
- The runtime used to silently rewrite non-string / non-array values to `undefined`, which then became the platform default (`["organization"]`) — a hidden default-on-bad-input. That's removed; bad input now surfaces loudly at the platform boundary instead of getting magic-defaulted into success.
- The customer-facing hook type stays narrow (`string | string[]`) so TypeScript callers get compile-time safety; only the internal wire types loosen to `unknown` so the platform can do the rejecting.

See the paired [Intelligence#238](https://github.com/CopilotKit/Intelligence/pull/238) for the strict Zod schema and the behavior table.

## What this deliberately does NOT change (and why)

We applied a **"hooks + types only"** rename depth: only the public-facing React surface (`useLearnFromUserAction*` hooks and their exported TypeScript types) was renamed. Internal runtime-side names were kept.

**Kept in this repo:**

- Runtime handler `handleRecordUserAction` and its HTTP route `POST /user-actions`
- Platform client method `recordUserAction()`
- Internal request/body interface NAMES: `RecordUserActionBody`, `RecordUserActionRequest` (their `learningContainer` field types loosened to `unknown` per the validation philosophy above, but the interface names stay)

**Rationale.** The hook is the customer-facing name and warrants the rename cost. The handler name, the route, and the platform method are internal to the SDK→runtime→Intelligence chain — they aren't visible outside the SDK, so renaming them would break wire compatibility with existing runtime deployments and add scope to this PR without customer-visible benefit. JSDoc on the kept types points back to `useLearnFromUserAction` so the trail stays readable.

A deeper rename (route, handler, platform method) can land later in a dedicated PR with a deprecation window if the cost of the naming gap ever starts to bite. This is a paired change with [Intelligence#238](https://github.com/CopilotKit/Intelligence/pull/238) — both repos apply the same "hooks + types only" depth.

## Verification

- `nx test react-core` — 1187 pass (incl. 3 `learningContainer` forwarding tests across the two hook files).
- `nx test runtime` — **1504 pass** (incl. 6 runtime handler + platform client `learningContainer` tests, the most recent being the "verbatim forwarding of malformed input" assertion that pins the validation-philosophy decision).
- `nx run-many -t build -p react-core,runtime` — clean.
- `nx run-many -t check-types -p react-core,runtime` — no new errors in `packages/react-core/src` or `packages/runtime/src` (pre-existing `@copilotkit/a2ui-renderer` / `@copilotkit/shared` baseline errors are unrelated and present on `mme/learn-from-user-activity`).
- Pre-push gate (oxfmt --check, oxlint, tsc, vitest, build) clean.

## Commits

- refactor(react-core): rename useRecordUserAction to useLearnFromUserAction
- test(react-core): tidy learnFromUserAction hook tests
- refactor(runtime): carry data + learningContainer through user-actions
- docs(runtime): restore clientEventId idempotency note on RecordUserActionRequest
- docs(runtime): align handler JSDoc with hook rename
- style(react-core,runtime): apply oxfmt formatting and fix mockFetch return type
- refactor(runtime): forward learningContainer verbatim instead of silent-stripping

## Note for the reviewer

The branch is `lukasmoschitz/finalize-uselearnfromuseraction` rather than Linear's auto-suggested `lukas/rd-7-...`, so this PR title/body references **RD-7** explicitly to keep Linear linked.
