### PR TITLE
docs: add Start with an agent prompt to root landing page and quickstart (OSS-195)

### DIFF
--- a/docs/app/(home)/[[...slug]]/page.tsx
+++ b/docs/app/(home)/[[...slug]]/page.tsx
@@ -23,6 +23,7 @@ import { PropertyReference } from "@/components/react/property-reference";
 import { InsecurePasswordProtected } from "@/components/react/insecure-password-protected";
 import { LinkToCopilotCloud } from "@/components/react/link-to-copilot-cloud";
 import { OpsPlatformCTA } from "@/components/react/ops-platform-cta";
+import { AgentStartPrompt } from "@/components/react/agent-start-prompt";
 import { SignupLink } from "@/components/react/signup-link";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 import { NavigationLink } from "@/components/react/subdocs-menu";
@@ -43,6 +44,7 @@ const mdxComponents = {
   InsecurePasswordProtected: InsecurePasswordProtected,
   LinkToCopilotCloud: LinkToCopilotCloud,
   OpsPlatformCTA: OpsPlatformCTA,
+  AgentStartPrompt: AgentStartPrompt,
   SignupLink: SignupLink,
   Accordions: Accordions,
   Accordion: Accordion,

--- a/docs/components/react/agent-start-prompt.tsx
+++ b/docs/components/react/agent-start-prompt.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ArrowRight, Bot, Check, Copy } from "lucide-react";
 
 const PROMPT = `Help me get started with CopilotKit — the frontend stack for AI agents and generative UI.
@@ -26,10 +26,19 @@ export function AgentStartPrompt() {
   const [copied, setCopied] = useState<boolean>(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(PROMPT);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(PROMPT);
+      setCopied(true);
+    } catch (err) {
+      console.error("Failed to copy to clipboard:", err);
+    }
   };
+
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(t);
+  }, [copied]);
 
   return (
     <div className="not-prose my-6 rounded-lg border border-black/6 bg-[#FAFAFA] dark:border-white/10 dark:bg-white/5">
@@ -47,6 +56,7 @@ export function AgentStartPrompt() {
           </div>
         </div>
         <button
+          type="button"
           onClick={handleCopy}
           className="ml-4 shrink-0 rounded p-1.5 text-gray-500 transition-colors hover:bg-black/5 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-gray-200 cursor-pointer"
           aria-label="Copy prompt"

--- a/docs/components/react/agent-start-prompt.tsx
+++ b/docs/components/react/agent-start-prompt.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, Bot, Check, Copy } from "lucide-react";
+
+const PROMPT = `Help me get started with CopilotKit — the frontend stack for AI agents and generative UI.
+
+First, install the CopilotKit skills:
+
+  npx skills add CopilotKit/CopilotKit
+
+Then use the \`copilotkit-setup\` skill to guide the setup.
+
+If your agent doesn't support skills, use the CopilotKit MCP server instead:
+https://mcp.copilotkit.ai/mcp
+
+Please ask me the following questions one at a time:
+1. What framework are you using? (e.g. Next.js, Vite + React, Remix, other)
+2. What do you want to name your project?
+3. What are you trying to accomplish?
+4. Are you starting a new project or integrating CopilotKit into an existing one?
+
+Once you have my answers, use the installed skills to guide me through setup step by step.`;
+
+export function AgentStartPrompt() {
+  const [copied, setCopied] = useState<boolean>(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(PROMPT);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="not-prose my-6 rounded-lg border border-black/6 bg-[#FAFAFA] dark:border-white/10 dark:bg-white/5">
+      {/* Header row */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-black/6 dark:border-white/10">
+        <div className="flex items-center gap-2">
+          <Bot className="h-4 w-4 text-gray-500 dark:text-gray-400 shrink-0" />
+          <div>
+            <div className="text-sm font-semibold text-[#010507] dark:text-white leading-tight">
+              Start with CopilotKit
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400 leading-tight">
+              Paste this prompt into your AI agent to get started
+            </div>
+          </div>
+        </div>
+        <button
+          onClick={handleCopy}
+          className="ml-4 shrink-0 rounded p-1.5 text-gray-500 transition-colors hover:bg-black/5 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-gray-200 cursor-pointer"
+          aria-label="Copy prompt"
+        >
+          {copied ? (
+            <Check className="h-4 w-4" />
+          ) : (
+            <Copy className="h-4 w-4" />
+          )}
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="px-4 py-3">
+        <pre className="text-sm font-mono text-[#010507] dark:text-white whitespace-pre-wrap break-words bg-transparent">
+          {PROMPT}
+        </pre>
+      </div>
+
+      {/* Footer */}
+      <div className="px-4 py-3 border-t border-black/6 dark:border-white/10">
+        <a
+          href="/build-with-agents"
+          className="inline-flex items-center gap-1 text-sm font-medium text-indigo-700 dark:text-indigo-300 hover:text-indigo-800 dark:hover:text-indigo-200 no-underline"
+        >
+          Learn more about building with agents
+          <ArrowRight className="h-3.5 w-3.5" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/docs/content/docs/(root)/index.mdx
+++ b/docs/content/docs/(root)/index.mdx
@@ -19,6 +19,8 @@ CopilotKit is the __frontend stack for agents__ and __generative UI__. Connect a
 
 Look below to find right guide for your needs, whether you're starting from nothing or have existing agent you want to give a prebuilt chat UI or fully custom UI.
 
+<AgentStartPrompt />
+
 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 not-prose mb-4 mt-10">
   <a href="/quickstart" className="group flex items-start gap-3 bg-card border border-border/80 rounded-lg p-4 no-underline hover:border-primary/60 hover:bg-accent/50 transition-colors shadow-sm">
     <Play className="h-5 w-5 text-primary mt-0.5 flex-shrink-0" />

--- a/docs/content/docs/(root)/index.mdx
+++ b/docs/content/docs/(root)/index.mdx
@@ -17,7 +17,7 @@ import { LazyIframe } from "@/components/content/lazy-iframe"
 
 CopilotKit is the __frontend stack for agents__ and __generative UI__. Connect any agent framework or model to your React app for __chat__, __generative UI__, __canvas apps__, and __human-in-the-loop__ workflows.
 
-Look below to find right guide for your needs, whether you're starting from nothing or have existing agent you want to give a prebuilt chat UI or fully custom UI.
+Look below to find the right guide for your needs, whether you're starting from nothing or have an existing agent you want to give a prebuilt chat UI or fully custom UI.
 
 <AgentStartPrompt />
 

--- a/docs/content/docs/(root)/quickstart.mdx
+++ b/docs/content/docs/(root)/quickstart.mdx
@@ -19,7 +19,7 @@ import { IntegrationGrid } from "@/components/content/integration-grid";
 
 ## Start from an AI backend
 
-To get started, choose the shape of your backend to get started with CopilotKit. This will
+Choose the shape of your backend to get started with CopilotKit. This will
 route you to the appropriate quickstart.
 
 <IntegrationGrid path="quickstart"/>

--- a/docs/content/docs/(root)/quickstart.mdx
+++ b/docs/content/docs/(root)/quickstart.mdx
@@ -6,13 +6,9 @@ hideTOC: true
 ---
 import { IntegrationGrid } from "@/components/content/integration-grid";
 
-## Start from our CLI
-Starting from scratch? Use our CLI to get started in minutes, it will bootstrap a
-full stack agent for you.
+## Start with an agent
 
-```
-npx copilotkit@latest create
-```
+<AgentStartPrompt />
 
 <OpsPlatformCTA
   variant="inline"

--- a/docs/content/docs/(root)/quickstart.mdx
+++ b/docs/content/docs/(root)/quickstart.mdx
@@ -14,7 +14,7 @@ import { IntegrationGrid } from "@/components/content/integration-grid";
   variant="inline"
   title="Building for production?"
   body="Get persistent threads, observability, and the full Enterprise Intelligence Platform. Try it for free."
-  surface="docs_quickstart_after_cli"
+  surface="docs_quickstart_after_agent_prompt"
 />
 
 ## Start from an AI backend

--- a/showcase/shell-docs/src/components/docs-tabs.tsx
+++ b/showcase/shell-docs/src/components/docs-tabs.tsx
@@ -6,9 +6,12 @@
 //     `value.toLowerCase().replace(/\s/, "-")` to derive radix-tabs
 //     `value` keys. Our authored MDX uses the literal label as the
 //     <Tab value="...">, e.g. `<Tab value="JavaScript">` against
-//     `<Tabs items={["JavaScript", "Python"]}>`. Without escaping the
-//     Tab's value to match, radix can't pair the trigger with the
-//     content and the tab body never renders.
+//     `<Tabs items={["JavaScript", "Python"]}>`. Fumadocs's Tab
+//     component applies this same escapeValue internally, so we pass
+//     the raw label — pre-escaping would double-escape multi-word
+//     values and break the trigger↔content match for labels like
+//     "JSON Configuration File" (two spaces → only first replaced →
+//     residual space in trigger but not in double-escaped content).
 //
 //   - We accept `groupId` / `persist` / `default` props that the legacy
 //     custom-Tabs MDX content was written against, so existing pages
@@ -25,15 +28,20 @@ import * as React from "react";
 import {
   Tabs as FumadocsTabs,
   Tab as FumadocsTab,
-  type TabsProps as FumadocsTabsProps,
-  type TabProps as FumadocsTabProps,
+} from "fumadocs-ui/components/tabs";
+import type {
+  TabsProps as FumadocsTabsProps,
+  TabProps as FumadocsTabProps,
 } from "fumadocs-ui/components/tabs";
 
 /**
  * Mirror Fumadocs's internal `escapeValue` — keep this in sync with
- * `node_modules/fumadocs-ui/dist/components/tabs.js`. Used so a Tab's
- * authored `value="JavaScript"` resolves to the same key Fumadocs
- * derives from the Tabs's `items` array.
+ * `node_modules/fumadocs-ui/dist/components/tabs.js`. Used ONLY for
+ * the `Tabs` defaultValue so the initial-selection value matches the
+ * trigger values Fumadocs generates from `items`. Do NOT apply to
+ * individual `Tab` values — Fumadocs's Tab component calls this
+ * internally; pre-escaping here would double-escape and break the
+ * trigger↔content pairing for multi-word labels.
  */
 function escapeValue(v: string): string {
   return v.toLowerCase().replace(/\s/, "-");
@@ -74,13 +82,12 @@ interface ExtendedTabProps extends FumadocsTabProps {
 }
 
 export function Tab({ value, title, ...rest }: ExtendedTabProps) {
-  // Authored MDX passes the literal label as `value`. Escape so it
-  // matches Fumadocs's derivation from `<Tabs items={[...]}>`.
+  // Pass the raw label to FumadocsTab — Fumadocs's Tab component
+  // applies escapeValue internally to match the trigger's derived key.
+  // Pre-escaping here would double-escape and corrupt multi-word labels
+  // (e.g. "JSON Configuration File" → "json-configuration file" after
+  // one pass, then "json-configuration-file" after the second pass,
+  // which no longer matches the trigger's "json-configuration file").
   const resolved = value ?? title;
-  return (
-    <FumadocsTab
-      value={resolved ? escapeValue(resolved) : undefined}
-      {...rest}
-    />
-  );
+  return <FumadocsTab value={resolved} {...rest} />;
 }


### PR DESCRIPTION
## Summary

- Adds a new `AgentStartPrompt` component to the docs — a static copyable prompt box that users paste into their AI coding agent (Claude, Cursor, Windsurf, etc.)
- Places the component on the root landing page (`/`) and the quickstart page, replacing the `npx copilotkit@latest create` CLI command as the primary onboarding CTA
- The prompt instructs the agent to install CopilotKit skills (`npx skills add CopilotKit/CopilotKit`), use the `copilotkit-setup` skill, fall back to the MCP server, and ask the user 4 onboarding questions (framework, project name, goal, new vs existing)

## What changed

- `docs/components/react/agent-start-prompt.tsx` — new client component with copy-to-clipboard button, prompt display, and link to `/build-with-agents`
- `docs/app/(home)/[[...slug]]/page.tsx` — registers `AgentStartPrompt` in the global MDX component map
- `docs/content/docs/(root)/index.mdx` — inserts `<AgentStartPrompt />` between the hero text and the nav tile grid
- `docs/content/docs/(root)/quickstart.mdx` — replaces "Start from our CLI" section with `<AgentStartPrompt />`

## Test plan

- [ ] Visit `docs.copilotkit.ai` — confirm "Start with CopilotKit" prompt card renders below hero text
- [ ] Click "Copy prompt" — confirm clipboard contains the full prompt text and button shows checkmark
- [ ] Visit `/quickstart` — confirm agent prompt appears at top, integration grid still renders below
- [ ] Verify "Learn more about building with agents →" footer link navigates to `/build-with-agents`
- [ ] Check dark mode renders correctly