### PR TITLE
feat(react-core): per-turn persistent intelligence indicator + tag finished state

### DIFF
--- a/examples/v2/react/storybook/stories/IntelligenceIndicator.stories.tsx
+++ b/examples/v2/react/storybook/stories/IntelligenceIndicator.stories.tsx
@@ -5,14 +5,12 @@ import type { IntelligenceIndicatorViewProps } from "@copilotkit/react-core/v2";
 
 /**
  * `IntelligenceIndicatorView` is the presentational face of the
- * "Using CopilotKit Intelligence" indicator — the default rendered by
- * the `intelligenceIndicator` slot on `CopilotChat`. It is a two-mode
- * component that owns its own spinner ⇄ tag cross-fade:
- *
- *   - `status="in-progress"` shows the glassmorphism pill with a
- *     spinning ring while Intelligence is working.
- *   - `status="finished"` shows the compact icon + text tag that
- *     stays in chat history per turn.
+ * "CopilotKit Intelligence" indicator — the default rendered by the
+ * `intelligenceIndicator` slot on `CopilotChat`. Single-element
+ * three-stage design: glassmorphism chrome around a 270° arc that
+ * morphs to a checkmark on `status="finished"`, after which the
+ * chrome fades and the label settles to a neutral gray with a slight
+ * italic-like slant.
  *
  * The orchestration brain (`IntelligenceIndicator`) is provider- and
  * agent-driven, so it's covered by unit/e2e tests rather than stories.
@@ -44,7 +42,7 @@ const meta = {
   ],
   args: {
     message: mockMessage,
-    label: "Using CopilotKit Intelligence",
+    label: "CopilotKit Intelligence",
     status: "in-progress",
   },
 } satisfies Meta<typeof IntelligenceIndicatorView>;

--- a/examples/v2/react/storybook/stories/IntelligenceIndicator.stories.tsx
+++ b/examples/v2/react/storybook/stories/IntelligenceIndicator.stories.tsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { IntelligenceIndicatorView } from "@copilotkit/react-core/v2";
+import type { IntelligenceIndicatorViewProps } from "@copilotkit/react-core/v2";
+
+/**
+ * `IntelligenceIndicatorView` is the presentational face of the
+ * "Using CopilotKit Intelligence" indicator — the default rendered by
+ * the `intelligenceIndicator` slot on `CopilotChat`. It is a two-mode
+ * component that owns its own spinner ⇄ tag cross-fade:
+ *
+ *   - `status="in-progress"` shows the glassmorphism pill with a
+ *     spinning ring while Intelligence is working.
+ *   - `status="finished"` shows the compact icon + text tag that
+ *     stays in chat history per turn.
+ *
+ * The orchestration brain (`IntelligenceIndicator`) is provider- and
+ * agent-driven, so it's covered by unit/e2e tests rather than stories.
+ */
+
+const mockMessage = {
+  id: "story-message",
+  role: "assistant" as const,
+  content: "",
+};
+
+const meta = {
+  title: "UI/IntelligenceIndicator",
+  component: IntelligenceIndicatorView,
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: "240px",
+          padding: "32px",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    message: mockMessage,
+    label: "Using CopilotKit Intelligence",
+    status: "in-progress",
+  },
+} satisfies Meta<typeof IntelligenceIndicatorView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Active phase: glassmorphism pill with a spinning ring. */
+export const InProgress: Story = {
+  args: { status: "in-progress" },
+};
+
+/**
+ * Persistent finished phase: compact icon + text tag. This is what
+ * sits quietly in chat history per turn — one tag per agent turn that
+ * used Intelligence, kept forever in scroll-back.
+ */
+export const Finished: Story = {
+  args: { status: "finished" },
+};
+
+/** Props-tier slot override demo: a custom label passed through the slot. */
+export const WithCustomLabel: Story = {
+  args: { status: "finished", label: "Recalling memory" },
+};
+
+/**
+ * Animated timeline: enter as `in-progress`, then flip to `finished`
+ * after ~1.5s. The face's built-in opacity cross-fade swaps the
+ * spinner pill out for the persistent tag. Click "Restart" to replay.
+ */
+export const Playground: Story = {
+  render: (args) => {
+    const [tick, setTick] = useState(0);
+    const [status, setStatus] = useState<"in-progress" | "finished">(
+      "in-progress",
+    );
+    useEffect(() => {
+      setStatus("in-progress");
+      const t = setTimeout(() => setStatus("finished"), 1500);
+      return () => clearTimeout(t);
+    }, [tick]);
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "16px",
+          alignItems: "center",
+        }}
+      >
+        <IntelligenceIndicatorView {...args} status={status} />
+        <button
+          onClick={() => setTick((n) => n + 1)}
+          style={{
+            padding: "6px 14px",
+            borderRadius: 6,
+            border: "1px solid #d4d4d8",
+            background: "#fafafa",
+            cursor: "pointer",
+          }}
+        >
+          Restart
+        </button>
+      </div>
+    );
+  },
+};
+
+/**
+ * A fully custom face — what a slot consumer would render when they
+ * pass `<CopilotChat intelligenceIndicator={MyCustomIndicator} />`. It
+ * receives the same `{ status, label, message }` props the brain hands
+ * the default face, and decides its own look from `status`.
+ */
+const CustomFace: React.FC<IntelligenceIndicatorViewProps> = ({
+  status,
+  label,
+}) => {
+  const isFinished = status === "finished";
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "6px 14px",
+        borderRadius: 999,
+        background: isFinished ? "#dcfce7" : "#fef3c7",
+        color: isFinished ? "#166534" : "#92400e",
+        fontSize: 13,
+        fontWeight: 600,
+        transition: "background 360ms ease-out, color 360ms ease-out",
+      }}
+    >
+      <span>{isFinished ? "✅" : "⏳"}</span>
+      <span>{isFinished ? `${label} — done` : `${label}…`}</span>
+    </span>
+  );
+};
+
+export const FullyCustomFace: Story = {
+  render: (args) => {
+    const [tick, setTick] = useState(0);
+    const [status, setStatus] = useState<"in-progress" | "finished">(
+      "in-progress",
+    );
+    useEffect(() => {
+      setStatus("in-progress");
+      const t = setTimeout(() => setStatus("finished"), 1500);
+      return () => clearTimeout(t);
+    }, [tick]);
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "16px",
+          alignItems: "center",
+        }}
+      >
+        <CustomFace {...args} status={status} />
+        <button
+          onClick={() => setTick((n) => n + 1)}
+          style={{
+            padding: "6px 14px",
+            borderRadius: 6,
+            border: "1px solid #d4d4d8",
+            background: "#fafafa",
+            cursor: "pointer",
+          }}
+        >
+          Restart
+        </button>
+      </div>
+    );
+  },
+};

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -26,6 +26,7 @@ import { useRenderActivityMessage, useRenderCustomMessages } from "../../hooks";
 import { useCopilotKit } from "../../providers/CopilotKitProvider";
 import { useCopilotChatConfiguration } from "../../providers/CopilotChatConfigurationProvider";
 import { IntelligenceIndicator } from "../intelligence-indicator";
+import type { IntelligenceIndicatorView } from "../intelligence-indicator";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
 
 /**
@@ -353,6 +354,7 @@ export type CopilotChatMessageViewProps = Omit<
       userMessage: typeof CopilotChatUserMessage;
       reasoningMessage: typeof CopilotChatReasoningMessage;
       cursor: typeof CopilotChatMessageView.Cursor;
+      intelligenceIndicator: typeof IntelligenceIndicatorView;
     },
     {
       isRunning?: boolean;
@@ -380,6 +382,7 @@ export function CopilotChatMessageView({
   userMessage,
   reasoningMessage,
   cursor,
+  intelligenceIndicator,
   isRunning = false,
   children,
   className,
@@ -619,6 +622,7 @@ export function CopilotChatMessageView({
           key={`${message.id}-intelligence`}
           message={message}
           agentId={config?.agentId ?? DEFAULT_AGENT_ID}
+          intelligenceIndicator={intelligenceIndicator}
         />,
       );
     }

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -379,10 +379,6 @@ export type CopilotChatMessageViewProps = Omit<
 // worth it and the simpler flat render is faster.
 const VIRTUALIZE_THRESHOLD = 50;
 
-// Stable empty map for the (common) non-intelligence case, so the anchors memo
-// doesn't churn its identity when intelligence mode is off.
-const EMPTY_TURN_ANCHORS: ReadonlyMap<string, string> = new Map();
-
 export function CopilotChatMessageView({
   messages = [],
   assistantMessage,
@@ -546,14 +542,13 @@ export function CopilotChatMessageView({
 
   // Map each Intelligence-using turn's anchor message → stable turn id. One
   // indicator is emitted per turn (keyed by the turn id) at its anchor, so it
-  // moves with the anchor without remounting. Computed over the deduplicated
-  // messages we actually render.
+  // moves with the anchor without remounting. `getIntelligenceTurnAnchors`
+  // only yields anchors for turns that invoked the knowledge-base tool, so
+  // non-Intelligence turns naturally produce an empty map (and the indicator
+  // itself also hard-gates on intelligence mode).
   const intelligenceTurnAnchors = useMemo(
-    () =>
-      copilotkit.intelligence !== undefined
-        ? getIntelligenceTurnAnchors(deduplicatedMessages)
-        : EMPTY_TURN_ANCHORS,
-    [copilotkit.intelligence, deduplicatedMessages],
+    () => getIntelligenceTurnAnchors(deduplicatedMessages),
+    [deduplicatedMessages],
   );
 
   // ---------------------------------------------------------------------------
@@ -629,11 +624,10 @@ export function CopilotChatMessageView({
     }
 
     // Auto-mount the IntelligenceIndicator once per Intelligence-using turn,
-    // at that turn's anchor message (its last bash-using assistant), keyed by
+    // at that turn's anchor message (its first bash-using assistant), keyed by
     // the stable turn id. Keying by turn (not message) means the indicator
     // moves with the anchor across a hand-off without remounting, and past
-    // turns keep their own indicator. `getIntelligenceTurnAnchors` already
-    // gated on intelligence mode (empty map when off).
+    // turns keep their own indicator.
     const intelligenceTurnId = intelligenceTurnAnchors.get(message.id);
     if (intelligenceTurnId !== undefined) {
       elements.push(

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -25,7 +25,10 @@ import { twMerge } from "tailwind-merge";
 import { useRenderActivityMessage, useRenderCustomMessages } from "../../hooks";
 import { useCopilotKit } from "../../providers/CopilotKitProvider";
 import { useCopilotChatConfiguration } from "../../providers/CopilotChatConfigurationProvider";
-import { IntelligenceIndicator } from "../intelligence-indicator";
+import {
+  IntelligenceIndicator,
+  getIntelligenceTurnAnchors,
+} from "../intelligence-indicator";
 import type { IntelligenceIndicatorView } from "../intelligence-indicator";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
 
@@ -376,6 +379,10 @@ export type CopilotChatMessageViewProps = Omit<
 // worth it and the simpler flat render is faster.
 const VIRTUALIZE_THRESHOLD = 50;
 
+// Stable empty map for the (common) non-intelligence case, so the anchors memo
+// doesn't churn its identity when intelligence mode is off.
+const EMPTY_TURN_ANCHORS: ReadonlyMap<string, string> = new Map();
+
 export function CopilotChatMessageView({
   messages = [],
   assistantMessage,
@@ -537,6 +544,18 @@ export function CopilotChatMessageView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldVirtualize, firstMessageId]);
 
+  // Map each Intelligence-using turn's anchor message → stable turn id. One
+  // indicator is emitted per turn (keyed by the turn id) at its anchor, so it
+  // moves with the anchor without remounting. Computed over the deduplicated
+  // messages we actually render.
+  const intelligenceTurnAnchors = useMemo(
+    () =>
+      copilotkit.intelligence !== undefined
+        ? getIntelligenceTurnAnchors(deduplicatedMessages)
+        : EMPTY_TURN_ANCHORS,
+    [copilotkit.intelligence, deduplicatedMessages],
+  );
+
   // ---------------------------------------------------------------------------
   // Per-message rendering helper (shared by flat and virtual paths)
   // ---------------------------------------------------------------------------
@@ -609,17 +628,17 @@ export function CopilotChatMessageView({
       );
     }
 
-    // Auto-mount the IntelligenceIndicator on assistant message slots
-    // when the runtime is in intelligence mode. The component self-gates
-    // further (latest matching-assistant slot, pending tool-call grace
-    // window) so only one pill renders at a time — mounting only for
-    // assistant messages avoids the per-slot `useAgent` subscription
-    // and four effects on user/reasoning/activity slots that would just
-    // return null at the role gate anyway.
-    if (copilotkit.intelligence !== undefined && message.role === "assistant") {
+    // Auto-mount the IntelligenceIndicator once per Intelligence-using turn,
+    // at that turn's anchor message (its last bash-using assistant), keyed by
+    // the stable turn id. Keying by turn (not message) means the indicator
+    // moves with the anchor across a hand-off without remounting, and past
+    // turns keep their own indicator. `getIntelligenceTurnAnchors` already
+    // gated on intelligence mode (empty map when off).
+    const intelligenceTurnId = intelligenceTurnAnchors.get(message.id);
+    if (intelligenceTurnId !== undefined) {
       elements.push(
         <IntelligenceIndicator
-          key={`${message.id}-intelligence`}
+          key={`intelligence-${intelligenceTurnId}`}
           message={message}
           agentId={config?.agentId ?? DEFAULT_AGENT_ID}
           intelligenceIndicator={intelligenceIndicator}

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -9,6 +9,7 @@ import { ScrollElementContext } from "./scroll-element-context";
 import type { WithSlots, SlotValue } from "../../lib/slots";
 import { renderSlot } from "../../lib/slots";
 import CopilotChatMessageView from "./CopilotChatMessageView";
+import type { IntelligenceIndicatorView } from "../intelligence-indicator";
 import type {
   CopilotChatInputProps,
   CopilotChatInputMode,
@@ -108,6 +109,12 @@ export type CopilotChatViewProps = WithSlots<
      * ```
      */
     disclaimer?: SlotValue<React.FC<React.HTMLAttributes<HTMLDivElement>>>;
+    /**
+     * Slot for the "Using CopilotKit Intelligence" indicator. Pass-through
+     * to `CopilotChatMessageView`'s `intelligenceIndicator` slot — accepts a
+     * className string, a props object, or a replacement component.
+     */
+    intelligenceIndicator?: SlotValue<typeof IntelligenceIndicatorView>;
   } & React.HTMLAttributes<HTMLDivElement>
 >;
 
