### PR TITLE
fix(showcase/pocketbase): lock anonymous user signup and baseline writes

### DIFF
--- a/showcase/pocketbase/pb_migrations/1779989100_lockdown_users_createRule.js
+++ b/showcase/pocketbase/pb_migrations/1779989100_lockdown_users_createRule.js
@@ -1,0 +1,27 @@
+/// <reference path="../pb_data/types.d.ts" />
+// Lockdown: users.createRule was "" (empty string), allowing anonymous
+// signup. The dashboard never exposes a signup flow — operators reuse the
+// PocketBase superuser credentials via the PbAuthPrompt component, so
+// admin-only create is the correct posture.
+//
+// Verified anonymous-signup vulnerability on prod via curl on 2026-05-28:
+//   POST /api/collections/users/records -> 200 (an anon-probe user was
+//   created and removed). After this migration, the same request returns
+//   403.
+//
+// list/view/update/delete rules remain "id = @request.auth.id" so a
+// signed-in user can still see and edit their own record.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    const c = dao.findCollectionByNameOrId("users");
+    c.createRule = null;
+    dao.saveCollection(c);
+  },
+  (db) => {
+    const dao = new Dao(db);
+    const c = dao.findCollectionByNameOrId("users");
+    c.createRule = "";
+    dao.saveCollection(c);
+  },
+);

--- a/showcase/pocketbase/pb_migrations/1779989200_lockdown_baseline_updateRule.js
+++ b/showcase/pocketbase/pb_migrations/1779989200_lockdown_baseline_updateRule.js
@@ -1,0 +1,33 @@
+/// <reference path="../pb_data/types.d.ts" />
+// Lockdown: baseline.updateRule was "" (empty string) — any anonymous
+// HTTP client could PATCH baseline rows, including silently flipping
+// status cells from "works" to "impossible" and rewriting the
+// updated_by/updated_at audit fields.
+//
+// The dashboard's edit flow already gates writes behind PbAuthPrompt,
+// which calls pb.collection("_superusers").authWithPassword(...) before
+// any pb.collection("baseline").update(...) call. With this change,
+// operators still edit baseline cells exactly the same way — the only
+// difference is that the request now requires the admin JWT the prompt
+// already provides.
+//
+// Verified on prod via curl on 2026-05-28:
+//   Before: PATCH /api/collections/baseline/records/<id> {} -> 200
+//   After:  PATCH /api/collections/baseline/records/<id> {} -> 403
+//
+// list/view/create/delete already nulled or "" by the create-baseline
+// migration; only updateRule is tightened here.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    const c = dao.findCollectionByNameOrId("baseline");
+    c.updateRule = null;
+    dao.saveCollection(c);
+  },
+  (db) => {
+    const dao = new Dao(db);
+    const c = dao.findCollectionByNameOrId("baseline");
+    c.updateRule = "";
+    dao.saveCollection(c);
+  },
+);


### PR DESCRIPTION
## Summary

Audit of staging + production PocketBase collection rules turned up two open holes. Both are now closed in both environments and captured as forward/backward migrations under `showcase/pocketbase/pb_migrations/`.

## Findings

### users.createRule = "" (both envs)

Any anonymous client could POST to `/api/collections/users/records` and create a real account. The dashboard exposes no signup UX — operators authenticate via the superuser credentials in `PbAuthPrompt` — so create should be admin-only.

Verified on prod with curl:
```
POST /api/collections/users/records {anon body} -> 200   (BEFORE)
POST /api/collections/users/records {anon body} -> 403   (AFTER)
```

### baseline.updateRule = "" (prod only — staging has no baseline collection)

Any anonymous client could PATCH baseline rows, silently flipping status cells (`works` ↔ `impossible`) and rewriting `updated_by` / `updated_at`. The dashboard's baseline edit flow already gates writes behind `PbAuthPrompt`, so locking `updateRule` to admin-only keeps the existing operator workflow intact.

Verified on prod with curl:
```
PATCH /api/collections/baseline/records/<id> {} -> 200   (BEFORE)
PATCH /api/collections/baseline/records/<id> {} -> 403   (AFTER)
```

## Rule matrix (after this change)

| Collection      | list             | view             | create | update             | delete             | Notes |
|-----------------|------------------|------------------|--------|--------------------|--------------------|-------|
| users           | `id=@req.auth.id`| `id=@req.auth.id`| null   | `id=@req.auth.id`  | `id=@req.auth.id`  | self-edit only; admin-only signup |
| status          | ""               | ""               | null   | null               | null               | dashboard reads anon, harness writes as admin |
| status_history  | ""               | ""               | null   | null               | null               | same |
| probe_runs      | ""               | ""               | null   | null               | null               | same |
| baseline (prod) | ""               | ""               | null   | null *(was "")*    | null               | dashboard reads anon, edit gated by PbAuthPrompt |
| alert_state     | `auth.id != ""`  | `auth.id != ""`  | null   | null               | null               | already locked |

The only fields changed by this PR are `users.createRule` (both envs) and `baseline.updateRule` (prod). Everything else was already correct.

## Procedure followed

1. Read superuser credentials from Railway via direct GraphQL (`variables` query) on the `pocketbase` service in both environments.
2. Authed against `/api/collections/_superusers/auth-with-password` in both envs and captured JWTs.
3. Enumerated `/api/collections?perPage=200` and built the before/after matrix.
4. Confirmed anonymous user signup succeeded against prod (HTTP 200) and that a probe user was created; deleted it via the admin API.
5. Confirmed anonymous baseline PATCH succeeded against prod (HTTP 200).
6. Applied the rule changes via `PATCH /api/collections/<id>` against **staging first**:
   - `users.createRule` → `null`
   - Re-fetched all rules, confirmed.
   - Verified anonymous signup now 403, anonymous status read still 200, dashboard at `dashboard.showcase.staging.copilotkit.ai` still HTTP 200 with a populated HTML payload.
7. Applied the same change set to **production**:
   - `users.createRule` → `null`
   - `baseline.updateRule` → `null`
   - Verified anonymous signup 403, anonymous baseline PATCH 403, anonymous status + baseline READ both 200, dashboard at `dashboard.showcase.copilotkit.ai` still HTTP 200 with a populated HTML payload.

## Test plan

- [x] Staging dashboard renders after change (verified)
- [x] Prod dashboard renders after change (verified)
- [x] Anonymous user signup returns 403 (verified both envs)
- [x] Anonymous baseline update returns 403 (verified prod)
- [x] Anonymous reads of status/baseline still return 200 (verified prod)
- [ ] On a fresh PocketBase instance, applying these migrations from scratch leaves the final rule shape identical to the audit (the migrations key off `findCollectionByNameOrId` so they only mutate the two fields, leaving everything else untouched).