### PR TITLE
fix(sdk-python): walk _client chain and install async hook on AsyncClient

### DIFF
--- a/sdk-python/copilotkit/header_propagation.py
+++ b/sdk-python/copilotkit/header_propagation.py
@@ -7,12 +7,24 @@ Matches the CopilotKit runtime's extractForwardableHeaders() behavior.
 
 import contextvars
 import warnings
-from typing import Dict
+from typing import Any, Dict, Optional
 
 # Ambient per-request state for headers to forward to LLM calls
 _forwarded_headers: contextvars.ContextVar[Dict[str, str]] = contextvars.ContextVar(
     "copilotkit_forwarded_headers"
 )
+
+# Marker used to identify hooks we have already installed, so install_httpx_hook
+# is idempotent across repeated calls on the same client.
+_HOOK_MARKER = "_copilotkit_forwarded_header_hook"
+
+# Bound on how deep we'll walk a ``._client`` chain looking for event_hooks.
+# The modern OpenAI SDK shape is:
+#   ChatOpenAI.client -> Completions/AsyncCompletions resource
+#     -> ._client = openai.OpenAI / AsyncOpenAI  (no event_hooks)
+#     -> ._client._client = httpx wrapper        (HAS event_hooks)
+# 5 hops is plenty of headroom for similar SDKs without risking pathological loops.
+_MAX_CHAIN_DEPTH = 5
 
 
 def set_forwarded_headers(headers: Dict[str, str]) -> None:
@@ -27,33 +39,118 @@ def get_forwarded_headers() -> Dict[str, str]:
     return _forwarded_headers.get({})
 
 
-def install_httpx_hook(client) -> None:
+def _find_event_hooks_target(client: Any) -> Optional[Any]:
+    """Walk the ``._client`` chain looking for the first object that exposes
+    an httpx-style ``event_hooks`` mapping.
+
+    Returns the target object, or ``None`` if no such object is found within
+    ``_MAX_CHAIN_DEPTH`` hops.
+    """
+    current = client
+    for _ in range(_MAX_CHAIN_DEPTH + 1):
+        if current is None:
+            return None
+        if hasattr(current, "event_hooks"):
+            return current
+        nxt = getattr(current, "_client", None)
+        if nxt is current or nxt is None:
+            return None
+        current = nxt
+    return None
+
+
+def install_httpx_hook(client: Any) -> None:
     """Append an event hook to an httpx client that injects forwarded headers.
 
-    Works with OpenAI and Anthropic Python SDKs (both use httpx internally).
-    No-op when no headers are set (demo traffic).
+    Works with OpenAI and Anthropic Python SDKs (both wrap httpx internally,
+    sometimes via several layers of ``._client`` indirection), as well as raw
+    ``httpx.Client`` / ``httpx.AsyncClient`` instances.
+
+    For ``httpx.AsyncClient`` an async hook is installed (httpx awaits request
+    hooks on async clients); for sync clients a sync hook is installed.
+
+    Idempotent: a marker attribute on the installed callable prevents double
+    installation on the same target.
 
     Parameters
     ----------
     client : object
         An OpenAI/Anthropic client instance, or a raw httpx.Client/AsyncClient.
-        For SDK clients the underlying transport lives at ``client._client``.
     """
+    target = _find_event_hooks_target(client)
 
-    def _inject_headers(request):
-        headers = get_forwarded_headers()
-        for key, value in headers.items():
-            request.headers[key] = value
-
-    # OpenAI / Anthropic SDKs wrap an httpx client at client._client
-    if hasattr(client, "_client") and hasattr(client._client, "event_hooks"):
-        client._client.event_hooks["request"].append(_inject_headers)
-    elif hasattr(client, "event_hooks"):
-        # Raw httpx.Client / httpx.AsyncClient
-        client.event_hooks["request"].append(_inject_headers)
-    else:
+    if target is None:
         warnings.warn(
             f"install_httpx_hook: client of type {type(client).__name__} has no "
             "recognized event_hooks attribute; x-* headers will not be forwarded",
             stacklevel=2,
         )
