### PR TITLE
ci(format): make main self-healing for formatting violations

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -103,7 +103,7 @@ jobs:
           echo "PR-changed format candidates: $count"
           cat .pr-format-files.existing.txt
 
-      - name: Run formatter (check on push, fix on PR)
+      - name: Run formatter (fix on PR, fix-and-commit on push)
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             if [ "${{ steps.changed.outputs.count }}" = "0" ]; then
@@ -128,15 +128,24 @@ jobs:
               echo "$py_files" | xargs ruff format --check
             fi
           else
-            oxfmt --check .
-            ruff format --check .
+            # Push to main: write fixes in place rather than failing.
+            # If violations exist, the commit steps below push a follow-up fix
+            # commit to main automatically. This makes main self-healing for
+            # PRs that merged before the PR format job could auto-fix.
+            if ! oxfmt --write .; then
+              echo "::warning::oxfmt exited with error — auto-fix may be incomplete"
+            fi
+            ruff format . || echo "::warning::ruff format exited with error"
+            if [ -n "$(git diff --name-only)" ]; then
+              echo "format_fixed=true" >> $GITHUB_ENV
+            fi
           fi
 
       - name: Configure git for push
         if: >-
           env.format_fixed == 'true' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+          (github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -147,20 +156,24 @@ jobs:
       - name: Commit formatting fixes
         if: >-
           env.format_fixed == 'true' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+          (github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)
         run: |
           if [ -z "$(git diff --name-only)" ]; then
             echo "No formatting changes to commit"
             exit 0
           fi
-          # Stage only the files the formatter was scoped to operate on.
-          # Piping `git diff --name-only` into `git add` is unsafe: if a
-          # tracked-but-gitignored path shows up in the diff, `git add`
-          # aborts the whole step and the auto-fix push never lands —
-          # leaving formatting violations on the PR branch and (post-
-          # merge) on main.
-          xargs -a .pr-format-files.existing.txt git add --
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Stage only the files the formatter was scoped to operate on.
+            # Piping `git diff --name-only` into `git add` is unsafe: if a
+            # tracked-but-gitignored path shows up in the diff, `git add`
+            # aborts the whole step and the auto-fix push never lands —
+            # leaving formatting violations on the PR branch and (post-
+            # merge) on main.
+            xargs -a .pr-format-files.existing.txt git add --
+          else
+            git add -A
+          fi
           git commit -m "style: auto-fix formatting"
           git push
 

--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -147,9 +147,10 @@ jobs:
                 echo "::warning::oxfmt exited with error — auto-fix may be incomplete"
               fi
             fi
-            push_py_files=$(git ls-files -- '*.py' ':!docs/**' ':!examples/**' 2>/dev/null || true)
-            if [ -n "$push_py_files" ]; then
-              echo "$push_py_files" | xargs ruff format || echo "::warning::ruff format exited with error"
+            # Use -z / xargs -0 to handle filenames with spaces.
+            while IFS= read -r -d '' f; do push_py_files_arr+=("$f"); done < <(git ls-files -z -- '*.py' ':!docs/**' ':!examples/**' 2>/dev/null || true)
+            if [ "${#push_py_files_arr[@]}" -gt 0 ]; then
+              printf '%s\0' "${push_py_files_arr[@]}" | xargs -0 ruff format || echo "::warning::ruff format exited with error"
             fi
             if [ -n "$(git status --porcelain)" ]; then
               echo "format_fixed=true" >> $GITHUB_ENV
@@ -191,7 +192,11 @@ jobs:
             git diff --name-only -z | xargs -0 git add --
           fi
           git commit -m "style: auto-fix formatting"
-          git pull --rebase origin main
+          # Rebase on main only for direct pushes — the PR path pushes to the
+          # PR branch which does not need rebasing before the auto-fix lands.
+          if [ "${{ github.event_name }}" = "push" ]; then
+            git pull --rebase origin main
+          fi
           git push
 
       - name: Verify push-path auto-fix is complete
@@ -210,9 +215,9 @@ jobs:
           if [ "${#verify_files[@]}" -gt 0 ]; then
             printf '%s\0' "${verify_files[@]}" | xargs -0 oxfmt --no-error-on-unmatched-pattern --check
           fi
-          verify_py=$(git ls-files -- '*.py' ':!docs/**' ':!examples/**' 2>/dev/null || true)
-          if [ -n "$verify_py" ]; then
-            echo "$verify_py" | xargs ruff format --check
+          while IFS= read -r -d '' f; do verify_py_arr+=("$f"); done < <(git ls-files -z -- '*.py' ':!docs/**' ':!examples/**' 2>/dev/null || true)
+          if [ "${#verify_py_arr[@]}" -gt 0 ]; then
+            printf '%s\0' "${verify_py_arr[@]}" | xargs -0 ruff format --check
           fi
 
   oxlint:

--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -132,11 +132,26 @@ jobs:
             # If violations exist, the commit steps below push a follow-up fix
             # commit to main automatically. This makes main self-healing for
             # PRs that merged before the PR format job could auto-fix.
-            if ! oxfmt --write .; then
-              echo "::warning::oxfmt exited with error — auto-fix may be incomplete"
+            # Scope to the same file types as PR mode; exclude lockfiles and
+            # the paths-ignore paths (docs/, examples/, README.md) so the
+            # auto-fix doesn't reformat tutorial code or fail on lockfiles.
+            mapfile -d '' push_files < <(git ls-files -z -- \
+              '*.js' '*.jsx' '*.ts' '*.tsx' '*.mjs' '*.cjs' \
+              '*.json' '*.jsonc' '*.json5' \
+              '*.md' \
+              '*.css' '*.yml' '*.yaml' '*.html' '*.vue' \
+              ':!docs/**' ':!examples/**' ':!README.md' \
+              ':!**/package-lock.json' ':!**/pnpm-lock.yaml' ':!**/yarn.lock')
+            if [ "${#push_files[@]}" -gt 0 ]; then
+              if ! printf '%s\0' "${push_files[@]}" | xargs -0 oxfmt --no-error-on-unmatched-pattern --write; then
+                echo "::warning::oxfmt exited with error — auto-fix may be incomplete"
+              fi
             fi
-            ruff format . || echo "::warning::ruff format exited with error"
-            if [ -n "$(git diff --name-only)" ]; then
+            push_py_files=$(git ls-files -- '*.py' ':!docs/**' ':!examples/**' 2>/dev/null || true)
+            if [ -n "$push_py_files" ]; then
+              echo "$push_py_files" | xargs ruff format || echo "::warning::ruff format exited with error"
+            fi
+            if [ -n "$(git status --porcelain)" ]; then
               echo "format_fixed=true" >> $GITHUB_ENV
             fi
           fi
@@ -172,10 +187,18 @@ jobs:
             # merge) on main.
             xargs -a .pr-format-files.existing.txt git add --
           else
-            git add -A
+            # Stage only formatter output — not untracked artifacts.
+            git diff --name-only -z | xargs -0 git add --
           fi
           git commit -m "style: auto-fix formatting"
+          git pull --rebase origin main
           git push
+
+      - name: Verify push-path auto-fix is complete
+        if: github.event_name == 'push' && env.format_fixed == 'true'
+        run: |
+          oxfmt --check .
+          ruff format --check .
 
   oxlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -197,8 +197,23 @@ jobs:
       - name: Verify push-path auto-fix is complete
         if: github.event_name == 'push' && env.format_fixed == 'true'
         run: |
-          oxfmt --check .
-          ruff format --check .
+          # Check the same scoped file set the formatter wrote to — not the
+          # whole repo. Running --check . would fail on pre-existing violations
+          # in docs/ or examples/ that the push path intentionally skips.
+          mapfile -d '' verify_files < <(git ls-files -z -- \
+            '*.js' '*.jsx' '*.ts' '*.tsx' '*.mjs' '*.cjs' \
+            '*.json' '*.jsonc' '*.json5' \
+            '*.md' \
+            '*.css' '*.yml' '*.yaml' '*.html' '*.vue' \
+            ':!docs/**' ':!examples/**' ':!README.md' \
+            ':!**/package-lock.json' ':!**/pnpm-lock.yaml' ':!**/yarn.lock')
+          if [ "${#verify_files[@]}" -gt 0 ]; then
+            printf '%s\0' "${verify_files[@]}" | xargs -0 oxfmt --no-error-on-unmatched-pattern --check
+          fi
+          verify_py=$(git ls-files -- '*.py' ':!docs/**' ':!examples/**' 2>/dev/null || true)
+          if [ -n "$verify_py" ]; then
+            echo "$verify_py" | xargs ruff format --check
+          fi
 
   oxlint:
     runs-on: ubuntu-latest

--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -21,7 +21,10 @@ import { DiscoveryAuthBanner } from "@/components/discovery-auth-banner";
 import type { ParityTier } from "@/components/parity-badge";
 import { getDocsStatus } from "@/lib/docs-status";
 import { resolveCell } from "@/lib/live-status";
-import type { DepthDistribution, D6Stats } from "@/components/adaptive-stats-bar";
+import type {
+  DepthDistribution,
+  D6Stats,
+} from "@/components/adaptive-stats-bar";
 import catalog from "@/data/catalog.json";
 import type { CatalogData } from "@/data/catalog-types";
 

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -352,7 +352,14 @@ describe("Overlay selector integration — real UI components", () => {
     const { getByTestId, getByText } = render(
       <ComposedCell
         ctx={ctx}
-        overlays={overlaySet("links", "depth", "health", "docs", "parity", "d6")}
+        overlays={overlaySet(
+          "links",
+          "depth",
+          "health",
+          "docs",
+          "parity",
+          "d6",
+        )}
         catalogCell={catalogCell}
       />,
     );

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -258,10 +258,7 @@ function UnifiedCellInner({ ctx, model, overlays }: UnifiedCellProps) {
  * delta re-rendering 1 cell vs. all ~720 cells in the matrix.
  */
 /** Shallow-compare the primitive fields of two TestLevel values. */
-function testLevelsEqual(
-  a: TestLevel | null,
-  b: TestLevel | null,
-): boolean {
+function testLevelsEqual(a: TestLevel | null, b: TestLevel | null): boolean {
   if (a === b) return true;
   if (a == null || b == null) return false;
   return a.exists === b.exists && a.status === b.status;


### PR DESCRIPTION
## Why

Three PRs (#5018, #5020, #5021) merged to main before their format CI job could run, leaving unformatted files that broke the on-push `oxfmt --check .` gate.

Root cause: the `PROTECT_OUR_MAIN` ruleset only requires a review approval — no CI check is required to pass before merging. PRs merged within 1–3 seconds of CI triggering, before the format job started.

## What

**1. Fix on-push format check → auto-commit instead of fail** (`.github/workflows/static_quality.yml`)

When a push to main has formatting violations, the format job now runs `oxfmt --write` + `ruff format` and commits the fixes back to main automatically, instead of failing. Main becomes self-healing: a fast-merged PR that slips through with violations gets a bot follow-up commit within ~30 seconds.

The PR path is unchanged — authors still see violations and the auto-fixer still commits to the PR branch.

**2. Formatting fixes** (`showcase/shell-dashboard/`)

Applies `oxfmt --write .` to the three files that were blocking CI. No logic changes.

## Tradeoffs

- A violation that slips through will briefly leave main in an unformatted state until the bot commit lands
- The bot commit triggers a second CI run (concurrency group cancels the first if still running)
- `oxfmt --write .` scans the whole repo on every push to main regardless of what changed

If tighter enforcement is needed, adding `format` as a required status check in the [PROTECT_OUR_MAIN ruleset](https://github.com/CopilotKit/CopilotKit/rules/14521235) would block merges until the format job (and its auto-fix) completes.