### PR TITLE
chore(showcase): bump copilotkit SDK pin to 0.1.92

### DIFF
--- a/showcase/integrations/langgraph-fastapi/requirements.txt
+++ b/showcase/integrations/langgraph-fastapi/requirements.txt
@@ -1,4 +1,4 @@
-copilotkit==0.1.91
+copilotkit==0.1.92
 langchain==1.2.15
 langchain-openai==1.1.9
 langchain-anthropic==1.4.1

--- a/showcase/integrations/langgraph-python/requirements.txt
+++ b/showcase/integrations/langgraph-python/requirements.txt
@@ -1,4 +1,4 @@
-copilotkit==0.1.91
+copilotkit==0.1.92
 langchain==1.2.15
 langchain-openai==1.1.9
 langchain-anthropic==1.4.1

--- a/showcase/integrations/strands/requirements.txt
+++ b/showcase/integrations/strands/requirements.txt
@@ -2,7 +2,7 @@ ag-ui-protocol==0.1.18
 ag_ui_strands==0.1.8
 strands-agents[OpenAI]==1.18.0
 strands-agents-tools==0.2.16
-copilotkit==0.1.91
+copilotkit==0.1.92
 langchain==1.2.15
 langchain-openai==1.1.9
 openai==1.109.1

--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the sorted, deduplicated `[FAIL] ...` lines from validate-pins.ts. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the per-package e2e-spec-count floor (single source of truth consumed by both the workflow and validate-parity.ts). NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
   "validatePinsFailCount": 106,
-  "validatePinsFailHash": "d340cdebe623177b957b62576821b51cde7f174b6b788040d67cc87e3d20b702",
+  "validatePinsFailHash": "4355457a222f8011c361da7a848d7361e897ee588ad0b8c6487b851fd0c23b77",
   "baselineDemoCount": 9
 }


### PR DESCRIPTION
## Summary

- Bumps `copilotkit==0.1.91` → `copilotkit==0.1.92` in the three showcase integrations that pin the Python SDK: `langgraph-python`, `langgraph-fastapi`, and `strands`.
- Picks up the `header_propagation` fix from #5088, so the runtime's `X-*` headers (notably `X-AIMock-Context`) propagate end-to-end through the Python SDK middleware. This unblocks D6 testing for `langgraph-python`.
- No lockfiles to regen — these are plain pip `requirements.txt` consumed directly by the integration Dockerfiles.

## Test plan

- [ ] **Gate on PyPI:** do not merge until `copilotkit==0.1.92` is confirmed live on PyPI (manual publish in progress). Merging early will break the showcase Docker builds on `pip install copilotkit==0.1.92`.
- [ ] After merge, showcase auto-deploys via the showcase path filter.
- [ ] Re-run `bin/showcase test langgraph-python --d6` and confirm `X-AIMock-Context` is observed end-to-end on the agent side.
- [ ] Spot-check `langgraph-fastapi` and `strands` deploys come up healthy with the new pin.