+        return
+
+    request_hooks = target.event_hooks.get("request", [])
+
+    # Idempotency: don't double-install on the same target.
+    for existing in request_hooks:
+        if getattr(existing, _HOOK_MARKER, False):
+            return
+
+    # Decide sync vs async hook flavor based on the target class.
+    # httpx.AsyncClient awaits request hooks; a sync hook returning None would
+    # raise "TypeError: object NoneType can't be used in 'await' expression",
+    # which surfaces as APIConnectionError to the caller.
+    is_async = _is_async_httpx_target(target)
+
+    if is_async:
+
+        async def _inject_headers_async(request):
+            headers = get_forwarded_headers()
+            for key, value in headers.items():
+                request.headers[key] = value
+
+        setattr(_inject_headers_async, _HOOK_MARKER, True)
+        request_hooks.append(_inject_headers_async)
+    else:
+
+        def _inject_headers(request):
+            headers = get_forwarded_headers()
+            for key, value in headers.items():
+                request.headers[key] = value
+
+        setattr(_inject_headers, _HOOK_MARKER, True)
+        request_hooks.append(_inject_headers)
+
+    # In case ``event_hooks`` returned a fresh list (defensive), make sure the
+    # mutation is reflected on the target.
+    target.event_hooks["request"] = request_hooks
+
+
+def _is_async_httpx_target(target: Any) -> bool:
+    """Best-effort detection: is this object an httpx async client?
+
+    Tries ``isinstance`` against the real ``httpx.AsyncClient`` / ``httpx.Client``
+    first (the authoritative answer for real clients). If httpx is not
+    importable, or the target is neither of those (e.g. a wrapped or
+    duck-typed client used in tests), falls back to an EXACT MRO class-name
+    match against ``"AsyncClient"``. Avoids a broad ``startswith("Async")``
+    check, which would misclassify a sync client whose MRO happens to
+    include an ``Async*``-named base (e.g. ``AsyncContextManager``) as
+    async — installing an async hook that httpx calls synchronously,
+    leaving the coroutine unawaited and headers silently dropped.
+    """
+    try:
+        import httpx  # local import keeps httpx an optional concern at import time
+
+        if isinstance(target, httpx.AsyncClient):
+            return True
+        if isinstance(target, httpx.Client):
+            return False
+    except (
+        ImportError
+    ):  # pragma: no cover - httpx should always be importable in practice
+        pass
+
+    # Fall back to exact class-name match for wrapped/duck-typed clients.
+    for cls in type(target).__mro__:
+        if cls.__name__ == "AsyncClient":
+            return True
+    return False

--- a/sdk-python/copilotkit/header_propagation.py
+++ b/sdk-python/copilotkit/header_propagation.py
@@ -1,15 +1,53 @@
-"""Header propagation for forwarding x-* prefixed headers to outgoing LLM calls.
+"""Forward CopilotKit request-context headers onto outbound LLM/provider HTTP calls
+so downstream services (e.g. the aimock test server, proxies, request routing /
+fixture-matching infrastructure) can correlate the outbound provider call with the
+original inbound request.
 
