### PR TITLE
fix(ci): pack workspace as tarball to bypass upload-artifact enumeration

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -141,22 +141,25 @@ jobs:
       - name: Build packages
         run: pnpm run build
 
-      # Exclude node_modules and build caches from the artifact. Including
-      # them produces ~6.4M files for this monorepo, which OOMs
-      # upload-artifact's Node process at its 4GB heap limit during
-      # enumeration. The publish job runs `pnpm install` after download to
-      # restore node_modules from pnpm-lock.yaml.
+      # Strip caches and pack the workspace into a single tarball before
+      # upload. upload-artifact's path filters are post-walk: it still
+      # descends into every node_modules and stats every file (~6.4M for
+      # this monorepo with pnpm's .pnpm/ symlink farm) before applying
+      # negations, which is the actual bottleneck. Removing the dirs and
+      # uploading one file collapses that to a single fast step. The
+      # publish job runs `pnpm install` after unpack to restore
+      # node_modules from pnpm-lock.yaml.
+      - name: Pack workspace
+        run: |
+          set -euo pipefail
+          find . -type d \( -name node_modules -o -name .nx -o -name .turbo -o -name .next \) -prune -exec rm -rf {} +
+          tar -czf /tmp/workspace.tgz .
+
       - name: Upload workspace
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workspace
-          path: |
-            .
-            !**/node_modules/**
-            !**/.next/**
-            !**/.turbo/**
-            !**/.nx/**
-          include-hidden-files: true
+          path: /tmp/workspace.tgz
           retention-days: 1
 
     outputs:
@@ -200,6 +203,12 @@ jobs:
         with:
           name: workspace
 
+      - name: Unpack workspace
+        run: |
+          set -euo pipefail
+          tar -xzf workspace.tgz
+          rm workspace.tgz
+
       - name: Configure git credentials
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -218,8 +227,8 @@ jobs:
           node-version: 22.x
           registry-url: https://registry.npmjs.org
 
-      # Restore node_modules — the build job excludes them from the
-      # uploaded workspace artifact (see "Upload workspace" above). Uses
+      # Restore node_modules — the build job strips them before packing
+      # the workspace tarball (see "Pack workspace" above). Uses
       # pnpm-lock.yaml from the artifact, so this is a deterministic
       # restore of exactly what the build job ran with.
       - name: Install Dependencies


### PR DESCRIPTION
## Summary

- Replace upload-artifact's filtered path approach (`!**/node_modules/**` etc.) with `find -prune -exec rm -rf` + `tar -czf` of the workspace, then a single-file upload. The publish job unpacks before configuring git credentials.
- upload-artifact's path filters are post-walk: even with negation filters, the action still descends into every `node_modules` and stats every file (~6.4M for this monorepo with pnpm's `.pnpm/` symlink farm) before applying negations. That enumeration is the actual bottleneck — the Upload workspace step still runs 10+ minutes with the filters alone.
- Re-applies the work from `worktree-prerelease-tar-pack` (122b2ab) against the single-workflow layout introduced by #5071. The original branch couldn't cherry-pick cleanly because `prerelease.yml` was deleted and `publish-release.yml` was substantially restructured.

## Test plan

- [ ] Dispatch `release / publish` with `mode=prerelease`, `dry-run=true` against this branch and confirm the build job's Pack/Upload steps run quickly (single-digit minutes) and the publish job's Download/Unpack steps succeed before the dry-run skip.
- [ ] After merge, observe a real prerelease run end-to-end to verify upload time dropped vs. pre-PR baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)