@@ -163,6 +170,8 @@ export function CopilotChatView({
   hasExplicitThreadId = false,
   // Deprecated — forwarded to input slot
   disclaimer,
+  // Pass-through to CopilotChatMessageView's intelligenceIndicator slot
+  intelligenceIndicator,
   children,
   className,
   ...props
@@ -239,6 +248,7 @@ export function CopilotChatView({
   const BoundMessageView = renderSlot(messageView, CopilotChatMessageView, {
     messages,
     isRunning,
+    intelligenceIndicator,
   });
 
   const BoundInput = renderSlot(input, CopilotChatInput, {

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
@@ -10,11 +10,12 @@ import { IntelligenceIndicatorView } from "./IntelligenceIndicatorView";
 /**
  * Grace window before showing the spinner. A matching tool call must
  * remain unresolved (no `tool`-role result message in `agent.messages`)
- * for at least this long before the pill appears. This filters out
- * history-replay flashes — during `connectAgent` replay, tool calls and
- * their results arrive back-to-back in sub-millisecond bursts, so the
- * timer is cancelled before it fires. Live runs cross the threshold
- * easily because the tool actually has to execute.
+ * for at least this long before the indicator transitions out of
+ * `hidden`. This filters out history-replay flashes — during
+ * `connectAgent` replay, tool calls and their results arrive
+ * back-to-back in sub-millisecond bursts, so the timer is cancelled
+ * before it fires. Live runs cross the threshold easily because the
+ * tool actually has to execute.
  */
 const PENDING_THRESHOLD_MS = 100;
 
@@ -32,12 +33,11 @@ const DEFAULT_TOOL_PATTERNS: readonly RegExp[] = [
 ];
 
 /**
- * Phase machine. Unlike the previous fade-out-and-unmount lifecycle, the
- * pill now persists once it reaches `finished` — it never returns to
- * `idle` and never unmounts on its own. Supersession by a newer matching
- * message is handled by the latest-matching gate, not by this machine.
+ * Phase machine. Once `finished` is reached the indicator persists
+ * indefinitely; supersession across messages is handled by the
+ * structural last-in-turn gate, not by this machine.
  */
-type Phase = "idle" | "spinner" | "finished";
+type Phase = "hidden" | "spinner" | "finished";
 
 export interface IntelligenceIndicatorProps {
   /** The message this indicator is attached to. */
@@ -65,6 +65,12 @@ export interface IntelligenceIndicatorProps {
 const isMatchingToolCallName = (name: unknown): boolean =>
   typeof name === "string" && DEFAULT_TOOL_PATTERNS.some((p) => p.test(name));
 
+const messageHasMatchingToolCall = (m: Message): boolean => {
+  if (m.role !== "assistant") return false;
+  const tcs = Array.isArray(m.toolCalls) ? m.toolCalls : [];
+  return tcs.some((tc) => isMatchingToolCallName(tc?.function?.name));
+};
+
 /**
  * "Tool-call-like" messages do NOT count as a real follow-up: tool
  * result messages, assistant messages that carry tool calls, and
@@ -87,37 +93,48 @@ const isToolCallLikeMessage = (m: Message): boolean => {
 /**
  * The "Using CopilotKit Intelligence" indicator brain. Auto-mounted by
  * `CopilotChatMessageView` for every assistant message slot when
- * `copilotkit.intelligence` is configured — callers do not register this
- * themselves. It owns all orchestration (run subscription, gating, and
- * the phase machine) and renders its swappable face via the
+ * `copilotkit.intelligence` is configured — callers do not register
+ * this themselves. It owns all orchestration (run subscription, gating,
+ * and the phase machine) and renders its swappable face via the
  * `intelligenceIndicator` slot.
  *
  * Render gates (all must hold):
  *   1. `copilotkit.intelligence !== undefined`
  *   2. The message is an assistant message with at least one tool call
- *      whose name matches {@link DEFAULT_TOOL_PATTERNS}
- *   3. The message is the *latest* such matching-assistant message in
- *      `agent.messages` — tool-result messages and prose-only assistant
- *      messages don't invalidate the slot, so the pill stays
- *      continuously through a multi-step tool chain.
- *   4. The phase machine is past `idle` (the pending-grace timer fired).
+ *      whose name matches {@link DEFAULT_TOOL_PATTERNS}.
+ *   3. The message is the *last bash-using assistant message in its
+ *      turn*. A turn is bounded by user messages: walking forward from
+ *      this message, hitting another bash-using assistant before a
+ *      user message (or the end of `agent.messages`) means we are NOT
+ *      last-in-turn and must return `null`.
+ *   4. The phase machine is past `hidden`.
+ *
+ * Per-turn semantics ensure that every prior agent turn that used
+ * Intelligence keeps its own persistent indicator in chat history —
+ * they never disappear when a new turn starts, because each anchors
+ * to a different assistant message that remains last-in-turn for its
+ * respective turn.
  *
  * Phase machine (per-instance, all timers local):
- *   - Starts in `idle` — nothing rendered.
- *   - `idle → spinner` once a matching tool call has been pending
+ *   - Starts in `hidden`, unless the message mounts onto an
+ *     already-completed turn (no pending work, agent stopped or a
+ *     real follow-up already present), in which case the lazy
+ *     `useState` initializer starts directly in `finished`. This is
+ *     what avoids a "hidden flash" on history replay.
+ *   - `hidden → spinner` once a matching tool call has been pending
  *     (no `tool`-role result with a matching `toolCallId`) for
  *     {@link PENDING_THRESHOLD_MS}. Replay flashes (tool call + result
  *     in the same tick) never cross this threshold.
+ *   - `hidden → finished` if after the grace window the turn is
+ *     already complete (no pending work AND
+ *     `sawRealFollowup || !agent.isRunning`). Handles very fast tools
+ *     whose result lands within the grace window.
  *   - `spinner → finished` as soon as EITHER `agent.isRunning` flips
  *     false OR a non-tool-call-like message appears later in
- *     `agent.messages` (i.e. the agent has produced a "real"
- *     follow-up — prose answer or a new user turn).
- *   - `finished` is terminal: the pill settles into its persistent
- *     resting state and stays mounted. It is removed only when a newer
- *     matching-assistant message supersedes it via gate 3.
- *
- * The "exactly one pill at a time" guarantee is structural: only one
- * message satisfies the latest-matching-assistant gate at any moment.
+ *     `agent.messages` (i.e. the agent produced a "real" follow-up —
+ *     prose answer or a new user turn).
+ *   - `finished` is terminal: the indicator settles into its
+ *     persistent tag form and stays mounted.
  */
 export function IntelligenceIndicator(
   props: IntelligenceIndicatorProps,
@@ -175,60 +192,66 @@ export function IntelligenceIndicator(
     return false;
   }, [agent.messages, message.id]);
 
-  const [phase, setPhase] = useState<Phase>("idle");
+  // Turn-completion signal — set the moment the agent stops running or
+  // a "real" follow-up (prose / user turn) appears after this message.
+  // Independent of whether the pending tool call resolved; if the run
+  // finishes with a still-unresolved match (rare in production, common
+  // in tests), the indicator should still settle.
+  const turnComplete = sawRealFollowup || !agent.isRunning;
 
-  // idle → spinner: pending tool call hasn't been resolved within the
-  // grace window. Cleared if the result arrives first (replay) or if
-  // there's nothing to wait on.
+  // Lazy init: if this indicator mounts onto a message whose turn has
+  // already completed (e.g. history replay finished before mount),
+  // skip directly to `finished` — no `hidden` flash, no spinner blip.
+  const [phase, setPhase] = useState<Phase>(() =>
+    turnComplete ? "finished" : "hidden",
+  );
+
+  // hidden → spinner OR hidden → finished (after grace window).
   useEffect(() => {
-    if (phase !== "idle") return undefined;
-    if (!hasPending) return undefined;
-    const t = setTimeout(() => setPhase("spinner"), PENDING_THRESHOLD_MS);
+    if (phase !== "hidden") return undefined;
+    const t = setTimeout(() => {
+      if (turnComplete) {
+        setPhase("finished");
+      } else if (hasPending) {
+        setPhase("spinner");
+      }
+      // else: stay hidden — turn is still live but no pending work
+      // matched yet (e.g. waiting for the tool call chunk to land).
+    }, PENDING_THRESHOLD_MS);
     return () => clearTimeout(t);
-  }, [phase, hasPending]);
+  }, [phase, hasPending, turnComplete]);
 
-  // spinner → finished: agent stopped running OR a real follow-up
-  // message arrived. Both are independent signals; whichever fires
-  // first wins. `finished` is terminal — no further transitions.
+  // spinner → finished
   useEffect(() => {
     if (phase !== "spinner") return undefined;
-    if (!agent.isRunning || sawRealFollowup) {
+    if (turnComplete) {
       setPhase("finished");
     }
     return undefined;
-  }, [phase, agent.isRunning, sawRealFollowup]);
+  }, [phase, turnComplete]);
 
   // ─── Render gates ────────────────────────────────────────────────────
   // Hooks above MUST run unconditionally; bail with `null` only after.
 
   if (copilotkit.intelligence === undefined) return null;
   if (!config) return null;
-  if (phase === "idle") return null;
+  if (phase === "hidden") return null;
 
   if (message.role !== "assistant") return null;
-  // Defensive: a malformed `toolCalls` (non-array, missing nested
-  // `function.name`) would otherwise throw inside `.some(...)` and take
-  // down the chat tree. Treat as "no match" instead.
-  const toolCalls = Array.isArray(message.toolCalls) ? message.toolCalls : [];
-  const hasMatch = toolCalls.some((tc) =>
-    isMatchingToolCallName(tc?.function?.name),
-  );
-  if (!hasMatch) return null;
+  if (!messageHasMatchingToolCall(message)) return null;
 
-  // Walk `agent.messages` from the end and find the latest assistant
-  // message that itself has a matching tool call. If that's not us,
-  // we're not the canonical slot — return `null`.
-  let latestMatchingAssistantId: string | undefined;
-  for (let i = agent.messages.length - 1; i >= 0; i -= 1) {
+  // Per-turn last-in-turn gate. Walk forward from this message; if we
+  // hit a user message (turn boundary) before encountering another
+  // bash-using assistant message, this message is the last-in-turn
+  // and the indicator renders here. Otherwise a later assistant in
+  // the same turn owns the indicator and we return `null`.
+  const idx = agent.messages.findIndex((m) => m.id === message.id);
+  if (idx < 0) return null;
+  for (let i = idx + 1; i < agent.messages.length; i += 1) {
     const m = agent.messages[i]!;
-    if (m.role !== "assistant") continue;
-    const tcs = Array.isArray(m.toolCalls) ? m.toolCalls : [];
-    if (tcs.some((tc) => isMatchingToolCallName(tc?.function?.name))) {
-      latestMatchingAssistantId = m.id;
-      break;
-    }
+    if (m.role === "user") break;
+    if (messageHasMatchingToolCall(m)) return null;
   }
-  if (latestMatchingAssistantId !== message.id) return null;
 
   // ─── Render the (swappable) face ──────────────────────────────────────
 

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
@@ -34,10 +34,42 @@ const DEFAULT_TOOL_PATTERNS: readonly RegExp[] = [
 
 /**
  * Phase machine. Once `finished` is reached the indicator persists
- * indefinitely; supersession across messages is handled by the
- * structural last-in-turn gate, not by this machine.
+ * indefinitely; placement (one indicator per turn, at the turn's first
+ * bash-using message) is owned by `getIntelligenceTurnAnchors`, not by
+ * this machine.
  */
-type Phase = "hidden" | "spinner" | "finished";
+export type Phase = "hidden" | "spinner" | "finished";
+
+/**
+ * Phase to start in when an indicator first mounts. A turn that is already
+ * complete at mount jumps straight to `finished` — no `hidden` flash, no
+ * spinner blip — which is what makes scrolled-back / replayed history render
+ * its indicators directly in the finished state.
+ *
+ * Pure and timing-free on purpose: the grace window ({@link
+ * PENDING_THRESHOLD_MS}) only controls *when* the live transition is applied;
+ * these functions decide *what* it resolves to, so the decision can be unit
+ * tested deterministically without any timers.
+ */
+export function initialIndicatorPhase(turnComplete: boolean): Phase {
+  return turnComplete ? "finished" : "hidden";
+}
+
+/**
+ * Phase the grace window resolves to once it elapses:
+ *   - completed turn → `finished` (replay-flash suppression: a tool whose
+ *     result lands within the window skips the spinner entirely),
+ *   - a still-pending matching tool call → `spinner`,
+ *   - otherwise stay `hidden` (the matching tool call hasn't landed yet).
+ */
+export function resolveGracePhase(
+  turnComplete: boolean,
+  hasPending: boolean,
+): Phase {
+  if (turnComplete) return "finished";
+  if (hasPending) return "spinner";
+  return "hidden";
+}
 
 export interface IntelligenceIndicatorProps {
   /** The message this indicator is attached to. */
@@ -142,7 +174,7 @@ const isToolCallLikeMessage = (m: Message): boolean => {
  * renders its swappable face via the `intelligenceIndicator` slot.
  *
  * Placement (which message anchors the turn) is decided by the view, so
- * this component does not self-gate "am I last-in-turn"; it only derives
+ * this component does not self-gate its own placement; it only derives
  * in-progress/finished for the turn it was mounted on.
  *
  * Render gates (all must hold):
@@ -244,20 +276,17 @@ export function IntelligenceIndicator(
   // already completed (e.g. history replay finished before mount),
   // skip directly to `finished` — no `hidden` flash, no spinner blip.
   const [phase, setPhase] = useState<Phase>(() =>
-    turnComplete ? "finished" : "hidden",
+    initialIndicatorPhase(turnComplete),
   );
 
-  // hidden → spinner OR hidden → finished (after grace window).
+  // hidden → spinner OR hidden → finished (after grace window). The grace
+  // window only controls the *timing*; `resolveGracePhase` owns the decision.
+  // Resolving back to `hidden` (matching tool call not landed yet) is a
+  // no-op `setPhase`, preserving the "only leave hidden once decided" rule.
   useEffect(() => {
     if (phase !== "hidden") return undefined;
     const t = setTimeout(() => {
-      if (turnComplete) {
-        setPhase("finished");
-      } else if (hasPending) {
-        setPhase("spinner");
-      }
-      // else: stay hidden — turn is still live but no pending work
-      // matched yet (e.g. waiting for the tool call chunk to land).
+      setPhase(resolveGracePhase(turnComplete, hasPending));
     }, PENDING_THRESHOLD_MS);
     return () => clearTimeout(t);
   }, [phase, hasPending, turnComplete]);
@@ -284,8 +313,8 @@ export function IntelligenceIndicator(
   // Placement (which message anchors this turn's indicator) is decided by
   // `CopilotChatMessageView` via `getIntelligenceTurnAnchors`, which mounts
   // exactly one instance per turn keyed by the turn id. The brain therefore
-  // no longer self-gates "am I the last-in-turn message"; it only owns the
-  // run-status → in-progress/finished derivation for the turn it anchors.
+  // does not decide its own placement; it only owns the run-status →
+  // in-progress/finished derivation for the turn it anchors.
 
   // ─── Render the (swappable) face ──────────────────────────────────────
 

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
@@ -3,6 +3,9 @@ import type { Message } from "@ag-ui/core";
 import { useCopilotKit } from "../../providers/CopilotKitProvider";
 import { useCopilotChatConfiguration } from "../../providers/CopilotChatConfigurationProvider";
 import { useAgent, UseAgentUpdate } from "../../hooks/use-agent";
+import { renderSlot } from "../../lib/slots";
+import type { SlotValue } from "../../lib/slots";
+import { IntelligenceIndicatorView } from "./IntelligenceIndicatorView";
 
 /**
  * Grace window before showing the spinner. A matching tool call must
@@ -14,15 +17,6 @@ import { useAgent, UseAgentUpdate } from "../../hooks/use-agent";
  * easily because the tool actually has to execute.
  */
 const PENDING_THRESHOLD_MS = 100;
-
-/** Hold the checkmark briefly before fading out. */
-const CHECK_HOLD_MS = 800;
-
-/**
- * Duration of the fade-out animation. Must match
- * `cpk-intelligence-pill-fade-out` keyframes in `v2/styles/globals.css`.
- */
-const FADE_OUT_ANIMATION_MS = 480;
 
 /**
  * Tool-name regex patterns that trigger the indicator. Matches any tool
@@ -37,7 +31,13 @@ const DEFAULT_TOOL_PATTERNS: readonly RegExp[] = [
   /copilotkit_knowledge_base_shell/,
 ];
 
-type Phase = "idle" | "spinner" | "check" | "fading" | "hidden";
+/**
+ * Phase machine. Unlike the previous fade-out-and-unmount lifecycle, the
+ * pill now persists once it reaches `finished` — it never returns to
+ * `idle` and never unmounts on its own. Supersession by a newer matching
+ * message is handled by the latest-matching gate, not by this machine.
+ */
+type Phase = "idle" | "spinner" | "finished";
 
 export interface IntelligenceIndicatorProps {
   /** The message this indicator is attached to. */
@@ -53,6 +53,13 @@ export interface IntelligenceIndicatorProps {
    * CopilotKit Intelligence".
    */
   label?: string;
+  /**
+   * Slot override for the presentational face. A className string, a
+   * props object, or a full replacement component — see
+   * {@link IntelligenceIndicatorView}. Forwarded from the
+   * `intelligenceIndicator` slot on `CopilotChat`.
+   */
+  intelligenceIndicator?: SlotValue<typeof IntelligenceIndicatorView>;
 }
 
 const isMatchingToolCallName = (name: unknown): boolean =>
@@ -78,11 +85,12 @@ const isToolCallLikeMessage = (m: Message): boolean => {
 };
 
 /**
- * The "Using CopilotKit Intelligence" pill. Auto-mounted by
- * `CopilotChatMessageView` for every message slot when
- * `copilotkit.intelligence` is configured — callers do not register
- * this themselves. Self-gates so only the canonical message renders a
- * pill.
+ * The "Using CopilotKit Intelligence" indicator brain. Auto-mounted by
+ * `CopilotChatMessageView` for every assistant message slot when
+ * `copilotkit.intelligence` is configured — callers do not register this
+ * themselves. It owns all orchestration (run subscription, gating, and
+ * the phase machine) and renders its swappable face via the
+ * `intelligenceIndicator` slot.
  *
  * Render gates (all must hold):
  *   1. `copilotkit.intelligence !== undefined`
@@ -92,8 +100,7 @@ const isToolCallLikeMessage = (m: Message): boolean => {
  *      `agent.messages` — tool-result messages and prose-only assistant
  *      messages don't invalidate the slot, so the pill stays
  *      continuously through a multi-step tool chain.
- *   4. The phase machine is past `idle` (the pending-grace timer fired)
- *      and not yet `hidden`.
+ *   4. The phase machine is past `idle` (the pending-grace timer fired).
  *
  * Phase machine (per-instance, all timers local):
  *   - Starts in `idle` — nothing rendered.
@@ -101,16 +108,13 @@ const isToolCallLikeMessage = (m: Message): boolean => {
  *     (no `tool`-role result with a matching `toolCallId`) for
  *     {@link PENDING_THRESHOLD_MS}. Replay flashes (tool call + result
  *     in the same tick) never cross this threshold.
- *   - `spinner → check` as soon as EITHER `agent.isRunning` flips
+ *   - `spinner → finished` as soon as EITHER `agent.isRunning` flips
  *     false OR a non-tool-call-like message appears later in
  *     `agent.messages` (i.e. the agent has produced a "real"
  *     follow-up — prose answer or a new user turn).
- *   - `check → fading` after {@link CHECK_HOLD_MS}.
- *   - `fading → hidden` after {@link FADE_OUT_ANIMATION_MS}.
- *
- * Once `hidden`, the phase is sticky — a finished pill never re-spawns
- * on the same message. New runs mount fresh indicator instances on
- * their own assistant messages.
+ *   - `finished` is terminal: the pill settles into its persistent
+ *     resting state and stays mounted. It is removed only when a newer
+ *     matching-assistant message supersedes it via gate 3.
  *
  * The "exactly one pill at a time" guarantee is structural: only one
  * message satisfies the latest-matching-assistant gate at any moment.
@@ -118,7 +122,12 @@ const isToolCallLikeMessage = (m: Message): boolean => {
 export function IntelligenceIndicator(
   props: IntelligenceIndicatorProps,
 ): React.ReactElement | null {
-  const { message, agentId, label = "Using CopilotKit Intelligence" } = props;
+  const {
+    message,
+    agentId,
+    label = "Using CopilotKit Intelligence",
+    intelligenceIndicator,
+  } = props;
 
   const { copilotkit } = useCopilotKit();
   const config = useCopilotChatConfiguration();
@@ -178,37 +187,23 @@ export function IntelligenceIndicator(
     return () => clearTimeout(t);
   }, [phase, hasPending]);
 
-  // spinner → check: agent stopped running OR a real follow-up
+  // spinner → finished: agent stopped running OR a real follow-up
   // message arrived. Both are independent signals; whichever fires
-  // first wins.
+  // first wins. `finished` is terminal — no further transitions.
   useEffect(() => {
     if (phase !== "spinner") return undefined;
     if (!agent.isRunning || sawRealFollowup) {
-      setPhase("check");
+      setPhase("finished");
     }
     return undefined;
   }, [phase, agent.isRunning, sawRealFollowup]);
-
-  // check → fading after the hold.
-  useEffect(() => {
-    if (phase !== "check") return undefined;
-    const t = setTimeout(() => setPhase("fading"), CHECK_HOLD_MS);
-    return () => clearTimeout(t);
-  }, [phase]);
-
-  // fading → hidden after the fade animation.
-  useEffect(() => {
-    if (phase !== "fading") return undefined;
-    const t = setTimeout(() => setPhase("hidden"), FADE_OUT_ANIMATION_MS);
-    return () => clearTimeout(t);
-  }, [phase]);
 
   // ─── Render gates ────────────────────────────────────────────────────
   // Hooks above MUST run unconditionally; bail with `null` only after.
 
   if (copilotkit.intelligence === undefined) return null;
   if (!config) return null;
-  if (phase === "idle" || phase === "hidden") return null;
+  if (phase === "idle") return null;
 
   if (message.role !== "assistant") return null;
   // Defensive: a malformed `toolCalls` (non-array, missing nested
@@ -235,55 +230,13 @@ export function IntelligenceIndicator(
   }
   if (latestMatchingAssistantId !== message.id) return null;
 
-  // ─── Visual ──────────────────────────────────────────────────────────
+  // ─── Render the (swappable) face ──────────────────────────────────────
 
-  const showSpinner = phase === "spinner";
-  const isFading = phase === "fading";
+  const status = phase === "finished" ? "finished" : "in-progress";
 
-  return (
-    <span
-      className={
-        "cpk-intelligence-pill" +
-        (isFading ? " cpk-intelligence-pill--fading" : "")
-      }
-      role="status"
-      aria-live="polite"
-      aria-hidden={isFading || undefined}
-      data-testid={`cpk-intelligence-pill-${message.id}`}
-      title={label}
-    >
-      <svg
-        className="cpk-intelligence-pill__icon"
-        viewBox="0 0 24 24"
-        width="14"
-        height="14"
-        aria-hidden="true"
-      >
-        <circle
-          cx="12"
-          cy="12"
-          r="9"
-          fill="none"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-          className={
-            "cpk-intelligence-pill__ring" +
-            (showSpinner ? "" : " cpk-intelligence-pill__ring--done")
-          }
-        />
-        <path
-          d="M8 12.5l3 3 5-6"
-          fill="none"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className={
-            "cpk-intelligence-pill__check" +
-            (showSpinner ? "" : " cpk-intelligence-pill__check--shown")
-          }
-        />
-      </svg>
-      <span>{label}</span>
-    </span>
-  );
+  return renderSlot(intelligenceIndicator, IntelligenceIndicatorView, {
+    message,
+    status,
+    label,
+  });
 }

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
@@ -72,6 +72,49 @@ const messageHasMatchingToolCall = (m: Message): boolean => {
 };
 
 /**
+ * Stable turn id for the messages that precede the first user message (a turn
+ * with no opening user message of its own). Used as the React key so the
+ * indicator for that turn never collides with a real user-message id.
+ */
+export const INTELLIGENCE_TURN_HEAD = "__cpk_turn_head__";
+
+/**
+ * Map each Intelligence-using turn to its anchor message — the FIRST bash-using
+ * assistant message of the turn — and a stable turn id (the id of the user
+ * message that opened the turn, or {@link INTELLIGENCE_TURN_HEAD} for the
+ * pre-first-user turn). Returns `Map<anchorMessageId, turnId>`.
+ *
+ * Anchoring to the FIRST (not last) bash-using message keeps the indicator
+ * fixed in place for the whole turn: later bash steps don't reposition it, so
+ * the spinner never abruptly jumps mid-turn (bug 1). `CopilotChatMessageView`
+ * emits exactly one `IntelligenceIndicator` per entry, keyed by the turn id and
+ * positioned at the anchor; the per-turn key also lets every past turn keep its
+ * own indicator in scroll-back.
+ */
+export function getIntelligenceTurnAnchors(
+  messages: readonly Message[],
+): Map<string, string> {
+  const anchors = new Map<string, string>();
+  let turnId = INTELLIGENCE_TURN_HEAD;
+  let anchorId: string | null = null;
+  const commit = (): void => {
+    if (anchorId !== null) anchors.set(anchorId, turnId);
+    anchorId = null;
+  };
+  for (const m of messages) {
+    if (m.role === "user") {
+      commit();
+      turnId = m.id;
+      continue;
+    }
+    // First bash-using message of the turn wins; later ones don't move it.
+    if (anchorId === null && messageHasMatchingToolCall(m)) anchorId = m.id;
+  }
+  commit();
+  return anchors;
+}
+
+/**
  * "Tool-call-like" messages do NOT count as a real follow-up: tool
  * result messages, assistant messages that carry tool calls, and
  * empty-content assistant messages (which some providers emit as a
@@ -92,28 +135,26 @@ const isToolCallLikeMessage = (m: Message): boolean => {
 
 /**
  * The "Using CopilotKit Intelligence" indicator brain. Auto-mounted by
- * `CopilotChatMessageView` for every assistant message slot when
- * `copilotkit.intelligence` is configured — callers do not register
- * this themselves. It owns all orchestration (run subscription, gating,
- * and the phase machine) and renders its swappable face via the
- * `intelligenceIndicator` slot.
+ * `CopilotChatMessageView` — once per Intelligence-using turn, at that
+ * turn's anchor message and keyed by the turn id (see
+ * {@link getIntelligenceTurnAnchors}). Callers do not register this
+ * themselves. It owns the run subscription and the phase machine and
+ * renders its swappable face via the `intelligenceIndicator` slot.
+ *
+ * Placement (which message anchors the turn) is decided by the view, so
+ * this component does not self-gate "am I last-in-turn"; it only derives
+ * in-progress/finished for the turn it was mounted on.
  *
  * Render gates (all must hold):
  *   1. `copilotkit.intelligence !== undefined`
- *   2. The message is an assistant message with at least one tool call
- *      whose name matches {@link DEFAULT_TOOL_PATTERNS}.
- *   3. The message is the *last bash-using assistant message in its
- *      turn*. A turn is bounded by user messages: walking forward from
- *      this message, hitting another bash-using assistant before a
- *      user message (or the end of `agent.messages`) means we are NOT
- *      last-in-turn and must return `null`.
- *   4. The phase machine is past `hidden`.
+ *   2. The (anchor) message is an assistant message with at least one
+ *      tool call whose name matches {@link DEFAULT_TOOL_PATTERNS}.
+ *   3. The phase machine is past `hidden`.
  *
- * Per-turn semantics ensure that every prior agent turn that used
- * Intelligence keeps its own persistent indicator in chat history —
- * they never disappear when a new turn starts, because each anchors
- * to a different assistant message that remains last-in-turn for its
- * respective turn.
+ * Because the view keys each indicator by its turn id, the instance moves
+ * with the anchor across a hand-off (no remount, no spinner restart), and
+ * every prior Intelligence-using turn keeps its own persistent indicator
+ * in chat history.
  *
  * Phase machine (per-instance, all timers local):
  *   - Starts in `hidden`, unless the message mounts onto an
@@ -240,18 +281,11 @@ export function IntelligenceIndicator(
   if (message.role !== "assistant") return null;
   if (!messageHasMatchingToolCall(message)) return null;
 
-  // Per-turn last-in-turn gate. Walk forward from this message; if we
-  // hit a user message (turn boundary) before encountering another
-  // bash-using assistant message, this message is the last-in-turn
-  // and the indicator renders here. Otherwise a later assistant in
-  // the same turn owns the indicator and we return `null`.
-  const idx = agent.messages.findIndex((m) => m.id === message.id);
-  if (idx < 0) return null;
-  for (let i = idx + 1; i < agent.messages.length; i += 1) {
-    const m = agent.messages[i]!;
-    if (m.role === "user") break;
-    if (messageHasMatchingToolCall(m)) return null;
-  }
+  // Placement (which message anchors this turn's indicator) is decided by
+  // `CopilotChatMessageView` via `getIntelligenceTurnAnchors`, which mounts
+  // exactly one instance per turn keyed by the turn id. The brain therefore
+  // no longer self-gates "am I the last-in-turn message"; it only owns the
+  // run-status → in-progress/finished derivation for the turn it anchors.
 
   // ─── Render the (swappable) face ──────────────────────────────────────
 

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx
@@ -49,8 +49,8 @@ export interface IntelligenceIndicatorProps {
    */
   agentId: string;
   /**
-   * Optional override for the visible label. Defaults to "Using
-   * CopilotKit Intelligence".
+   * Optional override for the visible label. Defaults to
+   * "CopilotKit Intelligence".
    */
   label?: string;
   /**
@@ -142,7 +142,7 @@ export function IntelligenceIndicator(
   const {
     message,
     agentId,
-    label = "Using CopilotKit Intelligence",
+    label = "CopilotKit Intelligence",
     intelligenceIndicator,
   } = props;
 

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { twMerge } from "tailwind-merge";
+import type { Message } from "@ag-ui/core";
+
+/** Lifecycle state the brain hands the face. */
+export type IntelligenceIndicatorStatus = "in-progress" | "finished";
+
+export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** The assistant message this indicator is attached to. */
+  message: Message;
+  /**
+   * Whether the intelligence work is still running (`in-progress`) or has
+   * settled (`finished`). Drives the spinner→checkmark transition and the
+   * persistent subdued resting style.
+   */
+  status: IntelligenceIndicatorStatus;
+  /** The visible label, e.g. "Using CopilotKit Intelligence". */
+  label: string;
+}
+
+/**
+ * The presentational "Using CopilotKit Intelligence" pill — the default
+ * face rendered by the {@link IntelligenceIndicator} brain and the default
+ * for the `intelligenceIndicator` slot.
+ *
+ * It is purely visual: it renders from `status` and `label` alone and holds
+ * no run state. In `in-progress` the ring spins; in `finished` the ring
+ * completes, the checkmark draws in, and the pill settles into a subdued
+ * resting style (it does not unmount).
+ *
+ * Customize it through the `intelligenceIndicator` slot on `CopilotChat`:
+ * pass a className string to restyle it, a props object to tweak it (e.g.
+ * `{ label }`), or a component to replace it entirely.
+ */
+export function IntelligenceIndicatorView({
+  message,
+  status,
+  label,
+  className,
+  ...rest
+}: IntelligenceIndicatorViewProps): React.ReactElement {
+  const isFinished = status === "finished";
+
+  return (
+    <span
+      className={twMerge(
+        "cpk-intelligence-pill",
+        isFinished && "cpk-intelligence-pill--finished",
+        className,
+      )}
+      role="status"
+      aria-live="polite"
+      data-testid={`cpk-intelligence-pill-${message.id}`}
+      data-status={status}
+      title={label}
+      {...rest}
+    >
+      <svg
+        className="cpk-intelligence-pill__icon"
+        viewBox="0 0 24 24"
+        width="14"
+        height="14"
+        aria-hidden="true"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="9"
+          fill="none"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          className={
+            "cpk-intelligence-pill__ring" +
+            (isFinished ? " cpk-intelligence-pill__ring--done" : "")
+          }
+        />
+        <path
+          d="M8 12.5l3 3 5-6"
+          fill="none"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={
+            "cpk-intelligence-pill__check" +
+            (isFinished ? " cpk-intelligence-pill__check--shown" : "")
+          }
+        />
+      </svg>
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
@@ -37,9 +37,13 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
  *     shape change. Chrome and text stay at full opacity throughout.
  *  3. **Settle (~400 ms, starts at +250 ms).** Chrome (background,
  *     border, shadow, backdrop-blur) fades to zero opacity. The label
- *     and icon stroke color alpha drops from 0.92 to 0.55. The text
- *     stays put — only its alpha changes — so there is no "bump"
- *     where the brand text disappears and reappears.
+ *     and icon stroke color transitions from saturated purple to a
+ *     neutral slate gray (industry-standard metadata color — same
+ *     family as Stripe, Linear, Claude, GitHub). The text stays put
+ *     — only its color changes — so there is no "bump" where the
+ *     brand text disappears and reappears. The hue shift reads as a
+ *     semantic class change ("active" → "settled metadata") rather
+ *     than as the same content getting dimmer.
  *
  * Hard sequence: stage 3 has a 250 ms transition-delay so it waits
  * for stage 2 to finish. Total settle time ~650 ms in production.

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
@@ -9,9 +9,8 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
   /** The assistant message this indicator is attached to. */
   message: Message;
   /**
-   * Whether the intelligence work is still running (`in-progress`) or has
-   * settled (`finished`). Drives the spinner→checkmark transition and the
-   * persistent subdued resting style.
+   * Whether the intelligence work is still running (`in-progress`) or
+   * has settled (`finished`). Drives the spinner ⇄ tag cross-fade.
    */
   status: IntelligenceIndicatorStatus;
   /** The visible label, e.g. "Using CopilotKit Intelligence". */
@@ -19,18 +18,26 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
 }
 
 /**
- * The presentational "Using CopilotKit Intelligence" pill — the default
- * face rendered by the {@link IntelligenceIndicator} brain and the default
- * for the `intelligenceIndicator` slot.
+ * The presentational "Using CopilotKit Intelligence" face — the default
+ * rendered by the {@link IntelligenceIndicator} brain and the default
+ * value for the `intelligenceIndicator` slot.
  *
- * It is purely visual: it renders from `status` and `label` alone and holds
- * no run state. In `in-progress` the ring spins; in `finished` the ring
- * completes, the checkmark draws in, and the pill settles into a subdued
- * resting style (it does not unmount).
+ * Two modes:
+ *  - `in-progress`: a glassmorphism pill with a spinning ring (the
+ *    same active visual users see while the intelligence tool runs).
+ *  - `finished`: a compact icon + text tag — visibly demoted so it
+ *    sits quietly in chat history per turn without competing with the
+ *    agent's answer. The tag's checkmark icon is the completion cue.
  *
- * Customize it through the `intelligenceIndicator` slot on `CopilotChat`:
- * pass a className string to restyle it, a props object to tweak it (e.g.
- * `{ label }`), or a component to replace it entirely.
+ * Both modes coexist in the DOM; status drives an opacity cross-fade
+ * so the swap reads as one smooth transition rather than two distinct
+ * mounts. The wrapper is `position: relative` and the tag is
+ * positioned absolutely over the pill's slot so the layout doesn't
+ * jump between two differently-sized elements.
+ *
+ * Customize via the `intelligenceIndicator` slot on `CopilotChat`:
+ * pass a className string to restyle the default, a props object to
+ * tweak it (e.g. `{ label }`), or a component to replace it entirely.
  */
 export function IntelligenceIndicatorView({
   message,
@@ -43,50 +50,68 @@ export function IntelligenceIndicatorView({
 
   return (
     <span
-      className={twMerge(
-        "cpk-intelligence-pill",
-        isFinished && "cpk-intelligence-pill--finished",
-        className,
-      )}
+      className={twMerge("cpk-intelligence-indicator", className)}
       role="status"
       aria-live="polite"
-      data-testid={`cpk-intelligence-pill-${message.id}`}
+      data-testid={`cpk-intelligence-indicator-${message.id}`}
       data-status={status}
       title={label}
       {...rest}
     >
-      <svg
-        className="cpk-intelligence-pill__icon"
-        viewBox="0 0 24 24"
-        width="14"
-        height="14"
-        aria-hidden="true"
+      {/* In-progress pill — full opacity while spinning, faded out
+          once status flips to finished. */}
+      <span
+        className={
+          "cpk-intelligence-indicator__pill" +
+          (isFinished ? " cpk-intelligence-indicator__pill--hidden" : "")
+        }
+        aria-hidden={isFinished || undefined}
       >
-        <circle
-          cx="12"
-          cy="12"
-          r="9"
+        <svg
+          className="cpk-intelligence-pill__icon"
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          aria-hidden="true"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="9"
+            fill="none"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            className="cpk-intelligence-pill__ring"
+          />
+        </svg>
+        <span>{label}</span>
+      </span>
+
+      {/* Finished tag — compact icon + text, faded in once work
+          completes. The checkmark is the completion cue. */}
+      <span
+        className={
+          "cpk-intelligence-indicator__tag" +
+          (isFinished ? " cpk-intelligence-indicator__tag--shown" : "")
+        }
+        aria-hidden={!isFinished || undefined}
+      >
+        <svg
+          className="cpk-intelligence-tag__icon"
+          viewBox="0 0 24 24"
+          width="12"
+          height="12"
           fill="none"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-          className={
-            "cpk-intelligence-pill__ring" +
-            (isFinished ? " cpk-intelligence-pill__ring--done" : "")
-          }
-        />
-        <path
-          d="M8 12.5l3 3 5-6"
-          fill="none"
+          stroke="currentColor"
           strokeWidth="2.5"
           strokeLinecap="round"
           strokeLinejoin="round"
-          className={
-            "cpk-intelligence-pill__check" +
-            (isFinished ? " cpk-intelligence-pill__check--shown" : "")
-          }
-        />
-      </svg>
-      <span>{label}</span>
+          aria-hidden="true"
+        >
+          <path d="M5 12.5l4 4 10-10" />
+        </svg>
+        <span>{label}</span>
+      </span>
     </span>
   );
 }

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
@@ -18,6 +18,16 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
 }
 
 /**
+ * If the in-progress label is a present participle ("Using …"), swap
+ * it to past tense ("Used …") for the finished resting state so the
+ * persistent tag reads naturally as scroll-back metadata. Other label
+ * shapes pass through unchanged — slot consumers who pass a custom
+ * label own its wording.
+ */
+const toFinishedLabel = (label: string): string =>
+  label.replace(/^Using\s+/i, "Used ");
+
+/**
  * The presentational "Using CopilotKit Intelligence" face — the default
  * rendered by the {@link IntelligenceIndicator} brain and the default
  * value for the `intelligenceIndicator` slot.
@@ -25,15 +35,17 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
  * Two modes:
  *  - `in-progress`: a glassmorphism pill with a spinning ring (the
  *    same active visual users see while the intelligence tool runs).
- *  - `finished`: a compact icon + text tag — visibly demoted so it
- *    sits quietly in chat history per turn without competing with the
- *    agent's answer. The tag's checkmark icon is the completion cue.
+ *  - `finished`: a tiny italic-gray "metadata line" — icon + past-tense
+ *    label, no border, no background. Reads as a footnote attached to
+ *    the assistant message rather than a status chip, so it disappears
+ *    into the chrome for someone scrolling and surfaces for someone
+ *    looking.
  *
- * Both modes coexist in the DOM; status drives an opacity cross-fade
- * so the swap reads as one smooth transition rather than two distinct
- * mounts. The wrapper is `position: relative` and the tag is
- * positioned absolutely over the pill's slot so the layout doesn't
- * jump between two differently-sized elements.
+ * Both modes coexist in the DOM; status drives a "shrink-and-settle"
+ * transition where the pill scales down (1 → 0.7) from its center as
+ * it fades out, and the tag scales up from the same center (0.7 → 1)
+ * with a 120 ms delay — the overlap reads as one element morphing
+ * rather than two elements being swapped. Total transition ~440 ms.
  *
  * Customize via the `intelligenceIndicator` slot on `CopilotChat`:
  * pass a className string to restyle the default, a props object to
@@ -58,8 +70,8 @@ export function IntelligenceIndicatorView({
       title={label}
       {...rest}
     >
-      {/* In-progress pill — full opacity while spinning, faded out
-          once status flips to finished. */}
+      {/* In-progress pill — full opacity while spinning, shrunk and
+          faded out once status flips to finished. */}
       <span
         className={
           "cpk-intelligence-indicator__pill" +
@@ -87,8 +99,8 @@ export function IntelligenceIndicatorView({
         <span>{label}</span>
       </span>
 
-      {/* Finished tag — compact icon + text, faded in once work
-          completes. The checkmark is the completion cue. */}
+      {/* Finished metadata line — italic gray text + small checkmark,
+          no border or background. The checkmark itself is the cue. */}
       <span
         className={
           "cpk-intelligence-indicator__tag" +
@@ -99,18 +111,18 @@ export function IntelligenceIndicatorView({
         <svg
           className="cpk-intelligence-tag__icon"
           viewBox="0 0 24 24"
-          width="12"
-          height="12"
+          width="10"
+          height="10"
           fill="none"
           stroke="currentColor"
-          strokeWidth="2.5"
+          strokeWidth="3"
           strokeLinecap="round"
           strokeLinejoin="round"
           aria-hidden="true"
         >
           <path d="M5 12.5l4 4 10-10" />
         </svg>
-        <span>{label}</span>
+        <span>{toFinishedLabel(label)}</span>
       </span>
     </span>
   );

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
@@ -10,7 +10,8 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
   message: Message;
   /**
    * Whether the intelligence work is still running (`in-progress`) or
-   * has settled (`finished`). Drives the spinner ⇄ tag cross-fade.
+   * has settled (`finished`). Drives the icon morph and chrome
+   * fade-out via the `data-status` attribute on the wrapper.
    */
   status: IntelligenceIndicatorStatus;
   /** The visible label, e.g. "Using CopilotKit Intelligence". */
@@ -18,39 +19,48 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
 }
 
 /**
- * If the in-progress label is a present participle ("Using …"), swap
- * it to past tense ("Used …") for the finished resting state so the
- * persistent tag reads naturally as scroll-back metadata. Other label
- * shapes pass through unchanged — slot consumers who pass a custom
- * label own its wording.
- */
-const toFinishedLabel = (label: string): string =>
-  label.replace(/^Using\s+/i, "Used ");
-
-/**
  * The presentational "Using CopilotKit Intelligence" face — the default
  * rendered by the {@link IntelligenceIndicator} brain and the default
  * value for the `intelligenceIndicator` slot.
  *
- * Two modes:
- *  - `in-progress`: a glassmorphism pill with a spinning ring (the
- *    same active visual users see while the intelligence tool runs).
- *  - `finished`: a "stripped pill" — same layout, padding, font, and
- *    purple text as the in-progress pill, but with the background,
- *    border, shadow, and backdrop-blur removed and the spinning ring
- *    swapped for a static checkmark. The frame visibly sheds while
- *    the icon morphs.
+ * Single-element three-stage design:
+ *  1. **In-progress.** Glassmorphism pill chrome around a 270° arc icon
+ *     and the label. The arc's stroke is dashed and its dashoffset is
+ *     animated continuously — "marching ants" creates the loading
+ *     sensation without rotating the SVG, which is what lets the
+ *     d-attribute morph land cleanly later (no rotation to snap back
+ *     to zero).
+ *  2. **Icon morph (~250 ms).** On status flip the single icon path
+ *     interpolates from the arc to a checkmark via CSS `d:` and the
+ *     dashed stroke transitions to solid. Chrome and text stay at
+ *     full opacity — the indicator visibly "commits" to done before
+ *     anything else moves.
+ *  3. **Settle (~400 ms, starts at +250 ms).** Chrome (background,
+ *     border, shadow, backdrop-blur) fades to zero opacity. The label
+ *     and icon stroke color alpha drops from 0.92 to 0.55. The text
+ *     stays put — only its alpha changes — so there is no "bump"
+ *     where the brand text disappears and reappears.
  *
- * Both modes coexist in the DOM at the same `grid-area` so they
- * overlap pixel-for-pixel. Status drives a cross-fade: the in-progress
- * pill fades out over 220 ms while the stripped pill fades in over
- * 320 ms with a 120 ms delay — the slight overlap reads as the frame
- * dissolving and the icon transforming rather than two distinct
- * elements being swapped.
+ * Hard sequence: stage 3 has a 250 ms transition-delay so it waits
+ * for stage 2 to finish. Total settle time ~650 ms in production.
+ *
+ * Both shapes are 3-segment cubic Bézier paths with matched command
+ * structure (one `M` plus three `C`s), which is what makes the d
+ * morph interpolate as a continuous shape change rather than snapping.
+ * The arc is drawn at the SVG's natural orientation — no `transform`
+ * is used anywhere on the icon, so there is no rotation state to
+ * reset when the marching-ants animation is removed.
+ *
+ * The label is identical in both states (e.g. "Using CopilotKit
+ * Intelligence"). An earlier draft swapped "Using…" → "Used…" on
+ * finished, which caused the brand text to drift ~1 character to
+ * the left during the morph because the leading verb was shorter.
+ * The static check icon already carries the "done" semantic.
  *
  * Customize via the `intelligenceIndicator` slot on `CopilotChat`:
- * pass a className string to restyle the default, a props object to
- * tweak it (e.g. `{ label }`), or a component to replace it entirely.
+ * a className string restyles the wrapper, a props object tweaks
+ * the default (`{ label }`), and a component replaces it entirely
+ * with full control over visuals and timing.
  */
 export function IntelligenceIndicatorView({
   message,
@@ -59,8 +69,6 @@ export function IntelligenceIndicatorView({
   className,
   ...rest
 }: IntelligenceIndicatorViewProps): React.ReactElement {
-  const isFinished = status === "finished";
-
   return (
     <span
       className={twMerge("cpk-intelligence-indicator", className)}
@@ -71,60 +79,31 @@ export function IntelligenceIndicatorView({
       title={label}
       {...rest}
     >
-      {/* In-progress pill — full opacity while spinning, shrunk and
-          faded out once status flips to finished. */}
-      <span
-        className={
-          "cpk-intelligence-indicator__pill" +
-          (isFinished ? " cpk-intelligence-indicator__pill--hidden" : "")
-        }
-        aria-hidden={isFinished || undefined}
-      >
+      {/* Chrome layer — bg, border, shadow, backdrop-blur. Sits behind
+          the content via `position: absolute; inset: 0`. Fades to zero
+          opacity once the icon morph completes. */}
+      <span className="cpk-intelligence-indicator__chrome" aria-hidden="true" />
+
+      {/* Content layer — icon + label. Stays put across the whole
+          transition; only its color alpha drops on settle. */}
+      <span className="cpk-intelligence-indicator__content">
         <svg
-          className="cpk-intelligence-pill__icon"
+          className="cpk-intelligence-indicator__icon"
           viewBox="0 0 24 24"
           width="14"
           height="14"
           aria-hidden="true"
         >
-          <circle
-            cx="12"
-            cy="12"
-            r="9"
-            fill="none"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            className="cpk-intelligence-pill__ring"
-          />
+          {/* Single path element whose `d` attribute morphs from the
+              arc to the checkmark via CSS `d:` interpolation. Both
+              shapes are 3-segment cubic Béziers; the arc is a 270°
+              quarter-by-quarter approximation of a circle, the
+              checkmark is a 2-stroke polyline split into 3 cubics
+              with collinear controls (so the segments render as
+              straight lines). */}
+          <path className="cpk-intelligence-indicator__icon-path" />
         </svg>
         <span>{label}</span>
-      </span>
-
-      {/* Finished "stripped pill" — same layout, text, and color as
-          the in-progress pill, but with no background/border/shadow,
-          and a static checkmark in place of the spinning ring. */}
-      <span
-        className={
-          "cpk-intelligence-indicator__tag" +
-          (isFinished ? " cpk-intelligence-indicator__tag--shown" : "")
-        }
-        aria-hidden={!isFinished || undefined}
-      >
-        <svg
-          className="cpk-intelligence-tag__icon"
-          viewBox="0 0 24 24"
-          width="14"
-          height="14"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M5 12.5l4 4 10-10" />
-        </svg>
-        <span>{toFinishedLabel(label)}</span>
       </span>
     </span>
   );

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
@@ -19,7 +19,7 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
 }
 
 /**
- * The presentational "Using CopilotKit Intelligence" face — the default
+ * The presentational "CopilotKit Intelligence" face — the default
  * rendered by the {@link IntelligenceIndicator} brain and the default
  * value for the `intelligenceIndicator` slot.
  *
@@ -38,12 +38,13 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
  *  3. **Settle (~400 ms, starts at +250 ms).** Chrome (background,
  *     border, shadow, backdrop-blur) fades to zero opacity. The label
  *     and icon stroke color transitions from saturated purple to a
- *     neutral slate gray (industry-standard metadata color — same
- *     family as Stripe, Linear, Claude, GitHub). The text stays put
- *     — only its color changes — so there is no "bump" where the
- *     brand text disappears and reappears. The hue shift reads as a
- *     semantic class change ("active" → "settled metadata") rather
- *     than as the same content getting dimmer.
+ *     true-neutral gray at 0.8 alpha — no hue cast, reads as "settled
+ *     history metadata." The label simultaneously skews to ~10° (a
+ *     transform-based italic feel that interpolates smoothly with the
+ *     color, rather than the discrete `font-style: italic` snap that
+ *     would cause a layout pop). The label text stays put — only its
+ *     color and slant change — so there is no "bump" where the brand
+ *     text disappears and reappears.
  *
  * Hard sequence: stage 3 has a 250 ms transition-delay so it waits
  * for stage 2 to finish. Total settle time ~650 ms in production.
@@ -52,11 +53,10 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
  * structure (one `M` plus three `C`s), which is what makes the d
  * morph interpolate as a continuous shape change rather than snapping.
  *
- * The label is identical in both states (e.g. "Using CopilotKit
- * Intelligence"). An earlier draft swapped "Using…" → "Used…" on
- * finished, which caused the brand text to drift ~1 character to
- * the left during the morph because the leading verb was shorter.
- * The static check icon already carries the "done" semantic.
+ * The label is identical in both states (default "CopilotKit
+ * Intelligence"). The static check icon carries the "done" semantic;
+ * the color + slant transition does the "settle" work without needing
+ * any wording change.
  *
  * Customize via the `intelligenceIndicator` slot on `CopilotChat`:
  * a className string restyles the wrapper, a props object tweaks
@@ -104,7 +104,7 @@ export function IntelligenceIndicatorView({
               straight lines). */}
           <path className="cpk-intelligence-indicator__icon-path" />
         </svg>
-        <span>{label}</span>
+        <span className="cpk-intelligence-indicator__label">{label}</span>
       </span>
     </span>
   );

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
@@ -35,17 +35,18 @@ const toFinishedLabel = (label: string): string =>
  * Two modes:
  *  - `in-progress`: a glassmorphism pill with a spinning ring (the
  *    same active visual users see while the intelligence tool runs).
- *  - `finished`: a tiny italic-gray "metadata line" — icon + past-tense
- *    label, no border, no background. Reads as a footnote attached to
- *    the assistant message rather than a status chip, so it disappears
- *    into the chrome for someone scrolling and surfaces for someone
- *    looking.
+ *  - `finished`: a "stripped pill" — same layout, padding, font, and
+ *    purple text as the in-progress pill, but with the background,
+ *    border, shadow, and backdrop-blur removed and the spinning ring
+ *    swapped for a static checkmark. The frame visibly sheds while
+ *    the icon morphs.
  *
- * Both modes coexist in the DOM; status drives a "shrink-and-settle"
- * transition where the pill scales down (1 → 0.7) from its center as
- * it fades out, and the tag scales up from the same center (0.7 → 1)
- * with a 120 ms delay — the overlap reads as one element morphing
- * rather than two elements being swapped. Total transition ~440 ms.
+ * Both modes coexist in the DOM at the same `grid-area` so they
+ * overlap pixel-for-pixel. Status drives a cross-fade: the in-progress
+ * pill fades out over 220 ms while the stripped pill fades in over
+ * 320 ms with a 120 ms delay — the slight overlap reads as the frame
+ * dissolving and the icon transforming rather than two distinct
+ * elements being swapped.
  *
  * Customize via the `intelligenceIndicator` slot on `CopilotChat`:
  * pass a className string to restyle the default, a props object to
@@ -99,8 +100,9 @@ export function IntelligenceIndicatorView({
         <span>{label}</span>
       </span>
 
-      {/* Finished metadata line — italic gray text + small checkmark,
-          no border or background. The checkmark itself is the cue. */}
+      {/* Finished "stripped pill" — same layout, text, and color as
+          the in-progress pill, but with no background/border/shadow,
+          and a static checkmark in place of the spinning ring. */}
       <span
         className={
           "cpk-intelligence-indicator__tag" +
@@ -111,11 +113,11 @@ export function IntelligenceIndicatorView({
         <svg
           className="cpk-intelligence-tag__icon"
           viewBox="0 0 24 24"
-          width="10"
-          height="10"
+          width="14"
+          height="14"
           fill="none"
           stroke="currentColor"
-          strokeWidth="3"
+          strokeWidth="2.5"
           strokeLinecap="round"
           strokeLinejoin="round"
           aria-hidden="true"

--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
@@ -25,16 +25,16 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
  *
  * Single-element three-stage design:
  *  1. **In-progress.** Glassmorphism pill chrome around a 270° arc icon
- *     and the label. The arc's stroke is dashed and its dashoffset is
- *     animated continuously — "marching ants" creates the loading
- *     sensation without rotating the SVG, which is what lets the
- *     d-attribute morph land cleanly later (no rotation to snap back
- *     to zero).
+ *     and the label. The arc has a single continuous visible stroke
+ *     (one `stroke-dasharray` dash + one gap, summing to the path
+ *     length) and the whole SVG rotates — so the viewer sees one
+ *     C-shaped arc spinning around the visual center.
  *  2. **Icon morph (~250 ms).** On status flip the single icon path
- *     interpolates from the arc to a checkmark via CSS `d:` and the
- *     dashed stroke transitions to solid. Chrome and text stay at
- *     full opacity — the indicator visibly "commits" to done before
- *     anything else moves.
+ *     interpolates from the arc to a checkmark via CSS `d:` while the
+ *     dashed stroke transitions to solid (filling in the gap that was
+ *     the spinner's open portion). The SVG rotation animation is
+ *     removed; the snap back to identity is masked by the simultaneous
+ *     shape change. Chrome and text stay at full opacity throughout.
  *  3. **Settle (~400 ms, starts at +250 ms).** Chrome (background,
  *     border, shadow, backdrop-blur) fades to zero opacity. The label
  *     and icon stroke color alpha drops from 0.92 to 0.55. The text
@@ -47,9 +47,6 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
  * Both shapes are 3-segment cubic Bézier paths with matched command
  * structure (one `M` plus three `C`s), which is what makes the d
  * morph interpolate as a continuous shape change rather than snapping.
- * The arc is drawn at the SVG's natural orientation — no `transform`
- * is used anywhere on the icon, so there is no rotation state to
- * reset when the marching-ants animation is removed.
  *
  * The label is identical in both states (e.g. "Using CopilotKit
  * Intelligence"). An earlier draft swapped "Using…" → "Used…" on

--- a/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
@@ -281,13 +281,13 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
 
   /**
    * Within a single turn (no user message between assistant messages),
-   * the indicator anchors to the LAST bash-using assistant message and
-   * moves as later bash-using messages arrive — there is exactly one
-   * indicator visible per turn at any time. After the turn finishes the
-   * indicator settles into its persistent finished state on the final
-   * bash-using message of that turn.
+   * the indicator anchors to the FIRST bash-using assistant message and
+   * STAYS there — later bash-using messages in the same turn do not move
+   * it. Keeping the anchor fixed means the spinner never abruptly jumps
+   * position mid-turn. After the turn finishes it settles into its
+   * persistent finished state on that same first message.
    */
-  it("within a single turn: anchors to the last bash-using assistant; settles to finished", async () => {
+  it("within a single turn: anchors to the first bash-using assistant and stays put; settles to finished", async () => {
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -304,18 +304,19 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
     await waitFor(() => expectIndicatorOn("m_a1"));
     expectIndicatorCount(1);
 
-    // A second bash-using assistant in the same turn takes over the slot.
+    // A second bash-using assistant in the same turn must NOT move the anchor.
     emitAssistantMessageWithToolCalls(agent, "m_a2", [
       { id: "tc_a2", arg: '{"cmd":"echo a2"}' },
     ]);
-    await waitFor(() => expectIndicatorOn("m_a2"));
-    await waitFor(() => expectNoIndicatorOn("m_a1"));
+    await new Promise((r) => setTimeout(r, 120));
+    expectIndicatorOn("m_a1");
+    expectNoIndicatorOn("m_a2");
     expectIndicatorCount(1);
 
-    // Turn finishes → indicator settles on m_a2 in finished state.
+    // Turn finishes → indicator settles on m_a1 (the first) in finished state.
     agent.emit(runFinishedEvent());
-    await waitFor(() => expectIndicatorStatus("m_a2", "finished"));
-    expectIndicatorOn("m_a2");
+    await waitFor(() => expectIndicatorStatus("m_a1", "finished"));
+    expectIndicatorOn("m_a1");
     expectIndicatorCount(1);
   });
 
@@ -363,10 +364,11 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
   });
 
   /**
-   * Within a turn, an earlier bash-using assistant must NOT keep the
-   * indicator once a later bash-using assistant arrives.
+   * Within a turn, the indicator stays anchored to the FIRST bash-using
+   * assistant and never jumps to a later one — only one indicator renders
+   * per turn, and it does not move.
    */
-  it("condition (last-in-turn): never renders on a non-last bash-using assistant of the turn", async () => {
+  it("condition (first-in-turn): stays on the first bash-using assistant; never moves to a later one", async () => {
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -376,19 +378,16 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
     emitAssistantMessageWithToolCalls(agent, "m_first", [
       { id: "tc_first", arg: "{}" },
     ]);
-    // Wait for m_first to render the indicator while it is still the
-    // last in the turn. Without this gate, both messages would land
-    // synchronously and m_first's renderer would never have been
-    // invoked while it was the last — turning a reactive assertion
-    // into a first-render correctness test by accident.
     await waitFor(() => expectIndicatorOn("m_first"));
 
     emitAssistantMessageWithToolCalls(agent, "m_second", [
       { id: "tc_second", arg: "{}" },
     ]);
 
-    await waitFor(() => expectIndicatorOn("m_second"));
-    expectNoIndicatorOn("m_first");
+    // The anchor does not move to the later bash-using message.
+    await new Promise((r) => setTimeout(r, 120));
+    expectIndicatorOn("m_first");
+    expectNoIndicatorOn("m_second");
     expectIndicatorCount(1);
   });
 
@@ -534,9 +533,10 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
     expectIndicatorCount(1);
   });
 
-  it("multi-step: indicator stays continuously across tool-result interleaving", async () => {
-    // Tool result arrives, then a second assistant message with bash.
-    // Within the same turn, the slot moves from m_step1 to m_step2.
+  it("multi-step: indicator stays continuously on the first bash message across tool-result interleaving", async () => {
+    // Tool result arrives, then a second assistant message with bash. Within
+    // the same turn the anchor stays fixed on the first bash message — it
+    // does not move to the second.
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -555,13 +555,14 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
     expectIndicatorOn("m_step1");
     expectIndicatorCount(1);
 
-    // Second assistant message with bash arrives. Slot moves; old
-    // instance stops rendering (no longer the last-in-turn).
+    // Second assistant message with bash arrives — the anchor stays on the
+    // first bash message; it does not jump to m_step2.
     emitAssistantMessageWithToolCalls(agent, "m_step2", [
       { id: "tc_step2", arg: '{"cmd":"pwd"}' },
     ]);
-    await waitFor(() => expectIndicatorOn("m_step2"));
-    expectNoIndicatorOn("m_step1");
+    await new Promise((r) => setTimeout(r, 150));
+    expectIndicatorOn("m_step1");
+    expectNoIndicatorOn("m_step2");
     expectIndicatorCount(1);
   });
 
@@ -587,6 +588,57 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
 
     await waitFor(() => expectIndicatorStatus("m_tool", "finished"));
     expectIndicatorCount(1);
+  });
+
+  it("bug 1 (no remount): the face is not torn down across an anchor hand-off within a turn", async () => {
+    // Within one turn the anchor moves from the first bash-using assistant
+    // message to a later one. The indicator is keyed by turn (not by message),
+    // so the SAME face instance moves with the anchor — no unmount, no remount,
+    // no spinner restart. A remount here is exactly bug 1's flicker. (Under the
+    // old per-message keying this counted two mounts + one unmount.)
+    let mountCount = 0;
+    let unmountCount = 0;
+    const Tracking = ({
+      status,
+      label,
+    }: IntelligenceIndicatorViewProps): React.ReactElement => {
+      React.useEffect(() => {
+        mountCount += 1;
+        return () => {
+          unmountCount += 1;
+        };
+      }, []);
+      return (
+        <div data-testid="tracking-indicator" data-custom-status={status}>
+          {label}
+        </div>
+      );
+    };
+
+    const agent = makeAgent();
+    renderForIndicator(agent, { intelligenceIndicator: Tracking });
+    await screen.findByTestId("trigger-run");
+
+    await triggerRun(agent);
+    startRun(agent);
+
+    emitAssistantMessageWithToolCalls(agent, "m_a1", [
+      { id: "tc_a1", arg: '{"cmd":"ls"}' },
+    ]);
+    // Face mounts exactly once, after the grace window.
+    await waitFor(() => expect(mountCount).toBe(1));
+
+    // A later bash-using assistant in the SAME turn takes over the anchor.
+    emitAssistantMessageWithToolCalls(agent, "m_a2", [
+      { id: "tc_a2", arg: '{"cmd":"pwd"}' },
+    ]);
+    // Allow React to reconcile and any (incorrect) remount to surface.
+    await new Promise((r) => setTimeout(r, 150));
+
+    // The instance moved with the anchor — it was never torn down.
+    expect(mountCount).toBe(1);
+    expect(unmountCount).toBe(0);
+    expect(screen.getAllByTestId("tracking-indicator")).toHaveLength(1);
   });
 
   // ─── Slot customization (the three SlotValue tiers) ──────────────────

--- a/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { afterEach, describe, expect, it } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { EventType } from "@ag-ui/client";
 import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
 import type { Observable } from "rxjs";
@@ -52,33 +58,35 @@ class IsRunningAccurateMockAgent extends MockStepwiseAgent {
   }
 }
 
-const PILL_TESTID_RE = /^cpk-intelligence-pill-/;
+const INDICATOR_TESTID_RE = /^cpk-intelligence-indicator-/;
 
-const expectPillCount = (n: number): void => {
-  expect(screen.queryAllByTestId(PILL_TESTID_RE).length).toBe(n);
+const expectIndicatorCount = (n: number): void => {
+  expect(screen.queryAllByTestId(INDICATOR_TESTID_RE).length).toBe(n);
 };
 
-const expectPillOn = (messageId: string): void => {
+const expectIndicatorOn = (messageId: string): void => {
   expect(
-    screen.getByTestId(`cpk-intelligence-pill-${messageId}`).textContent,
+    screen.getByTestId(`cpk-intelligence-indicator-${messageId}`).textContent,
   ).toContain("Using CopilotKit Intelligence");
 };
 
-const expectNoPillOn = (messageId: string): void => {
-  expect(screen.queryByTestId(`cpk-intelligence-pill-${messageId}`)).toBeNull();
+const expectNoIndicatorOn = (messageId: string): void => {
+  expect(
+    screen.queryByTestId(`cpk-intelligence-indicator-${messageId}`),
+  ).toBeNull();
 };
 
-const expectNoPillAnywhere = (): void => {
-  expect(screen.queryAllByTestId(PILL_TESTID_RE).length).toBe(0);
+const expectNoIndicatorAnywhere = (): void => {
+  expect(screen.queryAllByTestId(INDICATOR_TESTID_RE).length).toBe(0);
 };
 
-const expectPillStatus = (
+const expectIndicatorStatus = (
   messageId: string,
   status: "in-progress" | "finished",
 ): void => {
   expect(
     screen
-      .getByTestId(`cpk-intelligence-pill-${messageId}`)
+      .getByTestId(`cpk-intelligence-indicator-${messageId}`)
       .getAttribute("data-status"),
   ).toBe(status);
 };
@@ -121,6 +129,29 @@ const emitAssistantProse = (
   agent.emit(textMessageStartEvent(messageId));
   agent.emit(textMessageContentEvent(messageId, text));
   agent.emit(textMessageEndEvent(messageId));
+};
+
+/**
+ * Add a user message to `agent.messages`. User messages are turn
+ * boundaries — the indicator's per-turn gating treats every assistant
+ * message between two user messages as part of the same turn. We push
+ * directly via `addMessages` because text-message events emitted
+ * outside an active run don't flow through the AG-UI pipeline.
+ */
+const emitUserMessage = (
+  agent: MockStepwiseAgent,
+  messageId: string,
+  text: string,
+): void => {
+  act(() => {
+    agent.addMessages([
+      {
+        id: messageId,
+        role: "user",
+        content: text,
+      },
+    ]);
+  });
 };
 
 const startRun = (agent: MockStepwiseAgent): void => {
@@ -249,71 +280,93 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
   });
 
   /**
-   * Walks through the canonical scenario:
-   *
-   *   RUN A
-   *     m_a1 (assistant) → toolCall bash#1, bash#2
-   *   RUN B
-   *     m_b1 (assistant) → toolCall bash
-   *     m_b2 (assistant) → toolCall bash#1, bash#2
-   *
-   * The pill must render only on the last message of the latest
-   * in-flight run — never on multiple messages, never on stale runs,
-   * never on a non-last message of the current run.
+   * Within a single turn (no user message between assistant messages),
+   * the indicator anchors to the LAST bash-using assistant message and
+   * moves as later bash-using messages arrive — there is exactly one
+   * indicator visible per turn at any time. After the turn finishes the
+   * indicator settles into its persistent finished state on the final
+   * bash-using message of that turn.
    */
-  it("renders only on the last message of the latest in-flight run", async () => {
+  it("within a single turn: anchors to the last bash-using assistant; settles to finished", async () => {
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
 
-    expectNoPillAnywhere();
+    expectNoIndicatorAnywhere();
 
-    // ─── Run A: m_a1 with two tool calls → pill on m_a1 ───────────────
     await triggerRun(agent);
     startRun(agent);
+
     emitAssistantMessageWithToolCalls(agent, "m_a1", [
       { id: "tc_a1_1", arg: '{"cmd":"ls"}' },
       { id: "tc_a1_2", arg: '{"cmd":"pwd"}' },
     ]);
-    await waitFor(() => expectPillOn("m_a1"));
-    expectPillCount(1);
+    await waitFor(() => expectIndicatorOn("m_a1"));
+    expectIndicatorCount(1);
 
-    agent.emit(runFinishedEvent());
-
-    // ─── Run B: m_b1 (one bash) ──────────────────────────────────────
-    await triggerRun(agent);
-    startRun(agent);
-    emitAssistantMessageWithToolCalls(agent, "m_b1", [
-      { id: "tc_b1", arg: '{"cmd":"echo b1"}' },
+    // A second bash-using assistant in the same turn takes over the slot.
+    emitAssistantMessageWithToolCalls(agent, "m_a2", [
+      { id: "tc_a2", arg: '{"cmd":"echo a2"}' },
     ]);
-    await waitFor(() => expectPillOn("m_b1"));
-    // m_b1 supersedes m_a1 as the latest matching-assistant slot, so
-    // m_a1's pill is gated out — even though it had settled into its
-    // persistent finished state.
-    await waitFor(() => expectNoPillOn("m_a1"));
-    expectPillCount(1);
+    await waitFor(() => expectIndicatorOn("m_a2"));
+    await waitFor(() => expectNoIndicatorOn("m_a1"));
+    expectIndicatorCount(1);
 
-    // ─── m_b2 streams in — pill moves to m_b2, m_b1 loses pill ────────
-    emitAssistantMessageWithToolCalls(agent, "m_b2", [
-      { id: "tc_b2_1", arg: '{"cmd":"echo b2-1"}' },
-      { id: "tc_b2_2", arg: '{"cmd":"echo b2-2"}' },
-    ]);
-    await waitFor(() => expectPillOn("m_b2"));
-    expectNoPillOn("m_b1");
-    expectNoPillOn("m_a1");
-    expectPillCount(1);
-
-    // ─── Run B finishes — the pill persists on m_b2 in its finished
-    //      resting state rather than unmounting ─────────────────────────
+    // Turn finishes → indicator settles on m_a2 in finished state.
     agent.emit(runFinishedEvent());
-    await waitFor(() => expectPillStatus("m_b2", "finished"));
-    expectPillOn("m_b2");
-    expectPillCount(1);
+    await waitFor(() => expectIndicatorStatus("m_a2", "finished"));
+    expectIndicatorOn("m_a2");
+    expectIndicatorCount(1);
   });
 
-  // ─── Per-condition focused tests ────────────────────────────────────
+  /**
+   * Headline per-turn persistence test. A user message between two
+   * Intelligence-using runs marks a turn boundary. Each turn's
+   * indicator anchors on its own last bash-using assistant message, and
+   * the prior turn's indicator stays in chat history when a new turn
+   * starts — they coexist in the DOM.
+   */
+  it("per-turn persistence: indicators from past turns remain when a new turn starts", async () => {
+    const agent = makeAgent();
+    renderForIndicator(agent);
+    await screen.findByTestId("trigger-run");
 
-  it("condition (last-in-run): never renders on a non-last message of the run", async () => {
+    // ─── Turn 1 ──────────────────────────────────────────────────────
+    emitUserMessage(agent, "u1", "tell me about portland");
+    await triggerRun(agent);
+    startRun(agent);
+    emitAssistantMessageWithToolCalls(agent, "m_t1", [
+      { id: "tc_t1", arg: '{"cmd":"grep portland"}' },
+    ]);
+    await waitFor(() => expectIndicatorStatus("m_t1", "in-progress"));
+    agent.emit(runFinishedEvent());
+    await waitFor(() => expectIndicatorStatus("m_t1", "finished"));
+    expectIndicatorCount(1);
+
+    // ─── Turn 2 (user message marks the new turn) ───────────────────
+    emitUserMessage(agent, "u2", "what about seattle");
+    await triggerRun(agent);
+    startRun(agent);
+    emitAssistantMessageWithToolCalls(agent, "m_t2", [
+      { id: "tc_t2", arg: '{"cmd":"grep seattle"}' },
+    ]);
+
+    // Turn 2's indicator appears, and Turn 1's stays in the DOM.
+    await waitFor(() => expectIndicatorStatus("m_t2", "in-progress"));
+    expectIndicatorStatus("m_t1", "finished");
+    expectIndicatorCount(2);
+
+    agent.emit(runFinishedEvent());
+    await waitFor(() => expectIndicatorStatus("m_t2", "finished"));
+    expectIndicatorStatus("m_t1", "finished");
+    expectIndicatorCount(2);
+  });
+
+  /**
+   * Within a turn, an earlier bash-using assistant must NOT keep the
+   * indicator once a later bash-using assistant arrives.
+   */
+  it("condition (last-in-turn): never renders on a non-last bash-using assistant of the turn", async () => {
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -323,23 +376,23 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     emitAssistantMessageWithToolCalls(agent, "m_first", [
       { id: "tc_first", arg: "{}" },
     ]);
-    // Wait for m_first to render the pill while it is still the last
-    // message in the run. Without this gate, both messages would land
+    // Wait for m_first to render the indicator while it is still the
+    // last in the turn. Without this gate, both messages would land
     // synchronously and m_first's renderer would never have been
     // invoked while it was the last — turning a reactive assertion
     // into a first-render correctness test by accident.
-    await waitFor(() => expectPillOn("m_first"));
+    await waitFor(() => expectIndicatorOn("m_first"));
 
     emitAssistantMessageWithToolCalls(agent, "m_second", [
       { id: "tc_second", arg: "{}" },
     ]);
 
-    await waitFor(() => expectPillOn("m_second"));
-    expectNoPillOn("m_first");
-    expectPillCount(1);
+    await waitFor(() => expectIndicatorOn("m_second"));
+    expectNoIndicatorOn("m_first");
+    expectIndicatorCount(1);
   });
 
-  it("condition (in-flight): pill settles into a persistent finished state after the run finishes", async () => {
+  it("condition (in-flight): indicator settles into a persistent finished state after the run finishes", async () => {
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -349,34 +402,12 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     emitAssistantMessageWithToolCalls(agent, "m_only", [
       { id: "tc", arg: "{}" },
     ]);
-    await waitFor(() => expectPillStatus("m_only", "in-progress"));
+    await waitFor(() => expectIndicatorStatus("m_only", "in-progress"));
 
     agent.emit(runFinishedEvent());
-    await waitFor(() => expectPillStatus("m_only", "finished"));
-    expectPillOn("m_only");
-    expectPillCount(1);
-  });
-
-  it("condition (latest-run): never renders on a stale run after a newer run starts", async () => {
-    const agent = makeAgent();
-    renderForIndicator(agent);
-    await screen.findByTestId("trigger-run");
-
-    await triggerRun(agent);
-    startRun(agent);
-    emitAssistantMessageWithToolCalls(agent, "m_run1", [
-      { id: "tc_run1", arg: "{}" },
-    ]);
-    await waitFor(() => expectPillOn("m_run1"));
-    agent.emit(runFinishedEvent());
-
-    await triggerRun(agent);
-    startRun(agent);
-    emitAssistantMessageWithToolCalls(agent, "m_run2", [
-      { id: "tc_run2", arg: "{}" },
-    ]);
-    await waitFor(() => expectPillOn("m_run2"));
-    expectNoPillOn("m_run1");
+    await waitFor(() => expectIndicatorStatus("m_only", "finished"));
+    expectIndicatorOn("m_only");
+    expectIndicatorCount(1);
   });
 
   it("condition (tool-match): only renders when a configured tool name matches", async () => {
@@ -386,19 +417,19 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
 
     await triggerRun(agent);
     startRun(agent);
-    // First message has only a non-matching tool call; no pill.
+    // First message has only a non-matching tool call; no indicator.
     emitAssistantMessageWithToolCalls(agent, "m_no_match", [
       { id: "tc_no_match", name: "fetch", arg: "{}" },
     ]);
     await new Promise((r) => setTimeout(r, 80));
-    expectNoPillOn("m_no_match");
+    expectNoIndicatorOn("m_no_match");
 
-    // Second message has a bash call — pill should appear on it.
+    // Second message has a bash call — indicator should appear on it.
     emitAssistantMessageWithToolCalls(agent, "m_match", [
       { id: "tc_match", name: "copilotkit_knowledge_base_shell", arg: "{}" },
     ]);
-    await waitFor(() => expectPillOn("m_match"));
-    expectPillCount(1);
+    await waitFor(() => expectIndicatorOn("m_match"));
+    expectIndicatorCount(1);
   });
 
   it("condition (tool-match): renders for the namespaced mcp__ tool name", async () => {
@@ -417,8 +448,8 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
         arg: "{}",
       },
     ]);
-    await waitFor(() => expectPillOn("m_match"));
-    expectPillCount(1);
+    await waitFor(() => expectIndicatorOn("m_match"));
+    expectIndicatorCount(1);
   });
 
   it("intelligence gate: does not render when copilotkit.intelligence is undefined", async () => {
@@ -430,15 +461,15 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     startRun(agent);
     emitAssistantMessageWithToolCalls(agent, "m1", [{ id: "tc1", arg: "{}" }]);
 
-    // Without the gate, the pill would be visible by now.
+    // Without the gate, the indicator would be visible by now.
     await new Promise((r) => setTimeout(r, 80));
-    expectNoPillAnywhere();
+    expectNoIndicatorAnywhere();
   });
 
   it("auto-registration: no renderCustomMessages prop is required", async () => {
-    // This is the explicit assertion that the indicator auto-mounts.
+    // Explicit assertion that the indicator auto-mounts.
     // `renderForIndicator` does not pass `renderCustomMessages`, yet
-    // the pill renders solely because intelligence is configured.
+    // the indicator renders solely because intelligence is configured.
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -447,17 +478,15 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     startRun(agent);
     emitAssistantMessageWithToolCalls(agent, "m1", [{ id: "tc1", arg: "{}" }]);
 
-    await waitFor(() => expectPillOn("m1"));
-    expectPillCount(1);
+    await waitFor(() => expectIndicatorOn("m1"));
+    expectIndicatorCount(1);
   });
 
-  // ─── New gate: tool-call pending past grace window ──────────────────
-
-  it("replay-flash suppression: no pill when tool result arrives within the grace window", async () => {
+  it("replay-flash suppression: no indicator when tool result arrives within the grace window", async () => {
     // Models a `connectAgent` history replay: the tool call and its
     // matching `tool`-role result arrive in the same tick, well below
-    // PENDING_THRESHOLD_MS. The pill timer should be cancelled before
-    // it fires, so nothing renders.
+    // PENDING_THRESHOLD_MS. The hidden→spinner timer should be cancelled
+    // before it fires, so nothing renders.
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -469,15 +498,45 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     ]);
     emitToolResult(agent, "tc_replay", "tr_replay");
 
-    // Wait past the grace window — pill should never appear.
+    // Wait past the grace window — the indicator should never appear
+    // while the run is still ongoing without a real follow-up.
     await new Promise((r) => setTimeout(r, 200));
-    expectNoPillAnywhere();
+    expectNoIndicatorAnywhere();
   });
 
-  it("multi-step: pill stays continuously across tool-result interleaving", async () => {
+  /**
+   * When the brain mounts onto a message whose turn is already complete
+   * (e.g. `/connect` history replay finished before the component
+   * mounted), the indicator should render directly in finished state
+   * without flashing through spinner first.
+   */
+  it("historical replay: completed turn renders directly in finished state", async () => {
+    const agent = makeAgent();
+    renderForIndicator(agent);
+    await screen.findByTestId("trigger-run");
+
+    // Emit the assistant message + tool call + tool result + a prose
+    // follow-up before any "live" tracking can attach. By the time the
+    // assertions run, `hasPending` is false and `sawRealFollowup` is
+    // true — the brain has no live work to track.
+    await triggerRun(agent);
+    startRun(agent);
+    emitAssistantMessageWithToolCalls(agent, "m_hist", [
+      { id: "tc_hist", arg: "{}" },
+    ]);
+    emitToolResult(agent, "tc_hist", "tr_hist");
+    emitAssistantProse(agent, "m_prose", "Done.");
+    agent.emit(runFinishedEvent());
+
+    // The indicator should be in finished state immediately, without
+    // ever flashing through spinner.
+    await waitFor(() => expectIndicatorStatus("m_hist", "finished"));
+    expectIndicatorCount(1);
+  });
+
+  it("multi-step: indicator stays continuously across tool-result interleaving", async () => {
     // Tool result arrives, then a second assistant message with bash.
-    // The pill must not show the completed/fade animation between
-    // calls — it stays on m_step1 until m_step2 takes over the slot.
+    // Within the same turn, the slot moves from m_step1 to m_step2.
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -487,31 +546,31 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     emitAssistantMessageWithToolCalls(agent, "m_step1", [
       { id: "tc_step1", arg: '{"cmd":"ls"}' },
     ]);
-    await waitFor(() => expectPillOn("m_step1"));
+    await waitFor(() => expectIndicatorOn("m_step1"));
 
     // Tool result lands. agent.isRunning is still true, no real
-    // follow-up yet → pill stays on m_step1 in spinner.
+    // follow-up yet → indicator stays on m_step1 in spinner.
     emitToolResult(agent, "tc_step1", "tr_step1");
     await new Promise((r) => setTimeout(r, 150));
-    expectPillOn("m_step1");
-    expectPillCount(1);
+    expectIndicatorOn("m_step1");
+    expectIndicatorCount(1);
 
     // Second assistant message with bash arrives. Slot moves; old
-    // instance returns null without a fade animation.
+    // instance stops rendering (no longer the last-in-turn).
     emitAssistantMessageWithToolCalls(agent, "m_step2", [
       { id: "tc_step2", arg: '{"cmd":"pwd"}' },
     ]);
-    await waitFor(() => expectPillOn("m_step2"));
-    expectNoPillOn("m_step1");
-    expectPillCount(1);
+    await waitFor(() => expectIndicatorOn("m_step2"));
+    expectNoIndicatorOn("m_step1");
+    expectIndicatorCount(1);
   });
 
-  it("real-followup exit: prose assistant message after the tool flow settles the pill into finished", async () => {
+  it("real-followup exit: prose assistant after the tool flow settles the indicator into finished", async () => {
     // After the tool result the agent emits a final prose message —
-    // that's a "real follow-up" and should immediately exit the spinner
-    // (without waiting on isRunning), settling into the finished state.
-    // The prose message is not a matching-assistant message, so m_tool
-    // remains the latest matching slot and keeps the persistent pill.
+    // that's a "real follow-up" and should immediately exit the
+    // spinner, settling into finished state. The prose message is not
+    // a matching-assistant message, so m_tool remains the last-in-turn
+    // and keeps the persistent indicator.
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -521,13 +580,13 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     emitAssistantMessageWithToolCalls(agent, "m_tool", [
       { id: "tc_only", arg: '{"cmd":"ls"}' },
     ]);
-    await waitFor(() => expectPillStatus("m_tool", "in-progress"));
+    await waitFor(() => expectIndicatorStatus("m_tool", "in-progress"));
 
     emitToolResult(agent, "tc_only", "tr_only");
     emitAssistantProse(agent, "m_prose", "All done.");
 
-    await waitFor(() => expectPillStatus("m_tool", "finished"));
-    expectPillCount(1);
+    await waitFor(() => expectIndicatorStatus("m_tool", "finished"));
+    expectIndicatorCount(1);
   });
 
   // ─── Slot customization (the three SlotValue tiers) ──────────────────
@@ -542,20 +601,20 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
 
     agent.emit(runFinishedEvent());
     await waitFor(() => expectCustomStatus("finished"));
-    // The default pill is replaced entirely by the custom face.
-    expectPillCount(0);
+    // The default indicator is replaced entirely by the custom face.
+    expectIndicatorCount(0);
   });
 
-  it("slot override (string): a className is merged onto the default pill", async () => {
+  it("slot override (string): a className is merged onto the default indicator", async () => {
     const agent = makeAgent();
-    renderForIndicator(agent, { intelligenceIndicator: "my-custom-pill" });
+    renderForIndicator(agent, { intelligenceIndicator: "my-custom-cls" });
     await screen.findByTestId("trigger-run");
 
     await startMatchingRun(agent, "m1");
-    await waitFor(() => expectPillOn("m1"));
-    expect(screen.getByTestId("cpk-intelligence-pill-m1").className).toContain(
-      "my-custom-pill",
-    );
+    await waitFor(() => expectIndicatorOn("m1"));
+    expect(
+      screen.getByTestId("cpk-intelligence-indicator-m1").className,
+    ).toContain("my-custom-cls");
   });
 
   it("slot override (props): a props object overrides the label", async () => {
@@ -568,7 +627,7 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     await startMatchingRun(agent, "m1");
     await waitFor(() =>
       expect(
-        screen.getByTestId("cpk-intelligence-pill-m1").textContent,
+        screen.getByTestId("cpk-intelligence-indicator-m1").textContent,
       ).toContain("Recalling memory"),
     );
   });

--- a/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
@@ -70,12 +70,6 @@ const expectIndicatorOn = (messageId: string): void => {
   ).toContain("CopilotKit Intelligence");
 };
 
-const expectNoIndicatorOn = (messageId: string): void => {
-  expect(
-    screen.queryByTestId(`cpk-intelligence-indicator-${messageId}`),
-  ).toBeNull();
-};
-
 const expectNoIndicatorAnywhere = (): void => {
   expect(screen.queryAllByTestId(INDICATOR_TESTID_RE).length).toBe(0);
 };
@@ -304,15 +298,6 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
     await waitFor(() => expectIndicatorOn("m_a1"));
     expectIndicatorCount(1);
 
-    // A second bash-using assistant in the same turn must NOT move the anchor.
-    emitAssistantMessageWithToolCalls(agent, "m_a2", [
-      { id: "tc_a2", arg: '{"cmd":"echo a2"}' },
-    ]);
-    await new Promise((r) => setTimeout(r, 120));
-    expectIndicatorOn("m_a1");
-    expectNoIndicatorOn("m_a2");
-    expectIndicatorCount(1);
-
     // Turn finishes → indicator settles on m_a1 (the first) in finished state.
     agent.emit(runFinishedEvent());
     await waitFor(() => expectIndicatorStatus("m_a1", "finished"));
@@ -323,7 +308,7 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
   /**
    * Headline per-turn persistence test. A user message between two
    * Intelligence-using runs marks a turn boundary. Each turn's
-   * indicator anchors on its own last bash-using assistant message, and
+   * indicator anchors on its own first bash-using assistant message, and
    * the prior turn's indicator stays in chat history when a new turn
    * starts — they coexist in the DOM.
    */
@@ -363,33 +348,10 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
     expectIndicatorCount(2);
   });
 
-  /**
-   * Within a turn, the indicator stays anchored to the FIRST bash-using
-   * assistant and never jumps to a later one — only one indicator renders
-   * per turn, and it does not move.
-   */
-  it("condition (first-in-turn): stays on the first bash-using assistant; never moves to a later one", async () => {
-    const agent = makeAgent();
-    renderForIndicator(agent);
-    await screen.findByTestId("trigger-run");
-
-    await triggerRun(agent);
-    startRun(agent);
-    emitAssistantMessageWithToolCalls(agent, "m_first", [
-      { id: "tc_first", arg: "{}" },
-    ]);
-    await waitFor(() => expectIndicatorOn("m_first"));
-
-    emitAssistantMessageWithToolCalls(agent, "m_second", [
-      { id: "tc_second", arg: "{}" },
-    ]);
-
-    // The anchor does not move to the later bash-using message.
-    await new Promise((r) => setTimeout(r, 120));
-    expectIndicatorOn("m_first");
-    expectNoIndicatorOn("m_second");
-    expectIndicatorCount(1);
-  });
+  // NOTE: "anchors to the FIRST bash-using message of a turn, never a later
+  // one" is proven deterministically in `intelligence-indicator-logic.test.ts`
+  // (getIntelligenceTurnAnchors), so it's not re-driven through the live timer
+  // here.
 
   it("condition (in-flight): indicator settles into a persistent finished state after the run finishes", async () => {
     const agent = makeAgent();
@@ -416,14 +378,8 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
 
     await triggerRun(agent);
     startRun(agent);
-    // First message has only a non-matching tool call; no indicator.
-    emitAssistantMessageWithToolCalls(agent, "m_no_match", [
-      { id: "tc_no_match", name: "fetch", arg: "{}" },
-    ]);
-    await new Promise((r) => setTimeout(r, 80));
-    expectNoIndicatorOn("m_no_match");
-
-    // Second message has a bash call — indicator should appear on it.
+    // A bash call lights the pill. (That a *non*-matching tool name yields no
+    // anchor is proven in the getIntelligenceTurnAnchors logic test.)
     emitAssistantMessageWithToolCalls(agent, "m_match", [
       { id: "tc_match", name: "copilotkit_knowledge_base_shell", arg: "{}" },
     ]);
@@ -460,8 +416,10 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
     startRun(agent);
     emitAssistantMessageWithToolCalls(agent, "m1", [{ id: "tc1", arg: "{}" }]);
 
-    // Without the gate, the indicator would be visible by now.
-    await new Promise((r) => setTimeout(r, 80));
+    // The intelligence gate (`copilotkit.intelligence === undefined → null`) is
+    // a synchronous render gate, independent of the grace timer — the indicator
+    // is never produced. Wait for the message to reconcile, then assert absence.
+    await waitFor(() => expect(agent.messages.length).toBeGreaterThan(0));
     expectNoIndicatorAnywhere();
   });
 
@@ -481,27 +439,10 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
     expectIndicatorCount(1);
   });
 
-  it("replay-flash suppression: no indicator when tool result arrives within the grace window", async () => {
-    // Models a `connectAgent` history replay: the tool call and its
-    // matching `tool`-role result arrive in the same tick, well below
-    // PENDING_THRESHOLD_MS. The hidden→spinner timer should be cancelled
-    // before it fires, so nothing renders.
-    const agent = makeAgent();
-    renderForIndicator(agent);
-    await screen.findByTestId("trigger-run");
-
-    await triggerRun(agent);
-    startRun(agent);
-    emitAssistantMessageWithToolCalls(agent, "m_replay", [
-      { id: "tc_replay", arg: '{"cmd":"ls"}' },
-    ]);
-    emitToolResult(agent, "tc_replay", "tr_replay");
-
-    // Wait past the grace window — the indicator should never appear
-    // while the run is still ongoing without a real follow-up.
-    await new Promise((r) => setTimeout(r, 200));
-    expectNoIndicatorAnywhere();
-  });
+  // NOTE: replay-flash suppression (a tool call + result that resolve before
+  // the grace window elapses must not flash a spinner) is the pure decision
+  // `resolveGracePhase(turnComplete=false, hasPending=false) === "hidden"`,
+  // covered in `intelligence-indicator-logic.test.ts` without any timer.
 
   /**
    * When the brain mounts onto a message whose turn is already complete
@@ -533,44 +474,16 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
     expectIndicatorCount(1);
   });
 
-  it("multi-step: indicator stays continuously on the first bash message across tool-result interleaving", async () => {
-    // Tool result arrives, then a second assistant message with bash. Within
-    // the same turn the anchor stays fixed on the first bash message — it
-    // does not move to the second.
-    const agent = makeAgent();
-    renderForIndicator(agent);
-    await screen.findByTestId("trigger-run");
-
-    await triggerRun(agent);
-    startRun(agent);
-    emitAssistantMessageWithToolCalls(agent, "m_step1", [
-      { id: "tc_step1", arg: '{"cmd":"ls"}' },
-    ]);
-    await waitFor(() => expectIndicatorOn("m_step1"));
-
-    // Tool result lands. agent.isRunning is still true, no real
-    // follow-up yet → indicator stays on m_step1 in spinner.
-    emitToolResult(agent, "tc_step1", "tr_step1");
-    await new Promise((r) => setTimeout(r, 150));
-    expectIndicatorOn("m_step1");
-    expectIndicatorCount(1);
-
-    // Second assistant message with bash arrives — the anchor stays on the
-    // first bash message; it does not jump to m_step2.
-    emitAssistantMessageWithToolCalls(agent, "m_step2", [
-      { id: "tc_step2", arg: '{"cmd":"pwd"}' },
-    ]);
-    await new Promise((r) => setTimeout(r, 150));
-    expectIndicatorOn("m_step1");
-    expectNoIndicatorOn("m_step2");
-    expectIndicatorCount(1);
-  });
+  // NOTE: "the anchor stays fixed on the first bash message across tool-result
+  // interleaving and a later bash message" is the anchoring invariant proven in
+  // `intelligence-indicator-logic.test.ts`; continuity-without-remount across an
+  // anchor change is covered by the "bug 1 (no remount)" test below.
 
   it("real-followup exit: prose assistant after the tool flow settles the indicator into finished", async () => {
     // After the tool result the agent emits a final prose message —
     // that's a "real follow-up" and should immediately exit the
     // spinner, settling into finished state. The prose message is not
-    // a matching-assistant message, so m_tool remains the last-in-turn
+    // a matching-assistant message, so m_tool remains the turn's anchor
     // and keeps the persistent indicator.
     const agent = makeAgent();
     renderForIndicator(agent);
@@ -591,11 +504,11 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
   });
 
   it("bug 1 (no remount): the face is not torn down across an anchor hand-off within a turn", async () => {
-    // Within one turn the anchor moves from the first bash-using assistant
-    // message to a later one. The indicator is keyed by turn (not by message),
-    // so the SAME face instance moves with the anchor — no unmount, no remount,
-    // no spinner restart. A remount here is exactly bug 1's flicker. (Under the
-    // old per-message keying this counted two mounts + one unmount.)
+    // Within one turn a second bash-using assistant message arrives. The
+    // indicator is keyed by turn (not by message) and anchored to the FIRST
+    // bash message, so the SAME face instance stays mounted — no unmount, no
+    // remount, no spinner restart. A remount here is exactly bug 1's flicker.
+    // (Under the old per-message keying a later bash counted as a new mount.)
     let mountCount = 0;
     let unmountCount = 0;
     const Tracking = ({
@@ -628,14 +541,17 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
     // Face mounts exactly once, after the grace window.
     await waitFor(() => expect(mountCount).toBe(1));
 
-    // A later bash-using assistant in the SAME turn takes over the anchor.
+    // A later bash-using assistant arrives in the SAME turn.
     emitAssistantMessageWithToolCalls(agent, "m_a2", [
       { id: "tc_a2", arg: '{"cmd":"pwd"}' },
     ]);
-    // Allow React to reconcile and any (incorrect) remount to surface.
-    await new Promise((r) => setTimeout(r, 150));
+    // Wait for m_a2 to reconcile (deterministic, event-driven) — any incorrect
+    // remount would have surfaced by the time it is in the message tree.
+    await waitFor(() =>
+      expect(agent.messages.some((m) => m.id === "m_a2")).toBe(true),
+    );
 
-    // The instance moved with the anchor — it was never torn down.
+    // The instance was never torn down (keyed by turn, not by message).
     expect(mountCount).toBe(1);
     expect(unmountCount).toBe(0);
     expect(screen.getAllByTestId("tracking-indicator")).toHaveLength(1);

--- a/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
@@ -21,6 +21,13 @@ import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
 import { useCopilotKit } from "../../../providers/CopilotKitProvider";
 import { useAgent } from "../../../hooks/use-agent";
+import type { SlotValue } from "../../../lib/slots";
+import type {
+  IntelligenceIndicatorView,
+  IntelligenceIndicatorViewProps,
+} from "../IntelligenceIndicatorView";
+
+type IndicatorSlot = SlotValue<typeof IntelligenceIndicatorView>;
 
 /**
  * Mock agent with accurate per-run `isRunning` lifecycle. The shared
@@ -63,6 +70,17 @@ const expectNoPillOn = (messageId: string): void => {
 
 const expectNoPillAnywhere = (): void => {
   expect(screen.queryAllByTestId(PILL_TESTID_RE).length).toBe(0);
+};
+
+const expectPillStatus = (
+  messageId: string,
+  status: "in-progress" | "finished",
+): void => {
+  expect(
+    screen
+      .getByTestId(`cpk-intelligence-pill-${messageId}`)
+      .getAttribute("data-status"),
+  ).toBe(status);
 };
 
 const emitAssistantMessageWithToolCalls = (
@@ -151,13 +169,14 @@ const RunAgentHarness: React.FC<{ withIntelligence: boolean }> = ({
 
 interface RenderOptions {
   withIntelligence?: boolean;
+  intelligenceIndicator?: IndicatorSlot;
 }
 
 const renderForIndicator = (
   agent: MockStepwiseAgent,
   options: RenderOptions = {},
 ): void => {
-  const { withIntelligence = true } = options;
+  const { withIntelligence = true, intelligenceIndicator } = options;
 
   // No `renderCustomMessages` prop is passed — the indicator
   // auto-mounts when intelligence is configured.
@@ -166,7 +185,10 @@ const renderForIndicator = (
       <CopilotChatConfigurationProvider agentId="default" threadId="t">
         <RunAgentHarness withIntelligence={withIntelligence} />
         <div style={{ height: 400 }}>
-          <CopilotChat welcomeScreen={false} />
+          <CopilotChat
+            welcomeScreen={false}
+            intelligenceIndicator={intelligenceIndicator}
+          />
         </div>
       </CopilotChatConfigurationProvider>
     </CopilotKitProvider>,
@@ -179,8 +201,34 @@ const triggerRun = async (agent: MockStepwiseAgent): Promise<void> => {
   await waitFor(() => expect(agent.isRunning).toBe(true));
 };
 
-/** Phase machine fades over up to ~1780 ms (500 + 800 + 480). */
-const FADE_OUT_TIMEOUT_MS = 2500;
+/** Start a run that emits one assistant message with a single matching tool call. */
+const startMatchingRun = async (
+  agent: MockStepwiseAgent,
+  messageId: string,
+  toolCallId = "tc1",
+): Promise<void> => {
+  await triggerRun(agent);
+  startRun(agent);
+  emitAssistantMessageWithToolCalls(agent, messageId, [
+    { id: toolCallId, arg: "{}" },
+  ]);
+};
+
+/** A full-component slot override that surfaces the state it receives. */
+const CustomIndicator = ({
+  status,
+  label,
+}: IntelligenceIndicatorViewProps): React.ReactElement => (
+  <div data-testid="custom-indicator" data-custom-status={status}>
+    {label}
+  </div>
+);
+
+const expectCustomStatus = (status: "in-progress" | "finished"): void => {
+  expect(
+    screen.getByTestId("custom-indicator").getAttribute("data-custom-status"),
+  ).toBe(status);
+};
 
 describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounted)', () => {
   const activeAgents: IsRunningAccurateMockAgent[] = [];
@@ -239,11 +287,10 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
       { id: "tc_b1", arg: '{"cmd":"echo b1"}' },
     ]);
     await waitFor(() => expectPillOn("m_b1"));
-    // m_a1's pill may briefly remain in fade-out; lock the post-debounce
-    // state.
-    await waitFor(() => expectNoPillOn("m_a1"), {
-      timeout: FADE_OUT_TIMEOUT_MS,
-    });
+    // m_b1 supersedes m_a1 as the latest matching-assistant slot, so
+    // m_a1's pill is gated out — even though it had settled into its
+    // persistent finished state.
+    await waitFor(() => expectNoPillOn("m_a1"));
     expectPillCount(1);
 
     // ─── m_b2 streams in — pill moves to m_b2, m_b1 loses pill ────────
@@ -256,11 +303,12 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     expectNoPillOn("m_a1");
     expectPillCount(1);
 
-    // ─── Run B finishes — pill fades, eventually no pill anywhere ─────
+    // ─── Run B finishes — the pill persists on m_b2 in its finished
+    //      resting state rather than unmounting ─────────────────────────
     agent.emit(runFinishedEvent());
-    await waitFor(() => expectNoPillAnywhere(), {
-      timeout: FADE_OUT_TIMEOUT_MS,
-    });
+    await waitFor(() => expectPillStatus("m_b2", "finished"));
+    expectPillOn("m_b2");
+    expectPillCount(1);
   });
 
   // ─── Per-condition focused tests ────────────────────────────────────
@@ -291,7 +339,7 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     expectPillCount(1);
   });
 
-  it("condition (in-flight): pill clears after the run finishes", async () => {
+  it("condition (in-flight): pill settles into a persistent finished state after the run finishes", async () => {
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -301,12 +349,12 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     emitAssistantMessageWithToolCalls(agent, "m_only", [
       { id: "tc", arg: "{}" },
     ]);
-    await waitFor(() => expectPillOn("m_only"));
+    await waitFor(() => expectPillStatus("m_only", "in-progress"));
 
     agent.emit(runFinishedEvent());
-    await waitFor(() => expectNoPillOn("m_only"), {
-      timeout: FADE_OUT_TIMEOUT_MS,
-    });
+    await waitFor(() => expectPillStatus("m_only", "finished"));
+    expectPillOn("m_only");
+    expectPillCount(1);
   });
 
   it("condition (latest-run): never renders on a stale run after a newer run starts", async () => {
@@ -458,11 +506,12 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     expectPillCount(1);
   });
 
-  it("real-followup exit: prose assistant message after the tool flow clears the pill", async () => {
+  it("real-followup exit: prose assistant message after the tool flow settles the pill into finished", async () => {
     // After the tool result the agent emits a final prose message —
-    // that's a "real follow-up" and should immediately exit the
-    // spinner (without waiting on isRunning), advancing to check
-    // → fading → hidden.
+    // that's a "real follow-up" and should immediately exit the spinner
+    // (without waiting on isRunning), settling into the finished state.
+    // The prose message is not a matching-assistant message, so m_tool
+    // remains the latest matching slot and keeps the persistent pill.
     const agent = makeAgent();
     renderForIndicator(agent);
     await screen.findByTestId("trigger-run");
@@ -472,13 +521,55 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     emitAssistantMessageWithToolCalls(agent, "m_tool", [
       { id: "tc_only", arg: '{"cmd":"ls"}' },
     ]);
-    await waitFor(() => expectPillOn("m_tool"));
+    await waitFor(() => expectPillStatus("m_tool", "in-progress"));
 
     emitToolResult(agent, "tc_only", "tr_only");
     emitAssistantProse(agent, "m_prose", "All done.");
 
-    await waitFor(() => expectNoPillAnywhere(), {
-      timeout: FADE_OUT_TIMEOUT_MS,
+    await waitFor(() => expectPillStatus("m_tool", "finished"));
+    expectPillCount(1);
+  });
+
+  // ─── Slot customization (the three SlotValue tiers) ──────────────────
+
+  it("slot override (component): a custom face receives status and persists when finished", async () => {
+    const agent = makeAgent();
+    renderForIndicator(agent, { intelligenceIndicator: CustomIndicator });
+    await screen.findByTestId("trigger-run");
+
+    await startMatchingRun(agent, "m1");
+    await waitFor(() => expectCustomStatus("in-progress"));
+
+    agent.emit(runFinishedEvent());
+    await waitFor(() => expectCustomStatus("finished"));
+    // The default pill is replaced entirely by the custom face.
+    expectPillCount(0);
+  });
+
+  it("slot override (string): a className is merged onto the default pill", async () => {
+    const agent = makeAgent();
+    renderForIndicator(agent, { intelligenceIndicator: "my-custom-pill" });
+    await screen.findByTestId("trigger-run");
+
+    await startMatchingRun(agent, "m1");
+    await waitFor(() => expectPillOn("m1"));
+    expect(screen.getByTestId("cpk-intelligence-pill-m1").className).toContain(
+      "my-custom-pill",
+    );
+  });
+
+  it("slot override (props): a props object overrides the label", async () => {
+    const agent = makeAgent();
+    renderForIndicator(agent, {
+      intelligenceIndicator: { label: "Recalling memory" },
     });
+    await screen.findByTestId("trigger-run");
+
+    await startMatchingRun(agent, "m1");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("cpk-intelligence-pill-m1").textContent,
+      ).toContain("Recalling memory"),
+    );
   });
 });

--- a/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
@@ -67,7 +67,7 @@ const expectIndicatorCount = (n: number): void => {
 const expectIndicatorOn = (messageId: string): void => {
   expect(
     screen.getByTestId(`cpk-intelligence-indicator-${messageId}`).textContent,
-  ).toContain("Using CopilotKit Intelligence");
+  ).toContain("CopilotKit Intelligence");
 };
 
 const expectNoIndicatorOn = (messageId: string): void => {
@@ -261,7 +261,7 @@ const expectCustomStatus = (status: "in-progress" | "finished"): void => {
   ).toBe(status);
 };
 
-describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounted)', () => {
+describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', () => {
   const activeAgents: IsRunningAccurateMockAgent[] = [];
   const makeAgent = (): IsRunningAccurateMockAgent => {
     const agent = new IsRunningAccurateMockAgent();

--- a/packages/react-core/src/v2/components/intelligence-indicator/__tests__/intelligence-indicator-logic.test.ts
+++ b/packages/react-core/src/v2/components/intelligence-indicator/__tests__/intelligence-indicator-logic.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import type { Message } from "@ag-ui/client";
+import {
+  getIntelligenceTurnAnchors,
+  initialIndicatorPhase,
+  INTELLIGENCE_TURN_HEAD,
+  resolveGracePhase,
+} from "../IntelligenceIndicator";
+
+/**
+ * Pure logic for the intelligence indicator — the decisions that the live
+ * grace-window timer merely *delays*. Testing them directly keeps the suite
+ * deterministic with zero timers (no `setTimeout`, no fake clock): the timing
+ * is a trusted platform debounce, the logic is what we assert.
+ */
+
+// ── Message builders ────────────────────────────────────────────────────
+
+const BASH = "copilotkit_knowledge_base_shell";
+
+const assistant = (id: string, toolNames: string[] = []): Message =>
+  ({
+    id,
+    role: "assistant",
+    content: "",
+    toolCalls: toolNames.map((name, i) => ({
+      id: `${id}-tc${i}`,
+      type: "function",
+      function: { name, arguments: "{}" },
+    })),
+  }) as unknown as Message;
+
+const user = (id: string): Message =>
+  ({ id, role: "user", content: "hi" }) as unknown as Message;
+
+// ── initialIndicatorPhase ─────────────────────────────────────────────────
+
+describe("initialIndicatorPhase", () => {
+  it("mounts straight into finished when the turn is already complete", () => {
+    expect(initialIndicatorPhase(true)).toBe("finished");
+  });
+
+  it("mounts hidden while the turn is still in flight", () => {
+    expect(initialIndicatorPhase(false)).toBe("hidden");
+  });
+});
+
+// ── resolveGracePhase ─────────────────────────────────────────────────────
+
+describe("resolveGracePhase", () => {
+  it("resolves to finished when the turn completed within the grace window (replay-flash suppression)", () => {
+    // turnComplete wins even if a matching call still looks pending — this is
+    // exactly the "tool result landed in the same burst" case, which must NOT
+    // flash a spinner.
+    expect(resolveGracePhase(true, true)).toBe("finished");
+    expect(resolveGracePhase(true, false)).toBe("finished");
+  });
+
+  it("resolves to spinner for a still-pending matching tool call", () => {
+    expect(resolveGracePhase(false, true)).toBe("spinner");
+  });
+
+  it("stays hidden when nothing is pending yet and the turn is not complete", () => {
+    expect(resolveGracePhase(false, false)).toBe("hidden");
+  });
+});
+
+// ── getIntelligenceTurnAnchors ────────────────────────────────────────────
+
+describe("getIntelligenceTurnAnchors", () => {
+  it("returns no anchors when no message uses a matching tool", () => {
+    const anchors = getIntelligenceTurnAnchors([
+      user("u1"),
+      assistant("a1", ["some_other_tool"]),
+      assistant("a2"),
+    ]);
+    expect(anchors.size).toBe(0);
+  });
+
+  it("anchors the FIRST bash-using message of a turn, not later ones", () => {
+    const anchors = getIntelligenceTurnAnchors([
+      assistant("a1", [BASH]),
+      assistant("a2", [BASH]),
+    ]);
+    expect([...anchors.keys()]).toEqual(["a1"]);
+    expect(anchors.get("a1")).toBe(INTELLIGENCE_TURN_HEAD);
+  });
+
+  it("uses INTELLIGENCE_TURN_HEAD for a turn with no opening user message", () => {
+    const anchors = getIntelligenceTurnAnchors([assistant("a0", [BASH])]);
+    expect(anchors.get("a0")).toBe(INTELLIGENCE_TURN_HEAD);
+  });
+
+  it("keys each turn by its opening user message and keeps one anchor per turn", () => {
+    const anchors = getIntelligenceTurnAnchors([
+      user("u1"),
+      assistant("a1", [BASH]),
+      user("u2"),
+      assistant("a2", [BASH]),
+      assistant("a3", [BASH]),
+    ]);
+    expect(anchors.get("a1")).toBe("u1");
+    expect(anchors.get("a2")).toBe("u2");
+    expect(anchors.has("a3")).toBe(false);
+    expect(anchors.size).toBe(2);
+  });
+
+  it("matches the namespaced mcp__ tool name", () => {
+    const anchors = getIntelligenceTurnAnchors([
+      assistant("a1", [`mcp__intelligence__${BASH}`]),
+    ]);
+    expect(anchors.get("a1")).toBe(INTELLIGENCE_TURN_HEAD);
+  });
+
+  it("ignores tool calls on non-assistant messages", () => {
+    const toolMsg = {
+      id: "t1",
+      role: "tool",
+      toolCallId: "x",
+      content: "result",
+    } as unknown as Message;
+    expect(getIntelligenceTurnAnchors([toolMsg]).size).toBe(0);
+  });
+});

--- a/packages/react-core/src/v2/components/intelligence-indicator/index.ts
+++ b/packages/react-core/src/v2/components/intelligence-indicator/index.ts
@@ -1,2 +1,7 @@
 export { IntelligenceIndicator } from "./IntelligenceIndicator";
 export type { IntelligenceIndicatorProps } from "./IntelligenceIndicator";
+export { IntelligenceIndicatorView } from "./IntelligenceIndicatorView";
+export type {
+  IntelligenceIndicatorViewProps,
+  IntelligenceIndicatorStatus,
+} from "./IntelligenceIndicatorView";

--- a/packages/react-core/src/v2/components/intelligence-indicator/index.ts
+++ b/packages/react-core/src/v2/components/intelligence-indicator/index.ts
@@ -1,4 +1,8 @@
-export { IntelligenceIndicator } from "./IntelligenceIndicator";
+export {
+  IntelligenceIndicator,
+  getIntelligenceTurnAnchors,
+  INTELLIGENCE_TURN_HEAD,
+} from "./IntelligenceIndicator";
 export type { IntelligenceIndicatorProps } from "./IntelligenceIndicator";
 export { IntelligenceIndicatorView } from "./IntelligenceIndicatorView";
 export type {

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -230,51 +230,66 @@
   background-size: 100% 100%;
 }
 /*
- * IntelligenceIndicator — visual styles for the "Using CopilotKit
- * Intelligence" indicator. Two modes coexist in the DOM:
+ * IntelligenceIndicator — single-element, three-stage design.
  *
- *   • `.cpk-intelligence-indicator__pill`  — glassmorphism pill with
- *     a spinning ring, shown while work is in progress.
- *   • `.cpk-intelligence-indicator__tag`   — "stripped pill". Same
- *     layout, padding, font, and purple text as the pill, but the
- *     background, border, shadow, and backdrop-blur are gone and the
- *     spinning ring is replaced with a static checkmark.
+ * Layers (always in the DOM, always at full opacity for layout
+ * purposes — only individual properties animate):
  *
- * Both children stack in a single grid cell at the same `grid-area`,
- * so they overlap pixel-for-pixel and the cross-fade reads as the
- * pill's frame dissolving while the icon morphs from ring to check.
+ *   • `__chrome`   — the glassmorphism pill (bg, border, shadow,
+ *                    backdrop-blur). Absolute-positioned behind the
+ *                    content. Visible while in-progress; fades to 0
+ *                    once the icon morph completes.
+ *   • `__content`  — icon + label flex row. Stays in place across
+ *                    the whole transition. Only its `color` alpha
+ *                    drops on settle (0.92 → 0.55).
+ *   • `__icon-path` — single SVG path whose `d` morphs between a
+ *                    270° arc and a checkmark. Both shapes share the
+ *                    same 3-segment cubic Bézier topology, which is
+ *                    what makes the d interpolate cleanly. The "spin"
+ *                    is a marching-dash animation on the stroke, not
+ *                    an SVG rotation — so there is no rotation state
+ *                    to snap back to identity when the animation is
+ *                    removed at status flip.
  *
- * The cross-fade is implemented as one-shot CSS animations rather
- * than property transitions. Plain `transition`s don't fire when the
- * trigger class is already present at first paint — which is exactly
- * what happens on fast turns where the brain's `useState` lazy init
- * mounts the face directly in `finished` state. Animations always
- * play when their trigger class is applied, mount-time or otherwise.
+ * Stage timing (hard sequence — stage 2 waits for stage 1):
+ *   • Stage 1, icon morph: 0 → 250 ms.
+ *       - d interpolates arc → check
+ *       - stroke-dasharray transitions dashed → solid
+ *       - marching-dash animation is removed (`animation: none`)
+ *   • Stage 2, settle:     250 → 650 ms (transition-delay 250 ms).
+ *       - chrome opacity 1 → 0
+ *       - content color alpha 0.92 → 0.55
+ *
+ * Total ~650 ms in production. No moment exists where the icon or
+ * label is invisible, so the eye never sees a "bump."
+ *
+ * Mount-already-finished is handled implicitly: CSS transitions
+ * don't fire when the target value is the computed value at first
+ * paint, so a historical-replay turn renders directly in its
+ * settled state with no animation — which is the desired behavior.
  */
 .cpk-intelligence-indicator {
   position: relative;
-  display: grid;
-  /* Stack both children in one cell, left-aligned, vertically centered. */
-  justify-items: start;
+  display: inline-flex;
   align-items: center;
+  gap: 0.55rem;
+  padding: 0.4rem 0.85rem;
   /* Opt out of the parent flex-column's default `align-items: stretch`
      (the auto-mount lives inside `CopilotChatMessageView`'s
      `cpk:flex cpk:flex-col` container). Without this the indicator
      would stretch to the full chat width. */
   align-self: flex-start;
   margin: 0.4rem 0;
+  white-space: nowrap;
 }
 
-/* ─── In-progress pill ──────────────────────────────────────────────── */
+/* ─── Chrome layer (bg, border, shadow, backdrop-blur) ──────────────── */
 
-.cpk-intelligence-indicator__pill {
-  grid-area: 1 / 1;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  padding: 0.4rem 0.85rem;
-  border: 1px solid rgb(149 153 224 / 0.32);
+.cpk-intelligence-indicator__chrome {
+  position: absolute;
+  inset: 0;
   border-radius: 999px;
+  border: 1px solid rgb(149 153 224 / 0.32);
   background: linear-gradient(
     135deg,
     rgb(255 255 255 / 0.55) 0%,
@@ -282,120 +297,97 @@
   );
   -webkit-backdrop-filter: blur(14px) saturate(160%);
   backdrop-filter: blur(14px) saturate(160%);
-  color: rgb(91 33 182 / 0.92);
-  font-size: 0.78rem;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  white-space: nowrap;
   box-shadow:
     0 1px 2px rgb(94 100 173 / 0.06),
     0 8px 24px rgb(149 153 224 / 0.08),
     inset 0 1px 0 rgb(255 255 255 / 0.6);
-  opacity: 0;
-  animation: cpk-intelligence-pill-fade-in 280ms ease-out forwards;
-}
-
-.cpk-intelligence-indicator__pill--hidden {
-  /* Exit animation. Used in BOTH paths:
-       1. Live spinner → finished (--hidden added by React re-render).
-       2. Mount-already-finished (--hidden present at first paint).
-     A plain `transition` would skip case 2 because there'd be no value
-     change for the browser to interpolate — that's the "pop" users see. */
-  animation: cpk-intelligence-pill-exit 220ms ease-out forwards;
+  opacity: 1;
   pointer-events: none;
+  /* Stage 2 — wait 250 ms for the icon morph to complete, then fade. */
+  transition: opacity 400ms ease-out 250ms;
 }
 
-.cpk-intelligence-pill__icon {
-  display: block;
-  flex-shrink: 0;
-  color: rgb(124 58 237);
+.cpk-intelligence-indicator[data-status="finished"]
+  .cpk-intelligence-indicator__chrome {
+  opacity: 0;
 }
 
-.cpk-intelligence-pill__ring {
-  stroke: currentColor;
-  stroke-dasharray: 40 16.55;
-  stroke-dashoffset: 0;
-  transform-origin: 12px 12px;
-  animation: cpk-intelligence-pill-spin 0.9s linear infinite;
-}
+/* ─── Content layer (icon + label) ──────────────────────────────────── */
 
-/* ─── Finished "stripped pill" ──────────────────────────────────────── */
-/*
- * Same layout and text styling as the in-progress pill (padding, gap,
- * font-size, font-weight, color, letter-spacing) but with the
- * background, border, shadow, and backdrop-blur removed and the
- * spinning ring replaced with a static checkmark. The frame visibly
- * sheds while the icon morphs from ring to check.
- */
-
-.cpk-intelligence-indicator__tag {
-  grid-area: 1 / 1;
+.cpk-intelligence-indicator__content {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.55rem;
-  padding: 0.4rem 0.85rem;
+  /* `color` drives both the label text and the icon stroke (which uses
+     `currentColor`). In-progress alpha 0.92, settle alpha 0.55. */
   color: rgb(91 33 182 / 0.92);
   font-size: 0.78rem;
   font-weight: 500;
   letter-spacing: 0.01em;
-  white-space: nowrap;
-  opacity: 0;
-  pointer-events: none;
+  /* Stage 2 — same 250 ms delay as the chrome fade so they settle in
+     lock-step. */
+  transition: color 400ms ease-out 250ms;
 }
 
-.cpk-intelligence-indicator__tag--shown {
-  /* Entry animation — same mount-or-transition guarantee as the pill's
-     exit. 120 ms delay so the tag's fade-in overlaps the pill's
-     fade-out near its end, reading as one continuous morph rather
-     than two distinct swaps. */
-  animation: cpk-intelligence-tag-enter 320ms ease-out 120ms forwards;
-  pointer-events: auto;
+.cpk-intelligence-indicator[data-status="finished"]
+  .cpk-intelligence-indicator__content {
+  color: rgb(91 33 182 / 0.55);
 }
 
-.cpk-intelligence-indicator__tag--shown {
-  opacity: 1;
-  transform: scale(1);
-  pointer-events: auto;
-}
-
-.cpk-intelligence-tag__icon {
+.cpk-intelligence-indicator__icon {
   display: block;
   flex-shrink: 0;
-  /* `currentColor` so the checkmark matches the muted gray text. */
-  color: currentColor;
+}
+
+/* ─── Icon path — d-morph + dashed-to-solid stroke ──────────────────── */
+
+.cpk-intelligence-indicator__icon-path {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  /* In-progress shape: a 270° arc (3 cubic Béziers approximating three
+     quarter-circles, top → right → bottom → left). The fourth quarter
+     is the visible "gap" in the loader. */
+  d: path("M 12 3 C 17 3 21 7 21 12 C 21 17 17 21 12 21 C 7 21 3 17 3 12");
+  /* Dashed stroke + animated dashoffset = "marching ants" that read
+     as motion without rotating the SVG. */
+  stroke-dasharray: 8 4;
+  stroke-dashoffset: 0;
+  animation: cpk-intelligence-march 0.9s linear infinite;
+  /* Stage 1 — d and stroke-dasharray both interpolate over 250 ms with
+     the same eased curve so the morph reads as one motion. */
+  transition:
+    d 250ms cubic-bezier(0.4, 0, 0.2, 1),
+    stroke-dasharray 250ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.cpk-intelligence-indicator[data-status="finished"]
+  .cpk-intelligence-indicator__icon-path {
+  /* Finished shape: a checkmark expressed as 3 cubic Béziers with
+     collinear control points (so each segment renders as a straight
+     line). Three segments instead of the natural two so the topology
+     matches the 270° arc above and the d morph interpolates cleanly. */
+  d: path(
+    "M 5 12.5 C 6.33 13.83 7.67 15.17 9 16.5 C 10.67 14.83 12.33 13.17 14 11.5 C 15.67 9.83 17.33 8.17 19 6.5"
+  );
+  /* Large first value, zero gap = solid stroke. Interpolates from
+     `8 4` over 250 ms in lock-step with the d morph. */
+  stroke-dasharray: 100 0;
+  /* Stop the marching dashes. The dashoffset reverts to its base
+     value (0) instantly, but the dasharray has already transitioned
+     enough toward solid that the snap is not visible. */
+  animation: none;
 }
 
 /* ─── Keyframes ─────────────────────────────────────────────────────── */
 
-@keyframes cpk-intelligence-pill-fade-in {
-  from {
-    opacity: 0;
-  }
+@keyframes cpk-intelligence-march {
+  /* One full dash-period (`8 + 4 = 12`) per cycle, so the dashes appear
+     to flow continuously around the path. */
   to {
-    opacity: 1;
-  }
-}
-
-@keyframes cpk-intelligence-pill-exit {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes cpk-intelligence-tag-enter {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes cpk-intelligence-pill-spin {
-  to {
-    transform: rotate(360deg);
+    stroke-dashoffset: -12;
   }
 }

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -235,16 +235,16 @@
  *
  *   • `.cpk-intelligence-indicator__pill`  — glassmorphism pill with
  *     a spinning ring, shown while work is in progress.
- *   • `.cpk-intelligence-indicator__tag`   — italic muted-gray "metadata
- *     line", persistent in chat history once work completes.
+ *   • `.cpk-intelligence-indicator__tag`   — "stripped pill". Same
+ *     layout, padding, font, and purple text as the pill, but the
+ *     background, border, shadow, and backdrop-blur are gone and the
+ *     spinning ring is replaced with a static checkmark.
  *
- * Both children stack in a single grid cell anchored to the left edge,
- * so the shrink-and-settle morph rotates around a shared LEFT pivot
- * (not a shared center). That left-aligns the finished tag to the
- * assistant-message column instead of floating it in the middle of
- * where the pill was.
+ * Both children stack in a single grid cell at the same `grid-area`,
+ * so they overlap pixel-for-pixel and the cross-fade reads as the
+ * pill's frame dissolving while the icon morphs from ring to check.
  *
- * The transitions are implemented as one-shot CSS animations rather
+ * The cross-fade is implemented as one-shot CSS animations rather
  * than property transitions. Plain `transition`s don't fire when the
  * trigger class is already present at first paint — which is exactly
  * what happens on fast turns where the brain's `useState` lazy init
@@ -291,25 +291,17 @@
     0 1px 2px rgb(94 100 173 / 0.06),
     0 8px 24px rgb(149 153 224 / 0.08),
     inset 0 1px 0 rgb(255 255 255 / 0.6);
-  /* Shared LEFT-edge origin: pill shrinks toward its left edge while
-     the tag grows from the same left edge. The morph reads as one
-     element transforming around a fixed pivot. */
-  transform-origin: left center;
-  transform: scale(1);
   opacity: 0;
   animation: cpk-intelligence-pill-fade-in 280ms ease-out forwards;
 }
 
 .cpk-intelligence-indicator__pill--hidden {
-  /* Exit animation. Replaces the held final value of the fade-in (via
-     the animation property swap) and drives both opacity and transform
-     to their exit values. Used in BOTH paths:
+  /* Exit animation. Used in BOTH paths:
        1. Live spinner → finished (--hidden added by React re-render).
        2. Mount-already-finished (--hidden present at first paint).
      A plain `transition` would skip case 2 because there'd be no value
      change for the browser to interpolate — that's the "pop" users see. */
-  animation: cpk-intelligence-pill-exit 220ms cubic-bezier(0.22, 0.61, 0.36, 1)
-    forwards;
+  animation: cpk-intelligence-pill-exit 220ms ease-out forwards;
   pointer-events: none;
 }
 
@@ -327,38 +319,36 @@
   animation: cpk-intelligence-pill-spin 0.9s linear infinite;
 }
 
-/* ─── Finished metadata line ────────────────────────────────────────── */
+/* ─── Finished "stripped pill" ──────────────────────────────────────── */
 /*
- * Italic gray "footnote" — no border, no background, no padding.
- * Reads as scroll-back metadata so it disappears for someone passing
- * by and surfaces for someone looking. Stacks over the pill via grid
- * (no position: absolute) so it sits at the same left edge.
+ * Same layout and text styling as the in-progress pill (padding, gap,
+ * font-size, font-weight, color, letter-spacing) but with the
+ * background, border, shadow, and backdrop-blur removed and the
+ * spinning ring replaced with a static checkmark. The frame visibly
+ * sheds while the icon morphs from ring to check.
  */
 
 .cpk-intelligence-indicator__tag {
   grid-area: 1 / 1;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  color: rgb(120 120 130 / 0.85);
-  font-size: 0.6875rem;
-  font-style: italic;
-  font-weight: 400;
-  line-height: 1.4;
+  gap: 0.55rem;
+  padding: 0.4rem 0.85rem;
+  color: rgb(91 33 182 / 0.92);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
   white-space: nowrap;
-  transform-origin: left center;
-  transform: scale(0.7);
   opacity: 0;
   pointer-events: none;
 }
 
 .cpk-intelligence-indicator__tag--shown {
   /* Entry animation — same mount-or-transition guarantee as the pill's
-     exit. 120ms delay so the tag's grow-in overlaps the pill's shrink
-     near its end, reading as one continuous morph rather than two
-     swaps. */
-  animation: cpk-intelligence-tag-enter 320ms cubic-bezier(0.22, 0.61, 0.36, 1)
-    120ms forwards;
+     exit. 120 ms delay so the tag's fade-in overlaps the pill's
+     fade-out near its end, reading as one continuous morph rather
+     than two distinct swaps. */
+  animation: cpk-intelligence-tag-enter 320ms ease-out 120ms forwards;
   pointer-events: auto;
 }
 
@@ -389,22 +379,18 @@
 @keyframes cpk-intelligence-pill-exit {
   from {
     opacity: 1;
-    transform: scale(1);
   }
   to {
     opacity: 0;
-    transform: scale(0.7);
   }
 }
 
 @keyframes cpk-intelligence-tag-enter {
   from {
     opacity: 0;
-    transform: scale(0.7);
   }
   to {
     opacity: 1;
-    transform: scale(1);
   }
 }
 

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -338,6 +338,19 @@
 .cpk-intelligence-indicator__icon {
   display: block;
   flex-shrink: 0;
+  /* The whole SVG rotates while in-progress; the dash pattern on the
+     path inside is static, so what the viewer sees is one continuous
+     arc rotating around the SVG's visual center. Rotation is removed
+     on status flip — the snap back to identity is masked by the
+     simultaneous d-morph (the shape is changing so rapidly the eye
+     does not register the angle reset). */
+  transform-origin: 7px 7px;
+  animation: cpk-intelligence-spin 0.9s linear infinite;
+}
+
+.cpk-intelligence-indicator[data-status="finished"]
+  .cpk-intelligence-indicator__icon {
+  animation: none;
 }
 
 /* ─── Icon path — d-morph + dashed-to-solid stroke ──────────────────── */
@@ -352,11 +365,11 @@
      quarter-circles, top → right → bottom → left). The fourth quarter
      is the visible "gap" in the loader. */
   d: path("M 12 3 C 17 3 21 7 21 12 C 21 17 17 21 12 21 C 7 21 3 17 3 12");
-  /* Dashed stroke + animated dashoffset = "marching ants" that read
-     as motion without rotating the SVG. */
-  stroke-dasharray: 8 4;
-  stroke-dashoffset: 0;
-  animation: cpk-intelligence-march 0.9s linear infinite;
+  /* One continuous arc + one gap, summing to roughly the path length
+     (~42 units). The static dash pattern shows as a single C-shape
+     stroke; the rotation on the SVG above makes that C appear to
+     spin around the center. */
+  stroke-dasharray: 30 14;
   /* Stage 1 — d and stroke-dasharray both interpolate over 250 ms with
      the same eased curve so the morph reads as one motion. */
   transition:
@@ -374,20 +387,15 @@
     "M 5 12.5 C 6.33 13.83 7.67 15.17 9 16.5 C 10.67 14.83 12.33 13.17 14 11.5 C 15.67 9.83 17.33 8.17 19 6.5"
   );
   /* Large first value, zero gap = solid stroke. Interpolates from
-     `8 4` over 250 ms in lock-step with the d morph. */
+     `30 14` over 250 ms in lock-step with the d morph, filling in
+     the gap that was the spinner's "open" portion. */
   stroke-dasharray: 100 0;
-  /* Stop the marching dashes. The dashoffset reverts to its base
-     value (0) instantly, but the dasharray has already transitioned
-     enough toward solid that the snap is not visible. */
-  animation: none;
 }
 
 /* ─── Keyframes ─────────────────────────────────────────────────────── */
 
-@keyframes cpk-intelligence-march {
-  /* One full dash-period (`8 + 4 = 12`) per cycle, so the dashes appear
-     to flow continuously around the path. */
+@keyframes cpk-intelligence-spin {
   to {
-    stroke-dashoffset: -12;
+    transform: rotate(360deg);
   }
 }

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -230,23 +230,38 @@
   background-size: 100% 100%;
 }
 /*
- * IntelligenceIndicator pill — visual styles ported from
- * CopilotKit/Intelligence #155.
+ * IntelligenceIndicator — visual styles for the "Using CopilotKit
+ * Intelligence" indicator. Two modes coexist in the DOM:
  *
- * Violet/indigo glassmorphism — text #5B21B6, icon #7C3AED, border
- * #9599E0, gradient stop #EEE6FE, soft shadow #5E64AD.
+ *   • `.cpk-intelligence-indicator__pill`  — glassmorphism pill with
+ *     a spinning ring, shown while work is in progress.
+ *   • `.cpk-intelligence-indicator__tag`   — compact icon + text tag,
+ *     persistent in chat history once work completes.
+ *
+ * Opacity cross-fades the two modes; the tag is positioned absolutely
+ * over the pill's slot so the layout doesn't jump.
+ *
+ * Violet/indigo palette ported from CopilotKit/Intelligence #155 —
+ * text #5B21B6, icon #7C3AED, border #9599E0, gradient stop #EEE6FE,
+ * soft shadow #5E64AD.
  */
-.cpk-intelligence-pill {
-  display: inline-flex;
+.cpk-intelligence-indicator {
+  position: relative;
+  display: inline-block;
   /* Opt out of the parent flex-column's default `align-items: stretch`
      (the auto-mount lives inside `CopilotChatMessageView`'s
-     `cpk:flex cpk:flex-col` container). Without this the pill would
-     stretch to the full chat width even though `inline-flex` is
-     supposed to shrink to its content. */
+     `cpk:flex cpk:flex-col` container). Without this the indicator
+     would stretch to the full chat width. */
   align-self: flex-start;
+  margin: 0.4rem 0;
+}
+
+/* ─── In-progress pill ──────────────────────────────────────────────── */
+
+.cpk-intelligence-indicator__pill {
+  display: inline-flex;
   align-items: center;
   gap: 0.55rem;
-  margin: 0.4rem 0;
   padding: 0.4rem 0.85rem;
   border: 1px solid rgb(149 153 224 / 0.32);
   border-radius: 999px;
@@ -269,25 +284,16 @@
   opacity: 0;
   transform: translateY(2px);
   animation: cpk-intelligence-pill-fade-in 280ms ease-out forwards;
-  /* The background/shadow shift toward the subdued finished state eases
-     in; opacity is owned by the animation swap below. */
-  transition:
-    background 360ms ease-out,
-    box-shadow 360ms ease-out;
+  transition: opacity 250ms ease-out;
 }
 
-.cpk-intelligence-pill--finished {
-  /* Persistent resting state — the pill stays mounted once work
-     completes, settling into a less-prominent look rather than fading
-     out. Switching the `animation` property cancels the in-flight
-     fade-in and replaces its held final value (opacity:1 from
-     `forwards`) with the settle keyframe; a plain `opacity` declaration
-     would otherwise lose to the animation's held value. */
-  animation: cpk-intelligence-pill-settle 360ms ease-out forwards;
-  background: rgb(238 230 254 / 0.35);
-  box-shadow:
-    0 1px 2px rgb(94 100 173 / 0.05),
-    inset 0 1px 0 rgb(255 255 255 / 0.5);
+.cpk-intelligence-indicator__pill--hidden {
+  /* Cross-faded out once status flips to finished. `animation: none`
+     cancels the fade-in's held `forwards` final value so this opacity
+     declaration wins. */
+  animation: none;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .cpk-intelligence-pill__icon {
@@ -302,33 +308,46 @@
   stroke-dashoffset: 0;
   transform-origin: 12px 12px;
   animation: cpk-intelligence-pill-spin 0.9s linear infinite;
-  transition: stroke-dasharray 320ms ease-out;
 }
 
-.cpk-intelligence-pill__ring--done {
-  stroke-dasharray: 56.55 0;
-  animation: none;
-}
+/* ─── Finished tag ──────────────────────────────────────────────────── */
 
-.cpk-intelligence-pill__check {
-  stroke: currentColor;
-  stroke-dasharray: 12;
-  stroke-dashoffset: 12;
-  /* Opacity zero hides the rounded `stroke-linecap` end-cap that would
-     otherwise leak through as a stationary dot at path end (16, 9.5)
-     during spinner phase. The `dasharray + dashoffset` zeroes the
-     visible stroke length, but the cap is drawn at the dash boundary
-     regardless, so we need opacity to fully hide it. */
+.cpk-intelligence-indicator__tag {
+  position: absolute;
+  inset: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border: 1px solid rgb(149 153 224 / 0.25);
+  border-radius: 999px;
+  color: rgb(91 33 182 / 0.8);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  margin: auto;
   opacity: 0;
-  transition:
-    stroke-dashoffset 320ms ease-out 200ms,
-    opacity 200ms ease-out 200ms;
+  pointer-events: none;
+  transition: opacity 250ms ease-out;
 }
 
-.cpk-intelligence-pill__check--shown {
-  stroke-dashoffset: 0;
+.cpk-intelligence-indicator__tag--shown {
   opacity: 1;
+  pointer-events: auto;
 }
+
+.cpk-intelligence-tag__icon {
+  display: block;
+  flex-shrink: 0;
+  color: rgb(124 58 237 / 0.85);
+}
+
+/* ─── Keyframes ─────────────────────────────────────────────────────── */
 
 @keyframes cpk-intelligence-pill-fade-in {
   from {
@@ -338,15 +357,6 @@
   to {
     opacity: 1;
     transform: translateY(0);
-  }
-}
-
-@keyframes cpk-intelligence-pill-settle {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0.72;
   }
 }
 

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -269,15 +269,25 @@
   opacity: 0;
   transform: translateY(2px);
   animation: cpk-intelligence-pill-fade-in 280ms ease-out forwards;
+  /* The background/shadow shift toward the subdued finished state eases
+     in; opacity is owned by the animation swap below. */
+  transition:
+    background 360ms ease-out,
+    box-shadow 360ms ease-out;
 }
 
-.cpk-intelligence-pill--fading {
-  /* Switching the `animation` property cancels the in-flight fade-in
-     and replaces the held final-value (opacity:1 from `forwards`) with
-     this fade-out keyframe set. Plain `opacity: 0` declarations would
-     otherwise lose to the animation's held value. */
-  animation: cpk-intelligence-pill-fade-out 480ms ease-out forwards;
-  pointer-events: none;
+.cpk-intelligence-pill--finished {
+  /* Persistent resting state — the pill stays mounted once work
+     completes, settling into a less-prominent look rather than fading
+     out. Switching the `animation` property cancels the in-flight
+     fade-in and replaces its held final value (opacity:1 from
+     `forwards`) with the settle keyframe; a plain `opacity` declaration
+     would otherwise lose to the animation's held value. */
+  animation: cpk-intelligence-pill-settle 360ms ease-out forwards;
+  background: rgb(238 230 254 / 0.35);
+  box-shadow:
+    0 1px 2px rgb(94 100 173 / 0.05),
+    inset 0 1px 0 rgb(255 255 255 / 0.5);
 }
 
 .cpk-intelligence-pill__icon {
@@ -331,14 +341,12 @@
   }
 }
 
-@keyframes cpk-intelligence-pill-fade-out {
+@keyframes cpk-intelligence-pill-settle {
   from {
     opacity: 1;
-    transform: translateY(0);
   }
   to {
-    opacity: 0;
-    transform: translateY(-2px);
+    opacity: 0.72;
   }
 }
 

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -281,18 +281,26 @@
     0 1px 2px rgb(94 100 173 / 0.06),
     0 8px 24px rgb(149 153 224 / 0.08),
     inset 0 1px 0 rgb(255 255 255 / 0.6);
+  /* Shared origin for the morph: pill shrinks to center; tag grows
+     from the same center. */
+  transform-origin: center;
+  transform: scale(1);
   opacity: 0;
-  transform: translateY(2px);
   animation: cpk-intelligence-pill-fade-in 280ms ease-out forwards;
-  transition: opacity 250ms ease-out;
+  /* Out-transition (to finished): shrink + fade in 220 ms.
+     Apple-style ease-out cubic for the shrink so it eases cleanly. */
+  transition:
+    opacity 220ms ease-out,
+    transform 220ms cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 
 .cpk-intelligence-indicator__pill--hidden {
-  /* Cross-faded out once status flips to finished. `animation: none`
-     cancels the fade-in's held `forwards` final value so this opacity
-     declaration wins. */
+  /* `animation: none` cancels the fade-in's held `forwards` value so
+     these declarations win; the wrapper's transition then animates
+     the morph (opacity 1 → 0, scale 1 → 0.7) over 220 ms. */
   animation: none;
   opacity: 0;
+  transform: scale(0.7);
   pointer-events: none;
 }
 
@@ -310,7 +318,14 @@
   animation: cpk-intelligence-pill-spin 0.9s linear infinite;
 }
 
-/* ─── Finished tag ──────────────────────────────────────────────────── */
+/* ─── Finished metadata line ────────────────────────────────────────── */
+/*
+ * Italic gray "footnote" — no border, no background, no padding.
+ * Reads as scroll-back metadata so it disappears for someone passing
+ * by and surfaces for someone looking. Absolutely-positioned over the
+ * pill slot so the wrapper's footprint doesn't jump during the
+ * shrink-and-settle morph.
+ */
 
 .cpk-intelligence-indicator__tag {
   position: absolute;
@@ -318,12 +333,10 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 2px 8px;
-  border: 1px solid rgb(149 153 224 / 0.25);
-  border-radius: 999px;
-  color: rgb(91 33 182 / 0.8);
-  font-size: 0.75rem;
-  font-weight: 500;
+  color: rgb(120 120 130 / 0.85);
+  font-size: 0.6875rem;
+  font-style: italic;
+  font-weight: 400;
   line-height: 1.4;
   white-space: nowrap;
   width: -moz-fit-content;
@@ -331,20 +344,30 @@
   height: -moz-fit-content;
   height: fit-content;
   margin: auto;
+  transform-origin: center;
+  transform: scale(0.7);
   opacity: 0;
   pointer-events: none;
-  transition: opacity 250ms ease-out;
+  /* In-transition (to shown): scale up + fade in starting 120 ms after
+     the pill starts shrinking — the overlap creates the morph
+     illusion. Slightly longer than the pill's exit (320 ms vs 220 ms)
+     for a "settled" feel. */
+  transition:
+    opacity 320ms cubic-bezier(0.22, 0.61, 0.36, 1) 120ms,
+    transform 320ms cubic-bezier(0.22, 0.61, 0.36, 1) 120ms;
 }
 
 .cpk-intelligence-indicator__tag--shown {
   opacity: 1;
+  transform: scale(1);
   pointer-events: auto;
 }
 
 .cpk-intelligence-tag__icon {
   display: block;
   flex-shrink: 0;
-  color: rgb(124 58 237 / 0.85);
+  /* `currentColor` so the checkmark matches the muted gray text. */
+  color: currentColor;
 }
 
 /* ─── Keyframes ─────────────────────────────────────────────────────── */
@@ -352,11 +375,9 @@
 @keyframes cpk-intelligence-pill-fade-in {
   from {
     opacity: 0;
-    transform: translateY(2px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -235,19 +235,28 @@
  *
  *   • `.cpk-intelligence-indicator__pill`  — glassmorphism pill with
  *     a spinning ring, shown while work is in progress.
- *   • `.cpk-intelligence-indicator__tag`   — compact icon + text tag,
- *     persistent in chat history once work completes.
+ *   • `.cpk-intelligence-indicator__tag`   — italic muted-gray "metadata
+ *     line", persistent in chat history once work completes.
  *
- * Opacity cross-fades the two modes; the tag is positioned absolutely
- * over the pill's slot so the layout doesn't jump.
+ * Both children stack in a single grid cell anchored to the left edge,
+ * so the shrink-and-settle morph rotates around a shared LEFT pivot
+ * (not a shared center). That left-aligns the finished tag to the
+ * assistant-message column instead of floating it in the middle of
+ * where the pill was.
  *
- * Violet/indigo palette ported from CopilotKit/Intelligence #155 —
- * text #5B21B6, icon #7C3AED, border #9599E0, gradient stop #EEE6FE,
- * soft shadow #5E64AD.
+ * The transitions are implemented as one-shot CSS animations rather
+ * than property transitions. Plain `transition`s don't fire when the
+ * trigger class is already present at first paint — which is exactly
+ * what happens on fast turns where the brain's `useState` lazy init
+ * mounts the face directly in `finished` state. Animations always
+ * play when their trigger class is applied, mount-time or otherwise.
  */
 .cpk-intelligence-indicator {
   position: relative;
-  display: inline-block;
+  display: grid;
+  /* Stack both children in one cell, left-aligned, vertically centered. */
+  justify-items: start;
+  align-items: center;
   /* Opt out of the parent flex-column's default `align-items: stretch`
      (the auto-mount lives inside `CopilotChatMessageView`'s
      `cpk:flex cpk:flex-col` container). Without this the indicator
@@ -259,6 +268,7 @@
 /* ─── In-progress pill ──────────────────────────────────────────────── */
 
 .cpk-intelligence-indicator__pill {
+  grid-area: 1 / 1;
   display: inline-flex;
   align-items: center;
   gap: 0.55rem;
@@ -281,26 +291,25 @@
     0 1px 2px rgb(94 100 173 / 0.06),
     0 8px 24px rgb(149 153 224 / 0.08),
     inset 0 1px 0 rgb(255 255 255 / 0.6);
-  /* Shared origin for the morph: pill shrinks to center; tag grows
-     from the same center. */
-  transform-origin: center;
+  /* Shared LEFT-edge origin: pill shrinks toward its left edge while
+     the tag grows from the same left edge. The morph reads as one
+     element transforming around a fixed pivot. */
+  transform-origin: left center;
   transform: scale(1);
   opacity: 0;
   animation: cpk-intelligence-pill-fade-in 280ms ease-out forwards;
-  /* Out-transition (to finished): shrink + fade in 220 ms.
-     Apple-style ease-out cubic for the shrink so it eases cleanly. */
-  transition:
-    opacity 220ms ease-out,
-    transform 220ms cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 
 .cpk-intelligence-indicator__pill--hidden {
-  /* `animation: none` cancels the fade-in's held `forwards` value so
-     these declarations win; the wrapper's transition then animates
-     the morph (opacity 1 → 0, scale 1 → 0.7) over 220 ms. */
-  animation: none;
-  opacity: 0;
-  transform: scale(0.7);
+  /* Exit animation. Replaces the held final value of the fade-in (via
+     the animation property swap) and drives both opacity and transform
+     to their exit values. Used in BOTH paths:
+       1. Live spinner → finished (--hidden added by React re-render).
+       2. Mount-already-finished (--hidden present at first paint).
+     A plain `transition` would skip case 2 because there'd be no value
+     change for the browser to interpolate — that's the "pop" users see. */
+  animation: cpk-intelligence-pill-exit 220ms cubic-bezier(0.22, 0.61, 0.36, 1)
+    forwards;
   pointer-events: none;
 }
 
@@ -322,14 +331,12 @@
 /*
  * Italic gray "footnote" — no border, no background, no padding.
  * Reads as scroll-back metadata so it disappears for someone passing
- * by and surfaces for someone looking. Absolutely-positioned over the
- * pill slot so the wrapper's footprint doesn't jump during the
- * shrink-and-settle morph.
+ * by and surfaces for someone looking. Stacks over the pill via grid
+ * (no position: absolute) so it sits at the same left edge.
  */
 
 .cpk-intelligence-indicator__tag {
-  position: absolute;
-  inset: 0;
+  grid-area: 1 / 1;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -339,22 +346,20 @@
   font-weight: 400;
   line-height: 1.4;
   white-space: nowrap;
-  width: -moz-fit-content;
-  width: fit-content;
-  height: -moz-fit-content;
-  height: fit-content;
-  margin: auto;
-  transform-origin: center;
+  transform-origin: left center;
   transform: scale(0.7);
   opacity: 0;
   pointer-events: none;
-  /* In-transition (to shown): scale up + fade in starting 120 ms after
-     the pill starts shrinking — the overlap creates the morph
-     illusion. Slightly longer than the pill's exit (320 ms vs 220 ms)
-     for a "settled" feel. */
-  transition:
-    opacity 320ms cubic-bezier(0.22, 0.61, 0.36, 1) 120ms,
-    transform 320ms cubic-bezier(0.22, 0.61, 0.36, 1) 120ms;
+}
+
+.cpk-intelligence-indicator__tag--shown {
+  /* Entry animation — same mount-or-transition guarantee as the pill's
+     exit. 120ms delay so the tag's grow-in overlaps the pill's shrink
+     near its end, reading as one continuous morph rather than two
+     swaps. */
+  animation: cpk-intelligence-tag-enter 320ms cubic-bezier(0.22, 0.61, 0.36, 1)
+    120ms forwards;
+  pointer-events: auto;
 }
 
 .cpk-intelligence-indicator__tag--shown {
@@ -378,6 +383,28 @@
   }
   to {
     opacity: 1;
+  }
+}
+
+@keyframes cpk-intelligence-pill-exit {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.7);
+  }
+}
+
+@keyframes cpk-intelligence-tag-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.7);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -320,7 +320,12 @@
   align-items: center;
   gap: 0.55rem;
   /* `color` drives both the label text and the icon stroke (which uses
-     `currentColor`). In-progress alpha 0.92, settle alpha 0.55. */
+     `currentColor`). In-progress is a saturated purple at high alpha
+     (the active "this is happening now" state); finished transitions
+     all the way to a neutral slate gray (settled metadata — "a tool
+     call happened here"). The hue shift, not just an alpha drop, is
+     what makes the finished state read as a different semantic class
+     of content rather than just a dimmed version of the active one. */
   color: rgb(91 33 182 / 0.92);
   font-size: 0.78rem;
   font-weight: 500;
@@ -332,7 +337,13 @@
 
 .cpk-intelligence-indicator[data-status="finished"]
   .cpk-intelligence-indicator__content {
-  color: rgb(91 33 182 / 0.55);
+  /* Slate-500 (`#64748b`) — the industry-standard secondary/metadata
+     color (Stripe, Linear, Claude, GitHub all land within a few hex
+     units of it). Cool neutral undertone reads as "settled info you
+     can still scan" rather than "faded out." Full alpha because the
+     gray itself carries the muted feel — layering low alpha on top
+     would tip into "too washed out to read at a glance." */
+  color: rgb(100 116 139);
 }
 
 .cpk-intelligence-indicator__icon {

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -337,13 +337,34 @@
 
 .cpk-intelligence-indicator[data-status="finished"]
   .cpk-intelligence-indicator__content {
-  /* Slate-500 (`#64748b`) — the industry-standard secondary/metadata
-     color (Stripe, Linear, Claude, GitHub all land within a few hex
-     units of it). Cool neutral undertone reads as "settled info you
-     can still scan" rather than "faded out." Full alpha because the
-     gray itself carries the muted feel — layering low alpha on top
-     would tip into "too washed out to read at a glance." */
-  color: rgb(100 116 139);
+  /* True-neutral gray (`#737373`, R=G=B) at 0.8 alpha. No hue cast in
+     either direction (slate would lean blue, stone would lean warm).
+     The combination of pure-neutral hue + slight transparency reads
+     as "settled history metadata" without competing with the active
+     state for attention. */
+  color: rgb(115 115 115 / 0.8);
+}
+
+/* Label — slants on settle to read as italic-like history metadata.
+   `transform: skewX()` is used instead of `font-style: italic` because:
+   (a) font-style is a discrete property, so it would snap rather than
+   transition smoothly with the color shift; (b) real italic glyphs
+   are slightly wider than upright, causing a layout pop at the snap
+   moment. A CSS transform applies after layout — no reflow — and
+   interpolates over the same 400 ms / 250 ms-delay window as the
+   color, so the slant and the color settle as one motion. For the
+   sans-serif system fonts used by default, the browser-synthesized
+   italic is itself a slant on the upright forms, so this approach
+   matches what `font-style: italic` would have rendered anyway. */
+.cpk-intelligence-indicator__label {
+  display: inline-block;
+  transform: skewX(0deg);
+  transition: transform 400ms ease-out 250ms;
+}
+
+.cpk-intelligence-indicator[data-status="finished"]
+  .cpk-intelligence-indicator__label {
+  transform: skewX(-10deg);
 }
 
 .cpk-intelligence-indicator__icon {


### PR DESCRIPTION
## Summary

Refactors the `IntelligenceIndicator` along three axes:

1. **Per-turn persistence** — every agent turn that used Intelligence keeps its own indicator in chat history, instead of a single "latest only" indicator that supersedes prior turns.
2. **Subtle, premium visual** — the in-progress pill is unchanged, but the finished state collapses into an italic muted-gray "metadata line" (icon + past-tense label, no border, no background) that reads as a footnote attached to the assistant message, not as a status chip. The pill→tag transition is a "shrink-and-settle" morph rather than an opacity cross-fade.
3. **Multi-step-turn stability** — the in-turn flicker fix (see its own section below).

> **Scope / split:** this PR is the **indicator UI work**. The underlying `CopilotKitCore` runtime fix that stopped the whole transcript from blanking on a mid-session `/info` re-sync has been **split into a companion PR — #5178** — so it can be reviewed independently by core owners. The two have no compile coupling and can merge in any order.

## Behavior changes

| | Before | After |
|---|---|---|
| **Gate** | Latest matching-assistant across all of `agent.messages` (older turns disappeared) | **First** bash-using assistant *within its turn* (turns bounded by user messages). All turns' indicators coexist in history. |
| **History replay** | Brief `hidden` flash on mount before settling | `useState` lazy init → mounts directly into finished. No flash. |
| **Wrapper testid** | `cpk-intelligence-pill-{id}` | `cpk-intelligence-indicator-{id}` (the wrapper hosts both pill + tag modes; `data-status="in-progress"\|"finished"` distinguishes them). |

## Multi-step-turn stability (flicker fix)

When an assistant turn issued **multiple** `knowledge_base_shell` calls, the indicator visibly **flickered** — the spinner jumped / reset position as the turn progressed.

- **Cause:** the indicator was emitted per assistant message and keyed by **message id**, with the per-turn anchor being the *last* matching message. As more matching tool-calls streamed in, the anchor handed off from one message to the next, **remounting** the component (and resetting its local phase state).
- **Fix:** emit **one** indicator per turn, anchored at the **first** matching tool-call message (`getIntelligenceTurnAnchors` / `INTELLIGENCE_TURN_HEAD`) and **keyed by turn**. Anchor hand-offs within a turn now update a prop instead of remounting, so the pill stays put and transitions smoothly in place. The per-instance "last-in-turn" self-gate in the brain was removed — placement is now the view's job.

This per-turn keying also hardens the indicator against transient `agent.messages` churn — complementary to the root-cause runtime fix in #5178.

## Visual changes

**In-progress** (unchanged): glassmorphism pill with spinning ring.

**Finished**: italic muted-gray metadata line — `✓ Used CopilotKit Intelligence` in 11 px italic, color `rgba(120,120,130,0.85)`, no border, no background, no padding-as-chip. The full label is passed through `title` for tooltip. Past-tense transformation is automatic for `"Using …"` labels; slot consumers passing custom labels own their wording.

**Transition** (`in-progress` → `finished`):
- Pill scales `1 → 0.7` toward its center and fades out (220 ms, ease-out / Apple-style cubic-bezier for the scale).
- Tag scales `0.7 → 1` from the same center and fades in (320 ms, cubic-bezier(0.22, 0.61, 0.36, 1)) starting +120 ms after the pill begins shrinking.
- Both share `transform-origin: center`, so the overlap reads as one element morphing rather than two elements being swapped.
- Total ~440 ms.

The `intelligenceIndicator` slot contract on `<CopilotChat>` is unchanged — all three `SlotValue` tiers (component / className / props object) still work, and the slot still receives `{ status, label, message }`.

## Files

- `packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicator.tsx` — brain rewrite (per-turn gating + simplified phase machine with lazy init); first-anchor helper `getIntelligenceTurnAnchors` / `INTELLIGENCE_TURN_HEAD`, last-in-turn self-gate removed.
- `packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx` — two-mode face: glassmorphism pill in-progress, italic metadata line finished, built-in shrink-and-settle morph.
- `packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx` — emits **one** indicator per turn at the turn's first anchor, keyed by turn (mirrored in the virtualized branch).
- `packages/react-core/src/v2/components/intelligence-indicator/index.ts` — exports `getIntelligenceTurnAnchors` / `INTELLIGENCE_TURN_HEAD`.
- `packages/react-core/src/v2/styles/globals.css` — pill (unchanged in-progress look) + new metadata-line + shrink-and-settle transforms; removed dead `--fading` / `--finished` (subdued pill) / `settle` keyframes.
- `packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx` — 16 cases: per-turn persistence, historical-replay no-flash, first-anchor placement, and a multi-step-turn no-remount regression.
- `examples/v2/react/storybook/stories/IntelligenceIndicator.stories.tsx` — five demo stories (`InProgress`, `Finished`, `WithCustomLabel`, `Playground`, `FullyCustomFace`).

## Verification

- `nx test react-core` — **1190 tests passing**, 0 failures (IntelligenceIndicator e2e: 16 cases).
- `tsc --noEmit` — no new type errors introduced; the absolute count is pre-existing NodeNext extensionless-import noise present on the base branch too (verified +0 from this branch via stash diff).
- `oxlint` + `oxfmt` — clean on changed files (0 new warnings, verified via stash diff).
- `nx build:css` — emits the new `.cpk-intelligence-indicator` rules; old `--fading` / `--finished` / `settle` keyframes removed.
- Pre-commit hooks (check-binaries, lint-fix, test-and-check-packages, commitlint) all passed across the commits.
- Visual verification: 5 Storybook stories at `UI / IntelligenceIndicator` exercise each phase, the static endpoints, and the auto-play timeline.

## Status

Intelligence-side demo e2e is a sibling change on CopilotKit/Intelligence#240 that depends on this PR being released and the demo's `@copilotkit/react-core` dependency bumped. End-to-end verification happens via a StackBlitz package built from this branch, run against the Intelligence demo.

## Related

- **#5178** — `fix(core): preserve runtime-agent instances across mid-session /info re-sync` — the runtime root-cause fix, split out for independent core review. No compile coupling with this PR; either merge order is fine.

Refs RD-4