-Uses Python contextvars for per-request ambient state in async FastAPI handlers.
-An httpx event hook reads the ContextVar and injects headers on outgoing requests.
-Matches the CopilotKit runtime's extractForwardableHeaders() behavior.
+What this module does
+---------------------
+On each inbound request the application stores a small set of ``x-*`` prefixed
+headers (for example ``x-aimock-context``, ``x-aimock-session``, ``x-request-id``,
+``x-trace-id``) on a per-request ``contextvars.ContextVar``. When the application
+later makes an outbound HTTP call to an LLM provider (OpenAI, Anthropic, or any
+client that wraps ``httpx``), an httpx request event hook reads that ContextVar
+and copies those same headers onto the outbound request so downstream services
+can correlate the two.
+
+This is plain header propagation, not data collection. Scope and limits:
+
+* Only headers the application itself set on the request context via
+  ``set_forwarded_headers`` are forwarded. The module never reads request
+  bodies, cookies, user data, credentials, or anything off the inbound
+  request beyond the headers explicitly handed to it.
+* Only ``x-*`` prefixed headers pass the filter; ``authorization``,
+  ``content-type``, and any other non ``x-*`` headers are dropped.
+* Nothing is collected, persisted, logged, or sent anywhere by this module
+  itself — it only attaches headers to an HTTP request that the caller was
+  already going to make. There is no telemetry, no out-of-band channel, and
+  no end-user data flow.
+
+Mechanics
+---------
+``install_httpx_hook`` does two small things:
+
+1. It walks the ``._client`` chain on the given object (modern provider SDKs
+   wrap their httpx client behind several layers of ``._client``) to find the
+   first object that exposes an httpx-style ``event_hooks`` mapping.
+2. It attaches a request event hook to that mapping. The hook flavor matches
+   the client: an async coroutine hook for ``httpx.AsyncClient`` (httpx awaits
+   request hooks on async clients), and a plain sync hook for ``httpx.Client``.
+   Installation is idempotent via a marker attribute on the installed callable.
+
+This mirrors the CopilotKit runtime's ``extractForwardableHeaders()`` behavior
+on the Node side so the Python SDK forwards the same set of context headers.
 """
 
 import contextvars
 import warnings
 from typing import Any, Dict, Optional
 
-# Ambient per-request state for headers to forward to LLM calls
+# Per-request storage for the set of headers the application has asked to forward
+# onto outbound LLM/provider calls (populated by ``set_forwarded_headers``).
 _forwarded_headers: contextvars.ContextVar[Dict[str, str]] = contextvars.ContextVar(
     "copilotkit_forwarded_headers"
 )
@@ -28,14 +66,18 @@ _MAX_CHAIN_DEPTH = 5
 
 
 def set_forwarded_headers(headers: Dict[str, str]) -> None:
-    """Store headers to forward to outgoing LLM calls.
-    Filters to x-* prefixed headers only."""
+    """Record the set of headers to forward onto outbound LLM/provider calls
+    made later in this request context.
+
+    Only ``x-*`` prefixed headers are kept; everything else is dropped.
+    """
     filtered = {k.lower(): v for k, v in headers.items() if k.lower().startswith("x-")}
     _forwarded_headers.set(filtered)
 
 
 def get_forwarded_headers() -> Dict[str, str]:
-    """Get headers that should be forwarded to outgoing LLM calls."""
+    """Return the headers the application has asked to forward onto outbound
+    LLM/provider calls in the current request context."""
     return _forwarded_headers.get({})
 
 
@@ -60,14 +102,16 @@ def _find_event_hooks_target(client: Any) -> Optional[Any]:
 
 
 def install_httpx_hook(client: Any) -> None:
-    """Append an event hook to an httpx client that injects forwarded headers.
+    """Attach a request event hook to ``client``'s underlying httpx client so
+    that headers recorded via ``set_forwarded_headers`` are copied onto
+    outbound requests.
 
     Works with OpenAI and Anthropic Python SDKs (both wrap httpx internally,
     sometimes via several layers of ``._client`` indirection), as well as raw
     ``httpx.Client`` / ``httpx.AsyncClient`` instances.
 
-    For ``httpx.AsyncClient`` an async hook is installed (httpx awaits request
-    hooks on async clients); for sync clients a sync hook is installed.
+    For ``httpx.AsyncClient`` an async hook is attached (httpx awaits request
+    hooks on async clients); for sync clients a sync hook is attached.
 
     Idempotent: a marker attribute on the installed callable prevents double
     installation on the same target.
@@ -94,7 +138,7 @@ def install_httpx_hook(client: Any) -> None:
         if getattr(existing, _HOOK_MARKER, False):
             return
 
-    # Decide sync vs async hook flavor based on the target class.
+    # Choose sync vs async hook flavor based on the target class.
     # httpx.AsyncClient awaits request hooks; a sync hook returning None would
     # raise "TypeError: object NoneType can't be used in 'await' expression",
     # which surfaces as APIConnectionError to the caller.
@@ -134,8 +178,9 @@ def _is_async_httpx_target(target: Any) -> bool:
     match against ``"AsyncClient"``. Avoids a broad ``startswith("Async")``
     check, which would misclassify a sync client whose MRO happens to
     include an ``Async*``-named base (e.g. ``AsyncContextManager``) as
-    async — installing an async hook that httpx calls synchronously,
-    leaving the coroutine unawaited and headers silently dropped.
+    async — attaching an async hook that httpx calls synchronously would
+    leave the coroutine unawaited and the forwarded headers would not be
+    attached to the outbound request.
     """
     try:
         import httpx  # local import keeps httpx an optional concern at import time

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.91"
+version = "0.1.92"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"

--- a/sdk-python/tests/test_header_propagation.py
+++ b/sdk-python/tests/test_header_propagation.py
@@ -1,8 +1,11 @@
 """Tests for header propagation (x-* prefixed headers to outgoing LLM calls)."""
 
+import asyncio
 import contextvars
+import inspect
 import warnings
 
+import httpx
 import pytest
 
 from copilotkit.header_propagation import (
@@ -171,6 +174,250 @@ class TestInstallHttpxHook:
             install_httpx_hook(object())
             assert len(w) == 1
             assert "event_hooks" in str(w[0].message)
+
+
+class TestInstallHttpxHookNestedChain:
+    """install_httpx_hook walks the ``._client`` chain (modern OpenAI SDK shape)."""
+
+    def test_walks_chain_to_find_event_hooks(self):
+        """Modern OpenAI SDK: ChatOpenAI.client -> Resource -> openai.OpenAI
+        -> ._client = httpx wrapper (event_hooks here). The hook installer
+        must walk past intermediate ``._client`` hops that do NOT expose
+        event_hooks, and attach to the first one that does.
+        """
+
+        class HttpxWrapper:
+            def __init__(self):
+                self.event_hooks = {"request": []}
+
+        class OpenAIClient:
+            """Mirrors openai.OpenAI / openai.AsyncOpenAI: holds an httpx
+            wrapper at ``._client`` but exposes no event_hooks itself."""
+
+            def __init__(self):
+                self._client = HttpxWrapper()
+
+        class Resource:
+            """Mirrors openai resources (Completions, AsyncCompletions, etc):
+            holds the OpenAI client at ``._client``."""
+
+            def __init__(self):
+                self._client = OpenAIClient()
+
+        class LangChainWrapper:
+            """Mirrors langchain_openai.ChatOpenAI.client: the resource."""
+
+            def __init__(self):
+                self.client = Resource()
+
+        outer = LangChainWrapper()
+        install_httpx_hook(outer.client)
+
+        # The hook MUST land on the deepest object that has event_hooks
+        hooks = outer.client._client._client.event_hooks["request"]
+        assert len(hooks) == 1, (
+            f"expected hook installed on deepest httpx wrapper, got "
+            f"{len(hooks)} hook(s) (chain walk likely stopped too shallow)"
+        )
+
+    def test_idempotent_double_install(self):
+        """Calling install_httpx_hook twice must NOT register the hook twice."""
+
+        class FakeClient:
+            def __init__(self):
+                self.event_hooks = {"request": []}
+
+        client = FakeClient()
+        install_httpx_hook(client)
+        install_httpx_hook(client)
+        assert len(client.event_hooks["request"]) == 1, (
+            "install_httpx_hook must be idempotent — double install detected"
+        )
+
+    def test_header_agnostic_injection(self):
+        """Hook must forward whatever headers are in the ContextVar, not just x-aimock-*."""
+
+        class FakeRequest:
+            def __init__(self):
+                self.headers = {}
+
+        class FakeClient:
+            def __init__(self):
+                self.event_hooks = {"request": []}
+
+        client = FakeClient()
+        install_httpx_hook(client)
+
+        set_forwarded_headers(
+            {
+                "x-trace-id": "abc",
+                "x-team-id": "ck",
+                "x-anything-custom": "v",
+            }
+        )
+
+        request = FakeRequest()
+        client.event_hooks["request"][0](request)
+
+        assert request.headers["x-trace-id"] == "abc"
+        assert request.headers["x-team-id"] == "ck"
+        assert request.headers["x-anything-custom"] == "v"
+
+
+class TestInstallHttpxHookAsync:
+    """For httpx.AsyncClient instances the installed hook MUST be an
+    async callable; httpx awaits async-client request hooks."""
+
+    def test_async_client_gets_async_hook(self):
+        """httpx.AsyncClient -> the installed hook is a coroutine function."""
+
+        async def _run():
+            client = httpx.AsyncClient()
+            try:
+                install_httpx_hook(client)
+                hooks = client.event_hooks["request"]
+                assert len(hooks) == 1
+                hook = hooks[0]
+                assert inspect.iscoroutinefunction(hook), (
+                    f"AsyncClient must receive an async hook, got sync "
+                    f"callable {hook!r}"
+                )
+            finally:
+                await client.aclose()
+
+        asyncio.run(_run())
+
+    def test_async_hook_is_awaitable_and_injects_headers(self):
+        """Awaiting the installed async hook must inject forwarded headers."""
+
+        class FakeRequest:
+            def __init__(self):
+                self.headers = {}
+
+        async def _run():
+            client = httpx.AsyncClient()
+            try:
+                install_httpx_hook(client)
+                set_forwarded_headers({"x-aimock-strict": "true"})
+                hook = client.event_hooks["request"][0]
+                request = FakeRequest()
+                # Must be awaitable without TypeError
+                result = hook(request)
+                assert inspect.isawaitable(result), (
+                    "async-client hook must return an awaitable"
+                )
+                await result
+                assert request.headers["x-aimock-strict"] == "true"
+            finally:
+                await client.aclose()
+
+        asyncio.run(_run())
+
+    def test_sync_client_gets_sync_hook(self):
+        """httpx.Client -> the installed hook is a plain sync callable
+        (httpx calls request hooks synchronously on a sync client)."""
+        client = httpx.Client()
+        try:
+            install_httpx_hook(client)
+            hooks = client.event_hooks["request"]
+            assert len(hooks) == 1
+            hook = hooks[0]
+            assert not inspect.iscoroutinefunction(hook), (
+                f"sync Client must receive a sync hook, got coroutine function {hook!r}"
+            )
+        finally:
+            client.close()
+
+
+class TestInstallHttpxHookRegressions:
+    """Regression tests for chain-depth, async/sync MRO heuristic, and
+    foreign-hook preservation."""
+
+    def test_chain_depth_exhausted_warns(self):
+        """A ``._client`` chain LONGER than the walker's max depth where NO
+        node exposes event_hooks must emit a warning (loud-via-warning) and
+        not silently no-op."""
+
+        class ChainNode:
+            def __init__(self):
+                self._client: object | None = None  # filled in below
+
+        # Build a chain of depth well beyond _MAX_CHAIN_DEPTH (5 hops).
+        # 10 nodes total, none of which carries event_hooks.
+        nodes = [ChainNode() for _ in range(10)]
+        for i in range(len(nodes) - 1):
+            nodes[i]._client = nodes[i + 1]
+        # Terminate the chain at the last node with a non-None, non-event_hooks
+        # object so the walker doesn't short-circuit on None.
+        nodes[-1]._client = object()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            install_httpx_hook(nodes[0])
+            assert len(w) >= 1
+            assert any("event_hooks" in str(item.message) for item in w), (
+                f"expected a warning mentioning event_hooks, got {[str(i.message) for i in w]}"
+            )
+
+    def test_sync_client_with_async_named_mro_base_is_sync(self):
+        """A SYNC duck-typed client whose MRO includes a base class named
+        ``Async*`` (but whose own class name is neither ``AsyncClient`` nor
+        starts with ``Async``) must be classified as SYNC. An overbroad
+        ``startswith("Async")`` MRO heuristic would misclassify it as async
+        and install an async hook that httpx calls synchronously -> the
+        coroutine is never awaited and headers are silently dropped."""
+
+        class AsyncMixin:
+            """A base class whose NAME starts with ``Async`` but which does
+            not represent an async client (mirrors e.g. AsyncContextManager
+            appearing in MRO)."""
+
+            pass
+
+        class FakeSyncClient(AsyncMixin):
+            def __init__(self):
+                self.event_hooks = {"request": []}
+
+        client = FakeSyncClient()
+        install_httpx_hook(client)
+        hooks = client.event_hooks["request"]
+        assert len(hooks) == 1
+        hook = hooks[0]
+        assert not inspect.iscoroutinefunction(hook), (
+            f"sync duck-typed client (MRO contains Async*-named base) must "
+            f"receive a sync hook, got coroutine function {hook!r}"
+        )
+
+    def test_preexisting_foreign_hook_is_preserved(self):
+        """If event_hooks['request'] already contains an unrelated callable
+        (not carrying our idempotency marker), install_httpx_hook must
+        APPEND ours alongside it — not skip installation, not replace the
+        foreign hook."""
+
+        def foreign_hook(request):
+            # Unrelated pre-existing hook; carries no marker.
+            return None
+
+        class FakeClient:
+            def __init__(self):
+                self.event_hooks = {"request": [foreign_hook]}
+
+        client = FakeClient()
+        install_httpx_hook(client)
+
+        hooks = client.event_hooks["request"]
+        assert len(hooks) == 2, (
+            f"expected foreign hook + ours = 2 hooks, got {len(hooks)}: {hooks!r}"
+        )
+        # Foreign hook still present and unchanged.
+        assert foreign_hook in hooks
+        # Exactly one of the two hooks is ours (carries the marker).
+        from copilotkit.header_propagation import _HOOK_MARKER
+
+        marked = [h for h in hooks if getattr(h, _HOOK_MARKER, False)]
+        assert len(marked) == 1, (
+            f"expected exactly one hook to carry our marker, got {len(marked)}"
+        )
 
 
 class TestContextVarIsolation:

--- a/sdk-python/uv.lock
+++ b/sdk-python/uv.lock
@@ -5,7 +5,10 @@ requires-python = ">=3.11"
 [manifest]
 
 [manifest.dependency-groups]
-dev = [{ name = "pytest", specifier = ">=9.0.2,<10.0.0" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0,<2.0.0" },
+]
 
 [[package]]
 name = "colorama"
@@ -66,4 +69,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]


### PR DESCRIPTION
## Summary

Forwarded request headers (e.g. `X-AIMock-Context`, and `x-*` headers generally) were being dropped before reaching the wire in the Python SDK's httpx header-propagation hook. Two distinct bugs:

1. **Nested httpx client missed.** `install_httpx_hook` only attached the hook to the immediate client object, so when the real httpx client was nested one or more `._client` hops deep, the hook never reached the object carrying `event_hooks`. The hook now walks the `._client` chain (bounded depth) to find the correct target, and emits a warning rather than silently no-op'ing if no `event_hooks`-bearing target is found.

2. **Sync hook installed on an async client.** A sync `def` hook installed on an `httpx.AsyncClient` was invoked by httpx as a coroutine and never awaited — the header injection silently did nothing. The hook is now installed as `async def` for `AsyncClient` and sync `def` for `Client`. Async detection prefers `isinstance` against the real httpx classes and falls back to an **exact** `"AsyncClient"` MRO class-name match (deliberately not `startswith("Async")`, which would misclassify a sync client whose MRO includes an `Async*`-named base such as `AsyncContextManager`).

Bumps `copilotkit` to `v0.1.92`.

## Tests

New regression coverage in `tests/test_header_propagation.py` for the nested-chain walk, the async/sync hook selection (including the MRO-name edge case), chain-depth exhaustion warning, and preservation of pre-existing foreign hooks. Full file: 23 passed / 0 failed. Full SDK suite: 177 passed / 11 skipped / 0 failed. `pyright`: 0 errors on the changed files. `uv build` produces wheel + sdist cleanly.

## Test plan

- [x] `uv run pytest tests/test_header_propagation.py` — 23 passed
- [x] `uv run pytest -q` (full SDK suite) — 177 passed, 11 skipped
- [x] `uv run pyright copilotkit/header_propagation.py tests/test_header_propagation.py` — 0 errors
- [x] `uv build` — wheel + sdist produced
- [ ] Post-merge: publish `copilotkit==0.1.92`, bump showcase langgraph-python pins, rerun D6 integration tests for forwarded-header propagation