### PR TITLE
feat(showcase): multi-service deploy pipeline + runtime config

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -57,8 +57,9 @@ on:
 # whole point of the decoupling: rapid pushes to main no longer cancel
 # in-flight builds.
 
-# Top-level env intentionally empty: env IDs are sourced from the
-# showcase/scripts/railway-envs.ts SSOT by the redeploy-staging job.
+# Top-level env intentionally empty: env IDs are resolved inside
+# showcase/scripts/redeploy-env.ts from the showcase/scripts/railway-envs.ts
+# SSOT (and its emitted railway-envs.generated.json), not by this workflow.
 
 permissions:
   contents: read
@@ -175,12 +176,15 @@ jobs:
           FILTER_CHANGES: ${{ steps.filter.outputs.changes }}
         run: |
           # Full service config as JSON
-          # Fields: dispatch_name, filter_key, context, image, railway_id, timeout, lfs, build_args, build_args_sha, build_args_branch, dockerfile, health_path
-          # health_path: explicit endpoint the verify step probes. Required
-          # for every service — no fallback. An unscoped fallback could mask
-          # a broken endpoint when an unrelated catch-all/CDN/actuator happens
-          # to 200 at the other path. Misconfigured paths are a config bug to
-          # fix in the matrix, not runtime behavior to hide.
+          # Fields: dispatch_name, filter_key, context, image, railway_id, timeout, lfs, build_args, build_args_sha, build_args_branch, dockerfile, health_path, skip_build
+          # skip_build (optional, boolean): when true, the Docker build step
+          # is skipped for this slot (image is built out-of-band by another
+          # workflow/repo). Currently used by `webhooks` (built by the
+          # showcase-eval-webhook repo's own release workflow).
+          # health_path: historical field retained in the matrix for human
+          # reference. The actual verify probe is driven by per-service
+          # drivers in verify-deploy.ts (showcase/scripts/verify-deploy.ts),
+          # NOT by this field — it is informational only at this layer.
           ALL_SERVICES='[
             {"dispatch_name":"shell","filter_key":"shell","context":".","image":"showcase-shell","railway_id":"40eea0da-6071-4ea8-bdb9-39afb19225ec","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell/Dockerfile","health_path":"/"},
             {"dispatch_name":"langgraph-python","filter_key":"langgraph_python","context":"showcase/integrations/langgraph-python","image":"showcase-langgraph-python","railway_id":"90d03214-4569-41b0-b4c1-6438a8a7b203","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
@@ -330,6 +334,12 @@ jobs:
           BUILD_ARGS_SHA: ${{ matrix.service.build_args_sha }}
           BUILD_ARGS_BRANCH: ${{ matrix.service.build_args_branch }}
         run: |
+          # set -euo pipefail: without `-e`, a transient `$GITHUB_OUTPUT`
+          # write failure (disk pressure, ENOSPC) could silently produce
+          # empty build-args and we'd ship an image without COMMIT_SHA /
+          # BRANCH baked in — invisible drift between build label and
+          # what's actually running.
+          set -euo pipefail
           ARGS=""
           if [ -n "$BUILD_ARGS_SHA" ]; then
             ARGS="COMMIT_SHA=${BUILD_ARGS_SHA}"
@@ -522,20 +532,33 @@ jobs:
         id: changed
         env:
           MATRIX_JSON: ${{ needs.detect-changes.outputs.matrix }}
+          BUILD_RESULTS_JSON: ${{ needs.aggregate-build-results.outputs.results }}
         run: |
-          # detect-changes.outputs.matrix is a JSON array of objects, each with
-          # a dispatch_name field. We extract just those names into a CSV the
-          # redeploy-env.ts --services flag understands. resolveTargetServices()
-          # in the script accepts either SSOT keys OR dispatch_names.
+          # We feed the redeploy script with the INTERSECTION of:
+          #   (a) the scheduled build matrix (detect-changes.outputs.matrix —
+          #       JSON array of objects with `dispatch_name`), and
+          #   (b) the SUCCESS set from the aggregator
+          #       (aggregate-build-results.outputs.results — JSON array of
+          #       `{service: <dispatch_name>, status: success|failure|skipped}`;
+          #       the `service` field is the dispatch_name; shape defined in
+          #       showcase/scripts/lib/build-outputs.ts).
+          # Without this intersection a service whose Docker build FAILED
+          # would still be in the redeploy CSV, Railway would re-pull its
+          # stale `:latest`, and the verify workflow would report it as a
+          # fresh, healthy deploy — a false green. Skipped slots are also
+          # excluded (only `status == "success"` qualifies).
           set -euo pipefail
-          csv="$(echo "$MATRIX_JSON" | jq -r '[.[] | .dispatch_name] | join(",")')"
+          matrix_names="$(echo "$MATRIX_JSON" | jq -r '[.[] | .dispatch_name]')"
+          success_names="$(echo "$BUILD_RESULTS_JSON" | jq -r '[.[] | select(.status == "success") | .service]')"
+          csv="$(jq -rn --argjson m "$matrix_names" --argjson s "$success_names" \
+            '($m | map(select(. as $n | $s | index($n)))) | join(",")')"
           if [ -z "$csv" ]; then
-            echo "No services in matrix — skipping redeploy."
+            echo "No services in matrix ∩ success-set — skipping redeploy."
             echo "services=" >> "$GITHUB_OUTPUT"
           else
             echo "services=$csv" >> "$GITHUB_OUTPUT"
           fi
-          echo "Computed services CSV: $csv"
+          echo "Computed services CSV (matrix ∩ build-success): $csv"
       - name: Redeploy changed services in staging
         if: steps.changed.outputs.services != ''
         env:
@@ -576,7 +599,13 @@ jobs:
     if: >-
       ${{ !cancelled()
           && needs.detect-changes.outputs.has_changes == 'true'
+          && needs.build.result == 'failure'
           && needs.aggregate-build-results.outputs.any_success == 'false' }}
+    # The `needs.build.result == 'failure'` clause guards against the case
+    # where the build job itself was SKIPPED (e.g. verify-image-refs failed
+    # upstream, so the matrix never executed). Without it, the aggregator
+    # would still report `any_success=false` and we'd Slack-spam "all
+    # builds failed" even though builds never ran — a misleading alert.
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -599,7 +628,14 @@ jobs:
 
   notify:
     name: Notify on failure
-    needs: [build]
+    # Cover the whole build→aggregate→redeploy pipeline. `needs: [build]`
+    # alone meant a failure in aggregate-build-results or redeploy-staging
+    # produced ZERO Slack signal (verify just never ran). `if: failure()`
+    # already skips when none of the needs failed — so this still no-ops
+    # for the "no changes → build skipped" path, since skipped != failure.
+    # If `notify-all-builds-failed` also fires (genuine all-failed case),
+    # both alerts firing for the same event is acceptable per the alert SOP.
+    needs: [build, aggregate-build-results, redeploy-staging]
     if: failure()
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -203,8 +203,8 @@ jobs:
             {"dispatch_name":"claude-sdk-python","filter_key":"claude_sdk_python","context":"showcase/integrations/claude-sdk-python","image":"showcase-claude-sdk-python","railway_id":"b122ab65-9854-4cb2-a68e-b50ff13f7481","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"built-in-agent","filter_key":"built_in_agent","context":"showcase/integrations/built-in-agent","image":"showcase-built-in-agent","railway_id":"f4f8371a-bc46-45b2-b6d4-9c9af608bdbf","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},
-            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_ops_url":"https://showcase-harness-production.up.railway.app","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
-            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","build_args_base_url":"https://docs.copilotkit.ai","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_analytics":"yes","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
             {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/harness/Dockerfile","health_path":"/health"},
             {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","timeout":5,"lfs":false,"build_args":"","dockerfile":"showcase/aimock/Dockerfile","health_path":"/health"},
             {"dispatch_name":"webhooks","filter_key":"webhooks","context":".","image":"showcase-eval-webhook","railway_id":"ba6acc13-7585-41fe-a5ee-585b34a58fcd","timeout":5,"lfs":false,"build_args":"","dockerfile":"","health_path":"/health","skip_build":true}
@@ -329,46 +329,11 @@ jobs:
         env:
           BUILD_ARGS_SHA: ${{ matrix.service.build_args_sha }}
           BUILD_ARGS_BRANCH: ${{ matrix.service.build_args_branch }}
-          BUILD_ARGS_PB_URL: ${{ matrix.service.build_args_pb_url }}
-          BUILD_ARGS_BASE_URL: ${{ matrix.service.build_args_base_url }}
-          BUILD_ARGS_SHELL_URL: ${{ matrix.service.build_args_shell_url }}
-          BUILD_ARGS_OPS_URL: ${{ matrix.service.build_args_ops_url }}
-          BUILD_ARGS_ANALYTICS: ${{ matrix.service.build_args_analytics }}
-          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
-          NEXT_PUBLIC_REB2B_KEY: ${{ secrets.REB2B_KEY }}
-          NEXT_PUBLIC_SCARF_PIXEL_ID: ${{ secrets.SCARF_PIXEL_ID }}
-          NEXT_PUBLIC_REO_KEY: ${{ secrets.REO_PROJECT_KEY }}
-          NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID: ${{ secrets.GOOGLE_ANALYTICS_TRACKING_ID }}
         run: |
           ARGS=""
           if [ -n "$BUILD_ARGS_SHA" ]; then
             ARGS="COMMIT_SHA=${BUILD_ARGS_SHA}"
             ARGS="${ARGS}"$'\n'"BRANCH=${BUILD_ARGS_BRANCH}"
-          fi
-          if [ -n "$BUILD_ARGS_PB_URL" ]; then
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_POCKETBASE_URL=${BUILD_ARGS_PB_URL}"
-          fi
-          if [ -n "$BUILD_ARGS_BASE_URL" ]; then
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_BASE_URL=${BUILD_ARGS_BASE_URL}"
-          fi
-          if [ -n "$BUILD_ARGS_SHELL_URL" ]; then
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_SHELL_URL=${BUILD_ARGS_SHELL_URL}"
-          fi
-          if [ -n "$BUILD_ARGS_OPS_URL" ]; then
-            # OPS_BASE_URL is required at build time by shell-dashboard's
-            # next.config.ts rewrites() — without it `next build` aborts.
-            ARGS="${ARGS:+${ARGS}$'\n'}OPS_BASE_URL=${BUILD_ARGS_OPS_URL}"
-          fi
-          if [ "$BUILD_ARGS_ANALYTICS" = "yes" ]; then
-            # Client-side analytics keys for the shell-docs bundle.
-            # NEXT_PUBLIC_* values must reach `next build` so they get
-            # inlined into client JS chunks. Sourced from repo secrets;
-            # Railway runtime env doesn't reach this build step.
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}"
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_REB2B_KEY=${NEXT_PUBLIC_REB2B_KEY}"
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_SCARF_PIXEL_ID=${NEXT_PUBLIC_SCARF_PIXEL_ID}"
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_REO_KEY=${NEXT_PUBLIC_REO_KEY}"
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID=${NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID}"
           fi
           # Use delimiter to safely pass multiline value
           echo "args<<BUILDARGS_EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -416,6 +416,101 @@ jobs:
             ghcr.io/copilotkit/${{ matrix.service.image }}:${{ github.sha }}
           build-args: ${{ steps.build-args.outputs.args }}
 
+      - name: Write per-slot build result
+        if: always()
+        env:
+          SERVICE: ${{ matrix.service.dispatch_name }}
+          BUILD_STATUS: ${{ job.status }}
+        run: |
+          # job.status is one of: success, failure, cancelled. Normalize
+          # cancelled→skipped to match the BuildOutcome contract in
+          # showcase/scripts/lib/build-outputs.ts. We deliberately do NOT
+          # write to $GITHUB_OUTPUT — matrix-slot outputs are not
+          # aggregable across slots in GitHub Actions, so we publish the
+          # per-slot result as an artifact instead. The downstream
+          # aggregator job downloads every `build-result-*` artifact.
+          case "$BUILD_STATUS" in
+            success) STATUS=success ;;
+            failure) STATUS=failure ;;
+            *)       STATUS=skipped ;;
+          esac
+          mkdir -p "$RUNNER_TEMP/build-result"
+          printf '{"service":"%s","status":"%s"}\n' "$SERVICE" "$STATUS" \
+            > "$RUNNER_TEMP/build-result/result.json"
+
+      - name: Upload per-slot build-result artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          # Canonical per-slot name (see buildResultArtifactName in
+          # showcase/scripts/lib/build-outputs.ts). The aggregator
+          # downloads every artifact matching `build-result-*`.
+          name: build-result-${{ matrix.service.dispatch_name }}
+          path: ${{ runner.temp }}/build-result/result.json
+          if-no-files-found: error
+          retention-days: 7
+
+  aggregate-build-results:
+    name: Aggregate build results
+    needs: [detect-changes, build]
+    if: ${{ !cancelled() && needs.detect-changes.outputs.has_changes == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    outputs:
+      results: ${{ steps.collect.outputs.results }}
+      any_success: ${{ steps.collect.outputs.any_success }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+          cache: pnpm
+      - name: Install
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Download all per-slot build-result artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          # `pattern` matches every per-slot artifact emitted by the
+          # build matrix. `merge-multiple: false` keeps each artifact
+          # in its own subdirectory so we can iterate them deterministically.
+          pattern: build-result-*
+          path: ${{ runner.temp }}/build-results-in
+          merge-multiple: false
+
+      - name: Collect per-service build outcomes
+        id: collect
+        env:
+          INPUT_DIR: ${{ runner.temp }}/build-results-in
+          OUTPUT_DIR: ${{ runner.temp }}/build-results-out
+        run: |
+          set -euo pipefail
+          mkdir -p "$OUTPUT_DIR"
+          # Each per-slot artifact extracts to
+          #   $INPUT_DIR/build-result-<dispatch_name>/result.json
+          # The aggregator script (showcase/scripts/aggregate-build-results.ts)
+          # reads them, merges via the shared helper (mergeBuildResultFiles),
+          # writes $OUTPUT_DIR/results.json, and appends `results` +
+          # `any_success` to $GITHUB_OUTPUT. The contract (service +
+          # status enum) is enforced in one place (build-outputs.ts).
+          npx tsx showcase/scripts/aggregate-build-results.ts
+
+      - name: Upload aggregated build-results artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: build-results
+          path: ${{ runner.temp }}/build-results-out/results.json
+          if-no-files-found: error
+          retention-days: 7
+
   redeploy-staging:
     name: Trigger Railway staging redeploy
     needs: [detect-changes, build]

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -513,19 +513,24 @@ jobs:
 
   redeploy-staging:
     name: Trigger Railway staging redeploy
-    needs: [detect-changes, build]
+    needs: [detect-changes, build, aggregate-build-results]
     # Run if at least one service was in the matrix AND the build job
-    # was not outright cancelled or skipped. We tolerate per-slot build
-    # failures: redeploy what we did push (the script only redeploys
-    # requested services, and slots that failed to push will simply
-    # re-pull the previous :latest — which is a no-op). However, if the
-    # build job was SKIPPED entirely (e.g. the verify-image-refs prod
-    # digest-pin gate failed, blocking build), suppress the redeploy:
-    # nothing was pushed and there is no reason to redeploy staging.
-    # Partial build failures (fail-fast: false) still surface as
-    # needs.build.result == 'failure', so the intent of redeploying what
-    # did get pushed is preserved.
-    if: ${{ !cancelled() && needs.detect-changes.outputs.has_changes == 'true' && needs.build.result != 'skipped' && needs.build.result != 'cancelled' }}
+    # was not outright cancelled or skipped AND at least one slot
+    # succeeded (per aggregate-build-results.outputs.any_success). The
+    # any_success guard is the explicit "do not redeploy when nothing
+    # was pushed" check — without it, an all-failed build run would
+    # still kick a redeploy that just re-pulls the stale :latest and
+    # silently looks healthy. The skipped/cancelled checks on the build
+    # job still cover the "verify-image-refs gate blocked the build job
+    # entirely" path. Partial build failures (fail-fast: false) still
+    # surface as needs.build.result == 'failure' with any_success ==
+    # 'true', so redeploying what did get pushed is preserved.
+    if: >-
+      ${{ !cancelled()
+          && needs.detect-changes.outputs.has_changes == 'true'
+          && needs.build.result != 'skipped'
+          && needs.build.result != 'cancelled'
+          && needs.aggregate-build-results.outputs.any_success == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -565,6 +570,37 @@ jobs:
           # and writes per-service failures into $GITHUB_STEP_SUMMARY. The
           # verify-deploy workflow is the real release gate.
           npx tsx showcase/scripts/redeploy-env.ts staging --services "$SERVICES_CSV"
+
+  notify-all-builds-failed:
+    name: Notify all builds failed (staging unchanged)
+    needs: [detect-changes, build, aggregate-build-results]
+    # Explicit "everything failed; nothing redeployed" signal — distinct
+    # from the `notify:` job below which fires on any build-job failure
+    # (some slots may still have succeeded in that case). Both jobs can
+    # fire; that's intentional and matches the Slack alert SOP.
+    if: >-
+      ${{ !cancelled()
+          && needs.detect-changes.outputs.has_changes == 'true'
+          && needs.aggregate-build-results.outputs.any_success == 'false' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+    steps:
+      - name: Mark workflow red (no service succeeded)
+        run: |
+          echo "::error::All builds failed for this run; staging redeploy skipped; :latest unchanged."
+          exit 1
+      - name: Slack #oss-alerts
+        if: always() && env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            { "text": ${{ toJSON(format(':x: *Showcase: all builds failed*\nstaging unchanged (no redeploy)\nCommit: `{0}` by {1}\n<https://github.com/{2}/actions/runs/{3}|View run>', github.sha, github.actor, github.repository, github.run_id)) }} }
 
   notify:
     name: Notify on failure

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -541,11 +541,30 @@ jobs:
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           SERVICES_CSV: ${{ steps.changed.outputs.services }}
+          # Bridge the per-service redeploy summary to showcase_deploy.yml's
+          # `enforce-redeploy-gate` (consumed via the `redeploy-summary`
+          # artifact, extracted to `.redeploy/summary.json`). redeploy-env.ts
+          # writes this path atomically (.tmp → rename) but does NOT create
+          # parent dirs, so the step below mkdir's `.redeploy` first.
+          REDEPLOY_SUMMARY_JSON: .redeploy/summary.json
         run: |
           # Staging is non-blocking by design: the script always exits 0
           # and writes per-service failures into $GITHUB_STEP_SUMMARY. The
           # verify-deploy workflow is the real release gate.
+          mkdir -p .redeploy
           npx tsx showcase/scripts/redeploy-env.ts staging --services "$SERVICES_CSV"
+
+      - name: Upload redeploy summary
+        if: steps.changed.outputs.services != '' && hashFiles('.redeploy/summary.json') != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          # Artifact name MUST stay `redeploy-summary`: showcase_deploy.yml's
+          # `resolve-matrix` job downloads it by this exact name and reads
+          # `.redeploy/summary.json` inside.
+          name: redeploy-summary
+          path: .redeploy/summary.json
+          if-no-files-found: error
+          retention-days: 7
 
   notify-all-builds-failed:
     name: Notify all builds failed (staging unchanged)

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -609,6 +609,13 @@ jobs:
         # gating, and `if-no-files-found: error` on `always()` then trips
         # because summary.json was never written. So neither relaxation
         # alone opens a false-green window.
+        #
+        # However, swapping the guard to `if: always()` would ALSO red the
+        # legitimate `services == ''` (nothing-to-redeploy) path — no
+        # summary.json is written there either, so `if-no-files-found:
+        # error` would trip on every push that didn't redeploy anything.
+        # Net effect: trades the (already-closed) false-green risk for a
+        # false-red on every non-buildable push. Don't do it.
         if: steps.changed.outputs.services != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -579,17 +579,27 @@ jobs:
 
       - name: Upload redeploy summary
         # Upload is MANDATORY whenever a redeploy was attempted (services
-        # != ''). Do NOT additionally gate on hashFiles(): if redeploy-env.ts
-        # crashes before writing summary.json, the file is missing and we
-        # WANT this step to FAIL — failing here fails the redeploy-staging
-        # job → fails the build workflow → the deploy workflow's
-        # resolve-matrix.if (workflow_run.conclusion == 'success') blocks
-        # the deploy run from starting at all. That is the desired loud
-        # failure on the build side. If we additionally gated on
-        # hashFiles(), the upload would silently skip on crash, the deploy
-        # workflow would see "artifact absent" via check-redeploy-summary,
-        # treat it as "nothing redeployed", skip the gate, and ship a
-        # false-green — masking a real redeploy failure.
+        # != ''). Both failure modes red the build — no false-green path:
+        #
+        #   (A) HARD crash inside redeploy-env.ts BEFORE summary.json is
+        #       written. redeploy-env.ts writes the summary atomically
+        #       (.tmp → rename) AFTER the per-service loop completes, so
+        #       a crash leaves no file. The redeploy step itself exits
+        #       non-zero on that crash and fails the redeploy-staging
+        #       job; this upload step is then skipped entirely by
+        #       step-failure propagation. Build → red.
+        #
+        #   (B) redeploy step exits 0 but summary.json is absent (e.g. a
+        #       logic bug skipped the write). `if-no-files-found: error`
+        #       reds this step → reds the redeploy-staging job → reds the
+        #       build. The deploy workflow's resolve-matrix.if
+        #       (workflow_run.conclusion == 'success') then blocks the
+        #       deploy run from starting at all.
+        #
+        # Do NOT add hashFiles() guards here: that would silently skip
+        # the upload on (B), the deploy workflow would see "artifact
+        # absent" via check-redeploy-summary, treat it as "nothing
+        # redeployed", skip the gate, and ship a false-green.
         # The legitimate "services == '' → nothing redeployed → no upload"
         # path is preserved by the services != '' guard.
         if: steps.changed.outputs.services != ''

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -578,7 +578,21 @@ jobs:
           npx tsx showcase/scripts/redeploy-env.ts staging --services "$SERVICES_CSV"
 
       - name: Upload redeploy summary
-        if: steps.changed.outputs.services != '' && hashFiles('.redeploy/summary.json') != ''
+        # Upload is MANDATORY whenever a redeploy was attempted (services
+        # != ''). Do NOT additionally gate on hashFiles(): if redeploy-env.ts
+        # crashes before writing summary.json, the file is missing and we
+        # WANT this step to FAIL — failing here fails the redeploy-staging
+        # job → fails the build workflow → the deploy workflow's
+        # resolve-matrix.if (workflow_run.conclusion == 'success') blocks
+        # the deploy run from starting at all. That is the desired loud
+        # failure on the build side. If we additionally gated on
+        # hashFiles(), the upload would silently skip on crash, the deploy
+        # workflow would see "artifact absent" via check-redeploy-summary,
+        # treat it as "nothing redeployed", skip the gate, and ship a
+        # false-green — masking a real redeploy failure.
+        # The legitimate "services == '' → nothing redeployed → no upload"
+        # path is preserved by the services != '' guard.
+        if: steps.changed.outputs.services != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           # Artifact name MUST stay `redeploy-summary`: showcase_deploy.yml's

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -51,6 +51,7 @@ on:
           - shell-docs
           - showcase-harness
           - showcase-aimock
+          - webhooks
 
 # No top-level concurrency group. Every build run completes. This is the
 # whole point of the decoupling: rapid pushes to main no longer cancel
@@ -156,6 +157,14 @@ jobs:
               - 'showcase/integrations/*/manifest.yaml'
             showcase_aimock:
               - 'showcase/aimock/**'
+            webhooks:
+              # Sentinel pattern that cannot match any in-tree path.
+              # The webhooks GHCR image is built by the showcase-eval-webhook
+              # repo's own release workflow, so we never want a push-driven
+              # build run to include it. workflow_dispatch can still target
+              # webhooks explicitly via the service input — that path skips
+              # paths-filter entirely.
+              - 'showcase/__no_match_webhooks_built_out_of_band__'
 
       - name: Build service matrix
         id: build-matrix
@@ -197,7 +206,8 @@ jobs:
             {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_ops_url":"https://showcase-harness-production.up.railway.app","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
             {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","build_args_base_url":"https://docs.copilotkit.ai","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_analytics":"yes","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
             {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/harness/Dockerfile","health_path":"/health"},
-            {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","timeout":5,"lfs":false,"build_args":"","dockerfile":"showcase/aimock/Dockerfile","health_path":"/health"}
+            {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","timeout":5,"lfs":false,"build_args":"","dockerfile":"showcase/aimock/Dockerfile","health_path":"/health"},
+            {"dispatch_name":"webhooks","filter_key":"webhooks","context":".","image":"showcase-eval-webhook","railway_id":"ba6acc13-7585-41fe-a5ee-585b34a58fcd","timeout":5,"lfs":false,"build_args":"","dockerfile":"","health_path":"/health","skip_build":true}
           ]'
 
           DISPATCH="$DISPATCH_SERVICE"
@@ -401,6 +411,7 @@ jobs:
           done
 
       - name: Build and push
+        if: ${{ matrix.service.skip_build != true }}
         uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
         with:
           project: m2kw2wmmcp

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -56,8 +56,8 @@ on:
 # whole point of the decoupling: rapid pushes to main no longer cancel
 # in-flight builds.
 
-env:
-  RAILWAY_ENV_ID: "b14919f4-6417-429f-848d-c6ae2201e04f"
+# Top-level env intentionally empty: env IDs are sourced from the
+# showcase/scripts/railway-envs.ts SSOT by the redeploy-staging job.
 
 permissions:
   contents: read
@@ -416,33 +416,60 @@ jobs:
             ghcr.io/copilotkit/${{ matrix.service.image }}:${{ github.sha }}
           build-args: ${{ steps.build-args.outputs.args }}
 
-      - name: Trigger Railway redeploy
-        if: matrix.service.railway_id != ''
+  redeploy-staging:
+    name: Trigger Railway staging redeploy
+    needs: [detect-changes, build]
+    # Run if at least one service was in the matrix AND the build job
+    # was not outright cancelled or skipped. We tolerate per-slot build
+    # failures: redeploy what we did push (the script only redeploys
+    # requested services, and slots that failed to push will simply
+    # re-pull the previous :latest — which is a no-op). However, if the
+    # build job was SKIPPED entirely (e.g. the verify-image-refs prod
+    # digest-pin gate failed, blocking build), suppress the redeploy:
+    # nothing was pushed and there is no reason to redeploy staging.
+    # Partial build failures (fail-fast: false) still surface as
+    # needs.build.result == 'failure', so the intent of redeploying what
+    # did get pushed is preserved.
+    if: ${{ !cancelled() && needs.detect-changes.outputs.has_changes == 'true' && needs.build.result != 'skipped' && needs.build.result != 'cancelled' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+      - name: Compute changed-service list from build matrix
+        id: changed
+        env:
+          MATRIX_JSON: ${{ needs.detect-changes.outputs.matrix }}
+        run: |
+          # detect-changes.outputs.matrix is a JSON array of objects, each with
+          # a dispatch_name field. We extract just those names into a CSV the
+          # redeploy-env.ts --services flag understands. resolveTargetServices()
+          # in the script accepts either SSOT keys OR dispatch_names.
+          set -euo pipefail
+          csv="$(echo "$MATRIX_JSON" | jq -r '[.[] | .dispatch_name] | join(",")')"
+          if [ -z "$csv" ]; then
+            echo "No services in matrix — skipping redeploy."
+            echo "services=" >> "$GITHUB_OUTPUT"
+          else
+            echo "services=$csv" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Computed services CSV: $csv"
+      - name: Redeploy changed services in staging
+        if: steps.changed.outputs.services != ''
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          SERVICE_ID: ${{ matrix.service.railway_id }}
-          ENV_ID: ${{ env.RAILWAY_ENV_ID }}
+          SERVICES_CSV: ${{ steps.changed.outputs.services }}
         run: |
-          # Trigger Railway to pull the freshly-pushed :latest image.
-          # Not all services have environmentPatchCommit auto-update
-          # configured, so an explicit redeploy is the reliable path.
-          RESULT=$(curl -s --retry 2 --retry-all-errors --retry-delay 1 \
-            --fail-with-body \
-            -X POST "https://backboard.railway.com/graphql/v2" \
-            -H "Authorization: Bearer $RAILWAY_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{\"query\":\"mutation { serviceInstanceRedeploy(serviceId: \\\"$SERVICE_ID\\\", environmentId: \\\"$ENV_ID\\\") }\"}")
-          ERRORS=$(echo "$RESULT" | jq -r '.errors[]?.message // empty')
-          if [ -n "$ERRORS" ]; then
-            echo "::error::Railway redeploy failed for ${{ matrix.service.dispatch_name }}: $ERRORS"
-            exit 1
-          fi
-          OK=$(echo "$RESULT" | jq -r '.data.serviceInstanceRedeploy // false')
-          if [ "$OK" != "true" ]; then
-            echo "::error::Railway redeploy did not confirm success for ${{ matrix.service.dispatch_name }}: $RESULT"
-            exit 1
-          fi
-          echo "Railway redeploy triggered for ${{ matrix.service.dispatch_name }}"
+          # Staging is non-blocking by design: the script always exits 0
+          # and writes per-service failures into $GITHUB_STEP_SUMMARY. The
+          # verify-deploy workflow is the real release gate.
+          npx tsx showcase/scripts/redeploy-env.ts staging --services "$SERVICES_CSV"
 
   notify:
     name: Notify on failure

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -602,6 +602,13 @@ jobs:
         # redeployed", skip the gate, and ship a false-green.
         # The legitimate "services == '' → nothing redeployed → no upload"
         # path is preserved by the services != '' guard.
+        #
+        # If a future change ever switches this step to `if: always()`,
+        # `if-no-files-found: error` STILL reds path (A): the redeploy
+        # step's non-zero exit on a HARD crash is independent of upload
+        # gating, and `if-no-files-found: error` on `always()` then trips
+        # because summary.json was never written. So neither relaxation
+        # alone opens a false-green window.
         if: steps.changed.outputs.services != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/showcase_build_check.yml
+++ b/.github/workflows/showcase_build_check.yml
@@ -147,8 +147,8 @@ jobs:
             {"dispatch_name":"claude-sdk-python","filter_key":"claude_sdk_python","context":"showcase/integrations/claude-sdk-python","image":"showcase-claude-sdk-python","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
             {"dispatch_name":"built-in-agent","filter_key":"built_in_agent","context":"showcase/integrations/built-in-agent","image":"showcase-built-in-agent","timeout":15,"lfs":false,"build_args":"","dockerfile":""},
             {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile"},
-            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_ops_url":"https://showcase-harness-production.up.railway.app","dockerfile":"showcase/shell-dashboard/Dockerfile"},
-            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","build_args_base_url":"https://docs.copilotkit.ai","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_analytics":"yes","dockerfile":"showcase/shell-docs/Dockerfile"},
+            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell-dashboard/Dockerfile"},
+            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell-docs/Dockerfile"},
             {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/harness/Dockerfile"},
             {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","timeout":5,"lfs":false,"build_args":"","dockerfile":"showcase/aimock/Dockerfile"}
           ]'
@@ -203,35 +203,11 @@ jobs:
         env:
           BUILD_ARGS_SHA: ${{ matrix.service.build_args_sha }}
           BUILD_ARGS_BRANCH: ${{ matrix.service.build_args_branch }}
-          BUILD_ARGS_PB_URL: ${{ matrix.service.build_args_pb_url }}
-          BUILD_ARGS_BASE_URL: ${{ matrix.service.build_args_base_url }}
-          BUILD_ARGS_SHELL_URL: ${{ matrix.service.build_args_shell_url }}
-          BUILD_ARGS_OPS_URL: ${{ matrix.service.build_args_ops_url }}
-          BUILD_ARGS_ANALYTICS: ${{ matrix.service.build_args_analytics }}
         run: |
           ARGS=""
           if [ -n "$BUILD_ARGS_SHA" ]; then
             ARGS="COMMIT_SHA=${BUILD_ARGS_SHA}"
             ARGS="${ARGS}"$'\n'"BRANCH=${BUILD_ARGS_BRANCH}"
-          fi
-          if [ -n "$BUILD_ARGS_PB_URL" ]; then
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_POCKETBASE_URL=${BUILD_ARGS_PB_URL}"
-          fi
-          if [ -n "$BUILD_ARGS_BASE_URL" ]; then
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_BASE_URL=${BUILD_ARGS_BASE_URL}"
-          fi
-          if [ -n "$BUILD_ARGS_SHELL_URL" ]; then
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_SHELL_URL=${BUILD_ARGS_SHELL_URL}"
-          fi
-          if [ -n "$BUILD_ARGS_OPS_URL" ]; then
-            ARGS="${ARGS:+${ARGS}$'\n'}OPS_BASE_URL=${BUILD_ARGS_OPS_URL}"
-          fi
-          if [ "$BUILD_ARGS_ANALYTICS" = "yes" ]; then
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_POSTHOG_KEY=pr-build"
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_REB2B_KEY=pr-build"
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_SCARF_PIXEL_ID=pr-build"
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_REO_KEY=pr-build"
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID=G-PRBUILD"
           fi
           # Use delimiter to safely pass multiline value
           echo "args<<BUILDARGS_EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -154,13 +154,17 @@ jobs:
           # silently yields empty → redeploy_red=false AND ok_services=""
           # → resolve-verify-matrix skips verify on a real unverified
           # redeploy = green CI on a broken release. Refuse the ambiguity:
-          # if the file has entries but none carry an ok|error status,
-          # fail loud here so enforce-redeploy-gate reds the workflow
-          # (resolve-matrix.result == 'failure' fans into the gate).
+          # if the file has entries but ANY entry is missing a valid
+          # ok|error status (partial drift — some rows on the legacy schema,
+          # some on the new one), fail loud here so enforce-redeploy-gate
+          # reds the workflow (resolve-matrix.result == 'failure' fans into
+          # the gate). The previous TOTAL>0 && WITH_STATUS==0 check was
+          # all-or-nothing and silently dropped the drifted rows on a mixed
+          # summary.
           TOTAL=$(jq 'length' "$SUMMARY")
           WITH_STATUS=$(jq '[.[] | select(.status == "ok" or .status == "error")] | length' "$SUMMARY")
-          if [ "$TOTAL" -gt 0 ] && [ "$WITH_STATUS" -eq 0 ]; then
-            echo "::error::summary.json has $TOTAL entries but none with status ok|error (schema drift?)"
+          if [ "$TOTAL" -gt 0 ] && [ "$WITH_STATUS" -lt "$TOTAL" ]; then
+            echo "::error::summary.json shape drift: $WITH_STATUS of $TOTAL entries have status ok|error"
             exit 1
           fi
           # Per spec §3: the workflow MUST turn red on any staging
@@ -203,9 +207,10 @@ jobs:
         #       → intersect ok_services (SSOT key OR dispatchName aliases)
         #         with probe.staging-eligible SSOT services. has_services
         #         reflects CSV emptiness. When the intersection collapses
-        #         to empty (e.g. every ok service is non-probe-eligible),
-        #         verify is skipped and `enforce-redeploy-gate` reds the
-        #         workflow independently on redeploy_red=true.
+        #         to empty, verify is skipped; if there were per-service
+        #         errors, enforce-redeploy-gate reds the workflow — otherwise
+        #         the run is correctly green (every redeploy succeeded, just
+        #         none probe-eligible).
         run: npx tsx showcase/scripts/resolve-verify-matrix.ts
 
   verify:

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -1,14 +1,10 @@
 name: "Showcase: Verify Deploy"
 
-# Triggered after "Showcase: Build & Push" completes. This workflow verifies
-# that Railway deployed the new images and that each service is healthy.
-# The build workflow triggers Railway redeploys after pushing GHCR images;
-# this workflow only verifies the result.
-#
-# This workflow CAN use cancel-in-progress: true because verification is
-# idempotent. If a newer build completes while we're still verifying an
-# older one, the newer verification supersedes — the older images are
-# already stale.
+# Triggered after "Showcase: Build & Push" completes. Verifies that the
+# STAGING redeploy from the build workflow actually produced healthy
+# services. Push-to-main redeploys staging only (PR #5093). This workflow
+# is the staging gate; verify-deploy.ts is the parameterized probe driven
+# off showcase/scripts/railway-envs.ts (the SSOT).
 
 on:
   workflow_run:
@@ -18,45 +14,14 @@ on:
   workflow_dispatch:
     inputs:
       service:
-        description: "Service to verify"
+        description: "Service to verify (SSOT key or dispatch_name; 'all' = everything probe-eligible)"
         required: false
         default: "all"
-        type: choice
-        options:
-          - all
-          - shell
-          - langgraph-python
-          - mastra
-          - crewai-crews
-          - pydantic-ai
-          - google-adk
-          - ag2
-          - agno
-          - llamaindex
-          - langgraph-fastapi
-          - langgraph-typescript
-          - langroid
-          - spring-ai
-          - strands
-          - ms-agent-python
-          - claude-sdk-typescript
-          - ms-agent-dotnet
-          - ms-agent-harness-dotnet
-          - claude-sdk-python
-          - built-in-agent
-          - shell-dojo
-          - shell-dashboard
-          - shell-docs
-          - showcase-harness
-          - showcase-aimock
-          - webhooks
+        type: string
 
 concurrency:
   group: showcase-verify-deploy
   cancel-in-progress: true
-
-env:
-  RAILWAY_ENV_ID: "b14919f4-6417-429f-848d-c6ae2201e04f"
 
 permissions:
   contents: read
@@ -64,224 +29,161 @@ permissions:
 jobs:
   resolve-matrix:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     permissions:
       contents: read
       actions: read
-    # Only run verification when the build workflow succeeded.
-    # On workflow_dispatch, always run (workflow_run context is absent).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     outputs:
-      matrix: ${{ steps.build-matrix.outputs.matrix }}
-      has_services: ${{ steps.build-matrix.outputs.has_services }}
-      build_run_id: ${{ steps.build-matrix.outputs.build_run_id }}
-      build_run_url: ${{ steps.build-matrix.outputs.build_run_url }}
+      services_csv: ${{ steps.matrix.outputs.services_csv }}
+      has_services: ${{ steps.matrix.outputs.has_services }}
+      build_run_id: ${{ github.event.workflow_run.id }}
+      build_run_url: ${{ github.event.workflow_run.html_url }}
+      redeploy_red: ${{ steps.redeploy-gate.outputs.redeploy_red }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
 
-      - name: Build verification matrix
-        id: build-matrix
+      - name: Download redeploy summary from build workflow
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: redeploy-summary
+          path: .redeploy
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Gate on staging redeploy errors
+        id: redeploy-gate
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISPATCH_SERVICE: ${{ github.event.inputs.service }}
-          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
-          WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
-          REPO_FULL: ${{ github.repository }}
         run: |
-          # Service registry: same as showcase_build.yml but only the fields
-          # needed for verification (dispatch_name, railway_id, health_path).
-          ALL_SERVICES='[
-            {"dispatch_name":"shell","railway_id":"40eea0da-6071-4ea8-bdb9-39afb19225ec","health_path":"/"},
-            {"dispatch_name":"langgraph-python","railway_id":"90d03214-4569-41b0-b4c1-6438a8a7b203","health_path":"/api/health"},
-            {"dispatch_name":"mastra","railway_id":"d7979eb7-2405-4aab-ad21-438f4a1b08af","health_path":"/api/health"},
-            {"dispatch_name":"crewai-crews","railway_id":"0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4","health_path":"/api/health"},
-            {"dispatch_name":"pydantic-ai","railway_id":"0a106173-2282-4887-a994-0ca276a99d69","health_path":"/api/health"},
-            {"dispatch_name":"google-adk","railway_id":"87f60507-5a3d-4b8a-9e23-2b1de85d939c","health_path":"/api/health"},
-            {"dispatch_name":"ag2","railway_id":"4a37481b-f264-4eb7-a9cd-0a9ebb9ac05c","health_path":"/api/health"},
-            {"dispatch_name":"agno","railway_id":"32cab80b-e329-45bd-9c73-c4e1ddc94305","health_path":"/api/health"},
-            {"dispatch_name":"llamaindex","railway_id":"285386e8-492d-4cb8-b632-0a7d4607378f","health_path":"/api/health"},
-            {"dispatch_name":"langgraph-fastapi","railway_id":"06cccb5c-59f4-46b5-8adc-7113e77011a4","health_path":"/api/health"},
-            {"dispatch_name":"langgraph-typescript","railway_id":"66246d3b-a18e-46f0-be51-5f3ff7a36e5a","health_path":"/api/health"},
-            {"dispatch_name":"langroid","railway_id":"6dd9cb0a-66cc-46f1-972e-7cd74756157d","health_path":"/api/health"},
-            {"dispatch_name":"spring-ai","railway_id":"eed5d041-91be-4282-b414-beea00843401","health_path":"/api/health"},
-            {"dispatch_name":"strands","railway_id":"92e1cfad-ad53-403f-ab2b-5ab380832232","health_path":"/api/health"},
-            {"dispatch_name":"ms-agent-python","railway_id":"655db75a-af8d-427d-a4f9-441570ae5003","health_path":"/api/health"},
-            {"dispatch_name":"claude-sdk-typescript","railway_id":"18a98727-5700-44aa-b497-b60795dbbd6a","health_path":"/api/health"},
-            {"dispatch_name":"ms-agent-dotnet","railway_id":"beeb2dd6-87a4-4599-aa07-0578f7bd6519","health_path":"/api/health"},
-            {"dispatch_name":"ms-agent-harness-dotnet","railway_id":"6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37","health_path":"/api/health"},
-            {"dispatch_name":"claude-sdk-python","railway_id":"b122ab65-9854-4cb2-a68e-b50ff13f7481","health_path":"/api/health"},
-            {"dispatch_name":"built-in-agent","railway_id":"f4f8371a-bc46-45b2-b6d4-9c9af608bdbf","health_path":"/api/health"},
-            {"dispatch_name":"shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","health_path":"/"},
-            {"dispatch_name":"shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","health_path":"/"},
-            {"dispatch_name":"shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","health_path":"/"},
-            {"dispatch_name":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","health_path":"/health"},
-            {"dispatch_name":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","health_path":"/health"},
-            {"dispatch_name":"webhooks","railway_id":"ba6acc13-7585-41fe-a5ee-585b34a58fcd","health_path":"/health"}
-          ]'
-
-          DISPATCH="$DISPATCH_SERVICE"
-          BUILD_RUN_ID="$WORKFLOW_RUN_ID"
-          BUILD_RUN_URL="$WORKFLOW_RUN_URL"
-
-          if [ "$DISPATCH" = "all" ] || [ -z "$DISPATCH" ]; then
-            if [ -n "$BUILD_RUN_ID" ]; then
-              # Cross-workflow handoff: locate the `build-results` artifact
-              # produced by the aggregate-build-results job of the build
-              # run, download it, and derive the verification matrix from
-              # its structured JSON. No job-name parsing.
-              ART_ID=$(gh api \
-                "repos/${REPO_FULL}/actions/runs/${BUILD_RUN_ID}/artifacts" \
-                --paginate \
-                | jq -r '[.artifacts[] | select(.name == "build-results")][0].id // empty')
-              if [ -z "$ART_ID" ]; then
-                echo "::error::Build run ${BUILD_RUN_ID} did not publish a build-results artifact. Cannot derive the verification matrix without job-name parsing — fix the aggregate-build-results job in showcase_build.yml."
-                exit 1
-              fi
-              gh api -H 'Accept: application/vnd.github+json' \
-                "repos/${REPO_FULL}/actions/artifacts/${ART_ID}/zip" \
-                > /tmp/build-results.zip
-              unzip -p /tmp/build-results.zip results.json > /tmp/results.json
-              SUCCESS_LIST=$(jq -c '[.[] | select(.status == "success") | .service]' /tmp/results.json)
-              MATRIX=$(echo "$ALL_SERVICES" | jq -c --argjson built "$SUCCESS_LIST" '
-                [.[] | select(.dispatch_name as $dn | $built | index($dn) != null)]
-              ')
-            else
-              # workflow_dispatch with "all": no build run to filter by — verify every service.
-              MATRIX=$(echo "$ALL_SERVICES" | jq -c '.')
-            fi
+          set -euo pipefail
+          SUMMARY=".redeploy/summary.json"
+          if [ ! -f "$SUMMARY" ]; then
+            echo "No redeploy summary found (workflow_dispatch path or build did not upload). Skipping gate."
+            echo "redeploy_red=false" >> "$GITHUB_OUTPUT"
+            echo "ok_services=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Per spec §3: the workflow MUST turn red on any staging
+          # status:"error", while verify still runs against the success-set.
+          ERRORS=$(jq -c '[.[] | select(.status == "error")]' "$SUMMARY")
+          ERROR_COUNT=$(echo "$ERRORS" | jq 'length')
+          OK=$(jq -r '[.[] | select(.status == "ok") | .service] | join(",")' "$SUMMARY")
+          echo "ok_services=$OK" >> "$GITHUB_OUTPUT"
+          if [ "$ERROR_COUNT" -gt 0 ]; then
+            echo "::error::Staging redeploy reported $ERROR_COUNT per-service error(s):"
+            echo "$ERRORS" | jq -r '.[] | "  - \(.service): \(.error)"'
+            echo "redeploy_red=true" >> "$GITHUB_OUTPUT"
           else
-            # Specific service dispatch
-            MATRIX=$(echo "$ALL_SERVICES" | jq -c --arg svc "$DISPATCH" '[.[] | select(.dispatch_name == $svc)]')
+            echo "redeploy_red=false" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          if [ "$MATRIX" = "[]" ]; then
+      - name: Build verify matrix from SSOT
+        id: matrix
+        env:
+          DISPATCH_SERVICE: ${{ github.event.inputs.service }}
+          OK_FROM_REDEPLOY: ${{ steps.redeploy-gate.outputs.ok_services }}
+        run: |
+          set -euo pipefail
+          # The SSOT JSON is canonical for service identity, domain, and
+          # probe driver. The verify matrix is "every service where
+          # probe.staging===true, restricted to the success-set of the
+          # redeploy when present, restricted to --service when dispatched."
+          GENERATED="showcase/scripts/railway-envs.generated.json"
+          if [ ! -f "$GENERATED" ]; then
+            npx tsx showcase/scripts/emit-railway-envs-json.ts
+          fi
+          PROBE_ELIGIBLE=$(jq -r '.services[] | select(.probe.staging == true) | .name' "$GENERATED" | sort -u)
+          if [ -n "${OK_FROM_REDEPLOY:-}" ]; then
+            # Intersect with success-set (CSV may use dispatch_names; map to SSOT keys).
+            OK_KEYS=$(echo "$OK_FROM_REDEPLOY" | tr ',' '\n' | \
+              jq -R -s --slurpfile ssot <(jq -c '.services' "$GENERATED") '
+                split("\n") | map(select(length>0)) as $raw
+                | $ssot[0] as $svc
+                | $raw | map(. as $r | ($svc[] | select(.name == $r or .dispatchName == $r) | .name)) | unique
+              ' | jq -r '.[]')
+            PROBE_ELIGIBLE=$(comm -12 <(echo "$PROBE_ELIGIBLE") <(echo "$OK_KEYS" | sort -u))
+          fi
+          if [ "${DISPATCH_SERVICE:-all}" != "all" ] && [ -n "${DISPATCH_SERVICE:-}" ]; then
+            # Resolve dispatch input via SSOT (key or dispatchName).
+            RESOLVED=$(jq -r --arg s "$DISPATCH_SERVICE" '
+              .services[] | select(.name == $s or .dispatchName == $s) | .name
+            ' "$GENERATED" | head -n1)
+            if [ -z "$RESOLVED" ]; then
+              echo "::error::Unknown service '$DISPATCH_SERVICE' (not an SSOT key or dispatch_name)"
+              exit 1
+            fi
+            PROBE_ELIGIBLE="$RESOLVED"
+          fi
+          CSV=$(echo "$PROBE_ELIGIBLE" | tr '\n' ',' | sed 's/,$//')
+          echo "services_csv=$CSV" >> "$GITHUB_OUTPUT"
+          if [ -z "$CSV" ]; then
             echo "has_services=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_services=true" >> "$GITHUB_OUTPUT"
           fi
-          echo "build_run_id=${BUILD_RUN_ID}" >> "$GITHUB_OUTPUT"
-          echo "build_run_url=${BUILD_RUN_URL}" >> "$GITHUB_OUTPUT"
 
   verify:
     needs: [resolve-matrix]
     if: needs.resolve-matrix.outputs.has_services == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     environment: railway
     permissions:
       contents: read
       actions: read
-    strategy:
-      fail-fast: false
-      matrix:
-        service: ${{ fromJSON(needs.resolve-matrix.outputs.matrix) }}
-
     steps:
-      - name: Verify deploy health
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+
+      - name: Install
+        working-directory: showcase/scripts
+        run: npm ci
+
+      - name: Run verify-deploy --env staging
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          SERVICE_ID: ${{ matrix.service.railway_id }}
-          ENV_ID: ${{ env.RAILWAY_ENV_ID }}
+          SERVICES_CSV: ${{ needs.resolve-matrix.outputs.services_csv }}
         run: |
-          # Fail fast if RAILWAY_TOKEN is not set
           if [ -z "$RAILWAY_TOKEN" ]; then
             echo "::error::RAILWAY_TOKEN is not set"
             exit 1
           fi
+          npx tsx showcase/scripts/verify-deploy.ts --env staging --services "$SERVICES_CSV"
 
-          echo "Verifying Railway deploy for ${{ matrix.service.dispatch_name }}..."
-
-          # The build workflow triggers Railway redeploys after pushing
-          # GHCR images. We poll until the service is healthy. 600s
-          # budget accommodates JVM/slow-boot services.
-          # Require 2 consecutive healthy polls before declaring success.
-          HEALTHY_STREAK=0
-          REQUIRED_STREAK=2
-          START=$(date +%s)
-          BUDGET=600
-          i=0
-          while [ $(($(date +%s) - START)) -lt "$BUDGET" ]; do
-            i=$((i + 1))
-            RESULT=$(curl -s --retry 2 --retry-all-errors --retry-delay 1 \
-              --fail-with-body \
-              -H "Authorization: Bearer $RAILWAY_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d "{\"query\":\"query { deployments(first: 1, input: { serviceId: \\\"$SERVICE_ID\\\", environmentId: \\\"$ENV_ID\\\" }) { edges { node { id status staticUrl } } } }\"}" \
-              https://backboard.railway.app/graphql/v2 2>/dev/null)
-
-            # Surface GraphQL errors and fail fast
-            ERRORS=$(echo "$RESULT" | jq -r '.errors[]?.message // empty')
-            if [ -n "$ERRORS" ]; then
-              echo "::error::Railway API error: $ERRORS"
-              exit 1
-            fi
-
-            DEPLOY_ID=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.id // empty')
-            STATUS=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.status // empty')
-            DOMAIN=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.staticUrl // empty')
-            echo "Attempt $i: deploy=$DEPLOY_ID status=$STATUS domain=$DOMAIN streak=$HEALTHY_STREAK"
-
-            # Fail on any terminal failure status
-            case "$STATUS" in
-              CRASHED|FAILED|REMOVED|SKIPPED)
-                echo "::error::Service ${{ matrix.service.dispatch_name }} deploy status: $STATUS"
-                exit 1
-                ;;
-            esac
-
-            if [ "$STATUS" = "SUCCESS" ] && [ -n "$DOMAIN" ]; then
-              HEALTH_PATH="${{ matrix.service.health_path }}"
-              if [ -z "$HEALTH_PATH" ]; then
-                echo "::error::health_path not configured for service ${{ matrix.service.dispatch_name }}"
-                exit 1
-              fi
-              HEALTH_URL="https://${DOMAIN}${HEALTH_PATH}"
-              # Retry probe up to 3 times within this iteration before
-              # treating it as a genuine non-200
-              HTTP_CODE="000"
-              for probe_try in 1 2 3; do
-                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$HEALTH_URL" 2>/dev/null || echo "000")
-                if [ "$HTTP_CODE" = "200" ]; then
-                  break
-                fi
-                if [ "$probe_try" -lt 3 ]; then
-                  echo "HTTP check: $HEALTH_URL -> $HTTP_CODE (retry $probe_try/3)"
-                  sleep 2
-                fi
-              done
-              echo "HTTP check: $HEALTH_URL -> $HTTP_CODE"
-              # Fail fast on permanent client errors
-              case "$HTTP_CODE" in
-                404|410|501)
-                  echo "::error::Service ${{ matrix.service.dispatch_name }} health endpoint returned $HTTP_CODE at $HEALTH_URL"
-                  exit 1
-                  ;;
-              esac
-              if [ "$HTTP_CODE" = "200" ]; then
-                HEALTHY_STREAK=$((HEALTHY_STREAK + 1))
-                if [ "$HEALTHY_STREAK" -ge "$REQUIRED_STREAK" ]; then
-                  echo "Service healthy ($HEALTHY_STREAK consecutive 200s)"
-                  exit 0
-                fi
-              else
-                HEALTHY_STREAK=0
-              fi
-            else
-              HEALTHY_STREAK=0
-            fi
-
-            sleep 15
-          done
-          echo "::error::Service ${{ matrix.service.dispatch_name }} did not become healthy within 600s"
+  enforce-redeploy-gate:
+    # Spec §3: workflow turns red on any per-service redeploy error, even
+    # if verify against the success-set passes. This job is independent of
+    # verify so the user sees both signals (what was redeployed badly,
+    # what was redeployed and is unhealthy) rather than one masking the other.
+    needs: [resolve-matrix]
+    if: always() && needs.resolve-matrix.outputs.redeploy_red == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - name: Fail workflow on staging redeploy errors
+        run: |
+          echo "::error::One or more staging services reported status:error in the redeploy summary."
+          echo "See the resolve-matrix job's 'Gate on staging redeploy errors' step for details."
           exit 1
 
   notify-harness:
-    needs: [resolve-matrix, verify]
+    needs: [resolve-matrix, verify, enforce-redeploy-gate]
     if: always() && needs.resolve-matrix.outputs.has_services == 'true'
     permissions:
       contents: read
@@ -293,64 +195,28 @@ jobs:
         id: payload
         env:
           VERIFY_RESULT: ${{ needs.verify.result }}
-          MATRIX: ${{ needs.resolve-matrix.outputs.matrix }}
+          REDEPLOY_RESULT: ${{ needs.enforce-redeploy-gate.result }}
+          CSV: ${{ needs.resolve-matrix.outputs.services_csv }}
           BUILD_RUN_ID: ${{ needs.resolve-matrix.outputs.build_run_id }}
           BUILD_RUN_URL: ${{ needs.resolve-matrix.outputs.build_run_url }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_FULL: ${{ github.repository }}
         run: |
           set -euo pipefail
-
-          SERVICES=$(echo "$MATRIX" | jq -c '[.[].dispatch_name]' 2>/dev/null || echo '[]')
-          SERVICES=${SERVICES:-'[]'}
-
-          if [ "${VERIFY_RESULT}" = "cancelled" ]; then
-            FAILED='[]'
-            SUCCEEDED='[]'
-            CANCELLED=true
-          elif [ "${VERIFY_RESULT}" = "success" ]; then
-            FAILED='[]'
-            SUCCEEDED="$SERVICES"
-            CANCELLED=false
+          SERVICES=$(echo "$CSV" | jq -R 'split(",") | map(select(length>0))')
+          if [ "$VERIFY_RESULT" = "success" ] && [ "$REDEPLOY_RESULT" != "failure" ]; then
+            STATE="success"
+          elif [ "$VERIFY_RESULT" = "cancelled" ]; then
+            STATE="cancelled"
           else
-            # Partial failure: query per-job conclusions from the verify matrix
-            JOBS_JSON=$(gh api "repos/${REPO_FULL}/actions/runs/${RUN_ID}/jobs" --paginate 2>/dev/null \
-              | jq -cs '[.[].jobs[]?]' 2>/dev/null || echo '[]')
-            VERIFY_JOBS=$(echo "$JOBS_JSON" | jq -c '[.[] | select((.name // "") | startswith("verify"))]' 2>/dev/null || echo '[]')
-            FAILED=$(echo "$SERVICES" | jq -c --argjson jobs "$VERIFY_JOBS" '
-              [
-                .[] as $svc
-                | $jobs[]
-                | select((.name // "") as $n | ($n | contains($svc)))
-                | select(.conclusion == "failure")
-                | $svc
-              ] | unique
-            ' 2>/dev/null || echo "$SERVICES")
-            SUCCEEDED=$(echo "$SERVICES" | jq -c --argjson jobs "$VERIFY_JOBS" '
-              [
-                .[] as $svc
-                | $jobs[]
-                | select((.name // "") as $n | ($n | contains($svc)))
-                | select(.conclusion == "success")
-                | $svc
-              ] | unique
-            ' 2>/dev/null || echo '[]')
-            CANCELLED=false
+            STATE="failure"
           fi
           PAYLOAD=$(jq -cn \
-            --arg runId "$RUN_ID" \
-            --arg runUrl "$RUN_URL" \
-            --arg buildRunId "${BUILD_RUN_ID:-}" \
-            --arg buildRunUrl "${BUILD_RUN_URL:-}" \
-            --arg gateReason "" \
+            --arg runId "$RUN_ID" --arg runUrl "$RUN_URL" \
+            --arg buildRunId "${BUILD_RUN_ID:-}" --arg buildRunUrl "${BUILD_RUN_URL:-}" \
+            --arg state "$STATE" \
             --argjson services "$SERVICES" \
-            --argjson failed "$FAILED" \
-            --argjson succeeded "$SUCCEEDED" \
-            --argjson cancelled "$CANCELLED" \
-            --argjson gateSkipped false \
-            '{runId:$runId,runUrl:$runUrl,buildRunId:$buildRunId,buildRunUrl:$buildRunUrl,services:$services,failed:$failed,succeeded:$succeeded,cancelled:$cancelled,gateSkipped:$gateSkipped,gateReason:$gateReason}')
+            '{runId:$runId,runUrl:$runUrl,buildRunId:$buildRunId,buildRunUrl:$buildRunUrl,services:$services,state:$state}')
           {
             echo "payload<<EOF_PAYLOAD"
             echo "$PAYLOAD"
@@ -369,36 +235,12 @@ jobs:
             exit 0
           fi
           TS=$(date +%s)
-          METHOD="POST"
-          WEBHOOK_PATH="/webhooks/deploy"
           BODY_SHA=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hex | awk '{print $2}')
-          CANONICAL="${METHOD}|${WEBHOOK_PATH}|${TS}|${BODY_SHA}"
+          CANONICAL="POST|/webhooks/deploy|${TS}|${BODY_SHA}"
           SIG=$(printf '%s' "$CANONICAL" | openssl dgst -sha256 -hmac "$SHARED_SECRET" -hex | awk '{print $2}')
-          HTTP_CODE="000"
-          ATTEMPT=0
-          MAX_ATTEMPTS=3
-          while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
-            ATTEMPT=$((ATTEMPT + 1))
-            HTTP_CODE=$(curl -sS -o /tmp/body -w '%{http_code}' \
-              --connect-timeout 10 --max-time 30 \
-              --retry 2 --retry-all-errors --retry-delay 1 \
-              -X POST "${SHOWCASE_HARNESS_URL%/}${WEBHOOK_PATH}" \
-              -H 'content-type: application/json' \
-              -H "X-Ops-Timestamp: ${TS}" \
-              -H "X-Ops-Signature: sha256=${SIG}" \
-              --data-raw "$PAYLOAD" || echo "000")
-            echo "webhook attempt ${ATTEMPT}/${MAX_ATTEMPTS}: ${HTTP_CODE}"
-            if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "202" ]; then
-              cat /tmp/body || true
-              exit 0
-            fi
-            if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
-              SLEEP=$((ATTEMPT * 5))
-              echo "  retrying in ${SLEEP}s..."
-              sleep "$SLEEP"
-            fi
-          done
-          echo "webhook response body (last attempt):"
-          cat /tmp/body || true
-          echo "::error::showcase-harness webhook returned ${HTTP_CODE} after ${MAX_ATTEMPTS} attempts"
-          exit 1
+          curl -sS --fail-with-body \
+            -X POST "${SHOWCASE_HARNESS_URL%/}/webhooks/deploy" \
+            -H 'content-type: application/json' \
+            -H "X-Ops-Timestamp: ${TS}" \
+            -H "X-Ops-Signature: sha256=${SIG}" \
+            --data-raw "$PAYLOAD"

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -49,6 +49,7 @@ on:
           - shell-docs
           - showcase-harness
           - showcase-aimock
+          - webhooks
 
 concurrency:
   group: showcase-verify-deploy
@@ -118,7 +119,8 @@ jobs:
             {"dispatch_name":"shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","health_path":"/"},
             {"dispatch_name":"shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","health_path":"/"},
             {"dispatch_name":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","health_path":"/health"},
-            {"dispatch_name":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","health_path":"/health"}
+            {"dispatch_name":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","health_path":"/health"},
+            {"dispatch_name":"webhooks","railway_id":"ba6acc13-7585-41fe-a5ee-585b34a58fcd","health_path":"/health"}
           ]'
 
           DISPATCH="$DISPATCH_SERVICE"

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -2,9 +2,9 @@ name: "Showcase: Verify Deploy"
 
 # Triggered after "Showcase: Build & Push" completes. Verifies that the
 # STAGING redeploy from the build workflow actually produced healthy
-# services. Push-to-main redeploys staging only (PR #5093). This workflow
-# is the staging gate; verify-deploy.ts is the parameterized probe driven
-# off showcase/scripts/railway-envs.ts (the SSOT).
+# services. Push-to-main redeploys staging only. This workflow is the
+# staging gate; verify-deploy.ts is the parameterized probe driven off
+# showcase/scripts/railway-envs.ts (the SSOT).
 
 on:
   workflow_run:
@@ -51,6 +51,15 @@ jobs:
           node-version: 22.x
 
       - name: Download redeploy summary from build workflow
+        # Guarded to the workflow_run path; on workflow_dispatch the
+        # download is skipped and the bash `[ ! -f "$SUMMARY" ]` branch
+        # below handles the legitimate "no summary present" case.
+        # We intentionally do NOT use `continue-on-error: true` here:
+        # swallowing a genuine workflow_run artifact-download failure
+        # would land us in the same "no summary" branch, where the gate
+        # opens (`redeploy_red=false`, `ok_services=""`) and verify falls
+        # back to probing the FULL service set against stale `:latest` —
+        # masking a broken redeploy as a green deploy. Fail loud instead.
         if: github.event_name == 'workflow_run'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -58,7 +67,6 @@ jobs:
           path: .redeploy
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
 
       - name: Gate on staging redeploy errors
         id: redeploy-gate
@@ -170,7 +178,12 @@ jobs:
     # verify so the user sees both signals (what was redeployed badly,
     # what was redeployed and is unhealthy) rather than one masking the other.
     needs: [resolve-matrix]
-    if: always() && needs.resolve-matrix.outputs.redeploy_red == 'true'
+    # Trip the gate on EITHER a per-service redeploy error OR a complete
+    # resolve-matrix failure. A resolve-matrix failure leaves the
+    # `redeploy_red` output empty (jobs that fail mid-step don't publish
+    # outputs reliably), which would otherwise let an upstream crash slip
+    # past as "not red" — a silent bypass of the gate.
+    if: always() && (needs.resolve-matrix.outputs.redeploy_red == 'true' || needs.resolve-matrix.result == 'failure')
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -171,70 +171,24 @@ jobs:
           OK_FROM_REDEPLOY: ${{ steps.redeploy-gate.outputs.ok_services }}
           EVENT_NAME: ${{ github.event_name }}
           SUMMARY_PRESENT: ${{ steps.check-redeploy-summary.outputs.summary_present }}
-        run: |
-          set -euo pipefail
-          # The SSOT JSON is canonical for service identity, domain, and
-          # probe driver. The verify matrix is "every service where
-          # probe.staging===true, restricted to the success-set of the
-          # redeploy when present, restricted to --service when dispatched."
-          #
-          # Empty-OK_FROM_REDEPLOY has TWO distinct causes and we must
-          # NOT collapse them:
-          #   (1) workflow_run + summary artifact ABSENT — the upstream
-          #       build legitimately redeployed nothing (no buildable
-          #       service changed). There is nothing to verify; skip the
-          #       matrix entirely so `verify` doesn't probe the whole
-          #       staging fleet for a push that deployed nothing (which
-          #       would false-red the deploy workflow if any unrelated
-          #       staging service happens to be unhealthy at probe time).
-          #   (2) workflow_dispatch — manual verify-the-fleet (or a
-          #       specific --service). The fall-through below intentionally
-          #       resolves to the full probe-eligible set or the chosen
-          #       service.
-          # The workflow_run+summary-PRESENT+all-errors case is handled
-          # elsewhere: `redeploy-gate` sets redeploy_red=true and
-          # `enforce-redeploy-gate` trips RED. The empty intersection
-          # here in that case still produces has_services=false, which
-          # is fine — the gate job is what reds the workflow.
-          if [ "${EVENT_NAME:-}" = "workflow_run" ] && [ "${SUMMARY_PRESENT:-}" = "false" ]; then
-            echo "workflow_run with no redeploy-summary artifact — nothing was redeployed; skipping verify."
-            echo "services_csv=" >> "$GITHUB_OUTPUT"
-            echo "has_services=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          GENERATED="showcase/scripts/railway-envs.generated.json"
-          if [ ! -f "$GENERATED" ]; then
-            npx tsx showcase/scripts/emit-railway-envs-json.ts
-          fi
-          PROBE_ELIGIBLE=$(jq -r '.services[] | select(.probe.staging == true) | .name' "$GENERATED" | sort -u)
-          if [ -n "${OK_FROM_REDEPLOY:-}" ]; then
-            # Intersect with success-set (CSV may use dispatch_names; map to SSOT keys).
-            OK_KEYS=$(echo "$OK_FROM_REDEPLOY" | tr ',' '\n' | \
-              jq -R -s --slurpfile ssot <(jq -c '.services' "$GENERATED") '
-                split("\n") | map(select(length>0)) as $raw
-                | $ssot[0] as $svc
-                | $raw | map(. as $r | ($svc[] | select(.name == $r or .dispatchName == $r) | .name)) | unique
-              ' | jq -r '.[]')
-            PROBE_ELIGIBLE=$(comm -12 <(echo "$PROBE_ELIGIBLE") <(echo "$OK_KEYS" | sort -u))
-          fi
-          if [ "${DISPATCH_SERVICE:-all}" != "all" ] && [ -n "${DISPATCH_SERVICE:-}" ]; then
-            # Resolve dispatch input via SSOT (key or dispatchName).
-            RESOLVED=$(jq -r --arg s "$DISPATCH_SERVICE" '
-              .services[] | select(.name == $s or .dispatchName == $s) | .name
-            ' "$GENERATED" | head -n1)
-            if [ -z "$RESOLVED" ]; then
-              echo "::error::Unknown service '$DISPATCH_SERVICE' (not an SSOT key or dispatch_name)"
-              exit 1
-            fi
-            PROBE_ELIGIBLE="$RESOLVED"
-          fi
-          CSV=$(echo "$PROBE_ELIGIBLE" | tr '\n' ',' | sed 's/,$//')
-          echo "services_csv=$CSV" >> "$GITHUB_OUTPUT"
-          if [ -z "$CSV" ]; then
-            echo "has_services=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_services=true" >> "$GITHUB_OUTPUT"
-          fi
+        # The decision-table that picks the verify matrix lives in
+        # showcase/scripts/resolve-verify-matrix.ts (pure function +
+        # unit tests). Summary of cases:
+        #   - workflow_dispatch + 'all'/empty  → full probe-eligible set.
+        #   - workflow_dispatch + specific svc → just that service
+        #                                        (unknown name → error exit).
+        #   - workflow_run + summary_present=false → has_services=false
+        #                                            (build redeployed nothing).
+        #   - workflow_run + summary_present=true + ok empty
+        #       → has_services=false. Every service errored on redeploy;
+        #         the success-set is empty so there is nothing to verify.
+        #         `enforce-redeploy-gate` independently reds the workflow
+        #         on redeploy_red=true, so this case is already loud.
+        #   - workflow_run + summary_present=true + ok non-empty
+        #       → intersect ok_services (SSOT key OR dispatchName aliases)
+        #         with probe.staging-eligible SSOT services. has_services
+        #         reflects CSV emptiness.
+        run: npx tsx showcase/scripts/resolve-verify-matrix.ts
 
   verify:
     needs: [resolve-matrix]

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -50,17 +50,60 @@ jobs:
         with:
           node-version: 22.x
 
-      - name: Download redeploy summary from build workflow
-        # Guarded to the workflow_run path; on workflow_dispatch the
-        # download is skipped and the bash `[ ! -f "$SUMMARY" ]` branch
-        # below handles the legitimate "no summary present" case.
-        # We intentionally do NOT use `continue-on-error: true` here:
-        # swallowing a genuine workflow_run artifact-download failure
-        # would land us in the same "no summary" branch, where the gate
-        # opens (`redeploy_red=false`, `ok_services=""`) and verify falls
-        # back to probing the FULL service set against stale `:latest` —
-        # masking a broken redeploy as a green deploy. Fail loud instead.
+      - name: Check whether build uploaded a redeploy-summary artifact
+        id: check-redeploy-summary
+        # `actions/download-artifact@v4` with a `name:` HARD-FAILS when the
+        # named artifact does not exist. The artifact legitimately does
+        # NOT exist whenever the upstream build ran but redeployed nothing
+        # — e.g. a push touching `showcase/**` that fires the build's
+        # `paths:` filter, but `detect-changes` finds no buildable service
+        # changed, so `redeploy-staging` is skipped and never uploads.
+        # The build still concludes `success`, so this workflow fires on
+        # `workflow_run` and `resolve-matrix` runs. Without this pre-check
+        # the unguarded download would fail the job and (via
+        # `enforce-redeploy-gate` tripping on `result == 'failure'`) flip
+        # the whole deploy workflow RED — a false-red on a routine
+        # showcase-docs/script-only change. Listing artifacts via the API
+        # only requires `actions: read`, which `resolve-matrix` already has.
         if: github.event_name == 'workflow_run'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const runId = context.payload.workflow_run.id;
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+              per_page: 100,
+            });
+            const present = (data.artifacts || []).some(
+              (a) => a.name === "redeploy-summary",
+            );
+            core.setOutput("summary_present", present ? "true" : "false");
+            core.info(`redeploy-summary present for run ${runId}: ${present}`);
+
+      - name: Download redeploy summary from build workflow
+        # Three cases now handled distinctly:
+        #   (a) workflow_dispatch — no `workflow_run` payload exists; the
+        #       download is skipped and the bash `[ ! -f "$SUMMARY" ]`
+        #       branch below treats it as "nothing to gate" (correct: a
+        #       manual dispatch is not gated by a build's per-service set).
+        #   (b) workflow_run + artifact absent — the upstream build
+        #       redeployed nothing (e.g. no service had buildable
+        #       changes); the precheck reports `summary_present=false`,
+        #       the download is skipped, and the bash branch no-ops the
+        #       gate. The deploy workflow should NOT red here — there is
+        #       nothing to gate.
+        #   (c) workflow_run + artifact PRESENT — we always attempt the
+        #       download. We intentionally do NOT set
+        #       `continue-on-error: true`: if the artifact exists but the
+        #       download genuinely fails (network/permission), silently
+        #       opening the gate would let verify probe the FULL service
+        #       set against stale `:latest` and mask a broken redeploy as
+        #       a green deploy. Fail loud instead.
+        if: >-
+          github.event_name == 'workflow_run' &&
+          steps.check-redeploy-summary.outputs.summary_present == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: redeploy-summary

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -202,7 +202,7 @@ jobs:
               -H "Authorization: Bearer $RAILWAY_TOKEN" \
               -H "Content-Type: application/json" \
               -d "{\"query\":\"query { deployments(first: 1, input: { serviceId: \\\"$SERVICE_ID\\\", environmentId: \\\"$ENV_ID\\\" }) { edges { node { id status staticUrl } } } }\"}" \
-              https://backboard.railway.com/graphql/v2 2>/dev/null)
+              https://backboard.railway.app/graphql/v2 2>/dev/null)
 
             # Surface GraphQL errors and fail fast
             ERRORS=$(echo "$RESULT" | jq -r '.errors[]?.message // empty')

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -69,16 +69,42 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
+            // Fail loud on API error: github-script propagates unhandled
+            // rejections, which fails this step and (via the
+            // resolve-matrix.result == 'failure' clause on
+            // enforce-redeploy-gate) reds the workflow. Do NOT wrap this
+            // in try/catch — silently defaulting summary_present=false on
+            // a 5xx/403 would open the gate (skip verify) on what is
+            // actually a transient API failure, hiding a broken pipeline.
+            //
+            // Use the `name` query-param on listWorkflowRunArtifacts to
+            // ask the API to return only the redeploy-summary artifact.
+            // This makes the lookup robust to the build run uploading
+            // many artifacts (per-slot build-result-* + build-results +
+            // redeploy-summary — already ~28 today, well within per_page
+            // 100, but a future expansion past 100 would otherwise risk a
+            // false "absent" if redeploy-summary fell off the first page).
+            // The endpoint accepts `name` for an exact-match filter; we
+            // still paginate defensively in case the API returns multiple
+            // rows (e.g. an artifact with the same name re-uploaded).
             const runId = context.payload.workflow_run.id;
-            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: runId,
-              per_page: 100,
-            });
-            const present = (data.artifacts || []).some(
-              (a) => a.name === "redeploy-summary",
+            const iterator = github.paginate.iterator(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                name: "redeploy-summary",
+                per_page: 100,
+              },
             );
+            let present = false;
+            for await (const page of iterator) {
+              if ((page.data || []).some((a) => a.name === "redeploy-summary")) {
+                present = true;
+                break;
+              }
+            }
             core.setOutput("summary_present", present ? "true" : "false");
             core.info(`redeploy-summary present for run ${runId}: ${present}`);
 
@@ -143,12 +169,39 @@ jobs:
         env:
           DISPATCH_SERVICE: ${{ github.event.inputs.service }}
           OK_FROM_REDEPLOY: ${{ steps.redeploy-gate.outputs.ok_services }}
+          EVENT_NAME: ${{ github.event_name }}
+          SUMMARY_PRESENT: ${{ steps.check-redeploy-summary.outputs.summary_present }}
         run: |
           set -euo pipefail
           # The SSOT JSON is canonical for service identity, domain, and
           # probe driver. The verify matrix is "every service where
           # probe.staging===true, restricted to the success-set of the
           # redeploy when present, restricted to --service when dispatched."
+          #
+          # Empty-OK_FROM_REDEPLOY has TWO distinct causes and we must
+          # NOT collapse them:
+          #   (1) workflow_run + summary artifact ABSENT — the upstream
+          #       build legitimately redeployed nothing (no buildable
+          #       service changed). There is nothing to verify; skip the
+          #       matrix entirely so `verify` doesn't probe the whole
+          #       staging fleet for a push that deployed nothing (which
+          #       would false-red the deploy workflow if any unrelated
+          #       staging service happens to be unhealthy at probe time).
+          #   (2) workflow_dispatch — manual verify-the-fleet (or a
+          #       specific --service). The fall-through below intentionally
+          #       resolves to the full probe-eligible set or the chosen
+          #       service.
+          # The workflow_run+summary-PRESENT+all-errors case is handled
+          # elsewhere: `redeploy-gate` sets redeploy_red=true and
+          # `enforce-redeploy-gate` trips RED. The empty intersection
+          # here in that case still produces has_services=false, which
+          # is fine — the gate job is what reds the workflow.
+          if [ "${EVENT_NAME:-}" = "workflow_run" ] && [ "${SUMMARY_PRESENT:-}" = "false" ]; then
+            echo "workflow_run with no redeploy-summary artifact — nothing was redeployed; skipping verify."
+            echo "services_csv=" >> "$GITHUB_OUTPUT"
+            echo "has_services=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           GENERATED="showcase/scripts/railway-envs.generated.json"
           if [ ! -f "$GENERATED" ]; then
             npx tsx showcase/scripts/emit-railway-envs-json.ts

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -127,20 +127,28 @@ jobs:
 
           if [ "$DISPATCH" = "all" ] || [ -z "$DISPATCH" ]; then
             if [ -n "$BUILD_RUN_ID" ]; then
-              # workflow_run trigger: discover which services the build
-              # workflow actually built by inspecting its matrix job names.
-              # Job names follow "build (<dispatch_name>, ...)" pattern.
-              JOBS_JSON=$(gh api "repos/${REPO_FULL}/actions/runs/${BUILD_RUN_ID}/jobs" --paginate 2>/dev/null \
-                | jq -cs '[.[].jobs[]?]' 2>/dev/null || echo '[]')
-              BUILD_JOBS=$(echo "$JOBS_JSON" | jq -c '[.[] | select((.name // "") | startswith("build"))]')
-              # Extract dispatch_names from successful build job names
-              BUILT_SERVICES=$(echo "$BUILD_JOBS" | jq -c '[.[] | select(.conclusion == "success") | .name | capture("^build \\((?<svc>[^,)]+)") | .svc]')
-              # Filter ALL_SERVICES to only those that were actually built
-              MATRIX=$(echo "$ALL_SERVICES" | jq -c --argjson built "$BUILT_SERVICES" '
+              # Cross-workflow handoff: locate the `build-results` artifact
+              # produced by the aggregate-build-results job of the build
+              # run, download it, and derive the verification matrix from
+              # its structured JSON. No job-name parsing.
+              ART_ID=$(gh api \
+                "repos/${REPO_FULL}/actions/runs/${BUILD_RUN_ID}/artifacts" \
+                --paginate \
+                | jq -r '[.artifacts[] | select(.name == "build-results")][0].id // empty')
+              if [ -z "$ART_ID" ]; then
+                echo "::error::Build run ${BUILD_RUN_ID} did not publish a build-results artifact. Cannot derive the verification matrix without job-name parsing — fix the aggregate-build-results job in showcase_build.yml."
+                exit 1
+              fi
+              gh api -H 'Accept: application/vnd.github+json' \
+                "repos/${REPO_FULL}/actions/artifacts/${ART_ID}/zip" \
+                > /tmp/build-results.zip
+              unzip -p /tmp/build-results.zip results.json > /tmp/results.json
+              SUCCESS_LIST=$(jq -c '[.[] | select(.status == "success") | .service]' /tmp/results.json)
+              MATRIX=$(echo "$ALL_SERVICES" | jq -c --argjson built "$SUCCESS_LIST" '
                 [.[] | select(.dispatch_name as $dn | $built | index($dn) != null)]
               ')
             else
-              # workflow_dispatch with "all": verify every service
+              # workflow_dispatch with "all": no build run to filter by — verify every service.
               MATRIX=$(echo "$ALL_SERVICES" | jq -c '.')
             fi
           else

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -139,8 +139,6 @@ jobs:
 
       - name: Gate on staging redeploy errors
         id: redeploy-gate
-        env:
-          DISPATCH_SERVICE: ${{ github.event.inputs.service }}
         run: |
           set -euo pipefail
           SUMMARY=".redeploy/summary.json"
@@ -149,6 +147,21 @@ jobs:
             echo "redeploy_red=false" >> "$GITHUB_OUTPUT"
             echo "ok_services=" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+          # Shape guard: redeploy-env.ts writes per-entry `status` of
+          # exactly "ok" or "error". If the schema ever drifts (e.g.
+          # `status`→`state`, `ok`→`success`) every `select(.status==...)`
+          # silently yields empty → redeploy_red=false AND ok_services=""
+          # → resolve-verify-matrix skips verify on a real unverified
+          # redeploy = green CI on a broken release. Refuse the ambiguity:
+          # if the file has entries but none carry an ok|error status,
+          # fail loud here so enforce-redeploy-gate reds the workflow
+          # (resolve-matrix.result == 'failure' fans into the gate).
+          TOTAL=$(jq 'length' "$SUMMARY")
+          WITH_STATUS=$(jq '[.[] | select(.status == "ok" or .status == "error")] | length' "$SUMMARY")
+          if [ "$TOTAL" -gt 0 ] && [ "$WITH_STATUS" -eq 0 ]; then
+            echo "::error::summary.json has $TOTAL entries but none with status ok|error (schema drift?)"
+            exit 1
           fi
           # Per spec §3: the workflow MUST turn red on any staging
           # status:"error", while verify still runs against the success-set.
@@ -180,14 +193,19 @@ jobs:
         #   - workflow_run + summary_present=false → has_services=false
         #                                            (build redeployed nothing).
         #   - workflow_run + summary_present=true + ok empty
-        #       → has_services=false. Every service errored on redeploy;
-        #         the success-set is empty so there is nothing to verify.
-        #         `enforce-redeploy-gate` independently reds the workflow
-        #         on redeploy_red=true, so this case is already loud.
+        #       → has_services=false (success-set empty; verify is skipped).
+        #         In practice redeploy-env.ts only emits status ok|error,
+        #         so this branch implies redeploy_red=true and
+        #         enforce-redeploy-gate reds the workflow independently —
+        #         skipping verify here is correct (no ok services left to
+        #         probe; the gate has already turned the workflow red).
         #   - workflow_run + summary_present=true + ok non-empty
         #       → intersect ok_services (SSOT key OR dispatchName aliases)
         #         with probe.staging-eligible SSOT services. has_services
-        #         reflects CSV emptiness.
+        #         reflects CSV emptiness. When the intersection collapses
+        #         to empty (e.g. every ok service is non-probe-eligible),
+        #         verify is skipped and `enforce-redeploy-gate` reds the
+        #         workflow independently on redeploy_red=true.
         run: npx tsx showcase/scripts/resolve-verify-matrix.ts
 
   verify:

--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: "3.3"
           bundler-cache: false

--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -1,0 +1,231 @@
+name: "Showcase: Promote (staging → prod)"
+
+# Promotes the staging-tested digest of one or more services to prod.
+# Workflow_dispatch only. Humans trigger. No automatic prod promotes.
+#
+# Order:
+#   1. verify-staging-precondition  → live-probe staging for the target service(s).
+#                                     Refuse on red (matches bin/railway
+#                                     --require-staging-green default).
+#   2. promote                      → bin/railway promote <service>; runs the
+#                                     spec §7 hardening (P1..P6).
+#   3. verify-prod                  → verify-deploy.ts --env prod for the
+#                                     target service(s). Feature-level probes,
+#                                     not naked 200.
+#   4. notify                       → Slack #oss-alerts on any red. Never #engr.
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "SSOT key, dispatch_name, or 'all'"
+        required: true
+        default: "all"
+        type: string
+      digest:
+        description: "Optional digest override (default: snapshot from staging)"
+        required: false
+        type: string
+
+concurrency:
+  group: showcase-promote-${{ inputs.service }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-targets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    outputs:
+      services_csv: ${{ steps.resolve.outputs.services_csv }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+      - name: Generate SSOT artifact
+        working-directory: showcase/scripts
+        run: |
+          npm ci
+          npx tsx emit-railway-envs-json.ts
+      - name: Resolve target service set
+        id: resolve
+        env:
+          INPUT: ${{ inputs.service }}
+        run: |
+          set -euo pipefail
+          GENERATED="showcase/scripts/railway-envs.generated.json"
+          if [ "$INPUT" = "all" ]; then
+            CSV=$(jq -r '.services[] | select(.probe.prod == true) | .name' "$GENERATED" | sort -u | tr '\n' ',' | sed 's/,$//')
+          else
+            RESOLVED=$(jq -r --arg s "$INPUT" '
+              .services[] | select(.name == $s or .dispatchName == $s) | .name
+            ' "$GENERATED" | head -n1)
+            if [ -z "$RESOLVED" ]; then
+              echo "::error::Unknown service '$INPUT' (not an SSOT key or dispatch_name)"
+              exit 1
+            fi
+            CSV="$RESOLVED"
+          fi
+          echo "services_csv=$CSV" >> "$GITHUB_OUTPUT"
+
+  verify-staging-precondition:
+    needs: [resolve-targets]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: railway
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+      - working-directory: showcase/scripts
+        run: npm ci
+      - name: Live-probe staging for promote precondition
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          SERVICES_CSV: ${{ needs.resolve-targets.outputs.services_csv }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN is not set"
+            exit 1
+          fi
+          # Spec §7.2 P3: the live staging probe at promote time is
+          # authoritative. CI verify history is a leading indicator only.
+          npx tsx showcase/scripts/verify-deploy.ts --env staging --services "$SERVICES_CSV"
+
+  promote:
+    needs: [resolve-targets, verify-staging-precondition]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: railway
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+      - working-directory: showcase/scripts
+        run: |
+          npm ci
+          npx tsx emit-railway-envs-json.ts
+      - name: bin/railway promote
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SERVICES_CSV: ${{ needs.resolve-targets.outputs.services_csv }}
+          DIGEST: ${{ inputs.digest }}
+        run: |
+          set -euo pipefail
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN is not set"
+            exit 1
+          fi
+          # The local promote runs each service in turn; bin/railway
+          # handles spec §7 preconditions (P1..P6). --require-staging-green
+          # is default-on; the prior job already established staging is
+          # green but we keep the script-level guard as defense in depth.
+          IFS=',' read -ra SVCS <<< "$SERVICES_CSV"
+          for svc in "${SVCS[@]}"; do
+            args=(promote "$svc")
+            if [ -n "${DIGEST:-}" ]; then
+              args+=(--digest "$DIGEST")
+            fi
+            echo "==> showcase/bin/railway ${args[*]}"
+            showcase/bin/railway "${args[@]}"
+          done
+
+  verify-prod:
+    needs: [resolve-targets, promote]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: railway
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+      - working-directory: showcase/scripts
+        run: npm ci
+      - name: Run verify-deploy --env prod
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          SERVICES_CSV: ${{ needs.resolve-targets.outputs.services_csv }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN is not set"
+            exit 1
+          fi
+          npx tsx showcase/scripts/verify-deploy.ts --env prod --services "$SERVICES_CSV"
+
+  notify:
+    # Slack #oss-alerts only. Never #engr (engr is sacred — release alerts only).
+    needs: [resolve-targets, verify-staging-precondition, promote, verify-prod]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Compute state
+        id: state
+        env:
+          PRE: ${{ needs.verify-staging-precondition.result }}
+          PROMOTE: ${{ needs.promote.result }}
+          PROD: ${{ needs.verify-prod.result }}
+          CSV: ${{ needs.resolve-targets.outputs.services_csv }}
+        run: |
+          set -euo pipefail
+          if [ "$PRE" = "success" ] && [ "$PROMOTE" = "success" ] && [ "$PROD" = "success" ]; then
+            STATE="success"; ICON=":white_check_mark:"
+          else
+            STATE="failure"; ICON=":x:"
+          fi
+          {
+            echo "state=$STATE"
+            echo "icon=$ICON"
+            echo "csv=$CSV"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post to #oss-alerts
+        if: steps.state.outputs.state == 'failure'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ${{ toJSON(format(
+                '{0} *Showcase Promote Failed*\nServices: `{1}`\npre-staging={2} promote={3} verify-prod={4}\n<{5}/{6}/actions/runs/{7}|View run>',
+                steps.state.outputs.icon,
+                steps.state.outputs.csv,
+                needs.verify-staging-precondition.result,
+                needs.promote.result,
+                needs.verify-prod.result,
+                github.server_url,
+                github.repository,
+                github.run_id
+              )) }}
+            }

--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -4,6 +4,10 @@ name: "Showcase: Promote (staging → prod)"
 # Workflow_dispatch only. Humans trigger. No automatic prod promotes.
 #
 # Order:
+#   0. resolve-targets              → expand the workflow_dispatch `service`
+#                                     input (SSOT key, dispatch_name, or
+#                                     'all') into the canonical services_csv
+#                                     consumed by every downstream job.
 #   1. verify-staging-precondition  → live-probe staging for the target service(s).
 #                                     Refuse on red (matches bin/railway
 #                                     --require-staging-green default).

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -88,7 +88,7 @@
     {
       "files": [
         "showcase/shell-docs/src/content/**",
-        "showcase/**/*runtime-config*",
+        "showcase/**/lib/runtime-config*.{ts,tsx}",
         "showcase/**/*.test.{ts,tsx}",
         "showcase/**/*.spec.{ts,tsx}"
       ],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -73,6 +73,28 @@
         "typescript/no-import-type-side-effects": "off",
         "import/consistent-type-specifier-style": "off"
       }
+    },
+    {
+      "files": [
+        "showcase/shell-dashboard/src/**/*.{ts,tsx}",
+        "showcase/shell-docs/src/**/*.{ts,tsx}",
+        "showcase/shell/src/**/*.{ts,tsx}",
+        "showcase/shell-dojo/src/**/*.{ts,tsx}"
+      ],
+      "rules": {
+        "copilotkit/no-public-env-shell-read": "error"
+      }
+    },
+    {
+      "files": [
+        "showcase/shell-docs/src/content/**",
+        "showcase/**/*runtime-config*",
+        "showcase/**/*.test.{ts,tsx}",
+        "showcase/**/*.spec.{ts,tsx}"
+      ],
+      "rules": {
+        "copilotkit/no-public-env-shell-read": "off"
+      }
     }
   ],
   "ignorePatterns": [

--- a/packages/react-ui/oxlint-rules/copilotkit-plugin.mjs
+++ b/packages/react-ui/oxlint-rules/copilotkit-plugin.mjs
@@ -1,11 +1,13 @@
 import requireCpkPrefix from "./require-cpk-prefix.mjs";
 import noSingleArgZodRecord from "./no-single-arg-zod-record.mjs";
+import noPublicEnvShellRead from "./no-public-env-shell-read.mjs";
 
 const plugin = {
   meta: { name: "copilotkit" },
   rules: {
     "require-cpk-prefix": requireCpkPrefix,
     "no-single-arg-zod-record": noSingleArgZodRecord,
+    "no-public-env-shell-read": noPublicEnvShellRead,
   },
 };
 

--- a/packages/react-ui/oxlint-rules/no-public-env-shell-read.mjs
+++ b/packages/react-ui/oxlint-rules/no-public-env-shell-read.mjs
@@ -32,8 +32,22 @@
  *   - assignment LHS:          process.env.NEXT_PUBLIC_X = "..."
  *   - delete:                  delete process.env.NEXT_PUBLIC_X
  *
- * Out of scope (would require scope-tracking; documented as a known gap):
+ * Out of scope (deliberately NOT covered — documented here so the gaps are
+ * auditable rather than implicit):
  *   - aliasing:                const e = process.env; e.NEXT_PUBLIC_X
+ *                              (requires scope/flow tracking)
+ *   - bulk-iteration reads:    Object.keys(process.env), Object.values(process.env),
+ *                              Object.entries(process.env), for-in over process.env,
+ *                              spread `{...process.env}` — these read the whole
+ *                              env object without naming a key statically
+ *   - rest-pattern destructure: `const { ...rest } = process.env` — same shape
+ *                              as the iteration case (no static key in source)
+ *   - compound-assignment LHS: `process.env.X += "..."` — currently treated as
+ *                              an AssignmentExpression with operator !== "="
+ *                              (i.e. NOT flagged); fine in practice because
+ *                              showcase code does not append to env vars
+ *   - update operators:        `process.env.X++` / `process.env.X--` —
+ *                              defensively bailed; not flagged
  *
  * Scope is enforced via `overrides[].files` in `.oxlintrc.json` (shell
  * source trees only; `.mdx` content, runtime-config implementation files,
@@ -47,7 +61,12 @@
  * copilotkit oxlint plugin instead.
  */
 
-const BANNED_KEYS = new Set([
+// Exported so the table-driven test in
+// `showcase/scripts/__tests__/lint-rule-no-public-env.test.ts` can iterate
+// the rule's own banned set rather than hand-mirroring it (any drift would
+// silently weaken coverage). The exported value is the same Set the rule
+// uses internally — they cannot diverge.
+export const BANNED_KEYS = new Set([
   "NEXT_PUBLIC_POCKETBASE_URL",
   "NEXT_PUBLIC_SHELL_URL",
   "NEXT_PUBLIC_BASE_URL",
@@ -62,10 +81,17 @@ const BANNED_KEYS = new Set([
 ]);
 
 /**
- * True iff `node` is the `process.env` member expression (covers both
- * `process.env` and `process?.env`). All read forms hang off this anchor.
+ * True iff `node` (after unwrapping a wrapping `ChainExpression`) is the
+ * `process.env` member expression. All read forms hang off this anchor:
+ *   - bare:               process.env.X
+ *   - optional chain:     process?.env.X / process.env?.X / process?.env?.X
+ * Some parser flavors wrap the whole optional chain in a `ChainExpression`
+ * whose `.expression` is the MemberExpression we want to match; others
+ * surface the MemberExpression directly with `optional: true`. We accept
+ * both shapes by stripping the wrapper first.
  */
 function isProcessEnv(node) {
+  if (node && node.type === "ChainExpression") node = node.expression;
   if (!node || node.type !== "MemberExpression") return false;
   if (node.computed) return false;
   if (!node.object || node.object.type !== "Identifier") return false;
@@ -164,14 +190,13 @@ const rule = {
         if (!node.id || node.id.type !== "ObjectPattern") return;
         for (const prop of node.id.properties) {
           if (!prop || prop.type !== "Property") continue;
-          // The `key` is the source name on process.env; that's what
-          // we test against BANNED_KEYS regardless of any local alias.
-          if (prop.computed) continue;
-          const k = prop.key;
-          let keyName = null;
-          if (k && k.type === "Identifier") keyName = k.name;
-          else if (k && k.type === "Literal" && typeof k.value === "string")
-            keyName = k.value;
+          // The `key` is the source name on process.env; that's what we
+          // test against BANNED_KEYS regardless of any local alias. We
+          // route through staticKeyName() so the computed-string-key form
+          // `{ ["NEXT_PUBLIC_X"]: y } = process.env` and the no-expression
+          // template form `{ [`NEXT_PUBLIC_X`]: y } = process.env` are
+          // caught with the same parity as the bracket-member read.
+          const keyName = staticKeyName(prop.key, prop.computed);
           if (!keyName) continue;
           if (!BANNED_KEYS.has(keyName)) continue;
           context.report({ node: prop, messageId: "forbiddenRead" });

--- a/packages/react-ui/oxlint-rules/no-public-env-shell-read.mjs
+++ b/packages/react-ui/oxlint-rules/no-public-env-shell-read.mjs
@@ -1,11 +1,17 @@
 /**
  * Oxlint rule: no-public-env-shell-read
  *
- * Bans direct reads of `process.env.NEXT_PUBLIC_<URL/ANALYTICS>` keys in
- * showcase shell client/server code. Those values are now served at runtime
- * via `getRuntimeConfig()` (see workstream B / Option-B migration), and a
- * stray `process.env.NEXT_PUBLIC_*` read would silently re-freeze the value
- * at build time and regress the migration.
+ * Bans direct READS of a specific, enumerated set of `process.env.NEXT_PUBLIC_*`
+ * URL/analytics keys (see `BANNED_KEYS` below) in showcase shell client/server
+ * code. Those values are now served at runtime via `getRuntimeConfig()` (see
+ * workstream B / Option-B migration); a stray `process.env.NEXT_PUBLIC_<key>`
+ * read would silently re-freeze the value at build time and regress the
+ * migration.
+ *
+ * IMPORTANT: this rule does NOT ban every `NEXT_PUBLIC_*` read — only the
+ * explicit banned-key set. Build-stamp keys (NEXT_PUBLIC_COMMIT_SHA,
+ * NEXT_PUBLIC_BRANCH) and the local-dev computed key
+ * (NEXT_PUBLIC_LOCAL_BACKENDS) are intentionally NOT banned.
  *
  * Allowed (intentionally NOT in the banned set):
  *   - `NEXT_PUBLIC_COMMIT_SHA`   — build-stamped artifact identifier
@@ -13,12 +19,21 @@
  *   - `NEXT_PUBLIC_LOCAL_BACKENDS` — local-dev only, computed from
  *     `shared/local-ports.json` at build time (not a real env var)
  *
- * Banned keys:
- *   NEXT_PUBLIC_POCKETBASE_URL, NEXT_PUBLIC_SHELL_URL, NEXT_PUBLIC_BASE_URL,
- *   NEXT_PUBLIC_OPS_BASE_URL, NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL,
- *   NEXT_PUBLIC_POSTHOG_KEY, NEXT_PUBLIC_POSTHOG_HOST,
- *   NEXT_PUBLIC_SCARF_PIXEL_ID, NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID,
- *   NEXT_PUBLIC_REB2B_KEY, NEXT_PUBLIC_REO_KEY
+ * Forms detected as READS (each will be flagged):
+ *   - dotted member:           process.env.NEXT_PUBLIC_SHELL_URL
+ *   - string-bracket member:   process.env["NEXT_PUBLIC_SHELL_URL"]
+ *   - no-expression template:  process.env[`NEXT_PUBLIC_SHELL_URL`]
+ *   - optional chaining:       process.env?.NEXT_PUBLIC_SHELL_URL
+ *                              process.env?.["NEXT_PUBLIC_SHELL_URL"]
+ *   - destructuring read:      const { NEXT_PUBLIC_SHELL_URL } = process.env
+ *                              const { NEXT_PUBLIC_SHELL_URL: aliased } = process.env
+ *
+ * Forms intentionally NOT flagged (writes/deletes are not reads):
+ *   - assignment LHS:          process.env.NEXT_PUBLIC_X = "..."
+ *   - delete:                  delete process.env.NEXT_PUBLIC_X
+ *
+ * Out of scope (would require scope-tracking; documented as a known gap):
+ *   - aliasing:                const e = process.env; e.NEXT_PUBLIC_X
  *
  * Scope is enforced via `overrides[].files` in `.oxlintrc.json` (shell
  * source trees only; `.mdx` content, runtime-config implementation files,
@@ -46,12 +61,57 @@ const BANNED_KEYS = new Set([
   "NEXT_PUBLIC_REO_KEY",
 ]);
 
+/**
+ * True iff `node` is the `process.env` member expression (covers both
+ * `process.env` and `process?.env`). All read forms hang off this anchor.
+ */
+function isProcessEnv(node) {
+  if (!node || node.type !== "MemberExpression") return false;
+  if (node.computed) return false;
+  if (!node.object || node.object.type !== "Identifier") return false;
+  if (node.object.name !== "process") return false;
+  if (!node.property || node.property.type !== "Identifier") return false;
+  return node.property.name === "env";
+}
+
+/**
+ * Given a `node.property` from a MemberExpression read off `process.env`,
+ * return the static key name if we can determine one — or null if the key
+ * is dynamic (and therefore out of scope for a static lint).
+ *
+ * Handled key forms:
+ *   - Identifier (dotted: process.env.FOO)
+ *   - Literal string (bracket: process.env["FOO"])
+ *   - TemplateLiteral with no expressions (process.env[`FOO`])
+ */
+function staticKeyName(property, computed) {
+  if (!property) return null;
+  if (!computed && property.type === "Identifier") {
+    return property.name;
+  }
+  if (computed && property.type === "Literal" && typeof property.value === "string") {
+    return property.value;
+  }
+  if (
+    computed &&
+    property.type === "TemplateLiteral" &&
+    Array.isArray(property.expressions) &&
+    property.expressions.length === 0 &&
+    Array.isArray(property.quasis) &&
+    property.quasis.length === 1
+  ) {
+    const cooked = property.quasis[0]?.value?.cooked;
+    return typeof cooked === "string" ? cooked : null;
+  }
+  return null;
+}
+
 const rule = {
   meta: {
     type: "problem",
     docs: {
       description:
-        "Disallow direct `process.env.NEXT_PUBLIC_*` URL/analytics reads in shell code (use getRuntimeConfig)",
+        "Disallow shell-side reads of a banned set of NEXT_PUBLIC_* URL/analytics keys (process.env.<key>, process.env['<key>'], destructuring, optional chaining) — use getRuntimeConfig() instead",
     },
     schema: [],
     messages: {
@@ -62,42 +122,60 @@ const rule = {
 
   create(context) {
     return {
-      // Match `process.env.<KEY>` — i.e. a MemberExpression whose object is
-      // itself the MemberExpression `process.env` and whose property is the
-      // banned identifier.
+      // Member-expression reads: dotted, bracket-string, bracket-template,
+      // and optional-chained equivalents. We skip writes (assignment LHS)
+      // and `delete` targets — those are not reads of the value.
       MemberExpression(node) {
-        const obj = node.object;
-        if (
-          !obj ||
-          obj.type !== "MemberExpression" ||
-          obj.computed ||
-          !obj.object ||
-          obj.object.type !== "Identifier" ||
-          obj.object.name !== "process" ||
-          !obj.property ||
-          obj.property.type !== "Identifier" ||
-          obj.property.name !== "env"
-        ) {
+        if (!isProcessEnv(node.object)) return;
+
+        // Write target: `process.env.X = ...`. The MemberExpression is the
+        // LHS of an AssignmentExpression — not a read.
+        const parent = node.parent;
+        if (parent && parent.type === "AssignmentExpression" && parent.left === node) {
           return;
         }
-        // `node.property` is the key being read off `process.env`.
-        // Only flag the static dotted form (`process.env.FOO`) or the
-        // literal-string computed form (`process.env["FOO"]`).
-        let keyName = null;
-        if (!node.computed && node.property && node.property.type === "Identifier") {
-          keyName = node.property.name;
-        } else if (
-          node.computed &&
-          node.property &&
-          node.property.type === "Literal" &&
-          typeof node.property.value === "string"
-        ) {
-          keyName = node.property.value;
+        // `delete process.env.X` — not a read either.
+        if (parent && parent.type === "UnaryExpression" && parent.operator === "delete") {
+          return;
         }
+        // `update` operators (++/--): also a write, but extremely unlikely
+        // on a string env var. Defensive bail anyway.
+        if (parent && parent.type === "UpdateExpression") {
+          return;
+        }
+
+        const keyName = staticKeyName(node.property, node.computed);
         if (!keyName) return;
         if (!BANNED_KEYS.has(keyName)) return;
 
         context.report({ node, messageId: "forbiddenRead" });
+      },
+
+      // Destructuring reads: `const { NEXT_PUBLIC_X } = process.env` and the
+      // aliased form `const { NEXT_PUBLIC_X: y } = process.env`. We catch
+      // this at the VariableDeclarator level so we can confirm the init is
+      // exactly `process.env` (not some other object with same-named props).
+      //
+      // Note: this does NOT cover the aliasing case
+      // `const e = process.env; e.NEXT_PUBLIC_X` — that requires scope
+      // tracking and is intentionally out of scope; see file header.
+      VariableDeclarator(node) {
+        if (!node.init || !isProcessEnv(node.init)) return;
+        if (!node.id || node.id.type !== "ObjectPattern") return;
+        for (const prop of node.id.properties) {
+          if (!prop || prop.type !== "Property") continue;
+          // The `key` is the source name on process.env; that's what
+          // we test against BANNED_KEYS regardless of any local alias.
+          if (prop.computed) continue;
+          const k = prop.key;
+          let keyName = null;
+          if (k && k.type === "Identifier") keyName = k.name;
+          else if (k && k.type === "Literal" && typeof k.value === "string")
+            keyName = k.value;
+          if (!keyName) continue;
+          if (!BANNED_KEYS.has(keyName)) continue;
+          context.report({ node: prop, messageId: "forbiddenRead" });
+        }
       },
     };
   },

--- a/packages/react-ui/oxlint-rules/no-public-env-shell-read.mjs
+++ b/packages/react-ui/oxlint-rules/no-public-env-shell-read.mjs
@@ -115,7 +115,11 @@ function staticKeyName(property, computed) {
   if (!computed && property.type === "Identifier") {
     return property.name;
   }
-  if (computed && property.type === "Literal" && typeof property.value === "string") {
+  if (
+    computed &&
+    property.type === "Literal" &&
+    typeof property.value === "string"
+  ) {
     return property.value;
   }
   if (
@@ -157,11 +161,19 @@ const rule = {
         // Write target: `process.env.X = ...`. The MemberExpression is the
         // LHS of an AssignmentExpression — not a read.
         const parent = node.parent;
-        if (parent && parent.type === "AssignmentExpression" && parent.left === node) {
+        if (
+          parent &&
+          parent.type === "AssignmentExpression" &&
+          parent.left === node
+        ) {
           return;
         }
         // `delete process.env.X` — not a read either.
-        if (parent && parent.type === "UnaryExpression" && parent.operator === "delete") {
+        if (
+          parent &&
+          parent.type === "UnaryExpression" &&
+          parent.operator === "delete"
+        ) {
           return;
         }
         // `update` operators (++/--): also a write, but extremely unlikely

--- a/packages/react-ui/oxlint-rules/no-public-env-shell-read.mjs
+++ b/packages/react-ui/oxlint-rules/no-public-env-shell-read.mjs
@@ -1,0 +1,106 @@
+/**
+ * Oxlint rule: no-public-env-shell-read
+ *
+ * Bans direct reads of `process.env.NEXT_PUBLIC_<URL/ANALYTICS>` keys in
+ * showcase shell client/server code. Those values are now served at runtime
+ * via `getRuntimeConfig()` (see workstream B / Option-B migration), and a
+ * stray `process.env.NEXT_PUBLIC_*` read would silently re-freeze the value
+ * at build time and regress the migration.
+ *
+ * Allowed (intentionally NOT in the banned set):
+ *   - `NEXT_PUBLIC_COMMIT_SHA`   — build-stamped artifact identifier
+ *   - `NEXT_PUBLIC_BRANCH`       — build-stamped artifact identifier
+ *   - `NEXT_PUBLIC_LOCAL_BACKENDS` — local-dev only, computed from
+ *     `shared/local-ports.json` at build time (not a real env var)
+ *
+ * Banned keys:
+ *   NEXT_PUBLIC_POCKETBASE_URL, NEXT_PUBLIC_SHELL_URL, NEXT_PUBLIC_BASE_URL,
+ *   NEXT_PUBLIC_OPS_BASE_URL, NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL,
+ *   NEXT_PUBLIC_POSTHOG_KEY, NEXT_PUBLIC_POSTHOG_HOST,
+ *   NEXT_PUBLIC_SCARF_PIXEL_ID, NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID,
+ *   NEXT_PUBLIC_REB2B_KEY, NEXT_PUBLIC_REO_KEY
+ *
+ * Scope is enforced via `overrides[].files` in `.oxlintrc.json` (shell
+ * source trees only; `.mdx` content, runtime-config implementation files,
+ * and tests are excluded by a follow-up override that turns this rule
+ * back off).
+ *
+ * Note: plan-B's original spec called for oxlint's `eslint/no-restricted-syntax`
+ * with an AST selector regex. oxlint 1.x does not implement that rule
+ * (only `no-restricted-globals` / `no-restricted-imports`), so we
+ * implement the equivalent guard as a focused custom rule in the existing
+ * copilotkit oxlint plugin instead.
+ */
+
+const BANNED_KEYS = new Set([
+  "NEXT_PUBLIC_POCKETBASE_URL",
+  "NEXT_PUBLIC_SHELL_URL",
+  "NEXT_PUBLIC_BASE_URL",
+  "NEXT_PUBLIC_OPS_BASE_URL",
+  "NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL",
+  "NEXT_PUBLIC_POSTHOG_KEY",
+  "NEXT_PUBLIC_POSTHOG_HOST",
+  "NEXT_PUBLIC_SCARF_PIXEL_ID",
+  "NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID",
+  "NEXT_PUBLIC_REB2B_KEY",
+  "NEXT_PUBLIC_REO_KEY",
+]);
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow direct `process.env.NEXT_PUBLIC_*` URL/analytics reads in shell code (use getRuntimeConfig)",
+    },
+    schema: [],
+    messages: {
+      forbiddenRead:
+        "Do not read process.env.NEXT_PUBLIC_* directly in shell code. Use getRuntimeConfig() from @/lib/runtime-config.client (client) or @/lib/runtime-config (server). See workstream B.",
+    },
+  },
+
+  create(context) {
+    return {
+      // Match `process.env.<KEY>` — i.e. a MemberExpression whose object is
+      // itself the MemberExpression `process.env` and whose property is the
+      // banned identifier.
+      MemberExpression(node) {
+        const obj = node.object;
+        if (
+          !obj ||
+          obj.type !== "MemberExpression" ||
+          obj.computed ||
+          !obj.object ||
+          obj.object.type !== "Identifier" ||
+          obj.object.name !== "process" ||
+          !obj.property ||
+          obj.property.type !== "Identifier" ||
+          obj.property.name !== "env"
+        ) {
+          return;
+        }
+        // `node.property` is the key being read off `process.env`.
+        // Only flag the static dotted form (`process.env.FOO`) or the
+        // literal-string computed form (`process.env["FOO"]`).
+        let keyName = null;
+        if (!node.computed && node.property && node.property.type === "Identifier") {
+          keyName = node.property.name;
+        } else if (
+          node.computed &&
+          node.property &&
+          node.property.type === "Literal" &&
+          typeof node.property.value === "string"
+        ) {
+          keyName = node.property.value;
+        }
+        if (!keyName) return;
+        if (!BANNED_KEYS.has(keyName)) return;
+
+        context.report({ node, messageId: "forbiddenRead" });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -904,6 +904,74 @@ module Railway
 
     # promote — copy staging digests into production with prechecks.
     class PromoteCommand < BaseCommand
+        class MutationError < StandardError; end
+
+        SERVICE_INSTANCE_RECHECK_QUERY = <<~GQL
+            query ServiceInstanceRecheck($serviceId: String!, $envId: String!) {
+                serviceInstance(serviceId: $serviceId, environmentId: $envId) {
+                    id
+                    source { image }
+                    updatedAt
+                }
+            }
+        GQL
+
+        RETRY_COUNT     = 3
+        RETRY_DELAY_SEC = 10
+
+        # Pin + verify: confirms the boolean mutation result AND re-queries
+        # serviceInstance to confirm BOTH source.image advanced to the new
+        # digest AND updatedAt strictly advanced past the pre-mutation value.
+        # 3 retries 10s apart absorb Railway's eventual consistency.
+        # `sleeper:` is injected for tests.
+        def self.pin_and_verify(gql, service_id:, env_id:, image:, sleeper: ->(n) { sleep(n) })
+            # Capture pre-update serviceInstance.updatedAt so we can gate on a
+            # strict advance after the mutation (spec §7.2 P5). Image-equality
+            # alone is insufficient — a no-op re-pin to the current value would
+            # otherwise appear green. nil pre_ts means "no prior instance" and
+            # is treated as a permanent advance below.
+            pre_data = gql.query(SERVICE_INSTANCE_RECHECK_QUERY,
+                serviceId: service_id, envId: env_id)
+            pre_inst = pre_data && pre_data["serviceInstance"]
+            pre_update_ts = pre_inst && pre_inst["updatedAt"]
+
+            updated = gql.query(RestoreCommand::UPDATE_IMAGE_MUTATION,
+                serviceId: service_id, envId: env_id, image: image)
+            unless updated && updated["serviceInstanceUpdate"] == true
+                raise MutationError,
+                    "P5: serviceInstanceUpdate returned #{updated.inspect} (expected true) for #{service_id} -> #{image}"
+            end
+
+            gql.query(RestoreCommand::REDEPLOY_MUTATION,
+                serviceId: service_id, envId: env_id)
+
+            expected_digest = image.include?("@") ? image.split("@", 2).last : nil
+            last_seen_image = nil
+            last_seen_ts    = nil
+
+            RETRY_COUNT.times do |i|
+                data = gql.query(SERVICE_INSTANCE_RECHECK_QUERY,
+                    serviceId: service_id, envId: env_id)
+                inst = data && data["serviceInstance"]
+                actual_image  = inst && inst.dig("source", "image")
+                actual_ts     = inst && inst["updatedAt"]
+                actual_digest = actual_image && actual_image.include?("@") ? actual_image.split("@", 2).last : nil
+                last_seen_image = actual_image
+                last_seen_ts    = actual_ts
+
+                image_ok = expected_digest && actual_digest == expected_digest
+                ts_ok    = pre_update_ts.nil? || (actual_ts && actual_ts > pre_update_ts)
+                return inst if image_ok && ts_ok
+
+                sleeper.call(RETRY_DELAY_SEC) if i < RETRY_COUNT - 1
+            end
+
+            raise MutationError,
+                "P5: re-query did not observe image advance to #{image} AND updatedAt > #{pre_update_ts.inspect} " \
+                "after #{RETRY_COUNT} retries (last seen image=#{last_seen_image.inspect}, " \
+                "updatedAt=#{last_seen_ts.inspect}). Refusing to declare promote successful."
+        end
+
         def default_options
             super.merge(
                 include_startcommand:  false,
@@ -1099,12 +1167,16 @@ module Railway
                     puts "[dry-run] promote #{svc['name']} -> #{image}"
                     next
                 end
-
-                RestoreCommand.pin_and_redeploy(gql,
-                    service_id: pmatch["service_id"],
-                    env_id: PRODUCTION_ENV_ID,
-                    image: image)
-                puts "promoted #{svc['name']} -> #{image}"
+                begin
+                    PromoteCommand.pin_and_verify(gql,
+                        service_id: pmatch["service_id"],
+                        env_id: PRODUCTION_ENV_ID,
+                        image: image)
+                    puts "promoted #{svc['name']} -> #{image}"
+                rescue PromoteCommand::MutationError => e
+                    warn e.message
+                    return 1
+                end
             end
             0
         end

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -1022,8 +1022,43 @@ module Railway
             ["REFUSE: P1: GHCR check raised #{e.class}: #{e.message}"]
         end
 
-        # Stubs filled in by later phases; return [] so D.1 lands green.
-        def check_p2_staging_deployments(_staging); []; end
+        # P2 — for each staging service we are promoting, the most recent
+        # staging deployment must be SUCCESS AND its image digest must match
+        # the digest we are about to promote (otherwise a newer build is
+        # in flight; refuse to avoid the race).
+        def check_p2_staging_deployments(staging)
+            findings = []
+            (staging["services"] || []).each do |svc|
+                next if svc["service_id"].nil? || svc["image"].nil?
+                deployments = fetch_latest_staging_deployments(svc["service_id"])
+                latest = deployments.first
+                if latest.nil?
+                    findings << "REFUSE: P2 (#{svc['name']}): no staging deployments found."
+                    next
+                end
+                status = latest["status"]
+                if status != "SUCCESS"
+                    findings << "REFUSE: P2 (#{svc['name']}): latest staging deployment status is #{status}, not SUCCESS."
+                    next
+                end
+                deployed_image = latest.dig("meta", "image").to_s
+                deployed_digest = deployed_image.include?("@") ? deployed_image.split("@", 2).last : nil
+                snapshot_digest = svc["digest"]
+                if snapshot_digest && deployed_digest && deployed_digest != snapshot_digest
+                    findings << "REFUSE: P2 (#{svc['name']}): in-flight race — latest staging deployment is " \
+                                "#{deployed_digest} but snapshot has #{snapshot_digest}. Re-snapshot and retry."
+                end
+            end
+            findings
+        end
+
+        def fetch_latest_staging_deployments(service_id)
+            data = gql.query(RollbackCommand::DEPLOYMENTS_QUERY,
+                serviceId: service_id, envId: STAGING_ENV_ID)
+            (data.dig("deployments", "edges") || []).map { |e| e["node"] }
+        end
+
+        # Stubs filled in by later phases; return [] so D.2 lands green.
         def check_p3_staging_live_green(_staging); []; end
         def check_p6_parity(_staging, _prod); []; end
 

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -439,7 +439,17 @@ module Railway
     # We capture KEYS only for env vars (never values) so snapshots are safe
     # to commit/share.
     class SnapshotIO
-        SCHEMA_VERSION = 1
+        SCHEMA_VERSION = 2
+
+        # v1: initial fields (name, service_id, image, image_tag, digest,
+        #     start_command, auto_updates_disabled, latest_deployment_id,
+        #     env_keys, custom_domains).
+        # v2: adds healthcheck_path, region, replicas, restart_policy
+        #     (for the P6 parity matrix in promote). We accept v1 reads
+        #     for backwards-compat with historical committed snapshots —
+        #     promote always uses live snapshots, but rollback-commit
+        #     replays snapshots from arbitrary SHAs.
+        SUPPORTED_VERSIONS = [1, SCHEMA_VERSION].freeze
 
         def self.write(path, snapshot)
             FileUtils.mkdir_p(File.dirname(path)) unless path == "-"
@@ -454,8 +464,8 @@ module Railway
         def self.read(path)
             raw = path == "-" ? $stdin.read : File.read(path)
             data = YAML.safe_load(raw, permitted_classes: [Time, Symbol], aliases: false)
-            unless data.is_a?(Hash) && data["version"] == SCHEMA_VERSION
-                Railway.die!("Snapshot schema mismatch (expected version=#{SCHEMA_VERSION}).")
+            unless data.is_a?(Hash) && SUPPORTED_VERSIONS.include?(data["version"])
+                Railway.die!("Snapshot schema mismatch (expected version in #{SUPPORTED_VERSIONS.inspect}).")
             end
             data
         end
@@ -507,6 +517,10 @@ module Railway
                 serviceId
                 environmentId
                 startCommand
+                healthcheckPath
+                region
+                numReplicas
+                restartPolicyType
                 source { image repo }
                 latestDeployment { id status }
                 domains {
@@ -655,6 +669,10 @@ module Railway
                     "image_tag"             => tag_ref,
                     "digest"                => digest,
                     "start_command"         => inst["startCommand"],
+                    "healthcheck_path"      => inst["healthcheckPath"],
+                    "region"                => inst["region"],
+                    "replicas"              => inst["numReplicas"],
+                    "restart_policy"        => inst["restartPolicyType"],
                     "auto_updates_disabled" => nil,
                     "latest_deployment_id"  => inst.dig("latestDeployment", "id"),
                     "env_keys"              => (keys_by_service[node["id"]] || []).sort.uniq,
@@ -1126,9 +1144,83 @@ module Railway
             (data.dig("deployments", "edges") || []).map { |e| e["node"] }
         end
 
-        # Stubs filled in by later phases; return [] so D.2 lands green.
+        # Stub — P3 lands in a later commit.
         def check_p3_staging_live_green(_staging); []; end
-        def check_p6_parity(_staging, _prod); []; end
+
+        # P6 — parity matrix.
+        #   REFUSE: startCommand, healthcheckPath, image shape.
+        #   WARN:   region, replicas, restartPolicy, env-var KEY set.
+        #   IGNORE: env-var VALUES (printed as NOTE every run; see
+        #           run_with_preflight_only).
+        def check_p6_parity(staging, prod)
+            findings = []
+            (staging["services"] || []).each do |svc|
+                pmatch = Railway.find_service(prod, svc["name"])
+                next unless pmatch  # service-set parity catches this separately.
+                name = svc["name"]
+
+                # REFUSE — startCommand
+                if svc["start_command"] != pmatch["start_command"]
+                    findings << "REFUSE: P6 (#{name}): startCommand divergence " \
+                                "(staging=#{svc['start_command'].inspect} prod=#{pmatch['start_command'].inspect})"
+                end
+
+                # REFUSE — healthcheckPath
+                if svc["healthcheck_path"] != pmatch["healthcheck_path"]
+                    findings << "REFUSE: P6 (#{name}): healthcheckPath divergence " \
+                                "(staging=#{svc['healthcheck_path'].inspect} prod=#{pmatch['healthcheck_path'].inspect})"
+                end
+
+                # REFUSE — image shape (staging=:tag mutable, prod=@sha256 pinned).
+                staging_shape = image_shape(svc["image"])
+                prod_shape    = image_shape(pmatch["image"])
+                expected_staging_shape = :tag
+                expected_prod_shape    = :digest
+                if staging_shape != expected_staging_shape || prod_shape != expected_prod_shape
+                    findings << "REFUSE: P6 (#{name}): image shape wrong " \
+                                "(staging=#{staging_shape} expected=#{expected_staging_shape}; " \
+                                "prod=#{prod_shape} expected=#{expected_prod_shape})"
+                end
+
+                # WARN — region
+                if svc["region"] != pmatch["region"]
+                    findings << "WARN: P6 (#{name}): region divergence " \
+                                "(staging=#{svc['region'].inspect} prod=#{pmatch['region'].inspect})"
+                end
+
+                # WARN — replicas
+                if svc["replicas"] != pmatch["replicas"]
+                    findings << "WARN: P6 (#{name}): replicas divergence " \
+                                "(staging=#{svc['replicas']} prod=#{pmatch['replicas']})"
+                end
+
+                # WARN — restartPolicy
+                if svc["restart_policy"] != pmatch["restart_policy"]
+                    findings << "WARN: P6 (#{name}): restartPolicy divergence " \
+                                "(staging=#{svc['restart_policy'].inspect} prod=#{pmatch['restart_policy'].inspect})"
+                end
+
+                # WARN — env var KEY set
+                staging_keys = (svc["env_keys"] || []).sort
+                prod_keys    = (pmatch["env_keys"] || []).sort
+                if staging_keys != prod_keys
+                    only_staging = staging_keys - prod_keys
+                    only_prod    = prod_keys - staging_keys
+                    findings << "WARN: P6 (#{name}): env key set divergence " \
+                                "(only-in-staging=#{only_staging.inspect} only-in-prod=#{only_prod.inspect})"
+                end
+            end
+            findings
+        end
+
+        # Classify an image ref. :tag (mutable), :digest (immutable @sha256:),
+        # :missing, or :other.
+        def image_shape(ref)
+            return :missing if ref.nil? || ref.empty?
+            return :digest  if ref.include?("@sha256:")
+            return :tag     if ref.include?(":") && ref.split(":", 2).last !~ /\A\s*\z/
+            :other
+        end
 
         def check_service_set_parity(staging, prod)
             findings = []

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -960,8 +960,15 @@ module Railway
                     "P5: serviceInstanceUpdate returned #{updated.inspect} (expected true) for #{service_id} -> #{image}"
             end
 
-            gql.query(RestoreCommand::REDEPLOY_MUTATION,
+            # Symmetric assertion: serviceInstanceUpdate has already advanced
+            # source.image+updatedAt, so a failed redeploy could otherwise
+            # sneak through verification. Require truthy redeploy result.
+            redeployed = gql.query(RestoreCommand::REDEPLOY_MUTATION,
                 serviceId: service_id, envId: env_id)
+            unless redeployed && redeployed["serviceInstanceRedeploy"]
+                raise MutationError,
+                    "P5: serviceInstanceRedeploy returned #{redeployed.inspect} (expected truthy) for #{service_id} -> #{image}"
+            end
 
             expected_digest = image.include?("@") ? image.split("@", 2).last : nil
             last_seen_image = nil
@@ -1110,33 +1117,46 @@ module Railway
         # P1 — every staging digest about to be promoted must exist in GHCR.
         # Verifies the DIGEST-form ref that will actually be pinned to prod
         # (resolves tag refs first; refuses if the tag can't be resolved).
+        #
+        # Side-effect: populates @promote_refs (service_name => digest-pinned
+        # ref) so execute_promotion pins the EXACT ref P1 verified — staging
+        # `:latest` is mutable, so a second resolve_digest could return a
+        # different digest (TOCTOU) and prod would be pinned to a digest P1
+        # never verified.
         def check_p1_ghcr_digests(staging)
             findings = []
+            @promote_refs ||= {}
             (staging["services"] || []).each do |svc|
                 image = svc["image"] || svc["image_tag"]
                 next if image.nil? || image.empty?
 
-                resolved = resolved_prod_image(svc)
-                if resolved.nil?
-                    findings << "REFUSE: P1 (#{svc['name']}): cannot resolve #{image} to a GHCR digest; " \
-                                "refusing to pin prod to a mutable tag."
-                    next
-                end
+                # Per-service rescue: a GHCR error on one service must not
+                # discard findings already accumulated for earlier services.
+                begin
+                    resolved = resolved_prod_image(svc)
+                    if resolved.nil?
+                        findings << "REFUSE: P1 (#{svc['name']}): cannot resolve #{image} to a GHCR digest; " \
+                                    "refusing to pin prod to a mutable tag."
+                        next
+                    end
 
-                case ghcr.manifest_exists(resolved)
-                when :exists
-                    # ok
-                when :missing
-                    findings << "REFUSE: P1 (#{svc['name']}): #{resolved} not found in GHCR " \
-                                "(digest may have been garbage-collected; staging build may not have pushed)."
-                when :auth_failed
-                    findings << "REFUSE: P1 (#{svc['name']}): GHCR auth failed for #{resolved}. " \
-                                "Set GHCR_TOKEN (local: 'gh auth token') or GITHUB_TOKEN (CI: workflow token with packages:read)."
+                    case ghcr.manifest_exists(resolved)
+                    when :exists
+                        # Record the verified ref for use by execute_promotion
+                        # — guarantees pin parity with what P1 verified.
+                        @promote_refs[svc["name"]] = resolved
+                    when :missing
+                        findings << "REFUSE: P1 (#{svc['name']}): #{resolved} not found in GHCR " \
+                                    "(digest may have been garbage-collected; staging build may not have pushed)."
+                    when :auth_failed
+                        findings << "REFUSE: P1 (#{svc['name']}): GHCR auth failed for #{resolved}. " \
+                                    "Set GHCR_TOKEN (local: 'gh auth token') or GITHUB_TOKEN (CI: workflow token with packages:read)."
+                    end
+                rescue Railway::GHCR::Error => e
+                    findings << "REFUSE: P1 (#{svc['name']}): GHCR check raised #{e.class}: #{e.message}"
                 end
             end
             findings
-        rescue Railway::GHCR::Error => e
-            ["REFUSE: P1: GHCR check raised #{e.class}: #{e.message}"]
         end
 
         # P2 — for each staging service we are promoting, the most recent
@@ -1161,14 +1181,20 @@ module Railway
                 # Railway's Deployment.meta is a JSON scalar that may deserialize
                 # as a String (not a Hash). Guard the dig so the race-check is
                 # a best-effort no-op when meta isn't structured — SUCCESS
-                # status above is the real gate.
+                # status above is the real gate. When the skip happens, emit a
+                # WARN so the missing race-check is visible (not silent).
                 meta = latest["meta"]
-                deployed_image = meta.is_a?(Hash) ? meta["image"].to_s : ""
-                deployed_digest = deployed_image.include?("@") ? deployed_image.split("@", 2).last : nil
-                snapshot_digest = svc["digest"]
-                if snapshot_digest && deployed_digest && deployed_digest != snapshot_digest
-                    findings << "REFUSE: P2 (#{svc['name']}): in-flight race — latest staging deployment is " \
-                                "#{deployed_digest} but snapshot has #{snapshot_digest}. Re-snapshot and retry."
+                if meta.is_a?(Hash)
+                    deployed_image = meta["image"].to_s
+                    deployed_digest = deployed_image.include?("@") ? deployed_image.split("@", 2).last : nil
+                    snapshot_digest = svc["digest"]
+                    if snapshot_digest && deployed_digest && deployed_digest != snapshot_digest
+                        findings << "REFUSE: P2 (#{svc['name']}): in-flight race — latest staging deployment is " \
+                                    "#{deployed_digest} but snapshot has #{snapshot_digest}. Re-snapshot and retry."
+                    end
+                else
+                    findings << "WARN: P2 (#{svc['name']}): in-flight race check skipped — " \
+                                "deployment meta is #{meta.class}, expected Hash."
                 end
             end
             findings
@@ -1331,17 +1357,20 @@ module Railway
         end
 
         def execute_promotion(staging, prod)
+            @promote_refs ||= {}
+            already_pinned = []
             (staging["services"] || []).each do |svc|
                 pmatch = Railway.find_service(prod, svc["name"])
                 next unless pmatch
-                # Resolve staging tag → GHCR digest BEFORE pinning. Pinning a
-                # mutable tag (`:latest`) to prod would defeat the immutable-
-                # prod invariant; refuse rather than guess.
-                image = resolved_prod_image(svc)
+                # Use the EXACT ref P1 resolved+verified. Re-resolving here
+                # would risk TOCTOU on staging's mutable `:latest`. If the
+                # entry is missing, P1 either didn't run or didn't pass for
+                # this service — treat as an internal error rather than
+                # silently falling back to a tag.
+                image = @promote_refs[svc["name"]]
                 if image.nil?
-                    src = svc["image"] || svc["image_tag"]
-                    warn "P0/promote (#{svc['name']}): cannot resolve #{src} to a GHCR digest; " \
-                         "refusing to pin prod to a mutable tag."
+                    warn "P0/promote (#{svc['name']}): no P1-verified digest ref recorded; " \
+                         "refusing to pin (internal error — preflight did not capture this service)."
                     return 1
                 end
                 if options[:dry_run]
@@ -1354,8 +1383,13 @@ module Railway
                         env_id: PRODUCTION_ENV_ID,
                         image: image)
                     puts "promoted #{svc['name']} -> #{image}"
+                    already_pinned << svc["name"]
                 rescue PromoteCommand::MutationError => e
                     warn e.message
+                    warn "PARTIAL PROMOTION: already pinned #{already_pinned.inspect}; " \
+                         "FAILED on #{svc['name']}: #{e.message}. " \
+                         "Production is in a mixed state — run 'bin/railway rollback-commit' " \
+                         "against the prior snapshot to revert, or re-run promote to retry."
                     return 1
                 end
             end

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -943,6 +943,16 @@ module Railway
         # 3 retries 10s apart absorb Railway's eventual consistency.
         # `sleeper:` is injected for tests.
         def self.pin_and_verify(gql, service_id:, env_id:, image:, sleeper: ->(n) { sleep(n) })
+            # Upfront guard: this method's contract is to pin a DIGEST-form
+            # image. Pre-fix, a stray tag ref would fall through to retries
+            # (since expected_digest stayed nil and image_ok was always false)
+            # and ultimately surface as a misleading "did not observe image
+            # advance" error after 30s of futile waits.
+            unless image.include?("@sha256:")
+                raise ArgumentError,
+                    "pin_and_verify requires an @sha256:-pinned image, got #{image.inspect}"
+            end
+
             # Capture pre-update serviceInstance.updatedAt so we can gate on a
             # strict advance after the mutation (spec §7.2 P5). Image-equality
             # alone is insufficient — a no-op re-pin to the current value would
@@ -985,7 +995,12 @@ module Railway
                 last_seen_ts    = actual_ts
 
                 image_ok = expected_digest && actual_digest == expected_digest
-                ts_ok    = pre_update_ts.nil? || (actual_ts && actual_ts > pre_update_ts)
+                # Non-vacuous timestamp gate: a non-nil observed updatedAt is
+                # ALWAYS required. Pre-fix this collapsed to (pre_ts.nil? ||
+                # ...), which made the gate vacuous for new prod services and
+                # fell back to digest-equality alone — the exact weakness this
+                # gate was added to prevent.
+                ts_ok    = actual_ts && (pre_update_ts.nil? || actual_ts > pre_update_ts)
                 return inst if image_ok && ts_ok
 
                 sleeper.call(RETRY_DELAY_SEC) if i < RETRY_COUNT - 1
@@ -1125,13 +1140,27 @@ module Railway
         # never verified.
         def check_p1_ghcr_digests(staging)
             findings = []
-            @promote_refs ||= {}
+            # RESET (not memoize): a reused PromoteCommand instance running a
+            # second preflight against a different snapshot must not carry
+            # stale A-era refs into a B-era promote.
+            @promote_refs = {}
             (staging["services"] || []).each do |svc|
                 image = svc["image"] || svc["image_tag"]
-                next if image.nil? || image.empty?
+                if image.nil? || image.empty?
+                    # Make this loud — pre-fix this was a silent `next`, and
+                    # execute_promotion later emitted a misleading "internal
+                    # error" for the same service.
+                    findings << "REFUSE: P1 (#{svc['name']}): no image recorded in staging snapshot; " \
+                                "cannot promote."
+                    next
+                end
 
-                # Per-service rescue: a GHCR error on one service must not
+                # Per-service rescue: an error on one service must not
                 # discard findings already accumulated for earlier services.
+                # Broadened to StandardError — a non-GHCR error (e.g. an
+                # ArgumentError from parse_image_ref, or a network error
+                # wrapped as something else) would otherwise bypass the
+                # per-service rescue and crash the whole loop.
                 begin
                     resolved = resolved_prod_image(svc)
                     if resolved.nil?
@@ -1152,8 +1181,8 @@ module Railway
                         findings << "REFUSE: P1 (#{svc['name']}): GHCR auth failed for #{resolved}. " \
                                     "Set GHCR_TOKEN (local: 'gh auth token') or GITHUB_TOKEN (CI: workflow token with packages:read)."
                     end
-                rescue Railway::GHCR::Error => e
-                    findings << "REFUSE: P1 (#{svc['name']}): GHCR check raised #{e.class}: #{e.message}"
+                rescue StandardError => e
+                    findings << "REFUSE: P1 (#{svc['name']}): unexpected #{e.class}: #{e.message}"
                 end
             end
             findings
@@ -1179,18 +1208,24 @@ module Railway
                     next
                 end
                 # Railway's Deployment.meta is a JSON scalar that may deserialize
-                # as a String (not a Hash). Guard the dig so the race-check is
-                # a best-effort no-op when meta isn't structured — SUCCESS
-                # status above is the real gate. When the skip happens, emit a
-                # WARN so the missing race-check is visible (not silent).
+                # as a String (not a Hash). Parse it first; fall back to the
+                # WARN branch only if it is still non-Hash after the parse.
                 meta = latest["meta"]
+                meta = (JSON.parse(meta) rescue meta) if meta.is_a?(String)
                 if meta.is_a?(Hash)
                     deployed_image = meta["image"].to_s
                     deployed_digest = deployed_image.include?("@") ? deployed_image.split("@", 2).last : nil
-                    snapshot_digest = svc["digest"]
-                    if snapshot_digest && deployed_digest && deployed_digest != snapshot_digest
+                    # Compare against the digest P1 resolved+verified (recorded
+                    # in @promote_refs), NOT svc["digest"] — staging images are
+                    # tag-form, so svc["digest"] is nil and the race-check would
+                    # otherwise be dead code. P2 runs after P1 in the preflight,
+                    # so the entry must exist; if it doesn't, P1 has already
+                    # REFUSEd this service and we skip the race comparison.
+                    promote_ref = (@promote_refs || {})[svc["name"]]
+                    promote_digest = promote_ref && promote_ref.include?("@sha256:") ? promote_ref.split("@", 2).last : nil
+                    if promote_digest && deployed_digest && deployed_digest != promote_digest
                         findings << "REFUSE: P2 (#{svc['name']}): in-flight race — latest staging deployment is " \
-                                    "#{deployed_digest} but snapshot has #{snapshot_digest}. Re-snapshot and retry."
+                                    "#{deployed_digest} but P1 resolved #{promote_digest}. Re-snapshot and retry."
                     end
                 else
                     findings << "WARN: P2 (#{svc['name']}): in-flight race check skipped — " \
@@ -1203,7 +1238,11 @@ module Railway
         def fetch_latest_staging_deployments(service_id)
             data = gql.query(RollbackCommand::DEPLOYMENTS_QUERY,
                 serviceId: service_id, envId: STAGING_ENV_ID)
-            (data.dig("deployments", "edges") || []).map { |e| e["node"] }
+            nodes = (data.dig("deployments", "edges") || []).map { |e| e["node"] }
+            # Railway's deployments query has no explicit order; sort client-side
+            # by createdAt descending so `.first` is genuinely the newest. nil
+            # createdAt sorts last (treated as oldest).
+            nodes.sort_by { |n| n["createdAt"].to_s }.reverse
         end
 
         # P3 — re-probe staging live at promote time. Authoritative; CI history
@@ -1245,10 +1284,17 @@ module Railway
             # Use `tsx` (workspace dev dependency) for stdlib-free TS execution.
             # IO.popen preserves a clean child env (Kernel#`` would inherit the
             # parent shell verbatim — fine, but explicit is better for audit).
-            output = IO.popen(child_env, ["npx", "--yes", "tsx", probe_bin,
-                "--env", "staging",
-                "--services", services_arg,
-                err: [:child, :out]]) { |io| io.read }
+            # Wrap the launch in a rescue: a missing `npx` (Errno::ENOENT) or
+            # any other spawn-time failure should produce a clean REFUSE
+            # rather than a raw stack trace bubbling up out of P3.
+            begin
+                output = IO.popen(child_env, ["npx", "--yes", "tsx", probe_bin,
+                    "--env", "staging",
+                    "--services", services_arg,
+                    err: [:child, :out]]) { |io| io.read }
+            rescue Errno::ENOENT, StandardError => e
+                return { ok: false, summary: "staging probe failed to launch: #{e.class}: #{e.message}" }
+            end
             ok = $?.exitstatus == 0
             { ok: ok, summary: output.lines.last(10).join.strip }
         end
@@ -1357,22 +1403,38 @@ module Railway
         end
 
         def execute_promotion(staging, prod)
-            @promote_refs ||= {}
+            # Hard guard: @promote_refs is populated by check_p1_ghcr_digests.
+            # If it is nil, preflight did not run — refusing to silently pin
+            # nothing (which a memoize default `||= {}` would have done).
+            raise "internal error: execute_promotion invoked without preflight (@promote_refs nil)" if @promote_refs.nil?
+
+            # Pre-validation pass: every prod-matched staging service MUST
+            # have a digest-shaped @promote_refs entry BEFORE we pin anything.
+            # Pre-fix, a missing entry was detected lazily mid-loop, which
+            # could leave production partially-promoted (some services pinned
+            # to new digest, others still on prior digest). Fail fast here.
+            missing = []
+            (staging["services"] || []).each do |svc|
+                next unless Railway.find_service(prod, svc["name"])
+                ref = @promote_refs[svc["name"]]
+                if ref.nil? || !ref.include?("@sha256:")
+                    missing << "#{svc['name']}=#{ref.inspect}"
+                end
+            end
+            unless missing.empty?
+                warn "REFUSE: promote: P1-verified digest ref missing or non-digest for " \
+                     "#{missing.join(', ')} (internal error — preflight did not capture these services). " \
+                     "Refusing to pin (no mutations issued)."
+                return 1
+            end
+
             already_pinned = []
             (staging["services"] || []).each do |svc|
                 pmatch = Railway.find_service(prod, svc["name"])
                 next unless pmatch
                 # Use the EXACT ref P1 resolved+verified. Re-resolving here
-                # would risk TOCTOU on staging's mutable `:latest`. If the
-                # entry is missing, P1 either didn't run or didn't pass for
-                # this service — treat as an internal error rather than
-                # silently falling back to a tag.
+                # would risk TOCTOU on staging's mutable `:latest`.
                 image = @promote_refs[svc["name"]]
-                if image.nil?
-                    warn "P0/promote (#{svc['name']}): no P1-verified digest ref recorded; " \
-                         "refusing to pin (internal error — preflight did not capture this service)."
-                    return 1
-                end
                 if options[:dry_run]
                     puts "[dry-run] promote #{svc['name']} -> #{image}"
                     next
@@ -1384,12 +1446,17 @@ module Railway
                         image: image)
                     puts "promoted #{svc['name']} -> #{image}"
                     already_pinned << svc["name"]
-                rescue PromoteCommand::MutationError => e
-                    warn e.message
+                # Broadened rescue: a transient GraphQL or network error
+                # mid-loop must NOT crash the script (which would lose the
+                # PARTIAL-PROMOTION report — its entire reason for existing).
+                rescue PromoteCommand::MutationError, Railway::GraphQL::Error, StandardError => e
                     warn "PARTIAL PROMOTION: already pinned #{already_pinned.inspect}; " \
-                         "FAILED on #{svc['name']}: #{e.message}. " \
-                         "Production is in a mixed state — run 'bin/railway rollback-commit' " \
-                         "against the prior snapshot to revert, or re-run promote to retry."
+                         "FAILED on #{svc['name']}: #{e.class}: #{e.message}. " \
+                         "Production is in a mixed state — note that serviceInstanceUpdate " \
+                         "runs BEFORE serviceInstanceRedeploy, so #{svc['name']}'s prod " \
+                         "source.image may already be partially advanced on Railway's side. " \
+                         "Run 'bin/railway rollback-commit' against the prior snapshot to revert, " \
+                         "or re-run promote to retry."
                     return 1
                 end
             end

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -70,22 +70,28 @@ module Railway
         GOOGLE_API_KEY
     ].freeze
 
-    EXPECTED_DOMAINS = {
-        PRODUCTION_ENV_ID => %w[
-            showcase.copilotkit.ai
-            dashboard.showcase.copilotkit.ai
-            dojo.showcase.copilotkit.ai
-            docs.copilotkit.ai
-            hooks.showcase.copilotkit.ai
-        ].freeze,
-        STAGING_ENV_ID => %w[
-            showcase.staging.copilotkit.ai
-            dashboard.showcase.staging.copilotkit.ai
-            dojo.showcase.staging.copilotkit.ai
-            docs.staging.copilotkit.ai
-            hooks.staging.copilotkit.ai
-        ].freeze,
-    }.freeze
+    # EXPECTED_DOMAINS is derived from showcase/scripts/railway-envs.generated.json
+    # (canonical source: showcase/scripts/railway-envs.ts). The CI guard
+    # `npx tsx showcase/scripts/emit-railway-envs-json.ts --check` ensures the
+    # JSON artifact stays in sync with the TS SSOT on every PR. Only public
+    # (non-`*.up.railway.app`) hosts are included, preserving the original set.
+    EXPECTED_DOMAINS = begin
+        ssot_json = File.expand_path("../scripts/railway-envs.generated.json", __dir__)
+        unless File.exist?(ssot_json)
+            raise "railway-envs.generated.json not found at #{ssot_json}. " \
+                  "Re-run: npx tsx showcase/scripts/emit-railway-envs-json.ts"
+        end
+        data = JSON.parse(File.read(ssot_json))
+        by_env = { PRODUCTION_ENV_ID => [], STAGING_ENV_ID => [] }
+        data.fetch("services").each do |svc|
+            domains = svc.fetch("domains")
+            prod = domains.fetch("prod")
+            staging = domains.fetch("staging")
+            by_env[PRODUCTION_ENV_ID] << prod unless prod.end_with?(".up.railway.app")
+            by_env[STAGING_ENV_ID] << staging unless staging.end_with?(".up.railway.app")
+        end
+        by_env.transform_values { |v| v.sort.uniq.freeze }.freeze
+    end
 
     # Heuristic markers for env-scoped URLs (ignored in env-diff and promote).
     ENV_SCOPED_URL_MARKERS = [

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -75,15 +75,20 @@ module Railway
     # `npx tsx showcase/scripts/emit-railway-envs-json.ts --check` ensures the
     # JSON artifact stays in sync with the TS SSOT on every PR. Only public
     # (non-`*.up.railway.app`) hosts are included, preserving the original set.
-    EXPECTED_DOMAINS = begin
+    # Shared SSOT load — read once at class-load, derive both EXPECTED_DOMAINS
+    # and STAGING_SERVICES from the same generated.json so they cannot drift.
+    SSOT_DATA = begin
         ssot_json = File.expand_path("../scripts/railway-envs.generated.json", __dir__)
         unless File.exist?(ssot_json)
             raise "railway-envs.generated.json not found at #{ssot_json}. " \
                   "Re-run: npx tsx showcase/scripts/emit-railway-envs-json.ts"
         end
-        data = JSON.parse(File.read(ssot_json))
+        JSON.parse(File.read(ssot_json)).freeze
+    end
+
+    EXPECTED_DOMAINS = begin
         by_env = { PRODUCTION_ENV_ID => [], STAGING_ENV_ID => [] }
-        data.fetch("services").each do |svc|
+        SSOT_DATA.fetch("services").each do |svc|
             domains = svc.fetch("domains")
             prod = domains.fetch("prod")
             staging = domains.fetch("staging")
@@ -92,6 +97,11 @@ module Railway
         end
         by_env.transform_values { |v| v.sort.uniq.freeze }.freeze
     end
+
+    # Canonical staging service names — used to validate the optional
+    # positional `bin/railway promote <service>` argument. Sourced from the
+    # same SSOT as EXPECTED_DOMAINS so they cannot drift.
+    STAGING_SERVICES = SSOT_DATA.fetch("services").map { |s| s.fetch("name") }.sort.freeze
 
     # Heuristic markers for env-scoped URLs (ignored in env-diff and promote).
     ENV_SCOPED_URL_MARKERS = [
@@ -1016,15 +1026,24 @@ module Railway
             super.merge(
                 confirm_divergence:    false,
                 require_staging_green: true,   # default-on per spec §7.2 P3
+                service:               nil,    # optional positional: restrict to ONE service
+                digest:                nil,    # override resolved prod-image ref (single-service only)
             )
         end
 
         def parser
             OptionParser.new do |o|
                 o.banner = <<~BANNER
-                    Usage: bin/railway promote [--yes] [--non-interactive] [--dry-run]
+                    Usage: bin/railway promote [SERVICE] [--digest REF] [--yes] [--non-interactive] [--dry-run]
 
                       Promote staging snapshot to production.
+
+                      SERVICE (optional positional): restrict the promote to a single
+                        staging service by name. Without it, the entire staging fleet
+                        is promoted (interactive operator use).
+                      --digest REF: pin SERVICE's prod image to REF instead of the
+                        digest resolved from staging's :latest tag. Only valid with a
+                        positional SERVICE; errors otherwise.
 
                       MOVES: image digests (resolved to @sha256: at promote time);
                              autoUpdate=disabled flag.
@@ -1039,6 +1058,7 @@ module Railway
                 o.on("--confirm-divergence", "Proceed past WARN findings (region/replicas/etc.)") { options[:confirm_divergence] = true }
                 o.on("--require-staging-green", "Require live staging probe green at promote time (default)") { options[:require_staging_green] = true }
                 o.on("--no-require-staging-green", "Skip live staging probe (NOT recommended)") { options[:require_staging_green] = false }
+                o.on("--digest REF", "Pin SERVICE's prod image to REF (requires positional SERVICE).") { |v| options[:digest] = v }
                 o.on("--yes") { options[:yes] = true }
                 o.on("--non-interactive") { options[:non_interactive] = true }
                 o.on("--dry-run") { options[:dry_run] = true }
@@ -1048,8 +1068,87 @@ module Railway
 
         def run
             parser.parse!(argv)
+
+            # Optional positional service name; remaining argv after parse! is
+            # whatever the OptionParser left behind. The workflow shape is
+            # `promote <svc> [--digest REF]` — one positional only.
+            if argv.length > 1
+                Railway.die!("promote: too many positional args #{argv.inspect}; expected at most one service name.")
+            end
+            options[:service] = argv.first if argv.first && !argv.first.empty?
+
+            # --digest is meaningful only with a positional service. Without
+            # one it would otherwise silently promote the whole fleet pinned
+            # to one (likely wrong) digest — fail fast instead.
+            if options[:digest] && options[:service].nil?
+                Railway.die!("promote: --digest requires a positional service argument " \
+                             "(e.g. `bin/railway promote <service> --digest <ref>`). " \
+                             "Refusing to promote the fleet with a single digest.")
+            end
+
+            # Validate the positional service against the SSOT
+            # (railway-envs.generated.json). Unknown names must hard-fail with
+            # the valid set listed so the operator can self-correct; falling
+            # through would silently fleet-promote (the original bug).
+            if options[:service] && !STAGING_SERVICES.include?(options[:service])
+                Railway.die!("promote: unknown service #{options[:service].inspect}. " \
+                             "Valid staging services: #{STAGING_SERVICES.join(', ')}.")
+            end
+
             capture_snapshots
+
+            # When restricted to a single service, narrow PER-SERVICE views
+            # of both snapshots BEFORE preflight so per-service checks
+            # (P1..P3/P6, critical env keys, execute_promotion) operate
+            # only on the targeted service. FLEET-SCOPED invariants
+            # (check_expected_prod_domains, check_service_set_parity) MUST
+            # continue to evaluate against the FULL un-narrowed snapshots
+            # — they describe properties of the fleet itself, not the
+            # promote target. Co-narrowing them produces two failure
+            # modes that the per-service workflow can't tolerate:
+            #
+            #   (1) check_expected_prod_domains diffs the fleet-wide
+            #       EXPECTED_DOMAINS against the union of custom_domains
+            #       in `prod["services"]`. Narrowed prod carries at most
+            #       one service's domains → the other ~4 fleet hosts look
+            #       "missing" → spurious WARN → run_with_preflight_only
+            #       refuses (workflow doesn't pass --confirm-divergence).
+            #   (2) check_service_set_parity is a fleet-shape invariant
+            #       (no env has services the other lacks); evaluating it
+            #       on the narrowed pair makes it tautological when both
+            #       contain the same single name, and only accidentally
+            #       fires in the target-absent-from-prod case.
+            #
+            # We therefore retain references to the full snapshots and
+            # only narrow when the per-service branch is taken. The
+            # fleet-scoped checks always read @full_*_snapshot; everything
+            # else reads @staging_snapshot/@prod_snapshot (narrowed when
+            # a positional service is given, full otherwise).
+            @full_staging_snapshot = @staging_snapshot
+            @full_prod_snapshot    = @prod_snapshot
+            if options[:service]
+                narrow_snapshots_to_single_service!(options[:service])
+            end
+
             run_with_preflight_only
+        end
+
+        # Narrow @staging_snapshot and @prod_snapshot to only the named
+        # service. Staging presence is mandatory (validated against SSOT
+        # already); prod absence is tolerated here so the fleet-scoped
+        # service-set-parity REFUSE (now reading @full_prod_snapshot) can
+        # surface as the user-facing error rather than a silent rc=0
+        # 'success' (find_service returns nil, so execute_promotion would
+        # otherwise skip the absent service with no mutation).
+        def narrow_snapshots_to_single_service!(name)
+            staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }
+            if staging_match.empty?
+                Railway.die!("promote: service #{name.inspect} not present in staging snapshot " \
+                             "(SSOT lists it but Railway env returned no instance).")
+            end
+            @staging_snapshot = @staging_snapshot.merge("services" => staging_match)
+            prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }
+            @prod_snapshot = @prod_snapshot.merge("services" => prod_match)
         end
 
         # Test seam — capture_snapshots may be skipped by injecting
@@ -1067,9 +1166,19 @@ module Railway
             findings.concat(check_p2_staging_deployments(@staging_snapshot))
             findings.concat(check_p3_staging_live_green(@staging_snapshot))
             findings.concat(check_p6_parity(@staging_snapshot, @prod_snapshot))
-            findings.concat(check_service_set_parity(@staging_snapshot, @prod_snapshot))
+            # FLEET-SCOPED invariants — must see the FULL fleet so they
+            # produce the same verdict regardless of whether this run is
+            # full-fleet or restricted to a single service. See `run` for
+            # the @full_*_snapshot rationale. When `run` was bypassed
+            # (test seam — preflight invoked directly without capture),
+            # fall back to the current snapshot views so legacy tests
+            # that only set @staging_snapshot/@prod_snapshot continue to
+            # work (full-fleet semantics = full == narrowed).
+            full_staging = @full_staging_snapshot || @staging_snapshot
+            full_prod    = @full_prod_snapshot    || @prod_snapshot
+            findings.concat(check_service_set_parity(full_staging, full_prod))
             findings.concat(check_critical_env_key_parity(@staging_snapshot, @prod_snapshot))
-            findings.concat(check_expected_prod_domains(@prod_snapshot))
+            findings.concat(check_expected_prod_domains(full_prod))
 
             # Mandatory parity-NOTE that env var VALUES are not compared.
             puts "NOTE: env var VALUES are not compared between staging and prod " \
@@ -1115,6 +1224,15 @@ module Railway
         # Returns nil if the staging tag cannot be resolved (e.g. GHCR 404 /
         # auth failed); the caller MUST refuse rather than pin a tag.
         def resolved_prod_image(svc)
+            # --digest override: when the operator supplied an explicit ref AND
+            # we are restricted to a single service, use that ref verbatim. The
+            # `run` entry-point already enforces that --digest requires a
+            # positional service, and snapshots are narrowed to that service
+            # before preflight, so `svc["name"] == options[:service]` here.
+            if options[:digest] && options[:service] && svc["name"] == options[:service]
+                return options[:digest]
+            end
+
             image = svc["image"] || svc["image_tag"]
             return nil if image.nil? || image.empty?
             return image if image.include?("@sha256:")  # already pinned

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -992,7 +992,6 @@ module Railway
 
         def default_options
             super.merge(
-                include_startcommand:  false,
                 confirm_divergence:    false,
                 require_staging_green: true,   # default-on per spec §7.2 P3
             )
@@ -1001,21 +1000,20 @@ module Railway
         def parser
             OptionParser.new do |o|
                 o.banner = <<~BANNER
-                    Usage: bin/railway promote [--include-startcommand] [--yes] [--non-interactive] [--dry-run]
+                    Usage: bin/railway promote [--yes] [--non-interactive] [--dry-run]
 
                       Promote staging snapshot to production.
 
-                      MOVES: image digests; startCommand (only if --include-startcommand);
+                      MOVES: image digests (resolved to @sha256: at promote time);
                              autoUpdate=disabled flag.
                       VERIFY-REFUSE: service-set parity, critical env-key parity,
-                             PB superuser auth, PB collection parity,
-                             cross-env URL leak scan.
+                             startCommand parity, PB superuser auth,
+                             PB collection parity, cross-env URL leak scan.
                       WARN: missing/extra custom domains, sealed-var heuristics.
                       IGNORE: env-scoped URLs, volumes.
 
                       Exit 0 on clean promotion, 1 on refuse/findings, 2 on error.
                 BANNER
-                o.on("--include-startcommand") { options[:include_startcommand] = true }
                 o.on("--confirm-divergence", "Proceed past WARN findings (region/replicas/etc.)") { options[:confirm_divergence] = true }
                 o.on("--require-staging-green", "Require live staging probe green at promote time (default)") { options[:require_staging_green] = true }
                 o.on("--no-require-staging-green", "Skip live staging probe (NOT recommended)") { options[:require_staging_green] = false }
@@ -1085,21 +1083,54 @@ module Railway
             execute_promotion(@staging_snapshot, @prod_snapshot)
         end
 
+        # Resolve a staging service's image to the DIGEST-form ref that should
+        # be pinned to prod. The showcase deploy model is STAGING = mutable
+        # `:latest` tag, PROD = immutable `@sha256:<digest>`. Pinning prod to
+        # a tag would defeat the entire pipeline invariant — and verify-railway-
+        # image-refs PROD_SHAPE would later REFUSE.
+        #
+        # Returns the canonical `<ghcr.io/org/name>@sha256:<digest>` ref.
+        # Returns nil if the staging tag cannot be resolved (e.g. GHCR 404 /
+        # auth failed); the caller MUST refuse rather than pin a tag.
+        def resolved_prod_image(svc)
+            image = svc["image"] || svc["image_tag"]
+            return nil if image.nil? || image.empty?
+            return image if image.include?("@sha256:")  # already pinned
+
+            digest = ghcr.resolve_digest(image)
+            return nil if digest.nil?
+
+            # Strip the tag (`:latest`) and append the digest. parse_image_ref
+            # returns the structured parts; rebuild the canonical pinned ref.
+            parts = ghcr.parse_image_ref(image)
+            registry = parts[:registry] || "ghcr.io"
+            "#{registry}/#{parts[:org]}/#{parts[:name]}@#{digest}"
+        end
+
         # P1 — every staging digest about to be promoted must exist in GHCR.
+        # Verifies the DIGEST-form ref that will actually be pinned to prod
+        # (resolves tag refs first; refuses if the tag can't be resolved).
         def check_p1_ghcr_digests(staging)
             findings = []
             (staging["services"] || []).each do |svc|
-                image = svc["image"]
+                image = svc["image"] || svc["image_tag"]
                 next if image.nil? || image.empty?
-                next unless image.include?("@sha256:")
-                case ghcr.manifest_exists(image)
+
+                resolved = resolved_prod_image(svc)
+                if resolved.nil?
+                    findings << "REFUSE: P1 (#{svc['name']}): cannot resolve #{image} to a GHCR digest; " \
+                                "refusing to pin prod to a mutable tag."
+                    next
+                end
+
+                case ghcr.manifest_exists(resolved)
                 when :exists
                     # ok
                 when :missing
-                    findings << "REFUSE: P1 (#{svc['name']}): #{image} not found in GHCR " \
+                    findings << "REFUSE: P1 (#{svc['name']}): #{resolved} not found in GHCR " \
                                 "(digest may have been garbage-collected; staging build may not have pushed)."
                 when :auth_failed
-                    findings << "REFUSE: P1 (#{svc['name']}): GHCR auth failed for #{image}. " \
+                    findings << "REFUSE: P1 (#{svc['name']}): GHCR auth failed for #{resolved}. " \
                                 "Set GHCR_TOKEN (local: 'gh auth token') or GITHUB_TOKEN (CI: workflow token with packages:read)."
                 end
             end
@@ -1127,7 +1158,12 @@ module Railway
                     findings << "REFUSE: P2 (#{svc['name']}): latest staging deployment status is #{status}, not SUCCESS."
                     next
                 end
-                deployed_image = latest.dig("meta", "image").to_s
+                # Railway's Deployment.meta is a JSON scalar that may deserialize
+                # as a String (not a Hash). Guard the dig so the race-check is
+                # a best-effort no-op when meta isn't structured — SUCCESS
+                # status above is the real gate.
+                meta = latest["meta"]
+                deployed_image = meta.is_a?(Hash) ? meta["image"].to_s : ""
                 deployed_digest = deployed_image.include?("@") ? deployed_image.split("@", 2).last : nil
                 snapshot_digest = svc["digest"]
                 if snapshot_digest && deployed_digest && deployed_digest != snapshot_digest
@@ -1298,7 +1334,16 @@ module Railway
             (staging["services"] || []).each do |svc|
                 pmatch = Railway.find_service(prod, svc["name"])
                 next unless pmatch
-                image = svc["image"] || svc["image_tag"]
+                # Resolve staging tag → GHCR digest BEFORE pinning. Pinning a
+                # mutable tag (`:latest`) to prod would defeat the immutable-
+                # prod invariant; refuse rather than guess.
+                image = resolved_prod_image(svc)
+                if image.nil?
+                    src = svc["image"] || svc["image_tag"]
+                    warn "P0/promote (#{svc['name']}): cannot resolve #{src} to a GHCR digest; " \
+                         "refusing to pin prod to a mutable tag."
+                    return 1
+                end
                 if options[:dry_run]
                     puts "[dry-run] promote #{svc['name']} -> #{image}"
                     next

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -904,6 +904,14 @@ module Railway
 
     # promote — copy staging digests into production with prechecks.
     class PromoteCommand < BaseCommand
+        def default_options
+            super.merge(
+                include_startcommand:  false,
+                confirm_divergence:    false,
+                require_staging_green: true,   # default-on per spec §7.2 P3
+            )
+        end
+
         def parser
             OptionParser.new do |o|
                 o.banner = <<~BANNER
@@ -922,6 +930,9 @@ module Railway
                       Exit 0 on clean promotion, 1 on refuse/findings, 2 on error.
                 BANNER
                 o.on("--include-startcommand") { options[:include_startcommand] = true }
+                o.on("--confirm-divergence", "Proceed past WARN findings (region/replicas/etc.)") { options[:confirm_divergence] = true }
+                o.on("--require-staging-green", "Require live staging probe green at promote time (default)") { options[:require_staging_green] = true }
+                o.on("--no-require-staging-green", "Skip live staging probe (NOT recommended)") { options[:require_staging_green] = false }
                 o.on("--yes") { options[:yes] = true }
                 o.on("--non-interactive") { options[:non_interactive] = true }
                 o.on("--dry-run") { options[:dry_run] = true }
@@ -931,48 +942,52 @@ module Railway
 
         def run
             parser.parse!(argv)
+            capture_snapshots
+            run_with_preflight_only
+        end
 
-            # Capture both env snapshots.
-            staging = SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)
-            prod    = SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)
+        # Test seam — capture_snapshots may be skipped by injecting
+        # @staging_snapshot / @prod_snapshot directly.
+        def capture_snapshots
+            @staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)
+            @prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)
+        end
 
+        # All preconditions, then (if clean) the actual promote.
+        def run_with_preflight_only
             findings = []
 
-            # VERIFY: service-set parity.
-            s_names = (staging["services"] || []).map { |s| s["name"] }.sort
-            p_names = (prod["services"] || []).map { |s| s["name"] }.sort
-            missing_in_prod = s_names - p_names
-            missing_in_stg  = p_names - s_names
-            findings << "REFUSE: services in staging not in prod: #{missing_in_prod.join(', ')}" unless missing_in_prod.empty?
-            findings << "REFUSE: services in prod not in staging: #{missing_in_stg.join(', ')}" unless missing_in_stg.empty?
+            findings.concat(check_p1_ghcr_digests(@staging_snapshot))
+            findings.concat(check_p2_staging_deployments(@staging_snapshot))
+            findings.concat(check_p3_staging_live_green(@staging_snapshot))
+            findings.concat(check_p6_parity(@staging_snapshot, @prod_snapshot))
+            findings.concat(check_service_set_parity(@staging_snapshot, @prod_snapshot))
+            findings.concat(check_critical_env_key_parity(@staging_snapshot, @prod_snapshot))
+            findings.concat(check_expected_prod_domains(@prod_snapshot))
 
-            # VERIFY: critical env-key parity per service.
-            (staging["services"] || []).each do |svc|
-                pmatch = Railway.find_service(prod, svc["name"])
-                next unless pmatch
-                missing_keys = (CRITICAL_ENV_KEYS & svc["env_keys"]) - pmatch["env_keys"]
-                unless missing_keys.empty?
-                    findings << "REFUSE: #{svc['name']}: critical keys missing in prod: #{missing_keys.join(', ')}"
-                end
-            end
-
-            # WARN: domain audits.
-            expected_prod_domains = EXPECTED_DOMAINS[PRODUCTION_ENV_ID]
-            actual_prod_domains = (prod["services"] || []).flat_map { |s| s["custom_domains"] || [] }.uniq.sort
-            missing_domains = expected_prod_domains - actual_prod_domains
-            findings << "WARN: production missing expected custom domains: #{missing_domains.join(', ')}" unless missing_domains.empty?
-
-            # WARN: cross-env URL leak in env-key NAMES is impossible (we have names only);
-            # we cannot read values without an explicit per-key fetch. Log as IGNORE note.
+            # Mandatory parity-NOTE that env var VALUES are not compared.
+            puts "NOTE: env var VALUES are not compared between staging and prod " \
+                 "(intentional — staging and prod hold different secrets/URLs). " \
+                 "Only the set of keys is compared."
 
             refuses = findings.select { |f| f.start_with?("REFUSE") }
+            warns   = findings.select { |f| f.start_with?("WARN") }
+
             unless refuses.empty?
                 refuses.each { |f| puts f }
                 puts "Promote refused due to #{refuses.size} REFUSE finding(s)."
                 return 1
             end
 
-            findings.each { |f| puts f }
+            unless warns.empty?
+                warns.each { |f| puts f }
+                unless options[:confirm_divergence]
+                    puts "Promote refused: #{warns.size} WARN finding(s). " \
+                         "Re-run with --confirm-divergence after inspecting."
+                    return 1
+                end
+                puts "[--confirm-divergence set] proceeding past #{warns.size} WARN finding(s)."
+            end
 
             Railway.confirm_destructive!(
                 env_label: "production",
@@ -981,7 +996,66 @@ module Railway
                 yes: options[:yes],
             )
 
-            # Execute promotion: redeploy each prod service with staging's image.
+            execute_promotion(@staging_snapshot, @prod_snapshot)
+        end
+
+        # P1 — every staging digest about to be promoted must exist in GHCR.
+        def check_p1_ghcr_digests(staging)
+            findings = []
+            (staging["services"] || []).each do |svc|
+                image = svc["image"]
+                next if image.nil? || image.empty?
+                next unless image.include?("@sha256:")
+                case ghcr.manifest_exists(image)
+                when :exists
+                    # ok
+                when :missing
+                    findings << "REFUSE: P1 (#{svc['name']}): #{image} not found in GHCR " \
+                                "(digest may have been garbage-collected; staging build may not have pushed)."
+                when :auth_failed
+                    findings << "REFUSE: P1 (#{svc['name']}): GHCR auth failed for #{image}. " \
+                                "Set GHCR_TOKEN (local: 'gh auth token') or GITHUB_TOKEN (CI: workflow token with packages:read)."
+                end
+            end
+            findings
+        rescue Railway::GHCR::Error => e
+            ["REFUSE: P1: GHCR check raised #{e.class}: #{e.message}"]
+        end
+
+        # Stubs filled in by later phases; return [] so D.1 lands green.
+        def check_p2_staging_deployments(_staging); []; end
+        def check_p3_staging_live_green(_staging); []; end
+        def check_p6_parity(_staging, _prod); []; end
+
+        def check_service_set_parity(staging, prod)
+            findings = []
+            s_names = (staging["services"] || []).map { |s| s["name"] }.sort
+            p_names = (prod["services"] || []).map { |s| s["name"] }.sort
+            findings << "REFUSE: services in staging not in prod: #{(s_names - p_names).join(', ')}" unless (s_names - p_names).empty?
+            findings << "REFUSE: services in prod not in staging: #{(p_names - s_names).join(', ')}" unless (p_names - s_names).empty?
+            findings
+        end
+
+        def check_critical_env_key_parity(staging, prod)
+            findings = []
+            (staging["services"] || []).each do |svc|
+                pmatch = Railway.find_service(prod, svc["name"])
+                next unless pmatch
+                missing = (CRITICAL_ENV_KEYS & (svc["env_keys"] || [])) - (pmatch["env_keys"] || [])
+                findings << "REFUSE: #{svc['name']}: critical env keys missing in prod: #{missing.join(', ')}" unless missing.empty?
+            end
+            findings
+        end
+
+        def check_expected_prod_domains(prod)
+            expected = EXPECTED_DOMAINS[PRODUCTION_ENV_ID] || []
+            actual = (prod["services"] || []).flat_map { |s| s["custom_domains"] || [] }.uniq.sort
+            missing = expected - actual
+            return [] if missing.empty?
+            ["WARN: production missing expected custom domains: #{missing.join(', ')}"]
+        end
+
+        def execute_promotion(staging, prod)
             (staging["services"] || []).each do |svc|
                 pmatch = Railway.find_service(prod, svc["name"])
                 next unless pmatch
@@ -997,7 +1071,6 @@ module Railway
                     image: image)
                 puts "promoted #{svc['name']} -> #{image}"
             end
-
             0
         end
     end

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -1144,8 +1144,52 @@ module Railway
             (data.dig("deployments", "edges") || []).map { |e| e["node"] }
         end
 
-        # Stub — P3 lands in a later commit.
-        def check_p3_staging_live_green(_staging); []; end
+        # P3 — re-probe staging live at promote time. Authoritative; CI history
+        # is not, because showcase_deploy.yml uses cancel-in-progress.
+        # Default-on; can be disabled with --no-require-staging-green.
+        def check_p3_staging_live_green(staging)
+            unless options[:require_staging_green]
+                puts "P3 SKIPPED (--no-require-staging-green set; staging is NOT being live-re-probed)."
+                return []
+            end
+            services = (staging["services"] || []).map { |s| s["name"] }.compact.uniq
+            return [] if services.empty?
+            result = run_staging_probe(services: services)
+            return [] if result[:ok]
+            ["REFUSE: P3: staging is not green for #{services.join(', ')}: #{result[:summary]}"]
+        end
+
+        # Shell out to Workstream A's parameterized probe entrypoint.
+        # Contract: exit 0 = green, non-zero = red; stdout is the human summary.
+        #
+        # Explicitly forward RAILWAY_TOKEN (the probe enumerates Railway state
+        # over GraphQL) and GHCR_TOKEN / GITHUB_TOKEN (the probe may need to
+        # cross-check GHCR for the digest under test). All three are inherited
+        # from the parent process env when set; the explicit hash below makes
+        # the dependency visible and survives any future child-env sanitizing.
+        def run_staging_probe(services:)
+            probe_bin = File.expand_path("../scripts/verify-deploy.ts", __dir__)
+            unless File.exist?(probe_bin)
+                return { ok: false, summary: "verify-deploy.ts not found at #{probe_bin} — Workstream A dependency missing." }
+            end
+            services_arg = services.join(",")
+            child_env = {
+                "RAILWAY_TOKEN" => ENV["RAILWAY_TOKEN"],
+                "GHCR_TOKEN"    => ENV["GHCR_TOKEN"],
+                "GITHUB_TOKEN"  => ENV["GITHUB_TOKEN"],
+                "PATH"          => ENV["PATH"],
+                "HOME"          => ENV["HOME"],
+            }.compact
+            # Use `tsx` (workspace dev dependency) for stdlib-free TS execution.
+            # IO.popen preserves a clean child env (Kernel#`` would inherit the
+            # parent shell verbatim — fine, but explicit is better for audit).
+            output = IO.popen(child_env, ["npx", "--yes", "tsx", probe_bin,
+                "--env", "staging",
+                "--services", services_arg,
+                err: [:child, :out]]) { |io| io.read }
+            ok = $?.exitstatus == 0
+            { ok: ok, summary: output.lines.last(10).join.strip }
+        end
 
         # P6 — parity matrix.
         #   REFUSE: startCommand, healthcheckPath, image shape.

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -140,6 +140,21 @@ module Railway
             end
             t
         end
+
+        # GHCR bearer. Distinct from the Railway token (Auth.token).
+        # Resolution order:
+        #   1. GHCR_TOKEN — explicit PAT (local dev or CI override).
+        #   2. GITHUB_TOKEN — GitHub Actions automatic token (needs packages:read).
+        # Returns nil if no token is available; caller MUST refuse rather than
+        # silently fall through to anonymous (which works for public images but
+        # not for digest-existence verification against private repos).
+        def ghcr_token
+            t = ENV["GHCR_TOKEN"]
+            return t.strip if t && !t.strip.empty?
+            t = ENV["GITHUB_TOKEN"]
+            return t.strip if t && !t.strip.empty?
+            nil
+        end
     end
 
     # ── GraphQL Client ─────────────────────────────────────────────────────────
@@ -203,7 +218,7 @@ module Railway
             "application/vnd.docker.distribution.manifest.v2+json",
         ].join(", ").freeze
 
-        def initialize(token: ENV["GHCR_TOKEN"], http: nil)
+        def initialize(token: Railway::Auth.ghcr_token, http: nil)
             @token = token
             @http = http
         end
@@ -236,6 +251,44 @@ module Railway
             raise Error, "GHCR did not return Docker-Content-Digest for #{image_ref}" if digest.nil?
 
             digest
+        end
+
+        # Verify a digest-pinned image exists in GHCR. Returns:
+        #   :exists       — HEAD returned 200.
+        #   :missing      — HEAD returned 404 (digest GC'd or never built).
+        #   :auth_failed  — HEAD returned 401/403 (token missing/insufficient).
+        # Raises GHCR::Error on 5xx or transport failure.
+        #
+        # The caller MUST pass an image ref already pinned to @sha256:<digest>;
+        # this is the "P1 precondition" check from the showcase deploy spec, not
+        # a tag-resolution. We do not chase a tag here — we verify the exact
+        # bytes about to be pinned to prod.
+        def manifest_exists(image_ref)
+            parts = parse_image_ref(image_ref)
+            digest = parts[:digest]
+            raise ArgumentError, "manifest_exists requires a digest-pinned ref, got #{image_ref}" if digest.nil?
+
+            org  = parts[:org]
+            name = parts[:name]
+
+            bearer = bearer_for(org, name)
+            url = "https://ghcr.io/v2/#{org}/#{name}/manifests/#{digest}"
+
+            resp =
+                if @http
+                    @http.call(method: :head, url: url, headers: headers(bearer))
+                else
+                    http_head(url, headers: headers(bearer))
+                end
+
+            status = resp[:status]
+            case status
+            when 200       then :exists
+            when 404       then :missing
+            when 401, 403  then :auth_failed
+            else
+                raise Error, "GHCR manifest HEAD #{status} for #{image_ref}"
+            end
         end
 
         # Parse image ref into { registry, org, name, tag, digest }.

--- a/showcase/bin/spec/test_cli_parsing.rb
+++ b/showcase/bin/spec/test_cli_parsing.rb
@@ -58,9 +58,9 @@ class CLIParsingTest < Minitest::Test
     end
 
     def test_promote_flags_parse
-        c = Railway::PromoteCommand.new(["--include-startcommand", "--yes", "--dry-run"])
+        c = Railway::PromoteCommand.new(["--confirm-divergence", "--yes", "--dry-run"])
         c.parser.parse!(c.argv)
-        assert c.options[:include_startcommand]
+        assert c.options[:confirm_divergence]
         assert c.options[:yes]
         assert c.options[:dry_run]
     end

--- a/showcase/bin/spec/test_expected_domains_parity.rb
+++ b/showcase/bin/spec/test_expected_domains_parity.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require "json"
+
+# Parity test: Ruby's Railway::EXPECTED_DOMAINS (derived at load time from
+# showcase/scripts/railway-envs.generated.json) MUST equal the public-host
+# subset computed directly from the same TS SSOT artifact. If this test fails,
+# either the JSON artifact is stale or bin/railway's derivation logic drifted
+# from the TS SSOT shape.
+class ExpectedDomainsParityTest < Minitest::Test
+    SSOT_JSON = File.expand_path("../../scripts/railway-envs.generated.json", __dir__)
+
+    def test_generated_json_exists
+        assert File.exist?(SSOT_JSON),
+               "expected SSOT artifact at #{SSOT_JSON} — run " \
+               "`npx tsx showcase/scripts/emit-railway-envs-json.ts`"
+    end
+
+    def test_ruby_expected_domains_matches_ts_ssot_public_hosts
+        data = JSON.parse(File.read(SSOT_JSON))
+        prod_env_id = data.fetch("envIds").fetch("prod")
+        staging_env_id = data.fetch("envIds").fetch("staging")
+
+        expected_prod = data.fetch("services")
+                            .map { |s| s.fetch("domains").fetch("prod") }
+                            .reject { |h| h.end_with?(".up.railway.app") }
+                            .sort
+                            .uniq
+        expected_staging = data.fetch("services")
+                               .map { |s| s.fetch("domains").fetch("staging") }
+                               .reject { |h| h.end_with?(".up.railway.app") }
+                               .sort
+                               .uniq
+
+        # Sanity: the env-id constants in the Ruby file must match the SSOT.
+        assert_equal prod_env_id, Railway::PRODUCTION_ENV_ID,
+                     "PRODUCTION_ENV_ID drifted from SSOT envIds.prod"
+        assert_equal staging_env_id, Railway::STAGING_ENV_ID,
+                     "STAGING_ENV_ID drifted from SSOT envIds.staging"
+
+        actual = Railway::EXPECTED_DOMAINS
+        assert_equal expected_prod, actual.fetch(prod_env_id).sort,
+                     "Ruby EXPECTED_DOMAINS[prod] != TS SSOT public prod hosts"
+        assert_equal expected_staging, actual.fetch(staging_env_id).sort,
+                     "Ruby EXPECTED_DOMAINS[staging] != TS SSOT public staging hosts"
+    end
+
+    def test_expected_domains_keys_are_only_prod_and_staging_env_ids
+        keys = Railway::EXPECTED_DOMAINS.keys.sort
+        assert_equal [Railway::PRODUCTION_ENV_ID, Railway::STAGING_ENV_ID].sort, keys
+    end
+end

--- a/showcase/bin/spec/test_ghcr_manifest_exists.rb
+++ b/showcase/bin/spec/test_ghcr_manifest_exists.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+class GHCRManifestExistsTest < Minitest::Test
+    class FakeHTTP
+        def initialize(responses)
+            @responses = responses
+        end
+
+        def call(method:, url:, headers: {})
+            key = [method, url]
+            r = @responses[key] || @responses[url]
+            raise "no fake response for #{key.inspect}" unless r
+            r
+        end
+    end
+
+    DIGEST   = "sha256:cafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00d"
+    REF      = "ghcr.io/copilotkit/showcase-shell@#{DIGEST}"
+    URL      = "https://ghcr.io/v2/copilotkit/showcase-shell/manifests/#{DIGEST}"
+
+    def test_manifest_exists_returns_exists_on_200
+        fake = FakeHTTP.new(URL => { status: 200, headers: {}, body: "" })
+        g = Railway::GHCR.new(token: "x", http: fake)
+        assert_equal :exists, g.manifest_exists(REF)
+    end
+
+    def test_manifest_exists_returns_missing_on_404
+        fake = FakeHTTP.new(URL => { status: 404, headers: {}, body: "" })
+        g = Railway::GHCR.new(token: "x", http: fake)
+        assert_equal :missing, g.manifest_exists(REF)
+    end
+
+    def test_manifest_exists_returns_auth_failed_on_401_403
+        fake401 = FakeHTTP.new(URL => { status: 401, headers: {}, body: "" })
+        fake403 = FakeHTTP.new(URL => { status: 403, headers: {}, body: "" })
+        assert_equal :auth_failed, Railway::GHCR.new(token: "x", http: fake401).manifest_exists(REF)
+        assert_equal :auth_failed, Railway::GHCR.new(token: "x", http: fake403).manifest_exists(REF)
+    end
+
+    def test_manifest_exists_raises_on_5xx
+        fake = FakeHTTP.new(URL => { status: 500, headers: {}, body: "boom" })
+        g = Railway::GHCR.new(token: "x", http: fake)
+        assert_raises(Railway::GHCR::Error) { g.manifest_exists(REF) }
+    end
+
+    def test_manifest_exists_requires_pinned_digest
+        # An unpinned tag is a programmer error here — we are verifying the
+        # CONCRETE digest we are about to promote, not resolving a tag.
+        g = Railway::GHCR.new(token: "x")
+        assert_raises(ArgumentError) do
+            g.manifest_exists("ghcr.io/copilotkit/showcase-shell:latest")
+        end
+    end
+end

--- a/showcase/bin/spec/test_ghcr_token.rb
+++ b/showcase/bin/spec/test_ghcr_token.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+class GHCRTokenTest < Minitest::Test
+    def setup
+        @prior_github = ENV.delete("GITHUB_TOKEN")
+        @prior_ghcr   = ENV.delete("GHCR_TOKEN")
+    end
+
+    def teardown
+        ENV["GITHUB_TOKEN"] = @prior_github if @prior_github
+        ENV["GHCR_TOKEN"]   = @prior_ghcr   if @prior_ghcr
+    end
+
+    def test_prefers_explicit_ghcr_token
+        ENV["GITHUB_TOKEN"] = "ci-token"
+        ENV["GHCR_TOKEN"]   = "explicit-pat"
+        assert_equal "explicit-pat", Railway::Auth.ghcr_token
+    end
+
+    def test_falls_back_to_github_token_in_ci
+        ENV["GITHUB_TOKEN"] = "ci-token"
+        assert_equal "ci-token", Railway::Auth.ghcr_token
+    end
+
+    def test_returns_nil_when_no_token_available
+        # No GH_AUTH_TOKEN shim, no env vars: nil (caller decides to refuse).
+        assert_nil Railway::Auth.ghcr_token
+    end
+
+    def test_does_not_return_railway_token
+        ENV["RAILWAY_TOKEN"] = "railway-bearer"
+        assert_nil Railway::Auth.ghcr_token
+    ensure
+        ENV.delete("RAILWAY_TOKEN")
+    end
+end

--- a/showcase/bin/spec/test_ghcr_token.rb
+++ b/showcase/bin/spec/test_ghcr_token.rb
@@ -4,13 +4,20 @@ require_relative "spec_helper"
 
 class GHCRTokenTest < Minitest::Test
     def setup
-        @prior_github = ENV.delete("GITHUB_TOKEN")
-        @prior_ghcr   = ENV.delete("GHCR_TOKEN")
+        @prior_github  = ENV.delete("GITHUB_TOKEN")
+        @prior_ghcr    = ENV.delete("GHCR_TOKEN")
+        @prior_railway = ENV.delete("RAILWAY_TOKEN")
     end
 
     def teardown
-        ENV["GITHUB_TOKEN"] = @prior_github if @prior_github
-        ENV["GHCR_TOKEN"]   = @prior_ghcr   if @prior_ghcr
+        # Unconditionally delete any test-set values so they don't leak across
+        # tests, THEN re-set the saved priors if those were present.
+        ENV.delete("GITHUB_TOKEN")
+        ENV.delete("GHCR_TOKEN")
+        ENV.delete("RAILWAY_TOKEN")
+        ENV["GITHUB_TOKEN"]  = @prior_github  if @prior_github
+        ENV["GHCR_TOKEN"]    = @prior_ghcr    if @prior_ghcr
+        ENV["RAILWAY_TOKEN"] = @prior_railway if @prior_railway
     end
 
     def test_prefers_explicit_ghcr_token

--- a/showcase/bin/spec/test_promote_cr_fixes.rb
+++ b/showcase/bin/spec/test_promote_cr_fixes.rb
@@ -1,0 +1,401 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# Covers nine CR fixes against PromoteCommand:
+#   FIX-1: @promote_refs is RESET per check_p1_ghcr_digests run (not memoized
+#          across A→B preflight invocations), and execute_promotion HARD-GUARDS
+#          against a nil @promote_refs.
+#   FIX-2: P2 in-flight race compares deployed_digest vs the digest portion of
+#          @promote_refs[name] (not the snapshot's tag-form nil `digest`).
+#          Also: JSON-string `meta` is parsed (not WARN-skipped); and
+#          fetch_latest_staging_deployments sorts createdAt-desc so `.first`
+#          is genuinely latest.
+#   FIX-3: execute_promotion pre-validates ALL prod-matched services have a
+#          digest-shaped @promote_refs entry BEFORE pinning anything.
+#   FIX-4: execute_promotion rescue broadens to MutationError + GraphQL::Error
+#          + StandardError, retains PARTIAL-PROMOTION report, and drops the
+#          duplicate `warn e.message`.
+#   FIX-5: check_p1_ghcr_digests emits REFUSE: P1 ... "no image" when staging
+#          service has nil/empty image (instead of silent skip).
+#   FIX-6: P1 per-service rescue broadens to StandardError so non-GHCR errors
+#          don't bypass the loop.
+#   FIX-7: pin_and_verify raises ArgumentError immediately when called with a
+#          tag-form (non-digest) image.
+#   FIX-8: pin_and_verify timestamp gate is non-vacuous: a nil observed
+#          updatedAt does NOT declare success, even when pre_update_ts is nil.
+#   FIX-9: run_staging_probe rescues launch failures (Errno::ENOENT, etc.)
+#          and returns ok:false with a descriptive summary.
+class PromoteCRFixesTest < Minitest::Test
+    # ----- shared fakes -----
+
+    class NullGQL
+        def query(*); {}; end
+    end
+
+    # GQL that records calls and returns canned responses for P2/preflight only
+    # (no mutations).
+    class P2GQL
+        attr_reader :calls
+        def initialize(deployments_by_svc)
+            @deployments_by_svc = deployments_by_svc
+            @calls = []
+        end
+        def query(q, vars = {})
+            @calls << [q, vars]
+            if q.include?("query Deployments")
+                edges = (@deployments_by_svc[vars[:serviceId]] || []).map { |n| { "node" => n } }
+                return { "deployments" => { "edges" => edges } }
+            end
+            {}
+        end
+    end
+
+    # GHCR fake that always reports :exists and resolves any :latest -> a digest.
+    class PassGHCR
+        def initialize(resolve_map: {}); @resolve_map = resolve_map; end
+        def resolve_digest(ref)
+            return ref.split("@", 2).last if ref.include?("@sha256:")
+            @resolve_map[ref] || "sha256:resolved_for_#{ref}"
+        end
+        def manifest_exists(_); :exists; end
+        def parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+    end
+
+    def make_svc(name, image:)
+        {
+            "name" => name, "service_id" => "svc-stg-#{name}",
+            "image" => image,
+            "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+        }
+    end
+
+    # =================== FIX-1: @promote_refs is reset, not memoized ===================
+
+    def test_fix1_promote_refs_resets_between_p1_runs
+        # Reuse a single PromoteCommand instance across two distinct snapshots
+        # (snapshot A and snapshot B). After the second P1 run, @promote_refs
+        # must reflect ONLY snapshot B's services — no stale A entries.
+        cmd = Railway::PromoteCommand.new([])
+        cmd.instance_variable_set(:@ghcr, PassGHCR.new)
+
+        snapshot_a = { "services" => [make_svc("alpha", image: "ghcr.io/copilotkit/alpha:latest")] }
+        snapshot_b = { "services" => [make_svc("beta",  image: "ghcr.io/copilotkit/beta:latest")] }
+
+        cmd.send(:check_p1_ghcr_digests, snapshot_a)
+        refs_after_a = cmd.instance_variable_get(:@promote_refs).keys.sort
+        assert_equal ["alpha"], refs_after_a
+
+        cmd.send(:check_p1_ghcr_digests, snapshot_b)
+        refs_after_b = cmd.instance_variable_get(:@promote_refs).keys.sort
+        assert_equal ["beta"], refs_after_b,
+            "stale entries from snapshot A must be cleared; got #{refs_after_b.inspect}"
+    end
+
+    def test_fix1_execute_promotion_raises_when_promote_refs_nil
+        # execute_promotion called WITHOUT a prior preflight must raise an
+        # internal-error exception (not silently treat refs as empty).
+        cmd = Railway::PromoteCommand.new([])
+        cmd.instance_variable_set(:@ghcr, PassGHCR.new)
+        # Deliberately do NOT call check_p1_ghcr_digests; @promote_refs stays nil.
+        staging = { "services" => [make_svc("x", image: "ghcr.io/copilotkit/x:latest")] }
+        prod    = { "services" => [{ "name" => "x", "service_id" => "svc-prod-x",
+                                     "image" => "ghcr.io/copilotkit/x@sha256:OLD" }] }
+        err = assert_raises(RuntimeError) do
+            cmd.send(:execute_promotion, staging, prod)
+        end
+        assert_match(/internal error.*execute_promotion.*preflight/i, err.message)
+    end
+
+    # =================== FIX-2: P2 race-check is alive ===================
+
+    def test_fix2_p2_race_check_uses_promote_refs_not_snapshot_digest
+        # Staging service is tag-form (so svc["digest"] is nil — pre-fix the
+        # race-check was DEAD CODE). After fix: P2 compares against the digest
+        # captured in @promote_refs[name].
+        cmd = Railway::PromoteCommand.new([])
+        cmd.instance_variable_set(:@promote_refs, {
+            "x" => "ghcr.io/copilotkit/x@sha256:YYY",
+        })
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |_svc_id|
+            [{ "id" => "d1", "status" => "SUCCESS",
+               "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:XXX" },
+               "createdAt" => "2026-05-28T01:00:00Z" }]
+        end
+        staging = { "services" => [{
+            "name" => "x", "service_id" => "svc-1",
+            "image" => "ghcr.io/copilotkit/x:latest",  # tag-form; no "digest"
+            "env_keys" => [],
+        }] }
+        findings = cmd.send(:check_p2_staging_deployments, staging)
+        assert(findings.any? { |f| f =~ /REFUSE: P2 \(x\).*in-flight.*sha256:XXX.*sha256:YYY/ },
+            "expected REFUSE: P2 comparing deployed XXX vs P1-resolved YYY; got: #{findings.inspect}")
+    end
+
+    def test_fix2_p2_parses_meta_when_it_is_a_json_string
+        # Some Railway responses deserialize Deployment.meta as a JSON String
+        # (not a Hash). P2 must parse it before falling back to the WARN branch.
+        cmd = Railway::PromoteCommand.new([])
+        cmd.instance_variable_set(:@promote_refs, {
+            "x" => "ghcr.io/copilotkit/x@sha256:abc",
+        })
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |_svc_id|
+            [{ "id" => "d1", "status" => "SUCCESS",
+               "meta" => '{"image":"ghcr.io/copilotkit/x@sha256:abc"}',
+               "createdAt" => "2026-05-28T01:00:00Z" }]
+        end
+        staging = { "services" => [{
+            "name" => "x", "service_id" => "svc-1",
+            "image" => "ghcr.io/copilotkit/x:latest",
+            "env_keys" => [],
+        }] }
+        findings = cmd.send(:check_p2_staging_deployments, staging)
+        refute(findings.any? { |f| f =~ /WARN: P2 \(x\)/ },
+            "JSON-string meta must be parsed (not WARN-skipped); got: #{findings.inspect}")
+        refute(findings.any? { |f| f =~ /REFUSE: P2/ },
+            "matching digest in parsed meta must not REFUSE; got: #{findings.inspect}")
+    end
+
+    def test_fix2_fetch_latest_staging_deployments_sorts_newest_first
+        # Stub gql.query to return deployments in OLDEST-first order — the
+        # helper must sort by createdAt DESC so `.first` is the newest.
+        cmd = Railway::PromoteCommand.new([])
+        nodes = [
+            { "id" => "d-old", "status" => "SUCCESS", "createdAt" => "2026-05-01T00:00:00Z" },
+            { "id" => "d-new", "status" => "SUCCESS", "createdAt" => "2026-05-28T00:00:00Z" },
+            { "id" => "d-mid", "status" => "FAILED",  "createdAt" => "2026-05-15T00:00:00Z" },
+        ]
+        edges = nodes.map { |n| { "node" => n } }
+        fake_gql = Object.new
+        fake_gql.define_singleton_method(:query) do |_q, _vars = {}|
+            { "deployments" => { "edges" => edges } }
+        end
+        cmd.instance_variable_set(:@gql, fake_gql)
+        deployments = cmd.send(:fetch_latest_staging_deployments, "svc-1")
+        assert_equal "d-new", deployments.first["id"],
+            "fetch_latest_staging_deployments must sort newest-first; got: #{deployments.map { |d| d['id'] }.inspect}"
+    end
+
+    # =================== FIX-3: execute_promotion pre-validation ===================
+
+    def test_fix3_execute_promotion_pre_validates_all_refs_before_any_pin
+        # Two prod-matched services; ONE missing from @promote_refs. The
+        # pre-validation must REFUSE+return 1 BEFORE any serviceInstanceUpdate
+        # mutation is issued.
+        cmd = Railway::PromoteCommand.new([])
+        recorded = []
+        fake_gql = Object.new
+        fake_gql.define_singleton_method(:query) do |q, vars = {}|
+            recorded << [q, vars]
+            { "serviceInstanceUpdate" => true, "serviceInstanceRedeploy" => true }
+        end
+        cmd.instance_variable_set(:@gql, fake_gql)
+        cmd.instance_variable_set(:@promote_refs, {
+            "a" => "ghcr.io/copilotkit/a@sha256:aaa",
+            # "b" is MISSING
+        })
+        staging = { "services" => [make_svc("a", image: "ghcr.io/copilotkit/a:latest"),
+                                   make_svc("b", image: "ghcr.io/copilotkit/b:latest")] }
+        prod = { "services" => [
+            { "name" => "a", "service_id" => "svc-prod-a", "image" => "ghcr.io/copilotkit/a@sha256:OLD" },
+            { "name" => "b", "service_id" => "svc-prod-b", "image" => "ghcr.io/copilotkit/b@sha256:OLD" },
+        ] }
+        _out, _err = capture_io { @rc = cmd.send(:execute_promotion, staging, prod) }
+        assert_equal 1, @rc, "execute_promotion must return 1 when a ref is missing"
+        assert(recorded.none? { |q, _| q.include?("serviceInstanceUpdate") },
+            "no serviceInstanceUpdate mutations should be issued; got: #{recorded.map { |q, _| q[0, 30] }.inspect}")
+    end
+
+    # =================== FIX-4: broadened rescue + partial-promotion report ===================
+
+    def test_fix4_execute_promotion_rescues_graphql_error_with_partial_report
+        # First service pins successfully; second raises Railway::GraphQL::Error
+        # on its serviceInstanceUpdate mutation. The broadened rescue must
+        # catch it and still emit the PARTIAL-PROMOTION report.
+        cmd = Railway::PromoteCommand.new([])
+        call_count = 0
+        # FakeGQL that records calls and raises GraphQL::Error on the SECOND
+        # serviceInstanceUpdate mutation.
+        fake_gql = Object.new
+        @pinned = nil
+        @pre_ts = "2026-05-28T00:00:00Z"
+        pinned_ref = nil
+        fake_gql.define_singleton_method(:query) do |q, vars = {}|
+            if q.include?("serviceInstanceUpdate")
+                call_count += 1
+                raise Railway::GraphQL::Error, "boom on update #2" if call_count == 2
+                pinned_ref = vars[:image]
+                { "serviceInstanceUpdate" => true }
+            elsif q.include?("serviceInstanceRedeploy")
+                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("ServiceInstanceRecheck")
+                if pinned_ref
+                    { "serviceInstance" => { "id" => "i",
+                                              "source" => { "image" => pinned_ref },
+                                              "updatedAt" => "2026-05-29T00:00:01Z" } }
+                else
+                    { "serviceInstance" => { "id" => "i",
+                                              "source" => { "image" => "ghcr.io/copilotkit/x@sha256:OLD" },
+                                              "updatedAt" => "2026-05-28T00:00:00Z" } }
+                end
+            else
+                {}
+            end
+        end
+        cmd.instance_variable_set(:@gql, fake_gql)
+        cmd.instance_variable_set(:@promote_refs, {
+            "a" => "ghcr.io/copilotkit/a@sha256:aaa",
+            "b" => "ghcr.io/copilotkit/b@sha256:bbb",
+        })
+        # Silence pin_and_verify retries.
+        original = Railway::PromoteCommand.const_get(:RETRY_DELAY_SEC)
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, 0)
+        begin
+            staging = { "services" => [make_svc("a", image: "ghcr.io/copilotkit/a:latest"),
+                                       make_svc("b", image: "ghcr.io/copilotkit/b:latest")] }
+            prod = { "services" => [
+                { "name" => "a", "service_id" => "svc-prod-a", "image" => "ghcr.io/copilotkit/a@sha256:OLD" },
+                { "name" => "b", "service_id" => "svc-prod-b", "image" => "ghcr.io/copilotkit/b@sha256:OLD" },
+            ] }
+            out, err = capture_io { @rc = cmd.send(:execute_promotion, staging, prod) }
+            combined = out + err
+            assert_equal 1, @rc
+            assert_match(/PARTIAL PROMOTION/i, combined,
+                "must emit partial-promotion report on GraphQL::Error; combined=#{combined}")
+            assert_match(/already pinned.*\ba\b/m, combined,
+                "report must name 'a' as already-pinned; combined=#{combined}")
+            assert_match(/FAILED on b/, combined,
+                "report must name 'b' as failed; combined=#{combined}")
+            # Dedup check: the inner e.message should appear ONLY inside the
+            # composed PARTIAL-PROMOTION line, not on its own line as well.
+            assert_equal 1, combined.scan(/boom on update #2/).size,
+                "duplicate `warn e.message` line must be removed; combined=#{combined}"
+        ensure
+            Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+            Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, original)
+        end
+    end
+
+    # =================== FIX-5: P1 REFUSE on imageless service ===================
+
+    def test_fix5_p1_refuses_when_staging_service_has_no_image
+        cmd = Railway::PromoteCommand.new([])
+        cmd.instance_variable_set(:@ghcr, PassGHCR.new)
+        staging = { "services" => [
+            { "name" => "x", "service_id" => "svc-1", "image" => nil,
+              "env_keys" => [] },
+        ] }
+        findings = cmd.send(:check_p1_ghcr_digests, staging)
+        assert(findings.any? { |f| f =~ /REFUSE: P1 \(x\).*no image/i },
+            "expected REFUSE: P1 (x) about missing image; got: #{findings.inspect}")
+    end
+
+    # =================== FIX-6: P1 per-service rescue broadens to StandardError ===================
+
+    class ArgumentErrorGHCR
+        def resolve_digest(_); "sha256:fake"; end
+        def manifest_exists(_); raise ArgumentError, "non-ghcr error"; end
+        def parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+    end
+
+    def test_fix6_p1_rescue_catches_non_ghcr_errors
+        # ArgumentError raised inside manifest_exists must be caught by the
+        # per-service rescue (broadened to StandardError) — the loop must
+        # continue and the service must get a per-service REFUSE.
+        cmd = Railway::PromoteCommand.new([])
+        cmd.instance_variable_set(:@ghcr, ArgumentErrorGHCR.new)
+        staging = { "services" => [
+            make_svc("a", image: "ghcr.io/copilotkit/a:latest"),
+            make_svc("b", image: "ghcr.io/copilotkit/b:latest"),
+        ] }
+        findings = cmd.send(:check_p1_ghcr_digests, staging)
+        # Two services, each one should fail with ArgumentError-bearing REFUSE.
+        assert(findings.any? { |f| f =~ /REFUSE: P1 \(a\).*ArgumentError.*non-ghcr error/ },
+            "service 'a' must record a per-service REFUSE for ArgumentError; got: #{findings.inspect}")
+        assert(findings.any? { |f| f =~ /REFUSE: P1 \(b\).*ArgumentError.*non-ghcr error/ },
+            "service 'b' must record a per-service REFUSE for ArgumentError; got: #{findings.inspect}")
+    end
+
+    # =================== FIX-7: pin_and_verify upfront digest guard ===================
+
+    def test_fix7_pin_and_verify_raises_arg_error_on_tag_form_image
+        # Pre-fix: pin_and_verify would dutifully attempt N retries before
+        # raising a misleading MutationError. After fix: ArgumentError fires
+        # immediately, no retries.
+        gql = Object.new
+        gql.define_singleton_method(:query) { |*| raise "no query should be issued" }
+        err = assert_raises(ArgumentError) do
+            Railway::PromoteCommand.pin_and_verify(gql,
+                service_id: "svc-x", env_id: "env-prod",
+                image: "ghcr.io/copilotkit/x:latest",
+                sleeper: ->(_) {})
+        end
+        assert_match(/pin_and_verify.*@sha256.*pinned/i, err.message,
+            "ArgumentError message must explain the digest requirement; got: #{err.message}")
+    end
+
+    # =================== FIX-8: pin_and_verify ts gate is non-vacuous ===================
+
+    def test_fix8_pin_and_verify_requires_non_nil_updated_at_even_when_pre_ts_nil
+        # pre_update_ts is nil (new prod instance). Recheck returns matching
+        # digest but a nil updatedAt. Pre-fix: ts_ok was vacuously true → success.
+        # After fix: ts_ok requires actual_ts to be non-nil → kept retrying →
+        # MutationError after RETRY_COUNT attempts.
+        gql = Object.new
+        pinned = nil
+        gql.define_singleton_method(:query) do |q, vars = {}|
+            if q.include?("serviceInstanceUpdate")
+                pinned = vars[:image]
+                { "serviceInstanceUpdate" => true }
+            elsif q.include?("serviceInstanceRedeploy")
+                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("ServiceInstanceRecheck")
+                if pinned.nil?
+                    # Pre-update: brand-new instance — both fields are nil.
+                    { "serviceInstance" => nil }
+                else
+                    { "serviceInstance" => { "id" => "i",
+                                              "source" => { "image" => pinned },
+                                              "updatedAt" => nil } }
+                end
+            else
+                {}
+            end
+        end
+        err = assert_raises(Railway::PromoteCommand::MutationError) do
+            Railway::PromoteCommand.pin_and_verify(gql,
+                service_id: "svc-x", env_id: "env-prod",
+                image: "ghcr.io/copilotkit/x@sha256:abc",
+                sleeper: ->(_) {})
+        end
+        assert_match(/did not observe image advance/i, err.message,
+            "expected timeout-style MutationError; got: #{err.message}")
+    end
+
+    # =================== FIX-9: run_staging_probe rescue on launch failure ===================
+
+    def test_fix9_run_staging_probe_returns_clean_failure_on_io_popen_error
+        cmd = Railway::PromoteCommand.new([])
+        # The probe binary must APPEAR present so we reach the IO.popen call.
+        # (Skip the File.exist? early-return.)
+        original_exist = File.method(:exist?)
+        File.define_singleton_method(:exist?) { |_path| true }
+        # Stub IO.popen to raise Errno::ENOENT (npx missing on PATH).
+        original_popen = IO.method(:popen)
+        IO.define_singleton_method(:popen) do |*_args, **_kw, &_blk|
+            raise Errno::ENOENT, "npx"
+        end
+        begin
+            result = cmd.send(:run_staging_probe, services: ["x"])
+            assert_equal false, result[:ok], "must return ok:false on launch failure"
+            assert_match(/staging probe failed to launch.*ENOENT/i, result[:summary],
+                "summary must describe the launch failure; got: #{result[:summary].inspect}")
+        ensure
+            IO.define_singleton_method(:popen, &original_popen)
+            File.define_singleton_method(:exist?, &original_exist)
+        end
+    end
+end

--- a/showcase/bin/spec/test_promote_execute.rb
+++ b/showcase/bin/spec/test_promote_execute.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# execute_promotion must resolve any staging tag (e.g. ":latest") to its
+# concrete GHCR digest and pin THAT to prod — never a mutable tag. This is
+# the core invariant of the showcase deploy model (P6 enforces shape).
+class PromoteExecuteTest < Minitest::Test
+    # FakeGQL records every mutation so we can assert exactly what image
+    # was pinned via serviceInstanceUpdate.
+    class FakeGQL
+        def initialize; @calls = []; end
+        attr_reader :calls
+
+        def query(q, vars = {})
+            @calls << [q, vars]
+            if q.include?("serviceInstanceUpdate")
+                { "serviceInstanceUpdate" => true }
+            elsif q.include?("serviceInstanceRedeploy")
+                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("ServiceInstanceRecheck") || q.include?("serviceInstance(")
+                # Return the digest-pinned ref the test expects to have
+                # been promoted, with an advanced updatedAt.
+                {
+                    "serviceInstance" => {
+                        "id" => "i",
+                        "source" => { "image" => vars[:__expected_after_image] || @after_image },
+                        "updatedAt" => "2026-05-29T00:00:01Z",
+                    },
+                }
+            else
+                {}
+            end
+        end
+
+        # Hook for pin_and_verify post-recheck — the FakeGQL needs to know
+        # what digest-pinned ref the SUT just pinned so the recheck returns
+        # an advanced image. We read the most recent serviceInstanceUpdate
+        # mutation's `image:` variable.
+        def after_image_from_last_update
+            last = @calls.reverse.find { |q, _| q.include?("serviceInstanceUpdate") }
+            last && last[1][:image]
+        end
+    end
+
+    # A FakeGQL that returns the most-recently-pinned image on recheck,
+    # so pin_and_verify sees the advance. Records all calls for assertions.
+    class RecordingGQL
+        def initialize(pre_ts: "2026-05-28T00:00:00Z")
+            @calls = []
+            @pinned_image = nil
+            @pre_ts = pre_ts
+        end
+        attr_reader :calls
+
+        def query(q, vars = {})
+            @calls << [q, vars]
+            if q.include?("serviceInstanceUpdate")
+                @pinned_image = vars[:image]
+                { "serviceInstanceUpdate" => true }
+            elsif q.include?("serviceInstanceRedeploy")
+                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("ServiceInstanceRecheck")
+                if @pinned_image.nil?
+                    # Pre-update snapshot.
+                    {
+                        "serviceInstance" => {
+                            "id" => "i",
+                            "source" => { "image" => "ghcr.io/copilotkit/x@sha256:OLD" },
+                            "updatedAt" => @pre_ts,
+                        },
+                    }
+                else
+                    {
+                        "serviceInstance" => {
+                            "id" => "i",
+                            "source" => { "image" => @pinned_image },
+                            "updatedAt" => "2026-05-29T00:00:01Z",
+                        },
+                    }
+                end
+            else
+                {}
+            end
+        end
+
+        # Find the `image:` arg passed to the serviceInstanceUpdate mutation.
+        def pinned_image
+            row = @calls.find { |q, _| q.include?("serviceInstanceUpdate") }
+            row && row[1][:image]
+        end
+    end
+
+    # FakeGHCR that maps tag-form refs to a digest, and reports :exists for
+    # the corresponding digest-pinned ref so P1 passes.
+    class FakeGHCR
+        # `resolve_map` is { "ghcr.io/org/name:tag" => "sha256:abc..." } or nil for unresolvable.
+        # `exists_set` is the set of digest-pinned refs that report :exists.
+        def initialize(resolve_map: {}, exists_set: nil)
+            @resolve_map = resolve_map
+            @exists_set = exists_set
+        end
+
+        def resolve_digest(ref)
+            # Pass-through for already-pinned refs.
+            return ref.split("@", 2).last if ref.include?("@sha256:")
+            @resolve_map[ref]
+        end
+
+        def manifest_exists(ref)
+            return :missing if @exists_set && !@exists_set.include?(ref)
+            :exists
+        end
+
+        # Delegate to the real GHCR parser — pure function, no I/O.
+        def parse_image_ref(ref)
+            Railway::GHCR.allocate.parse_image_ref(ref)
+        end
+    end
+
+    # Build a command with staging-tag service, snapshot the prod target, and
+    # inject fakes. Returns [cmd, gql].
+    def build_cmd(staging_image:, resolve_map:, exists_set: nil)
+        # --confirm-divergence: bypass the (test-irrelevant) WARN that prod is
+        # missing the EXPECTED_DOMAINS set; we are testing pin behavior.
+        cmd = Railway::PromoteCommand.new(["--non-interactive", "--yes", "--confirm-divergence"])
+        cmd.parser.parse!(cmd.argv)
+        cmd.instance_variable_set(:@staging_snapshot, {
+            "services" => [{
+                "name" => "x", "service_id" => "svc-staging",
+                "image" => staging_image,
+                "env_keys" => [],
+                "start_command" => "node server.js", "healthcheck_path" => "/health",
+                "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+            }],
+        })
+        cmd.instance_variable_set(:@prod_snapshot, {
+            "services" => [{
+                "name" => "x", "service_id" => "svc-prod",
+                "image" => "ghcr.io/copilotkit/x@sha256:OLD",
+                "env_keys" => [],
+                "start_command" => "node server.js", "healthcheck_path" => "/health",
+                "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+            }],
+        })
+        gql = RecordingGQL.new
+        cmd.instance_variable_set(:@gql, gql)
+        cmd.instance_variable_set(:@ghcr, FakeGHCR.new(resolve_map: resolve_map, exists_set: exists_set))
+        # Skip P2 deployments query — make fetch_latest_staging_deployments return
+        # a SUCCESS deployment whose digest matches whatever we will resolve.
+        resolved_digest = resolve_map.values.first || (staging_image.include?("@") ? staging_image.split("@", 2).last : nil)
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |_svc_id|
+            [{ "id" => "d", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@#{resolved_digest}" } }]
+        end
+        cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
+        [cmd, gql]
+    end
+
+    # Silence pin_and_verify's 10s-per-retry waits. RETRY_DELAY_SEC is a
+    # constant on PromoteCommand; remap to 0 around the test body and restore.
+    def with_fast_sleeper
+        original = Railway::PromoteCommand.const_get(:RETRY_DELAY_SEC)
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, 0)
+        yield
+    ensure
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, original)
+    end
+
+    def test_resolves_staging_tag_to_digest_and_pins_digest_to_prod
+        # (a) staging image is `:latest`; resolve_map maps it to a digest.
+        cmd, gql = build_cmd(
+            staging_image: "ghcr.io/copilotkit/x:latest",
+            resolve_map:   { "ghcr.io/copilotkit/x:latest" => "sha256:abc123" },
+        )
+        out, _ = with_fast_sleeper { capture_io { @rc = cmd.run_with_preflight_only } }
+        assert_equal 0, @rc, "promote should succeed when staging tag resolves cleanly; got out=#{out}"
+        pinned = gql.pinned_image
+        assert_equal "ghcr.io/copilotkit/x@sha256:abc123", pinned,
+            "must pin the DIGEST-form ref, not the :latest tag; pinned=#{pinned.inspect}"
+        refute_includes pinned.to_s, ":latest", "must not pin a mutable tag"
+        assert_match(/promoted x -> ghcr\.io\/copilotkit\/x@sha256:abc123/, out)
+    end
+
+    def test_refuses_when_staging_tag_cannot_be_resolved_to_digest
+        # (b) staging :latest that GHCR cannot resolve (resolve_digest returns nil)
+        # → REFUSE; serviceInstanceUpdate is NEVER called.
+        cmd, gql = build_cmd(
+            staging_image: "ghcr.io/copilotkit/x:latest",
+            resolve_map:   {}, # unresolvable
+        )
+        out, _ = with_fast_sleeper { capture_io { @rc = cmd.run_with_preflight_only } }
+        assert_equal 1, @rc, "must refuse when staging tag is unresolvable"
+        assert_match(/cannot resolve .*:latest.* GHCR digest/i, out)
+        refuses_update = gql.calls.any? { |q, _| q.include?("serviceInstanceUpdate") }
+        refute refuses_update, "must NOT call serviceInstanceUpdate when refusing on unresolvable tag"
+    end
+
+    def test_already_digest_pinned_staging_image_is_used_as_is
+        # (c) Unit test of the resolved-prod-image helper. A staging service
+        # whose image is already digest-pinned must be passed through unchanged
+        # (no GHCR tag lookup needed, no rewrite). (This shape is irregular for
+        # showcase staging — P6 would normally REFUSE staging != :tag — but the
+        # helper itself must be safe and idempotent.)
+        cmd = Railway::PromoteCommand.new([])
+        cmd.instance_variable_set(:@ghcr, FakeGHCR.new(resolve_map: {}))
+        svc = { "name" => "x", "image" => "ghcr.io/copilotkit/x@sha256:def456" }
+        assert_equal "ghcr.io/copilotkit/x@sha256:def456",
+            cmd.send(:resolved_prod_image, svc)
+    end
+end

--- a/showcase/bin/spec/test_promote_execute.rb
+++ b/showcase/bin/spec/test_promote_execute.rb
@@ -6,43 +6,6 @@ require_relative "spec_helper"
 # concrete GHCR digest and pin THAT to prod — never a mutable tag. This is
 # the core invariant of the showcase deploy model (P6 enforces shape).
 class PromoteExecuteTest < Minitest::Test
-    # FakeGQL records every mutation so we can assert exactly what image
-    # was pinned via serviceInstanceUpdate.
-    class FakeGQL
-        def initialize; @calls = []; end
-        attr_reader :calls
-
-        def query(q, vars = {})
-            @calls << [q, vars]
-            if q.include?("serviceInstanceUpdate")
-                { "serviceInstanceUpdate" => true }
-            elsif q.include?("serviceInstanceRedeploy")
-                { "serviceInstanceRedeploy" => true }
-            elsif q.include?("ServiceInstanceRecheck") || q.include?("serviceInstance(")
-                # Return the digest-pinned ref the test expects to have
-                # been promoted, with an advanced updatedAt.
-                {
-                    "serviceInstance" => {
-                        "id" => "i",
-                        "source" => { "image" => vars[:__expected_after_image] || @after_image },
-                        "updatedAt" => "2026-05-29T00:00:01Z",
-                    },
-                }
-            else
-                {}
-            end
-        end
-
-        # Hook for pin_and_verify post-recheck — the FakeGQL needs to know
-        # what digest-pinned ref the SUT just pinned so the recheck returns
-        # an advanced image. We read the most recent serviceInstanceUpdate
-        # mutation's `image:` variable.
-        def after_image_from_last_update
-            last = @calls.reverse.find { |q, _| q.include?("serviceInstanceUpdate") }
-            last && last[1][:image]
-        end
-    end
-
     # A FakeGQL that returns the most-recently-pinned image on recheck,
     # so pin_and_verify sees the advance. Records all calls for assertions.
     class RecordingGQL
@@ -148,7 +111,11 @@ class PromoteExecuteTest < Minitest::Test
         cmd.instance_variable_set(:@ghcr, FakeGHCR.new(resolve_map: resolve_map, exists_set: exists_set))
         # Skip P2 deployments query — make fetch_latest_staging_deployments return
         # a SUCCESS deployment whose digest matches whatever we will resolve.
-        resolved_digest = resolve_map.values.first || (staging_image.include?("@") ? staging_image.split("@", 2).last : nil)
+        # Fall back to a placeholder digest so the fixture is never a malformed
+        # "...@" — the unresolvable-tag test path will REFUSE at P1 before P2
+        # consults this stub, so the placeholder value is benign.
+        resolved_digest = resolve_map.values.first ||
+            (staging_image.include?("@") ? staging_image.split("@", 2).last : "sha256:placeholder")
         cmd.define_singleton_method(:fetch_latest_staging_deployments) do |_svc_id|
             [{ "id" => "d", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@#{resolved_digest}" } }]
         end

--- a/showcase/bin/spec/test_promote_p1.rb
+++ b/showcase/bin/spec/test_promote_p1.rb
@@ -14,6 +14,15 @@ class PromoteP1Test < Minitest::Test
     class FakeGHCR
         def initialize(result); @result = result; end
         def manifest_exists(_ref); @result; end
+        # Tag refs resolve to a synthetic digest; digest refs pass through.
+        # Returning a stable digest makes the resolved ref deterministic so
+        # the existing P1 tests (which staged digest-pinned images) continue
+        # to verify the same code path.
+        def resolve_digest(ref)
+            return ref.split("@", 2).last if ref.include?("@sha256:")
+            "sha256:fake_resolved_digest"
+        end
+        def parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
     end
 
     def test_refuses_when_digest_missing_in_ghcr

--- a/showcase/bin/spec/test_promote_p1.rb
+++ b/showcase/bin/spec/test_promote_p1.rb
@@ -4,8 +4,11 @@ require_relative "spec_helper"
 
 class PromoteP1Test < Minitest::Test
     # Stub gql + ghcr clients used by PromoteCommand.
-    class FakeGQL
-        def query(*); raise "GraphQL must not be touched on P1 refusal"; end
+    # Preflight checks accumulate findings before any short-circuit, so even
+    # on a P1 REFUSE the P2 deployments query is still issued. Provide a
+    # benign empty-deployments shape so the test focuses solely on P1.
+    class FakeGQLEmpty
+        def query(*); { "deployments" => { "edges" => [] } }; end
     end
 
     class FakeGHCR
@@ -27,7 +30,7 @@ class PromoteP1Test < Minitest::Test
             }],
         })
         cmd.instance_variable_set(:@prod_snapshot, { "services" => [] })
-        cmd.instance_variable_set(:@gql,  FakeGQL.new)
+        cmd.instance_variable_set(:@gql,  FakeGQLEmpty.new)
         cmd.instance_variable_set(:@ghcr, FakeGHCR.new(:missing))
 
         out, _err = capture_io { @rc = cmd.run_with_preflight_only }
@@ -41,7 +44,9 @@ class PromoteP1Test < Minitest::Test
             "services" => [{ "name" => "x", "service_id" => "s", "image" => "ghcr.io/copilotkit/x@sha256:abc", "env_keys" => [] }],
         })
         cmd.instance_variable_set(:@prod_snapshot, { "services" => [] })
-        cmd.instance_variable_set(:@gql, FakeGQL.new)
+        # All preflight checks accumulate findings before any short-circuit;
+        # P2 will still query gql, so use the benign empty fake.
+        cmd.instance_variable_set(:@gql, FakeGQLEmpty.new)
         cmd.instance_variable_set(:@ghcr, FakeGHCR.new(:auth_failed))
 
         out, _err = capture_io { @rc = cmd.run_with_preflight_only }
@@ -56,7 +61,9 @@ class PromoteP1Test < Minitest::Test
             "services" => [{ "name" => "x", "service_id" => "s", "image" => "ghcr.io/copilotkit/x@sha256:abc", "env_keys" => [] }],
         })
         cmd.instance_variable_set(:@prod_snapshot, { "services" => [] })
-        cmd.instance_variable_set(:@gql, FakeGQL.new)
+        # P1 passes here so P2 will run — use the benign empty fake so
+        # the deployments query returns [].
+        cmd.instance_variable_set(:@gql, FakeGQLEmpty.new)
         cmd.instance_variable_set(:@ghcr, FakeGHCR.new(:exists))
 
         # P1 alone should not refuse; later checks (service-set parity) will,

--- a/showcase/bin/spec/test_promote_p1.rb
+++ b/showcase/bin/spec/test_promote_p1.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+class PromoteP1Test < Minitest::Test
+    # Stub gql + ghcr clients used by PromoteCommand.
+    class FakeGQL
+        def query(*); raise "GraphQL must not be touched on P1 refusal"; end
+    end
+
+    class FakeGHCR
+        def initialize(result); @result = result; end
+        def manifest_exists(_ref); @result; end
+    end
+
+    def test_refuses_when_digest_missing_in_ghcr
+        cmd = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        # Inject deterministic precondition input — bypass live snapshot capture.
+        cmd.instance_variable_set(:@staging_snapshot, {
+            "services" => [{
+                "name"       => "showcase-shell",
+                "service_id" => "svc-1",
+                "image"      => "ghcr.io/copilotkit/showcase-shell@sha256:deadbeef",
+                "image_tag"  => "ghcr.io/copilotkit/showcase-shell:latest",
+                "digest"     => "sha256:deadbeef",
+                "env_keys"   => [],
+            }],
+        })
+        cmd.instance_variable_set(:@prod_snapshot, { "services" => [] })
+        cmd.instance_variable_set(:@gql,  FakeGQL.new)
+        cmd.instance_variable_set(:@ghcr, FakeGHCR.new(:missing))
+
+        out, _err = capture_io { @rc = cmd.run_with_preflight_only }
+        assert_equal 1, @rc, "promote must exit 1 on REFUSE"
+        assert_match(/REFUSE: P1.*ghcr\.io.*not found in GHCR/i, out)
+    end
+
+    def test_refuses_with_clear_message_on_auth_failed
+        cmd = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        cmd.instance_variable_set(:@staging_snapshot, {
+            "services" => [{ "name" => "x", "service_id" => "s", "image" => "ghcr.io/copilotkit/x@sha256:abc", "env_keys" => [] }],
+        })
+        cmd.instance_variable_set(:@prod_snapshot, { "services" => [] })
+        cmd.instance_variable_set(:@gql, FakeGQL.new)
+        cmd.instance_variable_set(:@ghcr, FakeGHCR.new(:auth_failed))
+
+        out, _err = capture_io { @rc = cmd.run_with_preflight_only }
+        assert_equal 1, @rc
+        assert_match(/REFUSE: P1.*GHCR.*auth/i, out)
+        assert_match(/GHCR_TOKEN.*or.*GITHUB_TOKEN/i, out)
+    end
+
+    def test_passes_p1_when_digest_exists
+        cmd = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        cmd.instance_variable_set(:@staging_snapshot, {
+            "services" => [{ "name" => "x", "service_id" => "s", "image" => "ghcr.io/copilotkit/x@sha256:abc", "env_keys" => [] }],
+        })
+        cmd.instance_variable_set(:@prod_snapshot, { "services" => [] })
+        cmd.instance_variable_set(:@gql, FakeGQL.new)
+        cmd.instance_variable_set(:@ghcr, FakeGHCR.new(:exists))
+
+        # P1 alone should not refuse; later checks (service-set parity) will,
+        # but P1's own gate is clean for this fixture.
+        out, _err = capture_io { cmd.run_with_preflight_only }
+        refute_match(/REFUSE: P1/, out)
+    end
+end

--- a/showcase/bin/spec/test_promote_p1.rb
+++ b/showcase/bin/spec/test_promote_p1.rb
@@ -33,6 +33,7 @@ class PromoteP1Test < Minitest::Test
         cmd.instance_variable_set(:@gql,  FakeGQLEmpty.new)
         cmd.instance_variable_set(:@ghcr, FakeGHCR.new(:missing))
 
+        cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
         out, _err = capture_io { @rc = cmd.run_with_preflight_only }
         assert_equal 1, @rc, "promote must exit 1 on REFUSE"
         assert_match(/REFUSE: P1.*ghcr\.io.*not found in GHCR/i, out)
@@ -49,6 +50,7 @@ class PromoteP1Test < Minitest::Test
         cmd.instance_variable_set(:@gql, FakeGQLEmpty.new)
         cmd.instance_variable_set(:@ghcr, FakeGHCR.new(:auth_failed))
 
+        cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
         out, _err = capture_io { @rc = cmd.run_with_preflight_only }
         assert_equal 1, @rc
         assert_match(/REFUSE: P1.*GHCR.*auth/i, out)
@@ -68,6 +70,7 @@ class PromoteP1Test < Minitest::Test
 
         # P1 alone should not refuse; later checks (service-set parity) will,
         # but P1's own gate is clean for this fixture.
+        cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
         out, _err = capture_io { cmd.run_with_preflight_only }
         refute_match(/REFUSE: P1/, out)
     end

--- a/showcase/bin/spec/test_promote_p2.rb
+++ b/showcase/bin/spec/test_promote_p2.rb
@@ -26,7 +26,11 @@ class PromoteP2Test < Minitest::Test
         c.instance_variable_set(:@staging_snapshot, staging)
         c.instance_variable_set(:@prod_snapshot, { "services" => [] })
         c.instance_variable_set(:@gql, FakeGQL.new(deployments))
-        c.instance_variable_set(:@ghcr, Object.new.tap { |o| def o.manifest_exists(_); :exists; end })
+        c.instance_variable_set(:@ghcr, Object.new.tap do |o|
+            def o.manifest_exists(_); :exists; end
+            def o.resolve_digest(ref); ref.include?("@sha256:") ? ref.split("@", 2).last : "sha256:fake"; end
+            def o.parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+        end)
         # Stub P3 probe so the test does not shell out to verify-deploy.ts.
         c.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
         c
@@ -60,6 +64,27 @@ class PromoteP2Test < Minitest::Test
         out, _ = capture_io { @rc = cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
         assert_equal 1, @rc
         assert_match(/REFUSE: P2.*in-flight.*sha256:NEW.*sha256:OLD/i, out)
+    end
+
+    def test_does_not_crash_when_deployment_meta_is_a_string
+        # Railway's Deployment.meta is a JSON scalar that can come back as a
+        # String (not a Hash). `latest.dig("meta", "image")` would raise
+        # NoMethodError on a String. Guard: skip the race-check when meta is
+        # not a Hash — SUCCESS status alone gates the deployment.
+        staging = { "services" => [{
+            "name" => "x", "service_id" => "svc-1",
+            "image" => "ghcr.io/copilotkit/x@sha256:abc", "digest" => "sha256:abc",
+            "env_keys" => [],
+        }] }
+        deps = { "svc-1" => [
+            { "id" => "d1", "status" => "SUCCESS",
+              "meta" => "raw-string-not-a-hash",
+              "createdAt" => "2026-05-28T01:00:00Z" },
+        ] }
+        out, _ = capture_io { cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        # MUST NOT crash. P2 race-check is best-effort; SUCCESS is the real gate.
+        refute_match(/REFUSE: P2/, out)
+        refute_match(/NoMethodError/, out)
     end
 
     def test_passes_p2_when_latest_is_success_and_image_matches

--- a/showcase/bin/spec/test_promote_p2.rb
+++ b/showcase/bin/spec/test_promote_p2.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+class PromoteP2Test < Minitest::Test
+    class FakeGQL
+        def initialize(deployments_by_svc)
+            @deployments_by_svc = deployments_by_svc
+            @calls = []
+        end
+
+        attr_reader :calls
+
+        def query(q, vars = {})
+            @calls << [q, vars]
+            if q.include?("query Deployments")
+                edges = (@deployments_by_svc[vars[:serviceId]] || []).map { |n| { "node" => n } }
+                return { "deployments" => { "edges" => edges } }
+            end
+            raise "unexpected query: #{q[0,40]}"
+        end
+    end
+
+    def cmd_with(staging:, deployments:)
+        c = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        c.instance_variable_set(:@staging_snapshot, staging)
+        c.instance_variable_set(:@prod_snapshot, { "services" => [] })
+        c.instance_variable_set(:@gql, FakeGQL.new(deployments))
+        c.instance_variable_set(:@ghcr, Object.new.tap { |o| def o.manifest_exists(_); :exists; end })
+        c
+    end
+
+    def test_refuses_when_latest_deployment_not_success
+        staging = { "services" => [{
+            "name" => "x", "service_id" => "svc-1",
+            "image" => "ghcr.io/copilotkit/x@sha256:abc", "digest" => "sha256:abc",
+            "env_keys" => [],
+        }] }
+        deps = { "svc-1" => [
+            { "id" => "d2", "status" => "FAILED",  "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc" }, "createdAt" => "2026-05-28T01:00:00Z" },
+            { "id" => "d1", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc" }, "createdAt" => "2026-05-28T00:00:00Z" },
+        ] }
+        out, _ = capture_io { @rc = cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        assert_equal 1, @rc
+        assert_match(/REFUSE: P2.*x.*latest staging deployment.*FAILED/i, out)
+    end
+
+    def test_refuses_when_latest_success_image_does_not_match
+        # In-flight race: newer build with a different digest is the latest.
+        staging = { "services" => [{
+            "name" => "x", "service_id" => "svc-1",
+            "image" => "ghcr.io/copilotkit/x@sha256:OLD", "digest" => "sha256:OLD",
+            "env_keys" => [],
+        }] }
+        deps = { "svc-1" => [
+            { "id" => "d2", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:NEW" }, "createdAt" => "2026-05-28T01:00:00Z" },
+        ] }
+        out, _ = capture_io { @rc = cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        assert_equal 1, @rc
+        assert_match(/REFUSE: P2.*in-flight.*sha256:NEW.*sha256:OLD/i, out)
+    end
+
+    def test_passes_p2_when_latest_is_success_and_image_matches
+        staging = { "services" => [{
+            "name" => "x", "service_id" => "svc-1",
+            "image" => "ghcr.io/copilotkit/x@sha256:abc", "digest" => "sha256:abc",
+            "env_keys" => [],
+        }] }
+        deps = { "svc-1" => [
+            { "id" => "d1", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc" }, "createdAt" => "2026-05-28T01:00:00Z" },
+        ] }
+        out, _ = capture_io { cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        refute_match(/REFUSE: P2/, out)
+    end
+end

--- a/showcase/bin/spec/test_promote_p2.rb
+++ b/showcase/bin/spec/test_promote_p2.rb
@@ -27,6 +27,8 @@ class PromoteP2Test < Minitest::Test
         c.instance_variable_set(:@prod_snapshot, { "services" => [] })
         c.instance_variable_set(:@gql, FakeGQL.new(deployments))
         c.instance_variable_set(:@ghcr, Object.new.tap { |o| def o.manifest_exists(_); :exists; end })
+        # Stub P3 probe so the test does not shell out to verify-deploy.ts.
+        c.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
         c
     end
 

--- a/showcase/bin/spec/test_promote_p2.rb
+++ b/showcase/bin/spec/test_promote_p2.rb
@@ -46,9 +46,10 @@ class PromoteP2Test < Minitest::Test
             { "id" => "d2", "status" => "FAILED",  "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc" }, "createdAt" => "2026-05-28T01:00:00Z" },
             { "id" => "d1", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc" }, "createdAt" => "2026-05-28T00:00:00Z" },
         ] }
-        out, _ = capture_io { @rc = cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        out, err = capture_io { @rc = cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        combined = out + err
         assert_equal 1, @rc
-        assert_match(/REFUSE: P2.*x.*latest staging deployment.*FAILED/i, out)
+        assert_match(/REFUSE: P2.*x.*latest staging deployment.*FAILED/i, combined)
     end
 
     def test_refuses_when_latest_success_image_does_not_match
@@ -61,16 +62,17 @@ class PromoteP2Test < Minitest::Test
         deps = { "svc-1" => [
             { "id" => "d2", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:NEW" }, "createdAt" => "2026-05-28T01:00:00Z" },
         ] }
-        out, _ = capture_io { @rc = cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        out, err = capture_io { @rc = cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        combined = out + err
         assert_equal 1, @rc
-        assert_match(/REFUSE: P2.*in-flight.*sha256:NEW.*sha256:OLD/i, out)
+        assert_match(/REFUSE: P2.*in-flight.*sha256:NEW.*sha256:OLD/i, combined)
     end
 
     def test_does_not_crash_when_deployment_meta_is_a_string
         # Railway's Deployment.meta is a JSON scalar that can come back as a
-        # String (not a Hash). `latest.dig("meta", "image")` would raise
-        # NoMethodError on a String. Guard: skip the race-check when meta is
-        # not a Hash — SUCCESS status alone gates the deployment.
+        # String (not a Hash). After FIX-2 we PARSE it first; a non-JSON
+        # string falls back to a WARN, but MUST NOT crash and MUST NOT
+        # produce a P2 REFUSE.
         staging = { "services" => [{
             "name" => "x", "service_id" => "svc-1",
             "image" => "ghcr.io/copilotkit/x@sha256:abc", "digest" => "sha256:abc",
@@ -81,10 +83,11 @@ class PromoteP2Test < Minitest::Test
               "meta" => "raw-string-not-a-hash",
               "createdAt" => "2026-05-28T01:00:00Z" },
         ] }
-        out, _ = capture_io { cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        out, err = capture_io { cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        combined = out + err
         # MUST NOT crash. P2 race-check is best-effort; SUCCESS is the real gate.
-        refute_match(/REFUSE: P2/, out)
-        refute_match(/NoMethodError/, out)
+        refute_match(/REFUSE: P2/, combined)
+        refute_match(/NoMethodError/, combined)
     end
 
     def test_passes_p2_when_latest_is_success_and_image_matches
@@ -96,7 +99,8 @@ class PromoteP2Test < Minitest::Test
         deps = { "svc-1" => [
             { "id" => "d1", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc" }, "createdAt" => "2026-05-28T01:00:00Z" },
         ] }
-        out, _ = capture_io { cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
-        refute_match(/REFUSE: P2/, out)
+        out, err = capture_io { cmd_with(staging: staging, deployments: deps).run_with_preflight_only }
+        combined = out + err
+        refute_match(/REFUSE: P2/, combined)
     end
 end

--- a/showcase/bin/spec/test_promote_p3.rb
+++ b/showcase/bin/spec/test_promote_p3.rb
@@ -29,7 +29,11 @@ class PromoteP3Test < Minitest::Test
             }],
         })
         c.instance_variable_set(:@gql, Object.new.tap { |o| def o.query(*); { "deployments" => { "edges" => [{ "node" => { "id" => "d", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc" } } }] } }; end })
-        c.instance_variable_set(:@ghcr, Object.new.tap { |o| def o.manifest_exists(_); :exists; end })
+        c.instance_variable_set(:@ghcr, Object.new.tap do |o|
+            def o.manifest_exists(_); :exists; end
+            def o.resolve_digest(ref); ref.include?("@sha256:") ? ref.split("@", 2).last : "sha256:abc"; end
+            def o.parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+        end)
         # Inject the probe result as a stub.
         c.define_singleton_method(:run_staging_probe) { |services:| probe_result }
         c
@@ -44,6 +48,11 @@ class PromoteP3Test < Minitest::Test
 
     def test_skips_probe_when_no_require_staging_green
         cmd = make_cmd(probe_result: { ok: false, summary: "would have failed" }, flag: "--no-require-staging-green")
+        # Fail LOUD if the skip path ever calls the probe — the probe stub
+        # must be unreachable under --no-require-staging-green.
+        cmd.define_singleton_method(:run_staging_probe) do |services:|
+            raise "probe must not run under --no-require-staging-green"
+        end
         out, _ = capture_io { cmd.run_with_preflight_only }
         refute_match(/REFUSE: P3/, out)
         assert_match(/P3 SKIPPED.*--no-require-staging-green/, out)

--- a/showcase/bin/spec/test_promote_p3.rb
+++ b/showcase/bin/spec/test_promote_p3.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+class PromoteP3Test < Minitest::Test
+    def make_cmd(probe_result:, flag:)
+        argv = ["--non-interactive", "--yes"]
+        argv << flag if flag
+        c = Railway::PromoteCommand.new(argv)
+        # run_with_preflight_only skips parser.parse!; parse eagerly so the
+        # --no-require-staging-green / --confirm-divergence flags land.
+        c.parser.parse!(c.argv)
+        c.instance_variable_set(:@staging_snapshot, {
+            "services" => [{
+                "name" => "x", "service_id" => "svc-1",
+                "image" => "ghcr.io/copilotkit/x:latest", "digest" => "sha256:abc",
+                "env_keys" => [],
+                "start_command" => "node server.js", "healthcheck_path" => "/health",
+                "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+            }],
+        })
+        c.instance_variable_set(:@prod_snapshot, {
+            "services" => [{
+                "name" => "x", "service_id" => "svc-1",
+                "image" => "ghcr.io/copilotkit/x@sha256:abc", "digest" => "sha256:abc",
+                "env_keys" => [],
+                "start_command" => "node server.js", "healthcheck_path" => "/health",
+                "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+            }],
+        })
+        c.instance_variable_set(:@gql, Object.new.tap { |o| def o.query(*); { "deployments" => { "edges" => [{ "node" => { "id" => "d", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc" } } }] } }; end })
+        c.instance_variable_set(:@ghcr, Object.new.tap { |o| def o.manifest_exists(_); :exists; end })
+        # Inject the probe result as a stub.
+        c.define_singleton_method(:run_staging_probe) { |services:| probe_result }
+        c
+    end
+
+    def test_refuses_on_red_probe_when_flag_default_on
+        cmd = make_cmd(probe_result: { ok: false, summary: "x: HTTP 502 from docs.staging.copilotkit.ai" }, flag: nil)
+        out, _ = capture_io { @rc = cmd.run_with_preflight_only }
+        assert_equal 1, @rc
+        assert_match(/REFUSE: P3.*staging.*not green.*HTTP 502/i, out)
+    end
+
+    def test_skips_probe_when_no_require_staging_green
+        cmd = make_cmd(probe_result: { ok: false, summary: "would have failed" }, flag: "--no-require-staging-green")
+        out, _ = capture_io { cmd.run_with_preflight_only }
+        refute_match(/REFUSE: P3/, out)
+        assert_match(/P3 SKIPPED.*--no-require-staging-green/, out)
+    end
+
+    def test_passes_p3_on_green_probe
+        cmd = make_cmd(probe_result: { ok: true, summary: "all green" }, flag: nil)
+        out, _ = capture_io { cmd.run_with_preflight_only }
+        refute_match(/REFUSE: P3/, out)
+    end
+end

--- a/showcase/bin/spec/test_promote_p5.rb
+++ b/showcase/bin/spec/test_promote_p5.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+class PromoteP5Test < Minitest::Test
+    class FakeGQL
+        def initialize(plan); @plan = plan; @calls = []; end
+        attr_reader :calls
+
+        def query(q, vars = {})
+            @calls << [q, vars]
+            step = @plan.shift
+            raise "fake exhausted at call ##{@calls.size}: #{q[0,40]}" unless step
+            raise step[:raise] if step[:raise]
+            step[:data]   # inner data hash, matching GraphQL#query's return shape
+        end
+    end
+
+    # Helper: a "pre-update snapshot" GQL response with a given updatedAt.
+    def pre(ts) = { data: { "serviceInstance" => { "id" => "i", "source" => { "image" => "ghcr.io/copilotkit/x@sha256:OLD" }, "updatedAt" => ts } } }
+
+    # Helper: a "post-update re-query" response.
+    def post(image:, ts:) = { data: { "serviceInstance" => { "id" => "i", "source" => { "image" => image }, "updatedAt" => ts } } }
+
+    def test_refuses_when_update_returns_false
+        # Order: pre-update snapshot, then update (false) — refuse before redeploy.
+        gql = FakeGQL.new([
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate" => false } },
+        ])
+        assert_raises(Railway::PromoteCommand::MutationError) do
+            Railway::PromoteCommand.pin_and_verify(gql,
+                service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+                sleeper: ->(_n) {})
+        end
+    end
+
+    def test_verifies_image_AND_updatedAt_advanced_after_update
+        gql = FakeGQL.new([
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate"   => true } },
+            { data: { "serviceInstanceRedeploy" => true } },
+            post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: "2026-05-28T01:00:00Z"),
+        ])
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            sleeper: ->(_n) {})
+        assert_equal 4, gql.calls.size
+    end
+
+    def test_refuses_when_image_advanced_but_updatedAt_did_NOT_advance
+        # P5 guard for the no-op re-pin / cache-shaped race: image-equality
+        # alone is insufficient. updatedAt MUST strictly advance past
+        # pre_update_ts; if not, three retries then refuse.
+        pre_ts = "2026-05-27T00:00:00Z"
+        stale_ts_post = post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: pre_ts)
+        gql = FakeGQL.new([
+            pre(pre_ts),
+            { data: { "serviceInstanceUpdate"   => true } },
+            { data: { "serviceInstanceRedeploy" => true } },
+            stale_ts_post, stale_ts_post, stale_ts_post,
+        ])
+        assert_raises(Railway::PromoteCommand::MutationError) do
+            Railway::PromoteCommand.pin_and_verify(gql,
+                service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+                sleeper: ->(_n) {})
+        end
+    end
+
+    def test_retries_then_refuses_on_stale_image
+        # Three re-queries all report stale image.
+        stale = post(image: "ghcr.io/copilotkit/x@sha256:OLD", ts: "2026-05-27T00:00:00Z")
+        gql = FakeGQL.new([
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate"   => true } },
+            { data: { "serviceInstanceRedeploy" => true } },
+            stale, stale, stale,
+        ])
+        assert_raises(Railway::PromoteCommand::MutationError) do
+            Railway::PromoteCommand.pin_and_verify(gql,
+                service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+                sleeper: ->(_n) {})
+        end
+    end
+
+    def test_accepts_when_third_requery_shows_advance
+        new_ok = post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: "2026-05-28T02:00:00Z")
+        stale  = post(image: "ghcr.io/copilotkit/x@sha256:OLD", ts: "2026-05-27T00:00:00Z")
+        gql = FakeGQL.new([
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate"   => true } },
+            { data: { "serviceInstanceRedeploy" => true } },
+            stale, stale, new_ok,
+        ])
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            sleeper: ->(_n) {})
+    end
+end

--- a/showcase/bin/spec/test_promote_p6.rb
+++ b/showcase/bin/spec/test_promote_p6.rb
@@ -14,7 +14,11 @@ class PromoteP6Test < Minitest::Test
         c.instance_variable_set(:@staging_snapshot, staging)
         c.instance_variable_set(:@prod_snapshot, prod)
         c.instance_variable_set(:@gql, Object.new.tap { |o| def o.query(*); { "deployments" => { "edges" => [{ "node" => { "id" => "d", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc" } } }] } }; end })
-        c.instance_variable_set(:@ghcr, Object.new.tap { |o| def o.manifest_exists(_); :exists; end })
+        c.instance_variable_set(:@ghcr, Object.new.tap do |o|
+            def o.manifest_exists(_); :exists; end
+            def o.resolve_digest(ref); ref.include?("@sha256:") ? ref.split("@", 2).last : "sha256:abc"; end
+            def o.parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+        end)
         c.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
         c
     end
@@ -80,8 +84,13 @@ class PromoteP6Test < Minitest::Test
     def test_warns_proceed_with_confirm_divergence
         st = { "services" => [staging_svc("region" => "us-west")] }
         pr = { "services" => [prod_svc(   "region" => "us-east")] }
-        # capture_destructive_confirmation: --non-interactive + --yes bypasses prompt
-        out, _ = capture_io { cmd_with(st, pr, flag: "--confirm-divergence").run_with_preflight_only }
+        # capture_destructive_confirmation: --non-interactive + --yes bypasses prompt.
+        # Stub execute_promotion to isolate the WARN-proceed gate from the
+        # real mutation path (which would chase under-stubbed gql).
+        c = cmd_with(st, pr, flag: "--confirm-divergence")
+        c.define_singleton_method(:execute_promotion) { |_st, _pr| 0 }
+        out, _ = capture_io { @rc = c.run_with_preflight_only }
+        assert_equal 0, @rc, "WARN-proceed path with --confirm-divergence must exit 0"
         assert_match(/WARN.*x.*region/i, out)
         assert_match(/proceeding past .* WARN finding/i, out)
     end

--- a/showcase/bin/spec/test_promote_p6.rb
+++ b/showcase/bin/spec/test_promote_p6.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+class PromoteP6Test < Minitest::Test
+    def cmd_with(staging, prod, flag: nil)
+        argv = ["--non-interactive", "--yes"]
+        argv << flag if flag
+        c = Railway::PromoteCommand.new(argv)
+        # run_with_preflight_only skips the parser.parse!() that #run normally
+        # invokes; parse flags eagerly so --confirm-divergence etc. land in
+        # options[].
+        c.parser.parse!(c.argv)
+        c.instance_variable_set(:@staging_snapshot, staging)
+        c.instance_variable_set(:@prod_snapshot, prod)
+        c.instance_variable_set(:@gql, Object.new.tap { |o| def o.query(*); { "deployments" => { "edges" => [{ "node" => { "id" => "d", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc" } } }] } }; end })
+        c.instance_variable_set(:@ghcr, Object.new.tap { |o| def o.manifest_exists(_); :exists; end })
+        c.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
+        c
+    end
+
+    # Defaults represent the "good" parity baseline: staging tag-floating,
+    # prod digest-pinned, all other fields identical. Tests override fields
+    # with the specific divergence under test.
+    def staging_svc(over = {})
+        {
+            "name" => "x", "service_id" => "s", "image" => "ghcr.io/copilotkit/x:latest",
+            "digest" => "sha256:abc", "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+        }.merge(over)
+    end
+
+    def prod_svc(over = {})
+        {
+            "name" => "x", "service_id" => "s", "image" => "ghcr.io/copilotkit/x@sha256:abc",
+            "digest" => "sha256:abc", "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+        }.merge(over)
+    end
+
+    def test_refuses_on_start_command_divergence
+        st = { "services" => [staging_svc("start_command" => "node staging.js")] }
+        pr = { "services" => [prod_svc("start_command" => "node prod.js")] }
+        out, _ = capture_io { @rc = cmd_with(st, pr).run_with_preflight_only }
+        assert_equal 1, @rc
+        assert_match(/REFUSE: P6.*x.*startCommand/i, out)
+    end
+
+    def test_refuses_on_healthcheck_path_divergence
+        st = { "services" => [staging_svc("healthcheck_path" => "/health")] }
+        pr = { "services" => [prod_svc("healthcheck_path" => "/healthz")] }
+        out, _ = capture_io { @rc = cmd_with(st, pr).run_with_preflight_only }
+        assert_equal 1, @rc
+        assert_match(/REFUSE: P6.*x.*healthcheckPath/i, out)
+    end
+
+    def test_refuses_on_image_shape_divergence
+        # staging digest-pinned (wrong; expected tag), prod tag-floating
+        # (wrong; expected digest). Both shapes invert the parity.
+        st = { "services" => [staging_svc("image" => "ghcr.io/copilotkit/x@sha256:abc")] }
+        pr = { "services" => [prod_svc("image" => "ghcr.io/copilotkit/x:latest")] }
+        out, _ = capture_io { @rc = cmd_with(st, pr).run_with_preflight_only }
+        assert_equal 1, @rc
+        assert_match(/REFUSE: P6.*x.*image shape/i, out)
+    end
+
+    def test_warns_on_region_replicas_restartpolicy_envkeys_without_confirm_divergence
+        st = { "services" => [staging_svc("region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE", "env_keys" => ["A", "B"])] }
+        pr = { "services" => [prod_svc(   "region" => "us-east", "replicas" => 3, "restart_policy" => "ALWAYS",     "env_keys" => ["A", "C"])] }
+        out, _ = capture_io { @rc = cmd_with(st, pr).run_with_preflight_only }
+        assert_equal 1, @rc, "must refuse without --confirm-divergence even on WARN-only"
+        assert_match(/WARN.*x.*region/i, out)
+        assert_match(/WARN.*x.*replicas/i, out)
+        assert_match(/WARN.*x.*restartPolicy/i, out)
+        assert_match(/WARN.*x.*env key set/i, out)
+    end
+
+    def test_warns_proceed_with_confirm_divergence
+        st = { "services" => [staging_svc("region" => "us-west")] }
+        pr = { "services" => [prod_svc(   "region" => "us-east")] }
+        # capture_destructive_confirmation: --non-interactive + --yes bypasses prompt
+        out, _ = capture_io { cmd_with(st, pr, flag: "--confirm-divergence").run_with_preflight_only }
+        assert_match(/WARN.*x.*region/i, out)
+        assert_match(/proceeding past .* WARN finding/i, out)
+    end
+
+    def test_env_var_values_never_compared_message_printed_every_run
+        st = { "services" => [staging_svc] }
+        pr = { "services" => [prod_svc] }
+        out, _ = capture_io { cmd_with(st, pr).run_with_preflight_only }
+        assert_match(/env var VALUES are not compared/i, out)
+    end
+end

--- a/showcase/bin/spec/test_promote_resolve_once.rb
+++ b/showcase/bin/spec/test_promote_resolve_once.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# Covers five CR fixes against PromoteCommand:
+#   FIX-1: digest is resolved EXACTLY ONCE per staging service across the
+#          whole preflight+execute, and the SAME ref P1 verified is what
+#          gets pinned by execute_promotion (no TOCTOU).
+#   FIX-2: a Railway::GHCR::Error raised mid-loop in P1 produces a per-
+#          service REFUSE finding and the loop continues for remaining
+#          services — earlier findings are NOT discarded.
+#   FIX-3: pin_and_verify asserts the serviceInstanceRedeploy result is
+#          truthy (symmetric with the serviceInstanceUpdate result check).
+#   FIX-4: P2 emits a WARN finding when deployment meta is not a Hash, so
+#          the silent skip of the in-flight race-check is visible.
+#   FIX-5: when pin_and_verify raises mid-loop in execute_promotion, a
+#          loud PARTIAL-PROMOTION report names the already-pinned services.
+class PromoteResolveOnceTest < Minitest::Test
+    # FakeGHCR that counts resolve_digest calls per ref.
+    class CountingGHCR
+        attr_reader :resolve_calls
+
+        def initialize(resolve_map:, exists_set: nil)
+            @resolve_map   = resolve_map
+            @exists_set    = exists_set
+            @resolve_calls = Hash.new(0)
+        end
+
+        def resolve_digest(ref)
+            @resolve_calls[ref] += 1
+            return ref.split("@", 2).last if ref.include?("@sha256:")
+            @resolve_map[ref]
+        end
+
+        def manifest_exists(ref)
+            return :missing if @exists_set && !@exists_set.include?(ref)
+            :exists
+        end
+
+        def parse_image_ref(ref)
+            Railway::GHCR.allocate.parse_image_ref(ref)
+        end
+    end
+
+    # GQL fake reusing the pattern from PromoteExecuteTest::RecordingGQL,
+    # but with optional knobs for FIX-3 (redeploy returns false) and FIX-5
+    # (per-service update failure).
+    class RecordingGQL
+        def initialize(redeploy_result: true, update_fail_for: nil)
+            @calls            = []
+            # Per-service post-update state so multi-service test cases don't
+            # leak each other's pinned image into pre-update rechecks. Keyed by
+            # serviceId. Value is { image:, post_ts: }. Pre-update returns the
+            # "OLD" snapshot (with an early ts) for any service not yet pinned.
+            @post            = {}
+            @ts_counter      = 0
+            @redeploy_result = redeploy_result
+            @update_fail_for = update_fail_for  # service_id whose update returns false
+        end
+        attr_reader :calls
+
+        def query(q, vars = {})
+            @calls << [q, vars]
+            sid = vars[:serviceId]
+            if q.include?("serviceInstanceUpdate")
+                if @update_fail_for && sid == @update_fail_for
+                    return { "serviceInstanceUpdate" => false }
+                end
+                @ts_counter += 1
+                @post[sid] = { image: vars[:image], ts: "2026-05-29T00:00:%02dZ" % @ts_counter }
+                { "serviceInstanceUpdate" => true }
+            elsif q.include?("serviceInstanceRedeploy")
+                { "serviceInstanceRedeploy" => @redeploy_result }
+            elsif q.include?("ServiceInstanceRecheck")
+                if (entry = @post[sid])
+                    {
+                        "serviceInstance" => {
+                            "id" => "i",
+                            "source" => { "image" => entry[:image] },
+                            "updatedAt" => entry[:ts],
+                        },
+                    }
+                else
+                    {
+                        "serviceInstance" => {
+                            "id" => "i",
+                            "source" => { "image" => "ghcr.io/copilotkit/x@sha256:OLD" },
+                            "updatedAt" => "2026-05-28T00:00:00Z",
+                        },
+                    }
+                end
+            else
+                {}
+            end
+        end
+
+        def pinned_images
+            @calls.select { |q, _| q.include?("serviceInstanceUpdate") }.map { |_, v| v[:image] }
+        end
+    end
+
+    # Silence pin_and_verify's 10s-per-retry waits.
+    def with_fast_sleeper
+        original = Railway::PromoteCommand.const_get(:RETRY_DELAY_SEC)
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, 0)
+        yield
+    ensure
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, original)
+    end
+
+    def make_svc(name, image:)
+        {
+            "name" => name, "service_id" => "svc-stg-#{name}",
+            "image" => image,
+            "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+        }
+    end
+
+    def make_prod_svc(name)
+        {
+            "name" => name, "service_id" => "svc-prod-#{name}",
+            "image" => "ghcr.io/copilotkit/#{name}@sha256:OLD",
+            "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+        }
+    end
+
+    # =================== FIX-1 ===================
+
+    def test_fix1_resolve_digest_called_exactly_once_per_service
+        # Single :latest staging service. After full preflight + execute, the
+        # ghcr.resolve_digest call counter MUST be exactly 1 for that ref —
+        # not 2 (which was the pre-fix TOCTOU duplicate-resolve behavior).
+        ghcr = CountingGHCR.new(resolve_map: { "ghcr.io/copilotkit/x:latest" => "sha256:abc123" })
+        gql  = RecordingGQL.new
+
+        cmd = Railway::PromoteCommand.new(["--non-interactive", "--yes", "--confirm-divergence"])
+        cmd.parser.parse!(cmd.argv)
+        cmd.instance_variable_set(:@staging_snapshot, {
+            "services" => [make_svc("x", image: "ghcr.io/copilotkit/x:latest")],
+        })
+        cmd.instance_variable_set(:@prod_snapshot, { "services" => [make_prod_svc("x")] })
+        cmd.instance_variable_set(:@gql, gql)
+        cmd.instance_variable_set(:@ghcr, ghcr)
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |_svc_id|
+            [{ "id" => "d", "status" => "SUCCESS",
+               "meta" => { "image" => "ghcr.io/copilotkit/x@sha256:abc123" } }]
+        end
+        cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
+
+        out, _ = with_fast_sleeper { capture_io { @rc = cmd.run_with_preflight_only } }
+        assert_equal 0, @rc, "promote should succeed; got out=#{out}"
+
+        # The exact ref pinned MUST be what P1 verified (resolve-once).
+        assert_equal ["ghcr.io/copilotkit/x@sha256:abc123"], gql.pinned_images,
+            "must pin the SAME digest-form ref P1 verified"
+
+        # The :latest tag must have been resolved EXACTLY ONCE — not twice.
+        assert_equal 1, ghcr.resolve_calls["ghcr.io/copilotkit/x:latest"],
+            "resolve_digest must be called exactly once for the staging tag; calls=#{ghcr.resolve_calls.inspect}"
+    end
+
+    # =================== FIX-2 ===================
+
+    # GHCR fake whose manifest_exists raises Railway::GHCR::Error on the
+    # SECOND service. The first service's findings must survive.
+    class RaisingOnSecondGHCR
+        def initialize
+            @manifest_calls = 0
+        end
+
+        def resolve_digest(ref)
+            return ref.split("@", 2).last if ref.include?("@sha256:")
+            "sha256:resolved_for_#{ref}"
+        end
+
+        def manifest_exists(_ref)
+            @manifest_calls += 1
+            raise Railway::GHCR::Error, "boom on call ##{@manifest_calls}" if @manifest_calls == 2
+            :exists
+        end
+
+        def parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+    end
+
+    def test_fix2_p1_rescue_is_per_service_not_method_level
+        # Two services. The SECOND triggers a GHCR::Error in manifest_exists.
+        # Before the fix: method-level rescue replaced ALL findings with a
+        # single "REFUSE: P1: GHCR check raised ..." entry, dropping the
+        # first service's clean record AND scoping the error to "P1" with no
+        # service name. After the fix: the first service has no finding
+        # (it passed), the second service has a per-service REFUSE finding
+        # that names the service.
+        cmd = Railway::PromoteCommand.new([])
+        cmd.instance_variable_set(:@ghcr, RaisingOnSecondGHCR.new)
+        staging = {
+            "services" => [
+                make_svc("a", image: "ghcr.io/copilotkit/a:latest"),
+                make_svc("b", image: "ghcr.io/copilotkit/b:latest"),
+            ],
+        }
+        findings = cmd.send(:check_p1_ghcr_digests, staging)
+
+        refute(findings.any? { |f| f =~ /REFUSE: P1 \(a\)/ },
+            "service 'a' passed P1 and must have no REFUSE; findings=#{findings.inspect}")
+        assert(findings.any? { |f| f =~ /REFUSE: P1 \(b\).*boom on call #2/ },
+            "service 'b' must have a per-service P1 REFUSE naming it; findings=#{findings.inspect}")
+    end
+
+    # =================== FIX-3 ===================
+
+    def test_fix3_pin_and_verify_raises_when_redeploy_returns_false
+        gql = RecordingGQL.new(redeploy_result: false)
+        err = assert_raises(Railway::PromoteCommand::MutationError) do
+            Railway::PromoteCommand.pin_and_verify(gql,
+                service_id: "svc-x", env_id: "env-prod",
+                image: "ghcr.io/copilotkit/x@sha256:abc",
+                sleeper: ->(_) {})
+        end
+        assert_match(/serviceInstanceRedeploy/i, err.message,
+            "MutationError must reference the redeploy mutation; got: #{err.message}")
+    end
+
+    # =================== FIX-4 ===================
+
+    def test_fix4_p2_warns_when_meta_is_a_string
+        # P2 already guards meta.is_a?(Hash) (no crash), but the silent skip
+        # of the race-check should produce a WARN finding so it's visible.
+        cmd = Railway::PromoteCommand.new([])
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |_svc_id|
+            [{ "id" => "d", "status" => "SUCCESS",
+               "meta" => "raw-string-not-a-hash" }]
+        end
+        staging = {
+            "services" => [{
+                "name" => "x", "service_id" => "svc-1",
+                "image" => "ghcr.io/copilotkit/x@sha256:abc", "digest" => "sha256:abc",
+                "env_keys" => [],
+            }],
+        }
+        findings = cmd.send(:check_p2_staging_deployments, staging)
+        assert(findings.any? { |f| f =~ /WARN: P2 \(x\).*meta.*String.*Hash/ },
+            "expected WARN finding for non-Hash meta; got: #{findings.inspect}")
+    end
+
+    # =================== FIX-5 ===================
+
+    def test_fix5_partial_promotion_report_on_midloop_failure
+        # Three staging services [a, b, c]; pin succeeds for a and b, fails
+        # for c (serviceInstanceUpdate returns false → MutationError).
+        # The output must name a and b as already-pinned and c as failed.
+        ghcr = CountingGHCR.new(resolve_map: {
+            "ghcr.io/copilotkit/a:latest" => "sha256:aaa",
+            "ghcr.io/copilotkit/b:latest" => "sha256:bbb",
+            "ghcr.io/copilotkit/c:latest" => "sha256:ccc",
+        })
+        gql = RecordingGQL.new(update_fail_for: "svc-prod-c")
+
+        cmd = Railway::PromoteCommand.new(["--non-interactive", "--yes", "--confirm-divergence"])
+        cmd.parser.parse!(cmd.argv)
+        cmd.instance_variable_set(:@staging_snapshot, {
+            "services" => [
+                make_svc("a", image: "ghcr.io/copilotkit/a:latest"),
+                make_svc("b", image: "ghcr.io/copilotkit/b:latest"),
+                make_svc("c", image: "ghcr.io/copilotkit/c:latest"),
+            ],
+        })
+        cmd.instance_variable_set(:@prod_snapshot, {
+            "services" => [make_prod_svc("a"), make_prod_svc("b"), make_prod_svc("c")],
+        })
+        cmd.instance_variable_set(:@gql, gql)
+        cmd.instance_variable_set(:@ghcr, ghcr)
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |svc_id|
+            svc = svc_id.sub("svc-stg-", "")
+            digest = { "a" => "sha256:aaa", "b" => "sha256:bbb", "c" => "sha256:ccc" }.fetch(svc)
+            [{ "id" => "d", "status" => "SUCCESS",
+               "meta" => { "image" => "ghcr.io/copilotkit/#{svc}@#{digest}" } }]
+        end
+        cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
+
+        out, err = with_fast_sleeper { capture_io { @rc = cmd.run_with_preflight_only } }
+        assert_equal 1, @rc, "execute_promotion must return 1 when a mid-loop pin fails"
+        combined = out + err
+        assert_match(/PARTIAL PROMOTION/i, combined,
+            "must emit a loud PARTIAL PROMOTION report; output=#{combined}")
+        assert_match(/already pinned.*\ba\b.*\bb\b/m, combined,
+            "report must name the already-pinned services a and b; output=#{combined}")
+        assert_match(/FAILED on c/, combined,
+            "report must name the failing service c; output=#{combined}")
+    end
+end

--- a/showcase/bin/spec/test_promote_single_service.rb
+++ b/showcase/bin/spec/test_promote_single_service.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+# bin/railway promote — single-service positional + --digest support.
+#
+# Context: showcase_promote.yml loops services and invokes
+#   bin/railway promote "$svc" [--digest "$DIGEST"]
+# but the original PromoteCommand parser accepts NEITHER. The positional
+# was silently discarded (promoting the ENTIRE fleet per iteration) and
+# --digest raised OptionParser::InvalidOption (the workflow aborts under
+# set -euo pipefail). These tests pin the fix contract.
+
+require_relative "spec_helper"
+require "stringio"
+
+class PromoteSingleServiceTest < Minitest::Test
+    # Minimal benign GQL fake (P2 deployments query, etc.). The promotion
+    # tests below stub fetch_latest_staging_deployments and run_staging_probe
+    # so this is only used as a fallback.
+    class FakeGQLBenign
+        attr_reader :calls
+        def initialize
+            @calls = []
+            @pinned_by_service = {}  # serviceId => image; tracks per-service pin
+            @ts_counter = 0
+        end
+        def query(q, vars = {})
+            @calls << [q, vars]
+            sid = vars[:serviceId]
+            if q.include?("serviceInstanceUpdate")
+                @pinned_by_service[sid] = vars[:image]
+                { "serviceInstanceUpdate" => true }
+            elsif q.include?("serviceInstanceRedeploy")
+                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("ServiceInstanceRecheck")
+                pinned = @pinned_by_service[sid]
+                if pinned.nil?
+                    {
+                        "serviceInstance" => {
+                            "id" => "i",
+                            "source" => { "image" => "ghcr.io/copilotkit/old@sha256:OLD" },
+                            "updatedAt" => "2026-05-28T00:00:00Z",
+                        },
+                    }
+                else
+                    @ts_counter += 1
+                    {
+                        "serviceInstance" => {
+                            "id" => "i",
+                            "source" => { "image" => pinned },
+                            "updatedAt" => "2026-05-29T00:00:#{format('%02d', @ts_counter)}Z",
+                        },
+                    }
+                end
+            else
+                { "deployments" => { "edges" => [] } }
+            end
+        end
+
+        def pinned_services
+            @calls.select { |q, _| q.include?("serviceInstanceUpdate") }
+                  .map { |_, vars| [vars[:serviceId], vars[:image]] }
+        end
+
+        def pinned_image_for(service_id)
+            row = @calls.find { |q, vars| q.include?("serviceInstanceUpdate") && vars[:serviceId] == service_id }
+            row && row[1][:image]
+        end
+    end
+
+    class FakeGHCR
+        def initialize(resolve_map: {})
+            @resolve_map = resolve_map
+        end
+        def resolve_digest(ref)
+            return ref.split("@", 2).last if ref.include?("@sha256:")
+            @resolve_map[ref] || "sha256:default_digest_for_#{ref.sub(/[^a-z0-9]/i, '_')[0, 16]}"
+        end
+        def manifest_exists(_ref); :exists; end
+        def parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+    end
+
+    def make_service(name, prod_image: "ghcr.io/copilotkit/#{name}@sha256:OLD#{name.gsub('-', '')}")
+        {
+            "name" => name, "service_id" => "svc-#{name}",
+            "image" => "ghcr.io/copilotkit/#{name}:latest",
+            "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+        }
+    end
+
+    def make_prod(name)
+        {
+            "name" => name, "service_id" => "prod-#{name}",
+            "image" => "ghcr.io/copilotkit/#{name}@sha256:OLD#{name.gsub('-', '')}",
+            "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+        }
+    end
+
+    def build_cmd(argv)
+        cmd = Railway::PromoteCommand.new(argv + ["--non-interactive", "--yes", "--confirm-divergence"])
+        # IMPORTANT: do NOT call parser.parse! here — tests must exercise the
+        # full `run` path so argv parsing (positional + --digest) is covered.
+        cmd
+    end
+
+    def install_two_service_fixture(cmd, gql, ghcr)
+        # Two staging services — "aimock" and "harness" — both also in prod.
+        staging_svcs = [make_service("aimock"), make_service("harness")]
+        prod_svcs    = [make_prod("aimock"),    make_prod("harness")]
+        cmd.instance_variable_set(:@staging_snapshot, { "services" => staging_svcs })
+        cmd.instance_variable_set(:@prod_snapshot,    { "services" => prod_svcs })
+        cmd.instance_variable_set(:@gql, gql)
+        cmd.instance_variable_set(:@ghcr, ghcr)
+        # Skip P2 race-check: stub deployments to SUCCESS with the digest the
+        # promote will actually pin (which, when --digest is set, is the
+        # override — NOT the GHCR-resolved one). Read options[:digest] off the
+        # command at call-time so this works for both default and override
+        # paths without test-side branching.
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |service_id|
+            name = service_id.sub(/^svc-/, "")
+            override = options[:digest]
+            if override && options[:service] == name && override.include?("@")
+                ref = override
+            else
+                ghcr_obj = instance_variable_get(:@ghcr)
+                digest = ghcr_obj.resolve_digest("ghcr.io/copilotkit/#{name}:latest")
+                ref = "ghcr.io/copilotkit/#{name}@#{digest}"
+            end
+            [{ "id" => "d", "status" => "SUCCESS", "meta" => { "image" => ref } }]
+        end
+        cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
+    end
+
+    def with_fast_sleeper
+        original = Railway::PromoteCommand.const_get(:RETRY_DELAY_SEC)
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, 0)
+        yield
+    ensure
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, original)
+    end
+
+    # ── (a) Positional service: only that service is promoted. ────────────
+
+    def test_positional_service_promotes_only_that_service
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new(resolve_map: {
+            "ghcr.io/copilotkit/aimock:latest"  => "sha256:NEW_AIMOCK",
+            "ghcr.io/copilotkit/harness:latest" => "sha256:NEW_HARNESS",
+        })
+        cmd = build_cmd(["aimock"])
+        install_two_service_fixture(cmd, gql, ghcr)
+        rc = nil
+        out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
+        assert_equal 0, rc, "single-service promote should succeed; got out=#{out}"
+
+        pinned = gql.pinned_services
+        assert_equal 1, pinned.size, "must pin exactly ONE service when positional is given (got #{pinned.inspect})"
+        sid, image = pinned.first
+        assert_equal "prod-aimock", sid, "must target prod-aimock, not the whole fleet"
+        assert_equal "ghcr.io/copilotkit/aimock@sha256:NEW_AIMOCK", image
+        # Loud regression guard against silent fleet-wide pin.
+        refute gql.pinned_image_for("prod-harness"), "harness must NOT be touched when only aimock was requested"
+    end
+
+    # ── (b) Positional + --digest: digest overrides resolved ref. ─────────
+
+    def test_positional_service_with_digest_pins_that_digest
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new(resolve_map: {
+            "ghcr.io/copilotkit/aimock:latest"  => "sha256:NEW_AIMOCK",
+            "ghcr.io/copilotkit/harness:latest" => "sha256:NEW_HARNESS",
+        })
+        override = "ghcr.io/copilotkit/aimock@sha256:OVERRIDE_DIGEST"
+        cmd = build_cmd(["aimock", "--digest", override])
+        install_two_service_fixture(cmd, gql, ghcr)
+        rc = nil
+        out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
+        assert_equal 0, rc, "promote with --digest should succeed; got out=#{out}"
+
+        pinned = gql.pinned_services
+        assert_equal 1, pinned.size, "--digest must still pin only the named service"
+        sid, image = pinned.first
+        assert_equal "prod-aimock", sid
+        assert_equal override, image,
+            "must pin the EXPLICIT --digest ref, not the GHCR-resolved one"
+    end
+
+    # ── (c) --digest without positional → fail fast. ──────────────────────
+
+    def test_digest_without_service_fails_fast
+        cmd = build_cmd(["--digest", "ghcr.io/copilotkit/x@sha256:abc"])
+        ghcr = FakeGHCR.new
+        gql  = FakeGQLBenign.new
+        install_two_service_fixture(cmd, gql, ghcr)
+        ex = nil
+        # die! calls Kernel#exit which raises SystemExit; capture it so the
+        # test can assert the exit code AND the error message together.
+        out, err = capture_io { ex = assert_raises(SystemExit) { cmd.run } }
+        refute_equal 0, ex.status, "--digest without a service must NOT promote the fleet"
+        combined = out + err
+        assert_match(/--digest.*requires.*service|--digest.*without.*service|service.*required.*--digest/i,
+            combined, "must surface a clear error explaining --digest needs a positional service")
+        # And it must NOT have issued any pin mutations.
+        assert_empty gql.pinned_services, "no pin mutations should run on the fail-fast path"
+    end
+
+    # ── (d) Unknown positional service → fail fast with valid names. ──────
+
+    def test_unknown_positional_service_fails_with_valid_names_listed
+        cmd = build_cmd(["this-service-does-not-exist"])
+        ghcr = FakeGHCR.new
+        gql  = FakeGQLBenign.new
+        install_two_service_fixture(cmd, gql, ghcr)
+        ex = nil
+        out, err = capture_io { ex = assert_raises(SystemExit) { cmd.run } }
+        refute_equal 0, ex.status, "unknown service must fail, not silently no-op or fall through to fleet"
+        combined = out + err
+        assert_match(/unknown.*service|not.*known|invalid.*service/i, combined)
+        # The error must list at least one canonical staging name (e.g. aimock)
+        # so the operator can self-correct.
+        assert_match(/aimock/, combined,
+            "valid-names enumeration must include canonical staging services")
+        assert_empty gql.pinned_services, "no pin mutations on unknown-service error path"
+    end
+
+    # ── (e) No positional → preserve full-fleet behavior (regression). ────
+
+    def test_no_positional_preserves_full_fleet_promote
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new(resolve_map: {
+            "ghcr.io/copilotkit/aimock:latest"  => "sha256:NEW_AIMOCK",
+            "ghcr.io/copilotkit/harness:latest" => "sha256:NEW_HARNESS",
+        })
+        cmd = build_cmd([])
+        install_two_service_fixture(cmd, gql, ghcr)
+        rc = nil
+        out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
+        assert_equal 0, rc, "no-arg promote must keep working for operators; got out=#{out}"
+
+        pinned_ids = gql.pinned_services.map(&:first).sort
+        assert_equal ["prod-aimock", "prod-harness"], pinned_ids,
+            "no-arg promote must continue to pin the whole fleet"
+    end
+
+    # ── Parser-level coverage for --digest flag and positional acceptance. ─
+
+    def test_parser_accepts_digest_flag
+        c = Railway::PromoteCommand.new(["--digest", "ghcr.io/copilotkit/x@sha256:abc"])
+        # Must NOT raise InvalidOption.
+        c.parser.parse!(c.argv)
+        assert_equal "ghcr.io/copilotkit/x@sha256:abc", c.options[:digest]
+    end
+
+    def test_parser_leaves_positional_in_argv
+        c = Railway::PromoteCommand.new(["aimock", "--yes"])
+        c.parser.parse!(c.argv)
+        # OptionParser#parse! consumes known flags; the positional must remain.
+        assert_includes c.argv, "aimock"
+        assert c.options[:yes]
+    end
+end

--- a/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
+++ b/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
@@ -1,0 +1,281 @@
+# frozen_string_literal: true
+
+# bin/railway promote — fleet-scoped invariants must evaluate against the
+# FULL un-narrowed snapshots, not the single-service narrowed view.
+#
+# Background: the per-service `promote <svc>` feature narrows BOTH
+# @staging_snapshot and @prod_snapshot to one service before preflight. Two
+# fleet-scoped checks were incorrectly co-narrowed:
+#
+#   (1) check_expected_prod_domains compares the FLEET-WIDE public-host set
+#       (EXPECTED_DOMAINS[PRODUCTION_ENV_ID]) against the union of
+#       custom_domains across `prod["services"]`. Narrowed prod has ~1
+#       service → ~4 fleet hosts look "missing" → spurious WARN. The real
+#       workflow (.github/workflows/showcase_promote.yml) does NOT pass
+#       --confirm-divergence, so promote refuses on its first iteration and
+#       `set -e` aborts the loop. Healthy fleet, no real divergence,
+#       blocked.
+#
+#   (2) check_service_set_parity diffs staging vs prod service names. After
+#       narrowing both to the same single name, the diff is always empty —
+#       the invariant is dead. Worse: if the target is in staging but
+#       ABSENT from prod, execute_promotion's `next unless find_service`
+#       silently skips and returns rc=0. Operator sees "success" while
+#       prod was untouched.
+#
+# These tests pin the fix contract: fleet-scoped checks read the FULL
+# snapshots; per-service mutation reads the narrowed snapshots.
+
+require_relative "spec_helper"
+require "stringio"
+
+class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
+    # Reuse the same minimal benign GQL/GHCR fakes as
+    # test_promote_single_service.rb (parallel fixture style — kept inline
+    # here so this spec is self-contained).
+    class FakeGQLBenign
+        attr_reader :calls
+        def initialize
+            @calls = []
+            @pinned_by_service = {}
+            @ts_counter = 0
+        end
+        def query(q, vars = {})
+            @calls << [q, vars]
+            sid = vars[:serviceId]
+            if q.include?("serviceInstanceUpdate")
+                @pinned_by_service[sid] = vars[:image]
+                { "serviceInstanceUpdate" => true }
+            elsif q.include?("serviceInstanceRedeploy")
+                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("ServiceInstanceRecheck")
+                pinned = @pinned_by_service[sid]
+                if pinned.nil?
+                    {
+                        "serviceInstance" => {
+                            "id" => "i",
+                            "source" => { "image" => "ghcr.io/copilotkit/old@sha256:OLD" },
+                            "updatedAt" => "2026-05-28T00:00:00Z",
+                        },
+                    }
+                else
+                    @ts_counter += 1
+                    {
+                        "serviceInstance" => {
+                            "id" => "i",
+                            "source" => { "image" => pinned },
+                            "updatedAt" => "2026-05-29T00:00:#{format('%02d', @ts_counter)}Z",
+                        },
+                    }
+                end
+            else
+                { "deployments" => { "edges" => [] } }
+            end
+        end
+
+        def pinned_services
+            @calls.select { |q, _| q.include?("serviceInstanceUpdate") }
+                  .map { |_, vars| [vars[:serviceId], vars[:image]] }
+        end
+
+        def pinned_image_for(service_id)
+            row = @calls.find { |q, vars| q.include?("serviceInstanceUpdate") && vars[:serviceId] == service_id }
+            row && row[1][:image]
+        end
+    end
+
+    class FakeGHCR
+        def initialize(resolve_map: {})
+            @resolve_map = resolve_map
+        end
+        def resolve_digest(ref)
+            return ref.split("@", 2).last if ref.include?("@sha256:")
+            @resolve_map[ref] || "sha256:default_digest_for_#{ref.sub(/[^a-z0-9]/i, '_')[0, 16]}"
+        end
+        def manifest_exists(_ref); :exists; end
+        def parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+    end
+
+    # Public hosts as published by EXPECTED_DOMAINS for the production env.
+    # These are the SSOT-derived fleet-wide hosts; pulled here verbatim so
+    # the fixture's full prod snapshot legitimately satisfies the check.
+    FLEET_PUBLIC_PROD_HOSTS = [
+        "dashboard.showcase.copilotkit.ai",
+        "docs.copilotkit.ai",
+        "dojo.showcase.copilotkit.ai",
+        "hooks.showcase.copilotkit.ai",
+        "showcase.copilotkit.ai",
+    ].freeze
+
+    def make_staging_service(name)
+        {
+            "name" => name, "service_id" => "svc-#{name}",
+            "image" => "ghcr.io/copilotkit/#{name}:latest",
+            "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+        }
+    end
+
+    def make_prod_service(name, custom_domains: [])
+        {
+            "name" => name, "service_id" => "prod-#{name}",
+            "image" => "ghcr.io/copilotkit/#{name}@sha256:OLD#{name.gsub(/[^a-z0-9]/i, '')}",
+            "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+            "custom_domains" => custom_domains,
+        }
+    end
+
+    # Build a FLEET-SHAPED snapshot pair. The full prod snapshot's union of
+    # custom_domains across services EXACTLY satisfies the fleet-wide
+    # EXPECTED_DOMAINS[PRODUCTION_ENV_ID] set, so a healthy fleet must NOT
+    # produce a domain WARN. Two of those services ("aimock", "harness")
+    # also exist in staging — promote will target one of them.
+    def install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: true, target: "aimock")
+        # Five "domain-bearing" services so the prod fleet legitimately
+        # carries all FLEET_PUBLIC_PROD_HOSTS, even when promote is
+        # narrowed to a service that doesn't itself own any public host.
+        domain_services_prod = [
+            make_prod_service("dashboard", custom_domains: ["dashboard.showcase.copilotkit.ai"]),
+            make_prod_service("docs",      custom_domains: ["docs.copilotkit.ai"]),
+            make_prod_service("dojo",      custom_domains: ["dojo.showcase.copilotkit.ai"]),
+            make_prod_service("webhooks",  custom_domains: ["hooks.showcase.copilotkit.ai"]),
+            make_prod_service("shell",     custom_domains: ["showcase.copilotkit.ai"]),
+        ]
+        # Plus the targeted service (no public domain of its own — it's an
+        # internal aimock). Optionally OMIT it from prod to exercise BUG #2.
+        domain_services_prod << make_prod_service(target) if prod_includes_target
+        # And a non-targeted sibling that exists in both staging and prod.
+        sibling = "harness"
+        domain_services_prod << make_prod_service(sibling)
+
+        # Staging mirrors prod's service NAMES (set parity) — every prod
+        # service has a corresponding staging entry. (For BUG #2, target is
+        # in staging but absent from prod by design.)
+        staging_services = (domain_services_prod.map { |s| s["name"] } + [target]).uniq.map { |n| make_staging_service(n) }
+
+        cmd.instance_variable_set(:@staging_snapshot, { "services" => staging_services })
+        cmd.instance_variable_set(:@prod_snapshot,    { "services" => domain_services_prod })
+        cmd.instance_variable_set(:@gql, gql)
+        cmd.instance_variable_set(:@ghcr, ghcr)
+
+        # P2 race-check stub — see test_promote_single_service.rb for the
+        # same pattern. Mirror the pin the promote will actually issue.
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |service_id|
+            name = service_id.sub(/^svc-/, "")
+            override = options[:digest]
+            if override && options[:service] == name && override.include?("@")
+                ref = override
+            else
+                ghcr_obj = instance_variable_get(:@ghcr)
+                digest = ghcr_obj.resolve_digest("ghcr.io/copilotkit/#{name}:latest")
+                ref = "ghcr.io/copilotkit/#{name}@#{digest}"
+            end
+            [{ "id" => "d", "status" => "SUCCESS", "meta" => { "image" => ref } }]
+        end
+        cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
+    end
+
+    def build_cmd(argv)
+        # CRITICAL: this test MUST mirror the real workflow invocation —
+        # showcase_promote.yml calls `promote <svc>` WITHOUT
+        # --confirm-divergence. Do NOT add --confirm-divergence here.
+        Railway::PromoteCommand.new(argv + ["--non-interactive", "--yes"])
+    end
+
+    def with_fast_sleeper
+        original = Railway::PromoteCommand.const_get(:RETRY_DELAY_SEC)
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, 0)
+        yield
+    ensure
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, original)
+    end
+
+    # ── BUG #1: healthy fleet, single-service promote, NO --confirm-divergence.
+    # Today (red): narrowed prod has 1 service whose custom_domains do not
+    # include the 5 fleet public hosts → WARN → run_with_preflight_only
+    # refuses (rc=1) because options[:confirm_divergence] is false.
+    # After fix (green): rc=0, target pinned, siblings untouched.
+    def test_healthy_fleet_single_service_promote_without_confirm_divergence_succeeds
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new(resolve_map: {
+            "ghcr.io/copilotkit/aimock:latest" => "sha256:NEW_AIMOCK",
+        })
+        cmd = build_cmd(["aimock"])
+        install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: true, target: "aimock")
+
+        rc = nil
+        out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
+
+        assert_equal 0, rc,
+            "single-service promote against a HEALTHY fleet must NOT be " \
+            "refused for missing fleet-wide domains (workflow doesn't pass " \
+            "--confirm-divergence). Got rc=#{rc.inspect}; out=\n#{out}"
+
+        # Spurious-WARN smoke check: we must NOT have emitted a fleet-domains
+        # WARN since the un-narrowed fleet satisfies EXPECTED_DOMAINS.
+        refute_match(/WARN: production missing expected custom domains/, out,
+            "fleet-domain check should evaluate the FULL prod snapshot; the " \
+            "narrowed view must not synthesize a phantom 'missing' WARN")
+
+        pinned = gql.pinned_services
+        assert_equal 1, pinned.size,
+            "exactly one service should be promoted (target only); got #{pinned.inspect}"
+        sid, image = pinned.first
+        assert_equal "prod-aimock", sid
+        assert_equal "ghcr.io/copilotkit/aimock@sha256:NEW_AIMOCK", image
+
+        # Siblings must remain untouched.
+        refute gql.pinned_image_for("prod-harness"),
+            "harness must not be pinned when only aimock was promoted"
+        refute gql.pinned_image_for("prod-dashboard"),
+            "dashboard must not be pinned when only aimock was promoted"
+    end
+
+    # ── BUG #2: target exists in staging but is ABSENT from prod.
+    # Today (red): both snapshots get narrowed; service_set_parity (narrowed)
+    # diffs [target] vs [] but the test fixture wouldn't have a prod entry
+    # at all after narrowing... wait — narrowing prod yields an EMPTY
+    # services list (no match). check_service_set_parity then diffs
+    # ["aimock"] vs [] → finds REFUSE "services in staging not in prod".
+    # BUT: the per-service feature's narrowing also narrows staging to
+    # [target], so the diff against an empty prod *should* surface the
+    # REFUSE. Verify the failure mode is the silent-skip path:
+    # execute_promotion's `next unless find_service` for absent prod.
+    #
+    # Either way, the contract is: if the targeted service is in staging
+    # but ABSENT from prod, promote must FAIL LOUD (nonzero rc + clear
+    # message), never silently rc=0 with no pin mutations.
+    def test_target_absent_from_prod_fails_loud
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new(resolve_map: {
+            "ghcr.io/copilotkit/aimock:latest" => "sha256:NEW_AIMOCK",
+        })
+        cmd = build_cmd(["aimock"])
+        # prod_includes_target=false → "aimock" exists in staging but NOT
+        # in the full prod snapshot. The fleet otherwise mirrors itself
+        # (no spurious set-parity issues), so the REFUSE we observe is
+        # specifically the staging-only-target case.
+        install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: false, target: "aimock")
+
+        rc = nil
+        out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
+
+        refute_equal 0, rc,
+            "target service present in staging but ABSENT from prod must " \
+            "FAIL LOUD (nonzero rc), not silently succeed with no pin. " \
+            "Got rc=#{rc.inspect}; out=\n#{out}"
+
+        # The error message must be informative — surface the parity
+        # violation rather than a generic / opaque failure.
+        assert_match(/REFUSE: services in staging not in prod/, out,
+            "must surface a clear REFUSE explaining target is missing from prod")
+
+        assert_empty gql.pinned_services,
+            "no pin mutations may be issued when target is absent from prod"
+    end
+end

--- a/showcase/bin/spec/test_snapshot_graphql.rb
+++ b/showcase/bin/spec/test_snapshot_graphql.rb
@@ -59,15 +59,21 @@ class SnapshotGraphqlTest < Minitest::Test
         }
     end
 
-    def service_instance_response(image:, start_cmd: nil, domains: [])
+    def service_instance_response(image:, start_cmd: nil, domains: [],
+                                  healthcheck_path: nil, region: nil,
+                                  num_replicas: nil, restart_policy: nil)
         {
             "serviceInstance" => {
-                "id"               => "inst-#{image[/sha256:[a-f0-9]+/] || 'tag'}",
-                "serviceId"        => "svc-aimock",
-                "environmentId"    => Railway::PRODUCTION_ENV_ID,
-                "startCommand"     => start_cmd,
-                "source"           => { "image" => image, "repo" => nil },
-                "latestDeployment" => { "id" => "dep-1", "status" => "SUCCESS" },
+                "id"                 => "inst-#{image[/sha256:[a-f0-9]+/] || 'tag'}",
+                "serviceId"          => "svc-aimock",
+                "environmentId"      => Railway::PRODUCTION_ENV_ID,
+                "startCommand"       => start_cmd,
+                "healthcheckPath"    => healthcheck_path,
+                "region"             => region,
+                "numReplicas"        => num_replicas,
+                "restartPolicyType"  => restart_policy,
+                "source"             => { "image" => image, "repo" => nil },
+                "latestDeployment"   => { "id" => "dep-1", "status" => "SUCCESS" },
                 "domains" => {
                     "customDomains"  => domains.map { |d| { "id" => "cd-#{d}", "domain" => d } },
                     "serviceDomains" => [],
@@ -101,7 +107,7 @@ class SnapshotGraphqlTest < Minitest::Test
 
         snap = cmd.build_snapshot(Railway::PRODUCTION_ENV_ID)
 
-        assert_equal 1, snap["version"]
+        assert_equal 2, snap["version"]
         assert_equal 2, snap["services"].length
 
         aimock = snap["services"].find { |s| s["name"] == "aimock" }
@@ -168,6 +174,68 @@ class SnapshotGraphqlTest < Minitest::Test
         assert_match(/serviceInstanceUpdate\s*\(/, Railway::RestoreCommand::UPDATE_IMAGE_MUTATION)
         assert_match(/source:\s*\{\s*image:/, Railway::RestoreCommand::UPDATE_IMAGE_MUTATION)
         assert_match(/serviceInstanceRedeploy\s*\(/, Railway::RestoreCommand::REDEPLOY_MUTATION)
+    end
+
+    def test_snapshot_v2_captures_healthcheck_region_replicas_restart_policy
+        # P6 parity-matrix needs these four fields on every snapshot service.
+        # Snapshot schema is v2; SnapshotCommand#build_snapshot must map them
+        # from the new SERVICE_INSTANCE_QUERY selection set.
+        fake = FakeGQL.new(
+            "ProjectServices" => services_list_response,
+            "EnvVariables"    => env_vars_response_with_per_service_keys,
+            "ServiceInstance" => lambda do |vars|
+                if vars[:serviceId] == "svc-aimock"
+                    service_instance_response(
+                        image: "ghcr.io/copilotkit/showcase-aimock@sha256:cafef00d",
+                        start_cmd: "node /app/dist/cli.js",
+                        domains: ["aimock.showcase.copilotkit.ai"],
+                        healthcheck_path: "/healthz",
+                        region: "us-west2",
+                        num_replicas: 2,
+                        restart_policy: "ON_FAILURE",
+                    )
+                else
+                    service_instance_response(
+                        image: "ghcr.io/copilotkit/showcase-shell@sha256:beef1234",
+                        healthcheck_path: "/health",
+                        region: "us-east1",
+                        num_replicas: 1,
+                        restart_policy: "ALWAYS",
+                    )
+                end
+            end,
+        )
+
+        cmd = Railway::SnapshotCommand.new(["--env", "production", "--dry-run"])
+        cmd.instance_variable_set(:@gql, fake)
+        snap = cmd.build_snapshot(Railway::PRODUCTION_ENV_ID)
+
+        aimock = snap["services"].find { |s| s["name"] == "aimock" }
+        assert_equal "/healthz",    aimock["healthcheck_path"]
+        assert_equal "us-west2",    aimock["region"]
+        assert_equal 2,             aimock["replicas"]
+        assert_equal "ON_FAILURE",  aimock["restart_policy"]
+
+        shell = snap["services"].find { |s| s["name"] == "shell" }
+        assert_equal "/health",   shell["healthcheck_path"]
+        assert_equal "us-east1",  shell["region"]
+        assert_equal 1,           shell["replicas"]
+        assert_equal "ALWAYS",    shell["restart_policy"]
+    end
+
+    def test_snapshot_io_read_accepts_v1_and_v2_snapshots
+        # rollback-commit replays historical snapshots from arbitrary git SHAs,
+        # so SnapshotIO.read MUST stay backwards-compat with v1 even though
+        # all NEW snapshots are written as v2.
+        require "tempfile"
+        [1, 2].each do |ver|
+            Tempfile.create(["snap-v#{ver}", ".yaml"]) do |f|
+                f.write(YAML.dump("version" => ver, "services" => []))
+                f.flush
+                snap = Railway::SnapshotIO.read(f.path)
+                assert_equal ver, snap["version"]
+            end
+        end
     end
 
     def test_deploymentRollback_mutation_has_no_selection_set_because_it_returns_boolean

--- a/showcase/harness/README.md
+++ b/showcase/harness/README.md
@@ -432,7 +432,7 @@ docker buildx build --platform linux/amd64 --push \
 #    serviceInstanceDeployV2 forces a fresh snapshot — serviceInstanceRedeploy
 #    replays the prior manifest and can re-pull a stale digest.
 RW_TOKEN=$(jq -r .user.token ~/.railway/config.json)
-curl -s -X POST https://backboard.railway.com/graphql/v2 \
+curl -s -X POST https://backboard.railway.app/graphql/v2 \
   -H "Authorization: Bearer $RW_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query":"mutation { serviceInstanceDeployV2(serviceId:\"3a14bfed-0537-4d71-897b-7c593dca161d\", environmentId:\"b14919f4-6417-429f-848d-c6ae2201e04f\") }"}'

--- a/showcase/harness/config/probes/d6-all-pills-e2e.yml
+++ b/showcase/harness/config/probes/d6-all-pills-e2e.yml
@@ -36,6 +36,9 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
+      # Harness service for .NET integration testing — not a demo service,
+      # deployed: false in manifest, no aimock wiring yet.
+      - showcase-ms-agent-harness-dotnet
       # Decommissioned starters
       - showcase-starter-ag2
       - showcase-starter-agno

--- a/showcase/harness/config/probes/e2e-deep.yml
+++ b/showcase/harness/config/probes/e2e-deep.yml
@@ -87,6 +87,9 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
+      # Harness service for .NET integration testing — not a demo service,
+      # deployed: false in manifest, no aimock wiring yet.
+      - showcase-ms-agent-harness-dotnet
       # Decommissioned starters — Railway services stopped (PR #4390)
       - showcase-starter-ag2
       - showcase-starter-agno

--- a/showcase/harness/config/probes/e2e-demos.yml
+++ b/showcase/harness/config/probes/e2e-demos.yml
@@ -118,6 +118,9 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
+      # Harness service for .NET integration testing — not a demo service,
+      # deployed: false in manifest, no aimock wiring yet.
+      - showcase-ms-agent-harness-dotnet
       # Decommissioned starters — Railway services stopped (PR #4390)
       - showcase-starter-ag2
       - showcase-starter-agno

--- a/showcase/harness/config/probes/e2e-parity.yml
+++ b/showcase/harness/config/probes/e2e-parity.yml
@@ -102,6 +102,9 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
+      # Harness service for .NET integration testing — not a demo service,
+      # deployed: false in manifest, no aimock wiring yet.
+      - showcase-ms-agent-harness-dotnet
       # Decommissioned starters — Railway services stopped (PR #4390)
       - showcase-starter-ag2
       - showcase-starter-agno

--- a/showcase/harness/config/probes/e2e-smoke.yml
+++ b/showcase/harness/config/probes/e2e-smoke.yml
@@ -53,6 +53,9 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
+      # Harness service for .NET integration testing — not a demo service,
+      # deployed: false in manifest, no aimock wiring yet.
+      - showcase-ms-agent-harness-dotnet
       # Decommissioned starters — Railway services stopped (PR #4390)
       - showcase-starter-ag2
       - showcase-starter-agno

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -1241,7 +1241,7 @@ export function buildCronProbeResolver(
 /**
  * Minimal Railway GraphQL adapter used by the aimock-wiring probe.
  * Lists services in a project and fetches per-service env-var values
- * for a given environment. Endpoint: https://backboard.railway.com/graphql/v2.
+ * for a given environment. Endpoint: https://backboard.railway.app/graphql/v2.
  *
  * Routes through the shared `makeGql` helper exported from
  * `probes/discovery/railway-services.ts` so error taxonomy (Auth /

--- a/showcase/harness/src/probes/discovery/railway-services.ts
+++ b/showcase/harness/src/probes/discovery/railway-services.ts
@@ -229,7 +229,7 @@ const ConfigSchema = z
   })
   .passthrough();
 
-const ENDPOINT = "https://backboard.railway.com/graphql/v2";
+const ENDPOINT = "https://backboard.railway.app/graphql/v2";
 
 // Zod shapes for the GraphQL responses. Kept in-file (not exported) so the
 // schema errors carry consistent paths in their messages.

--- a/showcase/harness/src/probes/drivers/aimock-wiring.ts
+++ b/showcase/harness/src/probes/drivers/aimock-wiring.ts
@@ -163,7 +163,7 @@ function createRailwayAdapter(
   listServices: () => Promise<{ name: string; id: string }[]>;
   getServiceEnv: (name: string) => Promise<Record<string, string | undefined>>;
 } {
-  const endpoint = "https://backboard.railway.com/graphql/v2";
+  const endpoint = "https://backboard.railway.app/graphql/v2";
 
   async function gql<T>(
     query: string,

--- a/showcase/playwright.env-routing.config.ts
+++ b/showcase/playwright.env-routing.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for the env-routing test (B14).
+ *
+ * Scoped narrowly to `tests/env-routing.spec.ts` so it doesn't pull in
+ * the integrations smoke harness (`tests/playwright.config.ts` →
+ * `testDir: ./e2e`) or the shell-dashboard visual regression suite
+ * (`shell-dashboard/playwright.config.ts` → `testDir: ./tests/visual`).
+ *
+ * Runs against LIVE deployments (staging + prod). No webServer block:
+ * the test fetches public URLs; nothing local needs to be brought up.
+ *
+ * Usage:
+ *   npx playwright test --config=showcase/playwright.env-routing.config.ts
+ *
+ * In CI this is gated to run after the B15 Railway env-var wiring
+ * deploys settle.
+ */
+export default defineConfig({
+    testDir: "./tests",
+    testMatch: /env-routing\.spec\.ts$/,
+    timeout: 60_000,
+    expect: { timeout: 15_000 },
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    // Live-net tests can flake on transient TLS / DNS hiccups; one
+    // retry mirrors the integrations smoke config and avoids paging
+    // ops for a single jittered fetch.
+    retries: process.env.CI ? 1 : 0,
+    workers: process.env.CI ? 2 : 4,
+    reporter: process.env.CI ? "github" : "list",
+    use: {
+        ...devices["Desktop Chrome"],
+        trace: "retain-on-failure",
+        screenshot: "only-on-failure",
+    },
+});

--- a/showcase/playwright.env-routing.config.ts
+++ b/showcase/playwright.env-routing.config.ts
@@ -18,21 +18,21 @@ import { defineConfig, devices } from "@playwright/test";
  * deploys settle.
  */
 export default defineConfig({
-    testDir: "./tests",
-    testMatch: /env-routing\.spec\.ts$/,
-    timeout: 60_000,
-    expect: { timeout: 15_000 },
-    fullyParallel: true,
-    forbidOnly: !!process.env.CI,
-    // Live-net tests can flake on transient TLS / DNS hiccups; one
-    // retry mirrors the integrations smoke config and avoids paging
-    // ops for a single jittered fetch.
-    retries: process.env.CI ? 1 : 0,
-    workers: process.env.CI ? 2 : 4,
-    reporter: process.env.CI ? "github" : "list",
-    use: {
-        ...devices["Desktop Chrome"],
-        trace: "retain-on-failure",
-        screenshot: "only-on-failure",
-    },
+  testDir: "./tests",
+  testMatch: /env-routing\.spec\.ts$/,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  // Live-net tests can flake on transient TLS / DNS hiccups; one
+  // retry mirrors the integrations smoke config and avoids paging
+  // ops for a single jittered fetch.
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : 4,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    ...devices["Desktop Chrome"],
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
 });

--- a/showcase/scripts/__tests__/aggregate-build-results.test.ts
+++ b/showcase/scripts/__tests__/aggregate-build-results.test.ts
@@ -1,0 +1,154 @@
+/**
+ * aggregate-build-results.test.ts — covers the per-slot aggregator that
+ * runs in the `aggregate-build-results` job of showcase_build.yml.
+ *
+ * The script's `run({inputDir, outputDir, githubOutput})` entrypoint is
+ * exercised directly with temp dirs (so we never touch tracked files or
+ * spawn subprocesses). We verify:
+ *   1. empty INPUT_DIR → results.json = `[]`, any_success=false, no throw
+ *   2. build-result-<x> dir missing result.json → throws naming the slot
+ *   3. non-`build-result-*` dirs are ignored
+ *   4. mixed success/failure → correct merged array + any_success=true
+ *   5. GITHUB_OUTPUT receives heredoc-form `results` block + any_success
+ */
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { run } from "../aggregate-build-results";
+
+function makeSlot(
+  inputDir: string,
+  service: string,
+  status: "success" | "failure" | "skipped",
+): void {
+  const dir = join(inputDir, `build-result-${service}`);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "result.json"), JSON.stringify({ service, status }));
+}
+
+describe("aggregate-build-results.run", () => {
+  let inputDir: string;
+  let outputDir: string;
+  let githubOutput: string;
+
+  beforeEach(() => {
+    const base = mkdtempSync(join(tmpdir(), "agg-build-"));
+    inputDir = join(base, "in");
+    outputDir = join(base, "out");
+    githubOutput = join(base, "gh_output");
+    mkdirSync(inputDir, { recursive: true });
+    // OUTPUT_DIR intentionally NOT pre-created — run() must mkdir -p.
+    writeFileSync(githubOutput, "");
+  });
+
+  afterEach(() => {
+    // Temp dirs are under os.tmpdir(); OS reaps them. No tracked files
+    // touched, so no cleanup needed.
+  });
+
+  it("empty INPUT_DIR → results.json=[] and any_success=false", () => {
+    run({ inputDir, outputDir, githubOutput });
+
+    const results = JSON.parse(
+      readFileSync(join(outputDir, "results.json"), "utf-8"),
+    );
+    expect(results).toEqual([]);
+
+    const gh = readFileSync(githubOutput, "utf-8");
+    expect(gh).toContain("any_success=false");
+    // Heredoc form must be used even for [].
+    expect(gh).toMatch(/results<<(\S+)\n\[\]\n\1\n/);
+  });
+
+  it("throws naming the slot when build-result-<x>/result.json is missing", () => {
+    const slotDir = join(inputDir, "build-result-orphan");
+    mkdirSync(slotDir, { recursive: true });
+    // Note: NO result.json written.
+
+    expect(() => run({ inputDir, outputDir, githubOutput })).toThrow(
+      /aggregate-build-results: build-result-orphan is missing result\.json/,
+    );
+  });
+
+  it("ignores directories that do not match build-result-*", () => {
+    mkdirSync(join(inputDir, "some-other-artifact"), { recursive: true });
+    writeFileSync(
+      join(inputDir, "some-other-artifact", "result.json"),
+      JSON.stringify({ service: "noise", status: "success" }),
+    );
+    // A file (not a directory) at top level should also be ignored.
+    writeFileSync(join(inputDir, "build-result-not-a-dir"), "garbage");
+
+    makeSlot(inputDir, "real", "success");
+
+    run({ inputDir, outputDir, githubOutput });
+
+    const results = JSON.parse(
+      readFileSync(join(outputDir, "results.json"), "utf-8"),
+    );
+    expect(results).toEqual([{ service: "real", status: "success" }]);
+  });
+
+  it("merges mixed success/failure correctly and sets any_success=true", () => {
+    makeSlot(inputDir, "alpha", "success");
+    makeSlot(inputDir, "beta", "failure");
+    makeSlot(inputDir, "gamma", "skipped");
+
+    run({ inputDir, outputDir, githubOutput });
+
+    const results = JSON.parse(
+      readFileSync(join(outputDir, "results.json"), "utf-8"),
+    );
+    expect(results).toHaveLength(3);
+    const byName = new Map<string, string>(
+      (results as Array<{ service: string; status: string }>).map((r) => [
+        r.service,
+        r.status,
+      ]),
+    );
+    expect(byName.get("alpha")).toBe("success");
+    expect(byName.get("beta")).toBe("failure");
+    expect(byName.get("gamma")).toBe("skipped");
+
+    const gh = readFileSync(githubOutput, "utf-8");
+    expect(gh).toContain("any_success=true");
+  });
+
+  it("writes results to GITHUB_OUTPUT in multi-line heredoc form", () => {
+    makeSlot(inputDir, "alpha", "success");
+    makeSlot(inputDir, "beta", "failure");
+
+    run({ inputDir, outputDir, githubOutput });
+
+    const gh = readFileSync(githubOutput, "utf-8");
+
+    // The heredoc form is:
+    //   results<<EOF
+    //   <json>
+    //   EOF
+    // The delimiter token is implementation-defined but must match on
+    // both sides (GitHub Actions convention; commonly "EOF" or a unique
+    // token to avoid collision with embedded payloads).
+    const heredocRe = /results<<(\S+)\n([\s\S]*?)\n\1\n/;
+    const match = gh.match(heredocRe);
+    expect(match).not.toBeNull();
+    if (!match) return;
+    const [, , jsonBody] = match;
+    const parsed = JSON.parse(jsonBody);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(2);
+
+    // any_success line is still a plain key=value.
+    expect(gh).toMatch(/any_success=true\n/);
+  });
+
+  it("results.json has a trailing newline", () => {
+    makeSlot(inputDir, "alpha", "success");
+
+    run({ inputDir, outputDir, githubOutput });
+
+    const raw = readFileSync(join(outputDir, "results.json"), "utf-8");
+    expect(raw.endsWith("\n")).toBe(true);
+  });
+});

--- a/showcase/scripts/__tests__/aggregate-build-results.test.ts
+++ b/showcase/scripts/__tests__/aggregate-build-results.test.ts
@@ -47,18 +47,19 @@ describe("aggregate-build-results.run", () => {
     // touched, so no cleanup needed.
   });
 
-  it("empty INPUT_DIR → results.json=[] and any_success=false", () => {
-    run({ inputDir, outputDir, githubOutput });
-
-    const results = JSON.parse(
-      readFileSync(join(outputDir, "results.json"), "utf-8"),
+  it("empty INPUT_DIR → throws (broken artifact download — the aggregator only runs when >=1 service was scheduled)", () => {
+    // The aggregator is gated on `has_changes == 'true'` upstream, so the
+    // matrix is guaranteed non-empty by the time we run. A zero-slot input
+    // dir therefore means the per-slot artifact download produced nothing
+    // (broken download, expired artifacts, mis-scoped run-id). Silently
+    // emitting `any_success=false` with `results=[]` is indistinguishable
+    // from "all builds failed" — that's a false-green path because the
+    // deploy workflow then has no success set to intersect against and
+    // falls back to probing the full service set against stale :latest.
+    // We refuse the ambiguity and fail loud instead.
+    expect(() => run({ inputDir, outputDir, githubOutput })).toThrow(
+      /aggregate-build-results: found 0 build-result-\* slot dirs/,
     );
-    expect(results).toEqual([]);
-
-    const gh = readFileSync(githubOutput, "utf-8");
-    expect(gh).toContain("any_success=false");
-    // Heredoc form must be used even for [].
-    expect(gh).toMatch(/results<<(\S+)\n\[\]\n\1\n/);
   });
 
   it("throws naming the slot when build-result-<x>/result.json is missing", () => {

--- a/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
@@ -1,15 +1,27 @@
-import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const SCRIPT = resolve(__dirname, "..", "emit-railway-envs-json.ts");
-const OUTPUT = resolve(__dirname, "..", "railway-envs.generated.json");
 
 describe("emit-railway-envs-json", () => {
+  let workDir: string;
+  let outPath: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "emit-railway-envs-"));
+    outPath = join(workDir, "railway-envs.generated.json");
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
   it("emits canonical JSON containing every SSOT service", () => {
-    execFileSync("npx", ["tsx", SCRIPT], { stdio: "pipe" });
-    const json = JSON.parse(readFileSync(OUTPUT, "utf8"));
+    execFileSync("npx", ["tsx", SCRIPT, `--out=${outPath}`], { stdio: "pipe" });
+    const json = JSON.parse(readFileSync(outPath, "utf8"));
     expect(json.projectId).toBe("6f8c6bff-a80d-4f8f-b78d-50b32bcf4479");
     expect(json.envIds.staging).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
     expect(json.envIds.prod).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");
@@ -23,25 +35,42 @@ describe("emit-railway-envs-json", () => {
   });
 
   it("--check passes when on-disk JSON matches SSOT", () => {
-    execFileSync("npx", ["tsx", SCRIPT], { stdio: "pipe" });
-    const out = execFileSync("npx", ["tsx", SCRIPT, "--check"], {
-      stdio: "pipe",
-    }).toString();
+    execFileSync("npx", ["tsx", SCRIPT, `--out=${outPath}`], { stdio: "pipe" });
+    const out = execFileSync(
+      "npx",
+      ["tsx", SCRIPT, "--check", `--out=${outPath}`],
+      { stdio: "pipe" },
+    ).toString();
     expect(out).toMatch(/up to date/);
   });
 
-  it("--check FAILS when on-disk JSON is stale", () => {
-    execFileSync("npx", ["tsx", SCRIPT], { stdio: "pipe" });
-    const original = readFileSync(OUTPUT, "utf8");
-    try {
-      writeFileSync(OUTPUT, original.replace(/docs.copilotkit.ai/g, "x"));
-      expect(() =>
-        execFileSync("npx", ["tsx", SCRIPT, "--check"], {
-          stdio: "pipe",
-        }),
-      ).toThrow();
-    } finally {
-      writeFileSync(OUTPUT, original);
-    }
+  it("--check FAILS with a staleness diagnostic when on-disk JSON is stale", () => {
+    execFileSync("npx", ["tsx", SCRIPT, `--out=${outPath}`], { stdio: "pipe" });
+    const original = readFileSync(outPath, "utf8");
+    writeFileSync(outPath, original.replace(/docs.copilotkit.ai/g, "x"));
+    const result = spawnSync(
+      "npx",
+      ["tsx", SCRIPT, "--check", `--out=${outPath}`],
+      { encoding: "utf8" },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/stale/);
+  });
+
+  it("--check FAILS LOUD on non-ENOENT read errors (e.g. EISDIR)", () => {
+    // Point --out at a directory so readFileSync raises EISDIR (not ENOENT).
+    // The script must NOT silently treat this as drift; it must exit non-zero
+    // with a real error written to stderr, distinct from the staleness exit
+    // (we use exit code 2 vs 1 to make the distinction observable).
+    const subdir = mkdtempSync(join(workDir, "isdir-"));
+    const result = spawnSync(
+      "npx",
+      ["tsx", SCRIPT, "--check", `--out=${subdir}`],
+      { encoding: "utf8" },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/EISDIR|illegal operation on a directory/i);
+    // Must NOT be the staleness message
+    expect(result.stderr).not.toMatch(/is stale/);
   });
 });

--- a/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
@@ -1,0 +1,47 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT = resolve(__dirname, "..", "emit-railway-envs-json.ts");
+const OUTPUT = resolve(__dirname, "..", "railway-envs.generated.json");
+
+describe("emit-railway-envs-json", () => {
+  it("emits canonical JSON containing every SSOT service", () => {
+    execFileSync("npx", ["tsx", SCRIPT], { stdio: "pipe" });
+    const json = JSON.parse(readFileSync(OUTPUT, "utf8"));
+    expect(json.projectId).toBe("6f8c6bff-a80d-4f8f-b78d-50b32bcf4479");
+    expect(json.envIds.staging).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
+    expect(json.envIds.prod).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");
+    expect(json.services.length).toBe(27);
+    const docs = json.services.find(
+      (s: { name: string }) => s.name === "docs",
+    );
+    expect(docs.domains.staging).toBe("docs.staging.copilotkit.ai");
+    expect(docs.domains.prod).toBe("docs.copilotkit.ai");
+    expect(docs.probe.driver).toBe("docs");
+  });
+
+  it("--check passes when on-disk JSON matches SSOT", () => {
+    execFileSync("npx", ["tsx", SCRIPT], { stdio: "pipe" });
+    const out = execFileSync("npx", ["tsx", SCRIPT, "--check"], {
+      stdio: "pipe",
+    }).toString();
+    expect(out).toMatch(/up to date/);
+  });
+
+  it("--check FAILS when on-disk JSON is stale", () => {
+    execFileSync("npx", ["tsx", SCRIPT], { stdio: "pipe" });
+    const original = readFileSync(OUTPUT, "utf8");
+    try {
+      writeFileSync(OUTPUT, original.replace(/docs.copilotkit.ai/g, "x"));
+      expect(() =>
+        execFileSync("npx", ["tsx", SCRIPT, "--check"], {
+          stdio: "pipe",
+        }),
+      ).toThrow();
+    } finally {
+      writeFileSync(OUTPUT, original);
+    }
+  });
+});

--- a/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
@@ -26,9 +26,7 @@ describe("emit-railway-envs-json", () => {
     expect(json.envIds.staging).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
     expect(json.envIds.prod).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");
     expect(json.services.length).toBe(27);
-    const docs = json.services.find(
-      (s: { name: string }) => s.name === "docs",
-    );
+    const docs = json.services.find((s: { name: string }) => s.name === "docs");
     expect(docs.domains.staging).toBe("docs.staging.copilotkit.ai");
     expect(docs.domains.prod).toBe("docs.copilotkit.ai");
     expect(docs.probe.driver).toBe("docs");

--- a/showcase/scripts/__tests__/lint-rule-no-public-env.test.ts
+++ b/showcase/scripts/__tests__/lint-rule-no-public-env.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { execSync } from "node:child_process";
+import { writeFileSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// Repo root is two directories above this test file
+// (showcase/scripts/__tests__/X -> showcase/scripts -> showcase -> <repo>).
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
+const CONFIG_PATH = join(REPO_ROOT, ".oxlintrc.json");
+
+describe("oxlint copilotkit/no-public-env-shell-read NEXT_PUBLIC_* guard", () => {
+    it("fires on direct process.env.NEXT_PUBLIC_POCKETBASE_URL read in shell code", () => {
+        // Stage a forbidden file inside the actual repo path so the
+        // override `files` pattern matches. We use a `.lintfixture.tsx`
+        // suffix that the off-override (which excludes `*.test.{ts,tsx}` /
+        // `*.spec.{ts,tsx}` / `*runtime-config*`) does NOT match.
+        const target = join(
+            REPO_ROOT,
+            "showcase",
+            "shell-dashboard",
+            "src",
+            "lib",
+            "__bad.lintfixture.tsx",
+        );
+        writeFileSync(
+            target,
+            `export const x = process.env.NEXT_PUBLIC_POCKETBASE_URL;\n`,
+            "utf8",
+        );
+        try {
+            // Use an explicit -c to pin the config: in git worktrees nested
+            // under .claude/worktrees/, oxlint's automatic upward config
+            // search may resolve to a different .oxlintrc.json than the
+            // worktree's own. Pinning it makes the test deterministic.
+            const result = execSync(
+                `npx oxlint -c ${CONFIG_PATH} ${target} --quiet`,
+                { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], cwd: REPO_ROOT },
+            ).toString();
+            // Should not reach here — oxlint exits non-zero on errors.
+            expect(result).toBe("UNREACHABLE: oxlint should have failed");
+        } catch (e) {
+            const stderr = (e as { stderr?: Buffer | string }).stderr?.toString() ?? "";
+            const stdout = (e as { stdout?: Buffer | string }).stdout?.toString() ?? "";
+            const combined = stderr + stdout;
+            expect(combined).toMatch(/no-public-env-shell-read/);
+            expect(combined).toMatch(/getRuntimeConfig/);
+        } finally {
+            rmSync(target, { force: true });
+        }
+    });
+
+    it("does NOT fire on process.env.NEXT_PUBLIC_COMMIT_SHA (build-stamp, intentionally allowed)", () => {
+        const target = join(
+            REPO_ROOT,
+            "showcase",
+            "shell-dashboard",
+            "src",
+            "lib",
+            "__ok.lintfixture.tsx",
+        );
+        writeFileSync(
+            target,
+            `export const sha = process.env.NEXT_PUBLIC_COMMIT_SHA;\n`,
+            "utf8",
+        );
+        try {
+            // Should succeed (exit 0).
+            execSync(`npx oxlint -c ${CONFIG_PATH} ${target} --quiet`, {
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "pipe"],
+                cwd: REPO_ROOT,
+            });
+        } finally {
+            rmSync(target, { force: true });
+        }
+    });
+});

--- a/showcase/scripts/__tests__/lint-rule-no-public-env.test.ts
+++ b/showcase/scripts/__tests__/lint-rule-no-public-env.test.ts
@@ -9,11 +9,11 @@ import { pathToFileURL } from "node:url";
 const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
 const CONFIG_PATH = join(REPO_ROOT, ".oxlintrc.json");
 const RULE_MODULE_PATH = join(
-    REPO_ROOT,
-    "packages",
-    "react-ui",
-    "oxlint-rules",
-    "no-public-env-shell-read.mjs",
+  REPO_ROOT,
+  "packages",
+  "react-ui",
+  "oxlint-rules",
+  "no-public-env-shell-read.mjs",
 );
 
 // Import BANNED_KEYS from the rule module itself (rather than hand-mirroring
@@ -22,24 +22,24 @@ const RULE_MODULE_PATH = join(
 // test, the test set still expands automatically; if someone removes a key
 // from the rule, the test set contracts. The assertion is "the rule is
 // exhaustively table-driven against its own banned set."
-const ruleModule = (await import(
-    pathToFileURL(RULE_MODULE_PATH).href
-)) as { BANNED_KEYS: Set<string> };
+const ruleModule = (await import(pathToFileURL(RULE_MODULE_PATH).href)) as {
+  BANNED_KEYS: Set<string>;
+};
 if (
-    !ruleModule.BANNED_KEYS ||
-    !(ruleModule.BANNED_KEYS instanceof Set) ||
-    ruleModule.BANNED_KEYS.size === 0
+  !ruleModule.BANNED_KEYS ||
+  !(ruleModule.BANNED_KEYS instanceof Set) ||
+  ruleModule.BANNED_KEYS.size === 0
 ) {
-    throw new Error(
-        `Rule module did not export a non-empty BANNED_KEYS Set: ${RULE_MODULE_PATH}`,
-    );
+  throw new Error(
+    `Rule module did not export a non-empty BANNED_KEYS Set: ${RULE_MODULE_PATH}`,
+  );
 }
 const BANNED_KEYS = [...ruleModule.BANNED_KEYS] as readonly string[];
 
 const ALLOWED_KEYS = [
-    "NEXT_PUBLIC_COMMIT_SHA",
-    "NEXT_PUBLIC_BRANCH",
-    "NEXT_PUBLIC_LOCAL_BACKENDS",
+  "NEXT_PUBLIC_COMMIT_SHA",
+  "NEXT_PUBLIC_BRANCH",
+  "NEXT_PUBLIC_LOCAL_BACKENDS",
 ] as const;
 
 // Track every fixture we stage so afterEach reaps them — even on a thrown
@@ -49,270 +49,268 @@ const ALLOWED_KEYS = [
 const stagedPaths: string[] = [];
 
 function stageFile(absPath: string, source: string): void {
-    mkdirSync(dirname(absPath), { recursive: true });
-    writeFileSync(absPath, source, "utf8");
-    stagedPaths.push(absPath);
+  mkdirSync(dirname(absPath), { recursive: true });
+  writeFileSync(absPath, source, "utf8");
+  stagedPaths.push(absPath);
 }
 
 afterEach(() => {
-    while (stagedPaths.length > 0) {
-        const p = stagedPaths.pop();
-        if (p) rmSync(p, { force: true });
-    }
+  while (stagedPaths.length > 0) {
+    const p = stagedPaths.pop();
+    if (p) rmSync(p, { force: true });
+  }
 });
 
 interface LintOutcome {
-    exitCode: number;
-    combined: string;
+  exitCode: number;
+  combined: string;
 }
 
 function runOxlint(target: string): LintOutcome {
-    try {
-        const stdout = execSync(
-            `npx oxlint -c ${CONFIG_PATH} ${target} --quiet`,
-            { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], cwd: REPO_ROOT },
-        ).toString();
-        return { exitCode: 0, combined: stdout };
-    } catch (e) {
-        const err = e as {
-            status?: number;
-            stderr?: Buffer | string;
-            stdout?: Buffer | string;
-        };
-        const stderr = err.stderr?.toString() ?? "";
-        const stdout = err.stdout?.toString() ?? "";
-        return { exitCode: err.status ?? 1, combined: stderr + stdout };
-    }
+  try {
+    const stdout = execSync(`npx oxlint -c ${CONFIG_PATH} ${target} --quiet`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      cwd: REPO_ROOT,
+    }).toString();
+    return { exitCode: 0, combined: stdout };
+  } catch (e) {
+    const err = e as {
+      status?: number;
+      stderr?: Buffer | string;
+      stdout?: Buffer | string;
+    };
+    const stderr = err.stderr?.toString() ?? "";
+    const stdout = err.stdout?.toString() ?? "";
+    return { exitCode: err.status ?? 1, combined: stderr + stdout };
+  }
 }
 
 function shellFixturePath(name: string): string {
-    return join(
+  return join(
+    REPO_ROOT,
+    "showcase",
+    "shell-dashboard",
+    "src",
+    "lib",
+    `${name}.lintfixture.tsx`,
+  );
+}
+
+describe("oxlint copilotkit/no-public-env-shell-read NEXT_PUBLIC_* guard", () => {
+  describe("banned-key coverage (all variants flagged)", () => {
+    for (const key of BANNED_KEYS) {
+      it(`flags process.env.${key} (dotted member)`, () => {
+        const target = shellFixturePath(`bad-dotted-${key}`);
+        stageFile(target, `export const x = process.env.${key};\n`);
+        const r = runOxlint(target);
+        expect(r.exitCode).not.toBe(0);
+        expect(r.combined).toMatch(/no-public-env-shell-read/);
+        expect(r.combined).toMatch(/getRuntimeConfig/);
+      });
+
+      it(`flags process.env["${key}"] (bracket-string member)`, () => {
+        const target = shellFixturePath(`bad-bracket-${key}`);
+        stageFile(target, `export const x = process.env["${key}"];\n`);
+        const r = runOxlint(target);
+        expect(r.exitCode).not.toBe(0);
+        expect(r.combined).toMatch(/no-public-env-shell-read/);
+      });
+    }
+  });
+
+  describe("allowed-key non-firing (build-stamps + computed local-dev value)", () => {
+    for (const key of ALLOWED_KEYS) {
+      it(`does NOT flag process.env.${key}`, () => {
+        const target = shellFixturePath(`ok-${key}`);
+        stageFile(target, `export const x = process.env.${key};\n`);
+        const r = runOxlint(target);
+        expect(r.exitCode).toBe(0);
+      });
+    }
+  });
+
+  describe("variant coverage (destructuring / optional chaining / template-key)", () => {
+    it("flags const { NEXT_PUBLIC_SHELL_URL } = process.env (destructuring)", () => {
+      const target = shellFixturePath("bad-destructure");
+      stageFile(
+        target,
+        `const { NEXT_PUBLIC_SHELL_URL } = process.env;\nexport const x = NEXT_PUBLIC_SHELL_URL;\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.combined).toMatch(/no-public-env-shell-read/);
+    });
+
+    it("flags const { NEXT_PUBLIC_SHELL_URL: aliased } = process.env (destructuring with alias)", () => {
+      const target = shellFixturePath("bad-destructure-aliased");
+      stageFile(
+        target,
+        `const { NEXT_PUBLIC_SHELL_URL: aliased } = process.env;\nexport const x = aliased;\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.combined).toMatch(/no-public-env-shell-read/);
+    });
+
+    it("flags process.env?.NEXT_PUBLIC_SHELL_URL (optional chaining)", () => {
+      const target = shellFixturePath("bad-optchain");
+      stageFile(
+        target,
+        `export const x = process.env?.NEXT_PUBLIC_SHELL_URL;\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.combined).toMatch(/no-public-env-shell-read/);
+    });
+
+    it("flags process.env[`NEXT_PUBLIC_SHELL_URL`] (no-expression template literal key)", () => {
+      const target = shellFixturePath("bad-tplkey");
+      stageFile(
+        target,
+        "export const x = process.env[`NEXT_PUBLIC_SHELL_URL`];\n",
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.combined).toMatch(/no-public-env-shell-read/);
+    });
+
+    it('flags const { ["NEXT_PUBLIC_SHELL_URL"]: x } = process.env (destructuring with computed string key)', () => {
+      // Parity with the bracket-member form: the destructuring branch
+      // must apply the same staticKeyName() recognition as the member
+      // branch, otherwise a computed string key sneaks through.
+      const target = shellFixturePath("bad-destructure-computed-string");
+      stageFile(
+        target,
+        `const { ["NEXT_PUBLIC_SHELL_URL"]: x } = process.env;\nexport const y = x;\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.combined).toMatch(/no-public-env-shell-read/);
+    });
+
+    it("flags const { [`NEXT_PUBLIC_SHELL_URL`]: x } = process.env (destructuring with no-expression template key)", () => {
+      const target = shellFixturePath("bad-destructure-computed-template");
+      stageFile(
+        target,
+        "const { [`NEXT_PUBLIC_SHELL_URL`]: x } = process.env;\nexport const y = x;\n",
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.combined).toMatch(/no-public-env-shell-read/);
+    });
+
+    it("does NOT flag process.env.NEXT_PUBLIC_SHELL_URL = ... (assignment LHS)", () => {
+      // Writes (test/runtime overrides) are intentionally not flagged.
+      const target = shellFixturePath("ok-assign");
+      stageFile(
+        target,
+        `process.env.NEXT_PUBLIC_SHELL_URL = "x";\nexport {};\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).toBe(0);
+    });
+
+    it("does NOT flag delete process.env.NEXT_PUBLIC_SHELL_URL", () => {
+      const target = shellFixturePath("ok-delete");
+      stageFile(
+        target,
+        `delete process.env.NEXT_PUBLIC_SHELL_URL;\nexport {};\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).toBe(0);
+    });
+  });
+
+  describe("override scoping (shell-only enforcement; runtime-config + non-shell exempt)", () => {
+    it("does NOT flag inside a runtime-config implementation file (off-override)", () => {
+      // The off-override matches `showcase/**/lib/runtime-config*.{ts,tsx}`
+      // (and the `.client` variant). Confirm the rule is silenced there.
+      const target = join(
         REPO_ROOT,
         "showcase",
         "shell-dashboard",
         "src",
         "lib",
-        `${name}.lintfixture.tsx`,
-    );
-}
-
-describe("oxlint copilotkit/no-public-env-shell-read NEXT_PUBLIC_* guard", () => {
-    describe("banned-key coverage (all variants flagged)", () => {
-        for (const key of BANNED_KEYS) {
-            it(`flags process.env.${key} (dotted member)`, () => {
-                const target = shellFixturePath(`bad-dotted-${key}`);
-                stageFile(target, `export const x = process.env.${key};\n`);
-                const r = runOxlint(target);
-                expect(r.exitCode).not.toBe(0);
-                expect(r.combined).toMatch(/no-public-env-shell-read/);
-                expect(r.combined).toMatch(/getRuntimeConfig/);
-            });
-
-            it(`flags process.env["${key}"] (bracket-string member)`, () => {
-                const target = shellFixturePath(`bad-bracket-${key}`);
-                stageFile(
-                    target,
-                    `export const x = process.env["${key}"];\n`,
-                );
-                const r = runOxlint(target);
-                expect(r.exitCode).not.toBe(0);
-                expect(r.combined).toMatch(/no-public-env-shell-read/);
-            });
-        }
+        "runtime-config.lintfixture.tsx",
+      );
+      stageFile(
+        target,
+        `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).toBe(0);
     });
 
-    describe("allowed-key non-firing (build-stamps + computed local-dev value)", () => {
-        for (const key of ALLOWED_KEYS) {
-            it(`does NOT flag process.env.${key}`, () => {
-                const target = shellFixturePath(`ok-${key}`);
-                stageFile(target, `export const x = process.env.${key};\n`);
-                const r = runOxlint(target);
-                expect(r.exitCode).toBe(0);
-            });
-        }
+    it("does NOT flag inside packages/ (outside the shell trees)", () => {
+      const target = join(
+        REPO_ROOT,
+        "packages",
+        "react-ui",
+        "src",
+        "__noflag.lintfixture.tsx",
+      );
+      stageFile(
+        target,
+        `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).toBe(0);
     });
 
-    describe("variant coverage (destructuring / optional chaining / template-key)", () => {
-        it("flags const { NEXT_PUBLIC_SHELL_URL } = process.env (destructuring)", () => {
-            const target = shellFixturePath("bad-destructure");
-            stageFile(
-                target,
-                `const { NEXT_PUBLIC_SHELL_URL } = process.env;\nexport const x = NEXT_PUBLIC_SHELL_URL;\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).not.toBe(0);
-            expect(r.combined).toMatch(/no-public-env-shell-read/);
-        });
-
-        it("flags const { NEXT_PUBLIC_SHELL_URL: aliased } = process.env (destructuring with alias)", () => {
-            const target = shellFixturePath("bad-destructure-aliased");
-            stageFile(
-                target,
-                `const { NEXT_PUBLIC_SHELL_URL: aliased } = process.env;\nexport const x = aliased;\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).not.toBe(0);
-            expect(r.combined).toMatch(/no-public-env-shell-read/);
-        });
-
-        it("flags process.env?.NEXT_PUBLIC_SHELL_URL (optional chaining)", () => {
-            const target = shellFixturePath("bad-optchain");
-            stageFile(
-                target,
-                `export const x = process.env?.NEXT_PUBLIC_SHELL_URL;\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).not.toBe(0);
-            expect(r.combined).toMatch(/no-public-env-shell-read/);
-        });
-
-        it("flags process.env[`NEXT_PUBLIC_SHELL_URL`] (no-expression template literal key)", () => {
-            const target = shellFixturePath("bad-tplkey");
-            stageFile(
-                target,
-                "export const x = process.env[`NEXT_PUBLIC_SHELL_URL`];\n",
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).not.toBe(0);
-            expect(r.combined).toMatch(/no-public-env-shell-read/);
-        });
-
-        it('flags const { ["NEXT_PUBLIC_SHELL_URL"]: x } = process.env (destructuring with computed string key)', () => {
-            // Parity with the bracket-member form: the destructuring branch
-            // must apply the same staticKeyName() recognition as the member
-            // branch, otherwise a computed string key sneaks through.
-            const target = shellFixturePath("bad-destructure-computed-string");
-            stageFile(
-                target,
-                `const { ["NEXT_PUBLIC_SHELL_URL"]: x } = process.env;\nexport const y = x;\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).not.toBe(0);
-            expect(r.combined).toMatch(/no-public-env-shell-read/);
-        });
-
-        it("flags const { [`NEXT_PUBLIC_SHELL_URL`]: x } = process.env (destructuring with no-expression template key)", () => {
-            const target = shellFixturePath("bad-destructure-computed-template");
-            stageFile(
-                target,
-                "const { [`NEXT_PUBLIC_SHELL_URL`]: x } = process.env;\nexport const y = x;\n",
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).not.toBe(0);
-            expect(r.combined).toMatch(/no-public-env-shell-read/);
-        });
-
-        it("does NOT flag process.env.NEXT_PUBLIC_SHELL_URL = ... (assignment LHS)", () => {
-            // Writes (test/runtime overrides) are intentionally not flagged.
-            const target = shellFixturePath("ok-assign");
-            stageFile(
-                target,
-                `process.env.NEXT_PUBLIC_SHELL_URL = "x";\nexport {};\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).toBe(0);
-        });
-
-        it("does NOT flag delete process.env.NEXT_PUBLIC_SHELL_URL", () => {
-            const target = shellFixturePath("ok-delete");
-            stageFile(
-                target,
-                `delete process.env.NEXT_PUBLIC_SHELL_URL;\nexport {};\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).toBe(0);
-        });
+    it("DOES flag inside shell-docs/src (shell-tree, not runtime-config)", () => {
+      const target = join(
+        REPO_ROOT,
+        "showcase",
+        "shell-docs",
+        "src",
+        "__bad.lintfixture.tsx",
+      );
+      stageFile(
+        target,
+        `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.combined).toMatch(/no-public-env-shell-read/);
     });
 
-    describe("override scoping (shell-only enforcement; runtime-config + non-shell exempt)", () => {
-        it("does NOT flag inside a runtime-config implementation file (off-override)", () => {
-            // The off-override matches `showcase/**/lib/runtime-config*.{ts,tsx}`
-            // (and the `.client` variant). Confirm the rule is silenced there.
-            const target = join(
-                REPO_ROOT,
-                "showcase",
-                "shell-dashboard",
-                "src",
-                "lib",
-                "runtime-config.lintfixture.tsx",
-            );
-            stageFile(
-                target,
-                `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).toBe(0);
-        });
-
-        it("does NOT flag inside packages/ (outside the shell trees)", () => {
-            const target = join(
-                REPO_ROOT,
-                "packages",
-                "react-ui",
-                "src",
-                "__noflag.lintfixture.tsx",
-            );
-            stageFile(
-                target,
-                `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).toBe(0);
-        });
-
-        it("DOES flag inside shell-docs/src (shell-tree, not runtime-config)", () => {
-            const target = join(
-                REPO_ROOT,
-                "showcase",
-                "shell-docs",
-                "src",
-                "__bad.lintfixture.tsx",
-            );
-            stageFile(
-                target,
-                `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).not.toBe(0);
-            expect(r.combined).toMatch(/no-public-env-shell-read/);
-        });
-
-        it("DOES flag inside shell/src (shell-tree)", () => {
-            // The override list in .oxlintrc.json includes showcase/shell/src/**;
-            // exercise that branch explicitly so a future override-list edit that
-            // accidentally drops `shell` is caught.
-            const target = join(
-                REPO_ROOT,
-                "showcase",
-                "shell",
-                "src",
-                "__bad.lintfixture.tsx",
-            );
-            stageFile(
-                target,
-                `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).not.toBe(0);
-            expect(r.combined).toMatch(/no-public-env-shell-read/);
-        });
-
-        it("DOES flag inside shell-dojo/src (shell-tree)", () => {
-            // Same as above for the dojo shell tree.
-            const target = join(
-                REPO_ROOT,
-                "showcase",
-                "shell-dojo",
-                "src",
-                "__bad.lintfixture.tsx",
-            );
-            stageFile(
-                target,
-                `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
-            );
-            const r = runOxlint(target);
-            expect(r.exitCode).not.toBe(0);
-            expect(r.combined).toMatch(/no-public-env-shell-read/);
-        });
+    it("DOES flag inside shell/src (shell-tree)", () => {
+      // The override list in .oxlintrc.json includes showcase/shell/src/**;
+      // exercise that branch explicitly so a future override-list edit that
+      // accidentally drops `shell` is caught.
+      const target = join(
+        REPO_ROOT,
+        "showcase",
+        "shell",
+        "src",
+        "__bad.lintfixture.tsx",
+      );
+      stageFile(
+        target,
+        `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.combined).toMatch(/no-public-env-shell-read/);
     });
+
+    it("DOES flag inside shell-dojo/src (shell-tree)", () => {
+      // Same as above for the dojo shell tree.
+      const target = join(
+        REPO_ROOT,
+        "showcase",
+        "shell-dojo",
+        "src",
+        "__bad.lintfixture.tsx",
+      );
+      stageFile(
+        target,
+        `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
+      );
+      const r = runOxlint(target);
+      expect(r.exitCode).not.toBe(0);
+      expect(r.combined).toMatch(/no-public-env-shell-read/);
+    });
+  });
 });

--- a/showcase/scripts/__tests__/lint-rule-no-public-env.test.ts
+++ b/showcase/scripts/__tests__/lint-rule-no-public-env.test.ts
@@ -1,77 +1,245 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { execSync } from "node:child_process";
-import { writeFileSync, rmSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 
 // Repo root is two directories above this test file
 // (showcase/scripts/__tests__/X -> showcase/scripts -> showcase -> <repo>).
 const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
 const CONFIG_PATH = join(REPO_ROOT, ".oxlintrc.json");
 
+// Mirror of BANNED_KEYS in no-public-env-shell-read.mjs. We assert every
+// banned key is flagged so adding a new key to the rule without adding it
+// here trips the test — the assertion is "the rule is exhaustively
+// table-driven" rather than "any single key is flagged".
+const BANNED_KEYS = [
+    "NEXT_PUBLIC_POCKETBASE_URL",
+    "NEXT_PUBLIC_SHELL_URL",
+    "NEXT_PUBLIC_BASE_URL",
+    "NEXT_PUBLIC_OPS_BASE_URL",
+    "NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL",
+    "NEXT_PUBLIC_POSTHOG_KEY",
+    "NEXT_PUBLIC_POSTHOG_HOST",
+    "NEXT_PUBLIC_SCARF_PIXEL_ID",
+    "NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID",
+    "NEXT_PUBLIC_REB2B_KEY",
+    "NEXT_PUBLIC_REO_KEY",
+] as const;
+
+const ALLOWED_KEYS = [
+    "NEXT_PUBLIC_COMMIT_SHA",
+    "NEXT_PUBLIC_BRANCH",
+    "NEXT_PUBLIC_LOCAL_BACKENDS",
+] as const;
+
+// Track every fixture we stage so afterEach reaps them — even on a thrown
+// assertion mid-test. Without a centralized tracker, a thrown expect()
+// inside a try/finally branch can still leave a file behind if the cleanup
+// path itself diverges across tests.
+const stagedPaths: string[] = [];
+
+function stageFile(absPath: string, source: string): void {
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, source, "utf8");
+    stagedPaths.push(absPath);
+}
+
+afterEach(() => {
+    while (stagedPaths.length > 0) {
+        const p = stagedPaths.pop();
+        if (p) rmSync(p, { force: true });
+    }
+});
+
+interface LintOutcome {
+    exitCode: number;
+    combined: string;
+}
+
+function runOxlint(target: string): LintOutcome {
+    try {
+        const stdout = execSync(
+            `npx oxlint -c ${CONFIG_PATH} ${target} --quiet`,
+            { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], cwd: REPO_ROOT },
+        ).toString();
+        return { exitCode: 0, combined: stdout };
+    } catch (e) {
+        const err = e as {
+            status?: number;
+            stderr?: Buffer | string;
+            stdout?: Buffer | string;
+        };
+        const stderr = err.stderr?.toString() ?? "";
+        const stdout = err.stdout?.toString() ?? "";
+        return { exitCode: err.status ?? 1, combined: stderr + stdout };
+    }
+}
+
+function shellFixturePath(name: string): string {
+    return join(
+        REPO_ROOT,
+        "showcase",
+        "shell-dashboard",
+        "src",
+        "lib",
+        `${name}.lintfixture.tsx`,
+    );
+}
+
 describe("oxlint copilotkit/no-public-env-shell-read NEXT_PUBLIC_* guard", () => {
-    it("fires on direct process.env.NEXT_PUBLIC_POCKETBASE_URL read in shell code", () => {
-        // Stage a forbidden file inside the actual repo path so the
-        // override `files` pattern matches. We use a `.lintfixture.tsx`
-        // suffix that the off-override (which excludes `*.test.{ts,tsx}` /
-        // `*.spec.{ts,tsx}` / `*runtime-config*`) does NOT match.
-        const target = join(
-            REPO_ROOT,
-            "showcase",
-            "shell-dashboard",
-            "src",
-            "lib",
-            "__bad.lintfixture.tsx",
-        );
-        writeFileSync(
-            target,
-            `export const x = process.env.NEXT_PUBLIC_POCKETBASE_URL;\n`,
-            "utf8",
-        );
-        try {
-            // Use an explicit -c to pin the config: in git worktrees nested
-            // under .claude/worktrees/, oxlint's automatic upward config
-            // search may resolve to a different .oxlintrc.json than the
-            // worktree's own. Pinning it makes the test deterministic.
-            const result = execSync(
-                `npx oxlint -c ${CONFIG_PATH} ${target} --quiet`,
-                { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], cwd: REPO_ROOT },
-            ).toString();
-            // Should not reach here — oxlint exits non-zero on errors.
-            expect(result).toBe("UNREACHABLE: oxlint should have failed");
-        } catch (e) {
-            const stderr = (e as { stderr?: Buffer | string }).stderr?.toString() ?? "";
-            const stdout = (e as { stdout?: Buffer | string }).stdout?.toString() ?? "";
-            const combined = stderr + stdout;
-            expect(combined).toMatch(/no-public-env-shell-read/);
-            expect(combined).toMatch(/getRuntimeConfig/);
-        } finally {
-            rmSync(target, { force: true });
+    describe("banned-key coverage (all variants flagged)", () => {
+        for (const key of BANNED_KEYS) {
+            it(`flags process.env.${key} (dotted member)`, () => {
+                const target = shellFixturePath(`bad-dotted-${key}`);
+                stageFile(target, `export const x = process.env.${key};\n`);
+                const r = runOxlint(target);
+                expect(r.exitCode).not.toBe(0);
+                expect(r.combined).toMatch(/no-public-env-shell-read/);
+                expect(r.combined).toMatch(/getRuntimeConfig/);
+            });
+
+            it(`flags process.env["${key}"] (bracket-string member)`, () => {
+                const target = shellFixturePath(`bad-bracket-${key}`);
+                stageFile(
+                    target,
+                    `export const x = process.env["${key}"];\n`,
+                );
+                const r = runOxlint(target);
+                expect(r.exitCode).not.toBe(0);
+                expect(r.combined).toMatch(/no-public-env-shell-read/);
+            });
         }
     });
 
-    it("does NOT fire on process.env.NEXT_PUBLIC_COMMIT_SHA (build-stamp, intentionally allowed)", () => {
-        const target = join(
-            REPO_ROOT,
-            "showcase",
-            "shell-dashboard",
-            "src",
-            "lib",
-            "__ok.lintfixture.tsx",
-        );
-        writeFileSync(
-            target,
-            `export const sha = process.env.NEXT_PUBLIC_COMMIT_SHA;\n`,
-            "utf8",
-        );
-        try {
-            // Should succeed (exit 0).
-            execSync(`npx oxlint -c ${CONFIG_PATH} ${target} --quiet`, {
-                encoding: "utf8",
-                stdio: ["ignore", "pipe", "pipe"],
-                cwd: REPO_ROOT,
+    describe("allowed-key non-firing (build-stamps + computed local-dev value)", () => {
+        for (const key of ALLOWED_KEYS) {
+            it(`does NOT flag process.env.${key}`, () => {
+                const target = shellFixturePath(`ok-${key}`);
+                stageFile(target, `export const x = process.env.${key};\n`);
+                const r = runOxlint(target);
+                expect(r.exitCode).toBe(0);
             });
-        } finally {
-            rmSync(target, { force: true });
         }
+    });
+
+    describe("variant coverage (destructuring / optional chaining / template-key)", () => {
+        it("flags const { NEXT_PUBLIC_SHELL_URL } = process.env (destructuring)", () => {
+            const target = shellFixturePath("bad-destructure");
+            stageFile(
+                target,
+                `const { NEXT_PUBLIC_SHELL_URL } = process.env;\nexport const x = NEXT_PUBLIC_SHELL_URL;\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).not.toBe(0);
+            expect(r.combined).toMatch(/no-public-env-shell-read/);
+        });
+
+        it("flags const { NEXT_PUBLIC_SHELL_URL: aliased } = process.env (destructuring with alias)", () => {
+            const target = shellFixturePath("bad-destructure-aliased");
+            stageFile(
+                target,
+                `const { NEXT_PUBLIC_SHELL_URL: aliased } = process.env;\nexport const x = aliased;\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).not.toBe(0);
+            expect(r.combined).toMatch(/no-public-env-shell-read/);
+        });
+
+        it("flags process.env?.NEXT_PUBLIC_SHELL_URL (optional chaining)", () => {
+            const target = shellFixturePath("bad-optchain");
+            stageFile(
+                target,
+                `export const x = process.env?.NEXT_PUBLIC_SHELL_URL;\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).not.toBe(0);
+            expect(r.combined).toMatch(/no-public-env-shell-read/);
+        });
+
+        it("flags process.env[`NEXT_PUBLIC_SHELL_URL`] (no-expression template literal key)", () => {
+            const target = shellFixturePath("bad-tplkey");
+            stageFile(
+                target,
+                "export const x = process.env[`NEXT_PUBLIC_SHELL_URL`];\n",
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).not.toBe(0);
+            expect(r.combined).toMatch(/no-public-env-shell-read/);
+        });
+
+        it("does NOT flag process.env.NEXT_PUBLIC_SHELL_URL = ... (assignment LHS)", () => {
+            // Writes (test/runtime overrides) are intentionally not flagged.
+            const target = shellFixturePath("ok-assign");
+            stageFile(
+                target,
+                `process.env.NEXT_PUBLIC_SHELL_URL = "x";\nexport {};\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).toBe(0);
+        });
+
+        it("does NOT flag delete process.env.NEXT_PUBLIC_SHELL_URL", () => {
+            const target = shellFixturePath("ok-delete");
+            stageFile(
+                target,
+                `delete process.env.NEXT_PUBLIC_SHELL_URL;\nexport {};\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).toBe(0);
+        });
+    });
+
+    describe("override scoping (shell-only enforcement; runtime-config + non-shell exempt)", () => {
+        it("does NOT flag inside a runtime-config implementation file (off-override)", () => {
+            // The off-override matches `showcase/**/lib/runtime-config*.{ts,tsx}`
+            // (and the `.client` variant). Confirm the rule is silenced there.
+            const target = join(
+                REPO_ROOT,
+                "showcase",
+                "shell-dashboard",
+                "src",
+                "lib",
+                "runtime-config.lintfixture.tsx",
+            );
+            stageFile(
+                target,
+                `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).toBe(0);
+        });
+
+        it("does NOT flag inside packages/ (outside the shell trees)", () => {
+            const target = join(
+                REPO_ROOT,
+                "packages",
+                "react-ui",
+                "src",
+                "__noflag.lintfixture.tsx",
+            );
+            stageFile(
+                target,
+                `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).toBe(0);
+        });
+
+        it("DOES flag inside shell-docs/src (shell-tree, not runtime-config)", () => {
+            const target = join(
+                REPO_ROOT,
+                "showcase",
+                "shell-docs",
+                "src",
+                "__bad.lintfixture.tsx",
+            );
+            stageFile(
+                target,
+                `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).not.toBe(0);
+            expect(r.combined).toMatch(/no-public-env-shell-read/);
+        });
     });
 });

--- a/showcase/scripts/__tests__/lint-rule-no-public-env.test.ts
+++ b/showcase/scripts/__tests__/lint-rule-no-public-env.test.ts
@@ -2,29 +2,39 @@ import { afterEach, describe, expect, it } from "vitest";
 import { execSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 // Repo root is two directories above this test file
 // (showcase/scripts/__tests__/X -> showcase/scripts -> showcase -> <repo>).
 const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
 const CONFIG_PATH = join(REPO_ROOT, ".oxlintrc.json");
+const RULE_MODULE_PATH = join(
+    REPO_ROOT,
+    "packages",
+    "react-ui",
+    "oxlint-rules",
+    "no-public-env-shell-read.mjs",
+);
 
-// Mirror of BANNED_KEYS in no-public-env-shell-read.mjs. We assert every
-// banned key is flagged so adding a new key to the rule without adding it
-// here trips the test — the assertion is "the rule is exhaustively
-// table-driven" rather than "any single key is flagged".
-const BANNED_KEYS = [
-    "NEXT_PUBLIC_POCKETBASE_URL",
-    "NEXT_PUBLIC_SHELL_URL",
-    "NEXT_PUBLIC_BASE_URL",
-    "NEXT_PUBLIC_OPS_BASE_URL",
-    "NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL",
-    "NEXT_PUBLIC_POSTHOG_KEY",
-    "NEXT_PUBLIC_POSTHOG_HOST",
-    "NEXT_PUBLIC_SCARF_PIXEL_ID",
-    "NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID",
-    "NEXT_PUBLIC_REB2B_KEY",
-    "NEXT_PUBLIC_REO_KEY",
-] as const;
+// Import BANNED_KEYS from the rule module itself (rather than hand-mirroring
+// the list) so the table-driven coverage cannot drift from the rule's true
+// banned set. If someone adds a new banned key to the rule and forgets the
+// test, the test set still expands automatically; if someone removes a key
+// from the rule, the test set contracts. The assertion is "the rule is
+// exhaustively table-driven against its own banned set."
+const ruleModule = (await import(
+    pathToFileURL(RULE_MODULE_PATH).href
+)) as { BANNED_KEYS: Set<string> };
+if (
+    !ruleModule.BANNED_KEYS ||
+    !(ruleModule.BANNED_KEYS instanceof Set) ||
+    ruleModule.BANNED_KEYS.size === 0
+) {
+    throw new Error(
+        `Rule module did not export a non-empty BANNED_KEYS Set: ${RULE_MODULE_PATH}`,
+    );
+}
+const BANNED_KEYS = [...ruleModule.BANNED_KEYS] as readonly string[];
 
 const ALLOWED_KEYS = [
     "NEXT_PUBLIC_COMMIT_SHA",
@@ -167,6 +177,31 @@ describe("oxlint copilotkit/no-public-env-shell-read NEXT_PUBLIC_* guard", () =>
             expect(r.combined).toMatch(/no-public-env-shell-read/);
         });
 
+        it('flags const { ["NEXT_PUBLIC_SHELL_URL"]: x } = process.env (destructuring with computed string key)', () => {
+            // Parity with the bracket-member form: the destructuring branch
+            // must apply the same staticKeyName() recognition as the member
+            // branch, otherwise a computed string key sneaks through.
+            const target = shellFixturePath("bad-destructure-computed-string");
+            stageFile(
+                target,
+                `const { ["NEXT_PUBLIC_SHELL_URL"]: x } = process.env;\nexport const y = x;\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).not.toBe(0);
+            expect(r.combined).toMatch(/no-public-env-shell-read/);
+        });
+
+        it("flags const { [`NEXT_PUBLIC_SHELL_URL`]: x } = process.env (destructuring with no-expression template key)", () => {
+            const target = shellFixturePath("bad-destructure-computed-template");
+            stageFile(
+                target,
+                "const { [`NEXT_PUBLIC_SHELL_URL`]: x } = process.env;\nexport const y = x;\n",
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).not.toBe(0);
+            expect(r.combined).toMatch(/no-public-env-shell-read/);
+        });
+
         it("does NOT flag process.env.NEXT_PUBLIC_SHELL_URL = ... (assignment LHS)", () => {
             // Writes (test/runtime overrides) are intentionally not flagged.
             const target = shellFixturePath("ok-assign");
@@ -230,6 +265,44 @@ describe("oxlint copilotkit/no-public-env-shell-read NEXT_PUBLIC_* guard", () =>
                 REPO_ROOT,
                 "showcase",
                 "shell-docs",
+                "src",
+                "__bad.lintfixture.tsx",
+            );
+            stageFile(
+                target,
+                `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).not.toBe(0);
+            expect(r.combined).toMatch(/no-public-env-shell-read/);
+        });
+
+        it("DOES flag inside shell/src (shell-tree)", () => {
+            // The override list in .oxlintrc.json includes showcase/shell/src/**;
+            // exercise that branch explicitly so a future override-list edit that
+            // accidentally drops `shell` is caught.
+            const target = join(
+                REPO_ROOT,
+                "showcase",
+                "shell",
+                "src",
+                "__bad.lintfixture.tsx",
+            );
+            stageFile(
+                target,
+                `export const x = process.env.NEXT_PUBLIC_SHELL_URL;\n`,
+            );
+            const r = runOxlint(target);
+            expect(r.exitCode).not.toBe(0);
+            expect(r.combined).toMatch(/no-public-env-shell-read/);
+        });
+
+        it("DOES flag inside shell-dojo/src (shell-tree)", () => {
+            // Same as above for the dojo shell tree.
+            const target = join(
+                REPO_ROOT,
+                "showcase",
+                "shell-dojo",
                 "src",
                 "__bad.lintfixture.tsx",
             );

--- a/showcase/scripts/__tests__/redeploy-env.summary.test.ts
+++ b/showcase/scripts/__tests__/redeploy-env.summary.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runRedeploy } from "../redeploy-env";
+import { SERVICES } from "../railway-envs";
+
+// A.4: per-service JSON summary contract.
+//
+// Shape (cross-workstream contract, consumed by showcase_deploy.yml's
+// `enforce-redeploy-gate` job in A.7):
+//   Array<{ service: string; status: "ok" | "error"; error?: string }>
+//
+// When REDEPLOY_SUMMARY_JSON env var is set, runRedeploy MUST write the
+// records array to that path atomically (stage to .tmp, rename). When
+// unset, no JSON is written.
+//
+// PR #5093's exit-code contract MUST be preserved verbatim:
+//   - staging: exitCode === 0 even when all per-service redeploys fail
+//   - prod:    exitCode === 1 on any per-service failure
+// The JSON write happens BEFORE the exit-code computation; it never
+// changes exit semantics on disk hiccups (write failures are warn-only).
+describe("redeploy-env per-service JSON summary", () => {
+  let dir: string;
+  let summaryPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "redeploy-summary-"));
+    summaryPath = join(dir, "summary.json");
+    process.env.REDEPLOY_SUMMARY_JSON = summaryPath;
+  });
+
+  afterEach(() => {
+    delete process.env.REDEPLOY_SUMMARY_JSON;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes one JSON record per attempted service with status", async () => {
+    const ag2ServiceId = SERVICES["showcase-ag2"].serviceId;
+    const summary = await runRedeploy({
+      env: "staging",
+      services: ["showcase-mastra", "showcase-ag2"],
+      appendSummary: () => {},
+      redeploy: async (serviceId) => {
+        if (serviceId === ag2ServiceId) {
+          return { ok: false, error: "boom" };
+        }
+        return { ok: true };
+      },
+    });
+    expect(summary.exitCode).toBe(0); // staging contract intact
+    const records = JSON.parse(readFileSync(summaryPath, "utf8")) as Array<{
+      service: string;
+      status: "ok" | "error";
+      error?: string;
+    }>;
+    expect(records).toEqual(
+      expect.arrayContaining([
+        { service: "showcase-ag2", status: "error", error: "boom" },
+        { service: "showcase-mastra", status: "ok" },
+      ]),
+    );
+    expect(records).toHaveLength(2);
+  });
+
+  it("does NOT write JSON when REDEPLOY_SUMMARY_JSON is unset", async () => {
+    delete process.env.REDEPLOY_SUMMARY_JSON;
+    await runRedeploy({
+      env: "staging",
+      services: ["showcase-mastra"],
+      appendSummary: () => {},
+      redeploy: async () => ({ ok: true }),
+    });
+    // The temp dir we created is empty — assert nothing was written.
+    // (No path was given; the function had nowhere to write.)
+    expect(readdirSync(dir)).toEqual([]);
+  });
+
+  it("preserves PR #5093 contract: staging exits 0 even when all fail", async () => {
+    const summary = await runRedeploy({
+      env: "staging",
+      services: ["showcase-mastra", "showcase-ag2"],
+      appendSummary: () => {},
+      redeploy: async () => ({ ok: false, error: "boom" }),
+    });
+    expect(summary.exitCode).toBe(0);
+    expect(summary.failed).toBe(2);
+    const records = JSON.parse(readFileSync(summaryPath, "utf8")) as Array<{
+      service: string;
+      status: "ok" | "error";
+      error?: string;
+    }>;
+    expect(records.every((r) => r.status === "error")).toBe(true);
+    expect(records).toHaveLength(2);
+  });
+
+  it("preserves PR #5093 contract: prod exits 1 on any per-service failure", async () => {
+    const summary = await runRedeploy({
+      env: "prod",
+      services: ["showcase-mastra"],
+      appendSummary: () => {},
+      redeploy: async () => ({ ok: false, error: "boom" }),
+    });
+    expect(summary.exitCode).toBe(1);
+    const records = JSON.parse(readFileSync(summaryPath, "utf8")) as Array<{
+      service: string;
+      status: "ok" | "error";
+      error?: string;
+    }>;
+    expect(records).toEqual([
+      { service: "showcase-mastra", status: "error", error: "boom" },
+    ]);
+  });
+
+  it("records caught throws as status:error with the thrown message", async () => {
+    const summary = await runRedeploy({
+      env: "staging",
+      services: ["showcase-mastra"],
+      appendSummary: () => {},
+      redeploy: async () => {
+        throw new Error("kaboom");
+      },
+    });
+    expect(summary.exitCode).toBe(0);
+    expect(summary.failed).toBe(1);
+    const records = JSON.parse(readFileSync(summaryPath, "utf8")) as Array<{
+      service: string;
+      status: "ok" | "error";
+      error?: string;
+    }>;
+    expect(records).toEqual([
+      { service: "showcase-mastra", status: "error", error: "kaboom" },
+    ]);
+  });
+});

--- a/showcase/scripts/__tests__/redeploy-env.token.test.ts
+++ b/showcase/scripts/__tests__/redeploy-env.token.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveRailwayTokenFromConfig } from "../lib/railway-token";
+
+// Characterization test: pins the resolver contract that redeploy-env's
+// getToken path will use after E-2d. The resolver itself was proven
+// red-green in E-2a/E-2b; this test exists so a future change to the
+// resolver that breaks the redeploy-env consumer surfaces here too.
+// EXPECTED OUTCOME: PASS on first run (resolver already exists). This is
+// intentional — see the step header. Do NOT relabel this as a RED step.
+describe("redeploy-env token resolution contract", () => {
+  it("returns accessToken from a typical post-login config", () => {
+    const warn = vi.fn();
+    expect(
+      resolveRailwayTokenFromConfig(
+        { user: { accessToken: "abc-access-aaaaaaaaaaaaa" } },
+        { warn },
+      ),
+    ).toBe("abc-access-aaaaaaaaaaaaa");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when only user.token (legacy) is present", () => {
+    const warn = vi.fn();
+    expect(
+      resolveRailwayTokenFromConfig(
+        { user: { token: "legacy-xxxxxxxxxx" } },
+        { warn },
+      ),
+    ).toBe("legacy-xxxxxxxxxx");
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});

--- a/showcase/scripts/__tests__/resolve-verify-matrix.cli.test.ts
+++ b/showcase/scripts/__tests__/resolve-verify-matrix.cli.test.ts
@@ -23,7 +23,7 @@
  *   3. workflow_dispatch + no summary → full probe-eligible set, has_services=true.
  *   4. workflow_dispatch + service=<unknown> → non-zero exit, stderr ::error::Unknown service.
  */
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -55,35 +55,22 @@ function runCli(env: Record<string, string>): SpawnResult {
     GITHUB_OUTPUT: outputPath,
     ...env,
   };
-  try {
-    execFileSync("npx", ["tsx", SCRIPT], {
-      cwd: REPO_ROOT,
-      env: fullEnv,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    return {
-      status: 0,
-      stderr: "",
-      output: readFileSync(outputPath, "utf-8"),
-    };
-  } catch (e) {
-    // execFileSync throws on non-zero exit; the thrown error carries
-    // `.status` and `.stderr` (Buffer when stdio captures).
-    const err = e as {
-      status?: number;
-      stderr?: Buffer | string;
-    };
-    return {
-      status: typeof err.status === "number" ? err.status : 1,
-      stderr:
-        typeof err.stderr === "string"
-          ? err.stderr
-          : err.stderr
-            ? err.stderr.toString("utf-8")
-            : "",
-      output: readFileSync(outputPath, "utf-8"),
-    };
-  }
+  // spawnSync (rather than execFileSync) so we capture stderr on BOTH
+  // zero and non-zero exit. execFileSync exposes stderr only on throw,
+  // which means the ::warning:: drift path (exit 0 + stderr text) is
+  // invisible to the test harness. spawnSync returns a single object
+  // regardless of status, so we inspect `status` and `stderr` directly.
+  const res = spawnSync("npx", ["tsx", SCRIPT], {
+    cwd: REPO_ROOT,
+    env: fullEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+  return {
+    status: typeof res.status === "number" ? res.status : 1,
+    stderr: typeof res.stderr === "string" ? res.stderr : "",
+    output: readFileSync(outputPath, "utf-8"),
+  };
 }
 
 // Pull two real probe-eligible names off the actual SSOT so the test
@@ -122,22 +109,135 @@ describe("resolve-verify-matrix CLI (end-to-end against real SSOT)", () => {
   it(
     "workflow_run + summary_present + two real ok_services → sorted CSV + has_services=true",
     () => {
-      const probe = realProbeEligibleNames();
-      // Pick TWO probe-eligible names. Use a CSV order that is NOT
-      // already sorted so the sort-on-intersection assertion is real.
-      // probe[0] sorts before probe[1] (alphabetical); feed reversed.
-      const picked = [probe[0], probe[1]];
-      const reversedCsv = `${picked[1]},${picked[0]}`;
-      const sortedCsv = picked.join(",");
+      // Hard-code two real, stable probe-eligible SSOT names rather than
+      // picking probe[0]/probe[1] off the live list. The earlier
+      // probe-index version was tautological: it pulled sorted names from
+      // the SSOT, reversed them, fed them back, and asserted the resolver
+      // re-sorted to the same order — which would silently pass even on a
+      // resolver that did nothing (because probe[0] < probe[1] is the
+      // ALREADY-sorted SSOT order). Also: if the SSOT ever shrank to <2
+      // probe-eligible entries, the test would silently assert
+      // `services_csv=undefined,undefined`.
+      //
+      // `aimock` and `harness` are foundational infra services (not
+      // integration slots), so they will not churn out of the SSOT. We
+      // assert they're both still probe-eligible at runtime; if either
+      // ever leaves, this test fails LOUD with a specific message rather
+      // than silently degrading.
+      const probe = new Set(realProbeEligibleNames());
+      expect(probe.has("aimock")).toBe(true);
+      expect(probe.has("harness")).toBe(true);
+      // Feed unsorted so the sort-on-intersection assertion is real:
+      // "harness,aimock" must come out as "aimock,harness".
       const r = runCli({
         EVENT_NAME: "workflow_run",
         SUMMARY_PRESENT: "true",
-        OK_FROM_REDEPLOY: reversedCsv,
+        OK_FROM_REDEPLOY: "harness,aimock",
         DISPATCH_SERVICE: "",
       });
       expect(r.status).toBe(0);
-      expect(r.output).toBe(
-        `services_csv=${sortedCsv}\nhas_services=true\n`,
+      expect(r.output).toBe("services_csv=aimock,harness\nhas_services=true\n");
+    },
+    30_000,
+  );
+
+  // -----------------------------------------------------------------------
+  // FIX 3 — surface SSOT/build drift via ::warning::ok_services tokens
+  // dropped (no SSOT match). The intersection logic already silently drops
+  // unmatched tokens from the verify matrix; the WARNING is the entire
+  // drift-detection contract operators rely on to notice that a redeploy
+  // reported success for a service the SSOT has forgotten about (or vice
+  // versa). Without coverage here it could silently regress to "no warning
+  // emitted" and the gate would keep working while losing its early-warning
+  // signal.
+  // -----------------------------------------------------------------------
+  it(
+    "workflow_run + ok_services with bogus token → ::warning:: lists dropped tokens, real ones still verify",
+    () => {
+      const r = runCli({
+        EVENT_NAME: "workflow_run",
+        SUMMARY_PRESENT: "true",
+        // `svc-bogus` is not in the SSOT under any spelling; `aimock` is
+        // a real probe-eligible service. The verify CSV must drop the
+        // bogus token AND the wrapper must `::warning::` so the dropped
+        // token surfaces in the workflow log as an annotation.
+        OK_FROM_REDEPLOY: "svc-bogus,aimock",
+        DISPATCH_SERVICE: "",
+      });
+      expect(r.status).toBe(0);
+      expect(r.output).toContain("services_csv=aimock\n");
+      expect(r.output).toContain("has_services=true\n");
+      expect(r.stderr).toMatch(
+        /::warning::ok_services tokens dropped \(no SSOT match\): svc-bogus/,
+      );
+    },
+    30_000,
+  );
+
+  // -----------------------------------------------------------------------
+  // FIX 5 — EVENT_NAME must be exactly 'workflow_run' or 'workflow_dispatch'.
+  // The CLI used to do an unchecked `as` cast on EVENT_NAME, so a typo or
+  // accidental new trigger ('push', 'schedule') would compile-pass at the
+  // type layer and only fail deep inside the resolver. Make the boundary
+  // total: a narrowing helper rejects unknown EVENT_NAME values up front,
+  // matching the resolver's own runtime guard with a SINGLE consistent
+  // story (type system + runtime agree).
+  // -----------------------------------------------------------------------
+  it(
+    "EVENT_NAME=push → non-zero exit with ::error::resolve-verify-matrix: unexpected EVENT_NAME",
+    () => {
+      const r = runCli({
+        EVENT_NAME: "push",
+        SUMMARY_PRESENT: "",
+        OK_FROM_REDEPLOY: "",
+        DISPATCH_SERVICE: "",
+      });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(
+        /::error::resolve-verify-matrix: unexpected EVENT_NAME 'push'/,
+      );
+    },
+    30_000,
+  );
+
+  // -----------------------------------------------------------------------
+  // FIX 7 — workflow_run requires SUMMARY_PRESENT to be exactly "true" or
+  // "false". The check-redeploy-summary step always sets one of those two
+  // values, so any other input (including "" from a step-id wiring break,
+  // or "True" from a case-typo) means the wiring is broken and the gate
+  // would silently fall through to the intersection branch. Fail loud
+  // rather than silently emitting has_services=false on a real redeploy.
+  // workflow_dispatch ignores SUMMARY_PRESENT and must NOT trigger this.
+  // -----------------------------------------------------------------------
+  it(
+    "EVENT_NAME=workflow_run + SUMMARY_PRESENT='' → non-zero exit with workflow_run requires summary_present",
+    () => {
+      const r = runCli({
+        EVENT_NAME: "workflow_run",
+        SUMMARY_PRESENT: "",
+        OK_FROM_REDEPLOY: "",
+        DISPATCH_SERVICE: "",
+      });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(
+        /::error::resolve-verify-matrix: workflow_run requires summary_present in \{true,false\}, got ''/,
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "EVENT_NAME=workflow_run + SUMMARY_PRESENT='True' (case typo) → non-zero exit",
+    () => {
+      const r = runCli({
+        EVENT_NAME: "workflow_run",
+        SUMMARY_PRESENT: "True",
+        OK_FROM_REDEPLOY: "",
+        DISPATCH_SERVICE: "",
+      });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(
+        /::error::resolve-verify-matrix: workflow_run requires summary_present in \{true,false\}, got 'True'/,
       );
     },
     30_000,

--- a/showcase/scripts/__tests__/resolve-verify-matrix.cli.test.ts
+++ b/showcase/scripts/__tests__/resolve-verify-matrix.cli.test.ts
@@ -38,7 +38,10 @@ const __dirname = dirname(__filename);
 // repo root). Tests therefore must spawn from repo root.
 const REPO_ROOT = resolve(__dirname, "..", "..", "..");
 const SCRIPT = "showcase/scripts/resolve-verify-matrix.ts";
-const SSOT_PATH = join(REPO_ROOT, "showcase/scripts/railway-envs.generated.json");
+const SSOT_PATH = join(
+  REPO_ROOT,
+  "showcase/scripts/railway-envs.generated.json",
+);
 
 interface SpawnResult {
   status: number;
@@ -88,58 +91,50 @@ function realProbeEligibleNames(): string[] {
 
 describe("resolve-verify-matrix CLI (end-to-end against real SSOT)", () => {
   // The CLI spawns `npx tsx`. Cold-start can take >1s; bump timeout.
-  it(
-    "workflow_run + summary_present + empty ok_services → has_services=false (Issue A end-to-end)",
-    () => {
-      const r = runCli({
-        EVENT_NAME: "workflow_run",
-        SUMMARY_PRESENT: "true",
-        OK_FROM_REDEPLOY: "",
-        DISPATCH_SERVICE: "",
-      });
-      expect(r.status).toBe(0);
-      // Byte-for-byte: the workflow YAML compares against the literal
-      // strings 'true' / 'false'. Match the EXACT bytes (including the
-      // trailing newlines and key=value form).
-      expect(r.output).toBe("services_csv=\nhas_services=false\n");
-    },
-    30_000,
-  );
+  it("workflow_run + summary_present + empty ok_services → has_services=false (Issue A end-to-end)", () => {
+    const r = runCli({
+      EVENT_NAME: "workflow_run",
+      SUMMARY_PRESENT: "true",
+      OK_FROM_REDEPLOY: "",
+      DISPATCH_SERVICE: "",
+    });
+    expect(r.status).toBe(0);
+    // Byte-for-byte: the workflow YAML compares against the literal
+    // strings 'true' / 'false'. Match the EXACT bytes (including the
+    // trailing newlines and key=value form).
+    expect(r.output).toBe("services_csv=\nhas_services=false\n");
+  }, 30_000);
 
-  it(
-    "workflow_run + summary_present + two real ok_services → sorted CSV + has_services=true",
-    () => {
-      // Hard-code two real, stable probe-eligible SSOT names rather than
-      // picking probe[0]/probe[1] off the live list. The earlier
-      // probe-index version was tautological: it pulled sorted names from
-      // the SSOT, reversed them, fed them back, and asserted the resolver
-      // re-sorted to the same order — which would silently pass even on a
-      // resolver that did nothing (because probe[0] < probe[1] is the
-      // ALREADY-sorted SSOT order). Also: if the SSOT ever shrank to <2
-      // probe-eligible entries, the test would silently assert
-      // `services_csv=undefined,undefined`.
-      //
-      // `aimock` and `harness` are foundational infra services (not
-      // integration slots), so they will not churn out of the SSOT. We
-      // assert they're both still probe-eligible at runtime; if either
-      // ever leaves, this test fails LOUD with a specific message rather
-      // than silently degrading.
-      const probe = new Set(realProbeEligibleNames());
-      expect(probe.has("aimock")).toBe(true);
-      expect(probe.has("harness")).toBe(true);
-      // Feed unsorted so the sort-on-intersection assertion is real:
-      // "harness,aimock" must come out as "aimock,harness".
-      const r = runCli({
-        EVENT_NAME: "workflow_run",
-        SUMMARY_PRESENT: "true",
-        OK_FROM_REDEPLOY: "harness,aimock",
-        DISPATCH_SERVICE: "",
-      });
-      expect(r.status).toBe(0);
-      expect(r.output).toBe("services_csv=aimock,harness\nhas_services=true\n");
-    },
-    30_000,
-  );
+  it("workflow_run + summary_present + two real ok_services → sorted CSV + has_services=true", () => {
+    // Hard-code two real, stable probe-eligible SSOT names rather than
+    // picking probe[0]/probe[1] off the live list. The earlier
+    // probe-index version was tautological: it pulled sorted names from
+    // the SSOT, reversed them, fed them back, and asserted the resolver
+    // re-sorted to the same order — which would silently pass even on a
+    // resolver that did nothing (because probe[0] < probe[1] is the
+    // ALREADY-sorted SSOT order). Also: if the SSOT ever shrank to <2
+    // probe-eligible entries, the test would silently assert
+    // `services_csv=undefined,undefined`.
+    //
+    // `aimock` and `harness` are foundational infra services (not
+    // integration slots), so they will not churn out of the SSOT. We
+    // assert they're both still probe-eligible at runtime; if either
+    // ever leaves, this test fails LOUD with a specific message rather
+    // than silently degrading.
+    const probe = new Set(realProbeEligibleNames());
+    expect(probe.has("aimock")).toBe(true);
+    expect(probe.has("harness")).toBe(true);
+    // Feed unsorted so the sort-on-intersection assertion is real:
+    // "harness,aimock" must come out as "aimock,harness".
+    const r = runCli({
+      EVENT_NAME: "workflow_run",
+      SUMMARY_PRESENT: "true",
+      OK_FROM_REDEPLOY: "harness,aimock",
+      DISPATCH_SERVICE: "",
+    });
+    expect(r.status).toBe(0);
+    expect(r.output).toBe("services_csv=aimock,harness\nhas_services=true\n");
+  }, 30_000);
 
   // -----------------------------------------------------------------------
   // FIX 3 — surface SSOT/build drift via ::warning::ok_services tokens
@@ -151,28 +146,24 @@ describe("resolve-verify-matrix CLI (end-to-end against real SSOT)", () => {
   // emitted" and the gate would keep working while losing its early-warning
   // signal.
   // -----------------------------------------------------------------------
-  it(
-    "workflow_run + ok_services with bogus token → ::warning:: lists dropped tokens, real ones still verify",
-    () => {
-      const r = runCli({
-        EVENT_NAME: "workflow_run",
-        SUMMARY_PRESENT: "true",
-        // `svc-bogus` is not in the SSOT under any spelling; `aimock` is
-        // a real probe-eligible service. The verify CSV must drop the
-        // bogus token AND the wrapper must `::warning::` so the dropped
-        // token surfaces in the workflow log as an annotation.
-        OK_FROM_REDEPLOY: "svc-bogus,aimock",
-        DISPATCH_SERVICE: "",
-      });
-      expect(r.status).toBe(0);
-      expect(r.output).toContain("services_csv=aimock\n");
-      expect(r.output).toContain("has_services=true\n");
-      expect(r.stderr).toMatch(
-        /::warning::ok_services tokens dropped \(no SSOT match\): svc-bogus/,
-      );
-    },
-    30_000,
-  );
+  it("workflow_run + ok_services with bogus token → ::warning:: lists dropped tokens, real ones still verify", () => {
+    const r = runCli({
+      EVENT_NAME: "workflow_run",
+      SUMMARY_PRESENT: "true",
+      // `svc-bogus` is not in the SSOT under any spelling; `aimock` is
+      // a real probe-eligible service. The verify CSV must drop the
+      // bogus token AND the wrapper must `::warning::` so the dropped
+      // token surfaces in the workflow log as an annotation.
+      OK_FROM_REDEPLOY: "svc-bogus,aimock",
+      DISPATCH_SERVICE: "",
+    });
+    expect(r.status).toBe(0);
+    expect(r.output).toContain("services_csv=aimock\n");
+    expect(r.output).toContain("has_services=true\n");
+    expect(r.stderr).toMatch(
+      /::warning::ok_services tokens dropped \(no SSOT match\): svc-bogus/,
+    );
+  }, 30_000);
 
   // -----------------------------------------------------------------------
   // FIX 5 — EVENT_NAME must be exactly 'workflow_run' or 'workflow_dispatch'.
@@ -183,22 +174,18 @@ describe("resolve-verify-matrix CLI (end-to-end against real SSOT)", () => {
   // matching the resolver's own runtime guard with a SINGLE consistent
   // story (type system + runtime agree).
   // -----------------------------------------------------------------------
-  it(
-    "EVENT_NAME=push → non-zero exit with ::error::resolve-verify-matrix: unexpected EVENT_NAME",
-    () => {
-      const r = runCli({
-        EVENT_NAME: "push",
-        SUMMARY_PRESENT: "",
-        OK_FROM_REDEPLOY: "",
-        DISPATCH_SERVICE: "",
-      });
-      expect(r.status).not.toBe(0);
-      expect(r.stderr).toMatch(
-        /::error::resolve-verify-matrix: unexpected EVENT_NAME 'push'/,
-      );
-    },
-    30_000,
-  );
+  it("EVENT_NAME=push → non-zero exit with ::error::resolve-verify-matrix: unexpected EVENT_NAME", () => {
+    const r = runCli({
+      EVENT_NAME: "push",
+      SUMMARY_PRESENT: "",
+      OK_FROM_REDEPLOY: "",
+      DISPATCH_SERVICE: "",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(
+      /::error::resolve-verify-matrix: unexpected EVENT_NAME 'push'/,
+    );
+  }, 30_000);
 
   // -----------------------------------------------------------------------
   // FIX 7 — workflow_run requires SUMMARY_PRESENT to be exactly "true" or
@@ -209,72 +196,56 @@ describe("resolve-verify-matrix CLI (end-to-end against real SSOT)", () => {
   // rather than silently emitting has_services=false on a real redeploy.
   // workflow_dispatch ignores SUMMARY_PRESENT and must NOT trigger this.
   // -----------------------------------------------------------------------
-  it(
-    "EVENT_NAME=workflow_run + SUMMARY_PRESENT='' → non-zero exit with workflow_run requires summary_present",
-    () => {
-      const r = runCli({
-        EVENT_NAME: "workflow_run",
-        SUMMARY_PRESENT: "",
-        OK_FROM_REDEPLOY: "",
-        DISPATCH_SERVICE: "",
-      });
-      expect(r.status).not.toBe(0);
-      expect(r.stderr).toMatch(
-        /::error::resolve-verify-matrix: workflow_run requires summary_present in \{true,false\}, got ''/,
-      );
-    },
-    30_000,
-  );
+  it("EVENT_NAME=workflow_run + SUMMARY_PRESENT='' → non-zero exit with workflow_run requires summary_present", () => {
+    const r = runCli({
+      EVENT_NAME: "workflow_run",
+      SUMMARY_PRESENT: "",
+      OK_FROM_REDEPLOY: "",
+      DISPATCH_SERVICE: "",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(
+      /::error::resolve-verify-matrix: workflow_run requires summary_present in \{true,false\}, got ''/,
+    );
+  }, 30_000);
 
-  it(
-    "EVENT_NAME=workflow_run + SUMMARY_PRESENT='True' (case typo) → non-zero exit",
-    () => {
-      const r = runCli({
-        EVENT_NAME: "workflow_run",
-        SUMMARY_PRESENT: "True",
-        OK_FROM_REDEPLOY: "",
-        DISPATCH_SERVICE: "",
-      });
-      expect(r.status).not.toBe(0);
-      expect(r.stderr).toMatch(
-        /::error::resolve-verify-matrix: workflow_run requires summary_present in \{true,false\}, got 'True'/,
-      );
-    },
-    30_000,
-  );
+  it("EVENT_NAME=workflow_run + SUMMARY_PRESENT='True' (case typo) → non-zero exit", () => {
+    const r = runCli({
+      EVENT_NAME: "workflow_run",
+      SUMMARY_PRESENT: "True",
+      OK_FROM_REDEPLOY: "",
+      DISPATCH_SERVICE: "",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(
+      /::error::resolve-verify-matrix: workflow_run requires summary_present in \{true,false\}, got 'True'/,
+    );
+  }, 30_000);
 
-  it(
-    "workflow_dispatch + no summary → full probe-eligible set + has_services=true",
-    () => {
-      const probe = realProbeEligibleNames();
-      const r = runCli({
-        EVENT_NAME: "workflow_dispatch",
-        SUMMARY_PRESENT: "",
-        OK_FROM_REDEPLOY: "",
-        DISPATCH_SERVICE: "",
-      });
-      expect(r.status).toBe(0);
-      expect(r.output).toBe(
-        `services_csv=${probe.join(",")}\nhas_services=true\n`,
-      );
-    },
-    30_000,
-  );
+  it("workflow_dispatch + no summary → full probe-eligible set + has_services=true", () => {
+    const probe = realProbeEligibleNames();
+    const r = runCli({
+      EVENT_NAME: "workflow_dispatch",
+      SUMMARY_PRESENT: "",
+      OK_FROM_REDEPLOY: "",
+      DISPATCH_SERVICE: "",
+    });
+    expect(r.status).toBe(0);
+    expect(r.output).toBe(
+      `services_csv=${probe.join(",")}\nhas_services=true\n`,
+    );
+  }, 30_000);
 
-  it(
-    "workflow_dispatch + unknown service → non-zero exit with ::error::Unknown service",
-    () => {
-      const r = runCli({
-        EVENT_NAME: "workflow_dispatch",
-        SUMMARY_PRESENT: "",
-        OK_FROM_REDEPLOY: "",
-        DISPATCH_SERVICE: "totally-not-a-real-service",
-      });
-      expect(r.status).not.toBe(0);
-      expect(r.stderr).toMatch(
-        /::error::Unknown service 'totally-not-a-real-service'/,
-      );
-    },
-    30_000,
-  );
+  it("workflow_dispatch + unknown service → non-zero exit with ::error::Unknown service", () => {
+    const r = runCli({
+      EVENT_NAME: "workflow_dispatch",
+      SUMMARY_PRESENT: "",
+      OK_FROM_REDEPLOY: "",
+      DISPATCH_SERVICE: "totally-not-a-real-service",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(
+      /::error::Unknown service 'totally-not-a-real-service'/,
+    );
+  }, 30_000);
 });

--- a/showcase/scripts/__tests__/resolve-verify-matrix.cli.test.ts
+++ b/showcase/scripts/__tests__/resolve-verify-matrix.cli.test.ts
@@ -1,0 +1,180 @@
+/**
+ * resolve-verify-matrix.cli.test.ts — pins the byte-for-byte $GITHUB_OUTPUT
+ * contract that showcase_deploy.yml depends on.
+ *
+ * The deploy workflow's `verify:` job has
+ *   if: needs.resolve-matrix.outputs.has_services == 'true'
+ * which compares against the LITERAL strings 'true'/'false' (everything in
+ * $GITHUB_OUTPUT is a string). A regression that writes `has_services=1`
+ * or `has_services=True` would silently skip verify on every redeploy.
+ * Pin that contract here so the byte-for-byte format is part of the test
+ * surface, not just the pure-function unit tests.
+ *
+ * The pure resolver is covered by resolve-verify-matrix.test.ts. THIS
+ * file spawns the CLI as a child process against the real
+ * railway-envs.generated.json so the loader + parseSsotServices +
+ * writeGithubOutput contract gets end-to-end coverage.
+ *
+ * Cases (mirrors decision-table boundaries the workflow YAML depends on):
+ *   1. workflow_run + SUMMARY_PRESENT=true + OK_FROM_REDEPLOY=""
+ *        → services_csv=\nhas_services=false\n      [Issue A pinned end-to-end]
+ *   2. workflow_run + SUMMARY_PRESENT=true + OK_FROM_REDEPLOY="<two real names>"
+ *        → services_csv=<sorted CSV>\nhas_services=true\n
+ *   3. workflow_dispatch + no summary → full probe-eligible set, has_services=true.
+ *   4. workflow_dispatch + service=<unknown> → non-zero exit, stderr ::error::Unknown service.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// The repo root is the cwd the workflow YAML uses for the script (paths
+// inside the script are written as `showcase/scripts/...`, relative to
+// repo root). Tests therefore must spawn from repo root.
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const SCRIPT = "showcase/scripts/resolve-verify-matrix.ts";
+const SSOT_PATH = join(REPO_ROOT, "showcase/scripts/railway-envs.generated.json");
+
+interface SpawnResult {
+  status: number;
+  stderr: string;
+  output: string;
+}
+
+function runCli(env: Record<string, string>): SpawnResult {
+  const dir = mkdtempSync(join(tmpdir(), "rvm-cli-"));
+  const outputPath = join(dir, "gh_output");
+  writeFileSync(outputPath, "");
+  const fullEnv = {
+    ...process.env,
+    GITHUB_OUTPUT: outputPath,
+    ...env,
+  };
+  try {
+    execFileSync("npx", ["tsx", SCRIPT], {
+      cwd: REPO_ROOT,
+      env: fullEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return {
+      status: 0,
+      stderr: "",
+      output: readFileSync(outputPath, "utf-8"),
+    };
+  } catch (e) {
+    // execFileSync throws on non-zero exit; the thrown error carries
+    // `.status` and `.stderr` (Buffer when stdio captures).
+    const err = e as {
+      status?: number;
+      stderr?: Buffer | string;
+    };
+    return {
+      status: typeof err.status === "number" ? err.status : 1,
+      stderr:
+        typeof err.stderr === "string"
+          ? err.stderr
+          : err.stderr
+            ? err.stderr.toString("utf-8")
+            : "",
+      output: readFileSync(outputPath, "utf-8"),
+    };
+  }
+}
+
+// Pull two real probe-eligible names off the actual SSOT so the test
+// stays in lock-step with the emitter (rather than hard-coding fixtures
+// that could drift).
+function realProbeEligibleNames(): string[] {
+  const raw = JSON.parse(readFileSync(SSOT_PATH, "utf-8")) as {
+    services: { name: string; probe: { staging: boolean } }[];
+  };
+  return raw.services
+    .filter((s) => s.probe.staging === true)
+    .map((s) => s.name)
+    .sort();
+}
+
+describe("resolve-verify-matrix CLI (end-to-end against real SSOT)", () => {
+  // The CLI spawns `npx tsx`. Cold-start can take >1s; bump timeout.
+  it(
+    "workflow_run + summary_present + empty ok_services → has_services=false (Issue A end-to-end)",
+    () => {
+      const r = runCli({
+        EVENT_NAME: "workflow_run",
+        SUMMARY_PRESENT: "true",
+        OK_FROM_REDEPLOY: "",
+        DISPATCH_SERVICE: "",
+      });
+      expect(r.status).toBe(0);
+      // Byte-for-byte: the workflow YAML compares against the literal
+      // strings 'true' / 'false'. Match the EXACT bytes (including the
+      // trailing newlines and key=value form).
+      expect(r.output).toBe("services_csv=\nhas_services=false\n");
+    },
+    30_000,
+  );
+
+  it(
+    "workflow_run + summary_present + two real ok_services → sorted CSV + has_services=true",
+    () => {
+      const probe = realProbeEligibleNames();
+      // Pick TWO probe-eligible names. Use a CSV order that is NOT
+      // already sorted so the sort-on-intersection assertion is real.
+      // probe[0] sorts before probe[1] (alphabetical); feed reversed.
+      const picked = [probe[0], probe[1]];
+      const reversedCsv = `${picked[1]},${picked[0]}`;
+      const sortedCsv = picked.join(",");
+      const r = runCli({
+        EVENT_NAME: "workflow_run",
+        SUMMARY_PRESENT: "true",
+        OK_FROM_REDEPLOY: reversedCsv,
+        DISPATCH_SERVICE: "",
+      });
+      expect(r.status).toBe(0);
+      expect(r.output).toBe(
+        `services_csv=${sortedCsv}\nhas_services=true\n`,
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "workflow_dispatch + no summary → full probe-eligible set + has_services=true",
+    () => {
+      const probe = realProbeEligibleNames();
+      const r = runCli({
+        EVENT_NAME: "workflow_dispatch",
+        SUMMARY_PRESENT: "",
+        OK_FROM_REDEPLOY: "",
+        DISPATCH_SERVICE: "",
+      });
+      expect(r.status).toBe(0);
+      expect(r.output).toBe(
+        `services_csv=${probe.join(",")}\nhas_services=true\n`,
+      );
+    },
+    30_000,
+  );
+
+  it(
+    "workflow_dispatch + unknown service → non-zero exit with ::error::Unknown service",
+    () => {
+      const r = runCli({
+        EVENT_NAME: "workflow_dispatch",
+        SUMMARY_PRESENT: "",
+        OK_FROM_REDEPLOY: "",
+        DISPATCH_SERVICE: "totally-not-a-real-service",
+      });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(
+        /::error::Unknown service 'totally-not-a-real-service'/,
+      );
+    },
+    30_000,
+  );
+});

--- a/showcase/scripts/__tests__/resolve-verify-matrix.test.ts
+++ b/showcase/scripts/__tests__/resolve-verify-matrix.test.ts
@@ -1,0 +1,239 @@
+/**
+ * resolve-verify-matrix.test.ts — covers the pure resolver that decides
+ * which services the post-redeploy verify probe should target.
+ *
+ * The resolver replaces the inline bash+jq block in
+ * .github/workflows/showcase_deploy.yml's `resolve-matrix` job ("Build
+ * verify matrix from SSOT" step). The bash had produced two confirmed
+ * bugs across prior CR rounds, so the logic was extracted to a pure
+ * function with parity tests against the OLD behavior PLUS a new test
+ * for the Issue A fix:
+ *
+ *   workflow_run + summary_present=true + ok_services empty (all errored)
+ *   → has_services=false (skip verify). The previous bash fell through
+ *   to the full probe-eligible fleet, gratuitously probing all services
+ *   against stale `:latest` on a redeploy where everything errored. The
+ *   workflow still reds via `enforce-redeploy-gate` (independent of this
+ *   matrix), so skipping verify here is correct.
+ *
+ * Cases (mirrors the decision table in the resolver JSDoc):
+ *   1. workflow_dispatch + 'all' → full probe-eligible set, has_services=true.
+ *   2. workflow_dispatch + specific in-SSOT service → just that service.
+ *   3. workflow_dispatch + unknown service → throws (preserves bash).
+ *   4. workflow_run + summary_present=false → has_services=false.
+ *   5. workflow_run + summary_present=true + ok empty → has_services=false. [FIX]
+ *   6. workflow_run + summary_present=true + ok=[a,c] → intersection.
+ *   7. ok contains a non-probe-eligible service → excluded.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  resolveVerifyMatrix,
+  type SsotService,
+} from "../resolve-verify-matrix";
+
+// Fixture SSOT services: a mix of probe.staging=true and false, with
+// both `name` and `dispatchName` populated so the intersection logic
+// can be exercised against either spelling.
+const fixtureServices: SsotService[] = [
+  {
+    name: "svc-a",
+    dispatchName: "dispatch-a",
+    probe: { staging: true },
+  },
+  {
+    name: "svc-b",
+    dispatchName: "dispatch-b",
+    probe: { staging: true },
+  },
+  {
+    name: "svc-c",
+    dispatchName: "dispatch-c",
+    probe: { staging: true },
+  },
+  {
+    name: "svc-d",
+    dispatchName: "dispatch-d",
+    probe: { staging: true },
+  },
+  // probe.staging=false → never in the probe-eligible set.
+  {
+    name: "svc-noprobe-1",
+    dispatchName: "dispatch-noprobe-1",
+    probe: { staging: false },
+  },
+  {
+    name: "svc-noprobe-2",
+    dispatchName: null,
+    probe: { staging: false },
+  },
+];
+
+describe("resolveVerifyMatrix", () => {
+  it("workflow_dispatch + 'all' → full probe-eligible set, sorted, has_services=true", () => {
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_dispatch",
+      summaryPresent: "",
+      okFromRedeploy: "",
+      dispatchService: "all",
+      ssotServices: fixtureServices,
+    });
+    // The bash emits `jq -r '.services[] | select(.probe.staging == true) | .name' | sort -u`.
+    // Probe-eligible names: svc-a, svc-b, svc-c, svc-d. Sorted+dedup'd, CSV.
+    expect(out.servicesCsv).toBe("svc-a,svc-b,svc-c,svc-d");
+    expect(out.hasServices).toBe(true);
+  });
+
+  it("workflow_dispatch + empty dispatch input (defaults to 'all') → full probe-eligible set", () => {
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_dispatch",
+      summaryPresent: "",
+      okFromRedeploy: "",
+      dispatchService: "",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("svc-a,svc-b,svc-c,svc-d");
+    expect(out.hasServices).toBe(true);
+  });
+
+  it("workflow_dispatch + specific in-SSOT service (by name) → just that service", () => {
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_dispatch",
+      summaryPresent: "",
+      okFromRedeploy: "",
+      dispatchService: "svc-b",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("svc-b");
+    expect(out.hasServices).toBe(true);
+  });
+
+  it("workflow_dispatch + specific in-SSOT service (by dispatchName) → resolves to canonical name", () => {
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_dispatch",
+      summaryPresent: "",
+      okFromRedeploy: "",
+      dispatchService: "dispatch-c",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("svc-c");
+    expect(out.hasServices).toBe(true);
+  });
+
+  it("workflow_dispatch + unknown service → throws (preserves bash error/exit behavior)", () => {
+    // The bash printed `::error::Unknown service '$DISPATCH_SERVICE' (not
+    // an SSOT key or dispatch_name)` and `exit 1`. The resolver mirrors
+    // this by throwing; the CLI wrapper converts the throw into a non-zero
+    // process exit with the same `::error::` annotation.
+    expect(() =>
+      resolveVerifyMatrix({
+        eventName: "workflow_dispatch",
+        summaryPresent: "",
+        okFromRedeploy: "",
+        dispatchService: "totally-not-a-real-service",
+        ssotServices: fixtureServices,
+      }),
+    ).toThrow(/Unknown service 'totally-not-a-real-service'/);
+  });
+
+  it("workflow_run + summary_present=false → has_services=false (nothing was redeployed)", () => {
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_run",
+      summaryPresent: "false",
+      okFromRedeploy: "",
+      dispatchService: "",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("");
+    expect(out.hasServices).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------
+  // Issue A fix — write this FIRST and watch it RED against a naive
+  // implementation that falls through to the full probe-eligible fleet
+  // when OK_FROM_REDEPLOY is empty. The old bash collapsed (summary-
+  // present, all-errored) with (summary-absent / dispatch-fleet) and
+  // probed every service against stale :latest. The workflow already
+  // reds via `enforce-redeploy-gate` when redeploy_red=true, so this
+  // matrix should yield has_services=false in the all-errored case.
+  // ---------------------------------------------------------------------
+  it("workflow_run + summary_present=true + ok empty → has_services=false (Issue A fix)", () => {
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_run",
+      summaryPresent: "true",
+      okFromRedeploy: "",
+      dispatchService: "",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("");
+    expect(out.hasServices).toBe(false);
+  });
+
+  it("workflow_run + summary_present=true + ok=[svc-a,svc-c] → csv = sorted intersection with probe-eligible", () => {
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_run",
+      summaryPresent: "true",
+      okFromRedeploy: "svc-a,svc-c",
+      dispatchService: "",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("svc-a,svc-c");
+    expect(out.hasServices).toBe(true);
+  });
+
+  it("workflow_run + ok uses dispatchName aliases → resolved to canonical names in CSV", () => {
+    // The redeploy summary CSV may carry dispatch_names (the build matrix
+    // identifier) rather than SSOT keys. The bash mapped via
+    // `select(.name == $r or .dispatchName == $r) | .name` → canonical.
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_run",
+      summaryPresent: "true",
+      okFromRedeploy: "dispatch-a,dispatch-c",
+      dispatchService: "",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("svc-a,svc-c");
+    expect(out.hasServices).toBe(true);
+  });
+
+  it("workflow_run + ok contains a non-probe-eligible service → excluded from CSV", () => {
+    // svc-noprobe-1 has probe.staging=false; even if it redeployed OK
+    // it must not appear in the verify matrix because we have no probe
+    // driver for it.
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_run",
+      summaryPresent: "true",
+      okFromRedeploy: "svc-a,svc-noprobe-1,svc-d",
+      dispatchService: "",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("svc-a,svc-d");
+    expect(out.hasServices).toBe(true);
+  });
+
+  it("workflow_run + ok intersection collapses to empty → has_services=false", () => {
+    // Every OK service is non-probe-eligible. Old bash would have emitted
+    // services_csv='' and has_services=false here too (it set has_services
+    // off the CSV emptiness), so this is a parity case.
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_run",
+      summaryPresent: "true",
+      okFromRedeploy: "svc-noprobe-1,svc-noprobe-2",
+      dispatchService: "",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("");
+    expect(out.hasServices).toBe(false);
+  });
+
+  it("workflow_run + ok with duplicates → dedup'd in CSV", () => {
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_run",
+      summaryPresent: "true",
+      okFromRedeploy: "svc-a,svc-a,dispatch-a,svc-b",
+      dispatchService: "",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("svc-a,svc-b");
+    expect(out.hasServices).toBe(true);
+  });
+});

--- a/showcase/scripts/__tests__/resolve-verify-matrix.test.ts
+++ b/showcase/scripts/__tests__/resolve-verify-matrix.test.ts
@@ -27,6 +27,8 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  okCsvToCanonicalNames,
+  parseSsotServices,
   resolveVerifyMatrix,
   type SsotService,
 } from "../resolve-verify-matrix";
@@ -235,5 +237,169 @@ describe("resolveVerifyMatrix", () => {
     });
     expect(out.servicesCsv).toBe("svc-a,svc-b");
     expect(out.hasServices).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------
+  // FIX 3 — unknown eventName must throw rather than silently falling
+  // through to the workflow_run intersection branch. A typo or unexpected
+  // trigger today produces a SILENT skip (intersection of "" with probe-
+  // eligible = empty → has_services=false) which is indistinguishable from
+  // the legitimate "summary absent, nothing to verify" path.
+  // ---------------------------------------------------------------------
+  it("unknown eventName → throws with ::error:: annotation (fail-loud)", () => {
+    expect(() =>
+      resolveVerifyMatrix({
+        eventName: "schedule",
+        summaryPresent: "",
+        okFromRedeploy: "",
+        dispatchService: "",
+        ssotServices: fixtureServices,
+      }),
+    ).toThrow(/::error::resolve-verify-matrix: unexpected eventName 'schedule'/);
+  });
+});
+
+// -------------------------------------------------------------------------
+// FIX 4 — okCsvToCanonicalNames: trim tokens and report unmatched tokens.
+// The redeploy-gate bash emits `join(",")` which produces no spaces today,
+// but any future change to the bash (or a human-driven workflow_dispatch
+// caller that hand-types a CSV) that adds spaces silently dropped tokens
+// because `"a, b".split(",")` yields ["a", " b"] and " b" matches nothing.
+// We trim before matching, and surface unknown tokens so the CLI wrapper
+// can `::warning::` on SSOT/build drift (the function itself stays pure).
+// -------------------------------------------------------------------------
+describe("okCsvToCanonicalNames", () => {
+  it("trims whitespace around tokens — 'svc-a, svc-c' == 'svc-a,svc-c'", () => {
+    const a = okCsvToCanonicalNames("svc-a, svc-c", fixtureServices);
+    const b = okCsvToCanonicalNames("svc-a,svc-c", fixtureServices);
+    expect(Array.from(a.canonical).sort()).toEqual(["svc-a", "svc-c"]);
+    expect(Array.from(b.canonical).sort()).toEqual(["svc-a", "svc-c"]);
+    expect(a.dropped).toEqual([]);
+    expect(b.dropped).toEqual([]);
+  });
+
+  it("reports tokens that match no SSOT service in `dropped`", () => {
+    const out = okCsvToCanonicalNames(
+      "svc-a,not-a-real-service,svc-b",
+      fixtureServices,
+    );
+    expect(Array.from(out.canonical).sort()).toEqual(["svc-a", "svc-b"]);
+    expect(out.dropped).toEqual(["not-a-real-service"]);
+  });
+
+  it("ignores empty tokens (e.g. trailing comma) without reporting them as dropped", () => {
+    const out = okCsvToCanonicalNames("svc-a,,svc-b,", fixtureServices);
+    expect(Array.from(out.canonical).sort()).toEqual(["svc-a", "svc-b"]);
+    expect(out.dropped).toEqual([]);
+  });
+});
+
+// -------------------------------------------------------------------------
+// FIX 1 — parseSsotServices: validate the SSOT shape rather than blindly
+// casting JSON.parse() output. A truncated/drifted SSOT (emitter crashed
+// mid-write, or schema renamed) parses but silently shrinks/empties the
+// probe-eligible set → real redeploys go unverified, or verify is skipped
+// on a real redeploy. We refuse the ambiguity and throw with a
+// ::error::-prefixed message.
+// -------------------------------------------------------------------------
+describe("parseSsotServices", () => {
+  it("accepts a well-formed SSOT and returns the services array", () => {
+    const raw = {
+      services: [
+        { name: "svc-a", dispatchName: null, probe: { staging: true } },
+        { name: "svc-b", dispatchName: "dispatch-b", probe: { staging: false } },
+      ],
+    };
+    const out = parseSsotServices(raw, "test-path");
+    expect(out).toHaveLength(2);
+    expect(out[0].name).toBe("svc-a");
+    expect(out[1].probe.staging).toBe(false);
+  });
+
+  it("throws when `services` is not an array", () => {
+    expect(() =>
+      parseSsotServices({ services: { not: "an array" } }, "test-path"),
+    ).toThrow(/::error::SSOT test-path malformed: `services` is not an array/);
+  });
+
+  it("throws when `services` is an empty array (emitter crashed mid-write)", () => {
+    expect(() => parseSsotServices({ services: [] }, "test-path")).toThrow(
+      /::error::SSOT test-path malformed: `services` is empty/,
+    );
+  });
+
+  it("throws when a service entry has no `name`", () => {
+    expect(() =>
+      parseSsotServices(
+        {
+          services: [
+            { name: "svc-a", dispatchName: null, probe: { staging: true } },
+            { dispatchName: null, probe: { staging: true } },
+          ],
+        },
+        "test-path",
+      ),
+    ).toThrow(/::error::SSOT test-path malformed: services\[1\] missing `name`/);
+  });
+
+  it("throws when `probe` is missing", () => {
+    expect(() =>
+      parseSsotServices(
+        {
+          services: [{ name: "svc-a", dispatchName: null }],
+        },
+        "test-path",
+      ),
+    ).toThrow(/::error::SSOT test-path malformed: services\[0\] \(svc-a\) missing `probe`/);
+  });
+
+  it("accepts a missing `dispatchName` (live SSOT has services without one, e.g. pocketbase) and normalizes to null", () => {
+    const out = parseSsotServices(
+      {
+        services: [
+          { name: "svc-a", probe: { staging: true } },
+          { name: "svc-b", dispatchName: null, probe: { staging: true } },
+          { name: "svc-c", dispatchName: "dispatch-c", probe: { staging: true } },
+        ],
+      },
+      "test-path",
+    );
+    expect(out[0].dispatchName).toBeNull();
+    expect(out[1].dispatchName).toBeNull();
+    expect(out[2].dispatchName).toBe("dispatch-c");
+  });
+
+  it("throws when `dispatchName` is set to a non-string non-null value", () => {
+    expect(() =>
+      parseSsotServices(
+        {
+          services: [
+            { name: "svc-a", dispatchName: 42, probe: { staging: true } },
+          ],
+        },
+        "test-path",
+      ),
+    ).toThrow(
+      /::error::SSOT test-path malformed: services\[0\] \(svc-a\) `dispatchName` must be string, null, or absent/,
+    );
+  });
+
+  it("throws when `probe.staging` is not a boolean", () => {
+    expect(() =>
+      parseSsotServices(
+        {
+          services: [
+            {
+              name: "svc-a",
+              dispatchName: null,
+              probe: { staging: "true" },
+            },
+          ],
+        },
+        "test-path",
+      ),
+    ).toThrow(
+      /::error::SSOT test-path malformed: services\[0\] \(svc-a\) `probe.staging` is not boolean/,
+    );
   });
 });

--- a/showcase/scripts/__tests__/resolve-verify-matrix.test.ts
+++ b/showcase/scripts/__tests__/resolve-verify-matrix.test.ts
@@ -257,6 +257,58 @@ describe("resolveVerifyMatrix", () => {
       }),
     ).toThrow(/::error::resolve-verify-matrix: unexpected eventName 'schedule'/);
   });
+
+  // ---------------------------------------------------------------------
+  // FIX 7 — make the workflow_run boundary total. summaryPresent MUST be
+  // exactly "true" or "false" on workflow_run (check-redeploy-summary
+  // always sets one of the two). Any other value (including the empty
+  // string from a future step-id-rename wiring break, or "True" from a
+  // case-typo) used to fall through to the intersection branch and
+  // silently emit has_services=false — indistinguishable from a
+  // legitimate skip. Throw instead. workflow_dispatch ignores
+  // summaryPresent and must NOT throw.
+  // ---------------------------------------------------------------------
+  it("workflow_run + summaryPresent='' → throws (boundary is total)", () => {
+    expect(() =>
+      resolveVerifyMatrix({
+        eventName: "workflow_run",
+        summaryPresent: "",
+        okFromRedeploy: "",
+        dispatchService: "",
+        ssotServices: fixtureServices,
+      }),
+    ).toThrow(
+      /::error::resolve-verify-matrix: workflow_run requires summary_present in \{true,false\}, got ''/,
+    );
+  });
+
+  it("workflow_run + summaryPresent='True' (case typo) → throws", () => {
+    expect(() =>
+      resolveVerifyMatrix({
+        eventName: "workflow_run",
+        summaryPresent: "True",
+        okFromRedeploy: "",
+        dispatchService: "",
+        ssotServices: fixtureServices,
+      }),
+    ).toThrow(
+      /::error::resolve-verify-matrix: workflow_run requires summary_present in \{true,false\}, got 'True'/,
+    );
+  });
+
+  it("workflow_dispatch ignores summaryPresent (any value) — does NOT throw on empty", () => {
+    // workflow_dispatch path never reads summaryPresent; it must keep
+    // working even when the wrapper passes the default "".
+    const out = resolveVerifyMatrix({
+      eventName: "workflow_dispatch",
+      summaryPresent: "",
+      okFromRedeploy: "",
+      dispatchService: "all",
+      ssotServices: fixtureServices,
+    });
+    expect(out.servicesCsv).toBe("svc-a,svc-b,svc-c,svc-d");
+    expect(out.hasServices).toBe(true);
+  });
 });
 
 // -------------------------------------------------------------------------

--- a/showcase/scripts/__tests__/resolve-verify-matrix.test.ts
+++ b/showcase/scripts/__tests__/resolve-verify-matrix.test.ts
@@ -30,8 +30,8 @@ import {
   okCsvToCanonicalNames,
   parseSsotServices,
   resolveVerifyMatrix,
-  type SsotService,
 } from "../resolve-verify-matrix";
+import type { SsotService } from "../resolve-verify-matrix";
 
 // Fixture SSOT services: a mix of probe.staging=true and false, with
 // both `name` and `dispatchName` populated so the intersection logic
@@ -255,7 +255,9 @@ describe("resolveVerifyMatrix", () => {
         dispatchService: "",
         ssotServices: fixtureServices,
       }),
-    ).toThrow(/::error::resolve-verify-matrix: unexpected eventName 'schedule'/);
+    ).toThrow(
+      /::error::resolve-verify-matrix: unexpected eventName 'schedule'/,
+    );
   });
 
   // ---------------------------------------------------------------------
@@ -359,7 +361,11 @@ describe("parseSsotServices", () => {
     const raw = {
       services: [
         { name: "svc-a", dispatchName: null, probe: { staging: true } },
-        { name: "svc-b", dispatchName: "dispatch-b", probe: { staging: false } },
+        {
+          name: "svc-b",
+          dispatchName: "dispatch-b",
+          probe: { staging: false },
+        },
       ],
     };
     const out = parseSsotServices(raw, "test-path");
@@ -391,7 +397,9 @@ describe("parseSsotServices", () => {
         },
         "test-path",
       ),
-    ).toThrow(/::error::SSOT test-path malformed: services\[1\] missing `name`/);
+    ).toThrow(
+      /::error::SSOT test-path malformed: services\[1\] missing `name`/,
+    );
   });
 
   it("throws when `probe` is missing", () => {
@@ -402,7 +410,9 @@ describe("parseSsotServices", () => {
         },
         "test-path",
       ),
-    ).toThrow(/::error::SSOT test-path malformed: services\[0\] \(svc-a\) missing `probe`/);
+    ).toThrow(
+      /::error::SSOT test-path malformed: services\[0\] \(svc-a\) missing `probe`/,
+    );
   });
 
   it("accepts a missing `dispatchName` (live SSOT has services without one, e.g. pocketbase) and normalizes to null", () => {
@@ -411,7 +421,11 @@ describe("parseSsotServices", () => {
         services: [
           { name: "svc-a", probe: { staging: true } },
           { name: "svc-b", dispatchName: null, probe: { staging: true } },
-          { name: "svc-c", dispatchName: "dispatch-c", probe: { staging: true } },
+          {
+            name: "svc-c",
+            dispatchName: "dispatch-c",
+            probe: { staging: true },
+          },
         ],
       },
       "test-path",

--- a/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
@@ -14,9 +14,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { SERVICES } from "../railway-envs";
 import type { ProbeTarget } from "../verify-deploy";
+import fs from "fs";
+import os from "os";
+import path from "path";
 import {
     checkDeploymentSuccess,
     checkHealthcheck200,
+    defaultGetRailwayToken,
     envForTarget,
     probeBaseline,
     type FetchLike,
@@ -72,6 +76,78 @@ function gqlDeploymentResponse(status: string): ReturnType<FetchLike> {
         }),
     );
 }
+
+describe("defaultGetRailwayToken non-ENOENT errors are NOT swallowed", () => {
+    it("surfaces a clear diagnostic on non-ENOENT read errors (e.g. EISDIR via directory at config path)", () => {
+        // Point HOME at a tmpdir where ~/.railway/config.json is itself a
+        // directory — fs.readFileSync raises EISDIR. The previous bare
+        // `catch {}` swallowed it; the fix must NOT silently return
+        // undefined without a diagnostic on stderr identifying the path.
+        const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "verify-deploy-token-"));
+        const railwayDir = path.join(tmpHome, ".railway");
+        fs.mkdirSync(railwayDir, { recursive: true });
+        // Make config.json a directory (not a file).
+        fs.mkdirSync(path.join(railwayDir, "config.json"));
+
+        const origHome = process.env.HOME;
+        const origToken = process.env.RAILWAY_TOKEN;
+        delete process.env.RAILWAY_TOKEN;
+        process.env.HOME = tmpHome;
+
+        const stderr: string[] = [];
+        const realWrite = process.stderr.write.bind(process.stderr);
+        (process.stderr as unknown as { write: typeof process.stderr.write }).write =
+            ((chunk: string | Uint8Array): boolean => {
+                stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+                return true;
+            }) as typeof process.stderr.write;
+        try {
+            const out = defaultGetRailwayToken();
+            expect(out).toBeUndefined();
+            const joined = stderr.join("");
+            // The fix must log a diagnostic identifying the config path
+            // and the error — bare `catch {}` printed nothing.
+            expect(joined).toMatch(/config\.json/);
+            expect(joined).toMatch(/EISDIR|directory|read/i);
+        } finally {
+            (process.stderr as unknown as { write: typeof process.stderr.write }).write = realWrite;
+            if (origHome === undefined) delete process.env.HOME;
+            else process.env.HOME = origHome;
+            if (origToken === undefined) delete process.env.RAILWAY_TOKEN;
+            else process.env.RAILWAY_TOKEN = origToken;
+            try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* cleanup */ }
+        }
+    });
+
+    it("treats ENOENT (missing config file) as the legitimate no-token path (silent undefined)", () => {
+        const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "verify-deploy-token-"));
+        const origHome = process.env.HOME;
+        const origToken = process.env.RAILWAY_TOKEN;
+        delete process.env.RAILWAY_TOKEN;
+        process.env.HOME = tmpHome;
+
+        const stderr: string[] = [];
+        const realWrite = process.stderr.write.bind(process.stderr);
+        (process.stderr as unknown as { write: typeof process.stderr.write }).write =
+            ((chunk: string | Uint8Array): boolean => {
+                stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+                return true;
+            }) as typeof process.stderr.write;
+        try {
+            const out = defaultGetRailwayToken();
+            expect(out).toBeUndefined();
+            // ENOENT is the legitimate no-token path — no diagnostic spam.
+            expect(stderr.join("")).toBe("");
+        } finally {
+            (process.stderr as unknown as { write: typeof process.stderr.write }).write = realWrite;
+            if (origHome === undefined) delete process.env.HOME;
+            else process.env.HOME = origHome;
+            if (origToken === undefined) delete process.env.RAILWAY_TOKEN;
+            else process.env.RAILWAY_TOKEN = origToken;
+            try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* cleanup */ }
+        }
+    });
+});
 
 describe("envForTarget", () => {
     it("returns 'staging' when host matches the SSOT staging domain", () => {

--- a/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
@@ -1,0 +1,622 @@
+/**
+ * Red-green tests for the baseline `verify-deploy` driver impls.
+ *
+ * Drivers were originally stubs that returned `{ ok: false, error: "...
+ * not yet implemented ..." }`. These tests pin the agreed completion
+ * bar: every driver performs the two baseline checks (Railway
+ * deployment-SUCCESS via GraphQL + healthcheck HTTP 200) before any
+ * driver-specific extension runs.
+ *
+ * Network seams (`fetchImpl`, `getRailwayToken`) are injected so the
+ * suite runs fully offline. These are NOT LLM calls — plain vi-fn stubs
+ * are appropriate; aimock is not used here.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { SERVICES } from "../railway-envs";
+import type { ProbeTarget } from "../verify-deploy";
+import {
+    checkDeploymentSuccess,
+    checkHealthcheck200,
+    envForTarget,
+    probeBaseline,
+    type FetchLike,
+} from "../verify-deploy.drivers.baseline";
+import { probeShell } from "../verify-deploy.drivers.shell";
+import { probeDocs } from "../verify-deploy.drivers.docs";
+import { probeDashboard } from "../verify-deploy.drivers.dashboard";
+import { probeDojo } from "../verify-deploy.drivers.dojo";
+import { probeHarness } from "../verify-deploy.drivers.harness";
+import { probeEval } from "../verify-deploy.drivers.eval";
+import { probeAimock } from "../verify-deploy.drivers.aimock";
+import { probePocketbase } from "../verify-deploy.drivers.pocketbase";
+import { probeWebhooks } from "../verify-deploy.drivers.webhooks";
+import { probeAgent } from "../verify-deploy.drivers.agent";
+
+const TOKEN = "tok_test_abcdef";
+
+function mkResponse(body: {
+    status?: number;
+    json?: unknown;
+    text?: string;
+    ok?: boolean;
+}): Awaited<ReturnType<FetchLike>> {
+    const status = body.status ?? 200;
+    return {
+        ok: body.ok ?? (status >= 200 && status < 300),
+        status,
+        async text() {
+            return body.text ?? JSON.stringify(body.json ?? {});
+        },
+        async json() {
+            return body.json ?? {};
+        },
+    };
+}
+
+function makeFetch(
+    handler: (url: string, init?: Parameters<FetchLike>[1]) => ReturnType<FetchLike>,
+): FetchLike {
+    return vi.fn(handler);
+}
+
+function gqlDeploymentResponse(status: string): ReturnType<FetchLike> {
+    return Promise.resolve(
+        mkResponse({
+            json: {
+                data: {
+                    deployments: {
+                        edges: [{ node: { id: "d1", status } }],
+                    },
+                },
+            },
+        }),
+    );
+}
+
+describe("envForTarget", () => {
+    it("returns 'staging' when host matches the SSOT staging domain", () => {
+        const t: ProbeTarget = {
+            name: "docs",
+            host: SERVICES.docs.domains.staging,
+            driver: "docs",
+        };
+        expect(envForTarget(t)).toBe("staging");
+    });
+
+    it("returns 'prod' when host matches the SSOT prod domain", () => {
+        const t: ProbeTarget = {
+            name: "docs",
+            host: SERVICES.docs.domains.prod,
+            driver: "docs",
+        };
+        expect(envForTarget(t)).toBe("prod");
+    });
+
+    it("returns undefined for unknown host or unknown service", () => {
+        expect(
+            envForTarget({ name: "docs", host: "bogus.example", driver: "docs" }),
+        ).toBeUndefined();
+        expect(
+            envForTarget({ name: "nonsuch", host: "x", driver: "docs" }),
+        ).toBeUndefined();
+    });
+});
+
+describe("checkDeploymentSuccess", () => {
+    it("returns undefined when Railway reports SUCCESS", async () => {
+        const fetchImpl = makeFetch(() => gqlDeploymentResponse("SUCCESS"));
+        const err = await checkDeploymentSuccess(
+            "svc-id",
+            "staging",
+            TOKEN,
+            fetchImpl,
+            5000,
+            "shell",
+        );
+        expect(err).toBeUndefined();
+    });
+
+    it("returns an error string when status is not SUCCESS", async () => {
+        const fetchImpl = makeFetch(() => gqlDeploymentResponse("CRASHED"));
+        const err = await checkDeploymentSuccess(
+            "svc-id",
+            "prod",
+            TOKEN,
+            fetchImpl,
+            5000,
+            "shell",
+        );
+        expect(err).toMatch(/CRASHED/);
+        expect(err).toMatch(/prod/);
+    });
+
+    it("returns an error when GraphQL returns errors[]", async () => {
+        const fetchImpl = makeFetch(() =>
+            Promise.resolve(
+                mkResponse({ json: { errors: [{ message: "bad token" }] } }),
+            ),
+        );
+        const err = await checkDeploymentSuccess(
+            "svc-id",
+            "staging",
+            TOKEN,
+            fetchImpl,
+            5000,
+            "shell",
+        );
+        expect(err).toMatch(/bad token/);
+    });
+
+    it("returns an error on HTTP non-2xx", async () => {
+        const fetchImpl = makeFetch(() =>
+            Promise.resolve(mkResponse({ status: 401, text: "unauthorized" })),
+        );
+        const err = await checkDeploymentSuccess(
+            "svc-id",
+            "staging",
+            TOKEN,
+            fetchImpl,
+            5000,
+            "shell",
+        );
+        expect(err).toMatch(/401/);
+    });
+
+    it("returns an error when no deployment edge exists", async () => {
+        const fetchImpl = makeFetch(() =>
+            Promise.resolve(
+                mkResponse({ json: { data: { deployments: { edges: [] } } } }),
+            ),
+        );
+        const err = await checkDeploymentSuccess(
+            "svc-id",
+            "staging",
+            TOKEN,
+            fetchImpl,
+            5000,
+            "shell",
+        );
+        expect(err).toMatch(/no deployments/);
+    });
+
+    it("sends the Authorization bearer + serviceId/environmentId variables", async () => {
+        const calls: Array<{ url: string; body: unknown; auth?: string }> = [];
+        const fetchImpl = makeFetch((url, init) => {
+            calls.push({
+                url,
+                body: JSON.parse(String(init?.body ?? "{}")),
+                auth: init?.headers?.Authorization,
+            });
+            return gqlDeploymentResponse("SUCCESS");
+        });
+        await checkDeploymentSuccess(
+            "svc-123",
+            "staging",
+            TOKEN,
+            fetchImpl,
+            5000,
+            "shell",
+        );
+        expect(calls).toHaveLength(1);
+        expect(calls[0].url).toMatch(/backboard\.railway\.app\/graphql\/v2/);
+        expect(calls[0].auth).toBe(`Bearer ${TOKEN}`);
+        const body = calls[0].body as {
+            query: string;
+            variables: { serviceId: string; environmentId: string };
+        };
+        expect(body.query).toMatch(/deployments\(first: 1/);
+        expect(body.variables.serviceId).toBe("svc-123");
+        expect(body.variables.environmentId).toMatch(/^[0-9a-f-]{36}$/);
+    });
+});
+
+describe("checkHealthcheck200", () => {
+    it("returns undefined on HTTP 200", async () => {
+        const fetchImpl = makeFetch(() =>
+            Promise.resolve(mkResponse({ status: 200 })),
+        );
+        const err = await checkHealthcheck200(
+            "docs.example",
+            "/",
+            fetchImpl,
+            5000,
+            "docs",
+        );
+        expect(err).toBeUndefined();
+    });
+
+    it("returns an error string on non-200", async () => {
+        const fetchImpl = makeFetch(() =>
+            Promise.resolve(mkResponse({ status: 503 })),
+        );
+        const err = await checkHealthcheck200(
+            "docs.example",
+            "/",
+            fetchImpl,
+            5000,
+            "docs",
+        );
+        expect(err).toMatch(/503/);
+        expect(err).toMatch(/docs/);
+    });
+
+    it("composes https + host + path correctly", async () => {
+        const calls: string[] = [];
+        const fetchImpl = makeFetch((url) => {
+            calls.push(url);
+            return Promise.resolve(mkResponse({ status: 200 }));
+        });
+        await checkHealthcheck200(
+            "showcase-aimock-production.up.railway.app",
+            "/health",
+            fetchImpl,
+            5000,
+            "aimock",
+        );
+        expect(calls[0]).toBe(
+            "https://showcase-aimock-production.up.railway.app/health",
+        );
+    });
+
+    it("returns an error on fetch throw", async () => {
+        const fetchImpl = makeFetch(() =>
+            Promise.reject(new Error("ECONNREFUSED")),
+        );
+        const err = await checkHealthcheck200(
+            "docs.example",
+            "/",
+            fetchImpl,
+            5000,
+            "docs",
+        );
+        expect(err).toMatch(/ECONNREFUSED/);
+    });
+});
+
+describe("probeBaseline", () => {
+    function okFetch(): FetchLike {
+        return makeFetch((url) => {
+            if (url.includes("/graphql/v2"))
+                return gqlDeploymentResponse("SUCCESS");
+            return Promise.resolve(mkResponse({ status: 200 }));
+        });
+    }
+
+    it("returns ok when GraphQL = SUCCESS and healthcheck = 200", async () => {
+        const out = await probeBaseline(
+            {
+                name: "docs",
+                host: SERVICES.docs.domains.staging,
+                driver: "docs",
+            },
+            {
+                driverLabel: "docs",
+                healthcheckPath: "/",
+                fetchImpl: okFetch(),
+                getRailwayToken: () => TOKEN,
+            },
+        );
+        expect(out).toEqual({ ok: true });
+    });
+
+    it("fails loud when env cannot be resolved from host", async () => {
+        const out = await probeBaseline(
+            { name: "docs", host: "wrong.example", driver: "docs" },
+            {
+                driverLabel: "docs",
+                healthcheckPath: "/",
+                fetchImpl: okFetch(),
+                getRailwayToken: () => TOKEN,
+            },
+        );
+        expect(out.ok).toBe(false);
+        if (out.ok === false) {
+            expect(out.error).toMatch(/cannot resolve env/);
+        }
+    });
+
+    it("fails loud when no Railway token is available", async () => {
+        const out = await probeBaseline(
+            {
+                name: "docs",
+                host: SERVICES.docs.domains.staging,
+                driver: "docs",
+            },
+            {
+                driverLabel: "docs",
+                healthcheckPath: "/",
+                fetchImpl: okFetch(),
+                getRailwayToken: () => undefined,
+            },
+        );
+        expect(out.ok).toBe(false);
+        if (out.ok === false) {
+            expect(out.error).toMatch(/no Railway token/);
+        }
+    });
+
+    it("fails on deployment status != SUCCESS", async () => {
+        const fetchImpl = makeFetch((url) => {
+            if (url.includes("/graphql/v2"))
+                return gqlDeploymentResponse("CRASHED");
+            return Promise.resolve(mkResponse({ status: 200 }));
+        });
+        const out = await probeBaseline(
+            {
+                name: "docs",
+                host: SERVICES.docs.domains.staging,
+                driver: "docs",
+            },
+            {
+                driverLabel: "docs",
+                healthcheckPath: "/",
+                fetchImpl,
+                getRailwayToken: () => TOKEN,
+            },
+        );
+        expect(out.ok).toBe(false);
+        if (out.ok === false) expect(out.error).toMatch(/CRASHED/);
+    });
+
+    it("fails on healthcheck != 200", async () => {
+        const fetchImpl = makeFetch((url) => {
+            if (url.includes("/graphql/v2"))
+                return gqlDeploymentResponse("SUCCESS");
+            return Promise.resolve(mkResponse({ status: 502 }));
+        });
+        const out = await probeBaseline(
+            {
+                name: "docs",
+                host: SERVICES.docs.domains.staging,
+                driver: "docs",
+            },
+            {
+                driverLabel: "docs",
+                healthcheckPath: "/",
+                fetchImpl,
+                getRailwayToken: () => TOKEN,
+            },
+        );
+        expect(out.ok).toBe(false);
+        if (out.ok === false) expect(out.error).toMatch(/502/);
+    });
+});
+
+/**
+ * Per-driver tests. Each driver exports a probeX(target) that takes ONLY
+ * the target; the test seam is via `globalThis.fetch` + `RAILWAY_TOKEN`
+ * env var. We stub both for the duration of each test.
+ *
+ * What we pin per driver:
+ *   - It is no longer a "not yet implemented" stub.
+ *   - It calls Railway GraphQL with the SSOT serviceId for the matched
+ *     env, expecting `SUCCESS`.
+ *   - It hits the healthcheck URL appropriate to its service shape.
+ *   - It returns `{ok:true}` on a green baseline, `{ok:false}` on red.
+ */
+function withGlobalSeam(
+    fetchImpl: FetchLike,
+    token: string | undefined,
+    fn: () => Promise<void>,
+): Promise<void> {
+    const realFetch = globalThis.fetch;
+    const realToken = process.env.RAILWAY_TOKEN;
+    (globalThis as unknown as { fetch: FetchLike }).fetch = fetchImpl;
+    if (token === undefined) delete process.env.RAILWAY_TOKEN;
+    else process.env.RAILWAY_TOKEN = token;
+    return fn().finally(() => {
+        (globalThis as unknown as { fetch: typeof fetch }).fetch = realFetch;
+        if (realToken === undefined) delete process.env.RAILWAY_TOKEN;
+        else process.env.RAILWAY_TOKEN = realToken;
+    });
+}
+
+type DriverFn = (target: ProbeTarget) => Promise<
+    { ok: true } | { ok: false; error: string }
+>;
+
+interface DriverCase {
+    label: string;
+    driver: DriverFn;
+    service: keyof typeof SERVICES;
+    enumLiteral: string;
+    expectedHealthPath: string;
+}
+
+const DRIVER_CASES: DriverCase[] = [
+    {
+        label: "shell",
+        driver: probeShell,
+        service: "shell",
+        enumLiteral: "shell",
+        expectedHealthPath: "/",
+    },
+    {
+        label: "docs",
+        driver: probeDocs,
+        service: "docs",
+        enumLiteral: "docs",
+        expectedHealthPath: "/",
+    },
+    {
+        label: "dashboard",
+        driver: probeDashboard,
+        service: "dashboard",
+        enumLiteral: "dashboard",
+        expectedHealthPath: "/",
+    },
+    {
+        label: "dojo",
+        driver: probeDojo,
+        service: "dojo",
+        enumLiteral: "dojo",
+        expectedHealthPath: "/",
+    },
+    {
+        label: "harness",
+        driver: probeHarness,
+        service: "harness",
+        enumLiteral: "harness",
+        expectedHealthPath: "/health",
+    },
+    {
+        label: "aimock",
+        driver: probeAimock,
+        service: "aimock",
+        enumLiteral: "aimock",
+        expectedHealthPath: "/health",
+    },
+    {
+        label: "pocketbase",
+        driver: probePocketbase,
+        service: "pocketbase",
+        enumLiteral: "pocketbase",
+        expectedHealthPath: "/api/health",
+    },
+    {
+        label: "webhooks",
+        driver: probeWebhooks,
+        service: "webhooks",
+        enumLiteral: "webhooks",
+        expectedHealthPath: "/api/health",
+    },
+    {
+        // No service in the SSOT currently uses the `eval` driver literal,
+        // but the enum literal exists in railway-envs.ts and the dispatch
+        // switch wires probeEval. We still need probeEval to be a working
+        // impl. Test it by routing through any real SSOT service —
+        // probeEval's behavior is structurally identical to the agent
+        // driver; we use `harness` as the host carrier since it's the
+        // smallest standalone API surface in the SSOT.
+        label: "eval",
+        driver: probeEval,
+        service: "harness",
+        enumLiteral: "eval",
+        expectedHealthPath: "/api/health",
+    },
+    {
+        label: "agent",
+        driver: probeAgent,
+        service: "showcase-mastra",
+        enumLiteral: "agent",
+        expectedHealthPath: "/api/health",
+    },
+];
+
+describe.each(DRIVER_CASES)(
+    "$label driver",
+    ({ label, driver, service, expectedHealthPath }) => {
+        it("is no longer a 'not yet implemented' stub", async () => {
+            // GREEN baseline against the live seam.
+            const entry = SERVICES[service];
+            if (!entry) {
+                throw new Error(
+                    `test setup: SERVICES["${service}"] is missing — update DRIVER_CASES`,
+                );
+            }
+            const fetchImpl = makeFetch((url) => {
+                if (url.includes("/graphql/v2"))
+                    return gqlDeploymentResponse("SUCCESS");
+                return Promise.resolve(mkResponse({ status: 200 }));
+            });
+            await withGlobalSeam(fetchImpl, TOKEN, async () => {
+                const out = await driver({
+                    name: service,
+                    host: entry.domains.staging,
+                    driver: label as ProbeTarget["driver"],
+                });
+                expect(out.ok).toBe(true);
+                if (out.ok === false) {
+                    // Specifically reject the legacy stub message — that
+                    // was the bug we're fixing.
+                    expect(out.error).not.toMatch(/not yet implemented/);
+                }
+            });
+        });
+
+        it("hits the expected healthcheck path", async () => {
+            const entry = SERVICES[service];
+            if (!entry) throw new Error("test setup");
+            const seen: string[] = [];
+            const fetchImpl = makeFetch((url) => {
+                seen.push(url);
+                if (url.includes("/graphql/v2"))
+                    return gqlDeploymentResponse("SUCCESS");
+                return Promise.resolve(mkResponse({ status: 200 }));
+            });
+            await withGlobalSeam(fetchImpl, TOKEN, async () => {
+                await driver({
+                    name: service,
+                    host: entry.domains.prod,
+                    driver: label as ProbeTarget["driver"],
+                });
+            });
+            const healthUrls = seen.filter(
+                (u) => !u.includes("/graphql/v2"),
+            );
+            expect(healthUrls).toHaveLength(1);
+            expect(healthUrls[0]).toBe(
+                `https://${entry.domains.prod}${expectedHealthPath}`,
+            );
+        });
+
+        it("queries Railway with the SSOT serviceId for the resolved env", async () => {
+            const entry = SERVICES[service];
+            if (!entry) throw new Error("test setup");
+            let gqlBody: { variables?: { serviceId?: string } } | undefined;
+            const fetchImpl = makeFetch((url, init) => {
+                if (url.includes("/graphql/v2")) {
+                    gqlBody = JSON.parse(String(init?.body ?? "{}"));
+                    return gqlDeploymentResponse("SUCCESS");
+                }
+                return Promise.resolve(mkResponse({ status: 200 }));
+            });
+            await withGlobalSeam(fetchImpl, TOKEN, async () => {
+                await driver({
+                    name: service,
+                    host: entry.domains.staging,
+                    driver: label as ProbeTarget["driver"],
+                });
+            });
+            expect(gqlBody?.variables?.serviceId).toBe(entry.serviceId);
+        });
+
+        it("fails on CRASHED deployment status", async () => {
+            const entry = SERVICES[service];
+            if (!entry) throw new Error("test setup");
+            const fetchImpl = makeFetch((url) => {
+                if (url.includes("/graphql/v2"))
+                    return gqlDeploymentResponse("CRASHED");
+                return Promise.resolve(mkResponse({ status: 200 }));
+            });
+            await withGlobalSeam(fetchImpl, TOKEN, async () => {
+                const out = await driver({
+                    name: service,
+                    host: entry.domains.staging,
+                    driver: label as ProbeTarget["driver"],
+                });
+                expect(out.ok).toBe(false);
+                if (out.ok === false) expect(out.error).toMatch(/CRASHED/);
+            });
+        });
+
+        it("fails on healthcheck != 200", async () => {
+            const entry = SERVICES[service];
+            if (!entry) throw new Error("test setup");
+            const fetchImpl = makeFetch((url) => {
+                if (url.includes("/graphql/v2"))
+                    return gqlDeploymentResponse("SUCCESS");
+                return Promise.resolve(mkResponse({ status: 502 }));
+            });
+            await withGlobalSeam(fetchImpl, TOKEN, async () => {
+                const out = await driver({
+                    name: service,
+                    host: entry.domains.staging,
+                    driver: label as ProbeTarget["driver"],
+                });
+                expect(out.ok).toBe(false);
+                if (out.ok === false) expect(out.error).toMatch(/502/);
+            });
+        });
+    },
+);

--- a/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
@@ -18,13 +18,13 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import {
-    checkDeploymentSuccess,
-    checkHealthcheck200,
-    defaultGetRailwayToken,
-    envForTarget,
-    probeBaseline,
-    type FetchLike,
+  checkDeploymentSuccess,
+  checkHealthcheck200,
+  defaultGetRailwayToken,
+  envForTarget,
+  probeBaseline,
 } from "../verify-deploy.drivers.baseline";
+import type { FetchLike } from "../verify-deploy.drivers.baseline";
 import { probeShell } from "../verify-deploy.drivers.shell";
 import { probeDocs } from "../verify-deploy.drivers.docs";
 import { probeDashboard } from "../verify-deploy.drivers.dashboard";
@@ -39,423 +39,445 @@ import { probeAgent } from "../verify-deploy.drivers.agent";
 const TOKEN = "tok_test_abcdef";
 
 function mkResponse(body: {
-    status?: number;
-    json?: unknown;
-    text?: string;
-    ok?: boolean;
+  status?: number;
+  json?: unknown;
+  text?: string;
+  ok?: boolean;
 }): Awaited<ReturnType<FetchLike>> {
-    const status = body.status ?? 200;
-    return {
-        ok: body.ok ?? (status >= 200 && status < 300),
-        status,
-        async text() {
-            return body.text ?? JSON.stringify(body.json ?? {});
-        },
-        async json() {
-            return body.json ?? {};
-        },
-    };
+  const status = body.status ?? 200;
+  return {
+    ok: body.ok ?? (status >= 200 && status < 300),
+    status,
+    async text() {
+      return body.text ?? JSON.stringify(body.json ?? {});
+    },
+    async json() {
+      return body.json ?? {};
+    },
+  };
 }
 
 function makeFetch(
-    handler: (url: string, init?: Parameters<FetchLike>[1]) => ReturnType<FetchLike>,
+  handler: (
+    url: string,
+    init?: Parameters<FetchLike>[1],
+  ) => ReturnType<FetchLike>,
 ): FetchLike {
-    return vi.fn(handler);
+  return vi.fn(handler);
 }
 
 function gqlDeploymentResponse(status: string): ReturnType<FetchLike> {
-    return Promise.resolve(
-        mkResponse({
-            json: {
-                data: {
-                    deployments: {
-                        edges: [{ node: { id: "d1", status } }],
-                    },
-                },
-            },
-        }),
-    );
+  return Promise.resolve(
+    mkResponse({
+      json: {
+        data: {
+          deployments: {
+            edges: [{ node: { id: "d1", status } }],
+          },
+        },
+      },
+    }),
+  );
 }
 
 describe("defaultGetRailwayToken non-ENOENT errors are NOT swallowed", () => {
-    it("surfaces a clear diagnostic on non-ENOENT read errors (e.g. EISDIR via directory at config path)", () => {
-        // Point HOME at a tmpdir where ~/.railway/config.json is itself a
-        // directory — fs.readFileSync raises EISDIR. The previous bare
-        // `catch {}` swallowed it; the fix must NOT silently return
-        // undefined without a diagnostic on stderr identifying the path.
-        const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "verify-deploy-token-"));
-        const railwayDir = path.join(tmpHome, ".railway");
-        fs.mkdirSync(railwayDir, { recursive: true });
-        // Make config.json a directory (not a file).
-        fs.mkdirSync(path.join(railwayDir, "config.json"));
+  it("surfaces a clear diagnostic on non-ENOENT read errors (e.g. EISDIR via directory at config path)", () => {
+    // Point HOME at a tmpdir where ~/.railway/config.json is itself a
+    // directory — fs.readFileSync raises EISDIR. The previous bare
+    // `catch {}` swallowed it; the fix must NOT silently return
+    // undefined without a diagnostic on stderr identifying the path.
+    const tmpHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), "verify-deploy-token-"),
+    );
+    const railwayDir = path.join(tmpHome, ".railway");
+    fs.mkdirSync(railwayDir, { recursive: true });
+    // Make config.json a directory (not a file).
+    fs.mkdirSync(path.join(railwayDir, "config.json"));
 
-        const origHome = process.env.HOME;
-        const origToken = process.env.RAILWAY_TOKEN;
-        delete process.env.RAILWAY_TOKEN;
-        process.env.HOME = tmpHome;
+    const origHome = process.env.HOME;
+    const origToken = process.env.RAILWAY_TOKEN;
+    delete process.env.RAILWAY_TOKEN;
+    process.env.HOME = tmpHome;
 
-        const stderr: string[] = [];
-        const realWrite = process.stderr.write.bind(process.stderr);
-        (process.stderr as unknown as { write: typeof process.stderr.write }).write =
-            ((chunk: string | Uint8Array): boolean => {
-                stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
-                return true;
-            }) as typeof process.stderr.write;
-        try {
-            const out = defaultGetRailwayToken();
-            expect(out).toBeUndefined();
-            const joined = stderr.join("");
-            // The fix must log a diagnostic identifying the config path
-            // and the error — bare `catch {}` printed nothing.
-            expect(joined).toMatch(/config\.json/);
-            expect(joined).toMatch(/EISDIR|directory|read/i);
-        } finally {
-            (process.stderr as unknown as { write: typeof process.stderr.write }).write = realWrite;
-            if (origHome === undefined) delete process.env.HOME;
-            else process.env.HOME = origHome;
-            if (origToken === undefined) delete process.env.RAILWAY_TOKEN;
-            else process.env.RAILWAY_TOKEN = origToken;
-            try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* cleanup */ }
-        }
-    });
+    const stderr: string[] = [];
+    const realWrite = process.stderr.write.bind(process.stderr);
+    (
+      process.stderr as unknown as { write: typeof process.stderr.write }
+    ).write = ((chunk: string | Uint8Array): boolean => {
+      stderr.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const out = defaultGetRailwayToken();
+      expect(out).toBeUndefined();
+      const joined = stderr.join("");
+      // The fix must log a diagnostic identifying the config path
+      // and the error — bare `catch {}` printed nothing.
+      expect(joined).toMatch(/config\.json/);
+      expect(joined).toMatch(/EISDIR|directory|read/i);
+    } finally {
+      (
+        process.stderr as unknown as { write: typeof process.stderr.write }
+      ).write = realWrite;
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      if (origToken === undefined) delete process.env.RAILWAY_TOKEN;
+      else process.env.RAILWAY_TOKEN = origToken;
+      try {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      } catch {
+        /* cleanup */
+      }
+    }
+  });
 
-    it("treats ENOENT (missing config file) as the legitimate no-token path (silent undefined)", () => {
-        const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "verify-deploy-token-"));
-        const origHome = process.env.HOME;
-        const origToken = process.env.RAILWAY_TOKEN;
-        delete process.env.RAILWAY_TOKEN;
-        process.env.HOME = tmpHome;
+  it("treats ENOENT (missing config file) as the legitimate no-token path (silent undefined)", () => {
+    const tmpHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), "verify-deploy-token-"),
+    );
+    const origHome = process.env.HOME;
+    const origToken = process.env.RAILWAY_TOKEN;
+    delete process.env.RAILWAY_TOKEN;
+    process.env.HOME = tmpHome;
 
-        const stderr: string[] = [];
-        const realWrite = process.stderr.write.bind(process.stderr);
-        (process.stderr as unknown as { write: typeof process.stderr.write }).write =
-            ((chunk: string | Uint8Array): boolean => {
-                stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
-                return true;
-            }) as typeof process.stderr.write;
-        try {
-            const out = defaultGetRailwayToken();
-            expect(out).toBeUndefined();
-            // ENOENT is the legitimate no-token path — no diagnostic spam.
-            expect(stderr.join("")).toBe("");
-        } finally {
-            (process.stderr as unknown as { write: typeof process.stderr.write }).write = realWrite;
-            if (origHome === undefined) delete process.env.HOME;
-            else process.env.HOME = origHome;
-            if (origToken === undefined) delete process.env.RAILWAY_TOKEN;
-            else process.env.RAILWAY_TOKEN = origToken;
-            try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* cleanup */ }
-        }
-    });
+    const stderr: string[] = [];
+    const realWrite = process.stderr.write.bind(process.stderr);
+    (
+      process.stderr as unknown as { write: typeof process.stderr.write }
+    ).write = ((chunk: string | Uint8Array): boolean => {
+      stderr.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const out = defaultGetRailwayToken();
+      expect(out).toBeUndefined();
+      // ENOENT is the legitimate no-token path — no diagnostic spam.
+      expect(stderr.join("")).toBe("");
+    } finally {
+      (
+        process.stderr as unknown as { write: typeof process.stderr.write }
+      ).write = realWrite;
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      if (origToken === undefined) delete process.env.RAILWAY_TOKEN;
+      else process.env.RAILWAY_TOKEN = origToken;
+      try {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      } catch {
+        /* cleanup */
+      }
+    }
+  });
 });
 
 describe("envForTarget", () => {
-    it("returns 'staging' when host matches the SSOT staging domain", () => {
-        const t: ProbeTarget = {
-            name: "docs",
-            host: SERVICES.docs.domains.staging,
-            driver: "docs",
-        };
-        expect(envForTarget(t)).toBe("staging");
-    });
+  it("returns 'staging' when host matches the SSOT staging domain", () => {
+    const t: ProbeTarget = {
+      name: "docs",
+      host: SERVICES.docs.domains.staging,
+      driver: "docs",
+    };
+    expect(envForTarget(t)).toBe("staging");
+  });
 
-    it("returns 'prod' when host matches the SSOT prod domain", () => {
-        const t: ProbeTarget = {
-            name: "docs",
-            host: SERVICES.docs.domains.prod,
-            driver: "docs",
-        };
-        expect(envForTarget(t)).toBe("prod");
-    });
+  it("returns 'prod' when host matches the SSOT prod domain", () => {
+    const t: ProbeTarget = {
+      name: "docs",
+      host: SERVICES.docs.domains.prod,
+      driver: "docs",
+    };
+    expect(envForTarget(t)).toBe("prod");
+  });
 
-    it("returns undefined for unknown host or unknown service", () => {
-        expect(
-            envForTarget({ name: "docs", host: "bogus.example", driver: "docs" }),
-        ).toBeUndefined();
-        expect(
-            envForTarget({ name: "nonsuch", host: "x", driver: "docs" }),
-        ).toBeUndefined();
-    });
+  it("returns undefined for unknown host or unknown service", () => {
+    expect(
+      envForTarget({ name: "docs", host: "bogus.example", driver: "docs" }),
+    ).toBeUndefined();
+    expect(
+      envForTarget({ name: "nonsuch", host: "x", driver: "docs" }),
+    ).toBeUndefined();
+  });
 });
 
 describe("checkDeploymentSuccess", () => {
-    it("returns undefined when Railway reports SUCCESS", async () => {
-        const fetchImpl = makeFetch(() => gqlDeploymentResponse("SUCCESS"));
-        const err = await checkDeploymentSuccess(
-            "svc-id",
-            "staging",
-            TOKEN,
-            fetchImpl,
-            5000,
-            "shell",
-        );
-        expect(err).toBeUndefined();
-    });
+  it("returns undefined when Railway reports SUCCESS", async () => {
+    const fetchImpl = makeFetch(() => gqlDeploymentResponse("SUCCESS"));
+    const err = await checkDeploymentSuccess(
+      "svc-id",
+      "staging",
+      TOKEN,
+      fetchImpl,
+      5000,
+      "shell",
+    );
+    expect(err).toBeUndefined();
+  });
 
-    it("returns an error string when status is not SUCCESS", async () => {
-        const fetchImpl = makeFetch(() => gqlDeploymentResponse("CRASHED"));
-        const err = await checkDeploymentSuccess(
-            "svc-id",
-            "prod",
-            TOKEN,
-            fetchImpl,
-            5000,
-            "shell",
-        );
-        expect(err).toMatch(/CRASHED/);
-        expect(err).toMatch(/prod/);
-    });
+  it("returns an error string when status is not SUCCESS", async () => {
+    const fetchImpl = makeFetch(() => gqlDeploymentResponse("CRASHED"));
+    const err = await checkDeploymentSuccess(
+      "svc-id",
+      "prod",
+      TOKEN,
+      fetchImpl,
+      5000,
+      "shell",
+    );
+    expect(err).toMatch(/CRASHED/);
+    expect(err).toMatch(/prod/);
+  });
 
-    it("returns an error when GraphQL returns errors[]", async () => {
-        const fetchImpl = makeFetch(() =>
-            Promise.resolve(
-                mkResponse({ json: { errors: [{ message: "bad token" }] } }),
-            ),
-        );
-        const err = await checkDeploymentSuccess(
-            "svc-id",
-            "staging",
-            TOKEN,
-            fetchImpl,
-            5000,
-            "shell",
-        );
-        expect(err).toMatch(/bad token/);
-    });
+  it("returns an error when GraphQL returns errors[]", async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.resolve(
+        mkResponse({ json: { errors: [{ message: "bad token" }] } }),
+      ),
+    );
+    const err = await checkDeploymentSuccess(
+      "svc-id",
+      "staging",
+      TOKEN,
+      fetchImpl,
+      5000,
+      "shell",
+    );
+    expect(err).toMatch(/bad token/);
+  });
 
-    it("returns an error on HTTP non-2xx", async () => {
-        const fetchImpl = makeFetch(() =>
-            Promise.resolve(mkResponse({ status: 401, text: "unauthorized" })),
-        );
-        const err = await checkDeploymentSuccess(
-            "svc-id",
-            "staging",
-            TOKEN,
-            fetchImpl,
-            5000,
-            "shell",
-        );
-        expect(err).toMatch(/401/);
-    });
+  it("returns an error on HTTP non-2xx", async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.resolve(mkResponse({ status: 401, text: "unauthorized" })),
+    );
+    const err = await checkDeploymentSuccess(
+      "svc-id",
+      "staging",
+      TOKEN,
+      fetchImpl,
+      5000,
+      "shell",
+    );
+    expect(err).toMatch(/401/);
+  });
 
-    it("returns an error when no deployment edge exists", async () => {
-        const fetchImpl = makeFetch(() =>
-            Promise.resolve(
-                mkResponse({ json: { data: { deployments: { edges: [] } } } }),
-            ),
-        );
-        const err = await checkDeploymentSuccess(
-            "svc-id",
-            "staging",
-            TOKEN,
-            fetchImpl,
-            5000,
-            "shell",
-        );
-        expect(err).toMatch(/no deployments/);
-    });
+  it("returns an error when no deployment edge exists", async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.resolve(
+        mkResponse({ json: { data: { deployments: { edges: [] } } } }),
+      ),
+    );
+    const err = await checkDeploymentSuccess(
+      "svc-id",
+      "staging",
+      TOKEN,
+      fetchImpl,
+      5000,
+      "shell",
+    );
+    expect(err).toMatch(/no deployments/);
+  });
 
-    it("sends the Authorization bearer + serviceId/environmentId variables", async () => {
-        const calls: Array<{ url: string; body: unknown; auth?: string }> = [];
-        const fetchImpl = makeFetch((url, init) => {
-            calls.push({
-                url,
-                body: JSON.parse(String(init?.body ?? "{}")),
-                auth: init?.headers?.Authorization,
-            });
-            return gqlDeploymentResponse("SUCCESS");
-        });
-        await checkDeploymentSuccess(
-            "svc-123",
-            "staging",
-            TOKEN,
-            fetchImpl,
-            5000,
-            "shell",
-        );
-        expect(calls).toHaveLength(1);
-        expect(calls[0].url).toMatch(/backboard\.railway\.app\/graphql\/v2/);
-        expect(calls[0].auth).toBe(`Bearer ${TOKEN}`);
-        const body = calls[0].body as {
-            query: string;
-            variables: { serviceId: string; environmentId: string };
-        };
-        expect(body.query).toMatch(/deployments\(first: 1/);
-        expect(body.variables.serviceId).toBe("svc-123");
-        expect(body.variables.environmentId).toMatch(/^[0-9a-f-]{36}$/);
+  it("sends the Authorization bearer + serviceId/environmentId variables", async () => {
+    const calls: Array<{ url: string; body: unknown; auth?: string }> = [];
+    const fetchImpl = makeFetch((url, init) => {
+      calls.push({
+        url,
+        body: JSON.parse(String(init?.body ?? "{}")),
+        auth: init?.headers?.Authorization,
+      });
+      return gqlDeploymentResponse("SUCCESS");
     });
+    await checkDeploymentSuccess(
+      "svc-123",
+      "staging",
+      TOKEN,
+      fetchImpl,
+      5000,
+      "shell",
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toMatch(/backboard\.railway\.app\/graphql\/v2/);
+    expect(calls[0].auth).toBe(`Bearer ${TOKEN}`);
+    const body = calls[0].body as {
+      query: string;
+      variables: { serviceId: string; environmentId: string };
+    };
+    expect(body.query).toMatch(/deployments\(first: 1/);
+    expect(body.variables.serviceId).toBe("svc-123");
+    expect(body.variables.environmentId).toMatch(/^[0-9a-f-]{36}$/);
+  });
 });
 
 describe("checkHealthcheck200", () => {
-    it("returns undefined on HTTP 200", async () => {
-        const fetchImpl = makeFetch(() =>
-            Promise.resolve(mkResponse({ status: 200 })),
-        );
-        const err = await checkHealthcheck200(
-            "docs.example",
-            "/",
-            fetchImpl,
-            5000,
-            "docs",
-        );
-        expect(err).toBeUndefined();
-    });
+  it("returns undefined on HTTP 200", async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.resolve(mkResponse({ status: 200 })),
+    );
+    const err = await checkHealthcheck200(
+      "docs.example",
+      "/",
+      fetchImpl,
+      5000,
+      "docs",
+    );
+    expect(err).toBeUndefined();
+  });
 
-    it("returns an error string on non-200", async () => {
-        const fetchImpl = makeFetch(() =>
-            Promise.resolve(mkResponse({ status: 503 })),
-        );
-        const err = await checkHealthcheck200(
-            "docs.example",
-            "/",
-            fetchImpl,
-            5000,
-            "docs",
-        );
-        expect(err).toMatch(/503/);
-        expect(err).toMatch(/docs/);
-    });
+  it("returns an error string on non-200", async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.resolve(mkResponse({ status: 503 })),
+    );
+    const err = await checkHealthcheck200(
+      "docs.example",
+      "/",
+      fetchImpl,
+      5000,
+      "docs",
+    );
+    expect(err).toMatch(/503/);
+    expect(err).toMatch(/docs/);
+  });
 
-    it("composes https + host + path correctly", async () => {
-        const calls: string[] = [];
-        const fetchImpl = makeFetch((url) => {
-            calls.push(url);
-            return Promise.resolve(mkResponse({ status: 200 }));
-        });
-        await checkHealthcheck200(
-            "showcase-aimock-production.up.railway.app",
-            "/health",
-            fetchImpl,
-            5000,
-            "aimock",
-        );
-        expect(calls[0]).toBe(
-            "https://showcase-aimock-production.up.railway.app/health",
-        );
+  it("composes https + host + path correctly", async () => {
+    const calls: string[] = [];
+    const fetchImpl = makeFetch((url) => {
+      calls.push(url);
+      return Promise.resolve(mkResponse({ status: 200 }));
     });
+    await checkHealthcheck200(
+      "showcase-aimock-production.up.railway.app",
+      "/health",
+      fetchImpl,
+      5000,
+      "aimock",
+    );
+    expect(calls[0]).toBe(
+      "https://showcase-aimock-production.up.railway.app/health",
+    );
+  });
 
-    it("returns an error on fetch throw", async () => {
-        const fetchImpl = makeFetch(() =>
-            Promise.reject(new Error("ECONNREFUSED")),
-        );
-        const err = await checkHealthcheck200(
-            "docs.example",
-            "/",
-            fetchImpl,
-            5000,
-            "docs",
-        );
-        expect(err).toMatch(/ECONNREFUSED/);
-    });
+  it("returns an error on fetch throw", async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.reject(new Error("ECONNREFUSED")),
+    );
+    const err = await checkHealthcheck200(
+      "docs.example",
+      "/",
+      fetchImpl,
+      5000,
+      "docs",
+    );
+    expect(err).toMatch(/ECONNREFUSED/);
+  });
 });
 
 describe("probeBaseline", () => {
-    function okFetch(): FetchLike {
-        return makeFetch((url) => {
-            if (url.includes("/graphql/v2"))
-                return gqlDeploymentResponse("SUCCESS");
-            return Promise.resolve(mkResponse({ status: 200 }));
-        });
+  function okFetch(): FetchLike {
+    return makeFetch((url) => {
+      if (url.includes("/graphql/v2")) return gqlDeploymentResponse("SUCCESS");
+      return Promise.resolve(mkResponse({ status: 200 }));
+    });
+  }
+
+  it("returns ok when GraphQL = SUCCESS and healthcheck = 200", async () => {
+    const out = await probeBaseline(
+      {
+        name: "docs",
+        host: SERVICES.docs.domains.staging,
+        driver: "docs",
+      },
+      {
+        driverLabel: "docs",
+        healthcheckPath: "/",
+        fetchImpl: okFetch(),
+        getRailwayToken: () => TOKEN,
+      },
+    );
+    expect(out).toEqual({ ok: true });
+  });
+
+  it("fails loud when env cannot be resolved from host", async () => {
+    const out = await probeBaseline(
+      { name: "docs", host: "wrong.example", driver: "docs" },
+      {
+        driverLabel: "docs",
+        healthcheckPath: "/",
+        fetchImpl: okFetch(),
+        getRailwayToken: () => TOKEN,
+      },
+    );
+    expect(out.ok).toBe(false);
+    if (out.ok === false) {
+      expect(out.error).toMatch(/cannot resolve env/);
     }
+  });
 
-    it("returns ok when GraphQL = SUCCESS and healthcheck = 200", async () => {
-        const out = await probeBaseline(
-            {
-                name: "docs",
-                host: SERVICES.docs.domains.staging,
-                driver: "docs",
-            },
-            {
-                driverLabel: "docs",
-                healthcheckPath: "/",
-                fetchImpl: okFetch(),
-                getRailwayToken: () => TOKEN,
-            },
-        );
-        expect(out).toEqual({ ok: true });
-    });
+  it("fails loud when no Railway token is available", async () => {
+    const out = await probeBaseline(
+      {
+        name: "docs",
+        host: SERVICES.docs.domains.staging,
+        driver: "docs",
+      },
+      {
+        driverLabel: "docs",
+        healthcheckPath: "/",
+        fetchImpl: okFetch(),
+        getRailwayToken: () => undefined,
+      },
+    );
+    expect(out.ok).toBe(false);
+    if (out.ok === false) {
+      expect(out.error).toMatch(/no Railway token/);
+    }
+  });
 
-    it("fails loud when env cannot be resolved from host", async () => {
-        const out = await probeBaseline(
-            { name: "docs", host: "wrong.example", driver: "docs" },
-            {
-                driverLabel: "docs",
-                healthcheckPath: "/",
-                fetchImpl: okFetch(),
-                getRailwayToken: () => TOKEN,
-            },
-        );
-        expect(out.ok).toBe(false);
-        if (out.ok === false) {
-            expect(out.error).toMatch(/cannot resolve env/);
-        }
+  it("fails on deployment status != SUCCESS", async () => {
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("/graphql/v2")) return gqlDeploymentResponse("CRASHED");
+      return Promise.resolve(mkResponse({ status: 200 }));
     });
+    const out = await probeBaseline(
+      {
+        name: "docs",
+        host: SERVICES.docs.domains.staging,
+        driver: "docs",
+      },
+      {
+        driverLabel: "docs",
+        healthcheckPath: "/",
+        fetchImpl,
+        getRailwayToken: () => TOKEN,
+      },
+    );
+    expect(out.ok).toBe(false);
+    if (out.ok === false) expect(out.error).toMatch(/CRASHED/);
+  });
 
-    it("fails loud when no Railway token is available", async () => {
-        const out = await probeBaseline(
-            {
-                name: "docs",
-                host: SERVICES.docs.domains.staging,
-                driver: "docs",
-            },
-            {
-                driverLabel: "docs",
-                healthcheckPath: "/",
-                fetchImpl: okFetch(),
-                getRailwayToken: () => undefined,
-            },
-        );
-        expect(out.ok).toBe(false);
-        if (out.ok === false) {
-            expect(out.error).toMatch(/no Railway token/);
-        }
+  it("fails on healthcheck != 200", async () => {
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("/graphql/v2")) return gqlDeploymentResponse("SUCCESS");
+      return Promise.resolve(mkResponse({ status: 502 }));
     });
-
-    it("fails on deployment status != SUCCESS", async () => {
-        const fetchImpl = makeFetch((url) => {
-            if (url.includes("/graphql/v2"))
-                return gqlDeploymentResponse("CRASHED");
-            return Promise.resolve(mkResponse({ status: 200 }));
-        });
-        const out = await probeBaseline(
-            {
-                name: "docs",
-                host: SERVICES.docs.domains.staging,
-                driver: "docs",
-            },
-            {
-                driverLabel: "docs",
-                healthcheckPath: "/",
-                fetchImpl,
-                getRailwayToken: () => TOKEN,
-            },
-        );
-        expect(out.ok).toBe(false);
-        if (out.ok === false) expect(out.error).toMatch(/CRASHED/);
-    });
-
-    it("fails on healthcheck != 200", async () => {
-        const fetchImpl = makeFetch((url) => {
-            if (url.includes("/graphql/v2"))
-                return gqlDeploymentResponse("SUCCESS");
-            return Promise.resolve(mkResponse({ status: 502 }));
-        });
-        const out = await probeBaseline(
-            {
-                name: "docs",
-                host: SERVICES.docs.domains.staging,
-                driver: "docs",
-            },
-            {
-                driverLabel: "docs",
-                healthcheckPath: "/",
-                fetchImpl,
-                getRailwayToken: () => TOKEN,
-            },
-        );
-        expect(out.ok).toBe(false);
-        if (out.ok === false) expect(out.error).toMatch(/502/);
-    });
+    const out = await probeBaseline(
+      {
+        name: "docs",
+        host: SERVICES.docs.domains.staging,
+        driver: "docs",
+      },
+      {
+        driverLabel: "docs",
+        healthcheckPath: "/",
+        fetchImpl,
+        getRailwayToken: () => TOKEN,
+      },
+    );
+    expect(out.ok).toBe(false);
+    if (out.ok === false) expect(out.error).toMatch(/502/);
+  });
 });
 
 /**
@@ -471,228 +493,226 @@ describe("probeBaseline", () => {
  *   - It returns `{ok:true}` on a green baseline, `{ok:false}` on red.
  */
 function withGlobalSeam(
-    fetchImpl: FetchLike,
-    token: string | undefined,
-    fn: () => Promise<void>,
+  fetchImpl: FetchLike,
+  token: string | undefined,
+  fn: () => Promise<void>,
 ): Promise<void> {
-    const realFetch = globalThis.fetch;
-    const realToken = process.env.RAILWAY_TOKEN;
-    (globalThis as unknown as { fetch: FetchLike }).fetch = fetchImpl;
-    if (token === undefined) delete process.env.RAILWAY_TOKEN;
-    else process.env.RAILWAY_TOKEN = token;
-    return fn().finally(() => {
-        (globalThis as unknown as { fetch: typeof fetch }).fetch = realFetch;
-        if (realToken === undefined) delete process.env.RAILWAY_TOKEN;
-        else process.env.RAILWAY_TOKEN = realToken;
-    });
+  const realFetch = globalThis.fetch;
+  const realToken = process.env.RAILWAY_TOKEN;
+  (globalThis as unknown as { fetch: FetchLike }).fetch = fetchImpl;
+  if (token === undefined) delete process.env.RAILWAY_TOKEN;
+  else process.env.RAILWAY_TOKEN = token;
+  return fn().finally(() => {
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = realFetch;
+    if (realToken === undefined) delete process.env.RAILWAY_TOKEN;
+    else process.env.RAILWAY_TOKEN = realToken;
+  });
 }
 
-type DriverFn = (target: ProbeTarget) => Promise<
-    { ok: true } | { ok: false; error: string }
->;
+type DriverFn = (
+  target: ProbeTarget,
+) => Promise<{ ok: true } | { ok: false; error: string }>;
 
 interface DriverCase {
-    label: string;
-    driver: DriverFn;
-    service: keyof typeof SERVICES;
-    enumLiteral: string;
-    expectedHealthPath: string;
+  label: string;
+  driver: DriverFn;
+  service: keyof typeof SERVICES;
+  enumLiteral: string;
+  expectedHealthPath: string;
 }
 
 const DRIVER_CASES: DriverCase[] = [
-    {
-        label: "shell",
-        driver: probeShell,
-        service: "shell",
-        enumLiteral: "shell",
-        expectedHealthPath: "/",
-    },
-    {
-        label: "docs",
-        driver: probeDocs,
-        service: "docs",
-        enumLiteral: "docs",
-        expectedHealthPath: "/",
-    },
-    {
-        label: "dashboard",
-        driver: probeDashboard,
-        service: "dashboard",
-        enumLiteral: "dashboard",
-        expectedHealthPath: "/",
-    },
-    {
-        label: "dojo",
-        driver: probeDojo,
-        service: "dojo",
-        enumLiteral: "dojo",
-        expectedHealthPath: "/",
-    },
-    {
-        label: "harness",
-        driver: probeHarness,
-        service: "harness",
-        enumLiteral: "harness",
-        expectedHealthPath: "/health",
-    },
-    {
-        label: "aimock",
-        driver: probeAimock,
-        service: "aimock",
-        enumLiteral: "aimock",
-        expectedHealthPath: "/health",
-    },
-    {
-        label: "pocketbase",
-        driver: probePocketbase,
-        service: "pocketbase",
-        enumLiteral: "pocketbase",
-        expectedHealthPath: "/api/health",
-    },
-    {
-        label: "webhooks",
-        driver: probeWebhooks,
-        service: "webhooks",
-        enumLiteral: "webhooks",
-        expectedHealthPath: "/api/health",
-    },
-    {
-        // No service in the SSOT currently uses the `eval` driver literal,
-        // but the enum literal exists in railway-envs.ts and the dispatch
-        // switch wires probeEval. We still need probeEval to be a working
-        // impl. Test it by routing through any real SSOT service —
-        // probeEval's behavior is structurally identical to the agent
-        // driver; we use `harness` as the host carrier since it's the
-        // smallest standalone API surface in the SSOT.
-        label: "eval",
-        driver: probeEval,
-        service: "harness",
-        enumLiteral: "eval",
-        expectedHealthPath: "/api/health",
-    },
-    {
-        label: "agent",
-        driver: probeAgent,
-        service: "showcase-mastra",
-        enumLiteral: "agent",
-        expectedHealthPath: "/api/health",
-    },
+  {
+    label: "shell",
+    driver: probeShell,
+    service: "shell",
+    enumLiteral: "shell",
+    expectedHealthPath: "/",
+  },
+  {
+    label: "docs",
+    driver: probeDocs,
+    service: "docs",
+    enumLiteral: "docs",
+    expectedHealthPath: "/",
+  },
+  {
+    label: "dashboard",
+    driver: probeDashboard,
+    service: "dashboard",
+    enumLiteral: "dashboard",
+    expectedHealthPath: "/",
+  },
+  {
+    label: "dojo",
+    driver: probeDojo,
+    service: "dojo",
+    enumLiteral: "dojo",
+    expectedHealthPath: "/",
+  },
+  {
+    label: "harness",
+    driver: probeHarness,
+    service: "harness",
+    enumLiteral: "harness",
+    expectedHealthPath: "/health",
+  },
+  {
+    label: "aimock",
+    driver: probeAimock,
+    service: "aimock",
+    enumLiteral: "aimock",
+    expectedHealthPath: "/health",
+  },
+  {
+    label: "pocketbase",
+    driver: probePocketbase,
+    service: "pocketbase",
+    enumLiteral: "pocketbase",
+    expectedHealthPath: "/api/health",
+  },
+  {
+    label: "webhooks",
+    driver: probeWebhooks,
+    service: "webhooks",
+    enumLiteral: "webhooks",
+    expectedHealthPath: "/api/health",
+  },
+  {
+    // No service in the SSOT currently uses the `eval` driver literal,
+    // but the enum literal exists in railway-envs.ts and the dispatch
+    // switch wires probeEval. We still need probeEval to be a working
+    // impl. Test it by routing through any real SSOT service —
+    // probeEval's behavior is structurally identical to the agent
+    // driver; we use `harness` as the host carrier since it's the
+    // smallest standalone API surface in the SSOT.
+    label: "eval",
+    driver: probeEval,
+    service: "harness",
+    enumLiteral: "eval",
+    expectedHealthPath: "/api/health",
+  },
+  {
+    label: "agent",
+    driver: probeAgent,
+    service: "showcase-mastra",
+    enumLiteral: "agent",
+    expectedHealthPath: "/api/health",
+  },
 ];
 
 describe.each(DRIVER_CASES)(
-    "$label driver",
-    ({ label, driver, service, expectedHealthPath }) => {
-        it("is no longer a 'not yet implemented' stub", async () => {
-            // GREEN baseline against the live seam.
-            const entry = SERVICES[service];
-            if (!entry) {
-                throw new Error(
-                    `test setup: SERVICES["${service}"] is missing — update DRIVER_CASES`,
-                );
-            }
-            const fetchImpl = makeFetch((url) => {
-                if (url.includes("/graphql/v2"))
-                    return gqlDeploymentResponse("SUCCESS");
-                return Promise.resolve(mkResponse({ status: 200 }));
-            });
-            await withGlobalSeam(fetchImpl, TOKEN, async () => {
-                const out = await driver({
-                    name: service,
-                    host: entry.domains.staging,
-                    driver: label as ProbeTarget["driver"],
-                });
-                expect(out.ok).toBe(true);
-                if (out.ok === false) {
-                    // Specifically reject the legacy stub message — that
-                    // was the bug we're fixing.
-                    expect(out.error).not.toMatch(/not yet implemented/);
-                }
-            });
+  "$label driver",
+  ({ label, driver, service, expectedHealthPath }) => {
+    it("is no longer a 'not yet implemented' stub", async () => {
+      // GREEN baseline against the live seam.
+      const entry = SERVICES[service];
+      if (!entry) {
+        throw new Error(
+          `test setup: SERVICES["${service}"] is missing — update DRIVER_CASES`,
+        );
+      }
+      const fetchImpl = makeFetch((url) => {
+        if (url.includes("/graphql/v2"))
+          return gqlDeploymentResponse("SUCCESS");
+        return Promise.resolve(mkResponse({ status: 200 }));
+      });
+      await withGlobalSeam(fetchImpl, TOKEN, async () => {
+        const out = await driver({
+          name: service,
+          host: entry.domains.staging,
+          driver: label as ProbeTarget["driver"],
         });
+        expect(out.ok).toBe(true);
+        if (out.ok === false) {
+          // Specifically reject the legacy stub message — that
+          // was the bug we're fixing.
+          expect(out.error).not.toMatch(/not yet implemented/);
+        }
+      });
+    });
 
-        it("hits the expected healthcheck path", async () => {
-            const entry = SERVICES[service];
-            if (!entry) throw new Error("test setup");
-            const seen: string[] = [];
-            const fetchImpl = makeFetch((url) => {
-                seen.push(url);
-                if (url.includes("/graphql/v2"))
-                    return gqlDeploymentResponse("SUCCESS");
-                return Promise.resolve(mkResponse({ status: 200 }));
-            });
-            await withGlobalSeam(fetchImpl, TOKEN, async () => {
-                await driver({
-                    name: service,
-                    host: entry.domains.prod,
-                    driver: label as ProbeTarget["driver"],
-                });
-            });
-            const healthUrls = seen.filter(
-                (u) => !u.includes("/graphql/v2"),
-            );
-            expect(healthUrls).toHaveLength(1);
-            expect(healthUrls[0]).toBe(
-                `https://${entry.domains.prod}${expectedHealthPath}`,
-            );
+    it("hits the expected healthcheck path", async () => {
+      const entry = SERVICES[service];
+      if (!entry) throw new Error("test setup");
+      const seen: string[] = [];
+      const fetchImpl = makeFetch((url) => {
+        seen.push(url);
+        if (url.includes("/graphql/v2"))
+          return gqlDeploymentResponse("SUCCESS");
+        return Promise.resolve(mkResponse({ status: 200 }));
+      });
+      await withGlobalSeam(fetchImpl, TOKEN, async () => {
+        await driver({
+          name: service,
+          host: entry.domains.prod,
+          driver: label as ProbeTarget["driver"],
         });
+      });
+      const healthUrls = seen.filter((u) => !u.includes("/graphql/v2"));
+      expect(healthUrls).toHaveLength(1);
+      expect(healthUrls[0]).toBe(
+        `https://${entry.domains.prod}${expectedHealthPath}`,
+      );
+    });
 
-        it("queries Railway with the SSOT serviceId for the resolved env", async () => {
-            const entry = SERVICES[service];
-            if (!entry) throw new Error("test setup");
-            let gqlBody: { variables?: { serviceId?: string } } | undefined;
-            const fetchImpl = makeFetch((url, init) => {
-                if (url.includes("/graphql/v2")) {
-                    gqlBody = JSON.parse(String(init?.body ?? "{}"));
-                    return gqlDeploymentResponse("SUCCESS");
-                }
-                return Promise.resolve(mkResponse({ status: 200 }));
-            });
-            await withGlobalSeam(fetchImpl, TOKEN, async () => {
-                await driver({
-                    name: service,
-                    host: entry.domains.staging,
-                    driver: label as ProbeTarget["driver"],
-                });
-            });
-            expect(gqlBody?.variables?.serviceId).toBe(entry.serviceId);
+    it("queries Railway with the SSOT serviceId for the resolved env", async () => {
+      const entry = SERVICES[service];
+      if (!entry) throw new Error("test setup");
+      let gqlBody: { variables?: { serviceId?: string } } | undefined;
+      const fetchImpl = makeFetch((url, init) => {
+        if (url.includes("/graphql/v2")) {
+          gqlBody = JSON.parse(String(init?.body ?? "{}"));
+          return gqlDeploymentResponse("SUCCESS");
+        }
+        return Promise.resolve(mkResponse({ status: 200 }));
+      });
+      await withGlobalSeam(fetchImpl, TOKEN, async () => {
+        await driver({
+          name: service,
+          host: entry.domains.staging,
+          driver: label as ProbeTarget["driver"],
         });
+      });
+      expect(gqlBody?.variables?.serviceId).toBe(entry.serviceId);
+    });
 
-        it("fails on CRASHED deployment status", async () => {
-            const entry = SERVICES[service];
-            if (!entry) throw new Error("test setup");
-            const fetchImpl = makeFetch((url) => {
-                if (url.includes("/graphql/v2"))
-                    return gqlDeploymentResponse("CRASHED");
-                return Promise.resolve(mkResponse({ status: 200 }));
-            });
-            await withGlobalSeam(fetchImpl, TOKEN, async () => {
-                const out = await driver({
-                    name: service,
-                    host: entry.domains.staging,
-                    driver: label as ProbeTarget["driver"],
-                });
-                expect(out.ok).toBe(false);
-                if (out.ok === false) expect(out.error).toMatch(/CRASHED/);
-            });
+    it("fails on CRASHED deployment status", async () => {
+      const entry = SERVICES[service];
+      if (!entry) throw new Error("test setup");
+      const fetchImpl = makeFetch((url) => {
+        if (url.includes("/graphql/v2"))
+          return gqlDeploymentResponse("CRASHED");
+        return Promise.resolve(mkResponse({ status: 200 }));
+      });
+      await withGlobalSeam(fetchImpl, TOKEN, async () => {
+        const out = await driver({
+          name: service,
+          host: entry.domains.staging,
+          driver: label as ProbeTarget["driver"],
         });
+        expect(out.ok).toBe(false);
+        if (out.ok === false) expect(out.error).toMatch(/CRASHED/);
+      });
+    });
 
-        it("fails on healthcheck != 200", async () => {
-            const entry = SERVICES[service];
-            if (!entry) throw new Error("test setup");
-            const fetchImpl = makeFetch((url) => {
-                if (url.includes("/graphql/v2"))
-                    return gqlDeploymentResponse("SUCCESS");
-                return Promise.resolve(mkResponse({ status: 502 }));
-            });
-            await withGlobalSeam(fetchImpl, TOKEN, async () => {
-                const out = await driver({
-                    name: service,
-                    host: entry.domains.staging,
-                    driver: label as ProbeTarget["driver"],
-                });
-                expect(out.ok).toBe(false);
-                if (out.ok === false) expect(out.error).toMatch(/502/);
-            });
+    it("fails on healthcheck != 200", async () => {
+      const entry = SERVICES[service];
+      if (!entry) throw new Error("test setup");
+      const fetchImpl = makeFetch((url) => {
+        if (url.includes("/graphql/v2"))
+          return gqlDeploymentResponse("SUCCESS");
+        return Promise.resolve(mkResponse({ status: 502 }));
+      });
+      await withGlobalSeam(fetchImpl, TOKEN, async () => {
+        const out = await driver({
+          name: service,
+          host: entry.domains.staging,
+          driver: label as ProbeTarget["driver"],
         });
-    },
+        expect(out.ok).toBe(false);
+        if (out.ok === false) expect(out.error).toMatch(/502/);
+      });
+    });
+  },
 );

--- a/showcase/scripts/__tests__/verify-deploy.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.test.ts
@@ -1,154 +1,150 @@
 import { describe, expect, it } from "vitest";
-import {
-    parseArgs,
-    resolveProbeTargets,
-    type ProbeRunner,
-    runVerify,
-} from "../verify-deploy";
+import { parseArgs, resolveProbeTargets, runVerify } from "../verify-deploy";
+import type { ProbeRunner } from "../verify-deploy";
 
 describe("verify-deploy argv parsing", () => {
-    it("requires --env", () => {
-        expect(() => parseArgs([])).toThrow(/--env/);
-    });
+  it("requires --env", () => {
+    expect(() => parseArgs([])).toThrow(/--env/);
+  });
 
-    it("accepts --env staging and --env prod", () => {
-        expect(parseArgs(["--env", "staging"]).env).toBe("staging");
-        expect(parseArgs(["--env=prod"]).env).toBe("prod");
-    });
+  it("accepts --env staging and --env prod", () => {
+    expect(parseArgs(["--env", "staging"]).env).toBe("staging");
+    expect(parseArgs(["--env=prod"]).env).toBe("prod");
+  });
 
-    it("rejects unknown envs", () => {
-        expect(() => parseArgs(["--env", "dev"])).toThrow(/Unknown env/);
-    });
+  it("rejects unknown envs", () => {
+    expect(() => parseArgs(["--env", "dev"])).toThrow(/Unknown env/);
+  });
 
-    it("accepts optional --services CSV", () => {
-        const parsed = parseArgs(["--env", "staging", "--services", "docs,shell"]);
-        expect(parsed.services).toEqual(["docs", "shell"]);
-    });
+  it("accepts optional --services CSV", () => {
+    const parsed = parseArgs(["--env", "staging", "--services", "docs,shell"]);
+    expect(parsed.services).toEqual(["docs", "shell"]);
+  });
 
-    it("rejects empty --services= equals-form (mirrors space-form behavior)", () => {
-        expect(() =>
-            parseArgs(["--env", "staging", "--services="]),
-        ).toThrow(/--services/);
-    });
+  it("rejects empty --services= equals-form (mirrors space-form behavior)", () => {
+    expect(() => parseArgs(["--env", "staging", "--services="])).toThrow(
+      /--services/,
+    );
+  });
 
-    it("rejects --services space-form whose CSV is all empty entries (symmetry with equals-form)", () => {
-        // Bug: space-form previously only guarded `!v` on the raw next-arg,
-        // so `--services ,,` produced an empty list that fell through to a
-        // less-precise zero-targets error. Both forms must throw the same
-        // precise `--services requires a CSV value` here.
-        expect(() =>
-            parseArgs(["--env=staging", "--services", ",,"]),
-        ).toThrow(/--services requires a CSV value/);
-    });
+  it("rejects --services space-form whose CSV is all empty entries (symmetry with equals-form)", () => {
+    // Bug: space-form previously only guarded `!v` on the raw next-arg,
+    // so `--services ,,` produced an empty list that fell through to a
+    // less-precise zero-targets error. Both forms must throw the same
+    // precise `--services requires a CSV value` here.
+    expect(() => parseArgs(["--env=staging", "--services", ",,"])).toThrow(
+      /--services requires a CSV value/,
+    );
+  });
 
-    it("rejects bare trailing --env (no following value)", () => {
-        // Bug: `argv[++i]` was undefined and we deferred to a vague
-        // `resolveEnv` error. Must throw the precise message here.
-        expect(() => parseArgs(["--env"])).toThrow(
-            /--env requires a value \(staging\|prod\)/,
-        );
-    });
+  it("rejects bare trailing --env (no following value)", () => {
+    // Bug: `argv[++i]` was undefined and we deferred to a vague
+    // `resolveEnv` error. Must throw the precise message here.
+    expect(() => parseArgs(["--env"])).toThrow(
+      /--env requires a value \(staging\|prod\)/,
+    );
+  });
 
-    it("rejects --env= with empty value (symmetry with bare trailing --env)", () => {
-        expect(() => parseArgs(["--env="])).toThrow(
-            /--env requires a value \(staging\|prod\)/,
-        );
-    });
+  it("rejects --env= with empty value (symmetry with bare trailing --env)", () => {
+    expect(() => parseArgs(["--env="])).toThrow(
+      /--env requires a value \(staging\|prod\)/,
+    );
+  });
 });
 
 describe("resolveProbeTargets", () => {
-    it("filters SSOT to entries where probe[env] is true", () => {
-        const targets = resolveProbeTargets({ env: "staging" });
-        // docs is staging:true → must be present.
-        expect(targets.find((t) => t.name === "docs")).toBeDefined();
-    });
+  it("filters SSOT to entries where probe[env] is true", () => {
+    const targets = resolveProbeTargets({ env: "staging" });
+    // docs is staging:true → must be present.
+    expect(targets.find((t) => t.name === "docs")).toBeDefined();
+  });
 
-    it("REFUSES when a probe-required service has no domain for the env", () => {
-        expect(() =>
-            resolveProbeTargets({
-                env: "staging",
-                overrides: {
-                    docs: { domains: { staging: "", prod: "docs.copilotkit.ai" } },
-                },
-            }),
-        ).toThrow(/missing.*staging.*domain/i);
-    });
+  it("REFUSES when a probe-required service has no domain for the env", () => {
+    expect(() =>
+      resolveProbeTargets({
+        env: "staging",
+        overrides: {
+          docs: { domains: { staging: "", prod: "docs.copilotkit.ai" } },
+        },
+      }),
+    ).toThrow(/missing.*staging.*domain/i);
+  });
 
-    it("honors --services filter (subset of probe-eligible)", () => {
-        const targets = resolveProbeTargets({
-            env: "staging",
-            services: ["docs"],
-        });
-        expect(targets.length).toBe(1);
-        expect(targets[0].name).toBe("docs");
+  it("honors --services filter (subset of probe-eligible)", () => {
+    const targets = resolveProbeTargets({
+      env: "staging",
+      services: ["docs"],
     });
+    expect(targets.length).toBe(1);
+    expect(targets[0].name).toBe("docs");
+  });
 
-    it("REFUSES a typo'd service name (unknown service, not silent drop)", () => {
-        expect(() =>
-            resolveProbeTargets({ env: "staging", services: ["docss"] }),
-        ).toThrow(/unknown service.*docss/i);
-    });
+  it("REFUSES a typo'd service name (unknown service, not silent drop)", () => {
+    expect(() =>
+      resolveProbeTargets({ env: "staging", services: ["docss"] }),
+    ).toThrow(/unknown service.*docss/i);
+  });
 
-    it("REFUSES a service that exists in SSOT but is not probe-eligible for the env", () => {
-        // Find a service whose probe[staging] is false.
-        // Use override seam to flip probe state without mutating SSOT.
-        // Since resolveProbeTargets doesn't expose a probe-flag override,
-        // we pick a real service name and an env where the SSOT probe is
-        // false. Search SERVICES for an entry where probe.staging===false.
-        // If none exists, this test still validates the error string for
-        // the more common typo case via the prior test; we focus on the
-        // distinct error phrasing.
-        //
-        // Practical assertion: an unknown name surfaces as "unknown
-        // service", which is structurally a different (clearer) error
-        // than "not probe-eligible". The two paths must be distinguished.
-        expect(() =>
-            resolveProbeTargets({ env: "staging", services: ["totally-fake"] }),
-        ).toThrow(/unknown service/i);
-    });
+  it("REFUSES a service that exists in SSOT but is not probe-eligible for the env", () => {
+    // Find a service whose probe[staging] is false.
+    // Use override seam to flip probe state without mutating SSOT.
+    // Since resolveProbeTargets doesn't expose a probe-flag override,
+    // we pick a real service name and an env where the SSOT probe is
+    // false. Search SERVICES for an entry where probe.staging===false.
+    // If none exists, this test still validates the error string for
+    // the more common typo case via the prior test; we focus on the
+    // distinct error phrasing.
+    //
+    // Practical assertion: an unknown name surfaces as "unknown
+    // service", which is structurally a different (clearer) error
+    // than "not probe-eligible". The two paths must be distinguished.
+    expect(() =>
+      resolveProbeTargets({ env: "staging", services: ["totally-fake"] }),
+    ).toThrow(/unknown service/i);
+  });
 });
 
 describe("runVerify driver dispatch", () => {
-    it("calls the driver for each target and fails loud on any red", async () => {
-        const calls: string[] = [];
-        const runner: ProbeRunner = async (target) => {
-            calls.push(`${target.driver}:${target.host}`);
-            if (target.name === "docs") {
-                return { ok: false, error: "DOM string missing" };
-            }
-            return { ok: true };
-        };
-        const summary = await runVerify({
-            env: "staging",
-            services: ["docs", "shell"],
-            runner,
-        });
-        expect(calls).toContain("docs:docs.staging.copilotkit.ai");
-        expect(calls).toContain("shell:showcase.staging.copilotkit.ai");
-        expect(summary.failed.map((f) => f.name)).toEqual(["docs"]);
-        expect(summary.exitCode).toBe(1);
+  it("calls the driver for each target and fails loud on any red", async () => {
+    const calls: string[] = [];
+    const runner: ProbeRunner = async (target) => {
+      calls.push(`${target.driver}:${target.host}`);
+      if (target.name === "docs") {
+        return { ok: false, error: "DOM string missing" };
+      }
+      return { ok: true };
+    };
+    const summary = await runVerify({
+      env: "staging",
+      services: ["docs", "shell"],
+      runner,
     });
+    expect(calls).toContain("docs:docs.staging.copilotkit.ai");
+    expect(calls).toContain("shell:showcase.staging.copilotkit.ai");
+    expect(summary.failed.map((f) => f.name)).toEqual(["docs"]);
+    expect(summary.exitCode).toBe(1);
+  });
 
-    it("exits 0 when all probes green", async () => {
-        const summary = await runVerify({
-            env: "staging",
-            services: ["docs"],
-            runner: async () => ({ ok: true }),
-        });
-        expect(summary.exitCode).toBe(0);
+  it("exits 0 when all probes green", async () => {
+    const summary = await runVerify({
+      env: "staging",
+      services: ["docs"],
+      runner: async () => ({ ok: true }),
     });
+    expect(summary.exitCode).toBe(0);
+  });
 
-    it("FAILS LOUD on zero resolved targets (never silently exit 0)", async () => {
-        // resolveProbeTargets now throws on unknown service names, so the
-        // zero-target shape can only happen via the API (empty filter
-        // set). We exercise the runVerify guard directly: a runner that's
-        // never called and an exit code of 1 with a clear diagnostic.
-        const summary = await runVerify({
-            env: "staging",
-            services: [],
-            runner: async () => ({ ok: true }),
-        });
-        expect(summary.exitCode).not.toBe(0);
-        expect(summary.failed.length).toBeGreaterThan(0);
+  it("FAILS LOUD on zero resolved targets (never silently exit 0)", async () => {
+    // resolveProbeTargets now throws on unknown service names, so the
+    // zero-target shape can only happen via the API (empty filter
+    // set). We exercise the runVerify guard directly: a runner that's
+    // never called and an exit code of 1 with a clear diagnostic.
+    const summary = await runVerify({
+      env: "staging",
+      services: [],
+      runner: async () => ({ ok: true }),
     });
+    expect(summary.exitCode).not.toBe(0);
+    expect(summary.failed.length).toBeGreaterThan(0);
+  });
 });

--- a/showcase/scripts/__tests__/verify-deploy.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.test.ts
@@ -24,6 +24,12 @@ describe("verify-deploy argv parsing", () => {
         const parsed = parseArgs(["--env", "staging", "--services", "docs,shell"]);
         expect(parsed.services).toEqual(["docs", "shell"]);
     });
+
+    it("rejects empty --services= equals-form (mirrors space-form behavior)", () => {
+        expect(() =>
+            parseArgs(["--env", "staging", "--services="]),
+        ).toThrow(/--services/);
+    });
 });
 
 describe("resolveProbeTargets", () => {
@@ -51,6 +57,30 @@ describe("resolveProbeTargets", () => {
         });
         expect(targets.length).toBe(1);
         expect(targets[0].name).toBe("docs");
+    });
+
+    it("REFUSES a typo'd service name (unknown service, not silent drop)", () => {
+        expect(() =>
+            resolveProbeTargets({ env: "staging", services: ["docss"] }),
+        ).toThrow(/unknown service.*docss/i);
+    });
+
+    it("REFUSES a service that exists in SSOT but is not probe-eligible for the env", () => {
+        // Find a service whose probe[staging] is false.
+        // Use override seam to flip probe state without mutating SSOT.
+        // Since resolveProbeTargets doesn't expose a probe-flag override,
+        // we pick a real service name and an env where the SSOT probe is
+        // false. Search SERVICES for an entry where probe.staging===false.
+        // If none exists, this test still validates the error string for
+        // the more common typo case via the prior test; we focus on the
+        // distinct error phrasing.
+        //
+        // Practical assertion: an unknown name surfaces as "unknown
+        // service", which is structurally a different (clearer) error
+        // than "not probe-eligible". The two paths must be distinguished.
+        expect(() =>
+            resolveProbeTargets({ env: "staging", services: ["totally-fake"] }),
+        ).toThrow(/unknown service/i);
     });
 });
 
@@ -82,5 +112,19 @@ describe("runVerify driver dispatch", () => {
             runner: async () => ({ ok: true }),
         });
         expect(summary.exitCode).toBe(0);
+    });
+
+    it("FAILS LOUD on zero resolved targets (never silently exit 0)", async () => {
+        // resolveProbeTargets now throws on unknown service names, so the
+        // zero-target shape can only happen via the API (empty filter
+        // set). We exercise the runVerify guard directly: a runner that's
+        // never called and an exit code of 1 with a clear diagnostic.
+        const summary = await runVerify({
+            env: "staging",
+            services: [],
+            runner: async () => ({ ok: true }),
+        });
+        expect(summary.exitCode).not.toBe(0);
+        expect(summary.failed.length).toBeGreaterThan(0);
     });
 });

--- a/showcase/scripts/__tests__/verify-deploy.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+    parseArgs,
+    resolveProbeTargets,
+    type ProbeRunner,
+    runVerify,
+} from "../verify-deploy";
+
+describe("verify-deploy argv parsing", () => {
+    it("requires --env", () => {
+        expect(() => parseArgs([])).toThrow(/--env/);
+    });
+
+    it("accepts --env staging and --env prod", () => {
+        expect(parseArgs(["--env", "staging"]).env).toBe("staging");
+        expect(parseArgs(["--env=prod"]).env).toBe("prod");
+    });
+
+    it("rejects unknown envs", () => {
+        expect(() => parseArgs(["--env", "dev"])).toThrow(/Unknown env/);
+    });
+
+    it("accepts optional --services CSV", () => {
+        const parsed = parseArgs(["--env", "staging", "--services", "docs,shell"]);
+        expect(parsed.services).toEqual(["docs", "shell"]);
+    });
+});
+
+describe("resolveProbeTargets", () => {
+    it("filters SSOT to entries where probe[env] is true", () => {
+        const targets = resolveProbeTargets({ env: "staging" });
+        // docs is staging:true → must be present.
+        expect(targets.find((t) => t.name === "docs")).toBeDefined();
+    });
+
+    it("REFUSES when a probe-required service has no domain for the env", () => {
+        expect(() =>
+            resolveProbeTargets({
+                env: "staging",
+                overrides: {
+                    docs: { domains: { staging: "", prod: "docs.copilotkit.ai" } },
+                },
+            }),
+        ).toThrow(/missing.*staging.*domain/i);
+    });
+
+    it("honors --services filter (subset of probe-eligible)", () => {
+        const targets = resolveProbeTargets({
+            env: "staging",
+            services: ["docs"],
+        });
+        expect(targets.length).toBe(1);
+        expect(targets[0].name).toBe("docs");
+    });
+});
+
+describe("runVerify driver dispatch", () => {
+    it("calls the driver for each target and fails loud on any red", async () => {
+        const calls: string[] = [];
+        const runner: ProbeRunner = async (target) => {
+            calls.push(`${target.driver}:${target.host}`);
+            if (target.name === "docs") {
+                return { ok: false, error: "DOM string missing" };
+            }
+            return { ok: true };
+        };
+        const summary = await runVerify({
+            env: "staging",
+            services: ["docs", "shell"],
+            runner,
+        });
+        expect(calls).toContain("docs:docs.staging.copilotkit.ai");
+        expect(calls).toContain("shell:showcase.staging.copilotkit.ai");
+        expect(summary.failed.map((f) => f.name)).toEqual(["docs"]);
+        expect(summary.exitCode).toBe(1);
+    });
+
+    it("exits 0 when all probes green", async () => {
+        const summary = await runVerify({
+            env: "staging",
+            services: ["docs"],
+            runner: async () => ({ ok: true }),
+        });
+        expect(summary.exitCode).toBe(0);
+    });
+});

--- a/showcase/scripts/__tests__/verify-deploy.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.test.ts
@@ -30,6 +30,30 @@ describe("verify-deploy argv parsing", () => {
             parseArgs(["--env", "staging", "--services="]),
         ).toThrow(/--services/);
     });
+
+    it("rejects --services space-form whose CSV is all empty entries (symmetry with equals-form)", () => {
+        // Bug: space-form previously only guarded `!v` on the raw next-arg,
+        // so `--services ,,` produced an empty list that fell through to a
+        // less-precise zero-targets error. Both forms must throw the same
+        // precise `--services requires a CSV value` here.
+        expect(() =>
+            parseArgs(["--env=staging", "--services", ",,"]),
+        ).toThrow(/--services requires a CSV value/);
+    });
+
+    it("rejects bare trailing --env (no following value)", () => {
+        // Bug: `argv[++i]` was undefined and we deferred to a vague
+        // `resolveEnv` error. Must throw the precise message here.
+        expect(() => parseArgs(["--env"])).toThrow(
+            /--env requires a value \(staging\|prod\)/,
+        );
+    });
+
+    it("rejects --env= with empty value (symmetry with bare trailing --env)", () => {
+        expect(() => parseArgs(["--env="])).toThrow(
+            /--env requires a value \(staging\|prod\)/,
+        );
+    });
 });
 
 describe("resolveProbeTargets", () => {

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -10,11 +10,13 @@
 
 import { describe, it, expect } from "vitest";
 import {
+  findMissingServices,
   findUntrackedServices,
   summarizeFailures,
 } from "../verify-railway-image-refs";
 import {
   SERVICES,
+  repoNameFor,
   type ServiceEntry,
 } from "../railway-envs";
 
@@ -150,5 +152,51 @@ describe("summarizeFailures", () => {
     });
     expect(out.shouldFail).toBe(true);
     expect(out.lines.join("\n")).toMatch(/showcase-foo/);
+  });
+});
+
+describe("WS-C: all 27 services gateValidated, with correct overrides", () => {
+  const FIVE_NEW = [
+    ["dashboard", "showcase-shell-dashboard"],
+    ["docs", "showcase-shell-docs"],
+    ["dojo", "showcase-shell-dojo"],
+    ["shell", "showcase-shell"],
+    ["harness", "showcase-harness"],
+  ] as const;
+
+  it("has 27 services in the SSOT", () => {
+    expect(Object.keys(SERVICES)).toHaveLength(27);
+  });
+
+  it("marks every service gateValidated (no Phase-2 holdouts)", () => {
+    const unvalidated = Object.entries(SERVICES)
+      .filter(([, entry]) => !entry.gateValidated)
+      .map(([name]) => name);
+    expect(unvalidated).toEqual([]);
+  });
+
+  for (const [serviceKey, expectedRepo] of FIVE_NEW) {
+    it(`resolves ${serviceKey} -> ${expectedRepo} for both envs via repoNameFor`, () => {
+      expect(repoNameFor(serviceKey, "prod")).toBe(expectedRepo);
+      expect(repoNameFor(serviceKey, "staging")).toBe(expectedRepo);
+    });
+
+    it(`carries the repoNameOverride directly on the SERVICES entry for ${serviceKey}`, () => {
+      const entry = SERVICES[serviceKey];
+      expect(entry.repoNameOverride?.prod).toBe(expectedRepo);
+      expect(entry.repoNameOverride?.staging).toBe(expectedRepo);
+    });
+  }
+
+  it("findMissingServices treats all 27 as gateValidated targets", () => {
+    // With nothing "present", every gateValidated service should
+    // appear in the missing set; after C.3 that means all 27.
+    const missingProd = findMissingServices("prod", new Set<string>());
+    const missingStaging = findMissingServices(
+      "staging",
+      new Set<string>(),
+    );
+    expect(missingProd).toHaveLength(27);
+    expect(missingStaging).toHaveLength(27);
   });
 });

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -13,6 +13,7 @@ import {
   findMissingServices,
   findUntrackedServices,
   summarizeFailures,
+  validateImage,
 } from "../verify-railway-image-refs";
 import {
   SERVICES,
@@ -199,4 +200,72 @@ describe("WS-C: all 27 services gateValidated, with correct overrides", () => {
     expect(missingProd).toHaveLength(27);
     expect(missingStaging).toHaveLength(27);
   });
+});
+
+describe("WS-C: shape validation for the five newly-gated services", () => {
+  const PROD_DIGEST = "@sha256:" + "a".repeat(64);
+
+  const FIVE_NEW = [
+    { key: "dashboard", repo: "showcase-shell-dashboard" },
+    { key: "docs", repo: "showcase-shell-docs" },
+    { key: "dojo", repo: "showcase-shell-dojo" },
+    { key: "shell", repo: "showcase-shell" },
+    { key: "harness", repo: "showcase-harness" },
+  ] as const;
+
+  for (const { key, repo } of FIVE_NEW) {
+    it(`${key}: prod requires @sha256, :latest on prod fails`, () => {
+      const v = validateImage(`ghcr.io/copilotkit/${repo}:latest`, {
+        env: "prod",
+        repoName: repo,
+      });
+      expect(v).not.toBeNull();
+      expect(v?.reason).toMatch(/prod must be pinned to `@sha256:<digest>`/);
+    });
+
+    it(`${key}: prod accepts the canonical @sha256 shape`, () => {
+      const v = validateImage(
+        `ghcr.io/copilotkit/${repo}${PROD_DIGEST}`,
+        { env: "prod", repoName: repo },
+      );
+      expect(v).toBeNull();
+    });
+
+    it(`${key}: staging accepts :latest on the correct repo`, () => {
+      const v = validateImage(`ghcr.io/copilotkit/${repo}:latest`, {
+        env: "staging",
+        repoName: repo,
+      });
+      expect(v).toBeNull();
+    });
+
+    it(`${key}: staging rejects @sha256 (must float on :latest)`, () => {
+      const v = validateImage(
+        `ghcr.io/copilotkit/${repo}${PROD_DIGEST}`,
+        { env: "staging", repoName: repo },
+      );
+      expect(v).not.toBeNull();
+      expect(v?.reason).toMatch(/staging must float on :latest/);
+    });
+
+    it(`${key}: rejects the wrong GHCR repo name on prod`, () => {
+      // E.g. ghcr.io/copilotkit/dashboard@sha256:... — what the gate
+      // would see if someone added gateValidated:true without the
+      // matching repoNameOverride. Repo NAME must match override.
+      const wrongRepo = `ghcr.io/copilotkit/${key}${PROD_DIGEST}`;
+      const v = validateImage(wrongRepo, { env: "prod", repoName: repo });
+      expect(v).not.toBeNull();
+      expect(v?.reason).toMatch(/image repo name mismatches expected/);
+    });
+
+    it(`${key}: rejects the wrong GHCR repo name on staging`, () => {
+      const wrongRepo = `ghcr.io/copilotkit/${key}:latest`;
+      const v = validateImage(wrongRepo, {
+        env: "staging",
+        repoName: repo,
+      });
+      expect(v).not.toBeNull();
+      expect(v?.reason).toMatch(/image repo name mismatches expected/);
+    });
+  }
 });

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -15,11 +15,8 @@ import {
   summarizeFailures,
   validateImage,
 } from "../verify-railway-image-refs";
-import {
-  SERVICES,
-  repoNameFor,
-  type ServiceEntry,
-} from "../railway-envs";
+import { SERVICES, repoNameFor } from "../railway-envs";
+import type { ServiceEntry } from "../railway-envs";
 
 describe("ServiceEntry gateIgnore field", () => {
   it("is optional on the type and defaults to falsy when unset", () => {
@@ -193,10 +190,7 @@ describe("WS-C: all 27 services gateValidated, with correct overrides", () => {
     // With nothing "present", every gateValidated service should
     // appear in the missing set; after C.3 that means all 27.
     const missingProd = findMissingServices("prod", new Set<string>());
-    const missingStaging = findMissingServices(
-      "staging",
-      new Set<string>(),
-    );
+    const missingStaging = findMissingServices("staging", new Set<string>());
     expect(missingProd).toHaveLength(27);
     expect(missingStaging).toHaveLength(27);
   });
@@ -224,10 +218,10 @@ describe("WS-C: shape validation for the five newly-gated services", () => {
     });
 
     it(`${key}: prod accepts the canonical @sha256 shape`, () => {
-      const v = validateImage(
-        `ghcr.io/copilotkit/${repo}${PROD_DIGEST}`,
-        { env: "prod", repoName: repo },
-      );
+      const v = validateImage(`ghcr.io/copilotkit/${repo}${PROD_DIGEST}`, {
+        env: "prod",
+        repoName: repo,
+      });
       expect(v).toBeNull();
     });
 
@@ -240,10 +234,10 @@ describe("WS-C: shape validation for the five newly-gated services", () => {
     });
 
     it(`${key}: staging rejects @sha256 (must float on :latest)`, () => {
-      const v = validateImage(
-        `ghcr.io/copilotkit/${repo}${PROD_DIGEST}`,
-        { env: "staging", repoName: repo },
-      );
+      const v = validateImage(`ghcr.io/copilotkit/${repo}${PROD_DIGEST}`, {
+        env: "staging",
+        repoName: repo,
+      });
       expect(v).not.toBeNull();
       expect(v?.reason).toMatch(/staging must float on :latest/);
     });
@@ -276,8 +270,7 @@ describe("WS-C: malformed ref negatives", () => {
     // Looks vaguely like a digest pin but is actually a *tag* whose
     // literal name starts with "sha256-". This is the closest shape
     // to the 2026-04-21 "atest" corruption and must fail loudly.
-    const bad =
-      "ghcr.io/copilotkit/showcase-shell:sha256-" + "a".repeat(64);
+    const bad = "ghcr.io/copilotkit/showcase-shell:sha256-" + "a".repeat(64);
     const v = validateImage(bad, {
       env: "prod",
       repoName: "showcase-shell",
@@ -290,8 +283,7 @@ describe("WS-C: malformed ref negatives", () => {
   });
 
   it("rejects bare `@sha256:<too-short-hex>` on prod", () => {
-    const bad =
-      "ghcr.io/copilotkit/showcase-shell@sha256:" + "a".repeat(10);
+    const bad = "ghcr.io/copilotkit/showcase-shell@sha256:" + "a".repeat(10);
     const v = validateImage(bad, {
       env: "prod",
       repoName: "showcase-shell",

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -269,3 +269,58 @@ describe("WS-C: shape validation for the five newly-gated services", () => {
     });
   }
 });
+
+describe("WS-C: malformed ref negatives", () => {
+  it("rejects `:sha256-<hex>` on prod (missing the @ separator)", () => {
+    // Shape: ghcr.io/copilotkit/<repo>:sha256-<hex>
+    // Looks vaguely like a digest pin but is actually a *tag* whose
+    // literal name starts with "sha256-". This is the closest shape
+    // to the 2026-04-21 "atest" corruption and must fail loudly.
+    const bad =
+      "ghcr.io/copilotkit/showcase-shell:sha256-" + "a".repeat(64);
+    const v = validateImage(bad, {
+      env: "prod",
+      repoName: "showcase-shell",
+    });
+    expect(v).not.toBeNull();
+    expect(v?.image).toBe(bad);
+    // Reason must mention canonical prod shape so the operator knows
+    // exactly what to fix.
+    expect(v?.reason).toMatch(/canonical (prod )?shape/);
+  });
+
+  it("rejects bare `@sha256:<too-short-hex>` on prod", () => {
+    const bad =
+      "ghcr.io/copilotkit/showcase-shell@sha256:" + "a".repeat(10);
+    const v = validateImage(bad, {
+      env: "prod",
+      repoName: "showcase-shell",
+    });
+    expect(v).not.toBeNull();
+  });
+
+  it("rejects a truncated `atest`-style tag on staging", () => {
+    // The exact 2026-04-21 corruption shape from the script docstring.
+    const bad = "ghcr.io/copilotkit/showcase-shell-dashboardatest";
+    const v = validateImage(bad, {
+      env: "staging",
+      repoName: "showcase-shell-dashboard",
+    });
+    expect(v).not.toBeNull();
+  });
+
+  it("rejects non-ghcr.io registries on both envs", () => {
+    const prodBad =
+      "docker.io/copilotkit/showcase-shell@sha256:" + "b".repeat(64);
+    const stagingBad = "docker.io/copilotkit/showcase-shell:latest";
+    expect(
+      validateImage(prodBad, { env: "prod", repoName: "showcase-shell" }),
+    ).not.toBeNull();
+    expect(
+      validateImage(stagingBad, {
+        env: "staging",
+        repoName: "showcase-shell",
+      }),
+    ).not.toBeNull();
+  });
+});

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the Railway image-ref gate (`verify-railway-image-refs.ts`)
+ * and the SSOT fields it consumes (`railway-envs.ts`).
+ *
+ * Style note: validators are pure and exported; the GraphQL fetch is
+ * the only impure surface and is exercised manually (per the script's
+ * docstring). We unit-test the pure validators against synthesized
+ * inputs — no Railway API calls.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  findUntrackedServices,
+} from "../verify-railway-image-refs";
+import {
+  SERVICES,
+  type ServiceEntry,
+} from "../railway-envs";
+
+describe("ServiceEntry gateIgnore field", () => {
+  it("is optional on the type and defaults to falsy when unset", () => {
+    // Every real SSOT entry has gateIgnore unset (undefined / falsy).
+    for (const [name, entry] of Object.entries(SERVICES)) {
+      const gi = (entry as ServiceEntry).gateIgnore;
+      expect(gi === undefined || gi === false, `${name} gateIgnore`).toBe(true);
+    }
+  });
+});
+
+describe("findUntrackedServices (Railway -> SSOT direction)", () => {
+  it("returns empty when every Railway-reported service is in the SSOT", () => {
+    // The SSOT keys themselves are by definition all in the SSOT, so
+    // passing them as "Railway-reported" should yield zero untracked.
+    const all = new Set(Object.keys(SERVICES));
+    expect(findUntrackedServices(all)).toEqual([]);
+  });
+
+  it("flags a Railway service that is not in the SSOT", () => {
+    const railway = new Set<string>([
+      "showcase-mastra", // tracked
+      "phantom-relay", // untracked
+    ]);
+    expect(findUntrackedServices(railway)).toEqual(["phantom-relay"]);
+  });
+
+  it("returns names sorted for stable output", () => {
+    const railway = new Set<string>([
+      "zeta-svc",
+      "alpha-svc",
+      "showcase-mastra",
+    ]);
+    expect(findUntrackedServices(railway)).toEqual(["alpha-svc", "zeta-svc"]);
+  });
+
+  it("does NOT flag a service that the SSOT marks gateIgnore: true", () => {
+    // Inject a transient entry into SERVICES for this test, then remove.
+    const sentinel = "transient-third-party-relay";
+    (SERVICES as Record<string, ServiceEntry>)[sentinel] = {
+      serviceId: "00000000-0000-0000-0000-000000000000",
+      prodInstanceId: "11111111-1111-1111-1111-111111111111",
+      stagingInstanceId: "22222222-2222-2222-2222-222222222222",
+      ciBuilt: false,
+      gateValidated: false,
+      gateIgnore: true,
+      domains: {
+        staging: "transient-third-party-relay-staging.up.railway.app",
+        prod: "transient-third-party-relay-production.up.railway.app",
+      },
+      probe: { staging: false, prod: false, driver: "agent" },
+    };
+    try {
+      const railway = new Set<string>([sentinel, "showcase-mastra"]);
+      expect(findUntrackedServices(railway)).toEqual([]);
+    } finally {
+      delete (SERVICES as Record<string, ServiceEntry>)[sentinel];
+    }
+  });
+});
+
+describe("main() unknown-service policy", () => {
+  // We exercise the pure helper that main() uses, not main() itself
+  // (main wraps the live GraphQL call and process.exit; out of scope
+  // for a unit test).
+  it("reports an untracked Railway service as a hard violation", () => {
+    const railwayReported = new Set<string>([
+      "showcase-mastra",
+      "rogue-service",
+    ]);
+    const untracked = findUntrackedServices(railwayReported);
+    expect(untracked).toContain("rogue-service");
+    // Hard-fail semantics: any non-empty result must cause the gate
+    // to exit non-zero. We assert the contract by checking the
+    // boolean the caller will branch on:
+    expect(untracked.length > 0).toBe(true);
+  });
+});

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from "vitest";
 import {
   findUntrackedServices,
+  summarizeFailures,
 } from "../verify-railway-image-refs";
 import {
   SERVICES,
@@ -92,5 +93,62 @@ describe("main() unknown-service policy", () => {
     // to exit non-zero. We assert the contract by checking the
     // boolean the caller will branch on:
     expect(untracked.length > 0).toBe(true);
+  });
+});
+
+describe("summarizeFailures", () => {
+  it("includes untracked Railway services in the failure block and exits non-zero", () => {
+    const out = summarizeFailures({
+      violations: [],
+      missingByEnv: { prod: [], staging: [] },
+      untracked: ["phantom-relay"],
+      checked: 50,
+      skipped: 0,
+    });
+    expect(out.shouldFail).toBe(true);
+    expect(out.lines.join("\n")).toMatch(/phantom-relay/);
+    expect(out.lines.join("\n")).toMatch(/not in the SSOT/i);
+  });
+
+  it("does not fail when nothing is wrong", () => {
+    const out = summarizeFailures({
+      violations: [],
+      missingByEnv: { prod: [], staging: [] },
+      untracked: [],
+      checked: 54,
+      skipped: 0,
+    });
+    expect(out.shouldFail).toBe(false);
+  });
+
+  it("flags shape violations", () => {
+    const out = summarizeFailures({
+      violations: [
+        {
+          service: "showcase-mastra",
+          env: "prod",
+          image: "ghcr.io/copilotkit/showcase-mastra:latest",
+          reason: "prod must be pinned to `@sha256:<digest>` (got `:latest`)",
+        },
+      ],
+      missingByEnv: { prod: [], staging: [] },
+      untracked: [],
+      checked: 50,
+      skipped: 0,
+    });
+    expect(out.shouldFail).toBe(true);
+    expect(out.lines.join("\n")).toMatch(/showcase-mastra/);
+  });
+
+  it("flags missing services per env", () => {
+    const out = summarizeFailures({
+      violations: [],
+      missingByEnv: { prod: ["showcase-foo"], staging: [] },
+      untracked: [],
+      checked: 50,
+      skipped: 0,
+    });
+    expect(out.shouldFail).toBe(true);
+    expect(out.lines.join("\n")).toMatch(/showcase-foo/);
   });
 });

--- a/showcase/scripts/aggregate-build-results.ts
+++ b/showcase/scripts/aggregate-build-results.ts
@@ -1,0 +1,56 @@
+/**
+ * aggregate-build-results.ts — run in the `aggregate-build-results` job
+ * of showcase_build.yml AFTER actions/download-artifact has extracted
+ * every per-slot `build-result-<dispatch_name>` artifact into
+ * $INPUT_DIR/build-result-<dispatch_name>/result.json.
+ *
+ * Responsibilities:
+ *   1. Read every per-slot result.json under $INPUT_DIR.
+ *   2. Merge via mergeBuildResultFiles (single source of contract truth).
+ *   3. Write the canonical $OUTPUT_DIR/results.json (uploaded as the
+ *      `build-results` artifact for cross-workflow consumption).
+ *   4. Append `results=...` and `any_success=true|false` to $GITHUB_OUTPUT
+ *      so the redeploy-staging guard and the deploy workflow can read
+ *      them as job-level outputs.
+ *
+ * No GitHub API calls. No job-name parsing. Pure filesystem aggregation.
+ */
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { mergeBuildResultFiles, successSet } from "./lib/build-outputs";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (typeof v !== "string" || v.length === 0) {
+    throw new Error(`aggregate-build-results: $${name} is required`);
+  }
+  return v;
+}
+
+function main(): void {
+  const inDir = requireEnv("INPUT_DIR");
+  const outDir = requireEnv("OUTPUT_DIR");
+  const ghOutput = requireEnv("GITHUB_OUTPUT");
+
+  mkdirSync(outDir, { recursive: true });
+
+  const payloads = readdirSync(inDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && d.name.startsWith("build-result-"))
+    .map((d) => join(inDir, d.name, "result.json"))
+    .map((p) => readFileSync(p, "utf-8"));
+
+  const merged = mergeBuildResultFiles(payloads);
+  writeFileSync(join(outDir, "results.json"), JSON.stringify(merged));
+
+  const anySuccess = successSet(merged).length > 0 ? "true" : "false";
+  appendFileSync(ghOutput, `results=${JSON.stringify(merged)}\n`);
+  appendFileSync(ghOutput, `any_success=${anySuccess}\n`);
+}
+
+main();

--- a/showcase/scripts/aggregate-build-results.ts
+++ b/showcase/scripts/aggregate-build-results.ts
@@ -108,6 +108,22 @@ export function run(opts: RunOptions): void {
     .filter((d) => d.isDirectory() && d.name.startsWith("build-result-"))
     .map((d) => d.name);
 
+  // The aggregator job is gated upstream on `has_changes == 'true'`, so the
+  // build matrix is guaranteed non-empty by the time we run. A zero-slot
+  // input dir therefore signals a BROKEN per-slot artifact download (e.g.
+  // expired artifacts, wrong run-id, transient download error) — NOT a
+  // legitimate empty build set. Silently emitting `any_success=false` with
+  // `results=[]` would be indistinguishable from "all builds failed" and
+  // would push deploy down the false-green path where it probes the full
+  // service set against stale `:latest`. Fail loud instead.
+  if (slotDirs.length === 0) {
+    throw new Error(
+      `aggregate-build-results: found 0 build-result-* slot dirs in ${inputDir} — ` +
+        `the per-slot artifact download produced nothing; this indicates a broken ` +
+        `download, not an empty build set (the job only runs when >=1 service was scheduled).`,
+    );
+  }
+
   const payloads = slotDirs.map((name) => readSlotPayload(inputDir, name));
 
   const merged = mergeBuildResultFiles(payloads);

--- a/showcase/scripts/aggregate-build-results.ts
+++ b/showcase/scripts/aggregate-build-results.ts
@@ -96,7 +96,10 @@ function writeGithubOutput(
     githubOutput,
     `results<<${delimiter}\n${resultsJson}\n${delimiter}\n`,
   );
-  appendFileSync(githubOutput, `any_success=${anySuccess ? "true" : "false"}\n`);
+  appendFileSync(
+    githubOutput,
+    `any_success=${anySuccess ? "true" : "false"}\n`,
+  );
 }
 
 export function run(opts: RunOptions): void {

--- a/showcase/scripts/aggregate-build-results.ts
+++ b/showcase/scripts/aggregate-build-results.ts
@@ -14,6 +14,10 @@
  *      them as job-level outputs.
  *
  * No GitHub API calls. No job-name parsing. Pure filesystem aggregation.
+ *
+ * Testability: env reading lives in the CLI entrypoint at the bottom;
+ * the core is exported as `run({inputDir, outputDir, githubOutput})` so
+ * tests can drive it with temp dirs.
  */
 import {
   appendFileSync,
@@ -22,7 +26,9 @@ import {
   readdirSync,
   writeFileSync,
 } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { mergeBuildResultFiles, successSet } from "./lib/build-outputs";
 
 function requireEnv(name: string): string {
@@ -33,24 +39,113 @@ function requireEnv(name: string): string {
   return v;
 }
 
-function main(): void {
-  const inDir = requireEnv("INPUT_DIR");
-  const outDir = requireEnv("OUTPUT_DIR");
-  const ghOutput = requireEnv("GITHUB_OUTPUT");
-
-  mkdirSync(outDir, { recursive: true });
-
-  const payloads = readdirSync(inDir, { withFileTypes: true })
-    .filter((d) => d.isDirectory() && d.name.startsWith("build-result-"))
-    .map((d) => join(inDir, d.name, "result.json"))
-    .map((p) => readFileSync(p, "utf-8"));
-
-  const merged = mergeBuildResultFiles(payloads);
-  writeFileSync(join(outDir, "results.json"), JSON.stringify(merged));
-
-  const anySuccess = successSet(merged).length > 0 ? "true" : "false";
-  appendFileSync(ghOutput, `results=${JSON.stringify(merged)}\n`);
-  appendFileSync(ghOutput, `any_success=${anySuccess}\n`);
+export interface RunOptions {
+  inputDir: string;
+  outputDir: string;
+  githubOutput: string;
 }
 
-main();
+/**
+ * Read a single per-slot result.json. On failure (missing file, permission
+ * error, etc.), wraps the error with the offending slot directory so the
+ * job log identifies WHICH slot was the culprit instead of dumping a raw
+ * ENOENT against a long opaque path. We refuse to silently skip the slot —
+ * a missing per-slot artifact is a real defect (the build job's artifact
+ * upload step is broken or the matrix collapsed) and silently dropping it
+ * would let a failed build masquerade as "not present" downstream.
+ */
+function readSlotPayload(inputDir: string, slotDirName: string): string {
+  const path = join(inputDir, slotDirName, "result.json");
+  try {
+    return readFileSync(path, "utf-8");
+  } catch (e) {
+    const code =
+      e && typeof e === "object" && "code" in e
+        ? String((e as { code?: unknown }).code)
+        : e instanceof Error
+          ? e.message
+          : String(e);
+    throw new Error(
+      `aggregate-build-results: ${slotDirName} is missing result.json (${code})`,
+      { cause: e },
+    );
+  }
+}
+
+/**
+ * Emit the per-job outputs to $GITHUB_OUTPUT. `results` uses the
+ * multi-line heredoc form, which is the GHA-recommended encoding for
+ * any value that might contain (or grow to contain) a newline — most
+ * importantly, it survives pretty-printed JSON or other multi-line
+ * payloads without truncation. A random delimiter token prevents
+ * collision with embedded payloads. `any_success` stays a plain
+ * key=value line since the value is a fixed boolean literal.
+ *
+ * Written BEFORE results.json so a $GITHUB_OUTPUT write failure
+ * (e.g. the file is missing / not writable) aborts before we publish
+ * an artifact the downstream jobs would consume without seeing the
+ * matching job output.
+ */
+function writeGithubOutput(
+  githubOutput: string,
+  resultsJson: string,
+  anySuccess: boolean,
+): void {
+  const delimiter = `EOF_${randomBytes(8).toString("hex")}`;
+  appendFileSync(
+    githubOutput,
+    `results<<${delimiter}\n${resultsJson}\n${delimiter}\n`,
+  );
+  appendFileSync(githubOutput, `any_success=${anySuccess ? "true" : "false"}\n`);
+}
+
+export function run(opts: RunOptions): void {
+  const { inputDir, outputDir, githubOutput } = opts;
+
+  mkdirSync(outputDir, { recursive: true });
+
+  const slotDirs = readdirSync(inputDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && d.name.startsWith("build-result-"))
+    .map((d) => d.name);
+
+  const payloads = slotDirs.map((name) => readSlotPayload(inputDir, name));
+
+  const merged = mergeBuildResultFiles(payloads);
+  const resultsJson = JSON.stringify(merged);
+  const anySuccess = successSet(merged).length > 0;
+
+  // Emit $GITHUB_OUTPUT first so a write failure here doesn't leave a
+  // published results.json artifact without a matching job output.
+  writeGithubOutput(githubOutput, resultsJson, anySuccess);
+
+  // Trailing newline for consistency with conventional JSON-on-disk
+  // tooling (POSIX line, diff-friendly).
+  writeFileSync(join(outputDir, "results.json"), `${resultsJson}\n`);
+}
+
+function main(): void {
+  run({
+    inputDir: requireEnv("INPUT_DIR"),
+    outputDir: requireEnv("OUTPUT_DIR"),
+    githubOutput: requireEnv("GITHUB_OUTPUT"),
+  });
+}
+
+// CLI entrypoint: only run main() when invoked directly (e.g. `tsx
+// aggregate-build-results.ts`), NOT when imported by a test. Comparing
+// `import.meta.url` against process.argv[1] is the standard ESM idiom.
+const invokedDirectly = (() => {
+  try {
+    return (
+      typeof process !== "undefined" &&
+      Array.isArray(process.argv) &&
+      process.argv[1] === fileURLToPath(import.meta.url)
+    );
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main();
+}

--- a/showcase/scripts/create-integration/index.ts
+++ b/showcase/scripts/create-integration/index.ts
@@ -2011,7 +2011,7 @@ export function updateWorkflows(args: CLIArgs) {
             echo "::error::Railway placeholders not replaced" >&2
             exit 1
           fi
-          curl -sf -X POST https://backboard.railway.com/graphql/v2 \\
+          curl -sf -X POST https://backboard.railway.app/graphql/v2 \\
             -H "Authorization: Bearer \${{ secrets.RAILWAY_TOKEN }}" \\
             -H "Content-Type: application/json" \\
             -d '{"query":"mutation { serviceInstanceRedeploy(serviceId: \\"RAILWAY_SERVICE_ID\\", environmentId: \\"RAILWAY_ENVIRONMENT_ID\\") }"}' \\

--- a/showcase/scripts/deploy-to-railway.ts
+++ b/showcase/scripts/deploy-to-railway.ts
@@ -18,12 +18,13 @@ import fs from "fs";
 import path from "path";
 import yaml from "yaml";
 import { fileURLToPath } from "url";
+import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
 const PACKAGES_DIR = path.join(ROOT, "integrations");
 
-const RAILWAY_API = "https://backboard.railway.com/graphql/v2";
+const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
 
 const SHOWCASE = {
   projectId: "6f8c6bff-a80d-4f8f-b78d-50b32bcf4479",

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -11,6 +11,14 @@
  *
  * Idempotent: writes only when the serialized output differs from disk.
  * CI runs this with `--check`: non-zero exit if the on-disk file is stale.
+ *
+ * Flags:
+ *   --check            Exit 1 if on-disk JSON differs from SSOT (don't write).
+ *                      Exit 2 if the read fails for any reason other than the
+ *                      file being absent (e.g. EACCES, EISDIR) — fail loud
+ *                      rather than masquerade a real error as drift.
+ *   --out=<path>       Override the output path (used by tests for hermetic
+ *                      writes). Defaults to the canonical tracked artifact.
  */
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -22,7 +30,7 @@ import {
   STAGING_ENV_ID,
 } from "./railway-envs";
 
-const OUTPUT_PATH = resolve(
+const DEFAULT_OUTPUT_PATH = resolve(
   new URL(".", import.meta.url).pathname,
   "railway-envs.generated.json",
 );
@@ -74,18 +82,38 @@ function serialize(payload: Emitted): string {
   return JSON.stringify(payload, null, 2) + "\n";
 }
 
+function parseOutPath(args: string[]): string {
+  const flag = args.find((a) => a.startsWith("--out="));
+  if (flag) return resolve(flag.slice("--out=".length));
+  return DEFAULT_OUTPUT_PATH;
+}
+
 function main(): void {
   const args = process.argv.slice(2);
   const check = args.includes("--check");
+  const outputPath = parseOutPath(args);
   const payload = buildPayload();
   const next = serialize(payload);
 
   if (check) {
     let current = "";
     try {
-      current = readFileSync(OUTPUT_PATH, "utf8");
-    } catch {
-      // file missing — treat as drift
+      current = readFileSync(outputPath, "utf8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        // Non-ENOENT errors (EACCES, EISDIR, etc.) are real failures, not
+        // drift. Fail loud so CI surfaces the real cause instead of
+        // overwriting on a false signal or printing a misleading "stale"
+        // message.
+        process.stderr.write(
+          `emit-railway-envs-json: failed to read ${outputPath}: ${
+            (err as Error).message
+          }\n`,
+        );
+        process.exit(2);
+      }
+      // ENOENT — file missing, treat as drift below.
     }
     if (current !== next) {
       process.stderr.write(
@@ -97,9 +125,9 @@ function main(): void {
     return;
   }
 
-  mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
-  writeFileSync(OUTPUT_PATH, next);
-  process.stdout.write(`wrote ${OUTPUT_PATH}\n`);
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, next);
+  process.stdout.write(`wrote ${outputPath}\n`);
 }
 
 const isMain =

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env npx tsx
+/**
+ * emit-railway-envs-json.ts — Serialize the railway-envs.ts SSOT to a
+ * canonical JSON artifact at `showcase/scripts/railway-envs.generated.json`.
+ *
+ * Consumers:
+ *   - showcase/bin/railway (Ruby) reads this to derive EXPECTED_DOMAINS
+ *     instead of maintaining a parallel Ruby hash.
+ *   - .github/workflows/showcase_deploy.yml reads it to build the verify
+ *     matrix without duplicating the inline JSON array.
+ *
+ * Idempotent: writes only when the serialized output differs from disk.
+ * CI runs this with `--check`: non-zero exit if the on-disk file is stale.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import {
+  PRODUCTION_ENV_ID,
+  PROJECT_ID,
+  SERVICES,
+  STAGING_ENV_ID,
+} from "./railway-envs";
+
+const OUTPUT_PATH = resolve(
+  new URL(".", import.meta.url).pathname,
+  "railway-envs.generated.json",
+);
+
+interface Emitted {
+  projectId: string;
+  envIds: { staging: string; prod: string };
+  services: Array<{
+    name: string;
+    serviceId: string;
+    prodInstanceId: string;
+    stagingInstanceId: string;
+    ciBuilt: boolean;
+    gateValidated: boolean;
+    dispatchName?: string;
+    repoNameOverride?: { prod?: string; staging?: string };
+    domains: { staging: string; prod: string };
+    probe: { staging: boolean; prod: boolean; driver: string };
+  }>;
+}
+
+function buildPayload(): Emitted {
+  const services: Emitted["services"] = Object.entries(SERVICES)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, entry]) => ({
+      name,
+      serviceId: entry.serviceId,
+      prodInstanceId: entry.prodInstanceId,
+      stagingInstanceId: entry.stagingInstanceId,
+      ciBuilt: entry.ciBuilt,
+      gateValidated: entry.gateValidated,
+      dispatchName: entry.dispatchName,
+      repoNameOverride: entry.repoNameOverride,
+      domains: { staging: entry.domains.staging, prod: entry.domains.prod },
+      probe: {
+        staging: entry.probe.staging,
+        prod: entry.probe.prod,
+        driver: entry.probe.driver,
+      },
+    }));
+  return {
+    projectId: PROJECT_ID,
+    envIds: { staging: STAGING_ENV_ID, prod: PRODUCTION_ENV_ID },
+    services,
+  };
+}
+
+function serialize(payload: Emitted): string {
+  return JSON.stringify(payload, null, 2) + "\n";
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const check = args.includes("--check");
+  const payload = buildPayload();
+  const next = serialize(payload);
+
+  if (check) {
+    let current = "";
+    try {
+      current = readFileSync(OUTPUT_PATH, "utf8");
+    } catch {
+      // file missing — treat as drift
+    }
+    if (current !== next) {
+      process.stderr.write(
+        `railway-envs.generated.json is stale. Re-run:\n  npx tsx showcase/scripts/emit-railway-envs-json.ts\n`,
+      );
+      process.exit(1);
+    }
+    process.stdout.write("railway-envs.generated.json is up to date.\n");
+    return;
+  }
+
+  mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
+  writeFileSync(OUTPUT_PATH, next);
+  process.stdout.write(`wrote ${OUTPUT_PATH}\n`);
+}
+
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("emit-railway-envs-json.ts");
+if (isMain) main();

--- a/showcase/scripts/lib/__tests__/build-outputs.test.ts
+++ b/showcase/scripts/lib/__tests__/build-outputs.test.ts
@@ -139,6 +139,46 @@ describe("mergeBuildResultFiles", () => {
     expect(() => mergeBuildResultFiles(slotPayloads)).toThrow(/duplicate/i);
     expect(() => mergeBuildResultFiles(slotPayloads)).toThrow(/dup/);
   });
+
+  it("normalizes trailing whitespace in service to its trimmed canonical form", () => {
+    const result = mergeBuildResultFiles([
+      '{"service":"foo ","status":"success"}',
+    ]);
+    expect(result).toEqual([{ service: "foo", status: "success" }]);
+  });
+
+  it("normalizes leading whitespace in service to its trimmed canonical form", () => {
+    const result = mergeBuildResultFiles([
+      '{"service":" foo","status":"success"}',
+    ]);
+    expect(result).toEqual([{ service: "foo", status: "success" }]);
+  });
+
+  it("parseBuildOutputs also returns the trimmed canonical service", () => {
+    const json = JSON.stringify([{ service: "  bar  ", status: "success" }]);
+    expect(parseBuildOutputs(json)).toEqual([
+      { service: "bar", status: "success" },
+    ]);
+  });
+
+  it("detects duplicates that differ only by surrounding whitespace", () => {
+    const slotPayloads = [
+      '{"service":"foo","status":"failure"}',
+      '{"service":"foo ","status":"success"}',
+    ];
+    expect(() => mergeBuildResultFiles(slotPayloads)).toThrow(/duplicate/i);
+    expect(() => mergeBuildResultFiles(slotPayloads)).toThrow(/foo/);
+  });
+
+  it("rejects an array payload with a clear 'expected object' error (not 'missing service')", () => {
+    expect(() => mergeBuildResultFiles(["[]"])).toThrow(/expected object/i);
+    expect(() => mergeBuildResultFiles(["[]"])).not.toThrow(/missing/i);
+  });
+
+  it("parseBuildOutputs rejects an array nested as an entry with 'expected object'", () => {
+    const bad = JSON.stringify([[]]);
+    expect(() => parseBuildOutputs(bad)).toThrow(/expected object/i);
+  });
 });
 
 describe("shouldRedeployStaging", () => {

--- a/showcase/scripts/lib/__tests__/build-outputs.test.ts
+++ b/showcase/scripts/lib/__tests__/build-outputs.test.ts
@@ -3,6 +3,7 @@ import {
   buildResultArtifactName,
   mergeBuildResultFiles,
   parseBuildOutputs,
+  shouldRedeployStaging,
   successSet,
 } from "../build-outputs";
 import type { BuildOutcome, ServiceBuildResult } from "../build-outputs";
@@ -93,5 +94,29 @@ describe("mergeBuildResultFiles", () => {
 
   it("returns an empty array when no slot payloads are provided", () => {
     expect(mergeBuildResultFiles([])).toEqual([]);
+  });
+});
+
+describe("shouldRedeployStaging", () => {
+  it("returns true when at least one service succeeded", () => {
+    expect(
+      shouldRedeployStaging([
+        { service: "a", status: "success" },
+        { service: "b", status: "failure" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when every service failed or was skipped", () => {
+    expect(
+      shouldRedeployStaging([
+        { service: "a", status: "failure" },
+        { service: "b", status: "skipped" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns false on empty input", () => {
+    expect(shouldRedeployStaging([])).toBe(false);
   });
 });

--- a/showcase/scripts/lib/__tests__/build-outputs.test.ts
+++ b/showcase/scripts/lib/__tests__/build-outputs.test.ts
@@ -1,55 +1,97 @@
 import { describe, expect, it } from "vitest";
 import {
-    parseBuildOutputs,
-    successSet,
-    type BuildOutcome,
-    type ServiceBuildResult,
+  buildResultArtifactName,
+  mergeBuildResultFiles,
+  parseBuildOutputs,
+  successSet,
 } from "../build-outputs";
+import type { BuildOutcome, ServiceBuildResult } from "../build-outputs";
 
 const sample: ServiceBuildResult[] = [
-    { service: "showcase-mastra", status: "success" },
-    { service: "showcase-ag2", status: "failure" },
-    { service: "shell-docs", status: "skipped" },
-    { service: "showcase-aimock", status: "success" },
+  { service: "showcase-mastra", status: "success" },
+  { service: "showcase-ag2", status: "failure" },
+  { service: "shell-docs", status: "skipped" },
+  { service: "showcase-aimock", status: "success" },
 ];
 
 describe("build-outputs", () => {
-    it("parses a JSON array of {service,status} entries", () => {
-        const json = JSON.stringify(sample);
-        expect(parseBuildOutputs(json)).toEqual(sample);
-    });
+  it("parses a JSON array of {service,status} entries", () => {
+    const json = JSON.stringify(sample);
+    expect(parseBuildOutputs(json)).toEqual(sample);
+  });
 
-    it("throws on malformed JSON", () => {
-        expect(() => parseBuildOutputs("not json")).toThrow(/parse/i);
-    });
+  it("throws on malformed JSON", () => {
+    expect(() => parseBuildOutputs("not json")).toThrow(/parse/i);
+  });
 
-    it("throws on entries missing fields", () => {
-        expect(() => parseBuildOutputs(JSON.stringify([{ service: "x" }]))).toThrow(
-            /status/i,
-        );
-    });
+  it("throws on entries missing fields", () => {
+    expect(() => parseBuildOutputs(JSON.stringify([{ service: "x" }]))).toThrow(
+      /status/i,
+    );
+  });
 
-    it("throws on an unknown status value", () => {
-        const bad = JSON.stringify([{ service: "x", status: "weird" }]);
-        expect(() => parseBuildOutputs(bad)).toThrow(/status/i);
-    });
+  it("throws on an unknown status value", () => {
+    const bad = JSON.stringify([{ service: "x", status: "weird" }]);
+    expect(() => parseBuildOutputs(bad)).toThrow(/status/i);
+  });
 
-    it("successSet returns only services with status === 'success'", () => {
-        expect(successSet(sample).sort()).toEqual(
-            ["showcase-aimock", "showcase-mastra"].sort(),
-        );
-    });
+  it("successSet returns only services with status === 'success'", () => {
+    expect(successSet(sample).sort()).toEqual(
+      ["showcase-aimock", "showcase-mastra"].sort(),
+    );
+  });
 
-    it("successSet returns empty when no services succeeded", () => {
-        const allFailed: ServiceBuildResult[] = [
-            { service: "a", status: "failure" },
-            { service: "b", status: "failure" },
-        ];
-        expect(successSet(allFailed)).toEqual([]);
-    });
+  it("successSet returns empty when no services succeeded", () => {
+    const allFailed: ServiceBuildResult[] = [
+      { service: "a", status: "failure" },
+      { service: "b", status: "failure" },
+    ];
+    expect(successSet(allFailed)).toEqual([]);
+  });
 
-    it("type BuildOutcome enumerates success|failure|skipped", () => {
-        const outcomes: BuildOutcome[] = ["success", "failure", "skipped"];
-        expect(outcomes).toHaveLength(3);
-    });
+  it("type BuildOutcome enumerates success|failure|skipped", () => {
+    const outcomes: BuildOutcome[] = ["success", "failure", "skipped"];
+    expect(outcomes).toHaveLength(3);
+  });
+});
+
+describe("buildResultArtifactName", () => {
+  it("returns the canonical per-slot artifact name", () => {
+    expect(buildResultArtifactName("showcase-aimock")).toBe(
+      "build-result-showcase-aimock",
+    );
+  });
+
+  it("rejects empty service names (would collide with aggregate artifact)", () => {
+    expect(() => buildResultArtifactName("")).toThrow(/service/i);
+  });
+});
+
+describe("mergeBuildResultFiles", () => {
+  it("merges per-slot {service,status} JSON payloads into a single array", () => {
+    const slotPayloads = [
+      '{"service":"showcase-mastra","status":"success"}',
+      '{"service":"showcase-ag2","status":"failure"}',
+      '{"service":"showcase-aimock","status":"success"}',
+    ];
+    expect(mergeBuildResultFiles(slotPayloads)).toEqual([
+      { service: "showcase-mastra", status: "success" },
+      { service: "showcase-ag2", status: "failure" },
+      { service: "showcase-aimock", status: "success" },
+    ]);
+  });
+
+  it("throws when a slot payload is missing service or status", () => {
+    expect(() => mergeBuildResultFiles(['{"service":"x"}'])).toThrow(/status/i);
+  });
+
+  it("throws on an invalid status value", () => {
+    expect(() =>
+      mergeBuildResultFiles(['{"service":"x","status":"weird"}']),
+    ).toThrow(/status/i);
+  });
+
+  it("returns an empty array when no slot payloads are provided", () => {
+    expect(mergeBuildResultFiles([])).toEqual([]);
+  });
 });

--- a/showcase/scripts/lib/__tests__/build-outputs.test.ts
+++ b/showcase/scripts/lib/__tests__/build-outputs.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+    parseBuildOutputs,
+    successSet,
+    type BuildOutcome,
+    type ServiceBuildResult,
+} from "../build-outputs";
+
+const sample: ServiceBuildResult[] = [
+    { service: "showcase-mastra", status: "success" },
+    { service: "showcase-ag2", status: "failure" },
+    { service: "shell-docs", status: "skipped" },
+    { service: "showcase-aimock", status: "success" },
+];
+
+describe("build-outputs", () => {
+    it("parses a JSON array of {service,status} entries", () => {
+        const json = JSON.stringify(sample);
+        expect(parseBuildOutputs(json)).toEqual(sample);
+    });
+
+    it("throws on malformed JSON", () => {
+        expect(() => parseBuildOutputs("not json")).toThrow(/parse/i);
+    });
+
+    it("throws on entries missing fields", () => {
+        expect(() => parseBuildOutputs(JSON.stringify([{ service: "x" }]))).toThrow(
+            /status/i,
+        );
+    });
+
+    it("throws on an unknown status value", () => {
+        const bad = JSON.stringify([{ service: "x", status: "weird" }]);
+        expect(() => parseBuildOutputs(bad)).toThrow(/status/i);
+    });
+
+    it("successSet returns only services with status === 'success'", () => {
+        expect(successSet(sample).sort()).toEqual(
+            ["showcase-aimock", "showcase-mastra"].sort(),
+        );
+    });
+
+    it("successSet returns empty when no services succeeded", () => {
+        const allFailed: ServiceBuildResult[] = [
+            { service: "a", status: "failure" },
+            { service: "b", status: "failure" },
+        ];
+        expect(successSet(allFailed)).toEqual([]);
+    });
+
+    it("type BuildOutcome enumerates success|failure|skipped", () => {
+        const outcomes: BuildOutcome[] = ["success", "failure", "skipped"];
+        expect(outcomes).toHaveLength(3);
+    });
+});

--- a/showcase/scripts/lib/__tests__/build-outputs.test.ts
+++ b/showcase/scripts/lib/__tests__/build-outputs.test.ts
@@ -36,6 +36,24 @@ describe("build-outputs", () => {
     expect(() => parseBuildOutputs(bad)).toThrow(/status/i);
   });
 
+  it("rejects an empty service string", () => {
+    const bad = JSON.stringify([{ service: "", status: "success" }]);
+    expect(() => parseBuildOutputs(bad)).toThrow(/service/i);
+  });
+
+  it("rejects a whitespace-only service string", () => {
+    const bad = JSON.stringify([{ service: "   ", status: "success" }]);
+    expect(() => parseBuildOutputs(bad)).toThrow(/service/i);
+  });
+
+  it("error message for parseBuildOutputs includes the entry index", () => {
+    const bad = JSON.stringify([
+      { service: "ok", status: "success" },
+      { service: "x", status: "weird" },
+    ]);
+    expect(() => parseBuildOutputs(bad)).toThrow(/\[1\]/);
+  });
+
   it("successSet returns only services with status === 'success'", () => {
     expect(successSet(sample).sort()).toEqual(
       ["showcase-aimock", "showcase-mastra"].sort(),
@@ -66,6 +84,10 @@ describe("buildResultArtifactName", () => {
   it("rejects empty service names (would collide with aggregate artifact)", () => {
     expect(() => buildResultArtifactName("")).toThrow(/service/i);
   });
+
+  it("rejects whitespace-only service names", () => {
+    expect(() => buildResultArtifactName("   ")).toThrow(/service/i);
+  });
 });
 
 describe("mergeBuildResultFiles", () => {
@@ -94,6 +116,28 @@ describe("mergeBuildResultFiles", () => {
 
   it("returns an empty array when no slot payloads are provided", () => {
     expect(mergeBuildResultFiles([])).toEqual([]);
+  });
+
+  it("rejects an empty service in a slot payload", () => {
+    expect(() =>
+      mergeBuildResultFiles(['{"service":"","status":"success"}']),
+    ).toThrow(/service/i);
+  });
+
+  it("rejects a whitespace-only service in a slot payload", () => {
+    expect(() =>
+      mergeBuildResultFiles(['{"service":"   ","status":"success"}']),
+    ).toThrow(/service/i);
+  });
+
+  it("throws when duplicate service names appear across slot payloads", () => {
+    const slotPayloads = [
+      '{"service":"dup","status":"failure"}',
+      '{"service":"other","status":"success"}',
+      '{"service":"dup","status":"success"}',
+    ];
+    expect(() => mergeBuildResultFiles(slotPayloads)).toThrow(/duplicate/i);
+    expect(() => mergeBuildResultFiles(slotPayloads)).toThrow(/dup/);
   });
 });
 

--- a/showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 
 const REPO_ROOT = path.resolve(__dirname, "../../../..");
@@ -8,20 +8,45 @@ describe("Railway GraphQL host unification", () => {
   it("no source file references backboard.railway.com (must be .app)", () => {
     // grep across showcase/ and .github/workflows/. Use -F (literal) so
     // the dot in the pattern is not regex-interpreted. The test file
-    // itself contains the forbidden literal; exclude it via --glob.
-    // Also exclude two files that legitimately reference the deprecated
-    // host in documentation/negative-assertion form (no functional use):
+    // itself contains the forbidden literal; exclude it via git pathspec
+    // `:(exclude)` magic. Also exclude two files that legitimately
+    // reference the deprecated host in documentation/negative-assertion
+    // form (no functional use):
     //   - railway-graphql.ts JSDoc explains the deprecated .com endpoint
     //   - railway-graphql.test.ts asserts the endpoint is NOT .com
+    // Use --untracked so a newly-added (not-yet-committed) file that
+    // reintroduces the forbidden host still trips the guard. Use
+    // execFileSync with an args array so REPO_ROOT is not shell-parsed.
     let out = "";
     try {
-      out = execSync(
-        `git -C ${REPO_ROOT} grep -nF "backboard.railway.com" -- showcase ':(exclude)showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts' ':(exclude)showcase/scripts/lib/railway-graphql.ts' ':(exclude)showcase/scripts/lib/__tests__/railway-graphql.test.ts' .github/workflows`,
+      out = execFileSync(
+        "git",
+        [
+          "-C",
+          REPO_ROOT,
+          "grep",
+          "--untracked",
+          "-nF",
+          "backboard.railway.com",
+          "--",
+          "showcase",
+          ":(exclude)showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts",
+          ":(exclude)showcase/scripts/lib/railway-graphql.ts",
+          ":(exclude)showcase/scripts/lib/__tests__/railway-graphql.test.ts",
+          ".github/workflows",
+        ],
         { encoding: "utf-8" },
       );
-    } catch {
-      // git grep exits 1 when no matches — that's the success case.
-      out = "";
+    } catch (err) {
+      // git grep exits 1 when no matches — that's the clean-miss success
+      // case. Any other exit status (git missing, bad cwd, pathspec
+      // syntax error, etc.) must fail loud rather than silently pass.
+      const status = (err as { status?: number }).status;
+      if (status === 1) {
+        out = "";
+      } else {
+        throw err;
+      }
     }
     expect(out).toBe("");
   });

--- a/showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts
@@ -9,10 +9,14 @@ describe("Railway GraphQL host unification", () => {
     // grep across showcase/ and .github/workflows/. Use -F (literal) so
     // the dot in the pattern is not regex-interpreted. The test file
     // itself contains the forbidden literal; exclude it via --glob.
+    // Also exclude two files that legitimately reference the deprecated
+    // host in documentation/negative-assertion form (no functional use):
+    //   - railway-graphql.ts JSDoc explains the deprecated .com endpoint
+    //   - railway-graphql.test.ts asserts the endpoint is NOT .com
     let out = "";
     try {
       out = execSync(
-        `git -C ${REPO_ROOT} grep -nF "backboard.railway.com" -- showcase ':(exclude)showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts' .github/workflows`,
+        `git -C ${REPO_ROOT} grep -nF "backboard.railway.com" -- showcase ':(exclude)showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts' ':(exclude)showcase/scripts/lib/railway-graphql.ts' ':(exclude)showcase/scripts/lib/__tests__/railway-graphql.test.ts' .github/workflows`,
         { encoding: "utf-8" },
       );
     } catch {

--- a/showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { execSync } from "node:child_process";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+
+describe("Railway GraphQL host unification", () => {
+  it("no source file references backboard.railway.com (must be .app)", () => {
+    // grep across showcase/ and .github/workflows/. Use -F (literal) so
+    // the dot in the pattern is not regex-interpreted. The test file
+    // itself contains the forbidden literal; exclude it via --glob.
+    let out = "";
+    try {
+      out = execSync(
+        `git -C ${REPO_ROOT} grep -nF "backboard.railway.com" -- showcase ':(exclude)showcase/scripts/lib/__tests__/railway-graphql.scan.test.ts' .github/workflows`,
+        { encoding: "utf-8" },
+      );
+    } catch {
+      // git grep exits 1 when no matches — that's the success case.
+      out = "";
+    }
+    expect(out).toBe("");
+  });
+});

--- a/showcase/scripts/lib/__tests__/railway-graphql.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-graphql.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { RAILWAY_GRAPHQL_ENDPOINT } from "../railway-graphql";
+
+describe("railway-graphql", () => {
+    it("uses the canonical backboard.railway.app host", () => {
+        expect(RAILWAY_GRAPHQL_ENDPOINT).toBe(
+            "https://backboard.railway.app/graphql/v2",
+        );
+    });
+
+    it("never resolves to the .com host (historical drift target)", () => {
+        expect(RAILWAY_GRAPHQL_ENDPOINT).not.toContain("backboard.railway.com");
+    });
+});

--- a/showcase/scripts/lib/__tests__/railway-graphql.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-graphql.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { RAILWAY_GRAPHQL_ENDPOINT } from "../railway-graphql";
 
 describe("railway-graphql", () => {
-    it("uses the canonical backboard.railway.app host", () => {
-        expect(RAILWAY_GRAPHQL_ENDPOINT).toBe(
-            "https://backboard.railway.app/graphql/v2",
-        );
-    });
+  it("uses the canonical backboard.railway.app host", () => {
+    expect(RAILWAY_GRAPHQL_ENDPOINT).toBe(
+      "https://backboard.railway.app/graphql/v2",
+    );
+  });
 
-    it("never resolves to the .com host (historical drift target)", () => {
-        expect(RAILWAY_GRAPHQL_ENDPOINT).not.toContain("backboard.railway.com");
-    });
+  it("never resolves to the .com host (historical drift target)", () => {
+    expect(RAILWAY_GRAPHQL_ENDPOINT).not.toContain("backboard.railway.com");
+  });
 });

--- a/showcase/scripts/lib/__tests__/railway-token.envelope.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-token.envelope.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    resolveRailwayToken,
+    RailwayTokenError,
+} from "../railway-token";
+
+/**
+ * Envelope-level tests for resolveRailwayToken — the unified resolver
+ * used by redeploy-env.ts and verify-railway-image-refs.ts.
+ *
+ * Each failure mode must throw a DISTINCT, actionable error so the
+ * silent-token-fallthrough diagnostic gap can never re-open.
+ */
+describe("resolveRailwayToken (envelope)", () => {
+    let dir: string;
+    const originalEnv = process.env.RAILWAY_TOKEN;
+    const originalHome = process.env.HOME;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), "rwy-token-env-"));
+        delete process.env.RAILWAY_TOKEN;
+        process.env.HOME = dir;
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+        if (originalEnv === undefined) delete process.env.RAILWAY_TOKEN;
+        else process.env.RAILWAY_TOKEN = originalEnv;
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+    });
+
+    it("returns RAILWAY_TOKEN env var when set, source='env'", () => {
+        process.env.RAILWAY_TOKEN = "env-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        const result = resolveRailwayToken();
+        expect(result.token).toBe(
+            "env-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        );
+        expect(result.source).toBe("env");
+    });
+
+    it("returns token from ~/.railway/config.json when env unset, source='config'", () => {
+        mkdirSync(join(dir, ".railway"));
+        writeFileSync(
+            join(dir, ".railway", "config.json"),
+            JSON.stringify({
+                user: { accessToken: "from-config-aaaaaaaaaaaaaaaaaaaaaaaa" },
+            }),
+        );
+        const result = resolveRailwayToken();
+        expect(result.token).toBe("from-config-aaaaaaaaaaaaaaaaaaaaaaaa");
+        expect(result.source).toBe("config");
+    });
+
+    it("throws DISTINCT error when $HOME is unset and env-var also unset", () => {
+        delete process.env.HOME;
+        expect(() => resolveRailwayToken()).toThrow(RailwayTokenError);
+        try {
+            resolveRailwayToken();
+        } catch (e) {
+            expect(e).toBeInstanceOf(RailwayTokenError);
+            const err = e as RailwayTokenError;
+            expect(err.code).toBe("NO_HOME");
+            expect(err.message).toMatch(/\$HOME/);
+        }
+    });
+
+    it("throws DISTINCT error when ~/.railway/config.json does not exist", () => {
+        try {
+            resolveRailwayToken();
+            throw new Error("should have thrown");
+        } catch (e) {
+            expect(e).toBeInstanceOf(RailwayTokenError);
+            const err = e as RailwayTokenError;
+            expect(err.code).toBe("NO_FILE");
+            expect(err.message).toMatch(/RAILWAY_TOKEN/);
+            expect(err.message).toMatch(/railway login/);
+        }
+    });
+
+    it("throws DISTINCT error when ~/.railway/config.json is malformed JSON", () => {
+        mkdirSync(join(dir, ".railway"));
+        writeFileSync(join(dir, ".railway", "config.json"), "{ not json");
+        try {
+            resolveRailwayToken();
+            throw new Error("should have thrown");
+        } catch (e) {
+            expect(e).toBeInstanceOf(RailwayTokenError);
+            const err = e as RailwayTokenError;
+            expect(err.code).toBe("MALFORMED");
+            expect(err.message).toMatch(/Malformed ~\/\.railway\/config\.json/);
+        }
+    });
+
+    it("throws DISTINCT error when config parses but yields no usable token (the silent-fallthrough gap)", () => {
+        mkdirSync(join(dir, ".railway"));
+        // Parses fine — just no token field at any layer.
+        writeFileSync(
+            join(dir, ".railway", "config.json"),
+            JSON.stringify({ projects: { something: "else" } }),
+        );
+        try {
+            resolveRailwayToken();
+            throw new Error("should have thrown");
+        } catch (e) {
+            expect(e).toBeInstanceOf(RailwayTokenError);
+            const err = e as RailwayTokenError;
+            // CRITICAL: must NOT be the generic NO_FILE message — the
+            // user needs to know the file WAS found but had no token.
+            expect(err.code).toBe("NO_TOKEN_IN_CONFIG");
+            expect(err.message).toMatch(
+                /~\/\.railway\/config\.json.*no.*token|found.*no.*token/i,
+            );
+            // Must also hint at the remedy.
+            expect(err.message).toMatch(/railway login|RAILWAY_TOKEN/);
+        }
+    });
+});

--- a/showcase/scripts/lib/__tests__/railway-token.envelope.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-token.envelope.test.ts
@@ -60,11 +60,48 @@ describe("resolveRailwayToken (envelope)", () => {
         expect(() => resolveRailwayToken()).toThrow(RailwayTokenError);
         try {
             resolveRailwayToken();
+            throw new Error("should have thrown");
         } catch (e) {
             expect(e).toBeInstanceOf(RailwayTokenError);
             const err = e as RailwayTokenError;
             expect(err.code).toBe("NO_HOME");
             expect(err.message).toMatch(/\$HOME/);
+        }
+    });
+
+    it("trims RAILWAY_TOKEN env var (padded with whitespace/newline)", () => {
+        process.env.RAILWAY_TOKEN =
+            "  padded-token-xxxxxxxxxxxxxxxxxxxxxxxx\n";
+        const result = resolveRailwayToken();
+        expect(result.token).toBe("padded-token-xxxxxxxxxxxxxxxxxxxxxxxx");
+        expect(result.source).toBe("env");
+    });
+
+    it("treats whitespace-only RAILWAY_TOKEN as UNSET and falls through to config", () => {
+        process.env.RAILWAY_TOKEN = "   ";
+        mkdirSync(join(dir, ".railway"));
+        writeFileSync(
+            join(dir, ".railway", "config.json"),
+            JSON.stringify({
+                user: { accessToken: "from-config-bbbbbbbbbbbbbbbbbbbbbbbb" },
+            }),
+        );
+        const result = resolveRailwayToken();
+        expect(result.token).toBe("from-config-bbbbbbbbbbbbbbbbbbbbbbbb");
+        expect(result.source).toBe("config");
+    });
+
+    it("treats whitespace-only RAILWAY_TOKEN as UNSET and surfaces NO_FILE when no config exists", () => {
+        process.env.RAILWAY_TOKEN = "   \n";
+        try {
+            resolveRailwayToken();
+            throw new Error("should have thrown");
+        } catch (e) {
+            expect(e).toBeInstanceOf(RailwayTokenError);
+            const err = e as RailwayTokenError;
+            // Must NOT be returned as source="env" with a whitespace token —
+            // that produces invalid Bearer headers and silent 401s.
+            expect(err.code).toBe("NO_FILE");
         }
     });
 

--- a/showcase/scripts/lib/__tests__/railway-token.envelope.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-token.envelope.test.ts
@@ -2,10 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-    resolveRailwayToken,
-    RailwayTokenError,
-} from "../railway-token";
+import { resolveRailwayToken, RailwayTokenError } from "../railway-token";
 
 /**
  * Envelope-level tests for resolveRailwayToken — the unified resolver
@@ -15,144 +12,141 @@ import {
  * silent-token-fallthrough diagnostic gap can never re-open.
  */
 describe("resolveRailwayToken (envelope)", () => {
-    let dir: string;
-    const originalEnv = process.env.RAILWAY_TOKEN;
-    const originalHome = process.env.HOME;
+  let dir: string;
+  const originalEnv = process.env.RAILWAY_TOKEN;
+  const originalHome = process.env.HOME;
 
-    beforeEach(() => {
-        dir = mkdtempSync(join(tmpdir(), "rwy-token-env-"));
-        delete process.env.RAILWAY_TOKEN;
-        process.env.HOME = dir;
-    });
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rwy-token-env-"));
+    delete process.env.RAILWAY_TOKEN;
+    process.env.HOME = dir;
+  });
 
-    afterEach(() => {
-        rmSync(dir, { recursive: true, force: true });
-        if (originalEnv === undefined) delete process.env.RAILWAY_TOKEN;
-        else process.env.RAILWAY_TOKEN = originalEnv;
-        if (originalHome === undefined) delete process.env.HOME;
-        else process.env.HOME = originalHome;
-    });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (originalEnv === undefined) delete process.env.RAILWAY_TOKEN;
+    else process.env.RAILWAY_TOKEN = originalEnv;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+  });
 
-    it("returns RAILWAY_TOKEN env var when set, source='env'", () => {
-        process.env.RAILWAY_TOKEN = "env-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-        const result = resolveRailwayToken();
-        expect(result.token).toBe(
-            "env-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        );
-        expect(result.source).toBe("env");
-    });
+  it("returns RAILWAY_TOKEN env var when set, source='env'", () => {
+    process.env.RAILWAY_TOKEN = "env-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+    const result = resolveRailwayToken();
+    expect(result.token).toBe("env-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+    expect(result.source).toBe("env");
+  });
 
-    it("returns token from ~/.railway/config.json when env unset, source='config'", () => {
-        mkdirSync(join(dir, ".railway"));
-        writeFileSync(
-            join(dir, ".railway", "config.json"),
-            JSON.stringify({
-                user: { accessToken: "from-config-aaaaaaaaaaaaaaaaaaaaaaaa" },
-            }),
-        );
-        const result = resolveRailwayToken();
-        expect(result.token).toBe("from-config-aaaaaaaaaaaaaaaaaaaaaaaa");
-        expect(result.source).toBe("config");
-    });
+  it("returns token from ~/.railway/config.json when env unset, source='config'", () => {
+    mkdirSync(join(dir, ".railway"));
+    writeFileSync(
+      join(dir, ".railway", "config.json"),
+      JSON.stringify({
+        user: { accessToken: "from-config-aaaaaaaaaaaaaaaaaaaaaaaa" },
+      }),
+    );
+    const result = resolveRailwayToken();
+    expect(result.token).toBe("from-config-aaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(result.source).toBe("config");
+  });
 
-    it("throws DISTINCT error when $HOME is unset and env-var also unset", () => {
-        delete process.env.HOME;
-        expect(() => resolveRailwayToken()).toThrow(RailwayTokenError);
-        try {
-            resolveRailwayToken();
-            throw new Error("should have thrown");
-        } catch (e) {
-            expect(e).toBeInstanceOf(RailwayTokenError);
-            const err = e as RailwayTokenError;
-            expect(err.code).toBe("NO_HOME");
-            expect(err.message).toMatch(/\$HOME/);
-        }
-    });
+  it("throws DISTINCT error when $HOME is unset and env-var also unset", () => {
+    delete process.env.HOME;
+    expect(() => resolveRailwayToken()).toThrow(RailwayTokenError);
+    try {
+      resolveRailwayToken();
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RailwayTokenError);
+      const err = e as RailwayTokenError;
+      expect(err.code).toBe("NO_HOME");
+      expect(err.message).toMatch(/\$HOME/);
+    }
+  });
 
-    it("trims RAILWAY_TOKEN env var (padded with whitespace/newline)", () => {
-        process.env.RAILWAY_TOKEN =
-            "  padded-token-xxxxxxxxxxxxxxxxxxxxxxxx\n";
-        const result = resolveRailwayToken();
-        expect(result.token).toBe("padded-token-xxxxxxxxxxxxxxxxxxxxxxxx");
-        expect(result.source).toBe("env");
-    });
+  it("trims RAILWAY_TOKEN env var (padded with whitespace/newline)", () => {
+    process.env.RAILWAY_TOKEN = "  padded-token-xxxxxxxxxxxxxxxxxxxxxxxx\n";
+    const result = resolveRailwayToken();
+    expect(result.token).toBe("padded-token-xxxxxxxxxxxxxxxxxxxxxxxx");
+    expect(result.source).toBe("env");
+  });
 
-    it("treats whitespace-only RAILWAY_TOKEN as UNSET and falls through to config", () => {
-        process.env.RAILWAY_TOKEN = "   ";
-        mkdirSync(join(dir, ".railway"));
-        writeFileSync(
-            join(dir, ".railway", "config.json"),
-            JSON.stringify({
-                user: { accessToken: "from-config-bbbbbbbbbbbbbbbbbbbbbbbb" },
-            }),
-        );
-        const result = resolveRailwayToken();
-        expect(result.token).toBe("from-config-bbbbbbbbbbbbbbbbbbbbbbbb");
-        expect(result.source).toBe("config");
-    });
+  it("treats whitespace-only RAILWAY_TOKEN as UNSET and falls through to config", () => {
+    process.env.RAILWAY_TOKEN = "   ";
+    mkdirSync(join(dir, ".railway"));
+    writeFileSync(
+      join(dir, ".railway", "config.json"),
+      JSON.stringify({
+        user: { accessToken: "from-config-bbbbbbbbbbbbbbbbbbbbbbbb" },
+      }),
+    );
+    const result = resolveRailwayToken();
+    expect(result.token).toBe("from-config-bbbbbbbbbbbbbbbbbbbbbbbb");
+    expect(result.source).toBe("config");
+  });
 
-    it("treats whitespace-only RAILWAY_TOKEN as UNSET and surfaces NO_FILE when no config exists", () => {
-        process.env.RAILWAY_TOKEN = "   \n";
-        try {
-            resolveRailwayToken();
-            throw new Error("should have thrown");
-        } catch (e) {
-            expect(e).toBeInstanceOf(RailwayTokenError);
-            const err = e as RailwayTokenError;
-            // Must NOT be returned as source="env" with a whitespace token —
-            // that produces invalid Bearer headers and silent 401s.
-            expect(err.code).toBe("NO_FILE");
-        }
-    });
+  it("treats whitespace-only RAILWAY_TOKEN as UNSET and surfaces NO_FILE when no config exists", () => {
+    process.env.RAILWAY_TOKEN = "   \n";
+    try {
+      resolveRailwayToken();
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RailwayTokenError);
+      const err = e as RailwayTokenError;
+      // Must NOT be returned as source="env" with a whitespace token —
+      // that produces invalid Bearer headers and silent 401s.
+      expect(err.code).toBe("NO_FILE");
+    }
+  });
 
-    it("throws DISTINCT error when ~/.railway/config.json does not exist", () => {
-        try {
-            resolveRailwayToken();
-            throw new Error("should have thrown");
-        } catch (e) {
-            expect(e).toBeInstanceOf(RailwayTokenError);
-            const err = e as RailwayTokenError;
-            expect(err.code).toBe("NO_FILE");
-            expect(err.message).toMatch(/RAILWAY_TOKEN/);
-            expect(err.message).toMatch(/railway login/);
-        }
-    });
+  it("throws DISTINCT error when ~/.railway/config.json does not exist", () => {
+    try {
+      resolveRailwayToken();
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RailwayTokenError);
+      const err = e as RailwayTokenError;
+      expect(err.code).toBe("NO_FILE");
+      expect(err.message).toMatch(/RAILWAY_TOKEN/);
+      expect(err.message).toMatch(/railway login/);
+    }
+  });
 
-    it("throws DISTINCT error when ~/.railway/config.json is malformed JSON", () => {
-        mkdirSync(join(dir, ".railway"));
-        writeFileSync(join(dir, ".railway", "config.json"), "{ not json");
-        try {
-            resolveRailwayToken();
-            throw new Error("should have thrown");
-        } catch (e) {
-            expect(e).toBeInstanceOf(RailwayTokenError);
-            const err = e as RailwayTokenError;
-            expect(err.code).toBe("MALFORMED");
-            expect(err.message).toMatch(/Malformed ~\/\.railway\/config\.json/);
-        }
-    });
+  it("throws DISTINCT error when ~/.railway/config.json is malformed JSON", () => {
+    mkdirSync(join(dir, ".railway"));
+    writeFileSync(join(dir, ".railway", "config.json"), "{ not json");
+    try {
+      resolveRailwayToken();
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RailwayTokenError);
+      const err = e as RailwayTokenError;
+      expect(err.code).toBe("MALFORMED");
+      expect(err.message).toMatch(/Malformed ~\/\.railway\/config\.json/);
+    }
+  });
 
-    it("throws DISTINCT error when config parses but yields no usable token (the silent-fallthrough gap)", () => {
-        mkdirSync(join(dir, ".railway"));
-        // Parses fine — just no token field at any layer.
-        writeFileSync(
-            join(dir, ".railway", "config.json"),
-            JSON.stringify({ projects: { something: "else" } }),
-        );
-        try {
-            resolveRailwayToken();
-            throw new Error("should have thrown");
-        } catch (e) {
-            expect(e).toBeInstanceOf(RailwayTokenError);
-            const err = e as RailwayTokenError;
-            // CRITICAL: must NOT be the generic NO_FILE message — the
-            // user needs to know the file WAS found but had no token.
-            expect(err.code).toBe("NO_TOKEN_IN_CONFIG");
-            expect(err.message).toMatch(
-                /~\/\.railway\/config\.json.*no.*token|found.*no.*token/i,
-            );
-            // Must also hint at the remedy.
-            expect(err.message).toMatch(/railway login|RAILWAY_TOKEN/);
-        }
-    });
+  it("throws DISTINCT error when config parses but yields no usable token (the silent-fallthrough gap)", () => {
+    mkdirSync(join(dir, ".railway"));
+    // Parses fine — just no token field at any layer.
+    writeFileSync(
+      join(dir, ".railway", "config.json"),
+      JSON.stringify({ projects: { something: "else" } }),
+    );
+    try {
+      resolveRailwayToken();
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RailwayTokenError);
+      const err = e as RailwayTokenError;
+      // CRITICAL: must NOT be the generic NO_FILE message — the
+      // user needs to know the file WAS found but had no token.
+      expect(err.code).toBe("NO_TOKEN_IN_CONFIG");
+      expect(err.message).toMatch(
+        /~\/\.railway\/config\.json.*no.*token|found.*no.*token/i,
+      );
+      // Must also hint at the remedy.
+      expect(err.message).toMatch(/railway login|RAILWAY_TOKEN/);
+    }
+  });
 });

--- a/showcase/scripts/lib/__tests__/railway-token.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-token.test.ts
@@ -136,6 +136,53 @@ describe("resolveRailwayTokenFromConfig", () => {
         expect(warn).not.toHaveBeenCalled();
     });
 
+    it("returns the trimmed token when user.accessToken has surrounding whitespace", () => {
+        const cfg: RailwayConfigShape = {
+            user: { accessToken: "  padded-token-aaaaaaaaaaaaaaaaaaaa  " },
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBe("padded-token-aaaaaaaaaaaaaaaaaaaa");
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("returns the trimmed token when user.accessToken has a trailing newline", () => {
+        const cfg: RailwayConfigShape = {
+            user: { accessToken: "abc-access-token-aaaaaaaaaaaaaaaaaaaa\n" },
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBe("abc-access-token-aaaaaaaaaaaaaaaaaaaa");
+    });
+
+    it("returns the trimmed token when top-level accessToken has surrounding whitespace", () => {
+        const cfg: RailwayConfigShape = {
+            accessToken: "\ttop-padded-aaaaaaaaaaaaaaaaaaaaaaaa\n",
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBe("top-padded-aaaaaaaaaaaaaaaaaaaaaaaa");
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("returns the trimmed token for legacy user.token (with warn)", () => {
+        const cfg: RailwayConfigShape = {
+            user: { token: "  legacy-user-token-aaaaaaaaaa\n" },
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBe("legacy-user-token-aaaaaaaaaa");
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns the trimmed token for legacy top-level token (with warn)", () => {
+        const cfg: RailwayConfigShape = { token: "\nlegacy-top-aaaaaaaaa  " };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBe("legacy-top-aaaaaaaaa");
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
     it("returns undefined when config is an array", () => {
         const warn = vi.fn();
         const result = resolveRailwayTokenFromConfig(

--- a/showcase/scripts/lib/__tests__/railway-token.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-token.test.ts
@@ -1,195 +1,193 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-    resolveRailwayTokenFromConfig,
-    type RailwayConfigShape,
-} from "../railway-token";
+import { resolveRailwayTokenFromConfig } from "../railway-token";
+import type { RailwayConfigShape } from "../railway-token";
 
 describe("resolveRailwayTokenFromConfig", () => {
-    it("prefers user.accessToken when present", () => {
-        const cfg: RailwayConfigShape = {
-            user: {
-                accessToken: "new-access-token-43-chars-or-more-aaaaaaaa",
-                token: "legacy-short-token",
-            },
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBe("new-access-token-43-chars-or-more-aaaaaaaa");
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("prefers user.accessToken when present", () => {
+    const cfg: RailwayConfigShape = {
+      user: {
+        accessToken: "new-access-token-43-chars-or-more-aaaaaaaa",
+        token: "legacy-short-token",
+      },
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBe("new-access-token-43-chars-or-more-aaaaaaaa");
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("falls back to top-level accessToken", () => {
-        const cfg: RailwayConfigShape = {
-            accessToken: "top-level-access-token-aaaaaaaaaaaaaaaaaaaa",
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBe("top-level-access-token-aaaaaaaaaaaaaaaaaaaa");
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("falls back to top-level accessToken", () => {
+    const cfg: RailwayConfigShape = {
+      accessToken: "top-level-access-token-aaaaaaaaaaaaaaaaaaaa",
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBe("top-level-access-token-aaaaaaaaaaaaaaaaaaaa");
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("falls back to legacy user.token AND emits a deprecation warning", () => {
-        const cfg: RailwayConfigShape = {
-            user: { token: "legacy-short-token-aaaaaaaaaa" },
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBe("legacy-short-token-aaaaaaaaaa");
-        expect(warn).toHaveBeenCalledTimes(1);
-        expect(warn.mock.calls[0][0]).toMatch(
-            /deprecated.*user\.token.*accessToken/i,
-        );
-    });
+  it("falls back to legacy user.token AND emits a deprecation warning", () => {
+    const cfg: RailwayConfigShape = {
+      user: { token: "legacy-short-token-aaaaaaaaaa" },
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBe("legacy-short-token-aaaaaaaaaa");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(
+      /deprecated.*user\.token.*accessToken/i,
+    );
+  });
 
-    it("falls back to top-level token with deprecation warning", () => {
-        const cfg: RailwayConfigShape = { token: "legacy-top-aaaaaaaaa" };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBe("legacy-top-aaaaaaaaa");
-        expect(warn).toHaveBeenCalledTimes(1);
-    });
+  it("falls back to top-level token with deprecation warning", () => {
+    const cfg: RailwayConfigShape = { token: "legacy-top-aaaaaaaaa" };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBe("legacy-top-aaaaaaaaa");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
 
-    it("returns undefined and does not warn on an empty config", () => {
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig({}, { warn });
-        expect(result).toBeUndefined();
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("returns undefined and does not warn on an empty config", () => {
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig({}, { warn });
+    expect(result).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("ignores empty-string tokens at every layer", () => {
-        const cfg: RailwayConfigShape = {
-            user: { accessToken: "", token: "" },
-            accessToken: "",
-            token: "",
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBeUndefined();
-    });
+  it("ignores empty-string tokens at every layer", () => {
+    const cfg: RailwayConfigShape = {
+      user: { accessToken: "", token: "" },
+      accessToken: "",
+      token: "",
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBeUndefined();
+  });
 
-    it("treats whitespace-only user.accessToken as empty and falls through", () => {
-        const cfg: RailwayConfigShape = {
-            user: { accessToken: "   " },
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBeUndefined();
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("treats whitespace-only user.accessToken as empty and falls through", () => {
+    const cfg: RailwayConfigShape = {
+      user: { accessToken: "   " },
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("falls through whitespace-only user.accessToken to legacy user.token with warn", () => {
-        const cfg: RailwayConfigShape = {
-            user: {
-                accessToken: "\n\t  ",
-                token: "legacy-short-token-aaaaaaaaaa",
-            },
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBe("legacy-short-token-aaaaaaaaaa");
-        expect(warn).toHaveBeenCalledTimes(1);
-    });
+  it("falls through whitespace-only user.accessToken to legacy user.token with warn", () => {
+    const cfg: RailwayConfigShape = {
+      user: {
+        accessToken: "\n\t  ",
+        token: "legacy-short-token-aaaaaaaaaa",
+      },
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBe("legacy-short-token-aaaaaaaaaa");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
 
-    it("treats whitespace-only tokens at every layer as empty", () => {
-        const cfg: RailwayConfigShape = {
-            user: { accessToken: "  ", token: "\t" },
-            accessToken: "\n",
-            token: "   ",
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBeUndefined();
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("treats whitespace-only tokens at every layer as empty", () => {
+    const cfg: RailwayConfigShape = {
+      user: { accessToken: "  ", token: "\t" },
+      accessToken: "\n",
+      token: "   ",
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("returns undefined when config is null", () => {
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(null, { warn });
-        expect(result).toBeUndefined();
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("returns undefined when config is null", () => {
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(null, { warn });
+    expect(result).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("returns undefined when config is undefined", () => {
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(undefined, { warn });
-        expect(result).toBeUndefined();
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("returns undefined when config is undefined", () => {
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(undefined, { warn });
+    expect(result).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("returns undefined when config is a string (non-object JSON)", () => {
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(
-            "not-an-object" as unknown as RailwayConfigShape,
-            { warn },
-        );
-        expect(result).toBeUndefined();
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("returns undefined when config is a string (non-object JSON)", () => {
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(
+      "not-an-object" as unknown as RailwayConfigShape,
+      { warn },
+    );
+    expect(result).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("returns undefined when config is a number", () => {
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(
-            42 as unknown as RailwayConfigShape,
-            { warn },
-        );
-        expect(result).toBeUndefined();
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("returns undefined when config is a number", () => {
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(
+      42 as unknown as RailwayConfigShape,
+      { warn },
+    );
+    expect(result).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("returns the trimmed token when user.accessToken has surrounding whitespace", () => {
-        const cfg: RailwayConfigShape = {
-            user: { accessToken: "  padded-token-aaaaaaaaaaaaaaaaaaaa  " },
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBe("padded-token-aaaaaaaaaaaaaaaaaaaa");
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("returns the trimmed token when user.accessToken has surrounding whitespace", () => {
+    const cfg: RailwayConfigShape = {
+      user: { accessToken: "  padded-token-aaaaaaaaaaaaaaaaaaaa  " },
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBe("padded-token-aaaaaaaaaaaaaaaaaaaa");
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("returns the trimmed token when user.accessToken has a trailing newline", () => {
-        const cfg: RailwayConfigShape = {
-            user: { accessToken: "abc-access-token-aaaaaaaaaaaaaaaaaaaa\n" },
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBe("abc-access-token-aaaaaaaaaaaaaaaaaaaa");
-    });
+  it("returns the trimmed token when user.accessToken has a trailing newline", () => {
+    const cfg: RailwayConfigShape = {
+      user: { accessToken: "abc-access-token-aaaaaaaaaaaaaaaaaaaa\n" },
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBe("abc-access-token-aaaaaaaaaaaaaaaaaaaa");
+  });
 
-    it("returns the trimmed token when top-level accessToken has surrounding whitespace", () => {
-        const cfg: RailwayConfigShape = {
-            accessToken: "\ttop-padded-aaaaaaaaaaaaaaaaaaaaaaaa\n",
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBe("top-padded-aaaaaaaaaaaaaaaaaaaaaaaa");
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("returns the trimmed token when top-level accessToken has surrounding whitespace", () => {
+    const cfg: RailwayConfigShape = {
+      accessToken: "\ttop-padded-aaaaaaaaaaaaaaaaaaaaaaaa\n",
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBe("top-padded-aaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(warn).not.toHaveBeenCalled();
+  });
 
-    it("returns the trimmed token for legacy user.token (with warn)", () => {
-        const cfg: RailwayConfigShape = {
-            user: { token: "  legacy-user-token-aaaaaaaaaa\n" },
-        };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBe("legacy-user-token-aaaaaaaaaa");
-        expect(warn).toHaveBeenCalledTimes(1);
-    });
+  it("returns the trimmed token for legacy user.token (with warn)", () => {
+    const cfg: RailwayConfigShape = {
+      user: { token: "  legacy-user-token-aaaaaaaaaa\n" },
+    };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBe("legacy-user-token-aaaaaaaaaa");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
 
-    it("returns the trimmed token for legacy top-level token (with warn)", () => {
-        const cfg: RailwayConfigShape = { token: "\nlegacy-top-aaaaaaaaa  " };
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(cfg, { warn });
-        expect(result).toBe("legacy-top-aaaaaaaaa");
-        expect(warn).toHaveBeenCalledTimes(1);
-    });
+  it("returns the trimmed token for legacy top-level token (with warn)", () => {
+    const cfg: RailwayConfigShape = { token: "\nlegacy-top-aaaaaaaaa  " };
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(cfg, { warn });
+    expect(result).toBe("legacy-top-aaaaaaaaa");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
 
-    it("returns undefined when config is an array", () => {
-        const warn = vi.fn();
-        const result = resolveRailwayTokenFromConfig(
-            [] as unknown as RailwayConfigShape,
-            { warn },
-        );
-        expect(result).toBeUndefined();
-        expect(warn).not.toHaveBeenCalled();
-    });
+  it("returns undefined when config is an array", () => {
+    const warn = vi.fn();
+    const result = resolveRailwayTokenFromConfig(
+      [] as unknown as RailwayConfigShape,
+      { warn },
+    );
+    expect(result).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
 });

--- a/showcase/scripts/lib/__tests__/railway-token.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-token.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    resolveRailwayTokenFromConfig,
+    type RailwayConfigShape,
+} from "../railway-token";
+
+describe("resolveRailwayTokenFromConfig", () => {
+    it("prefers user.accessToken when present", () => {
+        const cfg: RailwayConfigShape = {
+            user: {
+                accessToken: "new-access-token-43-chars-or-more-aaaaaaaa",
+                token: "legacy-short-token",
+            },
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBe("new-access-token-43-chars-or-more-aaaaaaaa");
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("falls back to top-level accessToken", () => {
+        const cfg: RailwayConfigShape = {
+            accessToken: "top-level-access-token-aaaaaaaaaaaaaaaaaaaa",
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBe("top-level-access-token-aaaaaaaaaaaaaaaaaaaa");
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("falls back to legacy user.token AND emits a deprecation warning", () => {
+        const cfg: RailwayConfigShape = {
+            user: { token: "legacy-short-token-aaaaaaaaaa" },
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBe("legacy-short-token-aaaaaaaaaa");
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0][0]).toMatch(
+            /deprecated.*user\.token.*accessToken/i,
+        );
+    });
+
+    it("falls back to top-level token with deprecation warning", () => {
+        const cfg: RailwayConfigShape = { token: "legacy-top-aaaaaaaaa" };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBe("legacy-top-aaaaaaaaa");
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns undefined and does not warn on an empty config", () => {
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig({}, { warn });
+        expect(result).toBeUndefined();
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("ignores empty-string tokens at every layer", () => {
+        const cfg: RailwayConfigShape = {
+            user: { accessToken: "", token: "" },
+            accessToken: "",
+            token: "",
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBeUndefined();
+    });
+});

--- a/showcase/scripts/lib/__tests__/railway-token.test.ts
+++ b/showcase/scripts/lib/__tests__/railway-token.test.ts
@@ -66,4 +66,83 @@ describe("resolveRailwayTokenFromConfig", () => {
         const result = resolveRailwayTokenFromConfig(cfg, { warn });
         expect(result).toBeUndefined();
     });
+
+    it("treats whitespace-only user.accessToken as empty and falls through", () => {
+        const cfg: RailwayConfigShape = {
+            user: { accessToken: "   " },
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBeUndefined();
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("falls through whitespace-only user.accessToken to legacy user.token with warn", () => {
+        const cfg: RailwayConfigShape = {
+            user: {
+                accessToken: "\n\t  ",
+                token: "legacy-short-token-aaaaaaaaaa",
+            },
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBe("legacy-short-token-aaaaaaaaaa");
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats whitespace-only tokens at every layer as empty", () => {
+        const cfg: RailwayConfigShape = {
+            user: { accessToken: "  ", token: "\t" },
+            accessToken: "\n",
+            token: "   ",
+        };
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(cfg, { warn });
+        expect(result).toBeUndefined();
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined when config is null", () => {
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(null, { warn });
+        expect(result).toBeUndefined();
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined when config is undefined", () => {
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(undefined, { warn });
+        expect(result).toBeUndefined();
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined when config is a string (non-object JSON)", () => {
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(
+            "not-an-object" as unknown as RailwayConfigShape,
+            { warn },
+        );
+        expect(result).toBeUndefined();
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined when config is a number", () => {
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(
+            42 as unknown as RailwayConfigShape,
+            { warn },
+        );
+        expect(result).toBeUndefined();
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined when config is an array", () => {
+        const warn = vi.fn();
+        const result = resolveRailwayTokenFromConfig(
+            [] as unknown as RailwayConfigShape,
+            { warn },
+        );
+        expect(result).toBeUndefined();
+        expect(warn).not.toHaveBeenCalled();
+    });
 });

--- a/showcase/scripts/lib/build-outputs.ts
+++ b/showcase/scripts/lib/build-outputs.ts
@@ -1,0 +1,68 @@
+/**
+ * build-outputs.ts — Parse + merge the structured per-slot build results
+ * emitted by `showcase_build.yml`. Each matrix slot in the build job
+ * uploads a per-slot artifact named `build-result-<dispatch_name>`
+ * containing a single `result.json` payload of the shape
+ * `{service: "<dispatch_name>", status: "success"|"failure"|"skipped"}`.
+ * The aggregate-build-results job downloads every `build-result-*`
+ * artifact and merges the payloads via `mergeBuildResultFiles` below;
+ * the resulting array is uploaded as the canonical `build-results`
+ * artifact for cross-workflow consumption. The deploy workflow (and the
+ * redeploy guard) read this list instead of parsing job names.
+ */
+
+export type BuildOutcome = "success" | "failure" | "skipped";
+
+export interface ServiceBuildResult {
+    service: string;
+    status: BuildOutcome;
+}
+
+const VALID_STATUSES: ReadonlySet<BuildOutcome> = new Set([
+    "success",
+    "failure",
+    "skipped",
+]);
+
+export function parseBuildOutputs(raw: string): ServiceBuildResult[] {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (e) {
+        throw new Error(
+            `Failed to parse build outputs JSON: ${
+                e instanceof Error ? e.message : String(e)
+            }`,
+        );
+    }
+    if (!Array.isArray(parsed)) {
+        throw new Error("Build outputs must be a JSON array");
+    }
+    const results: ServiceBuildResult[] = [];
+    for (const entry of parsed) {
+        if (
+            typeof entry !== "object" ||
+            entry === null ||
+            typeof (entry as { service?: unknown }).service !== "string"
+        ) {
+            throw new Error(
+                `Build outputs entry missing required string field "service": ${JSON.stringify(entry)}`,
+            );
+        }
+        const status = (entry as { status?: unknown }).status;
+        if (typeof status !== "string" || !VALID_STATUSES.has(status as BuildOutcome)) {
+            throw new Error(
+                `Build outputs entry has invalid "status" (must be success|failure|skipped): ${JSON.stringify(entry)}`,
+            );
+        }
+        results.push({
+            service: (entry as { service: string }).service,
+            status: status as BuildOutcome,
+        });
+    }
+    return results;
+}
+
+export function successSet(results: ServiceBuildResult[]): string[] {
+    return results.filter((r) => r.status === "success").map((r) => r.service);
+}

--- a/showcase/scripts/lib/build-outputs.ts
+++ b/showcase/scripts/lib/build-outputs.ts
@@ -9,20 +9,79 @@
  * the resulting array is uploaded as the canonical `build-results`
  * artifact for cross-workflow consumption. The deploy workflow (and the
  * redeploy guard) read this list instead of parsing job names.
+ *
+ * NOTE: the "single result.json per slot" invariant is enforced
+ * workflow-side (each matrix slot writes exactly one file before
+ * uploading its artifact); this module assumes that contract and
+ * validates only the parsed payload shape, not the filesystem layout.
  */
 
-export type BuildOutcome = "success" | "failure" | "skipped";
+// Single source of truth for the set of valid build outcomes. The
+// `as const` tuple drives BOTH the compile-time `BuildOutcome` union
+// AND the runtime `VALID_STATUSES` set, so adding a status in one
+// place is enforced in the other. The exhaustiveness check below
+// guarantees the tuple and the union stay in lockstep.
+const BUILD_OUTCOMES = ["success", "failure", "skipped"] as const;
+
+export type BuildOutcome = (typeof BUILD_OUTCOMES)[number];
+
+const VALID_STATUSES: ReadonlySet<BuildOutcome> = new Set(BUILD_OUTCOMES);
+
+// Compile-time exhaustiveness check: if BuildOutcome ever drifts from
+// the BUILD_OUTCOMES tuple (e.g. a hand-edited union), this assignment
+// will fail to typecheck.
+const _exhaustive: ReadonlyArray<BuildOutcome> = BUILD_OUTCOMES;
+void _exhaustive;
 
 export interface ServiceBuildResult {
   service: string;
   status: BuildOutcome;
 }
 
-const VALID_STATUSES: ReadonlySet<BuildOutcome> = new Set([
-  "success",
-  "failure",
-  "skipped",
-]);
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Shared validator for a single `{service, status}` payload. Used by
+ * both `parseBuildOutputs` (per array entry) and `mergeBuildResultFiles`
+ * (per slot payload) so validation rules + error wording live in one
+ * place. `contextLabel` is prefixed to every error message — callers
+ * pass something like `"parseBuildOutputs entry[3]"` or
+ * `"mergeBuildResultFiles slot[2]"` so the failure points at the
+ * offending row.
+ */
+function validateServiceBuildResult(
+  raw: unknown,
+  contextLabel: string,
+): ServiceBuildResult {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error(
+      `${contextLabel}: expected object with {service, status}, got ${JSON.stringify(raw)}`,
+    );
+  }
+  const service = (raw as { service?: unknown }).service;
+  if (typeof service !== "string") {
+    throw new Error(
+      `${contextLabel}: missing required string field "service": ${JSON.stringify(raw)}`,
+    );
+  }
+  if (service.trim().length === 0) {
+    throw new Error(
+      `${contextLabel}: field "service" must be a non-empty, non-whitespace string: ${JSON.stringify(raw)}`,
+    );
+  }
+  const status = (raw as { status?: unknown }).status;
+  if (
+    typeof status !== "string" ||
+    !VALID_STATUSES.has(status as BuildOutcome)
+  ) {
+    throw new Error(
+      `${contextLabel}: invalid "status" (must be success|failure|skipped): ${JSON.stringify(raw)}`,
+    );
+  }
+  return { service, status: status as BuildOutcome };
+}
 
 export function parseBuildOutputs(raw: string): ServiceBuildResult[] {
   let parsed: unknown;
@@ -39,32 +98,9 @@ export function parseBuildOutputs(raw: string): ServiceBuildResult[] {
   if (!Array.isArray(parsed)) {
     throw new Error("Build outputs must be a JSON array");
   }
-  const results: ServiceBuildResult[] = [];
-  for (const entry of parsed) {
-    if (
-      typeof entry !== "object" ||
-      entry === null ||
-      typeof (entry as { service?: unknown }).service !== "string"
-    ) {
-      throw new Error(
-        `Build outputs entry missing required string field "service": ${JSON.stringify(entry)}`,
-      );
-    }
-    const status = (entry as { status?: unknown }).status;
-    if (
-      typeof status !== "string" ||
-      !VALID_STATUSES.has(status as BuildOutcome)
-    ) {
-      throw new Error(
-        `Build outputs entry has invalid "status" (must be success|failure|skipped): ${JSON.stringify(entry)}`,
-      );
-    }
-    results.push({
-      service: (entry as { service: string }).service,
-      status: status as BuildOutcome,
-    });
-  }
-  return results;
+  return parsed.map((entry, idx) =>
+    validateServiceBuildResult(entry, `parseBuildOutputs entry[${idx}]`),
+  );
 }
 
 export function successSet(results: ServiceBuildResult[]): string[] {
@@ -77,14 +113,14 @@ export function successSet(results: ServiceBuildResult[]): string[] {
  * artifact named `build-result-<dispatch_name>` containing a single
  * `result.json` file. The aggregator job downloads every artifact
  * matching the `build-result-*` pattern and merges them via
- * mergeBuildResultFiles below. We refuse empty service names so the
- * per-slot artifact cannot collide with the aggregated `build-results`
- * artifact published downstream.
+ * mergeBuildResultFiles below. We refuse empty/whitespace service
+ * names so the per-slot artifact cannot collide with the aggregated
+ * `build-results` artifact published downstream.
  */
 export function buildResultArtifactName(service: string): string {
-  if (typeof service !== "string" || service.length === 0) {
+  if (!isNonBlankString(service)) {
     throw new Error(
-      "buildResultArtifactName: `service` must be a non-empty string",
+      "buildResultArtifactName: `service` must be a non-empty, non-whitespace string",
     );
   }
   return `build-result-${service}`;
@@ -96,52 +132,57 @@ export function buildResultArtifactName(service: string): string {
  * Each payload MUST be a JSON object with `service: string` and
  * `status: success|failure|skipped`. The merge is order-preserving so
  * downstream consumers can rely on stable iteration.
+ *
+ * Fails loud on duplicate `service` names across slots: a duplicate
+ * means an upstream dispatch-name collision (two slots claiming the
+ * same service), which would let a `failure` + `success` pair for the
+ * same service spuriously look like a success in `successSet`. We
+ * surface the collision instead of silently deduping.
  */
 export function mergeBuildResultFiles(
   slotPayloads: readonly string[],
 ): ServiceBuildResult[] {
-  return slotPayloads.map((raw, idx) => {
+  const merged = slotPayloads.map((raw, idx) => {
     let parsed: unknown;
     try {
       parsed = JSON.parse(raw);
     } catch (e) {
       throw new Error(
-        `mergeBuildResultFiles: slot[${idx}] is not valid JSON: ${
+        `mergeBuildResultFiles slot[${idx}]: not valid JSON: ${
           e instanceof Error ? e.message : String(e)
         }`,
         { cause: e },
       );
     }
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      typeof (parsed as { service?: unknown }).service !== "string"
-    ) {
-      throw new Error(
-        `mergeBuildResultFiles: slot[${idx}] missing required string field "service": ${raw}`,
-      );
-    }
-    const status = (parsed as { status?: unknown }).status;
-    if (
-      typeof status !== "string" ||
-      !VALID_STATUSES.has(status as BuildOutcome)
-    ) {
-      throw new Error(
-        `mergeBuildResultFiles: slot[${idx}] has invalid "status" (must be success|failure|skipped): ${raw}`,
-      );
-    }
-    return {
-      service: (parsed as { service: string }).service,
-      status: status as BuildOutcome,
-    };
+    return validateServiceBuildResult(
+      parsed,
+      `mergeBuildResultFiles slot[${idx}]`,
+    );
   });
+
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const { service } of merged) {
+    if (seen.has(service)) {
+      duplicates.add(service);
+    } else {
+      seen.add(service);
+    }
+  }
+  if (duplicates.size > 0) {
+    const names = Array.from(duplicates).sort().join(", ");
+    throw new Error(
+      `mergeBuildResultFiles: duplicate service name(s) across slots: ${names}`,
+    );
+  }
+  return merged;
 }
 
 /**
  * Returns true iff at least one service in the build set finished as
- * `success`. The redeploy-staging job and the verify probe both gate on
- * this — when no service succeeded, redeploy MUST be skipped so we do
- * not re-pull the stale :latest and silently look healthy.
+ * `success`. Gates redeploy: when no service succeeded, redeploy MUST
+ * be skipped so we do not re-pull the stale `:latest` and silently
+ * look healthy.
  */
 export function shouldRedeployStaging(results: ServiceBuildResult[]): boolean {
   return results.some((r) => r.status === "success");

--- a/showcase/scripts/lib/build-outputs.ts
+++ b/showcase/scripts/lib/build-outputs.ts
@@ -136,3 +136,13 @@ export function mergeBuildResultFiles(
     };
   });
 }
+
+/**
+ * Returns true iff at least one service in the build set finished as
+ * `success`. The redeploy-staging job and the verify probe both gate on
+ * this — when no service succeeded, redeploy MUST be skipped so we do
+ * not re-pull the stale :latest and silently look healthy.
+ */
+export function shouldRedeployStaging(results: ServiceBuildResult[]): boolean {
+  return results.some((r) => r.status === "success");
+}

--- a/showcase/scripts/lib/build-outputs.ts
+++ b/showcase/scripts/lib/build-outputs.ts
@@ -17,21 +17,17 @@
  */
 
 // Single source of truth for the set of valid build outcomes. The
-// `as const` tuple drives BOTH the compile-time `BuildOutcome` union
-// AND the runtime `VALID_STATUSES` set, so adding a status in one
-// place is enforced in the other. The exhaustiveness check below
-// guarantees the tuple and the union stay in lockstep.
+// `as const` tuple drives BOTH the runtime `VALID_STATUSES` set AND
+// the compile-time `BuildOutcome` union (derived via indexed access
+// below), so the tuple is the only place a status needs to be added.
+// Since `BuildOutcome` is derived from this tuple there is no separate
+// union that could drift out of sync — no redundant exhaustiveness
+// assertion is needed.
 const BUILD_OUTCOMES = ["success", "failure", "skipped"] as const;
 
 export type BuildOutcome = (typeof BUILD_OUTCOMES)[number];
 
 const VALID_STATUSES: ReadonlySet<BuildOutcome> = new Set(BUILD_OUTCOMES);
-
-// Compile-time exhaustiveness check: if BuildOutcome ever drifts from
-// the BUILD_OUTCOMES tuple (e.g. a hand-edited union), this assignment
-// will fail to typecheck.
-const _exhaustive: ReadonlyArray<BuildOutcome> = BUILD_OUTCOMES;
-void _exhaustive;
 
 export interface ServiceBuildResult {
   service: string;
@@ -55,7 +51,7 @@ function validateServiceBuildResult(
   raw: unknown,
   contextLabel: string,
 ): ServiceBuildResult {
-  if (typeof raw !== "object" || raw === null) {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
     throw new Error(
       `${contextLabel}: expected object with {service, status}, got ${JSON.stringify(raw)}`,
     );
@@ -66,7 +62,8 @@ function validateServiceBuildResult(
       `${contextLabel}: missing required string field "service": ${JSON.stringify(raw)}`,
     );
   }
-  if (service.trim().length === 0) {
+  const trimmedService = service.trim();
+  if (trimmedService.length === 0) {
     throw new Error(
       `${contextLabel}: field "service" must be a non-empty, non-whitespace string: ${JSON.stringify(raw)}`,
     );
@@ -80,7 +77,7 @@ function validateServiceBuildResult(
       `${contextLabel}: invalid "status" (must be success|failure|skipped): ${JSON.stringify(raw)}`,
     );
   }
-  return { service, status: status as BuildOutcome };
+  return { service: trimmedService, status: status as BuildOutcome };
 }
 
 export function parseBuildOutputs(raw: string): ServiceBuildResult[] {

--- a/showcase/scripts/lib/build-outputs.ts
+++ b/showcase/scripts/lib/build-outputs.ts
@@ -14,55 +14,125 @@
 export type BuildOutcome = "success" | "failure" | "skipped";
 
 export interface ServiceBuildResult {
-    service: string;
-    status: BuildOutcome;
+  service: string;
+  status: BuildOutcome;
 }
 
 const VALID_STATUSES: ReadonlySet<BuildOutcome> = new Set([
-    "success",
-    "failure",
-    "skipped",
+  "success",
+  "failure",
+  "skipped",
 ]);
 
 export function parseBuildOutputs(raw: string): ServiceBuildResult[] {
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(raw);
-    } catch (e) {
-        throw new Error(
-            `Failed to parse build outputs JSON: ${
-                e instanceof Error ? e.message : String(e)
-            }`,
-        );
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(
+      `Failed to parse build outputs JSON: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+      { cause: e },
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("Build outputs must be a JSON array");
+  }
+  const results: ServiceBuildResult[] = [];
+  for (const entry of parsed) {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof (entry as { service?: unknown }).service !== "string"
+    ) {
+      throw new Error(
+        `Build outputs entry missing required string field "service": ${JSON.stringify(entry)}`,
+      );
     }
-    if (!Array.isArray(parsed)) {
-        throw new Error("Build outputs must be a JSON array");
+    const status = (entry as { status?: unknown }).status;
+    if (
+      typeof status !== "string" ||
+      !VALID_STATUSES.has(status as BuildOutcome)
+    ) {
+      throw new Error(
+        `Build outputs entry has invalid "status" (must be success|failure|skipped): ${JSON.stringify(entry)}`,
+      );
     }
-    const results: ServiceBuildResult[] = [];
-    for (const entry of parsed) {
-        if (
-            typeof entry !== "object" ||
-            entry === null ||
-            typeof (entry as { service?: unknown }).service !== "string"
-        ) {
-            throw new Error(
-                `Build outputs entry missing required string field "service": ${JSON.stringify(entry)}`,
-            );
-        }
-        const status = (entry as { status?: unknown }).status;
-        if (typeof status !== "string" || !VALID_STATUSES.has(status as BuildOutcome)) {
-            throw new Error(
-                `Build outputs entry has invalid "status" (must be success|failure|skipped): ${JSON.stringify(entry)}`,
-            );
-        }
-        results.push({
-            service: (entry as { service: string }).service,
-            status: status as BuildOutcome,
-        });
-    }
-    return results;
+    results.push({
+      service: (entry as { service: string }).service,
+      status: status as BuildOutcome,
+    });
+  }
+  return results;
 }
 
 export function successSet(results: ServiceBuildResult[]): string[] {
-    return results.filter((r) => r.status === "success").map((r) => r.service);
+  return results.filter((r) => r.status === "success").map((r) => r.service);
+}
+
+/**
+ * Canonical artifact-name convention for the per-slot build-result
+ * handoff. Each matrix slot in showcase_build.yml uploads exactly one
+ * artifact named `build-result-<dispatch_name>` containing a single
+ * `result.json` file. The aggregator job downloads every artifact
+ * matching the `build-result-*` pattern and merges them via
+ * mergeBuildResultFiles below. We refuse empty service names so the
+ * per-slot artifact cannot collide with the aggregated `build-results`
+ * artifact published downstream.
+ */
+export function buildResultArtifactName(service: string): string {
+  if (typeof service !== "string" || service.length === 0) {
+    throw new Error(
+      "buildResultArtifactName: `service` must be a non-empty string",
+    );
+  }
+  return `build-result-${service}`;
+}
+
+/**
+ * Merge a list of per-slot result.json payloads (raw strings, one per
+ * matrix slot's uploaded artifact) into a single ServiceBuildResult[].
+ * Each payload MUST be a JSON object with `service: string` and
+ * `status: success|failure|skipped`. The merge is order-preserving so
+ * downstream consumers can rely on stable iteration.
+ */
+export function mergeBuildResultFiles(
+  slotPayloads: readonly string[],
+): ServiceBuildResult[] {
+  return slotPayloads.map((raw, idx) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(
+        `mergeBuildResultFiles: slot[${idx}] is not valid JSON: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+        { cause: e },
+      );
+    }
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof (parsed as { service?: unknown }).service !== "string"
+    ) {
+      throw new Error(
+        `mergeBuildResultFiles: slot[${idx}] missing required string field "service": ${raw}`,
+      );
+    }
+    const status = (parsed as { status?: unknown }).status;
+    if (
+      typeof status !== "string" ||
+      !VALID_STATUSES.has(status as BuildOutcome)
+    ) {
+      throw new Error(
+        `mergeBuildResultFiles: slot[${idx}] has invalid "status" (must be success|failure|skipped): ${raw}`,
+      );
+    }
+    return {
+      service: (parsed as { service: string }).service,
+      status: status as BuildOutcome,
+    };
+  });
 }

--- a/showcase/scripts/lib/railway-graphql.ts
+++ b/showcase/scripts/lib/railway-graphql.ts
@@ -14,7 +14,7 @@
  * the `.com` host.
  */
 export const RAILWAY_GRAPHQL_ENDPOINT =
-    "https://backboard.railway.app/graphql/v2" as const;
+  "https://backboard.railway.app/graphql/v2" as const;
 
 // Fail-fast at module load if a hand-edit ever breaks the URL literal.
 new URL(RAILWAY_GRAPHQL_ENDPOINT);
@@ -37,15 +37,15 @@ export const RAILWAY_ERROR_BODY_MAX_DEFAULT = 200;
  * both consumers strip control chars at the source.
  */
 export function sanitizeErrorBody(
-    body: string,
-    max: number = RAILWAY_ERROR_BODY_MAX_DEFAULT,
+  body: string,
+  max: number = RAILWAY_ERROR_BODY_MAX_DEFAULT,
 ): string {
-    // Strip angle brackets (markdown-breaking) and control chars
-    // (newline/carriage-return/tab — break single-line log records
-    // and the markdown row redeploy-env produces). Original behavior
-    // removed `<>` without substitution; preserve that for `<>` and
-    // additionally remove `\n\r\t`.
-    const stripped = body.replace(/[<>\n\r\t]/g, "");
-    if (stripped.length <= max) return stripped;
-    return stripped.slice(0, max) + "…";
+  // Strip angle brackets (markdown-breaking) and control chars
+  // (newline/carriage-return/tab — break single-line log records
+  // and the markdown row redeploy-env produces). Original behavior
+  // removed `<>` without substitution; preserve that for `<>` and
+  // additionally remove `\n\r\t`.
+  const stripped = body.replace(/[<>\n\r\t]/g, "");
+  if (stripped.length <= max) return stripped;
+  return stripped.slice(0, max) + "…";
 }

--- a/showcase/scripts/lib/railway-graphql.ts
+++ b/showcase/scripts/lib/railway-graphql.ts
@@ -18,3 +18,34 @@ export const RAILWAY_GRAPHQL_ENDPOINT =
 
 // Fail-fast at module load if a hand-edit ever breaks the URL literal.
 new URL(RAILWAY_GRAPHQL_ENDPOINT);
+
+/** Default cap for sanitizeErrorBody. Multi-KB Cloudflare WAF HTML
+ * pages would otherwise spam stderr / $GITHUB_STEP_SUMMARY. */
+export const RAILWAY_ERROR_BODY_MAX_DEFAULT = 200;
+
+/**
+ * Sanitize a Railway API error body for inclusion in logs / the
+ * markdown summary. Railway/Cloudflare error responses can be
+ * multi-KB HTML pages:
+ *
+ *   - strip `<` and `>` (would break markdown tables)
+ *   - strip control chars `\n`, `\r`, `\t` (would break single-line
+ *     log records AND newline-bearing markdown rows in redeploy-env)
+ *   - cap at `max` chars (default 200) with an ellipsis on overflow
+ *
+ * Shared between redeploy-env.ts and verify-railway-image-refs.ts so
+ * both consumers strip control chars at the source.
+ */
+export function sanitizeErrorBody(
+    body: string,
+    max: number = RAILWAY_ERROR_BODY_MAX_DEFAULT,
+): string {
+    // Strip angle brackets (markdown-breaking) and control chars
+    // (newline/carriage-return/tab — break single-line log records
+    // and the markdown row redeploy-env produces). Original behavior
+    // removed `<>` without substitution; preserve that for `<>` and
+    // additionally remove `\n\r\t`.
+    const stripped = body.replace(/[<>\n\r\t]/g, "");
+    if (stripped.length <= max) return stripped;
+    return stripped.slice(0, max) + "…";
+}

--- a/showcase/scripts/lib/railway-graphql.ts
+++ b/showcase/scripts/lib/railway-graphql.ts
@@ -1,0 +1,11 @@
+/**
+ * railway-graphql.ts — Single source of truth for the Railway GraphQL
+ * endpoint host. ALL Railway GraphQL callers in this repo (TypeScript
+ * scripts, workflow inline curls, and Ruby `bin/railway` via its own
+ * constant) MUST resolve to this exact URL. The historic `.com` host
+ * (`backboard.railway.com`) is unauthenticated for the public GraphQL
+ * API and silently returns 401/403 — fixing here in one place prevents
+ * it from coming back.
+ */
+export const RAILWAY_GRAPHQL_ENDPOINT =
+    "https://backboard.railway.app/graphql/v2";

--- a/showcase/scripts/lib/railway-graphql.ts
+++ b/showcase/scripts/lib/railway-graphql.ts
@@ -1,11 +1,20 @@
 /**
  * railway-graphql.ts — Single source of truth for the Railway GraphQL
- * endpoint host. ALL Railway GraphQL callers in this repo (TypeScript
- * scripts, workflow inline curls, and Ruby `bin/railway` via its own
- * constant) MUST resolve to this exact URL. The historic `.com` host
- * (`backboard.railway.com`) is unauthenticated for the public GraphQL
- * API and silently returns 401/403 — fixing here in one place prevents
- * it from coming back.
+ * endpoint host for TypeScript importers in this repo. The historic
+ * `.com` host (`backboard.railway.com`) is unauthenticated for the
+ * public GraphQL API and silently returns 401/403; the canonical host
+ * is `backboard.railway.app`.
+ *
+ * Note: the Ruby `bin/railway` script and the inline `curl` commands
+ * embedded in `.github/workflows/*.yml` hold their OWN copies of this
+ * URL because they cannot import a TypeScript module. Those copies are
+ * kept in sync by hand and enforced by the regression guard in
+ * `./__tests__/railway-graphql.scan.test.ts`, which fails the build if
+ * any source file under `showcase/` or `.github/workflows/` reintroduces
+ * the `.com` host.
  */
 export const RAILWAY_GRAPHQL_ENDPOINT =
-    "https://backboard.railway.app/graphql/v2";
+    "https://backboard.railway.app/graphql/v2" as const;
+
+// Fail-fast at module load if a hand-edit ever breaks the URL literal.
+new URL(RAILWAY_GRAPHQL_ENDPOINT);

--- a/showcase/scripts/lib/railway-token.ts
+++ b/showcase/scripts/lib/railway-token.ts
@@ -155,16 +155,25 @@ export function resolveRailwayToken(
     const env = opts.env ?? process.env;
     const fsImpl = opts.fs ?? fs;
 
+    // Trim the env-var lane to honor the module's no-whitespace-in-header
+    // invariant. A `RAILWAY_TOKEN` secret with a trailing newline (common
+    // from `op read`/heredoc/shell export) would otherwise be returned
+    // verbatim and produce an invalid `Authorization: Bearer <token>\n`
+    // header → silent Railway 401. A whitespace-only value is treated as
+    // UNSET (falls through to the config-file lane).
     const envToken = env.RAILWAY_TOKEN;
-    if (typeof envToken === "string" && envToken.length > 0) {
-        return { token: envToken, source: "env" };
+    if (typeof envToken === "string") {
+        const trimmed = envToken.trim();
+        if (trimmed.length > 0) {
+            return { token: trimmed, source: "env" };
+        }
     }
 
     const home = opts.home ?? env.HOME;
     if (!home) {
         throw new RailwayTokenError(
             "NO_HOME",
-            "No Railway token found. RAILWAY_TOKEN is unset and $HOME is unset so ~/.railway/config.json cannot be located.",
+            "No Railway token found. RAILWAY_TOKEN is unset (or whitespace-only) and $HOME is unset so ~/.railway/config.json cannot be located.",
         );
     }
 

--- a/showcase/scripts/lib/railway-token.ts
+++ b/showcase/scripts/lib/railway-token.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 /**
  * railway-token.ts — Shared resolver for the Railway GraphQL bearer.
  *
@@ -81,4 +84,119 @@ export function resolveRailwayTokenFromConfig(
         return topLegacy.trim();
     }
     return undefined;
+}
+
+/**
+ * Failure-mode codes for resolveRailwayToken. Each is a distinct,
+ * actionable diagnostic so callers (and operators reading CI logs) can
+ * tell exactly WHY token resolution failed:
+ *
+ *   NO_HOME            : $HOME is unset (so ~/.railway/config.json can't
+ *                        be located) AND RAILWAY_TOKEN is also unset.
+ *   NO_FILE            : $HOME is set but ~/.railway/config.json does
+ *                        not exist (and env-var is unset).
+ *   MALFORMED          : ~/.railway/config.json exists but JSON.parse
+ *                        threw.
+ *   NO_TOKEN_IN_CONFIG : ~/.railway/config.json exists and parses OK
+ *                        but contains no usable token at any of the
+ *                        four known layers. (Closes the silent-token-
+ *                        fallthrough diagnostic gap where the operator
+ *                        previously saw the generic "No Railway token
+ *                        found" with no hint the file was inspected.)
+ */
+export type RailwayTokenErrorCode =
+    | "NO_HOME"
+    | "NO_FILE"
+    | "MALFORMED"
+    | "NO_TOKEN_IN_CONFIG";
+
+export class RailwayTokenError extends Error {
+    readonly code: RailwayTokenErrorCode;
+    constructor(code: RailwayTokenErrorCode, message: string) {
+        super(message);
+        this.name = "RailwayTokenError";
+        this.code = code;
+    }
+}
+
+export interface ResolveRailwayTokenOptions extends ResolverDeps {
+    /** Override $HOME lookup (testing only). */
+    home?: string;
+    /** Override env-var lookup (testing only). */
+    env?: NodeJS.ProcessEnv;
+    /** Filesystem injection (testing only). */
+    fs?: Pick<typeof fs, "existsSync" | "readFileSync">;
+}
+
+export interface RailwayTokenResolution {
+    token: string;
+    source: "env" | "config";
+}
+
+/**
+ * Unified entrypoint shared by redeploy-env.ts and
+ * verify-railway-image-refs.ts. Encapsulates the previously-duplicated
+ * getToken() envelope so the four failure modes can have distinct,
+ * actionable diagnostics in one place.
+ *
+ * Resolution order:
+ *   1. process.env.RAILWAY_TOKEN  (returned with source="env")
+ *   2. ~/.railway/config.json via resolveRailwayTokenFromConfig
+ *      (returned with source="config")
+ *
+ * Throws RailwayTokenError with a discriminator `.code` for each failure
+ * mode (NO_HOME / NO_FILE / MALFORMED / NO_TOKEN_IN_CONFIG). NEVER calls
+ * process.exit — the script entrypoint is responsible for mapping the
+ * error to a non-zero exit code so this function stays unit-testable.
+ */
+export function resolveRailwayToken(
+    opts: ResolveRailwayTokenOptions = {},
+): RailwayTokenResolution {
+    const env = opts.env ?? process.env;
+    const fsImpl = opts.fs ?? fs;
+
+    const envToken = env.RAILWAY_TOKEN;
+    if (typeof envToken === "string" && envToken.length > 0) {
+        return { token: envToken, source: "env" };
+    }
+
+    const home = opts.home ?? env.HOME;
+    if (!home) {
+        throw new RailwayTokenError(
+            "NO_HOME",
+            "No Railway token found. RAILWAY_TOKEN is unset and $HOME is unset so ~/.railway/config.json cannot be located.",
+        );
+    }
+
+    const configPath = path.join(home, ".railway", "config.json");
+    if (!fsImpl.existsSync(configPath)) {
+        throw new RailwayTokenError(
+            "NO_FILE",
+            "No Railway token found. Set RAILWAY_TOKEN or run `railway login`.",
+        );
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(fsImpl.readFileSync(configPath, "utf-8"));
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        throw new RailwayTokenError(
+            "MALFORMED",
+            `Malformed ~/.railway/config.json: ${msg}`,
+        );
+    }
+
+    const token = resolveRailwayTokenFromConfig(
+        parsed as RailwayConfigShape | null | undefined,
+        opts,
+    );
+    if (typeof token === "string" && token.length > 0) {
+        return { token, source: "config" };
+    }
+
+    throw new RailwayTokenError(
+        "NO_TOKEN_IN_CONFIG",
+        "No Railway token found: ~/.railway/config.json was found and parsed but contains no usable token (user.accessToken / accessToken / user.token / token). Set RAILWAY_TOKEN or re-run `railway login`.",
+    );
 }

--- a/showcase/scripts/lib/railway-token.ts
+++ b/showcase/scripts/lib/railway-token.ts
@@ -1,13 +1,16 @@
 /**
  * railway-token.ts — Shared resolver for the Railway GraphQL bearer.
  *
- * The Railway CLI stores the public-GraphQL bearer in `user.accessToken`
- * (43+ chars). The shorter `user.token` is a legacy CLI session token
- * that does NOT authenticate to the public GraphQL API. Older configs
- * still on disk have `user.token` set and `user.accessToken` empty;
- * those callers get a one-cycle deprecation warning and still work.
+ * The Railway CLI stores the public-GraphQL bearer in `user.accessToken`.
+ * The shorter `user.token` is a legacy CLI session token that does NOT
+ * authenticate to the public GraphQL API. Older configs still on disk
+ * have `user.token` set and `user.accessToken` empty; those callers get
+ * a one-cycle deprecation warning and still work.
  *
- * Resolution order mirrors `showcase/bin/railway:115-119`:
+ * Resolution order matches the first four candidates of
+ * `showcase/bin/railway` `Auth.token`; the per-project
+ * `projects.<id>.token` fallback is intentionally not honored (no
+ * project-scoped tokens here):
  *   1. user.accessToken
  *   2. accessToken (top-level)
  *   3. user.token        (legacy → warn)
@@ -35,29 +38,41 @@ const DEPRECATION_MESSAGE =
     "`user.token` / top-level `token` no longer authenticates the public " +
     "GraphQL API. The Railway CLI now writes `user.accessToken`; re-run " +
     "`railway login` to refresh ~/.railway/config.json. Support for the " +
-    "legacy field will be removed in the next release cycle.";
+    "legacy field will be removed in a future release.";
 
 function nonEmpty(v: unknown): v is string {
-    return typeof v === "string" && v.length > 0;
+    return typeof v === "string" && v.trim().length > 0;
 }
 
 export function resolveRailwayTokenFromConfig(
     config: RailwayConfigShape | null | undefined,
     deps: ResolverDeps = {},
 ): string | undefined {
-    if (!config) return undefined;
+    // Defensive guard: config originates from JSON.parse of
+    // ~/.railway/config.json (untrusted). Reject anything that isn't a
+    // plain object before property access.
+    if (config === null || config === undefined) return undefined;
+    if (typeof config !== "object") return undefined;
+    if (Array.isArray(config)) return undefined;
+
     const warn = deps.warn ?? ((m: string) => console.warn(m));
 
-    if (nonEmpty(config.user?.accessToken)) return config.user!.accessToken;
-    if (nonEmpty(config.accessToken)) return config.accessToken;
+    const userAccess = config.user?.accessToken;
+    if (nonEmpty(userAccess)) return userAccess;
 
-    if (nonEmpty(config.user?.token)) {
+    const topAccess = config.accessToken;
+    if (nonEmpty(topAccess)) return topAccess;
+
+    const userLegacy = config.user?.token;
+    if (nonEmpty(userLegacy)) {
         warn(DEPRECATION_MESSAGE);
-        return config.user!.token;
+        return userLegacy;
     }
-    if (nonEmpty(config.token)) {
+
+    const topLegacy = config.token;
+    if (nonEmpty(topLegacy)) {
         warn(DEPRECATION_MESSAGE);
-        return config.token;
+        return topLegacy;
     }
     return undefined;
 }

--- a/showcase/scripts/lib/railway-token.ts
+++ b/showcase/scripts/lib/railway-token.ts
@@ -18,6 +18,12 @@
  *
  * Returns undefined when no usable token is present; callers print the
  * "set RAILWAY_TOKEN or run `railway login`" error.
+ *
+ * This resolver reads ONLY the parsed config object passed in and does
+ * NOT consult `process.env.RAILWAY_TOKEN` — the caller is responsible
+ * for the environment-variable lane. Any returned value is trimmed so
+ * stray whitespace/newlines from `~/.railway/config.json` never reach
+ * an `Authorization: Bearer <token>` header.
  */
 
 export interface RailwayConfigShape {
@@ -58,21 +64,21 @@ export function resolveRailwayTokenFromConfig(
     const warn = deps.warn ?? ((m: string) => console.warn(m));
 
     const userAccess = config.user?.accessToken;
-    if (nonEmpty(userAccess)) return userAccess;
+    if (nonEmpty(userAccess)) return userAccess.trim();
 
     const topAccess = config.accessToken;
-    if (nonEmpty(topAccess)) return topAccess;
+    if (nonEmpty(topAccess)) return topAccess.trim();
 
     const userLegacy = config.user?.token;
     if (nonEmpty(userLegacy)) {
         warn(DEPRECATION_MESSAGE);
-        return userLegacy;
+        return userLegacy.trim();
     }
 
     const topLegacy = config.token;
     if (nonEmpty(topLegacy)) {
         warn(DEPRECATION_MESSAGE);
-        return topLegacy;
+        return topLegacy.trim();
     }
     return undefined;
 }

--- a/showcase/scripts/lib/railway-token.ts
+++ b/showcase/scripts/lib/railway-token.ts
@@ -30,60 +30,60 @@ import path from "node:path";
  */
 
 export interface RailwayConfigShape {
-    user?: {
-        accessToken?: string;
-        token?: string;
-    };
+  user?: {
     accessToken?: string;
     token?: string;
+  };
+  accessToken?: string;
+  token?: string;
 }
 
 export interface ResolverDeps {
-    warn?: (message: string) => void;
+  warn?: (message: string) => void;
 }
 
 const DEPRECATION_MESSAGE =
-    "[railway-token] WARNING: legacy Railway config field is deprecated: " +
-    "`user.token` / top-level `token` no longer authenticates the public " +
-    "GraphQL API. The Railway CLI now writes `user.accessToken`; re-run " +
-    "`railway login` to refresh ~/.railway/config.json. Support for the " +
-    "legacy field will be removed in a future release.";
+  "[railway-token] WARNING: legacy Railway config field is deprecated: " +
+  "`user.token` / top-level `token` no longer authenticates the public " +
+  "GraphQL API. The Railway CLI now writes `user.accessToken`; re-run " +
+  "`railway login` to refresh ~/.railway/config.json. Support for the " +
+  "legacy field will be removed in a future release.";
 
 function nonEmpty(v: unknown): v is string {
-    return typeof v === "string" && v.trim().length > 0;
+  return typeof v === "string" && v.trim().length > 0;
 }
 
 export function resolveRailwayTokenFromConfig(
-    config: RailwayConfigShape | null | undefined,
-    deps: ResolverDeps = {},
+  config: RailwayConfigShape | null | undefined,
+  deps: ResolverDeps = {},
 ): string | undefined {
-    // Defensive guard: config originates from JSON.parse of
-    // ~/.railway/config.json (untrusted). Reject anything that isn't a
-    // plain object before property access.
-    if (config === null || config === undefined) return undefined;
-    if (typeof config !== "object") return undefined;
-    if (Array.isArray(config)) return undefined;
+  // Defensive guard: config originates from JSON.parse of
+  // ~/.railway/config.json (untrusted). Reject anything that isn't a
+  // plain object before property access.
+  if (config === null || config === undefined) return undefined;
+  if (typeof config !== "object") return undefined;
+  if (Array.isArray(config)) return undefined;
 
-    const warn = deps.warn ?? ((m: string) => console.warn(m));
+  const warn = deps.warn ?? ((m: string) => console.warn(m));
 
-    const userAccess = config.user?.accessToken;
-    if (nonEmpty(userAccess)) return userAccess.trim();
+  const userAccess = config.user?.accessToken;
+  if (nonEmpty(userAccess)) return userAccess.trim();
 
-    const topAccess = config.accessToken;
-    if (nonEmpty(topAccess)) return topAccess.trim();
+  const topAccess = config.accessToken;
+  if (nonEmpty(topAccess)) return topAccess.trim();
 
-    const userLegacy = config.user?.token;
-    if (nonEmpty(userLegacy)) {
-        warn(DEPRECATION_MESSAGE);
-        return userLegacy.trim();
-    }
+  const userLegacy = config.user?.token;
+  if (nonEmpty(userLegacy)) {
+    warn(DEPRECATION_MESSAGE);
+    return userLegacy.trim();
+  }
 
-    const topLegacy = config.token;
-    if (nonEmpty(topLegacy)) {
-        warn(DEPRECATION_MESSAGE);
-        return topLegacy.trim();
-    }
-    return undefined;
+  const topLegacy = config.token;
+  if (nonEmpty(topLegacy)) {
+    warn(DEPRECATION_MESSAGE);
+    return topLegacy.trim();
+  }
+  return undefined;
 }
 
 /**
@@ -105,32 +105,32 @@ export function resolveRailwayTokenFromConfig(
  *                        found" with no hint the file was inspected.)
  */
 export type RailwayTokenErrorCode =
-    | "NO_HOME"
-    | "NO_FILE"
-    | "MALFORMED"
-    | "NO_TOKEN_IN_CONFIG";
+  | "NO_HOME"
+  | "NO_FILE"
+  | "MALFORMED"
+  | "NO_TOKEN_IN_CONFIG";
 
 export class RailwayTokenError extends Error {
-    readonly code: RailwayTokenErrorCode;
-    constructor(code: RailwayTokenErrorCode, message: string) {
-        super(message);
-        this.name = "RailwayTokenError";
-        this.code = code;
-    }
+  readonly code: RailwayTokenErrorCode;
+  constructor(code: RailwayTokenErrorCode, message: string) {
+    super(message);
+    this.name = "RailwayTokenError";
+    this.code = code;
+  }
 }
 
 export interface ResolveRailwayTokenOptions extends ResolverDeps {
-    /** Override $HOME lookup (testing only). */
-    home?: string;
-    /** Override env-var lookup (testing only). */
-    env?: NodeJS.ProcessEnv;
-    /** Filesystem injection (testing only). */
-    fs?: Pick<typeof fs, "existsSync" | "readFileSync">;
+  /** Override $HOME lookup (testing only). */
+  home?: string;
+  /** Override env-var lookup (testing only). */
+  env?: NodeJS.ProcessEnv;
+  /** Filesystem injection (testing only). */
+  fs?: Pick<typeof fs, "existsSync" | "readFileSync">;
 }
 
 export interface RailwayTokenResolution {
-    token: string;
-    source: "env" | "config";
+  token: string;
+  source: "env" | "config";
 }
 
 /**
@@ -150,62 +150,62 @@ export interface RailwayTokenResolution {
  * error to a non-zero exit code so this function stays unit-testable.
  */
 export function resolveRailwayToken(
-    opts: ResolveRailwayTokenOptions = {},
+  opts: ResolveRailwayTokenOptions = {},
 ): RailwayTokenResolution {
-    const env = opts.env ?? process.env;
-    const fsImpl = opts.fs ?? fs;
+  const env = opts.env ?? process.env;
+  const fsImpl = opts.fs ?? fs;
 
-    // Trim the env-var lane to honor the module's no-whitespace-in-header
-    // invariant. A `RAILWAY_TOKEN` secret with a trailing newline (common
-    // from `op read`/heredoc/shell export) would otherwise be returned
-    // verbatim and produce an invalid `Authorization: Bearer <token>\n`
-    // header → silent Railway 401. A whitespace-only value is treated as
-    // UNSET (falls through to the config-file lane).
-    const envToken = env.RAILWAY_TOKEN;
-    if (typeof envToken === "string") {
-        const trimmed = envToken.trim();
-        if (trimmed.length > 0) {
-            return { token: trimmed, source: "env" };
-        }
+  // Trim the env-var lane to honor the module's no-whitespace-in-header
+  // invariant. A `RAILWAY_TOKEN` secret with a trailing newline (common
+  // from `op read`/heredoc/shell export) would otherwise be returned
+  // verbatim and produce an invalid `Authorization: Bearer <token>\n`
+  // header → silent Railway 401. A whitespace-only value is treated as
+  // UNSET (falls through to the config-file lane).
+  const envToken = env.RAILWAY_TOKEN;
+  if (typeof envToken === "string") {
+    const trimmed = envToken.trim();
+    if (trimmed.length > 0) {
+      return { token: trimmed, source: "env" };
     }
+  }
 
-    const home = opts.home ?? env.HOME;
-    if (!home) {
-        throw new RailwayTokenError(
-            "NO_HOME",
-            "No Railway token found. RAILWAY_TOKEN is unset (or whitespace-only) and $HOME is unset so ~/.railway/config.json cannot be located.",
-        );
-    }
-
-    const configPath = path.join(home, ".railway", "config.json");
-    if (!fsImpl.existsSync(configPath)) {
-        throw new RailwayTokenError(
-            "NO_FILE",
-            "No Railway token found. Set RAILWAY_TOKEN or run `railway login`.",
-        );
-    }
-
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(fsImpl.readFileSync(configPath, "utf-8"));
-    } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        throw new RailwayTokenError(
-            "MALFORMED",
-            `Malformed ~/.railway/config.json: ${msg}`,
-        );
-    }
-
-    const token = resolveRailwayTokenFromConfig(
-        parsed as RailwayConfigShape | null | undefined,
-        opts,
-    );
-    if (typeof token === "string" && token.length > 0) {
-        return { token, source: "config" };
-    }
-
+  const home = opts.home ?? env.HOME;
+  if (!home) {
     throw new RailwayTokenError(
-        "NO_TOKEN_IN_CONFIG",
-        "No Railway token found: ~/.railway/config.json was found and parsed but contains no usable token (user.accessToken / accessToken / user.token / token). Set RAILWAY_TOKEN or re-run `railway login`.",
+      "NO_HOME",
+      "No Railway token found. RAILWAY_TOKEN is unset (or whitespace-only) and $HOME is unset so ~/.railway/config.json cannot be located.",
     );
+  }
+
+  const configPath = path.join(home, ".railway", "config.json");
+  if (!fsImpl.existsSync(configPath)) {
+    throw new RailwayTokenError(
+      "NO_FILE",
+      "No Railway token found. Set RAILWAY_TOKEN or run `railway login`.",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fsImpl.readFileSync(configPath, "utf-8"));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new RailwayTokenError(
+      "MALFORMED",
+      `Malformed ~/.railway/config.json: ${msg}`,
+    );
+  }
+
+  const token = resolveRailwayTokenFromConfig(
+    parsed as RailwayConfigShape | null | undefined,
+    opts,
+  );
+  if (typeof token === "string" && token.length > 0) {
+    return { token, source: "config" };
+  }
+
+  throw new RailwayTokenError(
+    "NO_TOKEN_IN_CONFIG",
+    "No Railway token found: ~/.railway/config.json was found and parsed but contains no usable token (user.accessToken / accessToken / user.token / token). Set RAILWAY_TOKEN or re-run `railway login`.",
+  );
 }

--- a/showcase/scripts/lib/railway-token.ts
+++ b/showcase/scripts/lib/railway-token.ts
@@ -1,0 +1,63 @@
+/**
+ * railway-token.ts — Shared resolver for the Railway GraphQL bearer.
+ *
+ * The Railway CLI stores the public-GraphQL bearer in `user.accessToken`
+ * (43+ chars). The shorter `user.token` is a legacy CLI session token
+ * that does NOT authenticate to the public GraphQL API. Older configs
+ * still on disk have `user.token` set and `user.accessToken` empty;
+ * those callers get a one-cycle deprecation warning and still work.
+ *
+ * Resolution order mirrors `showcase/bin/railway:115-119`:
+ *   1. user.accessToken
+ *   2. accessToken (top-level)
+ *   3. user.token        (legacy → warn)
+ *   4. token (top-level) (legacy → warn)
+ *
+ * Returns undefined when no usable token is present; callers print the
+ * "set RAILWAY_TOKEN or run `railway login`" error.
+ */
+
+export interface RailwayConfigShape {
+    user?: {
+        accessToken?: string;
+        token?: string;
+    };
+    accessToken?: string;
+    token?: string;
+}
+
+export interface ResolverDeps {
+    warn?: (message: string) => void;
+}
+
+const DEPRECATION_MESSAGE =
+    "[railway-token] WARNING: legacy Railway config field is deprecated: " +
+    "`user.token` / top-level `token` no longer authenticates the public " +
+    "GraphQL API. The Railway CLI now writes `user.accessToken`; re-run " +
+    "`railway login` to refresh ~/.railway/config.json. Support for the " +
+    "legacy field will be removed in the next release cycle.";
+
+function nonEmpty(v: unknown): v is string {
+    return typeof v === "string" && v.length > 0;
+}
+
+export function resolveRailwayTokenFromConfig(
+    config: RailwayConfigShape | null | undefined,
+    deps: ResolverDeps = {},
+): string | undefined {
+    if (!config) return undefined;
+    const warn = deps.warn ?? ((m: string) => console.warn(m));
+
+    if (nonEmpty(config.user?.accessToken)) return config.user!.accessToken;
+    if (nonEmpty(config.accessToken)) return config.accessToken;
+
+    if (nonEmpty(config.user?.token)) {
+        warn(DEPRECATION_MESSAGE);
+        return config.user!.token;
+    }
+    if (nonEmpty(config.token)) {
+        warn(DEPRECATION_MESSAGE);
+        return config.token;
+    }
+    return undefined;
+}

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -1,0 +1,506 @@
+{
+  "projectId": "6f8c6bff-a80d-4f8f-b78d-50b32bcf4479",
+  "envIds": {
+    "staging": "8edfef02-ea09-4a20-8689-261f21cc2849",
+    "prod": "b14919f4-6417-429f-848d-c6ae2201e04f"
+  },
+  "services": [
+    {
+      "name": "aimock",
+      "serviceId": "0fa0435d-8a66-46f0-84fd-e4250b580013",
+      "prodInstanceId": "5801d8be-5ad9-4eff-9c9c-7be61d9a023e",
+      "stagingInstanceId": "9f260dfd-d9d4-43e9-98fe-49696f87fe50",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "showcase-aimock",
+      "repoNameOverride": {
+        "prod": "showcase-aimock",
+        "staging": "showcase-aimock"
+      },
+      "domains": {
+        "staging": "aimock-staging.up.railway.app",
+        "prod": "showcase-aimock-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "aimock"
+      }
+    },
+    {
+      "name": "dashboard",
+      "serviceId": "4d5dfd74-be61-40b2-8564-b53b7dd4c15b",
+      "prodInstanceId": "e68f98fa-b2ef-41cc-82f6-2ed6f9533bf3",
+      "stagingInstanceId": "aea7332e-17a0-4fab-921c-ed5baad2a6f2",
+      "ciBuilt": true,
+      "gateValidated": false,
+      "dispatchName": "shell-dashboard",
+      "domains": {
+        "staging": "dashboard.showcase.staging.copilotkit.ai",
+        "prod": "dashboard.showcase.copilotkit.ai"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "dashboard"
+      }
+    },
+    {
+      "name": "docs",
+      "serviceId": "7badfb8d-4228-414c-9145-b4026803714f",
+      "prodInstanceId": "b15564fc-f832-49b3-82df-fd36f298fe96",
+      "stagingInstanceId": "d5caa51d-73ee-4669-bfea-d87bf1488b02",
+      "ciBuilt": true,
+      "gateValidated": false,
+      "dispatchName": "shell-docs",
+      "domains": {
+        "staging": "docs.staging.copilotkit.ai",
+        "prod": "docs.copilotkit.ai"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "docs"
+      }
+    },
+    {
+      "name": "dojo",
+      "serviceId": "7ad1ece7-2228-49cd-8a78-bddf30322907",
+      "prodInstanceId": "2ee4f2aa-11ec-4426-9a4a-41a1ad04f16d",
+      "stagingInstanceId": "1284d717-0ff5-432c-9326-fab12661df61",
+      "ciBuilt": true,
+      "gateValidated": false,
+      "dispatchName": "shell-dojo",
+      "domains": {
+        "staging": "dojo.showcase.staging.copilotkit.ai",
+        "prod": "dojo.showcase.copilotkit.ai"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "dojo"
+      }
+    },
+    {
+      "name": "harness",
+      "serviceId": "3a14bfed-0537-4d71-897b-7c593dca161d",
+      "prodInstanceId": "05fbcdf2-8a50-4b71-b4f6-c92c4b17e626",
+      "stagingInstanceId": "0811f68f-fac4-440e-a350-3a7ca5855b80",
+      "ciBuilt": true,
+      "gateValidated": false,
+      "dispatchName": "showcase-harness",
+      "domains": {
+        "staging": "harness-staging-2ee4.up.railway.app",
+        "prod": "showcase-harness-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "harness"
+      }
+    },
+    {
+      "name": "pocketbase",
+      "serviceId": "ba11e854-d695-4738-9a45-2b0776788824",
+      "prodInstanceId": "1ee376e2-13f2-4464-801e-d0aa0bf76532",
+      "stagingInstanceId": "0bc7db7b-5a43-4b33-af46-d07fb53c8610",
+      "ciBuilt": false,
+      "gateValidated": true,
+      "repoNameOverride": {
+        "prod": "showcase-pocketbase",
+        "staging": "showcase-pocketbase"
+      },
+      "domains": {
+        "staging": "pocketbase-staging-eec0.up.railway.app",
+        "prod": "showcase-pocketbase-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "pocketbase"
+      }
+    },
+    {
+      "name": "shell",
+      "serviceId": "40eea0da-6071-4ea8-bdb9-39afb19225ec",
+      "prodInstanceId": "01614ccf-e109-4b30-b41b-7c5551c0a34c",
+      "stagingInstanceId": "25b7de41-188c-4f2e-ac07-538212eaeb91",
+      "ciBuilt": true,
+      "gateValidated": false,
+      "dispatchName": "shell",
+      "domains": {
+        "staging": "showcase.staging.copilotkit.ai",
+        "prod": "showcase.copilotkit.ai"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "shell"
+      }
+    },
+    {
+      "name": "showcase-ag2",
+      "serviceId": "4a37481b-f264-4eb7-a9cd-0a9ebb9ac05c",
+      "prodInstanceId": "de571c97-03fd-486b-8a54-9767a4a53f95",
+      "stagingInstanceId": "ecaf81b3-93a8-4862-92b6-04a016b634ed",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "ag2",
+      "domains": {
+        "staging": "showcase-ag2-staging.up.railway.app",
+        "prod": "showcase-ag2-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-agno",
+      "serviceId": "32cab80b-e329-45bd-9c73-c4e1ddc94305",
+      "prodInstanceId": "026d12fb-2844-42af-8f92-b47bc8a06bc8",
+      "stagingInstanceId": "68964ab6-75ca-4095-a64a-52cacfb684f5",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "agno",
+      "domains": {
+        "staging": "showcase-agno-staging.up.railway.app",
+        "prod": "showcase-agno-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-built-in-agent",
+      "serviceId": "f4f8371a-bc46-45b2-b6d4-9c9af608bdbf",
+      "prodInstanceId": "40018ef7-1ed1-4979-b80c-9c2d957b6d88",
+      "stagingInstanceId": "b89ae7b3-01cc-4ed4-aca6-23aaa63cd59e",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "built-in-agent",
+      "domains": {
+        "staging": "showcase-built-in-agent-staging.up.railway.app",
+        "prod": "showcase-built-in-agent-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-claude-sdk-python",
+      "serviceId": "b122ab65-9854-4cb2-a68e-b50ff13f7481",
+      "prodInstanceId": "bb18caaf-9a3e-4fdd-85ec-562fd82a3a89",
+      "stagingInstanceId": "1ef25aec-5fbd-40b9-8685-57c2681bd45d",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "claude-sdk-python",
+      "domains": {
+        "staging": "showcase-claude-sdk-python-staging.up.railway.app",
+        "prod": "showcase-claude-sdk-python-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-claude-sdk-typescript",
+      "serviceId": "18a98727-5700-44aa-b497-b60795dbbd6a",
+      "prodInstanceId": "bee425e4-9661-4a88-8888-922b8cd4b61d",
+      "stagingInstanceId": "92305747-2f55-4122-aad4-882e989558ab",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "claude-sdk-typescript",
+      "domains": {
+        "staging": "showcase-claude-sdk-typescript-staging.up.railway.app",
+        "prod": "showcase-claude-sdk-typescript-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-crewai-crews",
+      "serviceId": "0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4",
+      "prodInstanceId": "3dab0cc3-cab1-4579-b772-947268088514",
+      "stagingInstanceId": "88c2a14f-435b-499e-a811-ee4f4be18fd8",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "crewai-crews",
+      "domains": {
+        "staging": "showcase-crewai-crews-staging.up.railway.app",
+        "prod": "showcase-crewai-crews-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-google-adk",
+      "serviceId": "87f60507-5a3d-4b8a-9e23-2b1de85d939c",
+      "prodInstanceId": "7b2da5db-87d2-40ad-a3d9-b2d7a5485a22",
+      "stagingInstanceId": "7efe2fa0-fa78-4585-bc4c-6d39c326e6d1",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "google-adk",
+      "domains": {
+        "staging": "showcase-google-adk-staging.up.railway.app",
+        "prod": "showcase-google-adk-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-langgraph-fastapi",
+      "serviceId": "06cccb5c-59f4-46b5-8adc-7113e77011a4",
+      "prodInstanceId": "105b7e01-acd0-48e2-9a09-541e2103e8d2",
+      "stagingInstanceId": "7899afe0-141b-4217-8dbb-5907813231dc",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "langgraph-fastapi",
+      "domains": {
+        "staging": "showcase-langgraph-fastapi-staging.up.railway.app",
+        "prod": "showcase-langgraph-fastapi-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-langgraph-python",
+      "serviceId": "90d03214-4569-41b0-b4c1-6438a8a7b203",
+      "prodInstanceId": "aec504f7-63d7-4ea6-9d50-601b00d2ae80",
+      "stagingInstanceId": "04d29664-a776-4670-9db3-b1d18bce1669",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "langgraph-python",
+      "domains": {
+        "staging": "showcase-langgraph-python-staging.up.railway.app",
+        "prod": "showcase-langgraph-python-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-langgraph-typescript",
+      "serviceId": "66246d3b-a18e-46f0-be51-5f3ff7a36e5a",
+      "prodInstanceId": "f53e9fdc-7c3e-4dfd-9fa8-d7241fd55bb8",
+      "stagingInstanceId": "481ab37f-da8a-4015-bd88-2b28d9eb261a",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "langgraph-typescript",
+      "domains": {
+        "staging": "showcase-langgraph-typescript-staging.up.railway.app",
+        "prod": "showcase-langgraph-typescript-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-langroid",
+      "serviceId": "6dd9cb0a-66cc-46f1-972e-7cd74756157d",
+      "prodInstanceId": "6b5e20b5-8f8e-4ec3-9288-7a41122e42e5",
+      "stagingInstanceId": "a213f7d9-2117-4944-988b-05e68d819dd5",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "langroid",
+      "domains": {
+        "staging": "showcase-langroid-staging.up.railway.app",
+        "prod": "showcase-langroid-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-llamaindex",
+      "serviceId": "285386e8-492d-4cb8-b632-0a7d4607378f",
+      "prodInstanceId": "b778856e-9f90-4136-9415-fb2b41173f8d",
+      "stagingInstanceId": "17899ea7-355c-43f2-a152-28cb0b7fa864",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "llamaindex",
+      "domains": {
+        "staging": "showcase-llamaindex-staging.up.railway.app",
+        "prod": "showcase-llamaindex-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-mastra",
+      "serviceId": "d7979eb7-2405-4aab-ad21-438f4a1b08af",
+      "prodInstanceId": "eaeddd9c-8b75-426f-b033-0fd935cbf6ef",
+      "stagingInstanceId": "eec22411-aab5-47a1-8f5b-d097e233d7f8",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "mastra",
+      "domains": {
+        "staging": "showcase-mastra-staging.up.railway.app",
+        "prod": "showcase-mastra-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-ms-agent-dotnet",
+      "serviceId": "beeb2dd6-87a4-4599-aa07-0578f7bd6519",
+      "prodInstanceId": "93ca0edf-7b59-4de4-b1fd-3412bb07bc6a",
+      "stagingInstanceId": "9826bc58-c472-41e6-b050-29249d4b2a52",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "ms-agent-dotnet",
+      "domains": {
+        "staging": "showcase-ms-agent-dotnet-staging.up.railway.app",
+        "prod": "showcase-ms-agent-dotnet-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-ms-agent-harness-dotnet",
+      "serviceId": "6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37",
+      "prodInstanceId": "8f91ebc6-95c0-4433-b1f7-657ff49c2d59",
+      "stagingInstanceId": "6b0fe181-9156-4a40-9e44-90befe09833a",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "ms-agent-harness-dotnet",
+      "domains": {
+        "staging": "showcase-ms-agent-harness-dotnet-staging.up.railway.app",
+        "prod": "showcase-ms-agent-harness-dotnet-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-ms-agent-python",
+      "serviceId": "655db75a-af8d-427d-a4f9-441570ae5003",
+      "prodInstanceId": "323ed911-4d28-45ab-8fc0-7d151828b938",
+      "stagingInstanceId": "741725ce-5fa1-4327-aff5-53dcc000c29c",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "ms-agent-python",
+      "domains": {
+        "staging": "showcase-ms-agent-python-staging.up.railway.app",
+        "prod": "showcase-ms-agent-python-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-pydantic-ai",
+      "serviceId": "0a106173-2282-4887-a994-0ca276a99d69",
+      "prodInstanceId": "192cd647-6824-4f01-937a-1da675d83805",
+      "stagingInstanceId": "6edf5ca5-6a56-4d28-92c3-2a3360c735db",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "pydantic-ai",
+      "domains": {
+        "staging": "showcase-pydantic-ai-staging.up.railway.app",
+        "prod": "showcase-pydantic-ai-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-spring-ai",
+      "serviceId": "eed5d041-91be-4282-b414-beea00843401",
+      "prodInstanceId": "2fbf1db2-5e51-44c9-983c-3f2242d95c61",
+      "stagingInstanceId": "189ac76f-bd77-45c0-9c45-3853dae763cc",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "spring-ai",
+      "domains": {
+        "staging": "showcase-spring-ai-staging.up.railway.app",
+        "prod": "showcase-spring-ai-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "showcase-strands",
+      "serviceId": "92e1cfad-ad53-403f-ab2b-5ab380832232",
+      "prodInstanceId": "2123c71b-9385-443c-a1c3-bcf4b1669eeb",
+      "stagingInstanceId": "f8a9d2ed-50ec-4f06-85d6-230baced8471",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "strands",
+      "domains": {
+        "staging": "showcase-strands-staging.up.railway.app",
+        "prod": "showcase-strands-production.up.railway.app"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "agent"
+      }
+    },
+    {
+      "name": "webhooks",
+      "serviceId": "ba6acc13-7585-41fe-a5ee-585b34a58fcd",
+      "prodInstanceId": "d82ef5b4-3bfd-462e-9436-3d5dbca8681a",
+      "stagingInstanceId": "450e87e0-aba5-4aba-afaf-15f4deab03f0",
+      "ciBuilt": false,
+      "gateValidated": true,
+      "dispatchName": "webhooks",
+      "repoNameOverride": {
+        "prod": "showcase-eval-webhook",
+        "staging": "showcase-eval-webhook"
+      },
+      "domains": {
+        "staging": "hooks.showcase.staging.copilotkit.ai",
+        "prod": "hooks.showcase.copilotkit.ai"
+      },
+      "probe": {
+        "staging": true,
+        "prod": true,
+        "driver": "webhooks"
+      }
+    }
+  ]
+}

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -33,8 +33,12 @@
       "prodInstanceId": "e68f98fa-b2ef-41cc-82f6-2ed6f9533bf3",
       "stagingInstanceId": "aea7332e-17a0-4fab-921c-ed5baad2a6f2",
       "ciBuilt": true,
-      "gateValidated": false,
+      "gateValidated": true,
       "dispatchName": "shell-dashboard",
+      "repoNameOverride": {
+        "prod": "showcase-shell-dashboard",
+        "staging": "showcase-shell-dashboard"
+      },
       "domains": {
         "staging": "dashboard.showcase.staging.copilotkit.ai",
         "prod": "dashboard.showcase.copilotkit.ai"
@@ -51,8 +55,12 @@
       "prodInstanceId": "b15564fc-f832-49b3-82df-fd36f298fe96",
       "stagingInstanceId": "d5caa51d-73ee-4669-bfea-d87bf1488b02",
       "ciBuilt": true,
-      "gateValidated": false,
+      "gateValidated": true,
       "dispatchName": "shell-docs",
+      "repoNameOverride": {
+        "prod": "showcase-shell-docs",
+        "staging": "showcase-shell-docs"
+      },
       "domains": {
         "staging": "docs.staging.copilotkit.ai",
         "prod": "docs.copilotkit.ai"
@@ -69,8 +77,12 @@
       "prodInstanceId": "2ee4f2aa-11ec-4426-9a4a-41a1ad04f16d",
       "stagingInstanceId": "1284d717-0ff5-432c-9326-fab12661df61",
       "ciBuilt": true,
-      "gateValidated": false,
+      "gateValidated": true,
       "dispatchName": "shell-dojo",
+      "repoNameOverride": {
+        "prod": "showcase-shell-dojo",
+        "staging": "showcase-shell-dojo"
+      },
       "domains": {
         "staging": "dojo.showcase.staging.copilotkit.ai",
         "prod": "dojo.showcase.copilotkit.ai"
@@ -87,8 +99,12 @@
       "prodInstanceId": "05fbcdf2-8a50-4b71-b4f6-c92c4b17e626",
       "stagingInstanceId": "0811f68f-fac4-440e-a350-3a7ca5855b80",
       "ciBuilt": true,
-      "gateValidated": false,
+      "gateValidated": true,
       "dispatchName": "showcase-harness",
+      "repoNameOverride": {
+        "prod": "showcase-harness",
+        "staging": "showcase-harness"
+      },
       "domains": {
         "staging": "harness-staging-2ee4.up.railway.app",
         "prod": "showcase-harness-production.up.railway.app"
@@ -126,8 +142,12 @@
       "prodInstanceId": "01614ccf-e109-4b30-b41b-7c5551c0a34c",
       "stagingInstanceId": "25b7de41-188c-4f2e-ac07-538212eaeb91",
       "ciBuilt": true,
-      "gateValidated": false,
+      "gateValidated": true,
       "dispatchName": "shell",
+      "repoNameOverride": {
+        "prod": "showcase-shell",
+        "staging": "showcase-shell"
+      },
       "domains": {
         "staging": "showcase.staging.copilotkit.ai",
         "prod": "showcase.copilotkit.ai"

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -3,12 +3,9 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   CI_BUILT_SERVICES,
-  type Domains,
   ENV_IDS,
   PRODUCTION_ENV_ID,
   PROJECT_ID,
-  type ProbeConfig,
-  type ProbeDriver,
   SERVICES,
   STAGING_ENV_ID,
   assertDispatchNamesUnique,
@@ -19,6 +16,7 @@ import {
   resolveEnv,
   serviceForDispatchName,
 } from "./railway-envs";
+import type { Domains, ProbeConfig, ProbeDriver } from "./railway-envs";
 
 // Compile-time guard: ensure the Domains type alias is referenced so this
 // import is not removed by an over-eager organizer. The runtime body of
@@ -285,14 +283,40 @@ describe("webhooks SSOT entry", () => {
     expect(SERVICES.webhooks.probe.staging).toBe(true);
     expect(SERVICES.webhooks.dispatchName).toBe("webhooks");
     // Pin the workflow's SSOT-driven contract so a future regression
-    // back to a hardcoded matrix is caught: deploy.yml must consume the
-    // generated SSOT JSON and select on probe.staging.
+    // back to a hardcoded matrix is caught. The matrix-building logic
+    // was extracted out of inline bash into
+    // showcase/scripts/resolve-verify-matrix.ts (the prior inline
+    // bash+jq produced two confirmed bugs across CR rounds, so the
+    // contract now lives in a pure, unit-tested TS module). The deploy
+    // workflow MUST invoke that script — that is the SSOT-consumption
+    // hand-off. The script itself MUST read
+    // `railway-envs.generated.json` and filter on `probe.staging===true`
+    // — that is the SSOT-consumption mechanism. Pinning both halves
+    // catches the two regression shapes that matter: (a) deploy.yml
+    // silently dropping the script call (back to a hardcoded matrix
+    // or inline jq) and (b) the script being kept but the SSOT/probe
+    // contract being weakened inside it.
     const yml = readFileSync(
       resolve(__dirname, "../../.github/workflows/showcase_deploy.yml"),
       "utf-8",
     );
-    expect(yml).toMatch(/railway-envs\.generated\.json/);
-    expect(yml).toMatch(/probe\.staging\s*==\s*true/);
+    expect(
+      yml,
+      "showcase_deploy.yml must invoke resolve-verify-matrix.ts to build the verify matrix from the SSOT",
+    ).toMatch(/resolve-verify-matrix\.ts/);
+
+    const resolver = readFileSync(
+      resolve(__dirname, "./resolve-verify-matrix.ts"),
+      "utf-8",
+    );
+    expect(
+      resolver,
+      "resolve-verify-matrix.ts must consume railway-envs.generated.json (the SSOT JSON)",
+    ).toMatch(/railway-envs\.generated\.json/);
+    expect(
+      resolver,
+      "resolve-verify-matrix.ts must select probe-eligible services on probe.staging===true",
+    ).toMatch(/probe\.staging\s*===\s*true/);
   });
 });
 
@@ -412,9 +436,7 @@ describe("railway-envs SSOT — domains + probe", () => {
     expect(() => domainFor("nope", "staging")).toThrow(
       /Unknown showcase service/,
     );
-    expect(() => domainFor("nope", "prod")).toThrow(
-      /Unknown showcase service/,
-    );
+    expect(() => domainFor("nope", "prod")).toThrow(/Unknown showcase service/);
   });
 
   it("domainFor throws on unknown env (defends against ad-hoc EnvName values)", () => {

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -3,18 +3,28 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   CI_BUILT_SERVICES,
+  type Domains,
   ENV_IDS,
   PRODUCTION_ENV_ID,
   PROJECT_ID,
+  type ProbeConfig,
+  type ProbeDriver,
   SERVICES,
   STAGING_ENV_ID,
   assertDispatchNamesUnique,
+  domainFor,
   instanceIdFor,
   listServiceNames,
   repoNameFor,
   resolveEnv,
   serviceForDispatchName,
 } from "./railway-envs";
+
+// Compile-time guard: ensure the Domains type alias is referenced so this
+// import is not removed by an over-eager organizer. The runtime body of
+// this assignment is unused; it exists solely to anchor the type.
+const _domainsTypeAnchor: Domains | undefined = undefined;
+void _domainsTypeAnchor;
 
 describe("railway-envs SSOT", () => {
   it("exposes the canonical project id", () => {
@@ -301,5 +311,118 @@ describe("dispatchName uniqueness invariant", () => {
       webhooks: { dispatchName: "webhooks" },
     };
     expect(() => assertDispatchNamesUnique(synthetic)).not.toThrow();
+  });
+});
+
+describe("railway-envs SSOT — domains + probe", () => {
+  it("every service exposes a domains.staging and domains.prod (no scheme)", () => {
+    for (const [name, entry] of Object.entries(SERVICES)) {
+      expect(entry.domains, `${name}.domains missing`).toBeDefined();
+      expect(entry.domains.staging, `${name}.domains.staging`).toMatch(
+        /^[A-Za-z0-9.-]+$/,
+      );
+      expect(entry.domains.prod, `${name}.domains.prod`).toMatch(
+        /^[A-Za-z0-9.-]+$/,
+      );
+      expect(
+        entry.domains.staging.startsWith("http"),
+        `${name}: staging domain must not include scheme`,
+      ).toBe(false);
+      expect(
+        entry.domains.prod.startsWith("http"),
+        `${name}: prod domain must not include scheme`,
+      ).toBe(false);
+    }
+  });
+
+  it("confirmed staging domains match the documented values", () => {
+    expect(SERVICES.pocketbase.domains.staging).toBe(
+      "pocketbase-staging-eec0.up.railway.app",
+    );
+    expect(SERVICES.harness.domains.staging).toBe(
+      "harness-staging-2ee4.up.railway.app",
+    );
+    expect(SERVICES.shell.domains.staging).toBe(
+      "showcase.staging.copilotkit.ai",
+    );
+    expect(SERVICES.docs.domains.staging).toBe("docs.staging.copilotkit.ai");
+    expect(SERVICES.dashboard.domains.staging).toBe(
+      "dashboard.showcase.staging.copilotkit.ai",
+    );
+  });
+
+  it("confirmed prod domains match the bin/railway:73-88 EXPECTED_DOMAINS", () => {
+    expect(SERVICES.shell.domains.prod).toBe("showcase.copilotkit.ai");
+    expect(SERVICES.dashboard.domains.prod).toBe(
+      "dashboard.showcase.copilotkit.ai",
+    );
+    expect(SERVICES.dojo.domains.prod).toBe("dojo.showcase.copilotkit.ai");
+    expect(SERVICES.docs.domains.prod).toBe("docs.copilotkit.ai");
+    expect(SERVICES.webhooks.domains.prod).toBe("hooks.showcase.copilotkit.ai");
+  });
+
+  it("every service exposes a probe.staging, probe.prod, probe.driver", () => {
+    const validDrivers: ProbeDriver[] = [
+      "shell",
+      "harness",
+      "eval",
+      "aimock",
+      "pocketbase",
+      "webhooks",
+      "dojo",
+      "docs",
+      "dashboard",
+      "agent",
+    ];
+    for (const [name, entry] of Object.entries(SERVICES)) {
+      expect(entry.probe, `${name}.probe missing`).toBeDefined();
+      expect(typeof entry.probe.staging).toBe("boolean");
+      expect(typeof entry.probe.prod).toBe("boolean");
+      expect(validDrivers).toContain(entry.probe.driver);
+    }
+  });
+
+  it("aimock probes BOTH envs by default (the carve-out is digest-only, not probe-skip)", () => {
+    // The aimock-prod carve-out only freezes the digest; the prod probe
+    // still runs against whatever is pinned. Spec §3 / §11.
+    expect(SERVICES.aimock.probe.prod).toBe(true);
+    expect(SERVICES.aimock.probe.staging).toBe(true);
+  });
+
+  it("domainFor returns the no-scheme host for known service+env", () => {
+    expect(domainFor("docs", "staging")).toBe("docs.staging.copilotkit.ai");
+    expect(domainFor("docs", "prod")).toBe("docs.copilotkit.ai");
+    expect(domainFor("pocketbase", "staging")).toBe(
+      "pocketbase-staging-eec0.up.railway.app",
+    );
+  });
+
+  it("domainFor throws on unknown service (no silent empty string)", () => {
+    expect(() => domainFor("nope", "staging")).toThrow(
+      /Unknown showcase service/,
+    );
+    expect(() => domainFor("nope", "prod")).toThrow(
+      /Unknown showcase service/,
+    );
+  });
+
+  it("domainFor throws on unknown env (defends against ad-hoc EnvName values)", () => {
+    // @ts-expect-error — intentionally passing a bad env at runtime.
+    expect(() => domainFor("docs", "dev")).toThrow(/Unknown env/);
+  });
+
+  it("STAGING_ENV_ID and PRODUCTION_ENV_ID are exported and stable", () => {
+    expect(STAGING_ENV_ID).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
+    expect(PRODUCTION_ENV_ID).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");
+  });
+
+  it("ProbeConfig type compiles with the documented shape", () => {
+    // Compile-time guard: this object must satisfy ProbeConfig.
+    const sample: ProbeConfig = {
+      staging: true,
+      prod: false,
+      driver: "shell",
+    };
+    expect(sample.driver).toBe("shell");
   });
 });

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -1,0 +1,247 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  CI_BUILT_SERVICES,
+  ENV_IDS,
+  PRODUCTION_ENV_ID,
+  PROJECT_ID,
+  SERVICES,
+  STAGING_ENV_ID,
+  instanceIdFor,
+  listServiceNames,
+  repoNameFor,
+  resolveEnv,
+  serviceForDispatchName,
+} from "./railway-envs";
+
+describe("railway-envs SSOT", () => {
+  it("exposes the canonical project id", () => {
+    expect(PROJECT_ID).toBe("6f8c6bff-a80d-4f8f-b78d-50b32bcf4479");
+  });
+
+  it("exposes both env ids and they differ", () => {
+    expect(PRODUCTION_ENV_ID).toMatch(/^[0-9a-f-]{36}$/);
+    expect(STAGING_ENV_ID).toMatch(/^[0-9a-f-]{36}$/);
+    expect(PRODUCTION_ENV_ID).not.toBe(STAGING_ENV_ID);
+  });
+
+  it("resolves env synonyms", () => {
+    expect(resolveEnv("prod").envId).toBe(PRODUCTION_ENV_ID);
+    expect(resolveEnv("production").envId).toBe(PRODUCTION_ENV_ID);
+    expect(resolveEnv("PROD").envId).toBe(PRODUCTION_ENV_ID);
+    expect(resolveEnv("staging").envId).toBe(STAGING_ENV_ID);
+    expect(resolveEnv(" Staging ").envId).toBe(STAGING_ENV_ID);
+  });
+
+  it("throws on unknown env names", () => {
+    expect(() => resolveEnv("dev")).toThrow(/Unknown env/);
+    expect(() => resolveEnv("")).toThrow(/Unknown env/);
+  });
+
+  it("ENV_IDS contains all synonyms", () => {
+    expect(ENV_IDS.prod).toBe(PRODUCTION_ENV_ID);
+    expect(ENV_IDS.production).toBe(PRODUCTION_ENV_ID);
+    expect(ENV_IDS.staging).toBe(STAGING_ENV_ID);
+  });
+
+  it("contains exactly 27 services", () => {
+    const names = listServiceNames();
+    expect(names.length).toBe(27);
+  });
+
+  it("contains the expected canonical services", () => {
+    const names = listServiceNames();
+    // Sample sentinels — checking the full list is overkill, but these
+    // are the ones we cannot tolerate losing without noticing.
+    for (const expected of [
+      "aimock",
+      "harness",
+      "pocketbase",
+      "shell",
+      "showcase-ag2",
+      "showcase-langgraph-python",
+      "showcase-mastra",
+      "webhooks",
+    ]) {
+      expect(names).toContain(expected);
+    }
+  });
+
+  it("every service has non-empty UUIDs for prod and staging", () => {
+    const uuid = /^[0-9a-f-]{36}$/;
+    for (const [name, entry] of Object.entries(SERVICES)) {
+      expect(entry.serviceId, `${name}.serviceId`).toMatch(uuid);
+      expect(entry.prodInstanceId, `${name}.prodInstanceId`).toMatch(uuid);
+      expect(entry.stagingInstanceId, `${name}.stagingInstanceId`).toMatch(
+        uuid,
+      );
+    }
+  });
+
+  it("prod and staging instance IDs differ per service", () => {
+    for (const [name, entry] of Object.entries(SERVICES)) {
+      expect(
+        entry.prodInstanceId,
+        `${name}: prod and staging instanceIds collided`,
+      ).not.toBe(entry.stagingInstanceId);
+    }
+  });
+
+  it("aimock has the showcase-aimock wrapper override in BOTH envs (permanent)", () => {
+    // Both prod and staging run the `showcase-aimock` wrapper image — the
+    // wrapper bakes showcase fixtures into base aimock and is the permanent
+    // image for the aimock showcase service. Prod is digest-pinned; staging
+    // floats :latest.
+    expect(SERVICES.aimock.repoNameOverride?.prod).toBe("showcase-aimock");
+    expect(SERVICES.aimock.repoNameOverride?.staging).toBe("showcase-aimock");
+  });
+
+  it("instanceIdFor returns the right ID per env", () => {
+    expect(instanceIdFor("showcase-mastra", "prod")).toBe(
+      "eaeddd9c-8b75-426f-b033-0fd935cbf6ef",
+    );
+    expect(instanceIdFor("showcase-mastra", "staging")).toBe(
+      "eec22411-aab5-47a1-8f5b-d097e233d7f8",
+    );
+  });
+
+  it("instanceIdFor throws on unknown service", () => {
+    expect(() => instanceIdFor("nope", "prod")).toThrow(
+      /Unknown showcase service/,
+    );
+  });
+
+  it("CI_BUILT_SERVICES contains exactly 25 services and excludes pocketbase/webhooks", () => {
+    expect(CI_BUILT_SERVICES.size).toBe(25);
+    expect(CI_BUILT_SERVICES.has("pocketbase")).toBe(false);
+    expect(CI_BUILT_SERVICES.has("webhooks")).toBe(false);
+    // Sample positives.
+    expect(CI_BUILT_SERVICES.has("showcase-mastra")).toBe(true);
+    expect(CI_BUILT_SERVICES.has("aimock")).toBe(true);
+    expect(CI_BUILT_SERVICES.has("dashboard")).toBe(true);
+  });
+
+  it("pocketbase and webhooks have per-env GHCR repo-name overrides", () => {
+    expect(SERVICES.pocketbase.repoNameOverride).toEqual({
+      prod: "showcase-pocketbase",
+      staging: "showcase-pocketbase",
+    });
+    expect(SERVICES.webhooks.repoNameOverride).toEqual({
+      prod: "showcase-eval-webhook",
+      staging: "showcase-eval-webhook",
+    });
+  });
+
+  it("pocketbase and webhooks are marked ciBuilt=false but gateValidated=true", () => {
+    expect(SERVICES.pocketbase.ciBuilt).toBe(false);
+    expect(SERVICES.pocketbase.gateValidated).toBe(true);
+    expect(SERVICES.webhooks.ciBuilt).toBe(false);
+    expect(SERVICES.webhooks.gateValidated).toBe(true);
+  });
+
+  it("repoNameFor resolves the showcase-aimock wrapper override in BOTH envs", () => {
+    // Both prod and staging run the `showcase-aimock` wrapper image
+    // (the fixture-baking wrapper is the permanent, canonical aimock
+    // showcase image — no migration). Prod is digest-pinned; staging
+    // floats :latest. The SSOT expresses this via overrides on both envs.
+    expect(repoNameFor("aimock", "prod")).toBe("showcase-aimock");
+    expect(repoNameFor("aimock", "staging")).toBe("showcase-aimock");
+  });
+
+  it("repoNameFor resolves pocketbase/webhooks overrides in BOTH envs", () => {
+    expect(repoNameFor("pocketbase", "prod")).toBe("showcase-pocketbase");
+    expect(repoNameFor("pocketbase", "staging")).toBe("showcase-pocketbase");
+    expect(repoNameFor("webhooks", "prod")).toBe("showcase-eval-webhook");
+    expect(repoNameFor("webhooks", "staging")).toBe("showcase-eval-webhook");
+  });
+
+  it("repoNameFor returns the service name verbatim when no override exists", () => {
+    expect(repoNameFor("showcase-mastra", "prod")).toBe("showcase-mastra");
+    expect(repoNameFor("showcase-mastra", "staging")).toBe("showcase-mastra");
+  });
+
+  it("serviceForDispatchName round-trips through SSOT keys", () => {
+    expect(serviceForDispatchName("mastra")).toBe("showcase-mastra");
+    expect(serviceForDispatchName("shell-dashboard")).toBe("dashboard");
+    expect(serviceForDispatchName("showcase-aimock")).toBe("aimock");
+    expect(serviceForDispatchName("shell")).toBe("shell");
+    expect(serviceForDispatchName("nonsense")).toBeUndefined();
+  });
+
+  it("every dispatchName resolves back to its own SSOT entry", () => {
+    for (const [name, entry] of Object.entries(SERVICES)) {
+      if (entry.dispatchName === undefined) continue;
+      expect(
+        serviceForDispatchName(entry.dispatchName),
+        `${name}.dispatchName="${entry.dispatchName}" did not round-trip`,
+      ).toBe(name);
+    }
+  });
+
+  it("dispatchName values are unique across SERVICES", () => {
+    const values = Object.values(SERVICES)
+      .map((entry) => entry.dispatchName)
+      .filter((v): v is string => v !== undefined);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("every showcase_build.yml ALL_SERVICES dispatch_name maps to an SSOT entry (bidirectional for CI-built)", () => {
+    // Forward-guard: parse the build workflow and assert every matrix
+    // `dispatch_name` resolves through the SSOT. Without this, a contributor
+    // can add a matrix entry whose dispatch_name has no SERVICES entry and
+    // only discover it at redeploy time when `redeploy-env.ts` throws
+    // `Unknown service` mid-deploy.
+    //
+    // Implementation note: ALL_SERVICES is a heredoc-style shell variable
+    // holding a JSON array INSIDE the YAML — so a YAML parser (we have
+    // `yaml` as a dep) wouldn't expose dispatch_names at any structural
+    // position. The robust extraction is a regex over the file text scoped
+    // to `"dispatch_name":"…"` JSON key/value pairs, which only appear
+    // inside the ALL_SERVICES JSON literal (the workflow_dispatch options
+    // list uses unkeyed YAML scalars and is not matched).
+    const workflowPath = resolve(
+      __dirname,
+      "../../.github/workflows/showcase_build.yml",
+    );
+    const yaml = readFileSync(workflowPath, "utf8");
+    const regex = /"dispatch_name"\s*:\s*"([^"]+)"/g;
+    const dispatchNames: string[] = [];
+    for (const match of yaml.matchAll(regex)) {
+      dispatchNames.push(match[1]);
+    }
+    // Sanity: we expect a populated list (25 CI-built services today).
+    expect(
+      dispatchNames.length,
+      "no dispatch_name entries found in showcase_build.yml — regex broken or file moved",
+    ).toBeGreaterThan(0);
+
+    // Forward direction: every YAML dispatch_name resolves to a defined
+    // SSOT key. Catches "added to matrix, forgot SSOT entry."
+    for (const dispatchName of dispatchNames) {
+      const resolved = serviceForDispatchName(dispatchName);
+      expect(
+        resolved,
+        `workflow dispatch_name "${dispatchName}" has no SSOT entry in railway-envs.ts`,
+      ).toBeDefined();
+    }
+
+    // Reverse direction (scoped to CI-built): every CI-built SSOT entry's
+    // dispatchName appears in the YAML matrix. Catches "added SSOT entry,
+    // forgot matrix slot." Non-CI-built services (pocketbase, webhooks)
+    // legitimately have no matrix entry — they're built by separate
+    // release workflows — so they are excluded from the reverse check.
+    const yamlSet = new Set(dispatchNames);
+    for (const name of CI_BUILT_SERVICES) {
+      const entry = SERVICES[name];
+      expect(
+        entry.dispatchName,
+        `CI-built service "${name}" has no dispatchName in SSOT`,
+      ).toBeDefined();
+      expect(
+        yamlSet.has(entry.dispatchName as string),
+        `CI-built service "${name}" (dispatchName="${entry.dispatchName}") has no matching entry in showcase_build.yml ALL_SERVICES matrix`,
+      ).toBe(true);
+    }
+  });
+});

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -422,6 +422,37 @@ describe("railway-envs SSOT — domains + probe", () => {
     expect(() => domainFor("docs", "dev")).toThrow(/Unknown env/);
   });
 
+  it("domainFor scheme guard rejects scheme-included literals but accepts http*-prefixed hosts", () => {
+    // The guard is intended to reject `http://...` / `https://...` literals
+    // accidentally pasted into the SSOT — NOT to reject any host whose name
+    // happens to begin with the letters "http" (e.g. `httpd-...`, `httpbin...`).
+    // Discriminator is the scheme separator `://`, not a `startsWith("http")`
+    // prefix check.
+    const saved = SERVICES.docs.domains.staging;
+    try {
+      // Regression: malformed `http://`-style literal MUST still throw.
+      (SERVICES.docs.domains as { staging: string }).staging =
+        "http://docs.staging.copilotkit.ai";
+      expect(() => domainFor("docs", "staging")).toThrow(
+        /malformed\/missing staging domain/,
+      );
+      (SERVICES.docs.domains as { staging: string }).staging =
+        "https://docs.staging.copilotkit.ai";
+      expect(() => domainFor("docs", "staging")).toThrow(
+        /malformed\/missing staging domain/,
+      );
+      // Positive: a hypothetical `httpd-`-prefixed host MUST be accepted.
+      (SERVICES.docs.domains as { staging: string }).staging =
+        "httpd-staging.up.railway.app";
+      expect(domainFor("docs", "staging")).toBe("httpd-staging.up.railway.app");
+      (SERVICES.docs.domains as { staging: string }).staging =
+        "httpbin.example.com";
+      expect(domainFor("docs", "staging")).toBe("httpbin.example.com");
+    } finally {
+      (SERVICES.docs.domains as { staging: string }).staging = saved;
+    }
+  });
+
   it("STAGING_ENV_ID and PRODUCTION_ENV_ID are exported and stable", () => {
     expect(STAGING_ENV_ID).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
     expect(PRODUCTION_ENV_ID).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -245,3 +245,31 @@ describe("railway-envs SSOT", () => {
     }
   });
 });
+
+describe("webhooks SSOT entry", () => {
+  it("has a dispatchName", () => {
+    expect(SERVICES.webhooks).toBeDefined();
+    expect(SERVICES.webhooks.dispatchName).toBe("webhooks");
+  });
+
+  it("is mirrored in showcase_build.yml dispatch choices", () => {
+    const yml = readFileSync(
+      resolve(__dirname, "../../.github/workflows/showcase_build.yml"),
+      "utf-8",
+    );
+    // The workflow_dispatch.inputs.service options list MUST include
+    // the SSOT dispatchName for webhooks so humans can target it.
+    expect(yml).toMatch(/^\s*- webhooks\s*$/m);
+    // The ALL_SERVICES matrix MUST include a webhooks entry.
+    expect(yml).toMatch(/"dispatch_name":"webhooks"/);
+  });
+
+  it("is mirrored in showcase_deploy.yml verify dispatch choices and ALL_SERVICES", () => {
+    const yml = readFileSync(
+      resolve(__dirname, "../../.github/workflows/showcase_deploy.yml"),
+      "utf-8",
+    );
+    expect(yml).toMatch(/^\s*- webhooks\s*$/m);
+    expect(yml).toMatch(/"dispatch_name":"webhooks"/);
+  });
+});

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -275,13 +275,24 @@ describe("webhooks SSOT entry", () => {
     expect(yml).toMatch(/"dispatch_name":"webhooks"/);
   });
 
-  it("is mirrored in showcase_deploy.yml verify dispatch choices and ALL_SERVICES", () => {
+  it("is wired into showcase_deploy.yml's verify matrix via the SSOT", () => {
+    // showcase_deploy.yml is SSOT-driven (A.7): the verify matrix is
+    // derived from railway-envs.generated.json by selecting services
+    // with `probe.staging === true`, and the workflow_dispatch input is
+    // a free-form string resolved against the SSOT (key or dispatchName).
+    // For webhooks to be probe-eligible AND human-dispatchable, the SSOT
+    // entry MUST carry probe.staging:true and a dispatchName of "webhooks".
+    expect(SERVICES.webhooks.probe.staging).toBe(true);
+    expect(SERVICES.webhooks.dispatchName).toBe("webhooks");
+    // Pin the workflow's SSOT-driven contract so a future regression
+    // back to a hardcoded matrix is caught: deploy.yml must consume the
+    // generated SSOT JSON and select on probe.staging.
     const yml = readFileSync(
       resolve(__dirname, "../../.github/workflows/showcase_deploy.yml"),
       "utf-8",
     );
-    expect(yml).toMatch(/^\s*- webhooks\s*$/m);
-    expect(yml).toMatch(/"dispatch_name":"webhooks"/);
+    expect(yml).toMatch(/railway-envs\.generated\.json/);
+    expect(yml).toMatch(/probe\.staging\s*==\s*true/);
   });
 });
 

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -8,6 +8,7 @@ import {
   PROJECT_ID,
   SERVICES,
   STAGING_ENV_ID,
+  assertDispatchNamesUnique,
   instanceIdFor,
   listServiceNames,
   repoNameFor,
@@ -271,5 +272,34 @@ describe("webhooks SSOT entry", () => {
     );
     expect(yml).toMatch(/^\s*- webhooks\s*$/m);
     expect(yml).toMatch(/"dispatch_name":"webhooks"/);
+  });
+});
+
+describe("dispatchName uniqueness invariant", () => {
+  it("the production SSOT has no duplicate dispatchNames", () => {
+    // This calls the invariant against the real exported SERVICES map;
+    // it MUST pass on a healthy tree.
+    expect(() => assertDispatchNamesUnique()).not.toThrow();
+  });
+
+  it("throws when two services share a dispatchName", () => {
+    // Synthetic input: same as production SERVICES but with two
+    // entries pointing at the same dispatchName "showcase-aimock".
+    const synthetic: Record<string, { dispatchName?: string }> = {
+      aimock: { dispatchName: "showcase-aimock" },
+      "showcase-aimock-dupe": { dispatchName: "showcase-aimock" },
+      mastra: { dispatchName: "mastra" },
+    };
+    expect(() => assertDispatchNamesUnique(synthetic)).toThrow(
+      /duplicate dispatchName.*showcase-aimock.*aimock.*showcase-aimock-dupe/i,
+    );
+  });
+
+  it("ignores entries without a dispatchName", () => {
+    const synthetic: Record<string, { dispatchName?: string }> = {
+      pocketbase: {}, // no dispatchName — out-of-band
+      webhooks: { dispatchName: "webhooks" },
+    };
+    expect(() => assertDispatchNamesUnique(synthetic)).not.toThrow();
   });
 });

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -1,0 +1,401 @@
+/**
+ * railway-envs.ts — Single source of truth for Railway IDs used by all
+ * TypeScript showcase tooling. Mirrors (but does not import) the IDs in
+ * `showcase/bin/railway` (Ruby). When these drift, prefer this file as
+ * the TS-side canonical source and reconcile bin/railway by hand.
+ *
+ * - PROJECT_ID is the CopilotKit Showcase Railway project.
+ * - ENV_IDS maps human env names (and common synonyms) to Railway env IDs.
+ * - SERVICES is the per-service map of serviceId + per-env serviceInstanceId.
+ *
+ * Service-instance IDs are env-scoped, so prod and staging IDs differ for
+ * the same service. Use instanceIdFor(serviceName, env) to get the right one.
+ */
+
+export const PROJECT_ID = "6f8c6bff-a80d-4f8f-b78d-50b32bcf4479";
+
+export const PRODUCTION_ENV_ID = "b14919f4-6417-429f-848d-c6ae2201e04f";
+export const STAGING_ENV_ID = "8edfef02-ea09-4a20-8689-261f21cc2849";
+
+export type EnvName = "prod" | "staging";
+
+// Accept common synonyms ("production", "prod", "staging") and normalize.
+export const ENV_IDS: Record<string, string> = {
+  prod: PRODUCTION_ENV_ID,
+  production: PRODUCTION_ENV_ID,
+  staging: STAGING_ENV_ID,
+};
+
+export function resolveEnv(name: string): { env: EnvName; envId: string } {
+  const lower = name.trim().toLowerCase();
+  if (lower === "prod" || lower === "production") {
+    return { env: "prod", envId: PRODUCTION_ENV_ID };
+  }
+  if (lower === "staging") {
+    return { env: "staging", envId: STAGING_ENV_ID };
+  }
+  throw new Error(
+    `Unknown env "${name}". Use one of: prod, production, staging.`,
+  );
+}
+
+export interface ServiceEntry {
+  /** Railway service ID (env-independent). */
+  serviceId: string;
+  /** serviceInstance ID for the production env. */
+  prodInstanceId: string;
+  /** serviceInstance ID for the staging env. */
+  stagingInstanceId: string;
+  /**
+   * True iff this service is built and pushed by `showcase_build.yml`.
+   * pocketbase and webhooks are first-party GHCR images but are built
+   * by their own repos' release workflows — they MUST NOT be touched
+   * by the showcase build's staging redeploy step.
+   */
+  ciBuilt: boolean;
+  /**
+   * True iff `verify-railway-image-refs.ts` validates this service's
+   * image refs. The historic gate filtered to `showcase-*`-prefix
+   * services only (19 of 27). WS4 expands that to include `aimock`
+   * (always was an override target), `pocketbase`, and `webhooks` —
+   * the three first-party non-`showcase-*` services. `dashboard`,
+   * `docs`, `dojo`, `harness`, and `shell` remain unvalidated for
+   * this PR and are scoped to Phase 2 (their Railway image refs were
+   * not part of the 27/27 prod-pinning audit).
+   */
+  gateValidated: boolean;
+  /**
+   * Optional GHCR repo name override per env. When unset for an env,
+   * the verify gate expects `ghcr.io/copilotkit/<serviceName>:<tag>`
+   * (or `@sha256:<digest>` in prod). When set, the gate uses
+   * `ghcr.io/copilotkit/<repoName>:<tag>` for that env only.
+   *
+   * Real cases (2026-05-28); headings use the actual SSOT keys:
+   *   aimock      — prod: "showcase-aimock"      (digest-pinned wrapper)
+   *                 staging: "showcase-aimock"   (wrapper, :latest)
+   *                 The `showcase-aimock` wrapper bakes showcase fixtures
+   *                 into base aimock and is the permanent, canonical
+   *                 image for the aimock showcase service in BOTH envs.
+   *                 It is the only aimock image CI builds.
+   *   pocketbase  — prod: "showcase-pocketbase"
+   *                 staging: "showcase-pocketbase"
+   *   webhooks    — prod: "showcase-eval-webhook"
+   *                 staging: "showcase-eval-webhook"
+   */
+  repoNameOverride?: { prod?: string; staging?: string };
+}
+
+/**
+ * Canonical per-service ID map. Keys are the EXACT Railway service names
+ * (`showcase-*` for integrations; bare names for infra services).
+ *
+ * Resolved 2026-05-28 via Railway GraphQL
+ * `project($id).services.edges[].serviceInstances.edges[]`.
+ *
+ * `dispatchName` (when set) is the EXACT `dispatch_name` value used by
+ * `.github/workflows/showcase_build.yml`'s `ALL_SERVICES` matrix entry
+ * for this service. The redeploy script uses it to convert the matrix
+ * output (which carries dispatch_names) back into SSOT keys.
+ */
+export const SERVICES: Record<
+  string,
+  ServiceEntry & { dispatchName?: string }
+> = {
+  aimock: {
+    serviceId: "0fa0435d-8a66-46f0-84fd-e4250b580013",
+    prodInstanceId: "5801d8be-5ad9-4eff-9c9c-7be61d9a023e",
+    stagingInstanceId: "9f260dfd-d9d4-43e9-98fe-49696f87fe50",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "showcase-aimock",
+    // Aimock runs the `showcase-aimock` wrapper image in BOTH envs.
+    // The wrapper (built from `showcase/aimock/Dockerfile`) bakes the
+    // showcase fixture tree into base aimock and is the permanent,
+    // canonical aimock image — it is the only aimock image CI builds.
+    // Prod is digest-pinned (`@sha256:<digest>`, promote-only); staging
+    // floats `:latest`. Both envs override to the same `showcase-aimock`
+    // GHCR repo; there is no migration to the unwrapped `aimock` repo.
+    repoNameOverride: { prod: "showcase-aimock", staging: "showcase-aimock" },
+  },
+  dashboard: {
+    serviceId: "4d5dfd74-be61-40b2-8564-b53b7dd4c15b",
+    prodInstanceId: "e68f98fa-b2ef-41cc-82f6-2ed6f9533bf3",
+    stagingInstanceId: "aea7332e-17a0-4fab-921c-ed5baad2a6f2",
+    ciBuilt: true,
+    gateValidated: false,
+    dispatchName: "shell-dashboard",
+    // No repoNameOverride here: gate validation for `dashboard`/`docs`/
+    // `dojo`/`shell` is OUT OF SCOPE for WS4. The current gate's
+    // `showcase-*`-prefix filter naturally excluded them, and we preserve
+    // that exclusion. Adding them is Phase 2 work.
+  },
+  docs: {
+    serviceId: "7badfb8d-4228-414c-9145-b4026803714f",
+    prodInstanceId: "b15564fc-f832-49b3-82df-fd36f298fe96",
+    stagingInstanceId: "d5caa51d-73ee-4669-bfea-d87bf1488b02",
+    ciBuilt: true,
+    gateValidated: false,
+    dispatchName: "shell-docs",
+  },
+  dojo: {
+    serviceId: "7ad1ece7-2228-49cd-8a78-bddf30322907",
+    prodInstanceId: "2ee4f2aa-11ec-4426-9a4a-41a1ad04f16d",
+    stagingInstanceId: "1284d717-0ff5-432c-9326-fab12661df61",
+    ciBuilt: true,
+    gateValidated: false,
+    dispatchName: "shell-dojo",
+  },
+  harness: {
+    serviceId: "3a14bfed-0537-4d71-897b-7c593dca161d",
+    prodInstanceId: "05fbcdf2-8a50-4b71-b4f6-c92c4b17e626",
+    stagingInstanceId: "0811f68f-fac4-440e-a350-3a7ca5855b80",
+    ciBuilt: true,
+    gateValidated: false,
+    dispatchName: "showcase-harness",
+    // Railway service name is `harness` (not `showcase-harness`); gate
+    // validation is deferred to Phase 2 alongside dashboard/docs/dojo/shell.
+    // ciBuilt: true, gateValidated: false — contrast with pocketbase/webhooks
+    // (ciBuilt: false, gateValidated: true).
+  },
+  pocketbase: {
+    serviceId: "ba11e854-d695-4738-9a45-2b0776788824",
+    prodInstanceId: "1ee376e2-13f2-4464-801e-d0aa0bf76532",
+    stagingInstanceId: "0bc7db7b-5a43-4b33-af46-d07fb53c8610",
+    // pocketbase is a first-party ghcr.io/copilotkit/ image, but its
+    // GHCR repo name is `showcase-pocketbase` (NOT `pocketbase`), and
+    // it is built by a separate release workflow — not showcase_build.yml.
+    ciBuilt: false,
+    gateValidated: true,
+    repoNameOverride: {
+      prod: "showcase-pocketbase",
+      staging: "showcase-pocketbase",
+    },
+  },
+  shell: {
+    serviceId: "40eea0da-6071-4ea8-bdb9-39afb19225ec",
+    prodInstanceId: "01614ccf-e109-4b30-b41b-7c5551c0a34c",
+    stagingInstanceId: "25b7de41-188c-4f2e-ac07-538212eaeb91",
+    ciBuilt: true,
+    gateValidated: false,
+    dispatchName: "shell",
+  },
+  "showcase-ag2": {
+    serviceId: "4a37481b-f264-4eb7-a9cd-0a9ebb9ac05c",
+    prodInstanceId: "de571c97-03fd-486b-8a54-9767a4a53f95",
+    stagingInstanceId: "ecaf81b3-93a8-4862-92b6-04a016b634ed",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "ag2",
+  },
+  "showcase-agno": {
+    serviceId: "32cab80b-e329-45bd-9c73-c4e1ddc94305",
+    prodInstanceId: "026d12fb-2844-42af-8f92-b47bc8a06bc8",
+    stagingInstanceId: "68964ab6-75ca-4095-a64a-52cacfb684f5",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "agno",
+  },
+  "showcase-built-in-agent": {
+    serviceId: "f4f8371a-bc46-45b2-b6d4-9c9af608bdbf",
+    prodInstanceId: "40018ef7-1ed1-4979-b80c-9c2d957b6d88",
+    stagingInstanceId: "b89ae7b3-01cc-4ed4-aca6-23aaa63cd59e",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "built-in-agent",
+  },
+  "showcase-claude-sdk-python": {
+    serviceId: "b122ab65-9854-4cb2-a68e-b50ff13f7481",
+    prodInstanceId: "bb18caaf-9a3e-4fdd-85ec-562fd82a3a89",
+    stagingInstanceId: "1ef25aec-5fbd-40b9-8685-57c2681bd45d",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "claude-sdk-python",
+  },
+  "showcase-claude-sdk-typescript": {
+    serviceId: "18a98727-5700-44aa-b497-b60795dbbd6a",
+    prodInstanceId: "bee425e4-9661-4a88-8888-922b8cd4b61d",
+    stagingInstanceId: "92305747-2f55-4122-aad4-882e989558ab",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "claude-sdk-typescript",
+  },
+  "showcase-crewai-crews": {
+    serviceId: "0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4",
+    prodInstanceId: "3dab0cc3-cab1-4579-b772-947268088514",
+    stagingInstanceId: "88c2a14f-435b-499e-a811-ee4f4be18fd8",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "crewai-crews",
+  },
+  "showcase-google-adk": {
+    serviceId: "87f60507-5a3d-4b8a-9e23-2b1de85d939c",
+    prodInstanceId: "7b2da5db-87d2-40ad-a3d9-b2d7a5485a22",
+    stagingInstanceId: "7efe2fa0-fa78-4585-bc4c-6d39c326e6d1",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "google-adk",
+  },
+  "showcase-langgraph-fastapi": {
+    serviceId: "06cccb5c-59f4-46b5-8adc-7113e77011a4",
+    prodInstanceId: "105b7e01-acd0-48e2-9a09-541e2103e8d2",
+    stagingInstanceId: "7899afe0-141b-4217-8dbb-5907813231dc",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "langgraph-fastapi",
+  },
+  "showcase-langgraph-python": {
+    serviceId: "90d03214-4569-41b0-b4c1-6438a8a7b203",
+    prodInstanceId: "aec504f7-63d7-4ea6-9d50-601b00d2ae80",
+    stagingInstanceId: "04d29664-a776-4670-9db3-b1d18bce1669",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "langgraph-python",
+  },
+  "showcase-langgraph-typescript": {
+    serviceId: "66246d3b-a18e-46f0-be51-5f3ff7a36e5a",
+    prodInstanceId: "f53e9fdc-7c3e-4dfd-9fa8-d7241fd55bb8",
+    stagingInstanceId: "481ab37f-da8a-4015-bd88-2b28d9eb261a",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "langgraph-typescript",
+  },
+  "showcase-langroid": {
+    serviceId: "6dd9cb0a-66cc-46f1-972e-7cd74756157d",
+    prodInstanceId: "6b5e20b5-8f8e-4ec3-9288-7a41122e42e5",
+    stagingInstanceId: "a213f7d9-2117-4944-988b-05e68d819dd5",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "langroid",
+  },
+  "showcase-llamaindex": {
+    serviceId: "285386e8-492d-4cb8-b632-0a7d4607378f",
+    prodInstanceId: "b778856e-9f90-4136-9415-fb2b41173f8d",
+    stagingInstanceId: "17899ea7-355c-43f2-a152-28cb0b7fa864",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "llamaindex",
+  },
+  "showcase-mastra": {
+    serviceId: "d7979eb7-2405-4aab-ad21-438f4a1b08af",
+    prodInstanceId: "eaeddd9c-8b75-426f-b033-0fd935cbf6ef",
+    stagingInstanceId: "eec22411-aab5-47a1-8f5b-d097e233d7f8",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "mastra",
+  },
+  "showcase-ms-agent-dotnet": {
+    serviceId: "beeb2dd6-87a4-4599-aa07-0578f7bd6519",
+    prodInstanceId: "93ca0edf-7b59-4de4-b1fd-3412bb07bc6a",
+    stagingInstanceId: "9826bc58-c472-41e6-b050-29249d4b2a52",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "ms-agent-dotnet",
+  },
+  "showcase-ms-agent-harness-dotnet": {
+    serviceId: "6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37",
+    prodInstanceId: "8f91ebc6-95c0-4433-b1f7-657ff49c2d59",
+    stagingInstanceId: "6b0fe181-9156-4a40-9e44-90befe09833a",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "ms-agent-harness-dotnet",
+  },
+  "showcase-ms-agent-python": {
+    serviceId: "655db75a-af8d-427d-a4f9-441570ae5003",
+    prodInstanceId: "323ed911-4d28-45ab-8fc0-7d151828b938",
+    stagingInstanceId: "741725ce-5fa1-4327-aff5-53dcc000c29c",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "ms-agent-python",
+  },
+  "showcase-pydantic-ai": {
+    serviceId: "0a106173-2282-4887-a994-0ca276a99d69",
+    prodInstanceId: "192cd647-6824-4f01-937a-1da675d83805",
+    stagingInstanceId: "6edf5ca5-6a56-4d28-92c3-2a3360c735db",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "pydantic-ai",
+  },
+  "showcase-spring-ai": {
+    serviceId: "eed5d041-91be-4282-b414-beea00843401",
+    prodInstanceId: "2fbf1db2-5e51-44c9-983c-3f2242d95c61",
+    stagingInstanceId: "189ac76f-bd77-45c0-9c45-3853dae763cc",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "spring-ai",
+  },
+  "showcase-strands": {
+    serviceId: "92e1cfad-ad53-403f-ab2b-5ab380832232",
+    prodInstanceId: "2123c71b-9385-443c-a1c3-bcf4b1669eeb",
+    stagingInstanceId: "f8a9d2ed-50ec-4f06-85d6-230baced8471",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "strands",
+  },
+  webhooks: {
+    serviceId: "ba6acc13-7585-41fe-a5ee-585b34a58fcd",
+    prodInstanceId: "d82ef5b4-3bfd-462e-9436-3d5dbca8681a",
+    stagingInstanceId: "450e87e0-aba5-4aba-afaf-15f4deab03f0",
+    // webhooks is a first-party ghcr.io/copilotkit/ image, but its
+    // GHCR repo name is `showcase-eval-webhook` (NOT `webhooks`), and
+    // it is built by a separate release workflow — not showcase_build.yml.
+    ciBuilt: false,
+    gateValidated: true,
+    repoNameOverride: {
+      prod: "showcase-eval-webhook",
+      staging: "showcase-eval-webhook",
+    },
+  },
+};
+
+export function instanceIdFor(serviceName: string, env: EnvName): string {
+  const entry = SERVICES[serviceName];
+  if (!entry) {
+    throw new Error(
+      `Unknown showcase service "${serviceName}". Add it to SERVICES in showcase/scripts/railway-envs.ts.`,
+    );
+  }
+  return env === "prod" ? entry.prodInstanceId : entry.stagingInstanceId;
+}
+
+export function listServiceNames(): string[] {
+  return Object.keys(SERVICES).sort();
+}
+
+/**
+ * The subset of SERVICES that `showcase_build.yml` actually builds and
+ * pushes. Excludes `pocketbase` and `webhooks` (released by their own
+ * repos). Default target set for `redeploy-env.ts <env>` when no
+ * explicit `--services` list is provided.
+ */
+export const CI_BUILT_SERVICES: ReadonlySet<string> = new Set(
+  Object.entries(SERVICES)
+    .filter(([, entry]) => entry.ciBuilt)
+    .map(([name]) => name),
+);
+
+/**
+ * Resolve the expected GHCR repo name for a (serviceName, env) pair.
+ * Exported so callers (verify-railway-image-refs.ts) and unit tests can
+ * exercise override resolution directly.
+ */
+export function repoNameFor(serviceName: string, env: EnvName): string {
+  const entry = SERVICES[serviceName];
+  if (!entry) return serviceName;
+  const override = entry.repoNameOverride?.[env];
+  return override ?? serviceName;
+}
+
+/**
+ * Resolve a `showcase_build.yml` `dispatch_name` (e.g. `mastra`,
+ * `shell-dashboard`, `showcase-aimock`) to the canonical SSOT key
+ * (e.g. `showcase-mastra`, `dashboard`, `aimock`). Returns undefined
+ * when the dispatch_name does not correspond to a CI-built service.
+ */
+export function serviceForDispatchName(
+  dispatchName: string,
+): string | undefined {
+  for (const [name, entry] of Object.entries(SERVICES)) {
+    if (entry.dispatchName === dispatchName) return name;
+  }
+  return undefined;
+}

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -646,11 +646,14 @@ export function domainFor(serviceName: string, env: EnvName): string {
     );
   }
   const host = entry.domains[env];
-  if (!host || host.startsWith("http")) {
+  if (!host || host.includes("://")) {
     // Defense-in-depth: SERVICES population is asserted by the
     // railway-envs.test.ts schema check, but if a future contributor
     // ships a scheme-included literal or an empty host this catches it
-    // at first use instead of returning a malformed value.
+    // at first use instead of returning a malformed value. We test for
+    // the scheme separator `://` rather than `startsWith("http")` so we
+    // don't false-reject legitimate hosts whose name happens to begin
+    // with the letters "http" (e.g. `httpd-…`, `httpbin…`).
     throw new Error(
       `Service "${serviceName}" has malformed/missing ${env} domain ("${host}").`,
     );

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -402,3 +402,49 @@ export function serviceForDispatchName(
   }
   return undefined;
 }
+
+/**
+ * Throw on SSOT load if any two services share the same `dispatchName`.
+ * `serviceForDispatchName` iterates `Object.entries(SERVICES)` and returns
+ * the first match — a silent collision would route redeploys to the wrong
+ * service. We fail loud at module load instead.
+ *
+ * Accepts an injected map for testing; defaults to the real SERVICES map.
+ */
+export function assertDispatchNamesUnique(
+  services: Record<string, { dispatchName?: string }> = SERVICES,
+): void {
+  const seen = new Map<string, string>(); // dispatchName -> first ssotKey
+  const collisions: Array<{
+    dispatchName: string;
+    keys: [string, string];
+  }> = [];
+  for (const [key, entry] of Object.entries(services)) {
+    const dn = entry.dispatchName;
+    if (typeof dn !== "string" || dn.length === 0) continue;
+    const prior = seen.get(dn);
+    if (prior !== undefined) {
+      collisions.push({ dispatchName: dn, keys: [prior, key] });
+    } else {
+      seen.set(dn, key);
+    }
+  }
+  if (collisions.length > 0) {
+    const lines = collisions
+      .map(
+        (c) =>
+          `  - duplicate dispatchName "${c.dispatchName}" on SSOT keys: ${c.keys[0]}, ${c.keys[1]}`,
+      )
+      .join("\n");
+    throw new Error(
+      `railway-envs SSOT invariant violated:\n${lines}\n` +
+        `Fix: each Railway service must have a unique dispatchName ` +
+        `(or no dispatchName at all for out-of-band services).`,
+    );
+  }
+}
+
+// Module-load assertion: fail any importer if the SSOT drifts into a
+// collision. Tests that exercise the invariant with synthetic input
+// call assertDispatchNamesUnique(synthetic) directly.
+assertDispatchNamesUnique();

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -131,8 +131,25 @@ export interface ServiceEntry {
    *                 staging: "showcase-pocketbase"
    *   webhooks    — prod: "showcase-eval-webhook"
    *                 staging: "showcase-eval-webhook"
+   *   dashboard   — prod/staging: "showcase-shell-dashboard"
+   *   docs        — prod/staging: "showcase-shell-docs"
+   *   dojo        — prod/staging: "showcase-shell-dojo"
+   *   shell       — prod/staging: "showcase-shell"
+   *   harness     — prod/staging: "showcase-harness"
    */
   repoNameOverride?: { prod?: string; staging?: string };
+  /**
+   * Opt-out flag for the image-ref gate. When `true`, the gate ignores
+   * this service entirely in BOTH the SSOT→Railway direction (no
+   * "missing from Railway" failure if absent) AND the Railway→SSOT
+   * direction (no "untracked Railway service" failure if Railway has
+   * a service with this name that is not WS4-managed). Default: false.
+   *
+   * Intentionally narrow: this exists for deliberately-untracked
+   * third-party relays or one-off experimental services. The default
+   * for every WS4-managed service is `false` (omitted).
+   */
+  gateIgnore?: boolean;
   /**
    * Public hosts per env, no scheme. Both must be set. `domainFor` is
    * the only API; it throws on unknown service/env so the verify probe

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -39,6 +39,56 @@ export function resolveEnv(name: string): { env: EnvName; envId: string } {
   );
 }
 
+/**
+ * Per-env domain host (no scheme). `staging` and `prod` MUST both be set —
+ * a service that does not exist in one env should not be in the SSOT at all.
+ * `domainFor(name, env)` is the only public API; it throws on missing data.
+ */
+export interface Domains {
+  staging: string;
+  prod: string;
+}
+
+/**
+ * The probe driver selects which feature-level verifier `verify-deploy.ts`
+ * runs against a service's URL. "200 ≠ healthy": every driver does more
+ * than a naked GET. See showcase/scripts/verify-deploy.ts for the per-driver
+ * implementation; the SSOT only names the driver here.
+ *
+ * - "shell" / "docs" / "dashboard" / "dojo" — Next.js shells: load the page
+ *   and assert a known DOM string plus a known network call.
+ * - "harness" / "eval" — synthetic e2e fixture against the service's API.
+ * - "aimock" — fixture replay with deterministic-response drift check.
+ * - "pocketbase" — admin login + known collection list.
+ * - "webhooks" — synthetic event POST and downstream confirmation.
+ * - "agent" — generic agent backend (the showcase-* integration services);
+ *   feature-level fixture call into the integration's /api endpoint.
+ */
+export type ProbeDriver =
+  | "shell"
+  | "harness"
+  | "eval"
+  | "aimock"
+  | "pocketbase"
+  | "webhooks"
+  | "dojo"
+  | "docs"
+  | "dashboard"
+  | "agent";
+
+/**
+ * Per-service probe configuration. `staging:false` or `prod:false` excludes
+ * the service from verify-deploy's pass for that env (e.g. a service we
+ * deliberately don't manage in one env). The default for every entry is
+ * `staging:true, prod:true` — only the aimock-prod CARVE-OUT (spec §11)
+ * lives as a comment; the probe still runs against the pinned aimock-prod.
+ */
+export interface ProbeConfig {
+  staging: boolean;
+  prod: boolean;
+  driver: ProbeDriver;
+}
+
 export interface ServiceEntry {
   /** Railway service ID (env-independent). */
   serviceId: string;
@@ -83,6 +133,18 @@ export interface ServiceEntry {
    *                 staging: "showcase-eval-webhook"
    */
   repoNameOverride?: { prod?: string; staging?: string };
+  /**
+   * Public hosts per env, no scheme. Both must be set. `domainFor` is
+   * the only API; it throws on unknown service/env so the verify probe
+   * fails loud rather than silently probing "".
+   */
+  domains: Domains;
+  /**
+   * Verify-deploy probe configuration. `verify-deploy.ts --env <env>`
+   * iterates SERVICES and runs `driver` for every service where
+   * `probe[env] === true`.
+   */
+  probe: ProbeConfig;
 }
 
 /**
@@ -116,6 +178,11 @@ export const SERVICES: Record<
     // floats `:latest`. Both envs override to the same `showcase-aimock`
     // GHCR repo; there is no migration to the unwrapped `aimock` repo.
     repoNameOverride: { prod: "showcase-aimock", staging: "showcase-aimock" },
+    domains: {
+      staging: "aimock-staging.up.railway.app",
+      prod: "showcase-aimock-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "aimock" },
   },
   dashboard: {
     serviceId: "4d5dfd74-be61-40b2-8564-b53b7dd4c15b",
@@ -128,6 +195,11 @@ export const SERVICES: Record<
     // `dojo`/`shell` is OUT OF SCOPE for WS4. The current gate's
     // `showcase-*`-prefix filter naturally excluded them, and we preserve
     // that exclusion. Adding them is Phase 2 work.
+    domains: {
+      staging: "dashboard.showcase.staging.copilotkit.ai",
+      prod: "dashboard.showcase.copilotkit.ai",
+    },
+    probe: { staging: true, prod: true, driver: "dashboard" },
   },
   docs: {
     serviceId: "7badfb8d-4228-414c-9145-b4026803714f",
@@ -136,6 +208,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: false,
     dispatchName: "shell-docs",
+    domains: {
+      staging: "docs.staging.copilotkit.ai",
+      prod: "docs.copilotkit.ai",
+    },
+    probe: { staging: true, prod: true, driver: "docs" },
   },
   dojo: {
     serviceId: "7ad1ece7-2228-49cd-8a78-bddf30322907",
@@ -144,6 +221,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: false,
     dispatchName: "shell-dojo",
+    domains: {
+      staging: "dojo.showcase.staging.copilotkit.ai",
+      prod: "dojo.showcase.copilotkit.ai",
+    },
+    probe: { staging: true, prod: true, driver: "dojo" },
   },
   harness: {
     serviceId: "3a14bfed-0537-4d71-897b-7c593dca161d",
@@ -156,6 +238,11 @@ export const SERVICES: Record<
     // validation is deferred to Phase 2 alongside dashboard/docs/dojo/shell.
     // ciBuilt: true, gateValidated: false — contrast with pocketbase/webhooks
     // (ciBuilt: false, gateValidated: true).
+    domains: {
+      staging: "harness-staging-2ee4.up.railway.app",
+      prod: "showcase-harness-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "harness" },
   },
   pocketbase: {
     serviceId: "ba11e854-d695-4738-9a45-2b0776788824",
@@ -170,6 +257,11 @@ export const SERVICES: Record<
       prod: "showcase-pocketbase",
       staging: "showcase-pocketbase",
     },
+    domains: {
+      staging: "pocketbase-staging-eec0.up.railway.app",
+      prod: "showcase-pocketbase-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "pocketbase" },
   },
   shell: {
     serviceId: "40eea0da-6071-4ea8-bdb9-39afb19225ec",
@@ -178,6 +270,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: false,
     dispatchName: "shell",
+    domains: {
+      staging: "showcase.staging.copilotkit.ai",
+      prod: "showcase.copilotkit.ai",
+    },
+    probe: { staging: true, prod: true, driver: "shell" },
   },
   "showcase-ag2": {
     serviceId: "4a37481b-f264-4eb7-a9cd-0a9ebb9ac05c",
@@ -186,6 +283,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ag2",
+    domains: {
+      staging: "showcase-ag2-staging.up.railway.app",
+      prod: "showcase-ag2-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-agno": {
     serviceId: "32cab80b-e329-45bd-9c73-c4e1ddc94305",
@@ -194,6 +296,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "agno",
+    domains: {
+      staging: "showcase-agno-staging.up.railway.app",
+      prod: "showcase-agno-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-built-in-agent": {
     serviceId: "f4f8371a-bc46-45b2-b6d4-9c9af608bdbf",
@@ -202,6 +309,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "built-in-agent",
+    domains: {
+      staging: "showcase-built-in-agent-staging.up.railway.app",
+      prod: "showcase-built-in-agent-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-claude-sdk-python": {
     serviceId: "b122ab65-9854-4cb2-a68e-b50ff13f7481",
@@ -210,6 +322,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "claude-sdk-python",
+    domains: {
+      staging: "showcase-claude-sdk-python-staging.up.railway.app",
+      prod: "showcase-claude-sdk-python-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-claude-sdk-typescript": {
     serviceId: "18a98727-5700-44aa-b497-b60795dbbd6a",
@@ -218,6 +335,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "claude-sdk-typescript",
+    domains: {
+      staging: "showcase-claude-sdk-typescript-staging.up.railway.app",
+      prod: "showcase-claude-sdk-typescript-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-crewai-crews": {
     serviceId: "0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4",
@@ -226,6 +348,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "crewai-crews",
+    domains: {
+      staging: "showcase-crewai-crews-staging.up.railway.app",
+      prod: "showcase-crewai-crews-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-google-adk": {
     serviceId: "87f60507-5a3d-4b8a-9e23-2b1de85d939c",
@@ -234,6 +361,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "google-adk",
+    domains: {
+      staging: "showcase-google-adk-staging.up.railway.app",
+      prod: "showcase-google-adk-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-langgraph-fastapi": {
     serviceId: "06cccb5c-59f4-46b5-8adc-7113e77011a4",
@@ -242,6 +374,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-fastapi",
+    domains: {
+      staging: "showcase-langgraph-fastapi-staging.up.railway.app",
+      prod: "showcase-langgraph-fastapi-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-langgraph-python": {
     serviceId: "90d03214-4569-41b0-b4c1-6438a8a7b203",
@@ -250,6 +387,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-python",
+    domains: {
+      staging: "showcase-langgraph-python-staging.up.railway.app",
+      prod: "showcase-langgraph-python-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-langgraph-typescript": {
     serviceId: "66246d3b-a18e-46f0-be51-5f3ff7a36e5a",
@@ -258,6 +400,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langgraph-typescript",
+    domains: {
+      staging: "showcase-langgraph-typescript-staging.up.railway.app",
+      prod: "showcase-langgraph-typescript-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-langroid": {
     serviceId: "6dd9cb0a-66cc-46f1-972e-7cd74756157d",
@@ -266,6 +413,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "langroid",
+    domains: {
+      staging: "showcase-langroid-staging.up.railway.app",
+      prod: "showcase-langroid-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-llamaindex": {
     serviceId: "285386e8-492d-4cb8-b632-0a7d4607378f",
@@ -274,6 +426,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "llamaindex",
+    domains: {
+      staging: "showcase-llamaindex-staging.up.railway.app",
+      prod: "showcase-llamaindex-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-mastra": {
     serviceId: "d7979eb7-2405-4aab-ad21-438f4a1b08af",
@@ -282,6 +439,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "mastra",
+    domains: {
+      staging: "showcase-mastra-staging.up.railway.app",
+      prod: "showcase-mastra-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-ms-agent-dotnet": {
     serviceId: "beeb2dd6-87a4-4599-aa07-0578f7bd6519",
@@ -290,6 +452,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-dotnet",
+    domains: {
+      staging: "showcase-ms-agent-dotnet-staging.up.railway.app",
+      prod: "showcase-ms-agent-dotnet-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-ms-agent-harness-dotnet": {
     serviceId: "6343d7f9-6c3f-4c8d-9a6e-79f03d2f1e37",
@@ -298,6 +465,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-harness-dotnet",
+    domains: {
+      staging: "showcase-ms-agent-harness-dotnet-staging.up.railway.app",
+      prod: "showcase-ms-agent-harness-dotnet-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-ms-agent-python": {
     serviceId: "655db75a-af8d-427d-a4f9-441570ae5003",
@@ -306,6 +478,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "ms-agent-python",
+    domains: {
+      staging: "showcase-ms-agent-python-staging.up.railway.app",
+      prod: "showcase-ms-agent-python-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-pydantic-ai": {
     serviceId: "0a106173-2282-4887-a994-0ca276a99d69",
@@ -314,6 +491,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "pydantic-ai",
+    domains: {
+      staging: "showcase-pydantic-ai-staging.up.railway.app",
+      prod: "showcase-pydantic-ai-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-spring-ai": {
     serviceId: "eed5d041-91be-4282-b414-beea00843401",
@@ -322,6 +504,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "spring-ai",
+    domains: {
+      staging: "showcase-spring-ai-staging.up.railway.app",
+      prod: "showcase-spring-ai-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   "showcase-strands": {
     serviceId: "92e1cfad-ad53-403f-ab2b-5ab380832232",
@@ -330,6 +517,11 @@ export const SERVICES: Record<
     ciBuilt: true,
     gateValidated: true,
     dispatchName: "strands",
+    domains: {
+      staging: "showcase-strands-staging.up.railway.app",
+      prod: "showcase-strands-production.up.railway.app",
+    },
+    probe: { staging: true, prod: true, driver: "agent" },
   },
   webhooks: {
     serviceId: "ba6acc13-7585-41fe-a5ee-585b34a58fcd",
@@ -347,6 +539,11 @@ export const SERVICES: Record<
       prod: "showcase-eval-webhook",
       staging: "showcase-eval-webhook",
     },
+    domains: {
+      staging: "hooks.showcase.staging.copilotkit.ai",
+      prod: "hooks.showcase.copilotkit.ai",
+    },
+    probe: { staging: true, prod: true, driver: "webhooks" },
   },
 };
 
@@ -386,6 +583,41 @@ export function repoNameFor(serviceName: string, env: EnvName): string {
   if (!entry) return serviceName;
   const override = entry.repoNameOverride?.[env];
   return override ?? serviceName;
+}
+
+/**
+ * Resolve the public host (no scheme) for a (serviceName, env) pair.
+ *
+ * THROWS on unknown service. THROWS on env values outside "staging"|"prod".
+ * Never returns "" — the verify probe and any consumer reading from the
+ * SSOT must fail loud, not silently probe an empty domain.
+ *
+ * Use this from verify-deploy.ts, from any TS caller that needs the URL,
+ * and from the JSON artifact emitter that the Ruby side consumes.
+ */
+export function domainFor(serviceName: string, env: EnvName): string {
+  const entry = SERVICES[serviceName];
+  if (!entry) {
+    throw new Error(
+      `Unknown showcase service "${serviceName}". Add it to SERVICES in showcase/scripts/railway-envs.ts.`,
+    );
+  }
+  if (env !== "prod" && env !== "staging") {
+    throw new Error(
+      `Unknown env "${String(env)}" passed to domainFor. Expected "prod" or "staging".`,
+    );
+  }
+  const host = entry.domains[env];
+  if (!host || host.startsWith("http")) {
+    // Defense-in-depth: SERVICES population is asserted by the
+    // railway-envs.test.ts schema check, but if a future contributor
+    // ships a scheme-included literal or an empty host this catches it
+    // at first use instead of returning a malformed value.
+    throw new Error(
+      `Service "${serviceName}" has malformed/missing ${env} domain ("${host}").`,
+    );
+  }
+  return host;
 }
 
 /**

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -335,11 +335,14 @@ export const SERVICES: Record<
     serviceId: "ba6acc13-7585-41fe-a5ee-585b34a58fcd",
     prodInstanceId: "d82ef5b4-3bfd-462e-9436-3d5dbca8681a",
     stagingInstanceId: "450e87e0-aba5-4aba-afaf-15f4deab03f0",
+    ciBuilt: false,
+    gateValidated: true,
+    dispatchName: "webhooks",
     // webhooks is a first-party ghcr.io/copilotkit/ image, but its
     // GHCR repo name is `showcase-eval-webhook` (NOT `webhooks`), and
     // it is built by a separate release workflow — not showcase_build.yml.
-    ciBuilt: false,
-    gateValidated: true,
+    // The dispatch_name entry below exists so humans can redeploy/verify
+    // webhooks from CI on demand; the build slot is no-op.
     repoNameOverride: {
       prod: "showcase-eval-webhook",
       staging: "showcase-eval-webhook",

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -105,13 +105,13 @@ export interface ServiceEntry {
   ciBuilt: boolean;
   /**
    * True iff `verify-railway-image-refs.ts` validates this service's
-   * image refs. The historic gate filtered to `showcase-*`-prefix
-   * services only (19 of 27). WS4 expands that to include `aimock`
-   * (always was an override target), `pocketbase`, and `webhooks` —
-   * the three first-party non-`showcase-*` services. `dashboard`,
-   * `docs`, `dojo`, `harness`, and `shell` remain unvalidated for
-   * this PR and are scoped to Phase 2 (their Railway image refs were
-   * not part of the 27/27 prod-pinning audit).
+   * image refs. As of WS-C completion this is `true` for every service
+   * in `SERVICES` — the historic Phase-2 deferral on dashboard, docs,
+   * dojo, shell, and harness has been retired. New services added to
+   * the SSOT MUST land with `gateValidated: true` (and a
+   * `repoNameOverride` if the Railway service name does not match the
+   * GHCR repo name); use the optional `gateIgnore: true` field only
+   * for deliberately-untracked third-party services.
    */
   gateValidated: boolean;
   /**
@@ -206,12 +206,15 @@ export const SERVICES: Record<
     prodInstanceId: "e68f98fa-b2ef-41cc-82f6-2ed6f9533bf3",
     stagingInstanceId: "aea7332e-17a0-4fab-921c-ed5baad2a6f2",
     ciBuilt: true,
-    gateValidated: false,
+    gateValidated: true,
     dispatchName: "shell-dashboard",
-    // No repoNameOverride here: gate validation for `dashboard`/`docs`/
-    // `dojo`/`shell` is OUT OF SCOPE for WS4. The current gate's
-    // `showcase-*`-prefix filter naturally excluded them, and we preserve
-    // that exclusion. Adding them is Phase 2 work.
+    // Railway service name is `dashboard`; GHCR repo is
+    // `showcase-shell-dashboard`. Same override for both envs:
+    // staging :latest, prod @sha256 — uniform across all services.
+    repoNameOverride: {
+      prod: "showcase-shell-dashboard",
+      staging: "showcase-shell-dashboard",
+    },
     domains: {
       staging: "dashboard.showcase.staging.copilotkit.ai",
       prod: "dashboard.showcase.copilotkit.ai",
@@ -223,8 +226,13 @@ export const SERVICES: Record<
     prodInstanceId: "b15564fc-f832-49b3-82df-fd36f298fe96",
     stagingInstanceId: "d5caa51d-73ee-4669-bfea-d87bf1488b02",
     ciBuilt: true,
-    gateValidated: false,
+    gateValidated: true,
     dispatchName: "shell-docs",
+    // Railway service name is `docs`; GHCR repo is `showcase-shell-docs`.
+    repoNameOverride: {
+      prod: "showcase-shell-docs",
+      staging: "showcase-shell-docs",
+    },
     domains: {
       staging: "docs.staging.copilotkit.ai",
       prod: "docs.copilotkit.ai",
@@ -236,8 +244,13 @@ export const SERVICES: Record<
     prodInstanceId: "2ee4f2aa-11ec-4426-9a4a-41a1ad04f16d",
     stagingInstanceId: "1284d717-0ff5-432c-9326-fab12661df61",
     ciBuilt: true,
-    gateValidated: false,
+    gateValidated: true,
     dispatchName: "shell-dojo",
+    // Railway service name is `dojo`; GHCR repo is `showcase-shell-dojo`.
+    repoNameOverride: {
+      prod: "showcase-shell-dojo",
+      staging: "showcase-shell-dojo",
+    },
     domains: {
       staging: "dojo.showcase.staging.copilotkit.ai",
       prod: "dojo.showcase.copilotkit.ai",
@@ -249,12 +262,15 @@ export const SERVICES: Record<
     prodInstanceId: "05fbcdf2-8a50-4b71-b4f6-c92c4b17e626",
     stagingInstanceId: "0811f68f-fac4-440e-a350-3a7ca5855b80",
     ciBuilt: true,
-    gateValidated: false,
+    gateValidated: true,
     dispatchName: "showcase-harness",
-    // Railway service name is `harness` (not `showcase-harness`); gate
-    // validation is deferred to Phase 2 alongside dashboard/docs/dojo/shell.
-    // ciBuilt: true, gateValidated: false — contrast with pocketbase/webhooks
-    // (ciBuilt: false, gateValidated: true).
+    // Railway service name is `harness`; GHCR repo is `showcase-harness`.
+    // ciBuilt: true, gateValidated: true — uniform with the rest of
+    // the CI-built integrations now that WS-C has flipped the five.
+    repoNameOverride: {
+      prod: "showcase-harness",
+      staging: "showcase-harness",
+    },
     domains: {
       staging: "harness-staging-2ee4.up.railway.app",
       prod: "showcase-harness-production.up.railway.app",
@@ -285,8 +301,13 @@ export const SERVICES: Record<
     prodInstanceId: "01614ccf-e109-4b30-b41b-7c5551c0a34c",
     stagingInstanceId: "25b7de41-188c-4f2e-ac07-538212eaeb91",
     ciBuilt: true,
-    gateValidated: false,
+    gateValidated: true,
     dispatchName: "shell",
+    // Railway service name is `shell`; GHCR repo is `showcase-shell`.
+    repoNameOverride: {
+      prod: "showcase-shell",
+      staging: "showcase-shell",
+    },
     domains: {
       staging: "showcase.staging.copilotkit.ai",
       prod: "showcase.copilotkit.ai",

--- a/showcase/scripts/redeploy-env.test.ts
+++ b/showcase/scripts/redeploy-env.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseArgs, runRedeploy, resolveTargetServices } from "./redeploy-env";
+import { SERVICES } from "./railway-envs";
+
+describe("runRedeploy", () => {
+  let consoleErrSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+  let summary: string;
+
+  beforeEach(() => {
+    consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    // runRedeploy's per-service progress lines go to process.stdout.write
+    // (NOT console.log); spy on that too or tests spam the terminal.
+    stdoutWriteSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    summary = "";
+  });
+
+  afterEach(() => {
+    consoleErrSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
+  });
+
+  const appendSummary = (s: string) => {
+    summary += s + "\n";
+  };
+
+  it("default scope (no --services) targets the 25 CI-built services, NOT all 27", async () => {
+    const seenNames: string[] = [];
+    const redeploy = vi.fn(async (serviceId: string) => {
+      // Reverse-lookup the SSOT name from serviceId so the test can
+      // assert exact membership rather than counting opaquely.
+      const name = Object.entries(SERVICES).find(
+        ([, e]) => e.serviceId === serviceId,
+      )?.[0];
+      if (name) seenNames.push(name);
+      return { ok: true as const };
+    });
+
+    const result = await runRedeploy({
+      env: "staging",
+      redeploy,
+      appendSummary,
+      // services omitted → default = CI_BUILT_SERVICES
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.attempted).toBe(25);
+    expect(result.succeeded).toBe(25);
+    expect(redeploy).toHaveBeenCalledTimes(25);
+    expect(seenNames).not.toContain("pocketbase");
+    expect(seenNames).not.toContain("webhooks");
+  });
+
+  it("default whole-env staging redeploy NEVER bounces pocketbase or webhooks", async () => {
+    // Explicit anti-regression test: this exact assertion exists
+    // because the v1 of this script iterated all 27 SERVICES.
+    const seenIds = new Set<string>();
+    const redeploy = vi.fn(async (serviceId: string) => {
+      seenIds.add(serviceId);
+      return { ok: true as const };
+    });
+    await runRedeploy({ env: "staging", redeploy, appendSummary });
+    expect(seenIds.has(SERVICES.pocketbase.serviceId)).toBe(false);
+    expect(seenIds.has(SERVICES.webhooks.serviceId)).toBe(false);
+  });
+
+  it("explicit --services list targets exactly that subset", async () => {
+    const seenIds: string[] = [];
+    const redeploy = vi.fn(async (serviceId: string) => {
+      seenIds.push(serviceId);
+      return { ok: true as const };
+    });
+    const result = await runRedeploy({
+      env: "staging",
+      redeploy,
+      appendSummary,
+      services: ["showcase-mastra", "showcase-ag2"],
+    });
+    expect(result.attempted).toBe(2);
+    expect(seenIds).toEqual([
+      SERVICES["showcase-ag2"].serviceId, // alphabetical iteration
+      SERVICES["showcase-mastra"].serviceId,
+    ]);
+  });
+
+  it("targets the staging env id", async () => {
+    const calls: Array<{ environmentId: string }> = [];
+    const redeploy = vi.fn(async (_svc: string, environmentId: string) => {
+      calls.push({ environmentId });
+      return { ok: true as const };
+    });
+    await runRedeploy({
+      env: "staging",
+      redeploy,
+      appendSummary,
+      services: ["showcase-mastra"],
+    });
+    for (const c of calls) {
+      expect(c.environmentId).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
+    }
+  });
+
+  it("targets the prod env id when env=prod", async () => {
+    const calls: Array<{ environmentId: string }> = [];
+    const redeploy = vi.fn(async (_svc: string, environmentId: string) => {
+      calls.push({ environmentId });
+      return { ok: true as const };
+    });
+    await runRedeploy({
+      env: "prod",
+      redeploy,
+      appendSummary,
+      services: ["showcase-mastra"],
+    });
+    for (const c of calls) {
+      expect(c.environmentId).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");
+    }
+  });
+
+  it("treats per-service failures as non-fatal and exits 0", async () => {
+    // Deterministic: fail on a specific named service so the test does
+    // not depend on the size of the default scope.
+    const failTarget = SERVICES["showcase-mastra"].serviceId;
+    const redeploy = vi.fn(async (serviceId: string) => {
+      if (serviceId === failTarget) {
+        return { ok: false as const, error: "boom" };
+      }
+      return { ok: true as const };
+    });
+
+    const result = await runRedeploy({
+      env: "staging",
+      redeploy,
+      appendSummary,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.succeeded + result.failed).toBe(result.attempted);
+    // Failure must be visible in the summary.
+    expect(summary).toMatch(/FAIL/);
+    expect(summary).toMatch(/boom/);
+  });
+
+  it("per-service catch records non-Error throws (null, string) as failures without crashing", async () => {
+    // Catch block previously did `(e as Error).message ?? String(e)`,
+    // which throws TypeError when e is null.
+    const failTarget = SERVICES["showcase-mastra"].serviceId;
+    const redeploy = vi.fn(async (serviceId: string) => {
+      if (serviceId === failTarget) {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw null;
+      }
+      return { ok: true as const };
+    });
+
+    const result = await runRedeploy({
+      env: "staging",
+      redeploy,
+      appendSummary,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(summary).toMatch(/FAIL/);
+  });
+
+  it("env=prod returns non-zero exitCode on per-service failure", async () => {
+    // Prod isn't wired yet, but the design must NOT silently swallow
+    // prod per-service failures the way staging intentionally does.
+    const redeploy = vi.fn(async () => ({
+      ok: false as const,
+      error: "kaboom",
+    }));
+    const result = await runRedeploy({
+      env: "prod",
+      redeploy,
+      appendSummary,
+      services: ["showcase-mastra"],
+    });
+    expect(result.failed).toBe(1);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("env=prod returns exitCode 0 when all services succeed", async () => {
+    const redeploy = vi.fn(async () => ({ ok: true as const }));
+    const result = await runRedeploy({
+      env: "prod",
+      redeploy,
+      appendSummary,
+      services: ["showcase-mastra"],
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reports zero failures with empty failure list in summary", async () => {
+    const redeploy = vi.fn(async () => ({ ok: true as const }));
+    await runRedeploy({ env: "staging", redeploy, appendSummary });
+    expect(summary).toMatch(/0 failed/);
+  });
+
+  it("throws on a --services entry that doesn't resolve to a known SSOT key", async () => {
+    const redeploy = vi.fn();
+    await expect(
+      runRedeploy({
+        env: "staging",
+        redeploy,
+        appendSummary,
+        services: ["nonsense"],
+      }),
+    ).rejects.toThrow(/Unknown service/);
+    expect(redeploy).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown env names", async () => {
+    const redeploy = vi.fn();
+    await expect(
+      runRedeploy({ env: "dev" as never, redeploy, appendSummary }),
+    ).rejects.toThrow(/Unknown env/);
+    expect(redeploy).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveTargetServices", () => {
+  it("accepts SSOT keys verbatim and resolves CI dispatch_names too", () => {
+    // The workflow passes detect-changes.outputs.matrix .dispatch_name
+    // values, but a human operator might pass SSOT keys directly.
+    // Both forms must resolve.
+    const resolved = resolveTargetServices([
+      "showcase-mastra", // already an SSOT key
+      "mastra", // dispatch_name → showcase-mastra
+      "shell-dashboard", // dispatch_name → dashboard
+      "showcase-aimock", // dispatch_name → aimock
+    ]);
+    expect(resolved).toEqual(["showcase-mastra", "dashboard", "aimock"]);
+    // Dedupes the duplicate showcase-mastra ↔ mastra.
+  });
+
+  it("throws on inputs that match neither SSOT keys nor dispatch_names", () => {
+    expect(() => resolveTargetServices(["mastra", "garbage"])).toThrow(
+      /Unknown service "garbage"/,
+    );
+  });
+
+  it("returns the CI_BUILT_SERVICES set sorted when given undefined", () => {
+    const resolved = resolveTargetServices(undefined);
+    expect(resolved.length).toBe(25);
+    expect(resolved).not.toContain("pocketbase");
+    expect(resolved).not.toContain("webhooks");
+  });
+});
+
+describe("parseArgs", () => {
+  it("parses bare env name", () => {
+    expect(parseArgs(["staging"])).toEqual({ env: "staging" });
+  });
+
+  it("parses --services with CSV value", () => {
+    expect(parseArgs(["staging", "--services", "mastra,ag2"])).toEqual({
+      env: "staging",
+      services: ["mastra", "ag2"],
+    });
+  });
+
+  it("parses --services=csv form", () => {
+    expect(parseArgs(["staging", "--services=mastra,ag2"])).toEqual({
+      env: "staging",
+      services: ["mastra", "ag2"],
+    });
+  });
+
+  it("throws when --services has no following value (bare flag at end)", () => {
+    expect(() => parseArgs(["staging", "--services"])).toThrow(
+      /--services requires a non-empty comma-separated value/,
+    );
+  });
+
+  it("throws when --services value is the empty string", () => {
+    expect(() => parseArgs(["staging", "--services", ""])).toThrow(
+      /--services requires a non-empty comma-separated value/,
+    );
+  });
+
+  it("throws when --services value is only commas/whitespace", () => {
+    expect(() => parseArgs(["staging", "--services", ","])).toThrow(
+      /--services requires a non-empty comma-separated value/,
+    );
+  });
+
+  it("throws when --services= value empties after split/filter", () => {
+    expect(() => parseArgs(["staging", "--services="])).toThrow(
+      /--services requires a non-empty comma-separated value/,
+    );
+  });
+
+  it("throws on unknown argument", () => {
+    expect(() => parseArgs(["staging", "--bogus"])).toThrow(/Unknown argument/);
+  });
+
+  it("throws on empty argv", () => {
+    expect(() => parseArgs([])).toThrow();
+  });
+});

--- a/showcase/scripts/redeploy-env.ts
+++ b/showcase/scripts/redeploy-env.ts
@@ -271,6 +271,17 @@ export async function runRedeploy(
   const names = resolveTargetServices(services).sort();
 
   const failures: Array<{ service: string; error: string }> = [];
+  // Per-service structured records — cross-workstream contract consumed
+  // by showcase_deploy.yml's `enforce-redeploy-gate` (A.7) via the
+  // REDEPLOY_SUMMARY_JSON artifact. Shape:
+  //   Array<{ service: string; status: "ok" | "error"; error?: string }>
+  // Built in parallel with the existing `failures`/`succeeded` tallies so
+  // PR #5093's exit-code computation below is untouched.
+  const records: Array<{
+    service: string;
+    status: "ok" | "error";
+    error?: string;
+  }> = [];
   let succeeded = 0;
 
   appendSummary(`## Railway redeploy — env=${env}`);
@@ -283,14 +294,17 @@ export async function runRedeploy(
       const outcome = await redeploy(entry.serviceId, envId);
       if (outcome.ok) {
         succeeded++;
+        records.push({ service: name, status: "ok" });
         process.stdout.write("OK\n");
       } else {
         failures.push({ service: name, error: outcome.error });
+        records.push({ service: name, status: "error", error: outcome.error });
         process.stdout.write(`FAIL: ${outcome.error}\n`);
       }
     } catch (e: unknown) {
       const error = e instanceof Error ? e.message : String(e);
       failures.push({ service: name, error });
+      records.push({ service: name, status: "error", error });
       process.stdout.write(`FAIL (threw): ${error}\n`);
     }
   }
@@ -317,6 +331,27 @@ export async function runRedeploy(
       appendSummary(
         "Staging redeploys are non-fatal — the verify-deploy workflow is the gate.",
       );
+    }
+  }
+
+  // A.4: optional per-service JSON summary for showcase_deploy.yml's
+  // `enforce-redeploy-gate` job. Atomic write (stage to .tmp, rename) so
+  // a CI consumer racing the writer never sees a partial file. A failure
+  // here is warn-only — PR #5093's exit-code semantics MUST NOT regress
+  // on a disk hiccup.
+  const jsonPath = process.env.REDEPLOY_SUMMARY_JSON;
+  if (jsonPath) {
+    try {
+      const tmp = `${jsonPath}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify(records, null, 2) + "\n");
+      fs.renameSync(tmp, jsonPath);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      process.stderr.write(
+        `warning: failed to write REDEPLOY_SUMMARY_JSON=${jsonPath} (${msg})\n`,
+      );
+      // Non-fatal: best-effort CI summary write; do NOT regress
+      // PR #5093's exit semantics on a disk hiccup.
     }
   }
 

--- a/showcase/scripts/redeploy-env.ts
+++ b/showcase/scripts/redeploy-env.ts
@@ -47,8 +47,10 @@ import {
   serviceForDispatchName,
 } from "./railway-envs";
 import type { EnvName } from "./railway-envs";
+import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
+import { resolveRailwayTokenFromConfig } from "./lib/railway-token";
 
-const RAILWAY_API = "https://backboard.railway.com/graphql/v2";
+const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
 const RAILWAY_ERROR_BODY_MAX = 200;
 
 function getToken(): string {
@@ -70,7 +72,9 @@ function getToken(): string {
       console.error(`Malformed ~/.railway/config.json: ${msg}`);
       process.exit(1);
     }
-    const token = (config as { user?: { token?: string } } | null)?.user?.token;
+    const token = resolveRailwayTokenFromConfig(
+      config as Parameters<typeof resolveRailwayTokenFromConfig>[0],
+    );
     if (typeof token === "string" && token.length > 0) return token;
   }
   console.error(

--- a/showcase/scripts/redeploy-env.ts
+++ b/showcase/scripts/redeploy-env.ts
@@ -1,0 +1,387 @@
+#!/usr/bin/env npx tsx
+/**
+ * redeploy-env.ts — Trigger Railway `serviceInstanceRedeploy` for the
+ * CI-built showcase services in the named environment.
+ *
+ * Usage:
+ *   npx tsx showcase/scripts/redeploy-env.ts <env> [--services <csv>]
+ *
+ *   npx tsx showcase/scripts/redeploy-env.ts staging
+ *     → redeploys all 25 CI_BUILT_SERVICES (default scope excludes
+ *       pocketbase/webhooks; explicit --services can still target them)
+ *
+ *   npx tsx showcase/scripts/redeploy-env.ts staging --services mastra,ag2
+ *     → redeploys only the listed services (CSV of SSOT keys OR
+ *       showcase_build.yml dispatch_names; mixed is fine).
+ *
+ * Behavior:
+ *   - Default target set: CI_BUILT_SERVICES (25 of 27 SSOT entries).
+ *     pocketbase and webhooks are first-party but released by their own
+ *     repos — they are excluded from the default scope. An explicit
+ *     `--services pocketbase` (or webhooks) WILL still redeploy them;
+ *     resolveTargetServices honors any SSOT key the caller asks for.
+ *   - When `--services` is provided, each entry is resolved via
+ *     resolveTargetServices() against SSOT keys + dispatch_names.
+ *   - Per-service Railway failures (including the all-services-fail case)
+ *     are logged to stderr and $GITHUB_STEP_SUMMARY but DO NOT fail the
+ *     process for staging. Staging is not a release gate; the
+ *     verify-deploy workflow is what fails on bad images. For env=prod,
+ *     per-service failures DO yield a non-zero exitCode (fail loud).
+ *   - Operator/config errors (bad env name, unknown service, missing or
+ *     malformed token) ALWAYS fail loud with a non-zero exit.
+ *
+ * Auth: RAILWAY_TOKEN env var or ~/.railway/config.json.
+ * Exit code: 0 on staging even when per-service redeploys fail; non-zero
+ * for prod per-service failures and for any operator/config error.
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  CI_BUILT_SERVICES,
+  PRODUCTION_ENV_ID,
+  SERVICES,
+  STAGING_ENV_ID,
+  resolveEnv,
+  serviceForDispatchName,
+} from "./railway-envs";
+import type { EnvName } from "./railway-envs";
+
+const RAILWAY_API = "https://backboard.railway.com/graphql/v2";
+const RAILWAY_ERROR_BODY_MAX = 200;
+
+function getToken(): string {
+  if (process.env.RAILWAY_TOKEN) return process.env.RAILWAY_TOKEN;
+  const home = process.env.HOME;
+  if (!home) {
+    console.error(
+      "No Railway token found. RAILWAY_TOKEN is unset and $HOME is unset so ~/.railway/config.json cannot be located.",
+    );
+    process.exit(1);
+  }
+  const configPath = path.join(home, ".railway", "config.json");
+  if (fs.existsSync(configPath)) {
+    let config: unknown;
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`Malformed ~/.railway/config.json: ${msg}`);
+      process.exit(1);
+    }
+    const token = (config as { user?: { token?: string } } | null)?.user?.token;
+    if (typeof token === "string" && token.length > 0) return token;
+  }
+  console.error(
+    "No Railway token found. Set RAILWAY_TOKEN or run `railway login`.",
+  );
+  process.exit(1);
+}
+
+/**
+ * Truncate a Railway API error body for inclusion in the markdown summary.
+ * Railway/Cloudflare error responses can be multi-KB HTML pages; strip the
+ * angle brackets that would break the markdown table and cap at ~200 chars.
+ */
+function sanitizeErrorBody(body: string): string {
+  const stripped = body.replace(/[<>]/g, "");
+  if (stripped.length <= RAILWAY_ERROR_BODY_MAX) return stripped;
+  return stripped.slice(0, RAILWAY_ERROR_BODY_MAX) + "…";
+}
+
+export interface RedeployResult {
+  ok: true;
+}
+export interface RedeployFailure {
+  ok: false;
+  error: string;
+}
+export type RedeployOutcome = RedeployResult | RedeployFailure;
+
+export type RedeployFn = (
+  serviceId: string,
+  environmentId: string,
+) => Promise<RedeployOutcome>;
+
+/**
+ * Build a `liveRedeploy` RedeployFn bound to a single resolved token, so
+ * token resolution happens once per process rather than once per service.
+ */
+function makeLiveRedeploy(token: string): RedeployFn {
+  return async function liveRedeploy(
+    serviceId: string,
+    environmentId: string,
+  ): Promise<RedeployOutcome> {
+    const res = await fetch(RAILWAY_API, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: `mutation serviceInstanceRedeploy($serviceId: String!, $environmentId: String!) {
+        serviceInstanceRedeploy(serviceId: $serviceId, environmentId: $environmentId)
+      }`,
+        variables: { serviceId, environmentId },
+      }),
+    });
+    if (!res.ok) {
+      const body = sanitizeErrorBody(await res.text());
+      return { ok: false, error: `HTTP ${res.status}: ${body}` };
+    }
+    const json = (await res.json()) as {
+      data?: { serviceInstanceRedeploy?: boolean };
+      errors?: Array<{ message: string }>;
+    };
+    if (json.errors?.length) {
+      return { ok: false, error: json.errors.map((e) => e.message).join("; ") };
+    }
+    if (json.data?.serviceInstanceRedeploy !== true) {
+      return {
+        ok: false,
+        error: `serviceInstanceRedeploy returned ${JSON.stringify(json.data?.serviceInstanceRedeploy)}`,
+      };
+    }
+    return { ok: true };
+  };
+}
+
+export interface RunRedeployOpts {
+  env: EnvName;
+  redeploy: RedeployFn;
+  appendSummary: (line: string) => void;
+  /**
+   * Explicit service list. Each entry may be either an SSOT key
+   * (e.g. `showcase-mastra`) or a `showcase_build.yml` dispatch_name
+   * (e.g. `mastra`, `shell-dashboard`, `showcase-aimock`).
+   *
+   * When undefined, the default scope is `CI_BUILT_SERVICES` (the 25
+   * services that `showcase_build.yml` actually builds). pocketbase
+   * and webhooks are NEVER in the default scope.
+   */
+  services?: string[];
+}
+
+export interface RunRedeploySummary {
+  exitCode: number;
+  attempted: number;
+  succeeded: number;
+  failed: number;
+}
+
+/**
+ * Normalize a caller-supplied service list (CSV of SSOT keys and/or
+ * dispatch_names, in any mix) into a deduped list of SSOT keys.
+ *
+ * Ordering is intentionally split by branch:
+ *   - When `input` is undefined, returns the default `CI_BUILT_SERVICES`
+ *     set sorted alphabetically (never includes pocketbase/webhooks).
+ *   - When `input` is provided, returns the resolved SSOT keys in the
+ *     caller's INSERTION order (deduped). `runRedeploy` then sorts before
+ *     iterating, so the user-visible iteration order is alphabetical in
+ *     both cases, but this function preserves insertion order so callers
+ *     that want it can opt in.
+ *
+ * Exported for direct unit testing.
+ */
+export function resolveTargetServices(input: string[] | undefined): string[] {
+  if (input === undefined) {
+    return [...CI_BUILT_SERVICES].sort();
+  }
+  const resolved = new Set<string>();
+  for (const raw of input) {
+    const name = raw.trim();
+    if (!name) continue;
+    if (SERVICES[name]) {
+      resolved.add(name);
+      continue;
+    }
+    const viaDispatch = serviceForDispatchName(name);
+    if (viaDispatch) {
+      resolved.add(viaDispatch);
+      continue;
+    }
+    throw new Error(
+      `Unknown service "${name}" — not an SSOT key or dispatch_name in railway-envs.ts. Add it to SERVICES (with a dispatchName) or fix the caller.`,
+    );
+  }
+  return [...resolved];
+}
+
+/**
+ * Pure argv parser. Accepts either `--services x,y,z` or `--services=x,y,z`.
+ * Throws if `--services` is provided with a missing/empty value (silent
+ * no-op in CI is worse than a loud failure). Throws on unknown args or
+ * empty argv. Exported for direct unit testing.
+ */
+export function parseArgs(argv: string[]): {
+  env: string;
+  services?: string[];
+} {
+  if (argv.length === 0) {
+    throw new Error(
+      "Usage: redeploy-env.ts <env> [--services <csv>] (env: prod | production | staging)",
+    );
+  }
+  const env = argv[0];
+  let services: string[] | undefined;
+
+  const ensureNonEmpty = (raw: string | undefined): string[] => {
+    if (raw === undefined || raw === "") {
+      throw new Error("--services requires a non-empty comma-separated value");
+    }
+    const parts = raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (parts.length === 0) {
+      throw new Error("--services requires a non-empty comma-separated value");
+    }
+    return parts;
+  };
+
+  for (let i = 1; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--services") {
+      services = ensureNonEmpty(argv[++i]);
+    } else if (a.startsWith("--services=")) {
+      services = ensureNonEmpty(a.slice("--services=".length));
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return services === undefined ? { env } : { env, services };
+}
+
+export async function runRedeploy(
+  opts: RunRedeployOpts,
+): Promise<RunRedeploySummary> {
+  const { env, redeploy, appendSummary, services } = opts;
+  if (env !== "prod" && env !== "staging") {
+    throw new Error(
+      `Unknown env: ${String(env)} (expected "prod" or "staging")`,
+    );
+  }
+  const envId = env === "prod" ? PRODUCTION_ENV_ID : STAGING_ENV_ID;
+  const names = resolveTargetServices(services).sort();
+
+  const failures: Array<{ service: string; error: string }> = [];
+  let succeeded = 0;
+
+  appendSummary(`## Railway redeploy — env=${env}`);
+  appendSummary("");
+
+  for (const name of names) {
+    const entry = SERVICES[name];
+    process.stdout.write(`  ${name.padEnd(36)} `);
+    try {
+      const outcome = await redeploy(entry.serviceId, envId);
+      if (outcome.ok) {
+        succeeded++;
+        process.stdout.write("OK\n");
+      } else {
+        failures.push({ service: name, error: outcome.error });
+        process.stdout.write(`FAIL: ${outcome.error}\n`);
+      }
+    } catch (e: unknown) {
+      const error = e instanceof Error ? e.message : String(e);
+      failures.push({ service: name, error });
+      process.stdout.write(`FAIL (threw): ${error}\n`);
+    }
+  }
+
+  const attempted = names.length;
+  const failed = failures.length;
+
+  appendSummary(`- attempted: **${attempted}**`);
+  appendSummary(`- succeeded: **${succeeded}**`);
+  appendSummary(`- ${failed} failed`);
+  appendSummary("");
+
+  if (failures.length > 0) {
+    appendSummary("### Failures");
+    appendSummary("");
+    appendSummary("| service | status | error |");
+    appendSummary("| --- | --- | --- |");
+    for (const f of failures) {
+      const safeErr = f.error.replace(/\|/g, "\\|").replace(/\n/g, " ");
+      appendSummary(`| \`${f.service}\` | FAIL | ${safeErr} |`);
+    }
+    appendSummary("");
+    if (env === "staging") {
+      appendSummary(
+        "Staging redeploys are non-fatal — the verify-deploy workflow is the gate.",
+      );
+    }
+  }
+
+  // Staging: per-service failures are non-fatal (the verify-deploy
+  // workflow is the real release gate). Prod: per-service failures must
+  // surface as a non-zero exit so an operator notices.
+  const exitCode = env === "prod" && failed > 0 ? 1 : 0;
+  return { exitCode, attempted, succeeded, failed };
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0) {
+    console.error(
+      "Usage: npx tsx showcase/scripts/redeploy-env.ts <env> [--services <csv>]",
+    );
+    console.error("  env: prod | production | staging");
+    console.error("  --services: optional CSV of SSOT keys or dispatch_names");
+    process.exit(2);
+  }
+  const parsed = parseArgs(argv);
+  const { env } = resolveEnv(parsed.env);
+  const services = parsed.services;
+
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  const appendSummary = (line: string) => {
+    if (summaryFile) {
+      try {
+        fs.appendFileSync(summaryFile, line + "\n");
+      } catch (e) {
+        // Best-effort: a non-writable $GITHUB_STEP_SUMMARY must not abort
+        // the run. Mirror to stderr so the failure is at least visible.
+        const msg = e instanceof Error ? e.message : String(e);
+        process.stderr.write(
+          `warning: failed to append to GITHUB_STEP_SUMMARY (${msg})\n`,
+        );
+      }
+    }
+    // Also mirror to stderr so local runs see it.
+    process.stderr.write(line + "\n");
+  };
+
+  // Resolve the Railway token ONCE for the whole run, then thread it
+  // through to liveRedeploy. Missing/malformed creds exit non-zero from
+  // getToken() before we ever enter the per-service loop.
+  const token = getToken();
+  const redeploy = makeLiveRedeploy(token);
+
+  const result = await runRedeploy({
+    env,
+    redeploy,
+    appendSummary,
+    services,
+  });
+  console.log(
+    `\n${result.succeeded}/${result.attempted} redeploys triggered (${result.failed} failed)`,
+  );
+  process.exit(result.exitCode);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error(e);
+    // Fail loud on operator/config errors (bad env name, unknown service,
+    // missing/malformed token, parseArgs rejection, etc.). Per-service
+    // Railway failures are caught INSIDE runRedeploy and reflected in
+    // result.exitCode — they never reach this catch — so reaching here
+    // means something is wrong with how the script was invoked or
+    // configured, and CI should see a red run instead of a silent no-op.
+    process.exit(1);
+  });
+}

--- a/showcase/scripts/redeploy-env.ts
+++ b/showcase/scripts/redeploy-env.ts
@@ -50,10 +50,7 @@ import {
   RAILWAY_GRAPHQL_ENDPOINT,
   sanitizeErrorBody,
 } from "./lib/railway-graphql";
-import {
-  RailwayTokenError,
-  resolveRailwayToken,
-} from "./lib/railway-token";
+import { RailwayTokenError, resolveRailwayToken } from "./lib/railway-token";
 
 const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
 

--- a/showcase/scripts/redeploy-env.ts
+++ b/showcase/scripts/redeploy-env.ts
@@ -36,7 +36,6 @@
  */
 
 import fs from "fs";
-import path from "path";
 import { fileURLToPath } from "url";
 import {
   CI_BUILT_SERVICES,
@@ -47,51 +46,34 @@ import {
   serviceForDispatchName,
 } from "./railway-envs";
 import type { EnvName } from "./railway-envs";
-import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
-import { resolveRailwayTokenFromConfig } from "./lib/railway-token";
+import {
+  RAILWAY_GRAPHQL_ENDPOINT,
+  sanitizeErrorBody,
+} from "./lib/railway-graphql";
+import {
+  RailwayTokenError,
+  resolveRailwayToken,
+} from "./lib/railway-token";
 
 const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
-const RAILWAY_ERROR_BODY_MAX = 200;
-
-function getToken(): string {
-  if (process.env.RAILWAY_TOKEN) return process.env.RAILWAY_TOKEN;
-  const home = process.env.HOME;
-  if (!home) {
-    console.error(
-      "No Railway token found. RAILWAY_TOKEN is unset and $HOME is unset so ~/.railway/config.json cannot be located.",
-    );
-    process.exit(1);
-  }
-  const configPath = path.join(home, ".railway", "config.json");
-  if (fs.existsSync(configPath)) {
-    let config: unknown;
-    try {
-      config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.error(`Malformed ~/.railway/config.json: ${msg}`);
-      process.exit(1);
-    }
-    const token = resolveRailwayTokenFromConfig(
-      config as Parameters<typeof resolveRailwayTokenFromConfig>[0],
-    );
-    if (typeof token === "string" && token.length > 0) return token;
-  }
-  console.error(
-    "No Railway token found. Set RAILWAY_TOKEN or run `railway login`.",
-  );
-  process.exit(1);
-}
 
 /**
- * Truncate a Railway API error body for inclusion in the markdown summary.
- * Railway/Cloudflare error responses can be multi-KB HTML pages; strip the
- * angle brackets that would break the markdown table and cap at ~200 chars.
+ * Resolve the Railway bearer token for this run. Wraps the shared
+ * `resolveRailwayToken` envelope and maps any RailwayTokenError onto
+ * the script's exit-1 contract for operator/config errors. The shared
+ * helper never calls process.exit — exit-code mapping lives HERE so the
+ * helper stays unit-testable.
  */
-function sanitizeErrorBody(body: string): string {
-  const stripped = body.replace(/[<>]/g, "");
-  if (stripped.length <= RAILWAY_ERROR_BODY_MAX) return stripped;
-  return stripped.slice(0, RAILWAY_ERROR_BODY_MAX) + "…";
+function getToken(): string {
+  try {
+    return resolveRailwayToken().token;
+  } catch (e) {
+    if (e instanceof RailwayTokenError) {
+      console.error(e.message);
+      process.exit(1);
+    }
+    throw e;
+  }
 }
 
 export interface RedeployResult {

--- a/showcase/scripts/resolve-verify-matrix.ts
+++ b/showcase/scripts/resolve-verify-matrix.ts
@@ -158,7 +158,7 @@ export function resolveVerifyMatrix(
     );
   }
 
-  // FIX 7 — make the workflow_run boundary total. `check-redeploy-summary`
+  // Make the workflow_run boundary total. `check-redeploy-summary`
   // always sets `summary_present` to exactly "true" or "false"; any other
   // value here (including "" from a future step-id-rename wiring break,
   // or "True" from a case-typo) means the wiring is broken upstream, NOT

--- a/showcase/scripts/resolve-verify-matrix.ts
+++ b/showcase/scripts/resolve-verify-matrix.ts
@@ -144,12 +144,37 @@ export function resolveVerifyMatrix(
   // explicitly handled — the prior fall-through to the workflow_run
   // intersection branch silently emitted has_services=false for both,
   // indistinguishable from a legit "no summary, nothing to verify" skip.
+  //
+  // The CLI wrapper narrows EVENT_NAME via `asSupportedEventName` before
+  // calling here, so on the CLI path this guard is defense-in-depth.
+  // Direct test callers (which build their own input object) still pay
+  // the runtime check, which is the point.
   if (
     eventName !== "workflow_run" &&
     eventName !== "workflow_dispatch"
   ) {
     throw new Error(
       `::error::resolve-verify-matrix: unexpected eventName '${eventName}' (expected 'workflow_run' or 'workflow_dispatch')`,
+    );
+  }
+
+  // FIX 7 — make the workflow_run boundary total. `check-redeploy-summary`
+  // always sets `summary_present` to exactly "true" or "false"; any other
+  // value here (including "" from a future step-id-rename wiring break,
+  // or "True" from a case-typo) means the wiring is broken upstream, NOT
+  // a legitimate skip. Without this guard, an empty/garbage summaryPresent
+  // falls through to the workflow_run intersection branch — which silently
+  // emits has_services=false on what may be a real redeploy. Throw instead
+  // so enforce-redeploy-gate (which fans in on resolve-matrix.result ==
+  // 'failure') reds the workflow.
+  // workflow_dispatch ignores summaryPresent and must NOT trip this guard.
+  if (
+    eventName === "workflow_run" &&
+    summaryPresent !== "true" &&
+    summaryPresent !== "false"
+  ) {
+    throw new Error(
+      `::error::resolve-verify-matrix: workflow_run requires summary_present in {true,false}, got '${summaryPresent}'`,
     );
   }
 
@@ -221,12 +246,17 @@ const SSOT_JSON = "showcase/scripts/railway-envs.generated.json";
 const EMIT_SCRIPT = "showcase/scripts/emit-railway-envs-json.ts";
 
 /**
- * Validate the parsed SSOT JSON shape. A truncated or schema-drifted
- * SSOT (emitter crashed mid-write, or someone renamed `probe.staging`)
- * parses fine but silently shrinks/empties the probe-eligible set,
- * which the resolver then propagates as a false-green skip. We require
- * the shape we depend on, and `::error::`-prefix the throw so the
- * workflow log surfaces it as an annotation.
+ * Validate the parsed SSOT JSON shape. Two distinct failure modes to
+ * guard against:
+ *   - SCHEMA DRIFT (e.g. someone renamed `probe.staging`): the JSON
+ *     parses fine but silently empties the probe-eligible set, which
+ *     the resolver would otherwise propagate as a false-green skip.
+ *   - TRUNCATION (emitter crashed mid-write): either fails `JSON.parse`
+ *     outright (loud) or — if the truncation happened to land on a
+ *     valid-JSON boundary — leaves an empty `services` array, caught
+ *     here by the non-empty check.
+ * We require the exact shape we depend on, and `::error::`-prefix the
+ * throw so the workflow log surfaces it as an annotation.
  */
 export function parseSsotServices(
   raw: unknown,
@@ -326,6 +356,24 @@ function requireEnv(name: string): string {
   return v;
 }
 
+/**
+ * Narrow a raw env-string EVENT_NAME into the resolver's literal union.
+ * Replaces the prior `as 'workflow_run' | 'workflow_dispatch'` unchecked
+ * cast — the type system and runtime now tell the same story. The
+ * resolver itself ALSO guards eventName, but doing the narrowing here
+ * means the CLI path fails loud at the boundary with a wrapper-specific
+ * `::error::` annotation (EVENT_NAME, not eventName) before the resolver
+ * is even called.
+ */
+function asSupportedEventName(s: string): SupportedEventName {
+  if (s !== "workflow_run" && s !== "workflow_dispatch") {
+    throw new Error(
+      `::error::resolve-verify-matrix: unexpected EVENT_NAME '${s}' (expected 'workflow_run' or 'workflow_dispatch')`,
+    );
+  }
+  return s;
+}
+
 function writeGithubOutput(
   githubOutput: string,
   servicesCsv: string,
@@ -349,13 +397,13 @@ function main(): void {
   const dispatchService = process.env.DISPATCH_SERVICE ?? "";
 
   try {
-    // Narrow the raw env-string to the resolver's literal union. The
-    // resolver itself also fails loud on unknown eventName (FIX 3) — the
-    // cast just satisfies the type system; runtime validation lives in
-    // the resolver so both call paths (tests + CLI) share one guard.
-    const eventName = eventNameRaw as
-      | "workflow_run"
-      | "workflow_dispatch";
+    // Narrow the raw env-string to the resolver's literal union. Replaces
+    // the prior unchecked `as` cast — the narrowing helper throws on
+    // unexpected EVENT_NAME with a wrapper-specific `::error::`
+    // annotation, so the type system and runtime tell the same story.
+    // The resolver's internal eventName guard becomes defense-in-depth
+    // for direct (test) callers that construct input objects by hand.
+    const eventName: SupportedEventName = asSupportedEventName(eventNameRaw);
 
     const ssotServices = loadSsotServices();
 
@@ -392,17 +440,17 @@ function main(): void {
   }
 }
 
-const invokedDirectly = (() => {
-  try {
-    return (
-      typeof process !== "undefined" &&
-      Array.isArray(process.argv) &&
-      process.argv[1] === fileURLToPath(import.meta.url)
-    );
-  } catch {
-    return false;
-  }
-})();
+// Detect "this module is the entrypoint" — used to gate the CLI bottom
+// half so tests can `import` the pure resolver without triggering env
+// reads or filesystem IO. Intentionally NO try/catch: an ESM-interop
+// failure here (e.g. `fileURLToPath` rejects `import.meta.url`) used to
+// silently return false → CLI no-ops → $GITHUB_OUTPUT never written →
+// downstream `verify:` step skips (false-green). Let it crash loud
+// instead; the workflow surfaces the stack and the gate stays honest.
+const invokedDirectly =
+  typeof process !== "undefined" &&
+  Array.isArray(process.argv) &&
+  process.argv[1] === fileURLToPath(import.meta.url);
 
 if (invokedDirectly) {
   main();

--- a/showcase/scripts/resolve-verify-matrix.ts
+++ b/showcase/scripts/resolve-verify-matrix.ts
@@ -53,9 +53,12 @@ export interface SsotService {
   probe: { staging: boolean };
 }
 
+/** Accepted github.event_name values for this resolver. */
+export type SupportedEventName = "workflow_run" | "workflow_dispatch";
+
 export interface ResolveVerifyMatrixInput {
   /** github.event_name — 'workflow_run' or 'workflow_dispatch'. */
-  eventName: string;
+  eventName: SupportedEventName;
   /** 'true' / 'false' / '' — the upstream `check-redeploy-summary` step output. */
   summaryPresent: string;
   /** CSV of services that redeployed OK (from `redeploy-gate.outputs.ok_services`). */
@@ -73,8 +76,10 @@ export interface ResolveVerifyMatrixOutput {
 
 /** Sorted, dedup'd list of every SSOT service with probe.staging===true. */
 function probeEligibleNames(ssotServices: SsotService[]): string[] {
+  // Shape is guaranteed by parseSsotServices (every service has a `probe`
+  // object with a boolean `staging`), so no defensive optional chain.
   const names = ssotServices
-    .filter((s) => s.probe?.staging === true)
+    .filter((s) => s.probe.staging === true)
     .map((s) => s.name);
   return Array.from(new Set(names)).sort();
 }
@@ -82,23 +87,43 @@ function probeEligibleNames(ssotServices: SsotService[]): string[] {
 /**
  * Map an `ok_services` CSV (which may carry SSOT keys OR dispatchName
  * aliases — the build matrix sometimes emits dispatch_names) into the
- * set of canonical SSOT names. Tokens that don't match any service are
- * silently dropped; the bash did the same (jq `select(...).name` simply
- * yielded no row for unknown tokens).
+ * set of canonical SSOT names.
+ *
+ * Tokens are .trim()'d before lookup so a future change to the
+ * redeploy-gate bash (or a human-typed workflow_dispatch caller) that
+ * emits "a, b" with spaces does not silently drop tokens. Unmatched
+ * tokens are returned in `dropped` so the CLI wrapper can surface them
+ * via `::warning::` — a silent drop here is the exact SSOT/build drift
+ * smell that the boundary hardening is supposed to detect. Empty tokens
+ * (trailing comma, double comma) are filtered before matching and are
+ * NOT reported as dropped (they carry no signal).
  */
-function okCsvToCanonicalNames(
+export interface OkCsvResult {
+  canonical: Set<string>;
+  dropped: string[];
+}
+
+export function okCsvToCanonicalNames(
   okFromRedeploy: string,
   ssotServices: SsotService[],
-): Set<string> {
+): OkCsvResult {
   const canonical = new Set<string>();
-  const tokens = okFromRedeploy.split(",").filter((t) => t.length > 0);
+  const dropped: string[] = [];
+  const tokens = okFromRedeploy
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
   for (const t of tokens) {
     const match = ssotServices.find(
       (s) => s.name === t || s.dispatchName === t,
     );
-    if (match) canonical.add(match.name);
+    if (match) {
+      canonical.add(match.name);
+    } else {
+      dropped.push(t);
+    }
   }
-  return canonical;
+  return { canonical, dropped };
 }
 
 export function resolveVerifyMatrix(
@@ -111,6 +136,22 @@ export function resolveVerifyMatrix(
     dispatchService,
     ssotServices,
   } = input;
+
+  // Fail loud on unrecognized eventName. Today only `workflow_run` and
+  // `workflow_dispatch` reach this resolver (showcase_deploy.yml's `on:`
+  // block is closed to those two). Any other value here means either a
+  // typo in the wrapper's env wiring or a new trigger that hasn't been
+  // explicitly handled — the prior fall-through to the workflow_run
+  // intersection branch silently emitted has_services=false for both,
+  // indistinguishable from a legit "no summary, nothing to verify" skip.
+  if (
+    eventName !== "workflow_run" &&
+    eventName !== "workflow_dispatch"
+  ) {
+    throw new Error(
+      `::error::resolve-verify-matrix: unexpected eventName '${eventName}' (expected 'workflow_run' or 'workflow_dispatch')`,
+    );
+  }
 
   // Case: workflow_run + nothing redeployed — the build legitimately
   // didn't redeploy anything (no buildable service changed). Skip verify.
@@ -162,7 +203,10 @@ export function resolveVerifyMatrix(
   // probe-eligible. Map ok-tokens to canonical names first (handles the
   // dispatchName-alias case). Drop anything not in probe-eligible (e.g.
   // a service that redeployed OK but has no probe driver).
-  const okCanonical = okCsvToCanonicalNames(okFromRedeploy, ssotServices);
+  const { canonical: okCanonical } = okCsvToCanonicalNames(
+    okFromRedeploy,
+    ssotServices,
+  );
   const intersection = probeEligible.filter((n) => okCanonical.has(n));
   const csv = intersection.join(",");
   return { servicesCsv: csv, hasServices: csv.length > 0 };
@@ -176,16 +220,102 @@ export function resolveVerifyMatrix(
 const SSOT_JSON = "showcase/scripts/railway-envs.generated.json";
 const EMIT_SCRIPT = "showcase/scripts/emit-railway-envs-json.ts";
 
+/**
+ * Validate the parsed SSOT JSON shape. A truncated or schema-drifted
+ * SSOT (emitter crashed mid-write, or someone renamed `probe.staging`)
+ * parses fine but silently shrinks/empties the probe-eligible set,
+ * which the resolver then propagates as a false-green skip. We require
+ * the shape we depend on, and `::error::`-prefix the throw so the
+ * workflow log surfaces it as an annotation.
+ */
+export function parseSsotServices(
+  raw: unknown,
+  path: string,
+): SsotService[] {
+  if (raw === null || typeof raw !== "object") {
+    throw new Error(
+      `::error::SSOT ${path} malformed: top-level value is not an object`,
+    );
+  }
+  const services = (raw as { services?: unknown }).services;
+  if (!Array.isArray(services)) {
+    throw new Error(
+      `::error::SSOT ${path} malformed: \`services\` is not an array`,
+    );
+  }
+  if (services.length === 0) {
+    throw new Error(
+      `::error::SSOT ${path} malformed: \`services\` is empty (emitter crashed mid-write or schema drift?)`,
+    );
+  }
+  const validated: SsotService[] = [];
+  for (let i = 0; i < services.length; i++) {
+    const s = services[i];
+    if (s === null || typeof s !== "object") {
+      throw new Error(
+        `::error::SSOT ${path} malformed: services[${i}] is not an object`,
+      );
+    }
+    const obj = s as {
+      name?: unknown;
+      dispatchName?: unknown;
+      probe?: unknown;
+    };
+    if (typeof obj.name !== "string" || obj.name.length === 0) {
+      throw new Error(
+        `::error::SSOT ${path} malformed: services[${i}] missing \`name\` (or not a non-empty string)`,
+      );
+    }
+    // dispatchName is OPTIONAL in the live SSOT (e.g. `pocketbase` has
+    // no dispatchName field — it is not a CI-built service). Accept
+    // missing OR null OR string; normalize to null internally.
+    if (
+      obj.dispatchName !== undefined &&
+      obj.dispatchName !== null &&
+      typeof obj.dispatchName !== "string"
+    ) {
+      throw new Error(
+        `::error::SSOT ${path} malformed: services[${i}] (${obj.name}) \`dispatchName\` must be string, null, or absent`,
+      );
+    }
+    if (obj.probe === null || typeof obj.probe !== "object") {
+      throw new Error(
+        `::error::SSOT ${path} malformed: services[${i}] (${obj.name}) missing \`probe\` object`,
+      );
+    }
+    const probe = obj.probe as { staging?: unknown };
+    if (typeof probe.staging !== "boolean") {
+      throw new Error(
+        `::error::SSOT ${path} malformed: services[${i}] (${obj.name}) \`probe.staging\` is not boolean`,
+      );
+    }
+    validated.push({
+      name: obj.name,
+      dispatchName:
+        typeof obj.dispatchName === "string" ? obj.dispatchName : null,
+      probe: { staging: probe.staging },
+    });
+  }
+  return validated;
+}
+
 function loadSsotServices(): SsotService[] {
   // Preserve the prior bash behavior: regenerate the JSON if it's missing
   // (e.g. a freshly-checked-out workspace that hasn't run the emitter).
   if (!existsSync(SSOT_JSON)) {
     execFileSync("npx", ["tsx", EMIT_SCRIPT], { stdio: "inherit" });
   }
-  const raw = JSON.parse(readFileSync(SSOT_JSON, "utf-8")) as {
-    services: SsotService[];
-  };
-  return raw.services;
+  // Re-check existence after the regen attempt: if the emitter exits 0
+  // without writing (transient race, broken IO, mis-configured cwd), the
+  // pre-fix code would JSON.parse a ReadFile-against-missing-path error
+  // and fail with a useless stack. Fail loud instead.
+  if (!existsSync(SSOT_JSON)) {
+    throw new Error(
+      `::error::SSOT ${SSOT_JSON} still missing after regenerate attempt (${EMIT_SCRIPT} exited 0 without writing?)`,
+    );
+  }
+  const raw: unknown = JSON.parse(readFileSync(SSOT_JSON, "utf-8"));
+  return parseSsotServices(raw, SSOT_JSON);
 }
 
 function requireEnv(name: string): string {
@@ -213,14 +343,35 @@ function writeGithubOutput(
 
 function main(): void {
   const githubOutput = requireEnv("GITHUB_OUTPUT");
-  const eventName = requireEnv("EVENT_NAME");
+  const eventNameRaw = requireEnv("EVENT_NAME");
   const summaryPresent = process.env.SUMMARY_PRESENT ?? "";
   const okFromRedeploy = process.env.OK_FROM_REDEPLOY ?? "";
   const dispatchService = process.env.DISPATCH_SERVICE ?? "";
 
-  const ssotServices = loadSsotServices();
-
   try {
+    // Narrow the raw env-string to the resolver's literal union. The
+    // resolver itself also fails loud on unknown eventName (FIX 3) — the
+    // cast just satisfies the type system; runtime validation lives in
+    // the resolver so both call paths (tests + CLI) share one guard.
+    const eventName = eventNameRaw as
+      | "workflow_run"
+      | "workflow_dispatch";
+
+    const ssotServices = loadSsotServices();
+
+    // Surface SSOT/build drift via ::warning:: when an ok_services token
+    // matches no SSOT service. The resolver-level intersection already
+    // drops the token; without this log, the operator never learns that
+    // a redeploy reported success for a service the SSOT has forgotten
+    // about (or vice versa). Keep this in the wrapper (not the pure
+    // function) so the resolver stays IO-free.
+    const okPreview = okCsvToCanonicalNames(okFromRedeploy, ssotServices);
+    if (okPreview.dropped.length > 0) {
+      process.stderr.write(
+        `::warning::ok_services tokens dropped (no SSOT match): ${okPreview.dropped.join(",")}\n`,
+      );
+    }
+
     const { servicesCsv, hasServices } = resolveVerifyMatrix({
       eventName,
       summaryPresent,
@@ -231,8 +382,9 @@ function main(): void {
     writeGithubOutput(githubOutput, servicesCsv, hasServices);
   } catch (e) {
     // Mirror the prior bash: print `::error::...` to stderr and exit 1.
-    // The Error message already carries the `::error::` annotation when
-    // it's an Unknown-service throw.
+    // Throws from this module already carry the `::error::` annotation
+    // (Unknown service, unexpected eventName, SSOT malformed, SSOT
+    // missing-after-regen).
     process.stderr.write(
       `${e instanceof Error ? e.message : String(e)}\n`,
     );

--- a/showcase/scripts/resolve-verify-matrix.ts
+++ b/showcase/scripts/resolve-verify-matrix.ts
@@ -1,0 +1,257 @@
+/**
+ * resolve-verify-matrix.ts — decide which staging services the
+ * post-redeploy verify probe should target.
+ *
+ * Replaces the inline bash+jq block in showcase_deploy.yml's
+ * `resolve-matrix` job ("Build verify matrix from SSOT" step). The bash
+ * had produced two confirmed bugs across prior CR rounds, so the logic
+ * was extracted into a pure, unit-testable TypeScript function.
+ *
+ * Decision table — `resolveVerifyMatrix` returns `{servicesCsv, hasServices}`:
+ *
+ *   workflow_dispatch + service='all'/empty
+ *     → full probe-eligible set (every SSOT service with probe.staging===true),
+ *       sorted+dedup'd. has_services=true.
+ *
+ *   workflow_dispatch + specific service (SSOT key OR dispatchName)
+ *     → just that one canonical name. Unknown service → throws (CLI wrapper
+ *       exits non-zero with `::error::` annotation, matching prior bash).
+ *
+ *   workflow_run + summary_present='false'
+ *     → has_services=false, services_csv=''. Nothing was redeployed (build
+ *       legitimately had no buildable changes); skip verify.
+ *
+ *   workflow_run + summary_present='true' + ok_services empty
+ *     → has_services=false, services_csv=''. ALL services errored on
+ *       redeploy → the success-set is empty → nothing left to verify.
+ *       `enforce-redeploy-gate` independently reds the workflow on
+ *       redeploy_red=true, so this case is already loud. The PRIOR bash
+ *       fell through to the full probe-eligible fleet here, gratuitously
+ *       probing every service against stale `:latest`; that was the
+ *       "Issue A" bug this module fixes.
+ *
+ *   workflow_run + summary_present='true' + ok_services non-empty
+ *     → intersect ok_services with probe-eligible SSOT services. The
+ *       ok_services CSV may carry SSOT keys OR dispatchName aliases;
+ *       both spellings resolve to the canonical name. Result is sorted,
+ *       dedup'd, CSV-joined. has_services=(csv non-empty).
+ *
+ * Testability: the pure function takes `ssotServices` as a parameter so
+ * tests run without filesystem IO. The CLI wrapper at the bottom reads
+ * env vars, loads `railway-envs.generated.json` (regenerating via
+ * emit-railway-envs-json.ts if missing — preserves the fallback the
+ * old bash had), and writes `services_csv=` / `has_services=` lines to
+ * $GITHUB_OUTPUT.
+ */
+import { execFileSync } from "node:child_process";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export interface SsotService {
+  name: string;
+  dispatchName: string | null;
+  probe: { staging: boolean };
+}
+
+export interface ResolveVerifyMatrixInput {
+  /** github.event_name — 'workflow_run' or 'workflow_dispatch'. */
+  eventName: string;
+  /** 'true' / 'false' / '' — the upstream `check-redeploy-summary` step output. */
+  summaryPresent: string;
+  /** CSV of services that redeployed OK (from `redeploy-gate.outputs.ok_services`). */
+  okFromRedeploy: string;
+  /** github.event.inputs.service — 'all', '', or an SSOT key / dispatchName. */
+  dispatchService: string;
+  /** The `services` array from railway-envs.generated.json. */
+  ssotServices: SsotService[];
+}
+
+export interface ResolveVerifyMatrixOutput {
+  servicesCsv: string;
+  hasServices: boolean;
+}
+
+/** Sorted, dedup'd list of every SSOT service with probe.staging===true. */
+function probeEligibleNames(ssotServices: SsotService[]): string[] {
+  const names = ssotServices
+    .filter((s) => s.probe?.staging === true)
+    .map((s) => s.name);
+  return Array.from(new Set(names)).sort();
+}
+
+/**
+ * Map an `ok_services` CSV (which may carry SSOT keys OR dispatchName
+ * aliases — the build matrix sometimes emits dispatch_names) into the
+ * set of canonical SSOT names. Tokens that don't match any service are
+ * silently dropped; the bash did the same (jq `select(...).name` simply
+ * yielded no row for unknown tokens).
+ */
+function okCsvToCanonicalNames(
+  okFromRedeploy: string,
+  ssotServices: SsotService[],
+): Set<string> {
+  const canonical = new Set<string>();
+  const tokens = okFromRedeploy.split(",").filter((t) => t.length > 0);
+  for (const t of tokens) {
+    const match = ssotServices.find(
+      (s) => s.name === t || s.dispatchName === t,
+    );
+    if (match) canonical.add(match.name);
+  }
+  return canonical;
+}
+
+export function resolveVerifyMatrix(
+  input: ResolveVerifyMatrixInput,
+): ResolveVerifyMatrixOutput {
+  const {
+    eventName,
+    summaryPresent,
+    okFromRedeploy,
+    dispatchService,
+    ssotServices,
+  } = input;
+
+  // Case: workflow_run + nothing redeployed — the build legitimately
+  // didn't redeploy anything (no buildable service changed). Skip verify.
+  if (eventName === "workflow_run" && summaryPresent === "false") {
+    return { servicesCsv: "", hasServices: false };
+  }
+
+  // Case: workflow_run + redeploy summary PRESENT + empty ok_services
+  // (every service errored on redeploy). The success-set is empty, so
+  // there is nothing to verify. `enforce-redeploy-gate` already reds
+  // the workflow on redeploy_red=true; this matrix simply skips. This
+  // is the "Issue A" fix: the old bash fell through to the full
+  // probe-eligible fleet here.
+  if (
+    eventName === "workflow_run" &&
+    summaryPresent === "true" &&
+    okFromRedeploy.length === 0
+  ) {
+    return { servicesCsv: "", hasServices: false };
+  }
+
+  const probeEligible = probeEligibleNames(ssotServices);
+
+  // workflow_dispatch: resolve the dispatch input first. If 'all' / empty,
+  // fall through to the full probe-eligible set. Otherwise resolve to
+  // the chosen service (by SSOT name OR dispatchName).
+  if (eventName === "workflow_dispatch") {
+    const dispatch = dispatchService || "all";
+    if (dispatch !== "all") {
+      const resolved = ssotServices.find(
+        (s) => s.name === dispatch || s.dispatchName === dispatch,
+      );
+      if (!resolved) {
+        // Preserves prior bash behavior: `::error::Unknown service...` +
+        // exit 1. The CLI wrapper converts this throw into a non-zero
+        // exit with the same annotation.
+        throw new Error(
+          `::error::Unknown service '${dispatch}' (not an SSOT key or dispatch_name)`,
+        );
+      }
+      const csv = resolved.name;
+      return { servicesCsv: csv, hasServices: csv.length > 0 };
+    }
+    const csv = probeEligible.join(",");
+    return { servicesCsv: csv, hasServices: csv.length > 0 };
+  }
+
+  // workflow_run + summary present + ok non-empty: intersect ok with
+  // probe-eligible. Map ok-tokens to canonical names first (handles the
+  // dispatchName-alias case). Drop anything not in probe-eligible (e.g.
+  // a service that redeployed OK but has no probe driver).
+  const okCanonical = okCsvToCanonicalNames(okFromRedeploy, ssotServices);
+  const intersection = probeEligible.filter((n) => okCanonical.has(n));
+  const csv = intersection.join(",");
+  return { servicesCsv: csv, hasServices: csv.length > 0 };
+}
+
+// ---------------------------------------------------------------------------
+// CLI wrapper — guarded by import.meta.url check so tests can import the
+// pure function without triggering env reads or filesystem IO.
+// ---------------------------------------------------------------------------
+
+const SSOT_JSON = "showcase/scripts/railway-envs.generated.json";
+const EMIT_SCRIPT = "showcase/scripts/emit-railway-envs-json.ts";
+
+function loadSsotServices(): SsotService[] {
+  // Preserve the prior bash behavior: regenerate the JSON if it's missing
+  // (e.g. a freshly-checked-out workspace that hasn't run the emitter).
+  if (!existsSync(SSOT_JSON)) {
+    execFileSync("npx", ["tsx", EMIT_SCRIPT], { stdio: "inherit" });
+  }
+  const raw = JSON.parse(readFileSync(SSOT_JSON, "utf-8")) as {
+    services: SsotService[];
+  };
+  return raw.services;
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (typeof v !== "string") {
+    throw new Error(`resolve-verify-matrix: $${name} is required`);
+  }
+  return v;
+}
+
+function writeGithubOutput(
+  githubOutput: string,
+  servicesCsv: string,
+  hasServices: boolean,
+): void {
+  // Plain key=value lines (no heredoc): both values are simple strings
+  // without newlines. Matches the style of the prior bash and aligns
+  // with the rest of resolve-matrix's $GITHUB_OUTPUT writes.
+  appendFileSync(githubOutput, `services_csv=${servicesCsv}\n`);
+  appendFileSync(
+    githubOutput,
+    `has_services=${hasServices ? "true" : "false"}\n`,
+  );
+}
+
+function main(): void {
+  const githubOutput = requireEnv("GITHUB_OUTPUT");
+  const eventName = requireEnv("EVENT_NAME");
+  const summaryPresent = process.env.SUMMARY_PRESENT ?? "";
+  const okFromRedeploy = process.env.OK_FROM_REDEPLOY ?? "";
+  const dispatchService = process.env.DISPATCH_SERVICE ?? "";
+
+  const ssotServices = loadSsotServices();
+
+  try {
+    const { servicesCsv, hasServices } = resolveVerifyMatrix({
+      eventName,
+      summaryPresent,
+      okFromRedeploy,
+      dispatchService,
+      ssotServices,
+    });
+    writeGithubOutput(githubOutput, servicesCsv, hasServices);
+  } catch (e) {
+    // Mirror the prior bash: print `::error::...` to stderr and exit 1.
+    // The Error message already carries the `::error::` annotation when
+    // it's an Unknown-service throw.
+    process.stderr.write(
+      `${e instanceof Error ? e.message : String(e)}\n`,
+    );
+    process.exit(1);
+  }
+}
+
+const invokedDirectly = (() => {
+  try {
+    return (
+      typeof process !== "undefined" &&
+      Array.isArray(process.argv) &&
+      process.argv[1] === fileURLToPath(import.meta.url)
+    );
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main();
+}

--- a/showcase/scripts/resolve-verify-matrix.ts
+++ b/showcase/scripts/resolve-verify-matrix.ts
@@ -149,10 +149,7 @@ export function resolveVerifyMatrix(
   // calling here, so on the CLI path this guard is defense-in-depth.
   // Direct test callers (which build their own input object) still pay
   // the runtime check, which is the point.
-  if (
-    eventName !== "workflow_run" &&
-    eventName !== "workflow_dispatch"
-  ) {
+  if (eventName !== "workflow_run" && eventName !== "workflow_dispatch") {
     throw new Error(
       `::error::resolve-verify-matrix: unexpected eventName '${eventName}' (expected 'workflow_run' or 'workflow_dispatch')`,
     );
@@ -258,10 +255,7 @@ const EMIT_SCRIPT = "showcase/scripts/emit-railway-envs-json.ts";
  * We require the exact shape we depend on, and `::error::`-prefix the
  * throw so the workflow log surfaces it as an annotation.
  */
-export function parseSsotServices(
-  raw: unknown,
-  path: string,
-): SsotService[] {
+export function parseSsotServices(raw: unknown, path: string): SsotService[] {
   if (raw === null || typeof raw !== "object") {
     throw new Error(
       `::error::SSOT ${path} malformed: top-level value is not an object`,
@@ -433,9 +427,7 @@ function main(): void {
     // Throws from this module already carry the `::error::` annotation
     // (Unknown service, unexpected eventName, SSOT malformed, SSOT
     // missing-after-regen).
-    process.stderr.write(
-      `${e instanceof Error ? e.message : String(e)}\n`,
-    );
+    process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
     process.exit(1);
   }
 }

--- a/showcase/scripts/verify-deploy.drivers.agent.ts
+++ b/showcase/scripts/verify-deploy.drivers.agent.ts
@@ -1,14 +1,23 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
 
 /**
- * Feature-level verifier for generic agent backends (showcase-* integration
- * services). Per spec §3.5: feature-level fixture call into the integration's
- * /api endpoint. Stub fails loud.
+ * Feature-level verifier for the generic agent backends — every
+ * `showcase-<framework>` integration service routes through this driver
+ * (mastra, ag2, agno, llamaindex, langgraph-*, crewai-*, pydantic-ai,
+ * google-adk, claude-sdk-*, ms-agent-*, langroid, spring-ai, strands,
+ * built-in-agent — 19 services in the SSOT at WS-C completion).
+ *
+ * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on
+ * `/api/health` (the uniform health path emitted by every showcase
+ * integration template). Future driver-specific layer: feature-level
+ * fixture POST into the integration's `/api` endpoint, asserting the
+ * AG-UI SSE stream opens and emits at least one TextMessageStart event.
  */
 export async function probeAgent(target: ProbeTarget): Promise<ProbeOutcome> {
-    return {
-        ok: false,
-        error: `agent driver not yet implemented for ${target.name} (${target.host})`,
-    };
+    return probeBaseline(target, {
+        driverLabel: "agent",
+        healthcheckPath: "/api/health",
+    });
 }

--- a/showcase/scripts/verify-deploy.drivers.agent.ts
+++ b/showcase/scripts/verify-deploy.drivers.agent.ts
@@ -1,0 +1,14 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+
+/**
+ * Feature-level verifier for generic agent backends (showcase-* integration
+ * services). Per spec §3.5: feature-level fixture call into the integration's
+ * /api endpoint. Stub fails loud.
+ */
+export async function probeAgent(target: ProbeTarget): Promise<ProbeOutcome> {
+    return {
+        ok: false,
+        error: `agent driver not yet implemented for ${target.name} (${target.host})`,
+    };
+}

--- a/showcase/scripts/verify-deploy.drivers.agent.ts
+++ b/showcase/scripts/verify-deploy.drivers.agent.ts
@@ -16,8 +16,8 @@ import { probeBaseline } from "./verify-deploy.drivers.baseline";
  * AG-UI SSE stream opens and emits at least one TextMessageStart event.
  */
 export async function probeAgent(target: ProbeTarget): Promise<ProbeOutcome> {
-    return probeBaseline(target, {
-        driverLabel: "agent",
-        healthcheckPath: "/api/health",
-    });
+  return probeBaseline(target, {
+    driverLabel: "agent",
+    healthcheckPath: "/api/health",
+  });
 }

--- a/showcase/scripts/verify-deploy.drivers.aimock.ts
+++ b/showcase/scripts/verify-deploy.drivers.aimock.ts
@@ -13,8 +13,8 @@ import { probeBaseline } from "./verify-deploy.drivers.baseline";
  * (POST a known prompt, assert recorded response shape).
  */
 export async function probeAimock(target: ProbeTarget): Promise<ProbeOutcome> {
-    return probeBaseline(target, {
-        driverLabel: "aimock",
-        healthcheckPath: "/health",
-    });
+  return probeBaseline(target, {
+    driverLabel: "aimock",
+    healthcheckPath: "/health",
+  });
 }

--- a/showcase/scripts/verify-deploy.drivers.aimock.ts
+++ b/showcase/scripts/verify-deploy.drivers.aimock.ts
@@ -1,13 +1,20 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
 
 /**
- * Feature-level verifier for the aimock service. Per spec §3.5: fixture
- * replay with deterministic-response drift check. Stub fails loud.
+ * Feature-level verifier for the `aimock` service (the showcase
+ * wrapper image baked with fixtures).
+ *
+ * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on
+ * `/health` (mirrors the `health_path` for `showcase-aimock` in
+ * `.github/workflows/showcase_deploy.yml`). Future driver-specific
+ * layer: fixture replay with deterministic-response drift check
+ * (POST a known prompt, assert recorded response shape).
  */
 export async function probeAimock(target: ProbeTarget): Promise<ProbeOutcome> {
-    return {
-        ok: false,
-        error: `aimock driver not yet implemented for ${target.name} (${target.host})`,
-    };
+    return probeBaseline(target, {
+        driverLabel: "aimock",
+        healthcheckPath: "/health",
+    });
 }

--- a/showcase/scripts/verify-deploy.drivers.aimock.ts
+++ b/showcase/scripts/verify-deploy.drivers.aimock.ts
@@ -1,0 +1,13 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+
+/**
+ * Feature-level verifier for the aimock service. Per spec §3.5: fixture
+ * replay with deterministic-response drift check. Stub fails loud.
+ */
+export async function probeAimock(target: ProbeTarget): Promise<ProbeOutcome> {
+    return {
+        ok: false,
+        error: `aimock driver not yet implemented for ${target.name} (${target.host})`,
+    };
+}

--- a/showcase/scripts/verify-deploy.drivers.baseline.ts
+++ b/showcase/scripts/verify-deploy.drivers.baseline.ts
@@ -12,10 +12,8 @@ import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
 import { resolveRailwayTokenFromConfig } from "./lib/railway-token";
 
 /**
- * Shared baseline implementation for every `verify-deploy` driver. Per
- * the completion bar agreed in the cross-workstream contract
- * (`~/.claude/specs/2026-05-28-showcase-pipeline-completion-plan.md`),
- * every driver must enforce the same two minimum invariants before any
+ * Shared baseline implementation for every `verify-deploy` driver. Every
+ * driver must enforce the same two minimum invariants before any
  * driver-specific feature-level checks run:
  *
  *   1. **deployment-SUCCESS** — query Railway GraphQL
@@ -30,11 +28,11 @@ import { resolveRailwayTokenFromConfig } from "./lib/railway-token";
  *
  * Each driver wraps `probeBaseline` with its own `driverLabel` and a
  * sensible `healthcheckPath` for that service shape (Next.js shells use
- * `/`, agent backends use `/api/health`, etc.; mirrors the per-service
- * `health_path` table in `.github/workflows/showcase_deploy.yml`). The
- * "200 ≠ healthy" rule (spec §3.5) is still owed to the per-driver
- * feature-level extensions (DOM string, fixture replay, admin login,
- * etc.) — `probeBaseline` is the floor, not the ceiling.
+ * `/`, agent backends use `/api/health`, etc.; matches the Railway
+ * healthcheck config set by `deploy-to-railway.ts`). The
+ * "200 ≠ healthy" rule is still owed to the per-driver feature-level
+ * extensions (DOM string, fixture replay, admin login, etc.) —
+ * `probeBaseline` is the floor, not the ceiling.
  *
  * Network seams (`fetchImpl`, `getRailwayToken`) are injected so tests
  * can run fully offline. Production callers omit them and get the real
@@ -68,7 +66,36 @@ export type FetchLike = (
     status: number;
     text(): Promise<string>;
     json(): Promise<unknown>;
+    /**
+     * Optional WHATWG body — exposed so we can drain/cancel it after
+     * reading status. Undici (Node's fetch impl) leaks sockets when the
+     * body is not consumed or cancelled. Test seams that return a plain
+     * stub omit this field; production fetch always populates it.
+     */
+    body?: { cancel?: () => Promise<void> } | null;
 }>;
+
+function isAbortError(e: unknown): boolean {
+    if (!e || typeof e !== "object") return false;
+    const name = (e as { name?: unknown }).name;
+    return name === "AbortError";
+}
+
+/**
+ * Drain/cancel an HTTP response body so undici releases the socket.
+ * Safe on stubs (test seams) that lack a body — we only cancel when
+ * the runtime supplies one.
+ */
+async function releaseBody(
+    res: Awaited<ReturnType<FetchLike>>,
+): Promise<void> {
+    try {
+        await res.body?.cancel?.();
+    } catch {
+        // Cancelling a body that was already consumed throws on some
+        // runtimes; that's harmless — the socket is already released.
+    }
+}
 
 export interface BaselineOpts {
     /** Short driver-name tag woven into every error string for grep-ability. */
@@ -108,10 +135,37 @@ export function defaultGetRailwayToken(): string | undefined {
     if (!home) return undefined;
     const configPath = path.join(home, ".railway", "config.json");
     if (!fs.existsSync(configPath)) return undefined;
+    let raw: string;
+    try {
+        raw = fs.readFileSync(configPath, "utf-8");
+    } catch (err: unknown) {
+        // ENOENT is the legitimate "no config file" path (TOCTOU between
+        // existsSync and readFileSync) — return undefined silently.
+        // Any OTHER error (EACCES, EISDIR, EIO, ...) is a configuration
+        // problem the operator needs to see; do NOT swallow it. Mirrors
+        // the read-vs-parse split in lib/railway-token.ts::resolveRailwayToken
+        // (NO_FILE vs MALFORMED) — here we keep returning undefined so the
+        // caller's "no token" failure path still fires, but with a clear
+        // stderr diagnostic identifying the offending config path.
+        const code = (err as NodeJS.ErrnoException | undefined)?.code;
+        if (code === "ENOENT") return undefined;
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+            `[verify-deploy] failed to read Railway config at ${configPath}: ${msg}\n`,
+        );
+        return undefined;
+    }
     let config: unknown;
     try {
-        config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    } catch {
+        config = JSON.parse(raw);
+    } catch (err: unknown) {
+        // Malformed JSON is distinct from a missing file — surface the
+        // diagnostic, then return undefined so the caller's no-token path
+        // produces a clean probe failure rather than crashing verify-deploy.
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+            `[verify-deploy] malformed JSON in Railway config at ${configPath}: ${msg}\n`,
+        );
         return undefined;
     }
     return resolveRailwayTokenFromConfig(
@@ -170,8 +224,15 @@ export async function checkDeploymentSuccess(
     fetchImpl: FetchLike,
     timeoutMs: number,
     driverLabel: string,
+    serviceName?: string,
 ): Promise<string | undefined> {
     const environmentId = envIdFor(env);
+    // Tag identifies the offending service in multi-service runs. When
+    // the caller does not supply a name we fall back to the serviceId so
+    // a Railway operator can still grep the diagnostic to a target.
+    const tag = serviceName
+        ? `service="${serviceName}" (serviceId=${serviceId})`
+        : `serviceId=${serviceId}`;
     const query = `query latestDeployment($serviceId: String!, $environmentId: String!) {
   deployments(first: 1, input: { serviceId: $serviceId, environmentId: $environmentId }) {
     edges { node { id status } }
@@ -196,31 +257,38 @@ export async function checkDeploymentSuccess(
             timeoutMs,
         );
     } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return `${driverLabel}: Railway GraphQL fetch failed: ${msg}`;
+        const msg = isAbortError(e)
+            ? `timed out after ${timeoutMs}ms`
+            : e instanceof Error
+                ? e.message
+                : String(e);
+        return `${driverLabel}: Railway GraphQL fetch failed [${tag}]: ${msg}`;
     }
     if (!res.ok) {
         const body = (await res.text()).slice(0, 200);
-        return `${driverLabel}: Railway GraphQL HTTP ${res.status}: ${body}`;
+        return `${driverLabel}: Railway GraphQL HTTP ${res.status} [${tag}]: ${body}`;
     }
     let json: RailwayDeploymentsResponse;
     try {
         json = (await res.json()) as RailwayDeploymentsResponse;
     } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
-        return `${driverLabel}: Railway GraphQL JSON parse failed: ${msg}`;
+        // Release the body in the error path even if json() partially
+        // consumed it — undici will leak the socket otherwise.
+        await releaseBody(res);
+        return `${driverLabel}: Railway GraphQL JSON parse failed [${tag}]: ${msg}`;
     }
     if (json.errors?.length) {
-        return `${driverLabel}: Railway GraphQL errors: ${json.errors
+        return `${driverLabel}: Railway GraphQL errors [${tag}]: ${json.errors
             .map((e) => e.message)
             .join("; ")}`;
     }
     const node = json.data?.deployments?.edges?.[0]?.node;
     if (!node) {
-        return `${driverLabel}: Railway returned no deployments for ${env}`;
+        return `${driverLabel}: Railway returned no deployments for ${env} [${tag}]`;
     }
     if (node.status !== "SUCCESS") {
-        return `${driverLabel}: latest ${env} deployment status="${node.status}" (expected SUCCESS)`;
+        return `${driverLabel}: latest ${env} deployment status="${node.status}" (expected SUCCESS) [${tag}]`;
     }
     return undefined;
 }
@@ -246,12 +314,22 @@ export async function checkHealthcheck200(
             timeoutMs,
         );
     } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
+        // The AbortController abort surfaces as a generic "The operation
+        // was aborted" — substitute an actionable, timeout-aware message.
+        const msg = isAbortError(e)
+            ? `timed out after ${timeoutMs}ms`
+            : e instanceof Error
+                ? e.message
+                : String(e);
         return `${driverLabel}: healthcheck GET ${url} failed: ${msg}`;
     }
+    // We only need the status, not the body — drain/cancel it so undici
+    // releases the socket. Applies on BOTH the 200 and non-200 branches.
     if (res.status !== 200) {
+        await releaseBody(res);
         return `${driverLabel}: healthcheck GET ${url} returned HTTP ${res.status} (expected 200)`;
     }
+    await releaseBody(res);
     return undefined;
 }
 
@@ -291,7 +369,7 @@ export async function probeBaseline(
     if (!token) {
         return {
             ok: false,
-            error: `${opts.driverLabel}: no Railway token (set RAILWAY_TOKEN or run \`railway login\`)`,
+            error: `${opts.driverLabel}: no Railway token (set RAILWAY_TOKEN — Railway workspace token)`,
         };
     }
 
@@ -302,6 +380,7 @@ export async function probeBaseline(
         fetchImpl,
         timeoutMs,
         opts.driverLabel,
+        target.name,
     );
     if (deployErr) return { ok: false, error: deployErr };
 

--- a/showcase/scripts/verify-deploy.drivers.baseline.ts
+++ b/showcase/scripts/verify-deploy.drivers.baseline.ts
@@ -91,9 +91,22 @@ async function releaseBody(
 ): Promise<void> {
     try {
         await res.body?.cancel?.();
-    } catch {
-        // Cancelling a body that was already consumed throws on some
-        // runtimes; that's harmless — the socket is already released.
+    } catch (e: unknown) {
+        // Expected benign case: undici throws when the body is already
+        // "locked" (a reader is attached, or it was fully read by an
+        // earlier `res.json()` / `res.text()`). In every such case the
+        // socket is already released, so this is a no-op — swallow it.
+        // Anything else is unexpected; surface it on stderr so we don't
+        // hide a real bug, but keep `releaseBody` best-effort (never
+        // propagate — undici socket release is an optimization, not a
+        // correctness invariant).
+        const msg = e instanceof Error ? e.message : String(e);
+        const locked = /lock/i.test(msg);
+        if (!locked) {
+            process.stderr.write(
+                `[verify-deploy] releaseBody: unexpected cancel error: ${msg}\n`,
+            );
+        }
     }
 }
 

--- a/showcase/scripts/verify-deploy.drivers.baseline.ts
+++ b/showcase/scripts/verify-deploy.drivers.baseline.ts
@@ -1,0 +1,318 @@
+import fs from "fs";
+import path from "path";
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+import {
+    PRODUCTION_ENV_ID,
+    SERVICES,
+    STAGING_ENV_ID,
+    type EnvName,
+} from "./railway-envs";
+import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
+import { resolveRailwayTokenFromConfig } from "./lib/railway-token";
+
+/**
+ * Shared baseline implementation for every `verify-deploy` driver. Per
+ * the completion bar agreed in the cross-workstream contract
+ * (`~/.claude/specs/2026-05-28-showcase-pipeline-completion-plan.md`),
+ * every driver must enforce the same two minimum invariants before any
+ * driver-specific feature-level checks run:
+ *
+ *   1. **deployment-SUCCESS** — query Railway GraphQL
+ *      (`deployments(first:1, input:{serviceId, environmentId})`) for the
+ *      service's latest deployment in the target env, and assert
+ *      `status === "SUCCESS"`. This catches the "Railway accepted the
+ *      image but the container crash-loops" case that a naked HTTP probe
+ *      can miss (Railway briefly serves the previous good deploy via
+ *      sticky routing).
+ *   2. **HTTP 200** — GET `https://<host><healthcheckPath>` and assert
+ *      `res.status === 200`.
+ *
+ * Each driver wraps `probeBaseline` with its own `driverLabel` and a
+ * sensible `healthcheckPath` for that service shape (Next.js shells use
+ * `/`, agent backends use `/api/health`, etc.; mirrors the per-service
+ * `health_path` table in `.github/workflows/showcase_deploy.yml`). The
+ * "200 ≠ healthy" rule (spec §3.5) is still owed to the per-driver
+ * feature-level extensions (DOM string, fixture replay, admin login,
+ * etc.) — `probeBaseline` is the floor, not the ceiling.
+ *
+ * Network seams (`fetchImpl`, `getRailwayToken`) are injected so tests
+ * can run fully offline. Production callers omit them and get the real
+ * `globalThis.fetch` + the `~/.railway/config.json` resolver.
+ */
+
+export interface RailwayDeploymentNode {
+    id: string;
+    status: string;
+}
+
+export interface RailwayDeploymentsResponse {
+    data?: {
+        deployments?: {
+            edges?: Array<{ node?: RailwayDeploymentNode }>;
+        };
+    };
+    errors?: Array<{ message: string }>;
+}
+
+export type FetchLike = (
+    input: string,
+    init?: {
+        method?: string;
+        headers?: Record<string, string>;
+        body?: string;
+        signal?: AbortSignal;
+    },
+) => Promise<{
+    ok: boolean;
+    status: number;
+    text(): Promise<string>;
+    json(): Promise<unknown>;
+}>;
+
+export interface BaselineOpts {
+    /** Short driver-name tag woven into every error string for grep-ability. */
+    driverLabel: string;
+    /** Path appended to `https://<host>` for the healthcheck GET. */
+    healthcheckPath: string;
+    /**
+     * Test seam — replaces `globalThis.fetch` for BOTH the Railway
+     * GraphQL call and the healthcheck call. Production callers omit
+     * this and get the real `fetch`.
+     */
+    fetchImpl?: FetchLike;
+    /**
+     * Test seam — provides the Railway bearer used for the GraphQL
+     * call. When omitted, the real resolver walks `RAILWAY_TOKEN` env
+     * var → `~/.railway/config.json`. Returns `undefined` when no
+     * usable credential is present; the driver fails loud at that
+     * point rather than hitting Railway unauthenticated.
+     */
+    getRailwayToken?: () => string | undefined;
+    /** Per-call timeout for each fetch (ms). Default 30s. */
+    timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Walk `RAILWAY_TOKEN` env var → `~/.railway/config.json` and return the
+ * Railway public-GraphQL bearer. Mirrors the resolution chain in
+ * `redeploy-env.ts::getToken` but returns `undefined` on miss instead of
+ * exiting the process — driver code surfaces the miss as a probe
+ * failure so verify-deploy can keep iterating remaining targets.
+ */
+export function defaultGetRailwayToken(): string | undefined {
+    if (process.env.RAILWAY_TOKEN) return process.env.RAILWAY_TOKEN;
+    const home = process.env.HOME;
+    if (!home) return undefined;
+    const configPath = path.join(home, ".railway", "config.json");
+    if (!fs.existsSync(configPath)) return undefined;
+    let config: unknown;
+    try {
+        config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    } catch {
+        return undefined;
+    }
+    return resolveRailwayTokenFromConfig(
+        config as Parameters<typeof resolveRailwayTokenFromConfig>[0],
+    );
+}
+
+/**
+ * Resolve the target env (`prod` / `staging`) for a probe target by
+ * matching its `host` against the SSOT's per-env domain literals.
+ *
+ * `ProbeTarget` intentionally does NOT carry the env (verify-deploy's
+ * `resolveProbeTargets` collapses it into the host literal so drivers
+ * cannot accidentally probe one env with the other env's token). We
+ * recover the env here by reversing the lookup against `SERVICES`. A
+ * service whose host matches neither env literal is a configuration
+ * bug — surface it as a probe failure, do not guess.
+ */
+export function envForTarget(target: ProbeTarget): EnvName | undefined {
+    const entry = SERVICES[target.name];
+    if (!entry) return undefined;
+    if (target.host === entry.domains.staging) return "staging";
+    if (target.host === entry.domains.prod) return "prod";
+    return undefined;
+}
+
+function envIdFor(env: EnvName): string {
+    return env === "prod" ? PRODUCTION_ENV_ID : STAGING_ENV_ID;
+}
+
+async function fetchWithTimeout(
+    fetchImpl: FetchLike,
+    url: string,
+    init: Parameters<FetchLike>[1],
+    timeoutMs: number,
+): Promise<Awaited<ReturnType<FetchLike>>> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        return await fetchImpl(url, { ...init, signal: controller.signal });
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+/**
+ * Query Railway for the latest deployment of the given service in the
+ * given env and assert `status === "SUCCESS"`. Returns a string error
+ * message on any failure (network, GraphQL `errors[]`, missing edge,
+ * non-SUCCESS status); returns `undefined` on success.
+ */
+export async function checkDeploymentSuccess(
+    serviceId: string,
+    env: EnvName,
+    token: string,
+    fetchImpl: FetchLike,
+    timeoutMs: number,
+    driverLabel: string,
+): Promise<string | undefined> {
+    const environmentId = envIdFor(env);
+    const query = `query latestDeployment($serviceId: String!, $environmentId: String!) {
+  deployments(first: 1, input: { serviceId: $serviceId, environmentId: $environmentId }) {
+    edges { node { id status } }
+  }
+}`;
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+        res = await fetchWithTimeout(
+            fetchImpl,
+            RAILWAY_GRAPHQL_ENDPOINT,
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    query,
+                    variables: { serviceId, environmentId },
+                }),
+            },
+            timeoutMs,
+        );
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return `${driverLabel}: Railway GraphQL fetch failed: ${msg}`;
+    }
+    if (!res.ok) {
+        const body = (await res.text()).slice(0, 200);
+        return `${driverLabel}: Railway GraphQL HTTP ${res.status}: ${body}`;
+    }
+    let json: RailwayDeploymentsResponse;
+    try {
+        json = (await res.json()) as RailwayDeploymentsResponse;
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return `${driverLabel}: Railway GraphQL JSON parse failed: ${msg}`;
+    }
+    if (json.errors?.length) {
+        return `${driverLabel}: Railway GraphQL errors: ${json.errors
+            .map((e) => e.message)
+            .join("; ")}`;
+    }
+    const node = json.data?.deployments?.edges?.[0]?.node;
+    if (!node) {
+        return `${driverLabel}: Railway returned no deployments for ${env}`;
+    }
+    if (node.status !== "SUCCESS") {
+        return `${driverLabel}: latest ${env} deployment status="${node.status}" (expected SUCCESS)`;
+    }
+    return undefined;
+}
+
+/**
+ * GET `https://<host><healthcheckPath>` and assert HTTP 200. Returns an
+ * error string on any non-200 / fetch failure; `undefined` on success.
+ */
+export async function checkHealthcheck200(
+    host: string,
+    healthcheckPath: string,
+    fetchImpl: FetchLike,
+    timeoutMs: number,
+    driverLabel: string,
+): Promise<string | undefined> {
+    const url = `https://${host}${healthcheckPath}`;
+    let res: Awaited<ReturnType<FetchLike>>;
+    try {
+        res = await fetchWithTimeout(
+            fetchImpl,
+            url,
+            { method: "GET", headers: { "User-Agent": "verify-deploy" } },
+            timeoutMs,
+        );
+    } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return `${driverLabel}: healthcheck GET ${url} failed: ${msg}`;
+    }
+    if (res.status !== 200) {
+        return `${driverLabel}: healthcheck GET ${url} returned HTTP ${res.status} (expected 200)`;
+    }
+    return undefined;
+}
+
+/**
+ * Baseline driver body. Runs deployment-SUCCESS check, then healthcheck
+ * 200 check. Either failure yields a structured ProbeOutcome `{ok:false,
+ * error}`; both passes yield `{ok:true}`. Driver-specific extensions
+ * (DOM strings, fixture replay, admin login, etc.) can compose on top
+ * by wrapping this and adding their own checks after a green baseline.
+ */
+export async function probeBaseline(
+    target: ProbeTarget,
+    opts: BaselineOpts,
+): Promise<ProbeOutcome> {
+    const fetchImpl: FetchLike =
+        opts.fetchImpl ?? ((globalThis.fetch as unknown) as FetchLike);
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const getToken = opts.getRailwayToken ?? defaultGetRailwayToken;
+
+    const env = envForTarget(target);
+    if (!env) {
+        return {
+            ok: false,
+            error: `${opts.driverLabel}: cannot resolve env for host "${target.host}" (service "${target.name}" not in SSOT or domain mismatch)`,
+        };
+    }
+    const entry = SERVICES[target.name];
+    // envForTarget already validated entry exists by returning a defined env.
+    if (!entry) {
+        return {
+            ok: false,
+            error: `${opts.driverLabel}: service "${target.name}" missing from SSOT`,
+        };
+    }
+
+    const token = getToken();
+    if (!token) {
+        return {
+            ok: false,
+            error: `${opts.driverLabel}: no Railway token (set RAILWAY_TOKEN or run \`railway login\`)`,
+        };
+    }
+
+    const deployErr = await checkDeploymentSuccess(
+        entry.serviceId,
+        env,
+        token,
+        fetchImpl,
+        timeoutMs,
+        opts.driverLabel,
+    );
+    if (deployErr) return { ok: false, error: deployErr };
+
+    const healthErr = await checkHealthcheck200(
+        target.host,
+        opts.healthcheckPath,
+        fetchImpl,
+        timeoutMs,
+        opts.driverLabel,
+    );
+    if (healthErr) return { ok: false, error: healthErr };
+
+    return { ok: true };
+}

--- a/showcase/scripts/verify-deploy.drivers.baseline.ts
+++ b/showcase/scripts/verify-deploy.drivers.baseline.ts
@@ -2,12 +2,8 @@ import fs from "fs";
 import path from "path";
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
-import {
-    PRODUCTION_ENV_ID,
-    SERVICES,
-    STAGING_ENV_ID,
-    type EnvName,
-} from "./railway-envs";
+import { PRODUCTION_ENV_ID, SERVICES, STAGING_ENV_ID } from "./railway-envs";
+import type { EnvName } from "./railway-envs";
 import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
 import { resolveRailwayTokenFromConfig } from "./lib/railway-token";
 
@@ -40,45 +36,45 @@ import { resolveRailwayTokenFromConfig } from "./lib/railway-token";
  */
 
 export interface RailwayDeploymentNode {
-    id: string;
-    status: string;
+  id: string;
+  status: string;
 }
 
 export interface RailwayDeploymentsResponse {
-    data?: {
-        deployments?: {
-            edges?: Array<{ node?: RailwayDeploymentNode }>;
-        };
+  data?: {
+    deployments?: {
+      edges?: Array<{ node?: RailwayDeploymentNode }>;
     };
-    errors?: Array<{ message: string }>;
+  };
+  errors?: Array<{ message: string }>;
 }
 
 export type FetchLike = (
-    input: string,
-    init?: {
-        method?: string;
-        headers?: Record<string, string>;
-        body?: string;
-        signal?: AbortSignal;
-    },
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
 ) => Promise<{
-    ok: boolean;
-    status: number;
-    text(): Promise<string>;
-    json(): Promise<unknown>;
-    /**
-     * Optional WHATWG body — exposed so we can drain/cancel it after
-     * reading status. Undici (Node's fetch impl) leaks sockets when the
-     * body is not consumed or cancelled. Test seams that return a plain
-     * stub omit this field; production fetch always populates it.
-     */
-    body?: { cancel?: () => Promise<void> } | null;
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+  /**
+   * Optional WHATWG body — exposed so we can drain/cancel it after
+   * reading status. Undici (Node's fetch impl) leaks sockets when the
+   * body is not consumed or cancelled. Test seams that return a plain
+   * stub omit this field; production fetch always populates it.
+   */
+  body?: { cancel?: () => Promise<void> } | null;
 }>;
 
 function isAbortError(e: unknown): boolean {
-    if (!e || typeof e !== "object") return false;
-    const name = (e as { name?: unknown }).name;
-    return name === "AbortError";
+  if (!e || typeof e !== "object") return false;
+  const name = (e as { name?: unknown }).name;
+  return name === "AbortError";
 }
 
 /**
@@ -86,51 +82,49 @@ function isAbortError(e: unknown): boolean {
  * Safe on stubs (test seams) that lack a body — we only cancel when
  * the runtime supplies one.
  */
-async function releaseBody(
-    res: Awaited<ReturnType<FetchLike>>,
-): Promise<void> {
-    try {
-        await res.body?.cancel?.();
-    } catch (e: unknown) {
-        // Expected benign case: undici throws when the body is already
-        // "locked" (a reader is attached, or it was fully read by an
-        // earlier `res.json()` / `res.text()`). In every such case the
-        // socket is already released, so this is a no-op — swallow it.
-        // Anything else is unexpected; surface it on stderr so we don't
-        // hide a real bug, but keep `releaseBody` best-effort (never
-        // propagate — undici socket release is an optimization, not a
-        // correctness invariant).
-        const msg = e instanceof Error ? e.message : String(e);
-        const locked = /lock/i.test(msg);
-        if (!locked) {
-            process.stderr.write(
-                `[verify-deploy] releaseBody: unexpected cancel error: ${msg}\n`,
-            );
-        }
+async function releaseBody(res: Awaited<ReturnType<FetchLike>>): Promise<void> {
+  try {
+    await res.body?.cancel?.();
+  } catch (e: unknown) {
+    // Expected benign case: undici throws when the body is already
+    // "locked" (a reader is attached, or it was fully read by an
+    // earlier `res.json()` / `res.text()`). In every such case the
+    // socket is already released, so this is a no-op — swallow it.
+    // Anything else is unexpected; surface it on stderr so we don't
+    // hide a real bug, but keep `releaseBody` best-effort (never
+    // propagate — undici socket release is an optimization, not a
+    // correctness invariant).
+    const msg = e instanceof Error ? e.message : String(e);
+    const locked = /lock/i.test(msg);
+    if (!locked) {
+      process.stderr.write(
+        `[verify-deploy] releaseBody: unexpected cancel error: ${msg}\n`,
+      );
     }
+  }
 }
 
 export interface BaselineOpts {
-    /** Short driver-name tag woven into every error string for grep-ability. */
-    driverLabel: string;
-    /** Path appended to `https://<host>` for the healthcheck GET. */
-    healthcheckPath: string;
-    /**
-     * Test seam — replaces `globalThis.fetch` for BOTH the Railway
-     * GraphQL call and the healthcheck call. Production callers omit
-     * this and get the real `fetch`.
-     */
-    fetchImpl?: FetchLike;
-    /**
-     * Test seam — provides the Railway bearer used for the GraphQL
-     * call. When omitted, the real resolver walks `RAILWAY_TOKEN` env
-     * var → `~/.railway/config.json`. Returns `undefined` when no
-     * usable credential is present; the driver fails loud at that
-     * point rather than hitting Railway unauthenticated.
-     */
-    getRailwayToken?: () => string | undefined;
-    /** Per-call timeout for each fetch (ms). Default 30s. */
-    timeoutMs?: number;
+  /** Short driver-name tag woven into every error string for grep-ability. */
+  driverLabel: string;
+  /** Path appended to `https://<host>` for the healthcheck GET. */
+  healthcheckPath: string;
+  /**
+   * Test seam — replaces `globalThis.fetch` for BOTH the Railway
+   * GraphQL call and the healthcheck call. Production callers omit
+   * this and get the real `fetch`.
+   */
+  fetchImpl?: FetchLike;
+  /**
+   * Test seam — provides the Railway bearer used for the GraphQL
+   * call. When omitted, the real resolver walks `RAILWAY_TOKEN` env
+   * var → `~/.railway/config.json`. Returns `undefined` when no
+   * usable credential is present; the driver fails loud at that
+   * point rather than hitting Railway unauthenticated.
+   */
+  getRailwayToken?: () => string | undefined;
+  /** Per-call timeout for each fetch (ms). Default 30s. */
+  timeoutMs?: number;
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -143,47 +137,47 @@ const DEFAULT_TIMEOUT_MS = 30_000;
  * failure so verify-deploy can keep iterating remaining targets.
  */
 export function defaultGetRailwayToken(): string | undefined {
-    if (process.env.RAILWAY_TOKEN) return process.env.RAILWAY_TOKEN;
-    const home = process.env.HOME;
-    if (!home) return undefined;
-    const configPath = path.join(home, ".railway", "config.json");
-    if (!fs.existsSync(configPath)) return undefined;
-    let raw: string;
-    try {
-        raw = fs.readFileSync(configPath, "utf-8");
-    } catch (err: unknown) {
-        // ENOENT is the legitimate "no config file" path (TOCTOU between
-        // existsSync and readFileSync) — return undefined silently.
-        // Any OTHER error (EACCES, EISDIR, EIO, ...) is a configuration
-        // problem the operator needs to see; do NOT swallow it. Mirrors
-        // the read-vs-parse split in lib/railway-token.ts::resolveRailwayToken
-        // (NO_FILE vs MALFORMED) — here we keep returning undefined so the
-        // caller's "no token" failure path still fires, but with a clear
-        // stderr diagnostic identifying the offending config path.
-        const code = (err as NodeJS.ErrnoException | undefined)?.code;
-        if (code === "ENOENT") return undefined;
-        const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(
-            `[verify-deploy] failed to read Railway config at ${configPath}: ${msg}\n`,
-        );
-        return undefined;
-    }
-    let config: unknown;
-    try {
-        config = JSON.parse(raw);
-    } catch (err: unknown) {
-        // Malformed JSON is distinct from a missing file — surface the
-        // diagnostic, then return undefined so the caller's no-token path
-        // produces a clean probe failure rather than crashing verify-deploy.
-        const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(
-            `[verify-deploy] malformed JSON in Railway config at ${configPath}: ${msg}\n`,
-        );
-        return undefined;
-    }
-    return resolveRailwayTokenFromConfig(
-        config as Parameters<typeof resolveRailwayTokenFromConfig>[0],
+  if (process.env.RAILWAY_TOKEN) return process.env.RAILWAY_TOKEN;
+  const home = process.env.HOME;
+  if (!home) return undefined;
+  const configPath = path.join(home, ".railway", "config.json");
+  if (!fs.existsSync(configPath)) return undefined;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, "utf-8");
+  } catch (err: unknown) {
+    // ENOENT is the legitimate "no config file" path (TOCTOU between
+    // existsSync and readFileSync) — return undefined silently.
+    // Any OTHER error (EACCES, EISDIR, EIO, ...) is a configuration
+    // problem the operator needs to see; do NOT swallow it. Mirrors
+    // the read-vs-parse split in lib/railway-token.ts::resolveRailwayToken
+    // (NO_FILE vs MALFORMED) — here we keep returning undefined so the
+    // caller's "no token" failure path still fires, but with a clear
+    // stderr diagnostic identifying the offending config path.
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") return undefined;
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[verify-deploy] failed to read Railway config at ${configPath}: ${msg}\n`,
     );
+    return undefined;
+  }
+  let config: unknown;
+  try {
+    config = JSON.parse(raw);
+  } catch (err: unknown) {
+    // Malformed JSON is distinct from a missing file — surface the
+    // diagnostic, then return undefined so the caller's no-token path
+    // produces a clean probe failure rather than crashing verify-deploy.
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[verify-deploy] malformed JSON in Railway config at ${configPath}: ${msg}\n`,
+    );
+    return undefined;
+  }
+  return resolveRailwayTokenFromConfig(
+    config as Parameters<typeof resolveRailwayTokenFromConfig>[0],
+  );
 }
 
 /**
@@ -198,30 +192,30 @@ export function defaultGetRailwayToken(): string | undefined {
  * bug — surface it as a probe failure, do not guess.
  */
 export function envForTarget(target: ProbeTarget): EnvName | undefined {
-    const entry = SERVICES[target.name];
-    if (!entry) return undefined;
-    if (target.host === entry.domains.staging) return "staging";
-    if (target.host === entry.domains.prod) return "prod";
-    return undefined;
+  const entry = SERVICES[target.name];
+  if (!entry) return undefined;
+  if (target.host === entry.domains.staging) return "staging";
+  if (target.host === entry.domains.prod) return "prod";
+  return undefined;
 }
 
 function envIdFor(env: EnvName): string {
-    return env === "prod" ? PRODUCTION_ENV_ID : STAGING_ENV_ID;
+  return env === "prod" ? PRODUCTION_ENV_ID : STAGING_ENV_ID;
 }
 
 async function fetchWithTimeout(
-    fetchImpl: FetchLike,
-    url: string,
-    init: Parameters<FetchLike>[1],
-    timeoutMs: number,
+  fetchImpl: FetchLike,
+  url: string,
+  init: Parameters<FetchLike>[1],
+  timeoutMs: number,
 ): Promise<Awaited<ReturnType<FetchLike>>> {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-        return await fetchImpl(url, { ...init, signal: controller.signal });
-    } finally {
-        clearTimeout(timer);
-    }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**
@@ -231,79 +225,79 @@ async function fetchWithTimeout(
  * non-SUCCESS status); returns `undefined` on success.
  */
 export async function checkDeploymentSuccess(
-    serviceId: string,
-    env: EnvName,
-    token: string,
-    fetchImpl: FetchLike,
-    timeoutMs: number,
-    driverLabel: string,
-    serviceName?: string,
+  serviceId: string,
+  env: EnvName,
+  token: string,
+  fetchImpl: FetchLike,
+  timeoutMs: number,
+  driverLabel: string,
+  serviceName?: string,
 ): Promise<string | undefined> {
-    const environmentId = envIdFor(env);
-    // Tag identifies the offending service in multi-service runs. When
-    // the caller does not supply a name we fall back to the serviceId so
-    // a Railway operator can still grep the diagnostic to a target.
-    const tag = serviceName
-        ? `service="${serviceName}" (serviceId=${serviceId})`
-        : `serviceId=${serviceId}`;
-    const query = `query latestDeployment($serviceId: String!, $environmentId: String!) {
+  const environmentId = envIdFor(env);
+  // Tag identifies the offending service in multi-service runs. When
+  // the caller does not supply a name we fall back to the serviceId so
+  // a Railway operator can still grep the diagnostic to a target.
+  const tag = serviceName
+    ? `service="${serviceName}" (serviceId=${serviceId})`
+    : `serviceId=${serviceId}`;
+  const query = `query latestDeployment($serviceId: String!, $environmentId: String!) {
   deployments(first: 1, input: { serviceId: $serviceId, environmentId: $environmentId }) {
     edges { node { id status } }
   }
 }`;
-    let res: Awaited<ReturnType<FetchLike>>;
-    try {
-        res = await fetchWithTimeout(
-            fetchImpl,
-            RAILWAY_GRAPHQL_ENDPOINT,
-            {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    query,
-                    variables: { serviceId, environmentId },
-                }),
-            },
-            timeoutMs,
-        );
-    } catch (e: unknown) {
-        const msg = isAbortError(e)
-            ? `timed out after ${timeoutMs}ms`
-            : e instanceof Error
-                ? e.message
-                : String(e);
-        return `${driverLabel}: Railway GraphQL fetch failed [${tag}]: ${msg}`;
-    }
-    if (!res.ok) {
-        const body = (await res.text()).slice(0, 200);
-        return `${driverLabel}: Railway GraphQL HTTP ${res.status} [${tag}]: ${body}`;
-    }
-    let json: RailwayDeploymentsResponse;
-    try {
-        json = (await res.json()) as RailwayDeploymentsResponse;
-    } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        // Release the body in the error path even if json() partially
-        // consumed it — undici will leak the socket otherwise.
-        await releaseBody(res);
-        return `${driverLabel}: Railway GraphQL JSON parse failed [${tag}]: ${msg}`;
-    }
-    if (json.errors?.length) {
-        return `${driverLabel}: Railway GraphQL errors [${tag}]: ${json.errors
-            .map((e) => e.message)
-            .join("; ")}`;
-    }
-    const node = json.data?.deployments?.edges?.[0]?.node;
-    if (!node) {
-        return `${driverLabel}: Railway returned no deployments for ${env} [${tag}]`;
-    }
-    if (node.status !== "SUCCESS") {
-        return `${driverLabel}: latest ${env} deployment status="${node.status}" (expected SUCCESS) [${tag}]`;
-    }
-    return undefined;
+  let res: Awaited<ReturnType<FetchLike>>;
+  try {
+    res = await fetchWithTimeout(
+      fetchImpl,
+      RAILWAY_GRAPHQL_ENDPOINT,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          query,
+          variables: { serviceId, environmentId },
+        }),
+      },
+      timeoutMs,
+    );
+  } catch (e: unknown) {
+    const msg = isAbortError(e)
+      ? `timed out after ${timeoutMs}ms`
+      : e instanceof Error
+        ? e.message
+        : String(e);
+    return `${driverLabel}: Railway GraphQL fetch failed [${tag}]: ${msg}`;
+  }
+  if (!res.ok) {
+    const body = (await res.text()).slice(0, 200);
+    return `${driverLabel}: Railway GraphQL HTTP ${res.status} [${tag}]: ${body}`;
+  }
+  let json: RailwayDeploymentsResponse;
+  try {
+    json = (await res.json()) as RailwayDeploymentsResponse;
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    // Release the body in the error path even if json() partially
+    // consumed it — undici will leak the socket otherwise.
+    await releaseBody(res);
+    return `${driverLabel}: Railway GraphQL JSON parse failed [${tag}]: ${msg}`;
+  }
+  if (json.errors?.length) {
+    return `${driverLabel}: Railway GraphQL errors [${tag}]: ${json.errors
+      .map((e) => e.message)
+      .join("; ")}`;
+  }
+  const node = json.data?.deployments?.edges?.[0]?.node;
+  if (!node) {
+    return `${driverLabel}: Railway returned no deployments for ${env} [${tag}]`;
+  }
+  if (node.status !== "SUCCESS") {
+    return `${driverLabel}: latest ${env} deployment status="${node.status}" (expected SUCCESS) [${tag}]`;
+  }
+  return undefined;
 }
 
 /**
@@ -311,39 +305,39 @@ export async function checkDeploymentSuccess(
  * error string on any non-200 / fetch failure; `undefined` on success.
  */
 export async function checkHealthcheck200(
-    host: string,
-    healthcheckPath: string,
-    fetchImpl: FetchLike,
-    timeoutMs: number,
-    driverLabel: string,
+  host: string,
+  healthcheckPath: string,
+  fetchImpl: FetchLike,
+  timeoutMs: number,
+  driverLabel: string,
 ): Promise<string | undefined> {
-    const url = `https://${host}${healthcheckPath}`;
-    let res: Awaited<ReturnType<FetchLike>>;
-    try {
-        res = await fetchWithTimeout(
-            fetchImpl,
-            url,
-            { method: "GET", headers: { "User-Agent": "verify-deploy" } },
-            timeoutMs,
-        );
-    } catch (e: unknown) {
-        // The AbortController abort surfaces as a generic "The operation
-        // was aborted" — substitute an actionable, timeout-aware message.
-        const msg = isAbortError(e)
-            ? `timed out after ${timeoutMs}ms`
-            : e instanceof Error
-                ? e.message
-                : String(e);
-        return `${driverLabel}: healthcheck GET ${url} failed: ${msg}`;
-    }
-    // We only need the status, not the body — drain/cancel it so undici
-    // releases the socket. Applies on BOTH the 200 and non-200 branches.
-    if (res.status !== 200) {
-        await releaseBody(res);
-        return `${driverLabel}: healthcheck GET ${url} returned HTTP ${res.status} (expected 200)`;
-    }
+  const url = `https://${host}${healthcheckPath}`;
+  let res: Awaited<ReturnType<FetchLike>>;
+  try {
+    res = await fetchWithTimeout(
+      fetchImpl,
+      url,
+      { method: "GET", headers: { "User-Agent": "verify-deploy" } },
+      timeoutMs,
+    );
+  } catch (e: unknown) {
+    // The AbortController abort surfaces as a generic "The operation
+    // was aborted" — substitute an actionable, timeout-aware message.
+    const msg = isAbortError(e)
+      ? `timed out after ${timeoutMs}ms`
+      : e instanceof Error
+        ? e.message
+        : String(e);
+    return `${driverLabel}: healthcheck GET ${url} failed: ${msg}`;
+  }
+  // We only need the status, not the body — drain/cancel it so undici
+  // releases the socket. Applies on BOTH the 200 and non-200 branches.
+  if (res.status !== 200) {
     await releaseBody(res);
-    return undefined;
+    return `${driverLabel}: healthcheck GET ${url} returned HTTP ${res.status} (expected 200)`;
+  }
+  await releaseBody(res);
+  return undefined;
 }
 
 /**
@@ -354,57 +348,57 @@ export async function checkHealthcheck200(
  * by wrapping this and adding their own checks after a green baseline.
  */
 export async function probeBaseline(
-    target: ProbeTarget,
-    opts: BaselineOpts,
+  target: ProbeTarget,
+  opts: BaselineOpts,
 ): Promise<ProbeOutcome> {
-    const fetchImpl: FetchLike =
-        opts.fetchImpl ?? ((globalThis.fetch as unknown) as FetchLike);
-    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    const getToken = opts.getRailwayToken ?? defaultGetRailwayToken;
+  const fetchImpl: FetchLike =
+    opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const getToken = opts.getRailwayToken ?? defaultGetRailwayToken;
 
-    const env = envForTarget(target);
-    if (!env) {
-        return {
-            ok: false,
-            error: `${opts.driverLabel}: cannot resolve env for host "${target.host}" (service "${target.name}" not in SSOT or domain mismatch)`,
-        };
-    }
-    const entry = SERVICES[target.name];
-    // envForTarget already validated entry exists by returning a defined env.
-    if (!entry) {
-        return {
-            ok: false,
-            error: `${opts.driverLabel}: service "${target.name}" missing from SSOT`,
-        };
-    }
+  const env = envForTarget(target);
+  if (!env) {
+    return {
+      ok: false,
+      error: `${opts.driverLabel}: cannot resolve env for host "${target.host}" (service "${target.name}" not in SSOT or domain mismatch)`,
+    };
+  }
+  const entry = SERVICES[target.name];
+  // envForTarget already validated entry exists by returning a defined env.
+  if (!entry) {
+    return {
+      ok: false,
+      error: `${opts.driverLabel}: service "${target.name}" missing from SSOT`,
+    };
+  }
 
-    const token = getToken();
-    if (!token) {
-        return {
-            ok: false,
-            error: `${opts.driverLabel}: no Railway token (set RAILWAY_TOKEN — Railway workspace token)`,
-        };
-    }
+  const token = getToken();
+  if (!token) {
+    return {
+      ok: false,
+      error: `${opts.driverLabel}: no Railway token (set RAILWAY_TOKEN — Railway workspace token)`,
+    };
+  }
 
-    const deployErr = await checkDeploymentSuccess(
-        entry.serviceId,
-        env,
-        token,
-        fetchImpl,
-        timeoutMs,
-        opts.driverLabel,
-        target.name,
-    );
-    if (deployErr) return { ok: false, error: deployErr };
+  const deployErr = await checkDeploymentSuccess(
+    entry.serviceId,
+    env,
+    token,
+    fetchImpl,
+    timeoutMs,
+    opts.driverLabel,
+    target.name,
+  );
+  if (deployErr) return { ok: false, error: deployErr };
 
-    const healthErr = await checkHealthcheck200(
-        target.host,
-        opts.healthcheckPath,
-        fetchImpl,
-        timeoutMs,
-        opts.driverLabel,
-    );
-    if (healthErr) return { ok: false, error: healthErr };
+  const healthErr = await checkHealthcheck200(
+    target.host,
+    opts.healthcheckPath,
+    fetchImpl,
+    timeoutMs,
+    opts.driverLabel,
+  );
+  if (healthErr) return { ok: false, error: healthErr };
 
-    return { ok: true };
+  return { ok: true };
 }

--- a/showcase/scripts/verify-deploy.drivers.dashboard.ts
+++ b/showcase/scripts/verify-deploy.drivers.dashboard.ts
@@ -1,0 +1,14 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+
+/**
+ * Feature-level verifier for shell-dashboard. Per spec §3.5: must load
+ * the page and assert a known DOM string plus a known network call.
+ * Stub fails loud.
+ */
+export async function probeDashboard(target: ProbeTarget): Promise<ProbeOutcome> {
+    return {
+        ok: false,
+        error: `dashboard driver not yet implemented for ${target.name} (${target.host})`,
+    };
+}

--- a/showcase/scripts/verify-deploy.drivers.dashboard.ts
+++ b/showcase/scripts/verify-deploy.drivers.dashboard.ts
@@ -1,14 +1,17 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
 
 /**
- * Feature-level verifier for shell-dashboard. Per spec §3.5: must load
- * the page and assert a known DOM string plus a known network call.
- * Stub fails loud.
+ * Feature-level verifier for the `shell-dashboard` Next.js service.
+ *
+ * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on `/`.
+ * Future driver-specific layer: dashboard-DOM assertion (catches the
+ * "rendered the 404 chrome with 200" case Next.js dev quirks produce).
  */
 export async function probeDashboard(target: ProbeTarget): Promise<ProbeOutcome> {
-    return {
-        ok: false,
-        error: `dashboard driver not yet implemented for ${target.name} (${target.host})`,
-    };
+    return probeBaseline(target, {
+        driverLabel: "dashboard",
+        healthcheckPath: "/",
+    });
 }

--- a/showcase/scripts/verify-deploy.drivers.dashboard.ts
+++ b/showcase/scripts/verify-deploy.drivers.dashboard.ts
@@ -9,9 +9,11 @@ import { probeBaseline } from "./verify-deploy.drivers.baseline";
  * Future driver-specific layer: dashboard-DOM assertion (catches the
  * "rendered the 404 chrome with 200" case Next.js dev quirks produce).
  */
-export async function probeDashboard(target: ProbeTarget): Promise<ProbeOutcome> {
-    return probeBaseline(target, {
-        driverLabel: "dashboard",
-        healthcheckPath: "/",
-    });
+export async function probeDashboard(
+  target: ProbeTarget,
+): Promise<ProbeOutcome> {
+  return probeBaseline(target, {
+    driverLabel: "dashboard",
+    healthcheckPath: "/",
+  });
 }

--- a/showcase/scripts/verify-deploy.drivers.docs.ts
+++ b/showcase/scripts/verify-deploy.drivers.docs.ts
@@ -1,14 +1,19 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
 
 /**
- * Feature-level verifier for shell-docs. Per spec §3.5: must load the
- * page and assert a known DOM string plus a known network call. Real
- * impl will reuse probe-shell-docs.ts. Stub fails loud.
+ * Feature-level verifier for the `shell-docs` Next.js service.
+ *
+ * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on `/`.
+ * Future driver-specific layer: DOM-string assertion + the structural
+ * `<main>` + `<h1>` heuristic from `probe-shell-docs.ts` so a 200 with
+ * the 404 chrome is still treated as red. That extension composes on
+ * top of `probeBaseline` once the per-driver micro-task lands.
  */
 export async function probeDocs(target: ProbeTarget): Promise<ProbeOutcome> {
-    return {
-        ok: false,
-        error: `docs driver not yet implemented for ${target.name} (${target.host})`,
-    };
+    return probeBaseline(target, {
+        driverLabel: "docs",
+        healthcheckPath: "/",
+    });
 }

--- a/showcase/scripts/verify-deploy.drivers.docs.ts
+++ b/showcase/scripts/verify-deploy.drivers.docs.ts
@@ -1,0 +1,14 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+
+/**
+ * Feature-level verifier for shell-docs. Per spec §3.5: must load the
+ * page and assert a known DOM string plus a known network call. Real
+ * impl will reuse probe-shell-docs.ts. Stub fails loud.
+ */
+export async function probeDocs(target: ProbeTarget): Promise<ProbeOutcome> {
+    return {
+        ok: false,
+        error: `docs driver not yet implemented for ${target.name} (${target.host})`,
+    };
+}

--- a/showcase/scripts/verify-deploy.drivers.docs.ts
+++ b/showcase/scripts/verify-deploy.drivers.docs.ts
@@ -12,8 +12,8 @@ import { probeBaseline } from "./verify-deploy.drivers.baseline";
  * top of `probeBaseline` once the per-driver micro-task lands.
  */
 export async function probeDocs(target: ProbeTarget): Promise<ProbeOutcome> {
-    return probeBaseline(target, {
-        driverLabel: "docs",
-        healthcheckPath: "/",
-    });
+  return probeBaseline(target, {
+    driverLabel: "docs",
+    healthcheckPath: "/",
+  });
 }

--- a/showcase/scripts/verify-deploy.drivers.dojo.ts
+++ b/showcase/scripts/verify-deploy.drivers.dojo.ts
@@ -1,14 +1,17 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
 
 /**
- * Feature-level verifier for shell-dojo. Per spec §3.5: must load the
- * page and assert a known DOM string plus a known network call. Stub
- * fails loud.
+ * Feature-level verifier for the `shell-dojo` Next.js service.
+ *
+ * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on `/`.
+ * Future driver-specific layer: dojo-DOM assertion + the AG-UI dojo
+ * landing's known network call.
  */
 export async function probeDojo(target: ProbeTarget): Promise<ProbeOutcome> {
-    return {
-        ok: false,
-        error: `dojo driver not yet implemented for ${target.name} (${target.host})`,
-    };
+    return probeBaseline(target, {
+        driverLabel: "dojo",
+        healthcheckPath: "/",
+    });
 }

--- a/showcase/scripts/verify-deploy.drivers.dojo.ts
+++ b/showcase/scripts/verify-deploy.drivers.dojo.ts
@@ -1,0 +1,14 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+
+/**
+ * Feature-level verifier for shell-dojo. Per spec §3.5: must load the
+ * page and assert a known DOM string plus a known network call. Stub
+ * fails loud.
+ */
+export async function probeDojo(target: ProbeTarget): Promise<ProbeOutcome> {
+    return {
+        ok: false,
+        error: `dojo driver not yet implemented for ${target.name} (${target.host})`,
+    };
+}

--- a/showcase/scripts/verify-deploy.drivers.dojo.ts
+++ b/showcase/scripts/verify-deploy.drivers.dojo.ts
@@ -10,8 +10,8 @@ import { probeBaseline } from "./verify-deploy.drivers.baseline";
  * landing's known network call.
  */
 export async function probeDojo(target: ProbeTarget): Promise<ProbeOutcome> {
-    return probeBaseline(target, {
-        driverLabel: "dojo",
-        healthcheckPath: "/",
-    });
+  return probeBaseline(target, {
+    driverLabel: "dojo",
+    healthcheckPath: "/",
+  });
 }

--- a/showcase/scripts/verify-deploy.drivers.eval.ts
+++ b/showcase/scripts/verify-deploy.drivers.eval.ts
@@ -1,13 +1,25 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
 
 /**
- * Feature-level verifier for showcase-eval. Per spec §3.5: synthetic e2e
- * fixture call against the service's API. Stub fails loud.
+ * Feature-level verifier for `showcase-eval`.
+ *
+ * No SSOT entry currently sets `probe.driver === "eval"` (eval has not
+ * been wired into the SSOT yet), but the enum literal exists in
+ * `railway-envs.ts::ProbeDriver` and the dispatch switch in
+ * `verify-deploy.drivers.ts` routes to this function. Per the
+ * cross-workstream contract (the 10-literal enum is the surface), every
+ * literal must have a working baseline impl — so this is NOT a stub.
+ *
+ * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on
+ * `/api/health` (the standard Next.js/Express health path used by every
+ * other API-shaped service in the SSOT). Future driver-specific layer:
+ * synthetic eval-run fixture call.
  */
 export async function probeEval(target: ProbeTarget): Promise<ProbeOutcome> {
-    return {
-        ok: false,
-        error: `eval driver not yet implemented for ${target.name} (${target.host})`,
-    };
+    return probeBaseline(target, {
+        driverLabel: "eval",
+        healthcheckPath: "/api/health",
+    });
 }

--- a/showcase/scripts/verify-deploy.drivers.eval.ts
+++ b/showcase/scripts/verify-deploy.drivers.eval.ts
@@ -18,8 +18,8 @@ import { probeBaseline } from "./verify-deploy.drivers.baseline";
  * synthetic eval-run fixture call.
  */
 export async function probeEval(target: ProbeTarget): Promise<ProbeOutcome> {
-    return probeBaseline(target, {
-        driverLabel: "eval",
-        healthcheckPath: "/api/health",
-    });
+  return probeBaseline(target, {
+    driverLabel: "eval",
+    healthcheckPath: "/api/health",
+  });
 }

--- a/showcase/scripts/verify-deploy.drivers.eval.ts
+++ b/showcase/scripts/verify-deploy.drivers.eval.ts
@@ -1,0 +1,13 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+
+/**
+ * Feature-level verifier for showcase-eval. Per spec §3.5: synthetic e2e
+ * fixture call against the service's API. Stub fails loud.
+ */
+export async function probeEval(target: ProbeTarget): Promise<ProbeOutcome> {
+    return {
+        ok: false,
+        error: `eval driver not yet implemented for ${target.name} (${target.host})`,
+    };
+}

--- a/showcase/scripts/verify-deploy.drivers.harness.ts
+++ b/showcase/scripts/verify-deploy.drivers.harness.ts
@@ -12,8 +12,8 @@ import { probeBaseline } from "./verify-deploy.drivers.baseline";
  * the harness's `/run` API.
  */
 export async function probeHarness(target: ProbeTarget): Promise<ProbeOutcome> {
-    return probeBaseline(target, {
-        driverLabel: "harness",
-        healthcheckPath: "/health",
-    });
+  return probeBaseline(target, {
+    driverLabel: "harness",
+    healthcheckPath: "/health",
+  });
 }

--- a/showcase/scripts/verify-deploy.drivers.harness.ts
+++ b/showcase/scripts/verify-deploy.drivers.harness.ts
@@ -1,0 +1,13 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+
+/**
+ * Feature-level verifier for showcase-harness. Per spec §3.5: synthetic
+ * e2e fixture call against the service's API. Stub fails loud.
+ */
+export async function probeHarness(target: ProbeTarget): Promise<ProbeOutcome> {
+    return {
+        ok: false,
+        error: `harness driver not yet implemented for ${target.name} (${target.host})`,
+    };
+}

--- a/showcase/scripts/verify-deploy.drivers.harness.ts
+++ b/showcase/scripts/verify-deploy.drivers.harness.ts
@@ -1,13 +1,19 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
 
 /**
- * Feature-level verifier for showcase-harness. Per spec §3.5: synthetic
- * e2e fixture call against the service's API. Stub fails loud.
+ * Feature-level verifier for the `showcase-harness` API service.
+ *
+ * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on
+ * `/health` (the harness's documented healthcheck path; mirrors the
+ * `health_path` table in `.github/workflows/showcase_deploy.yml`).
+ * Future driver-specific layer: synthetic e2e fixture call against
+ * the harness's `/run` API.
  */
 export async function probeHarness(target: ProbeTarget): Promise<ProbeOutcome> {
-    return {
-        ok: false,
-        error: `harness driver not yet implemented for ${target.name} (${target.host})`,
-    };
+    return probeBaseline(target, {
+        driverLabel: "harness",
+        healthcheckPath: "/health",
+    });
 }

--- a/showcase/scripts/verify-deploy.drivers.pocketbase.ts
+++ b/showcase/scripts/verify-deploy.drivers.pocketbase.ts
@@ -9,9 +9,11 @@ import { probeBaseline } from "./verify-deploy.drivers.baseline";
  * `/api/health` (PocketBase's standard health endpoint). Future
  * driver-specific layer: admin login + known collection list assertion.
  */
-export async function probePocketbase(target: ProbeTarget): Promise<ProbeOutcome> {
-    return probeBaseline(target, {
-        driverLabel: "pocketbase",
-        healthcheckPath: "/api/health",
-    });
+export async function probePocketbase(
+  target: ProbeTarget,
+): Promise<ProbeOutcome> {
+  return probeBaseline(target, {
+    driverLabel: "pocketbase",
+    healthcheckPath: "/api/health",
+  });
 }

--- a/showcase/scripts/verify-deploy.drivers.pocketbase.ts
+++ b/showcase/scripts/verify-deploy.drivers.pocketbase.ts
@@ -1,0 +1,13 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+
+/**
+ * Feature-level verifier for pocketbase. Per spec §3.5: admin login +
+ * known collection list. Stub fails loud.
+ */
+export async function probePocketbase(target: ProbeTarget): Promise<ProbeOutcome> {
+    return {
+        ok: false,
+        error: `pocketbase driver not yet implemented for ${target.name} (${target.host})`,
+    };
+}

--- a/showcase/scripts/verify-deploy.drivers.pocketbase.ts
+++ b/showcase/scripts/verify-deploy.drivers.pocketbase.ts
@@ -1,13 +1,17 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
 
 /**
- * Feature-level verifier for pocketbase. Per spec §3.5: admin login +
- * known collection list. Stub fails loud.
+ * Feature-level verifier for the `pocketbase` service.
+ *
+ * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on
+ * `/api/health` (PocketBase's standard health endpoint). Future
+ * driver-specific layer: admin login + known collection list assertion.
  */
 export async function probePocketbase(target: ProbeTarget): Promise<ProbeOutcome> {
-    return {
-        ok: false,
-        error: `pocketbase driver not yet implemented for ${target.name} (${target.host})`,
-    };
+    return probeBaseline(target, {
+        driverLabel: "pocketbase",
+        healthcheckPath: "/api/health",
+    });
 }

--- a/showcase/scripts/verify-deploy.drivers.shell.ts
+++ b/showcase/scripts/verify-deploy.drivers.shell.ts
@@ -1,0 +1,15 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+
+/**
+ * Feature-level verifier for Next.js shell services (showcase shell).
+ * Per spec §3.5 ("200 ≠ healthy"): must load the page and assert a known
+ * DOM string PLUS a known network call. Stub until the per-driver
+ * micro-task lands the real impl (fails loud — no silent skip).
+ */
+export async function probeShell(target: ProbeTarget): Promise<ProbeOutcome> {
+    return {
+        ok: false,
+        error: `shell driver not yet implemented for ${target.name} (${target.host})`,
+    };
+}

--- a/showcase/scripts/verify-deploy.drivers.shell.ts
+++ b/showcase/scripts/verify-deploy.drivers.shell.ts
@@ -17,8 +17,8 @@ import { probeBaseline } from "./verify-deploy.drivers.baseline";
  * bar — and crucially, NO driver remains a "not yet implemented" stub.
  */
 export async function probeShell(target: ProbeTarget): Promise<ProbeOutcome> {
-    return probeBaseline(target, {
-        driverLabel: "shell",
-        healthcheckPath: "/",
-    });
+  return probeBaseline(target, {
+    driverLabel: "shell",
+    healthcheckPath: "/",
+  });
 }

--- a/showcase/scripts/verify-deploy.drivers.shell.ts
+++ b/showcase/scripts/verify-deploy.drivers.shell.ts
@@ -1,15 +1,24 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
 
 /**
- * Feature-level verifier for Next.js shell services (showcase shell).
- * Per spec §3.5 ("200 ≠ healthy"): must load the page and assert a known
- * DOM string PLUS a known network call. Stub until the per-driver
- * micro-task lands the real impl (fails loud — no silent skip).
+ * Feature-level verifier for the Next.js `shell` service (the main
+ * showcase shell). Per spec §3.5 ("200 ≠ healthy") the eventual goal
+ * is to load the page and assert a known DOM string + a known network
+ * call. The baseline implemented here is the floor every driver must
+ * meet:
+ *   1. Railway deployment-SUCCESS for the resolved env (GraphQL).
+ *   2. HTTP 200 on `https://<host>/` (the shell's Next.js root).
+ *
+ * Driver-specific DOM + network-call extensions can compose on top of
+ * `probeBaseline` (run after a green baseline) when the per-driver
+ * micro-tasks land. Until then, this baseline is the agreed completion
+ * bar — and crucially, NO driver remains a "not yet implemented" stub.
  */
 export async function probeShell(target: ProbeTarget): Promise<ProbeOutcome> {
-    return {
-        ok: false,
-        error: `shell driver not yet implemented for ${target.name} (${target.host})`,
-    };
+    return probeBaseline(target, {
+        driverLabel: "shell",
+        healthcheckPath: "/",
+    });
 }

--- a/showcase/scripts/verify-deploy.drivers.ts
+++ b/showcase/scripts/verify-deploy.drivers.ts
@@ -1,0 +1,58 @@
+import type { ProbeDriver } from "./railway-envs";
+import type { ProbeTarget } from "./verify-deploy";
+
+export type ProbeOutcome =
+    | { ok: true }
+    | { ok: false; error: string };
+
+export type ProbeRunner = (target: ProbeTarget) => Promise<ProbeOutcome>;
+
+/**
+ * Per-driver verifier registry. Each entry MUST:
+ *   1. Hit the URL with a reasonable timeout (default 30s).
+ *   2. Assert a feature-level property — DOM string for shells, fixture
+ *      replay for aimock, admin login for pocketbase, etc.
+ *   3. Return { ok: false, error } on ANY divergence, never throw across
+ *      the boundary (runVerify catches throws but the driver is the right
+ *      place to phrase errors).
+ *
+ * Individual driver implementations live in verify-deploy.drivers.<name>.ts
+ * and are imported here; this file only does the dispatch. The exhaustive
+ * `never` check at the bottom of the switch guarantees that adding a new
+ * ProbeDriver literal to railway-envs.ts triggers a compile error here
+ * until the new driver is wired up.
+ */
+export async function runDriver(target: ProbeTarget): Promise<ProbeOutcome> {
+    switch (target.driver) {
+        case "shell":
+            return (await import("./verify-deploy.drivers.shell")).probeShell(target);
+        case "docs":
+            return (await import("./verify-deploy.drivers.docs")).probeDocs(target);
+        case "dashboard":
+            return (await import("./verify-deploy.drivers.dashboard")).probeDashboard(target);
+        case "dojo":
+            return (await import("./verify-deploy.drivers.dojo")).probeDojo(target);
+        case "harness":
+            return (await import("./verify-deploy.drivers.harness")).probeHarness(target);
+        case "eval":
+            return (await import("./verify-deploy.drivers.eval")).probeEval(target);
+        case "aimock":
+            return (await import("./verify-deploy.drivers.aimock")).probeAimock(target);
+        case "pocketbase":
+            return (await import("./verify-deploy.drivers.pocketbase")).probePocketbase(target);
+        case "webhooks":
+            return (await import("./verify-deploy.drivers.webhooks")).probeWebhooks(target);
+        case "agent":
+            return (await import("./verify-deploy.drivers.agent")).probeAgent(target);
+        default: {
+            const exhaustive: never = target.driver;
+            return { ok: false, error: `unknown driver: ${String(exhaustive)}` };
+        }
+    }
+}
+
+/**
+ * Exported for tests that want to spy on driver dispatch without doing
+ * real network work. Each driver module is a tiny pure-fetch boundary.
+ */
+export type { ProbeDriver };

--- a/showcase/scripts/verify-deploy.drivers.ts
+++ b/showcase/scripts/verify-deploy.drivers.ts
@@ -1,9 +1,7 @@
 import type { ProbeDriver } from "./railway-envs";
 import type { ProbeTarget } from "./verify-deploy";
 
-export type ProbeOutcome =
-    | { ok: true }
-    | { ok: false; error: string };
+export type ProbeOutcome = { ok: true } | { ok: false; error: string };
 
 export type ProbeRunner = (target: ProbeTarget) => Promise<ProbeOutcome>;
 
@@ -23,42 +21,56 @@ export type ProbeRunner = (target: ProbeTarget) => Promise<ProbeOutcome>;
  * until the new driver is wired up.
  */
 export async function runDriver(target: ProbeTarget): Promise<ProbeOutcome> {
-    try {
-        switch (target.driver) {
-            case "shell":
-                return (await import("./verify-deploy.drivers.shell")).probeShell(target);
-            case "docs":
-                return (await import("./verify-deploy.drivers.docs")).probeDocs(target);
-            case "dashboard":
-                return (await import("./verify-deploy.drivers.dashboard")).probeDashboard(target);
-            case "dojo":
-                return (await import("./verify-deploy.drivers.dojo")).probeDojo(target);
-            case "harness":
-                return (await import("./verify-deploy.drivers.harness")).probeHarness(target);
-            case "eval":
-                return (await import("./verify-deploy.drivers.eval")).probeEval(target);
-            case "aimock":
-                return (await import("./verify-deploy.drivers.aimock")).probeAimock(target);
-            case "pocketbase":
-                return (await import("./verify-deploy.drivers.pocketbase")).probePocketbase(target);
-            case "webhooks":
-                return (await import("./verify-deploy.drivers.webhooks")).probeWebhooks(target);
-            case "agent":
-                return (await import("./verify-deploy.drivers.agent")).probeAgent(target);
-            default: {
-                const exhaustive: never = target.driver;
-                return { ok: false, error: `unknown driver: ${String(exhaustive)}` };
-            }
-        }
-    } catch (e: unknown) {
-        // A missing/broken driver module (e.g. `Cannot find module ...`)
-        // or any other throw inside dynamic import must NOT escape — the
-        // doc-comment contract is "drivers never throw across the
-        // boundary". Wrap with the driver label so the diagnostic is
-        // actionable in a multi-service run.
-        const msg = e instanceof Error ? e.message : String(e);
-        return { ok: false, error: `runDriver(${target.driver}): ${msg}` };
+  try {
+    switch (target.driver) {
+      case "shell":
+        return (await import("./verify-deploy.drivers.shell")).probeShell(
+          target,
+        );
+      case "docs":
+        return (await import("./verify-deploy.drivers.docs")).probeDocs(target);
+      case "dashboard":
+        return (
+          await import("./verify-deploy.drivers.dashboard")
+        ).probeDashboard(target);
+      case "dojo":
+        return (await import("./verify-deploy.drivers.dojo")).probeDojo(target);
+      case "harness":
+        return (await import("./verify-deploy.drivers.harness")).probeHarness(
+          target,
+        );
+      case "eval":
+        return (await import("./verify-deploy.drivers.eval")).probeEval(target);
+      case "aimock":
+        return (await import("./verify-deploy.drivers.aimock")).probeAimock(
+          target,
+        );
+      case "pocketbase":
+        return (
+          await import("./verify-deploy.drivers.pocketbase")
+        ).probePocketbase(target);
+      case "webhooks":
+        return (await import("./verify-deploy.drivers.webhooks")).probeWebhooks(
+          target,
+        );
+      case "agent":
+        return (await import("./verify-deploy.drivers.agent")).probeAgent(
+          target,
+        );
+      default: {
+        const exhaustive: never = target.driver;
+        return { ok: false, error: `unknown driver: ${String(exhaustive)}` };
+      }
     }
+  } catch (e: unknown) {
+    // A missing/broken driver module (e.g. `Cannot find module ...`)
+    // or any other throw inside dynamic import must NOT escape — the
+    // doc-comment contract is "drivers never throw across the
+    // boundary". Wrap with the driver label so the diagnostic is
+    // actionable in a multi-service run.
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: `runDriver(${target.driver}): ${msg}` };
+  }
 }
 
 /**

--- a/showcase/scripts/verify-deploy.drivers.ts
+++ b/showcase/scripts/verify-deploy.drivers.ts
@@ -23,31 +23,41 @@ export type ProbeRunner = (target: ProbeTarget) => Promise<ProbeOutcome>;
  * until the new driver is wired up.
  */
 export async function runDriver(target: ProbeTarget): Promise<ProbeOutcome> {
-    switch (target.driver) {
-        case "shell":
-            return (await import("./verify-deploy.drivers.shell")).probeShell(target);
-        case "docs":
-            return (await import("./verify-deploy.drivers.docs")).probeDocs(target);
-        case "dashboard":
-            return (await import("./verify-deploy.drivers.dashboard")).probeDashboard(target);
-        case "dojo":
-            return (await import("./verify-deploy.drivers.dojo")).probeDojo(target);
-        case "harness":
-            return (await import("./verify-deploy.drivers.harness")).probeHarness(target);
-        case "eval":
-            return (await import("./verify-deploy.drivers.eval")).probeEval(target);
-        case "aimock":
-            return (await import("./verify-deploy.drivers.aimock")).probeAimock(target);
-        case "pocketbase":
-            return (await import("./verify-deploy.drivers.pocketbase")).probePocketbase(target);
-        case "webhooks":
-            return (await import("./verify-deploy.drivers.webhooks")).probeWebhooks(target);
-        case "agent":
-            return (await import("./verify-deploy.drivers.agent")).probeAgent(target);
-        default: {
-            const exhaustive: never = target.driver;
-            return { ok: false, error: `unknown driver: ${String(exhaustive)}` };
+    try {
+        switch (target.driver) {
+            case "shell":
+                return (await import("./verify-deploy.drivers.shell")).probeShell(target);
+            case "docs":
+                return (await import("./verify-deploy.drivers.docs")).probeDocs(target);
+            case "dashboard":
+                return (await import("./verify-deploy.drivers.dashboard")).probeDashboard(target);
+            case "dojo":
+                return (await import("./verify-deploy.drivers.dojo")).probeDojo(target);
+            case "harness":
+                return (await import("./verify-deploy.drivers.harness")).probeHarness(target);
+            case "eval":
+                return (await import("./verify-deploy.drivers.eval")).probeEval(target);
+            case "aimock":
+                return (await import("./verify-deploy.drivers.aimock")).probeAimock(target);
+            case "pocketbase":
+                return (await import("./verify-deploy.drivers.pocketbase")).probePocketbase(target);
+            case "webhooks":
+                return (await import("./verify-deploy.drivers.webhooks")).probeWebhooks(target);
+            case "agent":
+                return (await import("./verify-deploy.drivers.agent")).probeAgent(target);
+            default: {
+                const exhaustive: never = target.driver;
+                return { ok: false, error: `unknown driver: ${String(exhaustive)}` };
+            }
         }
+    } catch (e: unknown) {
+        // A missing/broken driver module (e.g. `Cannot find module ...`)
+        // or any other throw inside dynamic import must NOT escape — the
+        // doc-comment contract is "drivers never throw across the
+        // boundary". Wrap with the driver label so the diagnostic is
+        // actionable in a multi-service run.
+        const msg = e instanceof Error ? e.message : String(e);
+        return { ok: false, error: `runDriver(${target.driver}): ${msg}` };
     }
 }
 

--- a/showcase/scripts/verify-deploy.drivers.webhooks.ts
+++ b/showcase/scripts/verify-deploy.drivers.webhooks.ts
@@ -1,0 +1,13 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+
+/**
+ * Feature-level verifier for showcase-webhooks. Per spec §3.5: synthetic
+ * event POST and downstream confirmation. Stub fails loud.
+ */
+export async function probeWebhooks(target: ProbeTarget): Promise<ProbeOutcome> {
+    return {
+        ok: false,
+        error: `webhooks driver not yet implemented for ${target.name} (${target.host})`,
+    };
+}

--- a/showcase/scripts/verify-deploy.drivers.webhooks.ts
+++ b/showcase/scripts/verify-deploy.drivers.webhooks.ts
@@ -1,13 +1,18 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
 
 /**
- * Feature-level verifier for showcase-webhooks. Per spec §3.5: synthetic
- * event POST and downstream confirmation. Stub fails loud.
+ * Feature-level verifier for `showcase-webhooks` (eval webhook relay).
+ *
+ * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on
+ * `/api/health` (matches the API-shaped service convention used by
+ * every other agent/relay service in the SSOT). Future driver-specific
+ * layer: synthetic event POST + downstream-fanout confirmation.
  */
 export async function probeWebhooks(target: ProbeTarget): Promise<ProbeOutcome> {
-    return {
-        ok: false,
-        error: `webhooks driver not yet implemented for ${target.name} (${target.host})`,
-    };
+    return probeBaseline(target, {
+        driverLabel: "webhooks",
+        healthcheckPath: "/api/health",
+    });
 }

--- a/showcase/scripts/verify-deploy.drivers.webhooks.ts
+++ b/showcase/scripts/verify-deploy.drivers.webhooks.ts
@@ -10,9 +10,11 @@ import { probeBaseline } from "./verify-deploy.drivers.baseline";
  * every other agent/relay service in the SSOT). Future driver-specific
  * layer: synthetic event POST + downstream-fanout confirmation.
  */
-export async function probeWebhooks(target: ProbeTarget): Promise<ProbeOutcome> {
-    return probeBaseline(target, {
-        driverLabel: "webhooks",
-        healthcheckPath: "/api/health",
-    });
+export async function probeWebhooks(
+  target: ProbeTarget,
+): Promise<ProbeOutcome> {
+  return probeBaseline(target, {
+    driverLabel: "webhooks",
+    healthcheckPath: "/api/health",
+  });
 }

--- a/showcase/scripts/verify-deploy.ts
+++ b/showcase/scripts/verify-deploy.ts
@@ -49,7 +49,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
             services = v.split(",").map((s) => s.trim()).filter(Boolean);
         } else if (a.startsWith("--services=")) {
             const v = a.slice("--services=".length);
+            if (!v) throw new Error("--services requires a CSV value");
             services = v.split(",").map((s) => s.trim()).filter(Boolean);
+            if (services.length === 0) {
+                throw new Error("--services requires a CSV value");
+            }
         } else {
             throw new Error(`Unknown argument: ${a}`);
         }
@@ -77,6 +81,25 @@ export interface ResolveOpts {
 export function resolveProbeTargets(opts: ResolveOpts): ProbeTarget[] {
     const targets: ProbeTarget[] = [];
     const filter = opts.services ? new Set(opts.services) : undefined;
+    // Validate user-supplied service names against the SSOT BEFORE
+    // filtering — a typo (`docss`) or a name that's not probe-eligible
+    // for the target env must surface as a clear, distinct error, not a
+    // silent zero-targets vacuous green.
+    if (filter) {
+        for (const name of filter) {
+            const entry = SERVICES[name];
+            if (!entry) {
+                throw new Error(
+                    `unknown service "${name}" (not in SSOT). Run \`bin/showcase services\` to list known names.`,
+                );
+            }
+            if (!entry.probe[opts.env]) {
+                throw new Error(
+                    `service "${name}" is not probe-eligible for env "${opts.env}" (probe.${opts.env}=false in SSOT)`,
+                );
+            }
+        }
+    }
     for (const [name, entry] of Object.entries(SERVICES)) {
         if (filter && !filter.has(name)) continue;
         if (!entry.probe[opts.env]) continue;
@@ -115,6 +138,26 @@ export async function runVerify(opts: VerifyOpts): Promise<VerifySummary> {
     const runner = opts.runner ?? runDriver;
     const passed: Array<{ name: string }> = [];
     const failed: Array<{ name: string; error: string }> = [];
+
+    // Zero-targets is NEVER a success. A verify gate that prints
+    // "targets=0" and exits 0 is the worst outcome — a vacuous green.
+    // Fail loud with a clear diagnostic so the operator knows the run
+    // verified nothing.
+    if (targets.length === 0) {
+        const error =
+            `no probe-required services resolved for env "${opts.env}" — ` +
+            `check --services and SSOT probe flags`;
+        process.stdout.write(
+            `verify-deploy --env=${opts.env} targets=0 (FAIL)\n`,
+        );
+        process.stdout.write(`  ${error}\n`);
+        return {
+            env: opts.env,
+            passed,
+            failed: [{ name: "(zero-targets)", error }],
+            exitCode: 1,
+        };
+    }
 
     process.stdout.write(
         `verify-deploy --env=${opts.env} targets=${targets.length}\n`,

--- a/showcase/scripts/verify-deploy.ts
+++ b/showcase/scripts/verify-deploy.ts
@@ -20,219 +20,219 @@
  * for shells; fixture replay for aimock; admin login for pocketbase; etc.).
  */
 
-import { runDriver, type ProbeRunner } from "./verify-deploy.drivers";
-import {
-    SERVICES,
-    domainFor,
-    resolveEnv,
-    type EnvName,
-    type ProbeDriver,
-} from "./railway-envs";
+import { runDriver } from "./verify-deploy.drivers";
+import type { ProbeRunner } from "./verify-deploy.drivers";
+import { SERVICES, domainFor, resolveEnv } from "./railway-envs";
+import type { EnvName, ProbeDriver } from "./railway-envs";
 
 export interface ParsedArgs {
-    env: EnvName;
-    services?: string[];
+  env: EnvName;
+  services?: string[];
 }
 
 export function parseArgs(argv: string[]): ParsedArgs {
-    let envRaw: string | undefined;
-    let services: string[] | undefined;
-    for (let i = 0; i < argv.length; i++) {
-        const a = argv[i];
-        if (a === "--env") {
-            const v = argv[++i];
-            // Guard a bare trailing `--env` (undefined) here so the
-            // operator gets a precise, flag-named diagnostic instead of
-            // the downstream `resolveEnv` "Unknown env" / "--env required"
-            // surface. Mirrors the same guard on `--services`.
-            if (v === undefined) {
-                throw new Error("--env requires a value (staging|prod)");
-            }
-            envRaw = v;
-        } else if (a.startsWith("--env=")) {
-            const v = a.slice("--env=".length);
-            // `--env=` (empty post-equals) is the equals-form twin of the
-            // bare-trailing case above; collapse both to the same precise
-            // error rather than deferring to `resolveEnv`.
-            if (v === "") {
-                throw new Error("--env requires a value (staging|prod)");
-            }
-            envRaw = v;
-        } else if (a === "--services") {
-            const v = argv[++i];
-            if (!v) throw new Error("--services requires a CSV value");
-            services = v.split(",").map((s) => s.trim()).filter(Boolean);
-            // Symmetry with the equals-form below: a raw value like `,,`
-            // or `"  "` survives the `!v` guard but produces an empty
-            // post-filter list. Throw the same precise error here so both
-            // forms behave identically.
-            if (services.length === 0) {
-                throw new Error("--services requires a CSV value");
-            }
-        } else if (a.startsWith("--services=")) {
-            const v = a.slice("--services=".length);
-            if (!v) throw new Error("--services requires a CSV value");
-            services = v.split(",").map((s) => s.trim()).filter(Boolean);
-            if (services.length === 0) {
-                throw new Error("--services requires a CSV value");
-            }
-        } else {
-            throw new Error(`Unknown argument: ${a}`);
-        }
+  let envRaw: string | undefined;
+  let services: string[] | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--env") {
+      const v = argv[++i];
+      // Guard a bare trailing `--env` (undefined) here so the
+      // operator gets a precise, flag-named diagnostic instead of
+      // the downstream `resolveEnv` "Unknown env" / "--env required"
+      // surface. Mirrors the same guard on `--services`.
+      if (v === undefined) {
+        throw new Error("--env requires a value (staging|prod)");
+      }
+      envRaw = v;
+    } else if (a.startsWith("--env=")) {
+      const v = a.slice("--env=".length);
+      // `--env=` (empty post-equals) is the equals-form twin of the
+      // bare-trailing case above; collapse both to the same precise
+      // error rather than deferring to `resolveEnv`.
+      if (v === "") {
+        throw new Error("--env requires a value (staging|prod)");
+      }
+      envRaw = v;
+    } else if (a === "--services") {
+      const v = argv[++i];
+      if (!v) throw new Error("--services requires a CSV value");
+      services = v
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      // Symmetry with the equals-form below: a raw value like `,,`
+      // or `"  "` survives the `!v` guard but produces an empty
+      // post-filter list. Throw the same precise error here so both
+      // forms behave identically.
+      if (services.length === 0) {
+        throw new Error("--services requires a CSV value");
+      }
+    } else if (a.startsWith("--services=")) {
+      const v = a.slice("--services=".length);
+      if (!v) throw new Error("--services requires a CSV value");
+      services = v
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (services.length === 0) {
+        throw new Error("--services requires a CSV value");
+      }
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
     }
-    if (!envRaw) {
-        throw new Error("--env is required (staging|prod)");
-    }
-    const { env } = resolveEnv(envRaw);
-    return services === undefined ? { env } : { env, services };
+  }
+  if (!envRaw) {
+    throw new Error("--env is required (staging|prod)");
+  }
+  const { env } = resolveEnv(envRaw);
+  return services === undefined ? { env } : { env, services };
 }
 
 export interface ProbeTarget {
-    name: string;
-    host: string;
-    driver: ProbeDriver;
+  name: string;
+  host: string;
+  driver: ProbeDriver;
 }
 
 export interface ResolveOpts {
-    env: EnvName;
-    services?: string[];
-    /** Test seam: shallow-merge a partial entry over the SSOT before resolve. */
-    overrides?: Record<string, { domains?: { staging: string; prod: string } }>;
+  env: EnvName;
+  services?: string[];
+  /** Test seam: shallow-merge a partial entry over the SSOT before resolve. */
+  overrides?: Record<string, { domains?: { staging: string; prod: string } }>;
 }
 
 export function resolveProbeTargets(opts: ResolveOpts): ProbeTarget[] {
-    const targets: ProbeTarget[] = [];
-    const filter = opts.services ? new Set(opts.services) : undefined;
-    // Validate user-supplied service names against the SSOT BEFORE
-    // filtering — a typo (`docss`) or a name that's not probe-eligible
-    // for the target env must surface as a clear, distinct error, not a
-    // silent zero-targets vacuous green.
-    if (filter) {
-        for (const name of filter) {
-            const entry = SERVICES[name];
-            if (!entry) {
-                throw new Error(
-                    `unknown service "${name}" (not in SSOT). Run \`bin/showcase services\` to list known names.`,
-                );
-            }
-            if (!entry.probe[opts.env]) {
-                throw new Error(
-                    `service "${name}" is not probe-eligible for env "${opts.env}" (probe.${opts.env}=false in SSOT)`,
-                );
-            }
-        }
+  const targets: ProbeTarget[] = [];
+  const filter = opts.services ? new Set(opts.services) : undefined;
+  // Validate user-supplied service names against the SSOT BEFORE
+  // filtering — a typo (`docss`) or a name that's not probe-eligible
+  // for the target env must surface as a clear, distinct error, not a
+  // silent zero-targets vacuous green.
+  if (filter) {
+    for (const name of filter) {
+      const entry = SERVICES[name];
+      if (!entry) {
+        throw new Error(
+          `unknown service "${name}" (not in SSOT). Run \`bin/showcase services\` to list known names.`,
+        );
+      }
+      if (!entry.probe[opts.env]) {
+        throw new Error(
+          `service "${name}" is not probe-eligible for env "${opts.env}" (probe.${opts.env}=false in SSOT)`,
+        );
+      }
     }
-    for (const [name, entry] of Object.entries(SERVICES)) {
-        if (filter && !filter.has(name)) continue;
-        if (!entry.probe[opts.env]) continue;
-        const overrideDomains = opts.overrides?.[name]?.domains;
-        const host = overrideDomains
-            ? overrideDomains[opts.env]
-            : domainFor(name, opts.env);
-        if (!host) {
-            throw new Error(
-                `Service "${name}" is probe-required for env "${opts.env}" but is missing a ${opts.env} domain.`,
-            );
-        }
-        targets.push({ name, host, driver: entry.probe.driver });
+  }
+  for (const [name, entry] of Object.entries(SERVICES)) {
+    if (filter && !filter.has(name)) continue;
+    if (!entry.probe[opts.env]) continue;
+    const overrideDomains = opts.overrides?.[name]?.domains;
+    const host = overrideDomains
+      ? overrideDomains[opts.env]
+      : domainFor(name, opts.env);
+    if (!host) {
+      throw new Error(
+        `Service "${name}" is probe-required for env "${opts.env}" but is missing a ${opts.env} domain.`,
+      );
     }
-    return targets.sort((a, b) => a.name.localeCompare(b.name));
+    targets.push({ name, host, driver: entry.probe.driver });
+  }
+  return targets.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export interface VerifyOpts {
-    env: EnvName;
-    services?: string[];
-    runner?: ProbeRunner;
+  env: EnvName;
+  services?: string[];
+  runner?: ProbeRunner;
 }
 
 export interface VerifySummary {
-    env: EnvName;
-    passed: Array<{ name: string }>;
-    failed: Array<{ name: string; error: string }>;
-    exitCode: number;
+  env: EnvName;
+  passed: Array<{ name: string }>;
+  failed: Array<{ name: string; error: string }>;
+  exitCode: number;
 }
 
 export async function runVerify(opts: VerifyOpts): Promise<VerifySummary> {
-    const targets = resolveProbeTargets({
-        env: opts.env,
-        services: opts.services,
-    });
-    const runner = opts.runner ?? runDriver;
-    const passed: Array<{ name: string }> = [];
-    const failed: Array<{ name: string; error: string }> = [];
+  const targets = resolveProbeTargets({
+    env: opts.env,
+    services: opts.services,
+  });
+  const runner = opts.runner ?? runDriver;
+  const passed: Array<{ name: string }> = [];
+  const failed: Array<{ name: string; error: string }> = [];
 
-    // Zero-targets is NEVER a success. A verify gate that prints
-    // "targets=0" and exits 0 is the worst outcome — a vacuous green.
-    // Fail loud with a clear diagnostic so the operator knows the run
-    // verified nothing.
-    if (targets.length === 0) {
-        const error =
-            `no probe-required services resolved for env "${opts.env}" — ` +
-            `check --services and SSOT probe flags`;
-        process.stdout.write(
-            `verify-deploy --env=${opts.env} targets=0 (FAIL)\n`,
-        );
-        process.stdout.write(`  ${error}\n`);
-        return {
-            env: opts.env,
-            passed,
-            failed: [{ name: "(zero-targets)", error }],
-            exitCode: 1,
-        };
-    }
-
-    process.stdout.write(
-        `verify-deploy --env=${opts.env} targets=${targets.length}\n`,
-    );
-
-    for (const target of targets) {
-        process.stdout.write(`  ${target.name.padEnd(36)} ${target.host} `);
-        try {
-            const outcome = await runner(target);
-            if (outcome.ok) {
-                passed.push({ name: target.name });
-                process.stdout.write("OK\n");
-            } else {
-                failed.push({ name: target.name, error: outcome.error });
-                process.stdout.write(`FAIL: ${outcome.error}\n`);
-            }
-        } catch (e: unknown) {
-            const msg = e instanceof Error ? e.message : String(e);
-            failed.push({ name: target.name, error: msg });
-            process.stdout.write(`FAIL (threw): ${msg}\n`);
-        }
-    }
-
+  // Zero-targets is NEVER a success. A verify gate that prints
+  // "targets=0" and exits 0 is the worst outcome — a vacuous green.
+  // Fail loud with a clear diagnostic so the operator knows the run
+  // verified nothing.
+  if (targets.length === 0) {
+    const error =
+      `no probe-required services resolved for env "${opts.env}" — ` +
+      `check --services and SSOT probe flags`;
+    process.stdout.write(`verify-deploy --env=${opts.env} targets=0 (FAIL)\n`);
+    process.stdout.write(`  ${error}\n`);
     return {
-        env: opts.env,
-        passed,
-        failed,
-        exitCode: failed.length === 0 ? 0 : 1,
+      env: opts.env,
+      passed,
+      failed: [{ name: "(zero-targets)", error }],
+      exitCode: 1,
     };
+  }
+
+  process.stdout.write(
+    `verify-deploy --env=${opts.env} targets=${targets.length}\n`,
+  );
+
+  for (const target of targets) {
+    process.stdout.write(`  ${target.name.padEnd(36)} ${target.host} `);
+    try {
+      const outcome = await runner(target);
+      if (outcome.ok) {
+        passed.push({ name: target.name });
+        process.stdout.write("OK\n");
+      } else {
+        failed.push({ name: target.name, error: outcome.error });
+        process.stdout.write(`FAIL: ${outcome.error}\n`);
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      failed.push({ name: target.name, error: msg });
+      process.stdout.write(`FAIL (threw): ${msg}\n`);
+    }
+  }
+
+  return {
+    env: opts.env,
+    passed,
+    failed,
+    exitCode: failed.length === 0 ? 0 : 1,
+  };
 }
 
 async function main(): Promise<void> {
-    const parsed = parseArgs(process.argv.slice(2));
-    const summary = await runVerify(parsed);
-    if (summary.failed.length > 0) {
-        process.stderr.write(
-            `\n${summary.failed.length} service(s) failed verify in ${summary.env}:\n`,
-        );
-        for (const f of summary.failed) {
-            process.stderr.write(`  - ${f.name}: ${f.error}\n`);
-        }
+  const parsed = parseArgs(process.argv.slice(2));
+  const summary = await runVerify(parsed);
+  if (summary.failed.length > 0) {
+    process.stderr.write(
+      `\n${summary.failed.length} service(s) failed verify in ${summary.env}:\n`,
+    );
+    for (const f of summary.failed) {
+      process.stderr.write(`  - ${f.name}: ${f.error}\n`);
     }
-    process.exit(summary.exitCode);
+  }
+  process.exit(summary.exitCode);
 }
 
 const isMain = process.argv[1]?.endsWith("verify-deploy.ts");
 if (isMain) {
-    main().catch((e) => {
-        process.stderr.write(
-            `verify-deploy crashed: ${e instanceof Error ? e.message : String(e)}\n`,
-        );
-        process.exit(2);
-    });
+  main().catch((e) => {
+    process.stderr.write(
+      `verify-deploy crashed: ${e instanceof Error ? e.message : String(e)}\n`,
+    );
+    process.exit(2);
+  });
 }
 
 export type { ProbeRunner } from "./verify-deploy.drivers";

--- a/showcase/scripts/verify-deploy.ts
+++ b/showcase/scripts/verify-deploy.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env npx tsx
+/**
+ * verify-deploy.ts — Parameterized per-env probe driven off
+ * railway-envs.ts SSOT.
+ *
+ * Usage:
+ *   npx tsx showcase/scripts/verify-deploy.ts --env <staging|prod>
+ *     [--services <csv>]
+ *
+ * Behavior:
+ *   - Iterates SERVICES from the SSOT; for every entry where
+ *     probe[env] === true, runs the per-driver feature-level verifier
+ *     against domainFor(name, env). HTTP 200 is necessary, not sufficient.
+ *   - Refuses to start if a probe-required service has no domain for
+ *     the requested env (fail loud; no silent skip).
+ *   - Exits 0 only when every probed service is green. Any red → exit 1.
+ *
+ * Drivers live in showcase/scripts/verify-deploy.drivers.ts and dispatch on
+ * ProbeDriver. The driver is feature-level (DOM string + known network call
+ * for shells; fixture replay for aimock; admin login for pocketbase; etc.).
+ */
+
+import { runDriver, type ProbeRunner } from "./verify-deploy.drivers";
+import {
+    SERVICES,
+    domainFor,
+    resolveEnv,
+    type EnvName,
+    type ProbeDriver,
+} from "./railway-envs";
+
+export interface ParsedArgs {
+    env: EnvName;
+    services?: string[];
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+    let envRaw: string | undefined;
+    let services: string[] | undefined;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === "--env") {
+            envRaw = argv[++i];
+        } else if (a.startsWith("--env=")) {
+            envRaw = a.slice("--env=".length);
+        } else if (a === "--services") {
+            const v = argv[++i];
+            if (!v) throw new Error("--services requires a CSV value");
+            services = v.split(",").map((s) => s.trim()).filter(Boolean);
+        } else if (a.startsWith("--services=")) {
+            const v = a.slice("--services=".length);
+            services = v.split(",").map((s) => s.trim()).filter(Boolean);
+        } else {
+            throw new Error(`Unknown argument: ${a}`);
+        }
+    }
+    if (!envRaw) {
+        throw new Error("--env is required (staging|prod)");
+    }
+    const { env } = resolveEnv(envRaw);
+    return services === undefined ? { env } : { env, services };
+}
+
+export interface ProbeTarget {
+    name: string;
+    host: string;
+    driver: ProbeDriver;
+}
+
+export interface ResolveOpts {
+    env: EnvName;
+    services?: string[];
+    /** Test seam: shallow-merge a partial entry over the SSOT before resolve. */
+    overrides?: Record<string, { domains?: { staging: string; prod: string } }>;
+}
+
+export function resolveProbeTargets(opts: ResolveOpts): ProbeTarget[] {
+    const targets: ProbeTarget[] = [];
+    const filter = opts.services ? new Set(opts.services) : undefined;
+    for (const [name, entry] of Object.entries(SERVICES)) {
+        if (filter && !filter.has(name)) continue;
+        if (!entry.probe[opts.env]) continue;
+        const overrideDomains = opts.overrides?.[name]?.domains;
+        const host = overrideDomains
+            ? overrideDomains[opts.env]
+            : domainFor(name, opts.env);
+        if (!host) {
+            throw new Error(
+                `Service "${name}" is probe-required for env "${opts.env}" but is missing a ${opts.env} domain.`,
+            );
+        }
+        targets.push({ name, host, driver: entry.probe.driver });
+    }
+    return targets.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export interface VerifyOpts {
+    env: EnvName;
+    services?: string[];
+    runner?: ProbeRunner;
+}
+
+export interface VerifySummary {
+    env: EnvName;
+    passed: Array<{ name: string }>;
+    failed: Array<{ name: string; error: string }>;
+    exitCode: number;
+}
+
+export async function runVerify(opts: VerifyOpts): Promise<VerifySummary> {
+    const targets = resolveProbeTargets({
+        env: opts.env,
+        services: opts.services,
+    });
+    const runner = opts.runner ?? runDriver;
+    const passed: Array<{ name: string }> = [];
+    const failed: Array<{ name: string; error: string }> = [];
+
+    process.stdout.write(
+        `verify-deploy --env=${opts.env} targets=${targets.length}\n`,
+    );
+
+    for (const target of targets) {
+        process.stdout.write(`  ${target.name.padEnd(36)} ${target.host} `);
+        try {
+            const outcome = await runner(target);
+            if (outcome.ok) {
+                passed.push({ name: target.name });
+                process.stdout.write("OK\n");
+            } else {
+                failed.push({ name: target.name, error: outcome.error });
+                process.stdout.write(`FAIL: ${outcome.error}\n`);
+            }
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            failed.push({ name: target.name, error: msg });
+            process.stdout.write(`FAIL (threw): ${msg}\n`);
+        }
+    }
+
+    return {
+        env: opts.env,
+        passed,
+        failed,
+        exitCode: failed.length === 0 ? 0 : 1,
+    };
+}
+
+async function main(): Promise<void> {
+    const parsed = parseArgs(process.argv.slice(2));
+    const summary = await runVerify(parsed);
+    if (summary.failed.length > 0) {
+        process.stderr.write(
+            `\n${summary.failed.length} service(s) failed verify in ${summary.env}:\n`,
+        );
+        for (const f of summary.failed) {
+            process.stderr.write(`  - ${f.name}: ${f.error}\n`);
+        }
+    }
+    process.exit(summary.exitCode);
+}
+
+const isMain = process.argv[1]?.endsWith("verify-deploy.ts");
+if (isMain) {
+    main().catch((e) => {
+        process.stderr.write(
+            `verify-deploy crashed: ${e instanceof Error ? e.message : String(e)}\n`,
+        );
+        process.exit(2);
+    });
+}
+
+export type { ProbeRunner } from "./verify-deploy.drivers";

--- a/showcase/scripts/verify-deploy.ts
+++ b/showcase/scripts/verify-deploy.ts
@@ -40,13 +40,35 @@ export function parseArgs(argv: string[]): ParsedArgs {
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i];
         if (a === "--env") {
-            envRaw = argv[++i];
+            const v = argv[++i];
+            // Guard a bare trailing `--env` (undefined) here so the
+            // operator gets a precise, flag-named diagnostic instead of
+            // the downstream `resolveEnv` "Unknown env" / "--env required"
+            // surface. Mirrors the same guard on `--services`.
+            if (v === undefined) {
+                throw new Error("--env requires a value (staging|prod)");
+            }
+            envRaw = v;
         } else if (a.startsWith("--env=")) {
-            envRaw = a.slice("--env=".length);
+            const v = a.slice("--env=".length);
+            // `--env=` (empty post-equals) is the equals-form twin of the
+            // bare-trailing case above; collapse both to the same precise
+            // error rather than deferring to `resolveEnv`.
+            if (v === "") {
+                throw new Error("--env requires a value (staging|prod)");
+            }
+            envRaw = v;
         } else if (a === "--services") {
             const v = argv[++i];
             if (!v) throw new Error("--services requires a CSV value");
             services = v.split(",").map((s) => s.trim()).filter(Boolean);
+            // Symmetry with the equals-form below: a raw value like `,,`
+            // or `"  "` survives the `!v` guard but produces an empty
+            // post-filter list. Throw the same precise error here so both
+            // forms behave identically.
+            if (services.length === 0) {
+                throw new Error("--services requires a CSV value");
+            }
         } else if (a.startsWith("--services=")) {
             const v = a.slice("--services=".length);
             if (!v) throw new Error("--services requires a CSV value");

--- a/showcase/scripts/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/verify-railway-image-refs.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vitest";
+import {
+  findMissingServices,
+  validateImage,
+} from "./verify-railway-image-refs";
+import { SERVICES } from "./railway-envs";
+
+const ALL_GATE_VALIDATED = Object.entries(SERVICES)
+  .filter(([, e]) => e.gateValidated)
+  .map(([name]) => name);
+
+describe("validateImage — production env", () => {
+  it("accepts a digest-pinned ghcr ref matching the service name", () => {
+    const v = validateImage(
+      "ghcr.io/copilotkit/showcase-mastra@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      { env: "prod", repoName: "showcase-mastra" },
+    );
+    expect(v).toBeNull();
+  });
+
+  it("rejects :latest in prod", () => {
+    const v = validateImage("ghcr.io/copilotkit/showcase-mastra:latest", {
+      env: "prod",
+      repoName: "showcase-mastra",
+    });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/digest/i);
+  });
+
+  it("rejects a digest with the wrong repo name in prod", () => {
+    const v = validateImage(
+      "ghcr.io/copilotkit/showcase-ag2@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      { env: "prod", repoName: "showcase-mastra" },
+    );
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/repo name/i);
+  });
+
+  it("rejects a non-ghcr ref in prod", () => {
+    const v = validateImage(
+      "docker.io/library/nginx@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      { env: "prod", repoName: "showcase-mastra" },
+    );
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/canonical shape/i);
+  });
+
+  it("rejects an unset image in prod", () => {
+    const v = validateImage(null, { env: "prod", repoName: "showcase-mastra" });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/no image/i);
+  });
+
+  it("honors the showcase-aimock wrapper override in prod", () => {
+    // Aimock prod is digest-pinned to the WRAPPER repo `showcase-aimock`
+    // (the fixture-baking wrapper is the permanent, canonical aimock
+    // showcase image in BOTH envs). The SSOT expresses this via
+    // repoNameOverride.prod = "showcase-aimock".
+    const v = validateImage(
+      "ghcr.io/copilotkit/showcase-aimock@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      { env: "prod", repoName: "showcase-aimock" },
+    );
+    expect(v).toBeNull();
+  });
+
+  it("rejects the unwrapped aimock repo in prod (wrapper is the canonical image)", () => {
+    // Inverse of the above: a digest pin against the unwrapped
+    // `aimock` repo in prod must be flagged as a repo-name mismatch,
+    // because the canonical aimock showcase image is the wrapper.
+    const v = validateImage(
+      "ghcr.io/copilotkit/aimock@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      { env: "prod", repoName: "showcase-aimock" },
+    );
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/repo name/i);
+  });
+});
+
+describe("validateImage — staging env", () => {
+  it("accepts :latest in staging", () => {
+    const v = validateImage("ghcr.io/copilotkit/showcase-mastra:latest", {
+      env: "staging",
+      repoName: "showcase-mastra",
+    });
+    expect(v).toBeNull();
+  });
+
+  it("rejects a digest in staging", () => {
+    const v = validateImage(
+      "ghcr.io/copilotkit/showcase-mastra@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      { env: "staging", repoName: "showcase-mastra" },
+    );
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/:latest/);
+  });
+
+  it("rejects :latest with wrong repo name in staging", () => {
+    const v = validateImage("ghcr.io/copilotkit/showcase-ag2:latest", {
+      env: "staging",
+      repoName: "showcase-mastra",
+    });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/repo name/i);
+  });
+
+  it("rejects a non-ghcr ref in staging", () => {
+    const v = validateImage("docker.io/library/nginx:latest", {
+      env: "staging",
+      repoName: "showcase-mastra",
+    });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/not on ghcr\.io\/copilotkit/i);
+  });
+
+  it("honors the showcase-aimock wrapper override in staging too", () => {
+    // The aimock entry has the `showcase-aimock` wrapper override in BOTH
+    // envs (the fixture-baking wrapper is the permanent, canonical aimock
+    // showcase image — no migration narrative). Staging floats :latest
+    // on the wrapper repo and must validate cleanly; the bare unwrapped
+    // `aimock:latest` ref must be rejected as a repo-name mismatch.
+    const ok = validateImage("ghcr.io/copilotkit/showcase-aimock:latest", {
+      env: "staging",
+      repoName: "showcase-aimock",
+    });
+    expect(ok).toBeNull();
+
+    const bad = validateImage("ghcr.io/copilotkit/aimock:latest", {
+      env: "staging",
+      repoName: "showcase-aimock",
+    });
+    expect(bad).not.toBeNull();
+    expect(bad!.reason).toMatch(/repo name/i);
+  });
+});
+
+describe("validateImage — pocketbase (first-party, non-CI-built)", () => {
+  // pocketbase Railway service → ghcr.io/copilotkit/showcase-pocketbase
+  // override applies in BOTH envs.
+
+  it("accepts the prod digest pin", () => {
+    const v = validateImage(
+      "ghcr.io/copilotkit/showcase-pocketbase@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      { env: "prod", repoName: "showcase-pocketbase" },
+    );
+    expect(v).toBeNull();
+  });
+
+  it("accepts the staging :latest tag", () => {
+    const v = validateImage("ghcr.io/copilotkit/showcase-pocketbase:latest", {
+      env: "staging",
+      repoName: "showcase-pocketbase",
+    });
+    expect(v).toBeNull();
+  });
+
+  it("rejects :latest in prod", () => {
+    const v = validateImage("ghcr.io/copilotkit/showcase-pocketbase:latest", {
+      env: "prod",
+      repoName: "showcase-pocketbase",
+    });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/digest/i);
+  });
+});
+
+describe("validateImage — webhooks (first-party, non-CI-built)", () => {
+  // webhooks Railway service → ghcr.io/copilotkit/showcase-eval-webhook
+  // override applies in BOTH envs.
+
+  it("accepts the prod digest pin", () => {
+    const v = validateImage(
+      "ghcr.io/copilotkit/showcase-eval-webhook@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      { env: "prod", repoName: "showcase-eval-webhook" },
+    );
+    expect(v).toBeNull();
+  });
+
+  it("accepts the staging :latest tag", () => {
+    const v = validateImage("ghcr.io/copilotkit/showcase-eval-webhook:latest", {
+      env: "staging",
+      repoName: "showcase-eval-webhook",
+    });
+    expect(v).toBeNull();
+  });
+
+  it("rejects :latest in prod", () => {
+    const v = validateImage("ghcr.io/copilotkit/showcase-eval-webhook:latest", {
+      env: "prod",
+      repoName: "showcase-eval-webhook",
+    });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/digest/i);
+  });
+});
+
+describe("validateImage — generic non-canonical prod tags", () => {
+  // Per nit #5: a prod ref that is neither `:latest` nor `@sha256:<hex>`
+  // — e.g. a mutable arch-tag like `:latest-arm64` or a git-SHA tag like
+  // `:abc123` — must hit the "not canonical prod shape" branch (NOT the
+  // `:latest` branch).
+
+  it("rejects a prod ref tagged with a non-latest arch suffix", () => {
+    const v = validateImage("ghcr.io/copilotkit/showcase-mastra:latest-arm64", {
+      env: "prod",
+      repoName: "showcase-mastra",
+    });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/canonical prod shape/i);
+    expect(v!.reason).not.toMatch(/^prod must be pinned to/);
+  });
+
+  it("rejects a prod ref tagged with a short git SHA", () => {
+    const v = validateImage("ghcr.io/copilotkit/showcase-mastra:abc123", {
+      env: "prod",
+      repoName: "showcase-mastra",
+    });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/canonical prod shape/i);
+  });
+});
+
+describe("findMissingServices — coverage assertion", () => {
+  // The gate must fail loudly when a gateValidated SSOT service is
+  // missing from the Railway response. Today the main() loop silently
+  // skips missing services because it only iterates what Railway returns.
+
+  it("returns [] when every gateValidated service is present", () => {
+    const present = new Set(ALL_GATE_VALIDATED);
+    expect(findMissingServices("prod", present)).toEqual([]);
+    expect(findMissingServices("staging", present)).toEqual([]);
+  });
+
+  it("returns the omitted gateValidated service name when one is missing", () => {
+    const omitted = "showcase-mastra";
+    const present = new Set(ALL_GATE_VALIDATED.filter((n) => n !== omitted));
+    expect(findMissingServices("prod", present)).toEqual([omitted]);
+    expect(findMissingServices("staging", present)).toEqual([omitted]);
+  });
+
+  it("returns multiple omitted names sorted, in either env", () => {
+    const omitted = ["showcase-mastra", "showcase-ag2", "pocketbase"];
+    const present = new Set(
+      ALL_GATE_VALIDATED.filter((n) => !omitted.includes(n)),
+    );
+    const expected = [...omitted].sort();
+    expect(findMissingServices("prod", present)).toEqual(expected);
+    expect(findMissingServices("staging", present)).toEqual(expected);
+  });
+
+  it("does NOT require non-gateValidated SSOT entries (no false positives)", () => {
+    // dashboard/docs/dojo/harness/shell are SSOT entries but
+    // gateValidated:false — they must not be reported missing.
+    const present = new Set(ALL_GATE_VALIDATED);
+    const missing = findMissingServices("prod", present);
+    for (const nonGV of ["dashboard", "docs", "dojo", "harness", "shell"]) {
+      expect(missing).not.toContain(nonGV);
+    }
+  });
+
+  it("ignores unknown service names in the present set", () => {
+    // A Railway-side service unknown to SSOT must not affect coverage.
+    const present = new Set([...ALL_GATE_VALIDATED, "some-future-service"]);
+    expect(findMissingServices("prod", present)).toEqual([]);
+  });
+});
+
+describe("validateImage — clearer staging violation messages (bucket b)", () => {
+  it("non-ghcr staging image identifies the wrong registry/repo", () => {
+    const v = validateImage("docker.io/library/nginx:latest", {
+      env: "staging",
+      repoName: "showcase-mastra",
+    });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/not on ghcr\.io\/copilotkit/i);
+    expect(v!.reason).toContain("docker.io/library/nginx:latest");
+  });
+
+  it("staging digest pin says staging must float on :latest", () => {
+    const v = validateImage(
+      "ghcr.io/copilotkit/showcase-mastra@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      { env: "staging", repoName: "showcase-mastra" },
+    );
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/staging must float on :latest/i);
+    expect(v!.reason).toMatch(/@sha256:/);
+  });
+
+  it("staging ghcr ref that is not :latest says so explicitly", () => {
+    const v = validateImage("ghcr.io/copilotkit/showcase-mastra:abc123", {
+      env: "staging",
+      repoName: "showcase-mastra",
+    });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/not the `:latest`/i);
+  });
+});
+
+describe("validateImage — empty-string image rendering (bucket b)", () => {
+  it("treats empty-string image as unset (no image)", () => {
+    const v = validateImage("", { env: "prod", repoName: "showcase-mastra" });
+    expect(v).not.toBeNull();
+    expect(v!.reason).toMatch(/no image/i);
+    // Normalized so the reporter renders `<unset>`, not a blank line.
+    expect(v!.image).toBeNull();
+  });
+});

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -201,6 +201,36 @@ export function findMissingServices(
   return missing.sort();
 }
 
+/**
+ * Coverage assertion — Railway → SSOT direction. Returns the names of
+ * Railway services that are NOT present in the SSOT (or are present but
+ * marked `gateIgnore: true`). A non-empty result means the gate should
+ * fail (drift in the Railway→SSOT direction: an out-of-band service was
+ * added to the Railway project without updating the SSOT).
+ *
+ * Pure / unit-testable. Caller (main()) is responsible for collecting
+ * the set of Railway-reported service names from the GraphQL response.
+ *
+ * Note: complements `findMissingServices` (SSOT→Railway direction); see
+ * its docstring above. The two directions are NOT the same check — do
+ * NOT collapse them.
+ */
+export function findUntrackedServices(
+  railwayServiceNames: ReadonlySet<string>,
+): string[] {
+  const untracked: string[] = [];
+  for (const name of railwayServiceNames) {
+    const entry = SERVICES[name];
+    // Present in SSOT and not opted-out — tracked. Skip.
+    if (entry && !entry.gateIgnore) continue;
+    // Present in SSOT but gateIgnore — skip (deliberate opt-out).
+    if (entry && entry.gateIgnore) continue;
+    // Not present in SSOT at all — untracked, failure candidate.
+    untracked.push(name);
+  }
+  return untracked.sort();
+}
+
 // ── Railway GraphQL plumbing ────────────────────────────────────────────
 
 function getToken(): string {

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -231,6 +231,72 @@ export function findUntrackedServices(
   return untracked.sort();
 }
 
+export interface FailureSummaryInput {
+  violations: Violation[];
+  missingByEnv: Record<EnvName, string[]>;
+  untracked: string[];
+  checked: number;
+  skipped: number;
+}
+
+export interface FailureSummaryOutput {
+  shouldFail: boolean;
+  lines: string[];
+}
+
+/**
+ * Pure failure-summary builder. Takes the three classes of finding
+ * the gate produces and returns the lines main() should print plus a
+ * boolean indicating whether to exit non-zero. Extracted from main()
+ * so it can be unit-tested without going through GraphQL.
+ *
+ * Three failure classes (all REFUSE — none are warnings):
+ *   1. shape violations (Violation[])
+ *   2. SSOT->Railway drift (gateValidated SSOT services missing on Railway)
+ *   3. Railway->SSOT drift (Railway services not in the SSOT, NOT
+ *      opted out via gateIgnore)
+ */
+export function summarizeFailures(
+  input: FailureSummaryInput,
+): FailureSummaryOutput {
+  const { violations, missingByEnv, untracked, checked, skipped } = input;
+  const totalMissing = missingByEnv.prod.length + missingByEnv.staging.length;
+  const shouldFail =
+    violations.length > 0 || totalMissing > 0 || untracked.length > 0;
+  const lines: string[] = [];
+
+  if (!shouldFail) return { shouldFail, lines };
+
+  lines.push(
+    `\n✗ Railway image-ref drift detected (${violations.length} violations across ${checked} env-scoped instances; ${totalMissing} missing services; ${untracked.length} untracked Railway services; ${skipped} skipped)\n`,
+  );
+  for (const v of violations) {
+    lines.push(`  ✗ [${v.env}] ${v.service}`);
+    lines.push(`    current:  ${v.image ?? "<unset>"}`);
+    lines.push(`    reason:   ${v.reason}`);
+  }
+  for (const env of ["prod", "staging"] as const) {
+    for (const name of missingByEnv[env]) {
+      lines.push(`  ✗ [${env}] ${name}`);
+      lines.push(`    current:  <missing from Railway>`);
+      lines.push(
+        `    reason:   gateValidated SSOT service has no serviceInstance in ${env} — was it deleted or renamed?`,
+      );
+    }
+  }
+  for (const name of untracked) {
+    lines.push(`  ✗ [railway] ${name}`);
+    lines.push(`    current:  <present on Railway, absent from SSOT>`);
+    lines.push(
+      `    reason:   Railway service "${name}" is not in the SSOT. Either add it to SERVICES in showcase/scripts/railway-envs.ts (preferred), or mark an existing entry with gateIgnore: true if it is deliberately unmanaged by WS4.`,
+    );
+  }
+  lines.push(
+    `\nFix via Railway dashboard, \`bin/railway pin\`, \`bin/railway promote\`, or \`showcase/scripts/redeploy-env.ts\`.\n`,
+  );
+  return { shouldFail, lines };
+}
+
 // ── Railway GraphQL plumbing ────────────────────────────────────────────
 
 function getToken(): string {
@@ -339,29 +405,34 @@ async function main(): Promise<void> {
     prod: new Set<string>(),
     staging: new Set<string>(),
   };
+  // Names Railway actually reported back, used post-loop for the
+  // Railway -> SSOT coverage assertion (findUntrackedServices).
+  const railwayReportedNames = new Set<string>();
 
   for (const edge of data.project.services.edges) {
     const svc = edge.node;
+    railwayReportedNames.add(svc.name);
     const entry = SERVICES[svc.name];
 
-    // Unknown-service policy (WS4): log a warning and keep the gate
-    // green. Rationale: a NEW Railway service that we haven't added to
-    // the SSOT yet is operator drift, not image-ref corruption — the
-    // image-ref gate is the wrong place to fail. (A separate "SSOT
-    // parity" check is the right shape if we ever want to fail on
-    // drift in that direction; that's out of WS4 scope.)
-    if (!entry) {
-      console.warn(
-        `⚠ Skipping unknown Railway service "${svc.name}" — add it to railway-envs.ts SERVICES if it should be verified.`,
-      );
+    // Railway -> SSOT direction is handled post-loop via
+    // findUntrackedServices(); do NOT log a warning here. An unknown
+    // service that ALSO has a shape problem will surface in the
+    // post-loop failure block under the "untracked" class, which is
+    // the right shape (we can't validate shape without an expected
+    // repo name, and there is no SSOT entry to derive one from).
+    if (!entry) continue;
+
+    // gateIgnore: deliberately unmanaged. Skip both shape validation
+    // and Railway->SSOT membership reporting (the helper also honours
+    // this flag for that direction).
+    if (entry.gateIgnore) {
+      skipped++;
       continue;
     }
 
-    // Per-WS4 gate scope: only services explicitly marked
-    // gateValidated. The historic gate filtered to `showcase-*`-prefix
-    // services; WS4 inherits that scope plus aimock + pocketbase +
-    // webhooks (set on the SSOT entry). dashboard/docs/dojo/harness/
-    // shell are deferred to Phase 2.
+    // Per-WS-C gate scope: only services explicitly marked
+    // gateValidated. After WS-C lands the 5-service flip this is
+    // every entry in SERVICES — the Phase-2 deferral is retired.
     if (!entry.gateValidated) {
       skipped++;
       continue;
@@ -389,37 +460,27 @@ async function main(): Promise<void> {
     }
   }
 
-  // Coverage assertion: a gateValidated SSOT service that did not
-  // show up in the Railway response (deleted/renamed/missing instance
-  // in that env) is drift. Fail loudly through the same path as a
-  // shape violation.
+  // Coverage assertions:
+  //   - SSOT->Railway: a gateValidated SSOT service that did not show
+  //     up in the Railway response is drift.
+  //   - Railway->SSOT: a Railway service that has no SSOT entry (and
+  //     is not opted out via gateIgnore) is drift.
   const missingByEnv: Record<EnvName, string[]> = {
     prod: findMissingServices("prod", seenByEnv.prod),
     staging: findMissingServices("staging", seenByEnv.staging),
   };
-  const totalMissing = missingByEnv.prod.length + missingByEnv.staging.length;
+  const untracked = findUntrackedServices(railwayReportedNames);
 
-  if (violations.length > 0 || totalMissing > 0) {
-    console.error(
-      `\n✗ Railway image-ref drift detected (${violations.length} violations across ${checked} env-scoped instances; ${totalMissing} missing services; ${skipped} skipped)\n`,
-    );
-    for (const v of violations) {
-      console.error(`  ✗ [${v.env}] ${v.service}`);
-      console.error(`    current:  ${v.image ?? "<unset>"}`);
-      console.error(`    reason:   ${v.reason}`);
-    }
-    for (const env of ["prod", "staging"] as const) {
-      for (const name of missingByEnv[env]) {
-        console.error(`  ✗ [${env}] ${name}`);
-        console.error(`    current:  <missing from Railway>`);
-        console.error(
-          `    reason:   gateValidated SSOT service has no serviceInstance in ${env} — was it deleted or renamed?`,
-        );
-      }
-    }
-    console.error(
-      `\nFix via Railway dashboard, \`bin/railway pin\`, \`bin/railway promote\`, or \`showcase/scripts/redeploy-env.ts\`.\n`,
-    );
+  const summary = summarizeFailures({
+    violations,
+    missingByEnv,
+    untracked,
+    checked,
+    skipped,
+  });
+
+  if (summary.shouldFail) {
+    for (const line of summary.lines) console.error(line);
     process.exit(1);
   }
 

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -1,68 +1,227 @@
 #!/usr/bin/env npx tsx
 /**
- * verify-railway-image-refs.ts — Drift assertion for Railway showcase image refs.
+ * verify-railway-image-refs.ts — Per-env drift assertion for Railway
+ * showcase image refs.
  *
- * Fetches every service in the CopilotKit Showcase project and validates that
- * the configured Docker image reference matches the canonical GHCR form:
- *   ghcr.io/copilotkit/<service-name>:latest
+ * Fetches every service in the CopilotKit Showcase Railway project and
+ * validates the image reference configured on each env-scoped service
+ * instance against the canonical shape for that env:
+ *
+ *   STAGING : ghcr.io/copilotkit/<repo>:latest              (mutable tag)
+ *   PROD    : ghcr.io/copilotkit/<repo>@sha256:<digest>     (immutable pin)
+ *
+ * <repo> defaults to the Railway service name; per-env overrides live
+ * in railway-envs.ts via `repoNameOverride` (currently: SSOT key
+ * `aimock` overrides BOTH prod and staging to repo `showcase-aimock`
+ * — the fixture-baking wrapper is the permanent, canonical aimock
+ * image; prod must be `@sha256`-pinned, staging is `:latest`. Plus
+ * pocketbase and webhooks, which override BOTH envs to
+ * `showcase-pocketbase` and `showcase-eval-webhook` respectively).
  *
  * Backstory: on 2026-04-21, 18 production services were found with malformed
- * image refs of the form `ghcr.io/copilotkit/showcase-<slug>atest` (missing
- * the `:` before `latest`, so Docker treats `...atest` as the tag). The root
- * cause was an out-of-band MCP/manual mutation — no committed code touched
- * these refs. This script exists so any future corruption, regardless of
- * source, fails loudly and early in CI before a bad deploy goes out.
+ * image refs `ghcr.io/copilotkit/showcase-<slug>atest` (missing the `:`
+ * before `latest`, so Docker treats `...atest` as the tag). The root cause
+ * was an out-of-band MCP/manual mutation — no committed code touched them.
+ * This script exists so any future corruption fails loudly and early in CI
+ * before a bad deploy goes out.
  *
  * Usage:
  *   npx tsx showcase/scripts/verify-railway-image-refs.ts
  *
  * Requires: RAILWAY_TOKEN env var or ~/.railway/config.json
- * Exit: 0 when every service matches the canonical shape, 1 on any violation.
+ * Exit: 0 when every env-scoped instance matches; 1 on any violation.
  */
 
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import {
+  PRODUCTION_ENV_ID,
+  PROJECT_ID,
+  SERVICES,
+  STAGING_ENV_ID,
+  repoNameFor,
+} from "./railway-envs";
+import type { EnvName } from "./railway-envs";
 
 const RAILWAY_API = "https://backboard.railway.com/graphql/v2";
 
-const SHOWCASE = {
-  projectId: "6f8c6bff-a80d-4f8f-b78d-50b32bcf4479",
-  environmentId: "b14919f4-6417-429f-848d-c6ae2201e04f",
-};
+// Canonical shapes per env.
+//   Staging :latest pattern — exact-match against `<repo>:latest`.
+//   Prod    @sha256:<hex>  — exact-match against `<repo>@sha256:<64 hex>`.
+const STAGING_SHAPE = /^ghcr\.io\/copilotkit\/[a-z0-9-]+:latest$/;
+const PROD_SHAPE = /^ghcr\.io\/copilotkit\/[a-z0-9-]+@sha256:[0-9a-f]{64}$/;
 
-// Canonical shape: ghcr.io/copilotkit/<name>:latest where <name> is the
-// service name itself. This single pattern covers showcase-<slug>,
-// showcase-pocketbase, showcase-harness, and any future showcase-* service.
-// Enforcing identity between Railway service
-// name and image name (modulo the ghcr.io/copilotkit/ prefix and :latest
-// tag) is the invariant — if these ever drift apart we want to know.
-//
-// The regex accepts both `showcase-*` and bare `<name>` images to
-// accommodate services like aimock whose wrapper was eliminated — the
-// Railway service is still named `showcase-aimock` but the image is now
-// `ghcr.io/copilotkit/aimock:latest`.
-const IMAGE_SHAPE = /^ghcr\.io\/copilotkit\/[a-z0-9-]+:latest$/;
+export interface ValidateOpts {
+  env: EnvName;
+  /** Expected GHCR repo name. Caller resolves this from SERVICES + env. */
+  repoName: string;
+}
 
-// Services whose GHCR image name intentionally differs from the Railway
-// service name. After the aimock wrapper elimination (PR #128), Railway
-// pulls `ghcr.io/copilotkit/aimock:latest` directly instead of the old
-// `showcase-aimock` wrapper image. The verify job must accept this
-// divergence rather than requiring image === service name.
-const IMAGE_OVERRIDES: Record<string, string> = {
-  "showcase-aimock": "ghcr.io/copilotkit/aimock:latest",
-};
+export interface Violation {
+  service: string;
+  env: EnvName;
+  image: string | null;
+  reason: string;
+}
+
+/**
+ * Pure, unit-testable validator. Caller is responsible for resolving
+ * the expected repo name from the SERVICES map (handling per-env
+ * overrides) and passing it in here.
+ *
+ * Returns null when valid, or a Violation describing the failure.
+ * The `service` field is left blank ("") so the main loop can fill it in;
+ * tests can ignore it.
+ */
+export function validateImage(
+  image: string | null,
+  opts: ValidateOpts,
+): Violation | null {
+  const { env, repoName } = opts;
+  // Normalize empty-string to null so the reporter renders `<unset>`
+  // rather than a blank line on a missing image.
+  const normalizedImage = image === "" ? null : image;
+  if (!normalizedImage) {
+    return {
+      service: "",
+      env,
+      image: null,
+      reason:
+        "no image source configured (expected a Docker image, not a repo)",
+    };
+  }
+
+  if (env === "staging") {
+    if (!STAGING_SHAPE.test(normalizedImage)) {
+      if (!normalizedImage.startsWith("ghcr.io/copilotkit/")) {
+        return {
+          service: "",
+          env,
+          image: normalizedImage,
+          reason: `image is not on ghcr.io/copilotkit (got: ${normalizedImage}); staging expects ghcr.io/copilotkit/<repo>:latest`,
+        };
+      }
+      if (/@sha256:/.test(normalizedImage)) {
+        return {
+          service: "",
+          env,
+          image: normalizedImage,
+          reason:
+            "staging must float on :latest, found a @sha256: digest pin. Promote-back-from-prod bug?",
+        };
+      }
+      return {
+        service: "",
+        env,
+        image: normalizedImage,
+        reason:
+          "image is on ghcr.io/copilotkit but is not the `:latest` shape (staging requires the mutable :latest tag)",
+      };
+    }
+    const expected = `ghcr.io/copilotkit/${repoName}:latest`;
+    if (normalizedImage !== expected) {
+      return {
+        service: "",
+        env,
+        image: normalizedImage,
+        reason: `image repo name mismatches expected (expected exactly ${expected})`,
+      };
+    }
+    return null;
+  }
+
+  // env === "prod"
+  if (!PROD_SHAPE.test(normalizedImage)) {
+    if (!normalizedImage.startsWith("ghcr.io/copilotkit/")) {
+      return {
+        service: "",
+        env,
+        image: normalizedImage,
+        reason:
+          "does not match canonical shape ^ghcr\\.io/copilotkit/[a-z0-9-]+@sha256:[0-9a-f]{64}$",
+      };
+    }
+    if (normalizedImage.endsWith(":latest")) {
+      return {
+        service: "",
+        env,
+        image: normalizedImage,
+        reason:
+          "prod must be pinned to `@sha256:<digest>` (got `:latest`). Run `bin/railway promote` to pin from staging.",
+      };
+    }
+    return {
+      service: "",
+      env,
+      image: normalizedImage,
+      reason:
+        "does not match canonical prod shape ^ghcr\\.io/copilotkit/[a-z0-9-]+@sha256:[0-9a-f]{64}$",
+    };
+  }
+  // Validate the repo portion (everything before `@sha256:`) matches.
+  const repoPart = normalizedImage.split("@", 1)[0]; // "ghcr.io/copilotkit/<repo>"
+  const expectedRepo = `ghcr.io/copilotkit/${repoName}`;
+  if (repoPart !== expectedRepo) {
+    return {
+      service: "",
+      env,
+      image: normalizedImage,
+      reason: `image repo name mismatches expected (expected exactly ${expectedRepo}@sha256:<digest>)`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Coverage assertion — returns the names of SSOT services with
+ * `gateValidated: true` that are NOT present in the Railway response
+ * for the given env. A non-empty result means the gate should fail
+ * (drift in the SSOT-vs-Railway direction: a service was deleted or
+ * renamed on Railway without updating the SSOT).
+ *
+ * Pure / unit-testable. Caller (main()) is responsible for collecting
+ * the set of seen SSOT-known service names from the Railway response.
+ *
+ * Note: `env` is accepted for symmetry and future per-env scoping,
+ * but currently the gateValidated flag is env-independent so the
+ * result does not depend on it. Result is sorted for stable output.
+ */
+export function findMissingServices(
+  _env: EnvName,
+  presentServiceNames: Set<string>,
+): string[] {
+  const missing: string[] = [];
+  for (const [name, entry] of Object.entries(SERVICES)) {
+    if (!entry.gateValidated) continue;
+    if (!presentServiceNames.has(name)) missing.push(name);
+  }
+  return missing.sort();
+}
+
+// ── Railway GraphQL plumbing ────────────────────────────────────────────
 
 function getToken(): string {
   if (process.env.RAILWAY_TOKEN) return process.env.RAILWAY_TOKEN;
-  const configPath = path.join(
-    process.env.HOME || "~",
-    ".railway",
-    "config.json",
-  );
+  const home = process.env.HOME;
+  if (!home) {
+    console.error(
+      "No Railway token found. RAILWAY_TOKEN is unset and $HOME is unset so ~/.railway/config.json cannot be located.",
+    );
+    process.exit(1);
+  }
+  const configPath = path.join(home, ".railway", "config.json");
   if (fs.existsSync(configPath)) {
-    const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    if (config?.user?.token) return config.user.token;
+    let config: unknown;
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`Malformed ~/.railway/config.json: ${msg}`);
+      process.exit(1);
+    }
+    const token = (config as { user?: { token?: string } } | null)?.user?.token;
+    if (typeof token === "string" && token.length > 0) return token;
   }
   console.error(
     "No Railway token found. Set RAILWAY_TOKEN or run `railway login`.",
@@ -119,43 +278,6 @@ interface ProjectServicesWithInstances {
   };
 }
 
-interface Violation {
-  service: string;
-  image: string | null;
-  reason: string;
-}
-
-export function validateImage(
-  serviceName: string,
-  image: string | null,
-): Violation | null {
-  if (!image) {
-    return {
-      service: serviceName,
-      image,
-      reason:
-        "no image source configured (expected a Docker image, not a repo)",
-    };
-  }
-  if (!IMAGE_SHAPE.test(image)) {
-    return {
-      service: serviceName,
-      image,
-      reason: `does not match canonical shape ^ghcr\\.io/copilotkit/[a-z0-9-]+:latest$`,
-    };
-  }
-  const expected =
-    IMAGE_OVERRIDES[serviceName] ?? `ghcr.io/copilotkit/${serviceName}:latest`;
-  if (image !== expected) {
-    return {
-      service: serviceName,
-      image,
-      reason: `image name mismatches service name (expected exactly ${expected})`,
-    };
-  }
-  return null;
-}
-
 async function main(): Promise<void> {
   const data = await railwayGql<ProjectServicesWithInstances>(
     `query project($id: String!) {
@@ -171,47 +293,105 @@ async function main(): Promise<void> {
         }
       }
     }`,
-    { id: SHOWCASE.projectId },
+    { id: PROJECT_ID },
   );
-
-  const services = data.project.services.edges
-    .map((e) => e.node)
-    .filter((s) => s.name.startsWith("showcase-"));
 
   const violations: Violation[] = [];
   let checked = 0;
-  for (const svc of services) {
-    const instance = svc.serviceInstances.edges.find(
-      (e) => e.node.environmentId === SHOWCASE.environmentId,
-    );
-    const image = instance?.node.source?.image ?? null;
-    checked++;
-    const v = validateImage(svc.name, image);
-    if (v) violations.push(v);
+  let skipped = 0;
+  // Per-env set of SSOT-known, gateValidated service names we actually
+  // saw in the Railway response. Used post-loop for coverage assertion.
+  const seenByEnv: Record<EnvName, Set<string>> = {
+    prod: new Set<string>(),
+    staging: new Set<string>(),
+  };
+
+  for (const edge of data.project.services.edges) {
+    const svc = edge.node;
+    const entry = SERVICES[svc.name];
+
+    // Unknown-service policy (WS4): log a warning and keep the gate
+    // green. Rationale: a NEW Railway service that we haven't added to
+    // the SSOT yet is operator drift, not image-ref corruption — the
+    // image-ref gate is the wrong place to fail. (A separate "SSOT
+    // parity" check is the right shape if we ever want to fail on
+    // drift in that direction; that's out of WS4 scope.)
+    if (!entry) {
+      console.warn(
+        `⚠ Skipping unknown Railway service "${svc.name}" — add it to railway-envs.ts SERVICES if it should be verified.`,
+      );
+      continue;
+    }
+
+    // Per-WS4 gate scope: only services explicitly marked
+    // gateValidated. The historic gate filtered to `showcase-*`-prefix
+    // services; WS4 inherits that scope plus aimock + pocketbase +
+    // webhooks (set on the SSOT entry). dashboard/docs/dojo/harness/
+    // shell are deferred to Phase 2.
+    if (!entry.gateValidated) {
+      skipped++;
+      continue;
+    }
+
+    for (const env of ["prod", "staging"] as const) {
+      const envId = env === "prod" ? PRODUCTION_ENV_ID : STAGING_ENV_ID;
+      const instance = svc.serviceInstances.edges.find(
+        (e) => e.node.environmentId === envId,
+      );
+      // A gateValidated SSOT service with no serviceInstance for this
+      // env is genuine drift; don't count it as "seen" so the coverage
+      // assertion catches it.
+      if (!instance) continue;
+      seenByEnv[env].add(svc.name);
+
+      const image = instance.node.source?.image ?? null;
+
+      checked++;
+      const repoName = repoNameFor(svc.name, env);
+      const v = validateImage(image, { env, repoName });
+      if (v) {
+        violations.push({ ...v, service: svc.name });
+      }
+    }
   }
 
-  if (violations.length > 0) {
+  // Coverage assertion: a gateValidated SSOT service that did not
+  // show up in the Railway response (deleted/renamed/missing instance
+  // in that env) is drift. Fail loudly through the same path as a
+  // shape violation.
+  const missingByEnv: Record<EnvName, string[]> = {
+    prod: findMissingServices("prod", seenByEnv.prod),
+    staging: findMissingServices("staging", seenByEnv.staging),
+  };
+  const totalMissing = missingByEnv.prod.length + missingByEnv.staging.length;
+
+  if (violations.length > 0 || totalMissing > 0) {
     console.error(
-      `\n✗ Railway image-ref drift detected (${violations.length}/${checked} services)\n`,
-    );
-    console.error(
-      `Expected shape: ghcr.io/copilotkit/<service-name>:latest` +
-        ` (note the ':' before 'latest')\n`,
+      `\n✗ Railway image-ref drift detected (${violations.length} violations across ${checked} env-scoped instances; ${totalMissing} missing services; ${skipped} skipped)\n`,
     );
     for (const v of violations) {
-      console.error(`  ${v.service}`);
+      console.error(`  ✗ [${v.env}] ${v.service}`);
       console.error(`    current:  ${v.image ?? "<unset>"}`);
-      console.error(`    expected: ghcr.io/copilotkit/${v.service}:latest`);
       console.error(`    reason:   ${v.reason}`);
     }
+    for (const env of ["prod", "staging"] as const) {
+      for (const name of missingByEnv[env]) {
+        console.error(`  ✗ [${env}] ${name}`);
+        console.error(`    current:  <missing from Railway>`);
+        console.error(
+          `    reason:   gateValidated SSOT service has no serviceInstance in ${env} — was it deleted or renamed?`,
+        );
+      }
+    }
     console.error(
-      `\nFix via Railway dashboard or the showcase deploy-to-railway script.` +
-        ` A common past cause was ':' dropped from ':latest' by an out-of-band API mutation.\n`,
+      `\nFix via Railway dashboard, \`bin/railway pin\`, \`bin/railway promote\`, or \`showcase/scripts/redeploy-env.ts\`.\n`,
     );
     process.exit(1);
   }
 
-  console.log(`✓ ${checked} services verified`);
+  console.log(
+    `✓ ${checked} env-scoped instances verified (${skipped} skipped)`,
+  );
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -32,8 +32,6 @@
  * Exit: 0 when every env-scoped instance matches; 1 on any violation.
  */
 
-import fs from "fs";
-import path from "path";
 import { fileURLToPath } from "url";
 import {
   PRODUCTION_ENV_ID,
@@ -43,8 +41,14 @@ import {
   repoNameFor,
 } from "./railway-envs";
 import type { EnvName } from "./railway-envs";
-import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
-import { resolveRailwayTokenFromConfig } from "./lib/railway-token";
+import {
+  RAILWAY_GRAPHQL_ENDPOINT,
+  sanitizeErrorBody,
+} from "./lib/railway-graphql";
+import {
+  RailwayTokenError,
+  resolveRailwayToken,
+} from "./lib/railway-token";
 
 const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
 
@@ -221,11 +225,9 @@ export function findUntrackedServices(
   const untracked: string[] = [];
   for (const name of railwayServiceNames) {
     const entry = SERVICES[name];
-    // Present in SSOT and not opted-out — tracked. Skip.
-    if (entry && !entry.gateIgnore) continue;
-    // Present in SSOT but gateIgnore — skip (deliberate opt-out).
-    if (entry && entry.gateIgnore) continue;
-    // Not present in SSOT at all — untracked, failure candidate.
+    // Any SSOT entry — gateIgnored or not — is known/accounted-for in
+    // the Railway->SSOT direction. Only absence from the SSOT counts.
+    if (entry) continue;
     untracked.push(name);
   }
   return untracked.sort();
@@ -299,34 +301,22 @@ export function summarizeFailures(
 
 // ── Railway GraphQL plumbing ────────────────────────────────────────────
 
+/**
+ * Resolve the Railway bearer token for this run. Wraps the shared
+ * `resolveRailwayToken` envelope and maps any RailwayTokenError onto
+ * the script's exit-1 contract (operator/config error). The shared
+ * helper never calls process.exit — exit-code mapping lives HERE.
+ */
 function getToken(): string {
-  if (process.env.RAILWAY_TOKEN) return process.env.RAILWAY_TOKEN;
-  const home = process.env.HOME;
-  if (!home) {
-    console.error(
-      "No Railway token found. RAILWAY_TOKEN is unset and $HOME is unset so ~/.railway/config.json cannot be located.",
-    );
-    process.exit(1);
-  }
-  const configPath = path.join(home, ".railway", "config.json");
-  if (fs.existsSync(configPath)) {
-    let config: unknown;
-    try {
-      config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.error(`Malformed ~/.railway/config.json: ${msg}`);
+  try {
+    return resolveRailwayToken().token;
+  } catch (e) {
+    if (e instanceof RailwayTokenError) {
+      console.error(e.message);
       process.exit(1);
     }
-    const token = resolveRailwayTokenFromConfig(
-      config as Parameters<typeof resolveRailwayTokenFromConfig>[0],
-    );
-    if (typeof token === "string" && token.length > 0) return token;
+    throw e;
   }
-  console.error(
-    "No Railway token found. Set RAILWAY_TOKEN or run `railway login`.",
-  );
-  process.exit(1);
 }
 
 async function railwayGql<T = unknown>(
@@ -343,7 +333,11 @@ async function railwayGql<T = unknown>(
     body: JSON.stringify({ query, variables }),
   });
   if (!res.ok) {
-    throw new Error(`Railway API error: ${res.status} ${await res.text()}`);
+    // sanitize: Cloudflare WAF blocks return multi-KB HTML pages —
+    // strip angle brackets + control chars and cap at the shared
+    // default to keep CI logs readable.
+    const body = sanitizeErrorBody(await res.text());
+    throw new Error(`Railway API error: ${res.status} ${body}`);
   }
   const json = (await res.json()) as {
     data?: T;
@@ -358,6 +352,9 @@ async function railwayGql<T = unknown>(
 }
 
 interface ProjectServicesWithInstances {
+  // Railway returns project: null (no GraphQL `errors` block) when the
+  // PROJECT_ID is wrong OR the token lacks access — type accordingly so
+  // the null-check in main() is enforced by the compiler.
   project: {
     services: {
       edges: Array<{
@@ -375,7 +372,7 @@ interface ProjectServicesWithInstances {
         };
       }>;
     };
-  };
+  } | null;
 }
 
 async function main(): Promise<void> {
@@ -395,6 +392,15 @@ async function main(): Promise<void> {
     }`,
     { id: PROJECT_ID },
   );
+
+  // Railway returns project: null with NO `errors` array when PROJECT_ID
+  // is wrong or the token lacks access — without this guard, reading
+  // `data.project.services` throws a confusing TypeError.
+  if (data.project === null || data.project === undefined) {
+    throw new Error(
+      `Railway project ${PROJECT_ID} returned null — check PROJECT_ID and that the Railway token has access to this project.`,
+    );
+  }
 
   const violations: Violation[] = [];
   let checked = 0;

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -43,8 +43,10 @@ import {
   repoNameFor,
 } from "./railway-envs";
 import type { EnvName } from "./railway-envs";
+import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
+import { resolveRailwayTokenFromConfig } from "./lib/railway-token";
 
-const RAILWAY_API = "https://backboard.railway.com/graphql/v2";
+const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
 
 // Canonical shapes per env.
 //   Staging :latest pattern — exact-match against `<repo>:latest`.
@@ -220,7 +222,9 @@ function getToken(): string {
       console.error(`Malformed ~/.railway/config.json: ${msg}`);
       process.exit(1);
     }
-    const token = (config as { user?: { token?: string } } | null)?.user?.token;
+    const token = resolveRailwayTokenFromConfig(
+      config as Parameters<typeof resolveRailwayTokenFromConfig>[0],
+    );
     if (typeof token === "string" && token.length > 0) return token;
   }
   console.error(

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -207,10 +207,10 @@ export function findMissingServices(
 
 /**
  * Coverage assertion — Railway → SSOT direction. Returns the names of
- * Railway services that are NOT present in the SSOT (or are present but
- * marked `gateIgnore: true`). A non-empty result means the gate should
- * fail (drift in the Railway→SSOT direction: an out-of-band service was
- * added to the Railway project without updating the SSOT).
+ * Railway services that are NOT present in the SSOT. A non-empty result
+ * means the gate should fail (drift in the Railway→SSOT direction: an
+ * out-of-band service was added to the Railway project without updating
+ * the SSOT).
  *
  * Pure / unit-testable. Caller (main()) is responsible for collecting
  * the set of Railway-reported service names from the GraphQL response.

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -45,10 +45,7 @@ import {
   RAILWAY_GRAPHQL_ENDPOINT,
   sanitizeErrorBody,
 } from "./lib/railway-graphql";
-import {
-  RailwayTokenError,
-  resolveRailwayToken,
-} from "./lib/railway-token";
+import { RailwayTokenError, resolveRailwayToken } from "./lib/railway-token";
 
 const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
 

--- a/showcase/shell-dashboard/Dockerfile
+++ b/showcase/shell-dashboard/Dockerfile
@@ -55,8 +55,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=10000
 # URL env vars (POCKETBASE_URL / SHELL_URL / OPS_BASE_URL) are read at
-# runtime by `src/lib/runtime-config.ts` from the Railway service env
-# under Option B — no Dockerfile ARG/ENV plumbing required for them.
+# runtime by `src/lib/runtime-config.ts` from the Railway service env —
+# no Dockerfile ARG/ENV plumbing required for them.
 # COMMIT_SHA / BRANCH stay build-baked because they identify the artifact,
 # not the deploy. See showcase/RAILWAY.md and runtime-config.ts.
 

--- a/showcase/shell-dashboard/Dockerfile
+++ b/showcase/shell-dashboard/Dockerfile
@@ -28,20 +28,6 @@ COPY showcase/shell-dashboard/ ./shell-dashboard/
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}
 ENV NEXT_PUBLIC_BRANCH=${BRANCH}
 
-# NEXT_PUBLIC_* vars are inlined by Next.js at build time. Must be
-# provided as Docker build args — runtime env vars on Railway are too late.
-ARG NEXT_PUBLIC_SHELL_URL
-ENV NEXT_PUBLIC_SHELL_URL=${NEXT_PUBLIC_SHELL_URL}
-ARG NEXT_PUBLIC_POCKETBASE_URL
-ENV NEXT_PUBLIC_POCKETBASE_URL=${NEXT_PUBLIC_POCKETBASE_URL}
-# `next.config.ts` reads OPS_BASE_URL inside `rewrites()` and throws if it
-# is unset. `next build` evaluates rewrites at build time to generate the
-# routing manifest, so the value must be in the BUILDER environment — not
-# just runtime. Without this, `npx next build` aborts with the
-# "OPS_BASE_URL must be set" error from next.config.ts.
-ARG OPS_BASE_URL
-ENV OPS_BASE_URL=${OPS_BASE_URL}
-
 # Generate registry + docs status, then build Next.js
 RUN cd scripts && node node_modules/tsx/dist/cli.mjs generate-registry.ts \
     && node node_modules/tsx/dist/cli.mjs probe-docs.ts \
@@ -68,10 +54,11 @@ FROM node:20-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=10000
-# NEXT_PUBLIC_* are statically inlined at build time; the runtime env vars
-# from the builder stage are not inherited here and would be undefined
-# regardless. Don't re-declare them — they'd just be noise and create the
-# illusion that changing them at runtime does anything.
+# URL env vars (POCKETBASE_URL / SHELL_URL / OPS_BASE_URL) are read at
+# runtime by `src/lib/runtime-config.ts` from the Railway service env
+# under Option B — no Dockerfile ARG/ENV plumbing required for them.
+# COMMIT_SHA / BRANCH stay build-baked because they identify the artifact,
+# not the deploy. See showcase/RAILWAY.md and runtime-config.ts.
 
 # Copy build artifacts with `node:node` ownership so the runtime process
 # (dropped to USER node below) can read them. The `node` user/group ships

--- a/showcase/shell-dashboard/next.config.ts
+++ b/showcase/shell-dashboard/next.config.ts
@@ -12,16 +12,21 @@ import type { NextConfig } from "next";
  *   2. We don't want the ops base URL inlined into the client bundle (it
  *      would also force `NEXT_PUBLIC_*` exposure semantics).
  *
- * `OPS_BASE_URL` is required at build/start. Without it the rewrite cannot
- * be constructed and the dashboard would silently render "All probes idle"
- * because every `/api/ops/probes` call would 404 against this app.
+ * `OPS_BASE_URL` is required at start. `next start` evaluates this
+ * `rewrites()` function once at process boot — without `OPS_BASE_URL`
+ * the rewrite cannot be constructed and the dashboard would silently
+ * render "All probes idle" because every `/api/ops/probes` call would
+ * 404 against this app. Under runtime-injection (workstream B) every
+ * NEXT_PUBLIC_* URL is read at request time from the Railway env, but
+ * `rewrites()` is evaluated once at start and therefore needs the env
+ * present in the running process — not at build.
  */
 const nextConfig: NextConfig = {
   async rewrites() {
     const opsBase = process.env.OPS_BASE_URL;
     if (!opsBase) {
       throw new Error(
-        "OPS_BASE_URL must be set — see showcase/RAILWAY.md " +
+        "OPS_BASE_URL must be set on this Railway service — see showcase/RAILWAY.md " +
           "(without it, /api/ops/* requests cannot proxy to showcase-harness)",
       );
     }

--- a/showcase/shell-dashboard/next.config.ts
+++ b/showcase/shell-dashboard/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { PHASE_PRODUCTION_BUILD } from "next/constants";
 
 /**
  * Next.js config for the dashboard shell.
@@ -12,33 +13,52 @@ import type { NextConfig } from "next";
  *   2. We don't want the ops base URL inlined into the client bundle (it
  *      would also force `NEXT_PUBLIC_*` exposure semantics).
  *
- * `OPS_BASE_URL` is required at start. `next start` evaluates this
- * `rewrites()` function once at process boot — without `OPS_BASE_URL`
- * the rewrite cannot be constructed and the dashboard would silently
- * render "All probes idle" because every `/api/ops/probes` call would
- * 404 against this app. Under runtime-injection (workstream B) every
- * NEXT_PUBLIC_* URL is read at request time from the Railway env, but
- * `rewrites()` is evaluated once at start and therefore needs the env
- * present in the running process — not at build.
+ * `OPS_BASE_URL` is required at START — not at build. `next build`
+ * evaluates `rewrites()` so route metadata can be persisted into the
+ * artifact, AND `next start` evaluates it again at process boot.
+ * Throwing at build time would prevent the runtime-injection deploy
+ * pattern (single artifact, env supplied at start). So when invoked
+ * under the build phase we accept the absence with a sentinel
+ * destination — the rewrite is reconstructed with the real env value
+ * at start. At start time, missing OPS_BASE_URL still throws loudly to
+ * surface the wiring bug.
+ *
+ * The config is exported as a function `(phase) => NextConfig` so the
+ * build-vs-start distinction is reliable without relying on the
+ * `NEXT_PHASE` env (which Next.js does not always export to user code).
  */
-const nextConfig: NextConfig = {
-  async rewrites() {
-    const opsBase = process.env.OPS_BASE_URL;
-    if (!opsBase) {
-      throw new Error(
-        "OPS_BASE_URL must be set on this Railway service — see showcase/RAILWAY.md " +
-          "(without it, /api/ops/* requests cannot proxy to showcase-harness)",
-      );
-    }
-    // Strip trailing slashes so we never produce `https://host//api/...`
-    // (some servers reject the double slash). Mirrors the same
-    // normalization in `src/lib/ops-api.ts:resolveBaseUrl` so the
-    // server-side rewrite and client-side fetch agree on the URL shape.
-    const normalized = opsBase.replace(/\/+$/, "");
-    return [
-      { source: "/api/ops/:path*", destination: `${normalized}/api/:path*` },
-    ];
-  },
-};
+const SENTINEL_OPS_BASE = "http://ops.invalid";
 
-export default nextConfig;
+export default function nextConfig(phase: string): NextConfig {
+  const isBuildPhase = phase === PHASE_PRODUCTION_BUILD;
+  return {
+    async rewrites() {
+      const opsBase = process.env.OPS_BASE_URL;
+      if (!opsBase) {
+        if (isBuildPhase) {
+          // Build phase: emit a parseable sentinel destination so
+          // `next build` succeeds. `rewrites()` runs again at
+          // `next start` with the real env value (or throws below).
+          return [
+            {
+              source: "/api/ops/:path*",
+              destination: `${SENTINEL_OPS_BASE}/api/:path*`,
+            },
+          ];
+        }
+        throw new Error(
+          "OPS_BASE_URL must be set on this Railway service — see showcase/RAILWAY.md " +
+            "(without it, /api/ops/* requests cannot proxy to showcase-harness)",
+        );
+      }
+      // Strip trailing slashes so we never produce `https://host//api/...`
+      // (some servers reject the double slash). Mirrors the same
+      // normalization in `src/lib/ops-api.ts:resolveBaseUrl` so the
+      // server-side rewrite and client-side fetch agree on the URL shape.
+      const normalized = opsBase.replace(/\/+$/, "");
+      return [
+        { source: "/api/ops/:path*", destination: `${normalized}/api/:path*` },
+      ];
+    },
+  };
+}

--- a/showcase/shell-dashboard/src/app/layout.tsx
+++ b/showcase/shell-dashboard/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { getRuntimeConfig } from "@/lib/runtime-config";
+import { serializeRuntimeConfig } from "@/lib/runtime-config-serialize";
 
 export const metadata: Metadata = {
   title: "CopilotKit Internal Showcase",
@@ -32,45 +33,10 @@ const themeInitScript = `
 })();
 `;
 
-/**
- * Serialize the runtime config for inline injection. We must
- * JSON.stringify-then-escape because the value lands inside a
- * `<script>...</script>` tag, where four substrings would otherwise
- * break out of (or corrupt) the parser:
- *
- *   - `<` — guards against the `</script>` breakout (XSS).
- *     `JSON.stringify` does NOT escape `<` by default, so a URL
- *     containing `</script>` (e.g. a hostile env value) would
- *     terminate the inline script and inject HTML. Escape every
- *     `<` to `<` so the substring `</script>` can never appear.
- *   - ` ` (LINE SEPARATOR) and ` ` (PARAGRAPH SEPARATOR) —
- *     legal inside JSON strings, but a syntax error inside a JS
- *     string literal in older engines / when the page is parsed as
- *     `text/javascript`. Escape both.
- *
- * IMPORTANT: the regex sources below are written with explicit
- * ` ` / ` ` ECMAScript-Unicode escapes (the regex literal
- * `/ /` matches the actual U+2028 codepoint at runtime — the
- * regex engine resolves the escape, not the source-file encoding).
- * Using a literal ASCII space in the regex source would be a no-op
- * and silently leave the XSS / parser hazards in place. Reviewers MUST
- * confirm the regex sources are ` ` / ` ` literally.
- *
- * Canonical OWASP-recommended escape for inline JSON in HTML.
- */
-function serializeRuntimeConfig(cfg: unknown): string {
-  // Regex sources reference the literal codepoints via the RegExp
-  // constructor with `\u` escapes (resolved at runtime by the regex
-  // engine). Using the actual U+2028 / U+2029 characters in a regex
-  // literal is a parse error in TypeScript / many JS engines because
-  // both codepoints are line terminators that would prematurely
-  // terminate the regex literal. Same OWASP-recommended escape as for
-  // inline JSON.
-  return JSON.stringify(cfg)
-    .replace(new RegExp("<", "g"), "\\u003c")
-    .replace(new RegExp("\u2028", "g"), "\\u2028")
-    .replace(new RegExp("\u2029", "g"), "\\u2029");
-}
+// serializeRuntimeConfig is extracted to `lib/runtime-config-serialize.ts`
+// so it can be unit-tested for the OWASP escape behavior (XSS via
+// `</script>`, U+2028/U+2029 line-terminator injection) without
+// importing the layout into the test runner.
 
 export default function RootLayout({
   children,

--- a/showcase/shell-dashboard/src/app/layout.tsx
+++ b/showcase/shell-dashboard/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
+import { getRuntimeConfig } from "@/lib/runtime-config";
 
 export const metadata: Metadata = {
   title: "CopilotKit Internal Showcase",
@@ -31,14 +32,72 @@ const themeInitScript = `
 })();
 `;
 
+/**
+ * Serialize the runtime config for inline injection. We must
+ * JSON.stringify-then-escape because the value lands inside a
+ * `<script>...</script>` tag, where four substrings would otherwise
+ * break out of (or corrupt) the parser:
+ *
+ *   - `<` — guards against the `</script>` breakout (XSS).
+ *     `JSON.stringify` does NOT escape `<` by default, so a URL
+ *     containing `</script>` (e.g. a hostile env value) would
+ *     terminate the inline script and inject HTML. Escape every
+ *     `<` to `<` so the substring `</script>` can never appear.
+ *   - ` ` (LINE SEPARATOR) and ` ` (PARAGRAPH SEPARATOR) —
+ *     legal inside JSON strings, but a syntax error inside a JS
+ *     string literal in older engines / when the page is parsed as
+ *     `text/javascript`. Escape both.
+ *
+ * IMPORTANT: the regex sources below are written with explicit
+ * ` ` / ` ` ECMAScript-Unicode escapes (the regex literal
+ * `/ /` matches the actual U+2028 codepoint at runtime — the
+ * regex engine resolves the escape, not the source-file encoding).
+ * Using a literal ASCII space in the regex source would be a no-op
+ * and silently leave the XSS / parser hazards in place. Reviewers MUST
+ * confirm the regex sources are ` ` / ` ` literally.
+ *
+ * Canonical OWASP-recommended escape for inline JSON in HTML.
+ */
+function serializeRuntimeConfig(cfg: unknown): string {
+  // Regex sources reference the literal codepoints via the RegExp
+  // constructor with `\u` escapes (resolved at runtime by the regex
+  // engine). Using the actual U+2028 / U+2029 characters in a regex
+  // literal is a parse error in TypeScript / many JS engines because
+  // both codepoints are line terminators that would prematurely
+  // terminate the regex literal. Same OWASP-recommended escape as for
+  // inline JSON.
+  return JSON.stringify(cfg)
+    .replace(new RegExp("<", "g"), "\\u003c")
+    .replace(new RegExp("\u2028", "g"), "\\u2028")
+    .replace(new RegExp("\u2029", "g"), "\\u2029");
+}
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // Server-side: read live env at request time. `unstable_noStore()`
+  // inside getRuntimeConfig opts this segment out of the static
+  // cache so the inline <script> below always reflects the current
+  // Railway env vars.
+  const runtimeConfig = getRuntimeConfig();
+  const injection = `window.__SHOWCASE_CONFIG__=${serializeRuntimeConfig(runtimeConfig)};`;
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/*
+         * Order matters: __showcase_config__ MUST run before any
+         * client component reads window.__SHOWCASE_CONFIG__. We
+         * put it FIRST in <head>, before the theme-init script
+         * (which has no dependency on it) and well before
+         * <body> where client components mount.
+         */}
+        <script
+          id="__showcase_config__"
+          dangerouslySetInnerHTML={{ __html: injection }}
+        />
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <body>

--- a/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
@@ -21,8 +21,8 @@ const mockState = {
   fetchCount: 0,
 };
 
-vi.mock("../lib/pb", () => ({
-  pb: {
+vi.mock("../lib/pb", () => {
+  const pb = {
     filter: (raw: string) => raw,
     collection: () => ({
       getList: vi.fn(async () => {
@@ -30,10 +30,13 @@ vi.mock("../lib/pb", () => ({
         return { items: mockState.history.slice(0, 1), totalItems: 1 };
       }),
     }),
-  },
-  pbIsMisconfigured: false,
-  PB_MISCONFIG_MESSAGE: "",
-}));
+  };
+  return {
+    getPb: () => pb,
+    pbIsMisconfigured: () => false,
+    PB_MISCONFIG_MESSAGE: "",
+  };
+});
 
 beforeEach(() => {
   mockState.history = [];

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -16,6 +16,7 @@ import { LevelStrip } from "@/components/level-strip";
 import { OverlayColumnHeader } from "@/components/overlay-column-header";
 import { RefDepthHeader, RefDepthCell } from "@/components/ref-depth-column";
 import { buildCellModel } from "@/lib/cell-model";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
 import type { CatalogCell } from "@/components/depth-utils";
 import type { Overlay } from "@/lib/overlay-types";
 import type { ParityTier } from "@/components/parity-badge";
@@ -158,32 +159,14 @@ export function computeColumnTallyDetail(
 }
 
 /**
- * Resolve the shell URL used to build Demo/Code links.
- *
- * `NEXT_PUBLIC_SHELL_URL` is inlined at build time. In production builds we
- * REFUSE to silently fall back to `http://localhost:3000` — those links ship
- * in the deployed bundle and render as broken "localhost:3000" references
- * for every visitor on Vercel/Railway. Instead, surface a sentinel URL
- * (`about:blank#shell-url-missing`) so the link visibly breaks and operators
- * see the misconfiguration on first click; also emit a build-time warning
- * on the server render path.
- *
- * In development/test we retain the historical localhost fallback to keep
- * local iteration friction-free.
+ * Resolve the shell URL used to build Demo / Code / docs-shell links.
+ * Reads from the runtime config injected by the root layout. The
+ * sentinel `about:blank#shell-url-missing` is set inside
+ * runtime-config.ts when the env var is missing in production —
+ * visibly broken links, not silent localhost rendering.
  */
 function resolveShellUrl(): string {
-  const env = process.env.NEXT_PUBLIC_SHELL_URL;
-  if (env && env.length > 0) return env;
-  if (process.env.NODE_ENV === "production") {
-    // eslint-disable-next-line no-console
-    console.error(
-      "[feature-grid] FATAL-CONFIG: NEXT_PUBLIC_SHELL_URL is unset in a " +
-        "production build; Demo / Code / docs-shell links will render as " +
-        "about:blank#shell-url-missing. Rebuild with the env var set.",
-    );
-    return "about:blank#shell-url-missing";
-  }
-  return "http://localhost:3000";
+  return getRuntimeConfig().shellUrl;
 }
 
 /* ------------------------------------------------------------------ */

--- a/showcase/shell-dashboard/src/components/pb-auth-prompt.tsx
+++ b/showcase/shell-dashboard/src/components/pb-auth-prompt.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
-import { pb } from "@/lib/pb";
+import { getPb } from "@/lib/pb";
 
 export interface PbAuthPromptProps {
   onSuccess: () => void;
@@ -27,6 +27,8 @@ export function PbAuthPrompt({ onSuccess, onCancel }: PbAuthPromptProps) {
     e.preventDefault();
     setError(null);
     setLoading(true);
+
+    const pb = getPb();
 
     try {
       // PB 0.22+ uses a _superusers collection for admin auth

--- a/showcase/shell-dashboard/src/hooks/__tests__/useBaseline.test.ts
+++ b/showcase/shell-dashboard/src/hooks/__tests__/useBaseline.test.ts
@@ -29,37 +29,38 @@ const mockState = {
 // Updated: useBaseline now calls getFullList({batch: 1000}) instead of
 // paginated getList. Mock returns a plain array (same as useLiveStatus pattern).
 vi.mock("../../lib/pb", () => {
-  return {
-    pbIsMisconfigured: false,
-    PB_MISCONFIG_MESSAGE: "Dashboard misconfigured (test stub)",
-    pb: {
-      collection: (_name: string) => ({
-        getFullList: vi.fn(async () => {
-          mockState.getFullListCalls += 1;
-          if (mockState.failRemaining > 0) {
-            mockState.failRemaining -= 1;
-            throw new Error("PB getFullList failed");
-          }
-          return [...mockState.initial];
-        }),
-        subscribe: vi.fn(async (_topic: string, cb: Listener) => {
-          mockState.subscribeCalls += 1;
-          mockState.listener = cb;
-          return async () => {
-            mockState.unsubscribeCalls += 1;
-            mockState.listener = null;
-          };
-        }),
-        update: vi.fn(async (id: string, data: Record<string, unknown>) => {
-          mockState.updateCalls.push({ id, data });
-          if (mockState.updateFailNext) {
-            mockState.updateFailNext = false;
-            throw new Error("PB update failed");
-          }
-          return { ...data, id };
-        }),
+  const pb = {
+    collection: (_name: string) => ({
+      getFullList: vi.fn(async () => {
+        mockState.getFullListCalls += 1;
+        if (mockState.failRemaining > 0) {
+          mockState.failRemaining -= 1;
+          throw new Error("PB getFullList failed");
+        }
+        return [...mockState.initial];
       }),
-    },
+      subscribe: vi.fn(async (_topic: string, cb: Listener) => {
+        mockState.subscribeCalls += 1;
+        mockState.listener = cb;
+        return async () => {
+          mockState.unsubscribeCalls += 1;
+          mockState.listener = null;
+        };
+      }),
+      update: vi.fn(async (id: string, data: Record<string, unknown>) => {
+        mockState.updateCalls.push({ id, data });
+        if (mockState.updateFailNext) {
+          mockState.updateFailNext = false;
+          throw new Error("PB update failed");
+        }
+        return { ...data, id };
+      }),
+    }),
+  };
+  return {
+    pbIsMisconfigured: () => false,
+    PB_MISCONFIG_MESSAGE: "Dashboard misconfigured (test stub)",
+    getPb: () => pb,
   };
 });
 

--- a/showcase/shell-dashboard/src/hooks/use-probes.integration.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/use-probes.integration.test.tsx
@@ -24,7 +24,6 @@ import { useProbes } from "./use-probes";
 import type { ProbesResponse } from "../lib/ops-api";
 
 let fetchSpy: ReturnType<typeof vi.fn>;
-let savedOpsBaseUrl: string | undefined;
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -36,21 +35,18 @@ function jsonResponse(body: unknown): Response {
 beforeEach(() => {
   fetchSpy = vi.fn();
   vi.stubGlobal("fetch", fetchSpy);
-  // Snapshot + clear NEXT_PUBLIC_OPS_BASE_URL so the resolveBaseUrl()
-  // fallback path is exercised. Restored in afterEach so test ordering
-  // never leaks env state to the next file.
-  savedOpsBaseUrl = process.env.NEXT_PUBLIC_OPS_BASE_URL;
-  delete process.env.NEXT_PUBLIC_OPS_BASE_URL;
+  // Clear runtime config so the resolveBaseUrl() fallback path is
+  // exercised. The runtime config is normally injected by the root
+  // layout into `window.__SHOWCASE_CONFIG__`.
+  delete (window as Window & { __SHOWCASE_CONFIG__?: unknown })
+    .__SHOWCASE_CONFIG__;
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
-  if (savedOpsBaseUrl !== undefined) {
-    process.env.NEXT_PUBLIC_OPS_BASE_URL = savedOpsBaseUrl;
-  } else {
-    delete process.env.NEXT_PUBLIC_OPS_BASE_URL;
-  }
+  delete (window as Window & { __SHOWCASE_CONFIG__?: unknown })
+    .__SHOWCASE_CONFIG__;
 });
 
 describe("useProbes → ops-api → fetch wiring", () => {

--- a/showcase/shell-dashboard/src/hooks/useBaseline.ts
+++ b/showcase/shell-dashboard/src/hooks/useBaseline.ts
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState, useCallback, useRef } from "react";
-import { pb, pbIsMisconfigured, PB_MISCONFIG_MESSAGE } from "../lib/pb";
+import { getPb, pbIsMisconfigured, PB_MISCONFIG_MESSAGE } from "../lib/pb";
 import type {
   BaselineCell,
   BaselineStatus,
@@ -61,13 +61,14 @@ export function useBaseline(): UseBaselineResult {
   }, [cells]);
 
   useEffect(() => {
-    if (pbIsMisconfigured) {
+    if (pbIsMisconfigured()) {
       setCells(new Map());
       setStatus("error");
       setError(PB_MISCONFIG_MESSAGE);
       return;
     }
 
+    const pb = getPb();
     let alive = true;
     let attempts = 0;
     let cancel: (() => void) | null = null;
@@ -249,6 +250,7 @@ export function useBaseline(): UseBaselineResult {
       });
 
       try {
+        const pb = getPb();
         await pb.collection("baseline").update(current.id, {
           status: newStatus,
           tags: newTags,

--- a/showcase/shell-dashboard/src/hooks/useLastTransition.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/useLastTransition.test.tsx
@@ -14,10 +14,8 @@ const mockState = {
   shouldThrow: false,
 };
 
-vi.mock("../lib/pb", () => ({
-  pbIsMisconfigured: false,
-  PB_MISCONFIG_MESSAGE: "Dashboard misconfigured (test stub)",
-  pb: {
+vi.mock("../lib/pb", () => {
+  const pb = {
     // pb.filter helper returns the rendered template for our tests.
     filter: (raw: string, params?: Record<string, unknown>) => {
       let out = raw;
@@ -47,8 +45,13 @@ vi.mock("../lib/pb", () => ({
         },
       ),
     }),
-  },
-}));
+  };
+  return {
+    pbIsMisconfigured: () => false,
+    PB_MISCONFIG_MESSAGE: "Dashboard misconfigured (test stub)",
+    getPb: () => pb,
+  };
+});
 
 import {
   useLastTransition,

--- a/showcase/shell-dashboard/src/hooks/useLastTransition.ts
+++ b/showcase/shell-dashboard/src/hooks/useLastTransition.ts
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import { pb } from "../lib/pb";
+import { getPb } from "../lib/pb";
 
 /**
  * A `status_history` row per the PB migration (1745193700_init_status_history).
@@ -184,6 +184,7 @@ export function useLastTransition(
     let alive = true;
     (async (): Promise<void> => {
       try {
+        const pb = getPb();
         // Parameterized filter via PB SDK helper — avoids injection and
         // handles quoting/escaping per `pb.filter` semantics.
         const filter = pb.filter("key = {:key}", { key });

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.test.tsx
@@ -32,70 +32,71 @@ const mockState = {
 };
 
 vi.mock("../lib/pb", () => {
-  return {
-    pbIsMisconfigured: false,
-    PB_MISCONFIG_MESSAGE: "Dashboard misconfigured (test stub)",
-    pb: {
-      filter: (raw: string, params?: Record<string, unknown>) => {
-        let out = raw;
-        if (params) {
-          for (const [k, v] of Object.entries(params)) {
-            out = out.replace(
-              new RegExp(`\\{:${k}\\}`, "g"),
-              JSON.stringify(v),
-            );
-          }
+  const pb = {
+    filter: (raw: string, params?: Record<string, unknown>) => {
+      let out = raw;
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          out = out.replace(
+            new RegExp(`\\{:${k}\\}`, "g"),
+            JSON.stringify(v),
+          );
         }
-        return out;
-      },
-      collection: (_name: string) => ({
-        // getFullList is used by the initial fetch (replaces paginated getList).
-        // Returns a plain array, respecting the `batch` option as a cap.
-        getFullList: vi.fn(
-          async (opts?: { batch?: number; filter?: string }) => {
-            mockState.getListCalls += 1;
-            mockState.lastInitialGetListOpts = opts;
-            if (mockState.failRemaining > 0) {
-              mockState.failRemaining -= 1;
-              throw new Error("pb-unreachable");
-            }
-            const cap = opts?.batch ?? Infinity;
-            return mockState.initial.slice(0, cap);
-          },
-        ),
-        // getList is still used for heartbeat pings (getList(1, 1)).
-        getList: vi.fn(
-          async (_page: number, _perPage: number, _opts?: unknown) => {
-            mockState.getListCalls += 1;
-            if (mockState.heartbeatFailRemaining > 0) {
-              mockState.heartbeatFailRemaining -= 1;
-              throw new Error("heartbeat-fail");
-            }
-            return {
-              items: mockState.initial.slice(0, 1),
-              page: 1,
-              perPage: 1,
-              totalItems: mockState.initial.length,
-              totalPages: 1,
-            };
-          },
-        ),
-        subscribe: vi.fn(
-          async (_topic: string, cb: Listener, opts?: unknown) => {
-            mockState.subscribeCalls += 1;
-            mockState.listener = cb;
-            mockState.lastSubscribeOpts = opts;
-            return async () => {
-              mockState.unsubscribeCalls += 1;
-              mockState.listener = null;
-            };
-          },
-        ),
-        unsubscribe: vi.fn(async () => {
-          mockState.listener = null;
-        }),
-      }),
+      }
+      return out;
     },
+    collection: (_name: string) => ({
+      // getFullList is used by the initial fetch (replaces paginated getList).
+      // Returns a plain array, respecting the `batch` option as a cap.
+      getFullList: vi.fn(
+        async (opts?: { batch?: number; filter?: string }) => {
+          mockState.getListCalls += 1;
+          mockState.lastInitialGetListOpts = opts;
+          if (mockState.failRemaining > 0) {
+            mockState.failRemaining -= 1;
+            throw new Error("pb-unreachable");
+          }
+          const cap = opts?.batch ?? Infinity;
+          return mockState.initial.slice(0, cap);
+        },
+      ),
+      // getList is still used for heartbeat pings (getList(1, 1)).
+      getList: vi.fn(
+        async (_page: number, _perPage: number, _opts?: unknown) => {
+          mockState.getListCalls += 1;
+          if (mockState.heartbeatFailRemaining > 0) {
+            mockState.heartbeatFailRemaining -= 1;
+            throw new Error("heartbeat-fail");
+          }
+          return {
+            items: mockState.initial.slice(0, 1),
+            page: 1,
+            perPage: 1,
+            totalItems: mockState.initial.length,
+            totalPages: 1,
+          };
+        },
+      ),
+      subscribe: vi.fn(
+        async (_topic: string, cb: Listener, opts?: unknown) => {
+          mockState.subscribeCalls += 1;
+          mockState.listener = cb;
+          mockState.lastSubscribeOpts = opts;
+          return async () => {
+            mockState.unsubscribeCalls += 1;
+            mockState.listener = null;
+          };
+        },
+      ),
+      unsubscribe: vi.fn(async () => {
+        mockState.listener = null;
+      }),
+    }),
+  };
+  return {
+    pbIsMisconfigured: () => false,
+    PB_MISCONFIG_MESSAGE: "Dashboard misconfigured (test stub)",
+    getPb: () => pb,
   };
 });
 
@@ -490,7 +491,7 @@ describe("useLiveStatus", () => {
     // The mocked pb.collection returns a minimal stub (see vi.mock above),
     // not a real PocketBase RecordService — casting through `unknown` to a
     // narrowed shape is the correct seam.
-    const pbHandle = pbMod.pb as unknown as {
+    const pbHandle = pbMod.getPb() as unknown as {
       collection: (name: string) => Record<string, unknown>;
     };
     const origCollection = pbHandle.collection;

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.test.tsx
@@ -37,10 +37,7 @@ vi.mock("../lib/pb", () => {
       let out = raw;
       if (params) {
         for (const [k, v] of Object.entries(params)) {
-          out = out.replace(
-            new RegExp(`\\{:${k}\\}`, "g"),
-            JSON.stringify(v),
-          );
+          out = out.replace(new RegExp(`\\{:${k}\\}`, "g"), JSON.stringify(v));
         }
       }
       return out;
@@ -48,18 +45,16 @@ vi.mock("../lib/pb", () => {
     collection: (_name: string) => ({
       // getFullList is used by the initial fetch (replaces paginated getList).
       // Returns a plain array, respecting the `batch` option as a cap.
-      getFullList: vi.fn(
-        async (opts?: { batch?: number; filter?: string }) => {
-          mockState.getListCalls += 1;
-          mockState.lastInitialGetListOpts = opts;
-          if (mockState.failRemaining > 0) {
-            mockState.failRemaining -= 1;
-            throw new Error("pb-unreachable");
-          }
-          const cap = opts?.batch ?? Infinity;
-          return mockState.initial.slice(0, cap);
-        },
-      ),
+      getFullList: vi.fn(async (opts?: { batch?: number; filter?: string }) => {
+        mockState.getListCalls += 1;
+        mockState.lastInitialGetListOpts = opts;
+        if (mockState.failRemaining > 0) {
+          mockState.failRemaining -= 1;
+          throw new Error("pb-unreachable");
+        }
+        const cap = opts?.batch ?? Infinity;
+        return mockState.initial.slice(0, cap);
+      }),
       // getList is still used for heartbeat pings (getList(1, 1)).
       getList: vi.fn(
         async (_page: number, _perPage: number, _opts?: unknown) => {
@@ -77,17 +72,15 @@ vi.mock("../lib/pb", () => {
           };
         },
       ),
-      subscribe: vi.fn(
-        async (_topic: string, cb: Listener, opts?: unknown) => {
-          mockState.subscribeCalls += 1;
-          mockState.listener = cb;
-          mockState.lastSubscribeOpts = opts;
-          return async () => {
-            mockState.unsubscribeCalls += 1;
-            mockState.listener = null;
-          };
-        },
-      ),
+      subscribe: vi.fn(async (_topic: string, cb: Listener, opts?: unknown) => {
+        mockState.subscribeCalls += 1;
+        mockState.listener = cb;
+        mockState.lastSubscribeOpts = opts;
+        return async () => {
+          mockState.unsubscribeCalls += 1;
+          mockState.listener = null;
+        };
+      }),
       unsubscribe: vi.fn(async () => {
         mockState.listener = null;
       }),

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import { pb, pbIsMisconfigured, PB_MISCONFIG_MESSAGE } from "../lib/pb";
+import { getPb, pbIsMisconfigured, PB_MISCONFIG_MESSAGE } from "../lib/pb";
 import type { StatusRow } from "../lib/live-status";
 import { upsertByKey } from "../lib/live-status";
 
@@ -54,7 +54,7 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
     // sentinel URL with retries. Surface a clear user-facing error to the
     // UI banner immediately so operators see the actual root cause rather
     // than a generic DNS failure.
-    if (pbIsMisconfigured) {
+    if (pbIsMisconfigured()) {
       // Clear any previously-cached rows so downstream consumers (resolveCell)
       // don't render stale-green lies behind an offline banner (spec §5.3).
       setRows([]);
@@ -63,6 +63,7 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
       return;
     }
 
+    const pb = getPb();
     let alive = true;
     let attempts = 0;
     let cancel: (() => void) | null = null;

--- a/showcase/shell-dashboard/src/lib/__tests__/baseline-types.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/baseline-types.test.ts
@@ -148,8 +148,8 @@ describe("FEATURE_CATEGORIES", () => {
 /*  BASELINE_PARTNERS                                                  */
 /* ------------------------------------------------------------------ */
 describe("BASELINE_PARTNERS", () => {
-  it("has exactly 25 partners", () => {
-    expect(BASELINE_PARTNERS).toHaveLength(25);
+  it("has exactly 26 partners", () => {
+    expect(BASELINE_PARTNERS).toHaveLength(26);
   });
 
   it("each partner has name and slug", () => {

--- a/showcase/shell-dashboard/src/lib/ops-api.test.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.test.ts
@@ -7,9 +7,10 @@
  *   - GET  <base>/probes/<id>             → { probe, runs }
  *   - POST <base>/probes/<id>/trigger     → TriggerResponse
  *
- * `baseUrl` resolution order is: explicit param → NEXT_PUBLIC_OPS_BASE_URL
- * → fallback `/api/ops` (proxy). The trigger token is supplied per-call;
- * the client just attaches it as a Bearer header.
+ * `baseUrl` resolution order is: explicit param → runtimeConfig.opsBaseUrl
+ * (from `window.__SHOWCASE_CONFIG__`) → fallback `/api/ops` (proxy). The
+ * trigger token is supplied per-call; the client just attaches it as a
+ * Bearer header.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
@@ -72,9 +73,11 @@ let fetchSpy: ReturnType<typeof vi.fn>;
 beforeEach(() => {
   fetchSpy = vi.fn();
   vi.stubGlobal("fetch", fetchSpy);
-  // Reset env across tests so explicit-param vs env-var resolution is
-  // exercised cleanly.
-  delete process.env.NEXT_PUBLIC_OPS_BASE_URL;
+  // Reset runtime config across tests so explicit-param vs env-var
+  // resolution is exercised cleanly. The runtime config is normally
+  // injected by the root layout into `window.__SHOWCASE_CONFIG__`.
+  delete (window as Window & { __SHOWCASE_CONFIG__?: unknown })
+    .__SHOWCASE_CONFIG__;
 });
 
 afterEach(() => {
@@ -99,8 +102,13 @@ describe("fetchProbes", () => {
     expect(String(url)).toBe("/api/ops/probes");
   });
 
-  it("uses NEXT_PUBLIC_OPS_BASE_URL when explicit param omitted", async () => {
-    process.env.NEXT_PUBLIC_OPS_BASE_URL = "https://ops.example.com";
+  it("uses runtimeConfig.opsBaseUrl when explicit param omitted", async () => {
+    (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
+      {
+        pocketbaseUrl: "",
+        shellUrl: "",
+        opsBaseUrl: "https://ops.example.com",
+      };
     fetchSpy.mockResolvedValue(jsonResponse(emptyProbesResponse()));
     await fetchProbes();
     const [url] = fetchSpy.mock.calls[0]!;

--- a/showcase/shell-dashboard/src/lib/ops-api.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.ts
@@ -10,13 +10,10 @@
  *
  * `baseUrl` resolution order (per call):
  *   1. explicit `baseUrl` param (overrides everything; used in tests + SSR)
- *   2. `process.env.NEXT_PUBLIC_OPS_BASE_URL` — opt-in escape hatch for
- *      direct cross-origin calls; production does NOT use this because
- *      showcase-harness has no CORS allowlist. Note: Next inlines `NEXT_PUBLIC_*`
- *      into the client bundle at build time, but this module ALSO runs in
- *      SSR + tests where `process.env` is read live at call time — so
- *      `delete process.env.NEXT_PUBLIC_OPS_BASE_URL` in a test does take
- *      effect on subsequent `resolveBaseUrl()` calls.
+ *   2. `runtimeConfig.opsBaseUrl` (read from `window.__SHOWCASE_CONFIG__`,
+ *      populated at request time by the root layout's inline <script>) —
+ *      opt-in escape hatch for direct cross-origin calls; production does
+ *      NOT set this because showcase-harness has no CORS allowlist.
  *   3. `/api/ops` — same-origin path served by the Next.js rewrite in
  *      `next.config.ts`. This is the production contract, not a guess: the
  *      rewrite forwards `/api/ops/:path*` to `${OPS_BASE_URL}/api/:path*`
@@ -135,22 +132,41 @@ export interface TriggerResponse {
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────
 
+import { getRuntimeConfig } from "./runtime-config.client";
+
 const FALLBACK_BASE_URL = "/api/ops";
 
 /**
- * Resolve the API base URL with the precedence documented at the top of
- * this module. Trailing slashes are stripped so callers don't end up with
- * a double-slash like `http://host//probes` that some servers reject.
+ * Resolve the API base URL with this precedence:
+ *  1. explicit `baseUrl` param — used in tests + SSR.
+ *  2. `runtimeConfig.opsBaseUrl` — set by the env when a deploy wants
+ *     direct cross-origin calls (e.g. local dev hitting a remote
+ *     harness). Production deploys leave this empty so the call stays
+ *     same-origin via the next.config.ts rewrite.
+ *  3. `/api/ops` — same-origin path served by the Next.js rewrite.
  *
- * `NEXT_PUBLIC_OPS_BASE_URL` is treated as missing when it is undefined,
- * empty, or whitespace-only. `??` only falls through on `null`/`undefined`,
- * so without this an env var set to `""` would silently produce
- * `baseUrl === ""` and URLs like `"/probes"` (no `/api/ops` prefix) — a
- * silent failure mode where the dashboard hits its own origin and 404s.
+ * Whitespace-only and empty values are treated as missing — the same
+ * defensive trim as the prior `process.env.NEXT_PUBLIC_OPS_BASE_URL?.trim()`
+ * pattern, preserving the "do not silently 404 against own origin" guard.
  */
 function resolveBaseUrl(explicit?: string): string {
-  const envBase = process.env.NEXT_PUBLIC_OPS_BASE_URL?.trim();
-  const raw = explicit ?? (envBase || undefined) ?? FALLBACK_BASE_URL;
+  // On the server (SSR) there is no window. `getRuntimeConfig` (client
+  // variant) throws in that case — we MUST fall back to the same-origin
+  // path or the explicit override. In a browser the root layout's
+  // inline <script> populates `window.__SHOWCASE_CONFIG__` before any
+  // client code runs; if it's missing (wiring bug, or a test that
+  // forgot to set it) we treat that as "no override" rather than
+  // throwing here, since the same-origin rewrite is the safe default.
+  let envBase: string | undefined;
+  if (typeof window !== "undefined") {
+    try {
+      const trimmed = getRuntimeConfig().opsBaseUrl?.trim();
+      if (trimmed && trimmed.length > 0) envBase = trimmed;
+    } catch {
+      // window.__SHOWCASE_CONFIG__ missing — fall through to FALLBACK_BASE_URL.
+    }
+  }
+  const raw = explicit ?? envBase ?? FALLBACK_BASE_URL;
   return raw.replace(/\/+$/, "");
 }
 

--- a/showcase/shell-dashboard/src/lib/pb.ts
+++ b/showcase/shell-dashboard/src/lib/pb.ts
@@ -1,85 +1,50 @@
 import PocketBase from "pocketbase";
+import { getRuntimeConfig } from "./runtime-config.client";
 
-// MODULE-LOAD SEMANTICS (F5.4):
-// `resolvePbUrl()` reads `process.env.NEXT_PUBLIC_POCKETBASE_URL` and
-// `process.env.NODE_ENV` ONCE at module initialization (the `const
-// resolvedUrl = resolvePbUrl()` call below). The PocketBase client, the
-// `pbIsMisconfigured` flag, and the dev/prod fallback decision are frozen
-// at that point. Changing the env var at runtime has no effect — you must
-// restart the Next.js dev server (or rebuild the production image) for a
-// new value to take effect. This mirrors Next.js's own behavior for
-// `NEXT_PUBLIC_*` vars, which are inlined into the client bundle at build
-// time rather than read from `process.env` in the browser.
-//
-// Public-read client for live status + status_history. No authentication:
-// per spec §3.1/§3.2 those collections have listRule/viewRule = "" (public).
-// CORS restricts which origins may make the request (§5.2).
-//
-// NEXT_PUBLIC_POCKETBASE_URL is inlined at build time (Next.js convention).
-// If the env var is NOT set when `next build` runs, the PB URL we bake in
-// is whatever fallback we choose — which is exactly the "silent prod
-// pointing" failure mode we want to avoid.
-//
-// The client is constructed eagerly at module load (this file runs during
-// both SSG prerender and browser hydration), so we can't throw on missing
-// env var — that would break the entire build in environments where the
-// var is injected via `--build-args` rather than the shell env, but not
-// until the docker build context supplies it.
-//
-// Strategy:
-//   - If NEXT_PUBLIC_POCKETBASE_URL is set: use it.
-//   - Else if NODE_ENV === "production": use a placeholder URL that is
-//     clearly invalid (`http://pocketbase.invalid`) so any attempted
-//     request fails fast with a DNS error the hook surfaces as an
-//     offline banner — no silent prod-pointing. ALSO emit a build-time
-//     warning (surfaces in `next build` logs) and a runtime console
-//     error so the misconfiguration is hard to miss.
-//   - Else (dev/test): fall back to a LOCAL PocketBase URL
-//     (`http://127.0.0.1:8090`). Pointing dev at the production Railway
-//     instance is a silent-failure footgun: a developer running the
-//     dashboard without env wiring would inadvertently query prod,
-//     polluting prod observability and risking authenticated requests
-//     leaking against the prod collection. Local fallback forces the
-//     operator to start a local PB (`pnpm pb:dev` / docker-compose) or
-//     set NEXT_PUBLIC_POCKETBASE_URL explicitly.
-const DEV_FALLBACK_URL = "http://127.0.0.1:8090";
+// Lazy PocketBase client. The URL is read from the runtime config the
+// FIRST time `getPb()` is called — not at module import. This is what
+// makes one built artifact serve different PB hosts across staging vs
+// prod: the runtime config is populated by the root layout's inline
+// <script> before any client component calls `getPb()`.
+
+/** Human-readable error surfaced to hooks when the runtime URL is the prod sentinel. */
+export const PB_MISCONFIG_MESSAGE =
+  "Dashboard misconfigured: POCKETBASE_URL was unset at runtime on this " +
+  "deploy, so the app cannot reach PocketBase. Set the env var on the " +
+  "Railway service.";
+
 const PROD_INVALID_URL = "http://pocketbase.invalid";
 
-/** Human-readable error surfaced to hooks when the sentinel URL is live. */
-export const PB_MISCONFIG_MESSAGE =
-  "Dashboard misconfigured: NEXT_PUBLIC_POCKETBASE_URL was unset at build " +
-  "time, so the app cannot reach PocketBase. Rebuild the shell-dashboard " +
-  "image with the env var set.";
-
-function resolvePbUrl(): string {
-  const env = process.env.NEXT_PUBLIC_POCKETBASE_URL;
-  if (env && env.length > 0) return env;
-  if (process.env.NODE_ENV === "production") {
-    // Deliberate noisy signal — this string appears in build logs AND
-    // browser consoles in any deploy where the env var wasn't supplied.
-    // eslint-disable-next-line no-console
-    console.error(
-      "[pb.ts] FATAL-CONFIG: NEXT_PUBLIC_POCKETBASE_URL is unset in a " +
-        "production build; dashboard will not reach PocketBase. Set the " +
-        "env var at build time.",
-    );
-    return PROD_INVALID_URL;
-  }
-  // eslint-disable-next-line no-console
-  console.warn(
-    `[pb.ts] NEXT_PUBLIC_POCKETBASE_URL unset; using dev fallback ${DEV_FALLBACK_URL}`,
-  );
-  return DEV_FALLBACK_URL;
-}
-
-const resolvedUrl = resolvePbUrl();
+let cachedClient: PocketBase | null = null;
+let cachedUrl: string | null = null;
 
 /**
- * `true` iff the client is using the sentinel placeholder URL because no
- * `NEXT_PUBLIC_POCKETBASE_URL` was supplied at build time. Hooks can
- * short-circuit with a clear misconfig error instead of waiting for a
- * DNS failure to surface.
+ * Returns the singleton `PocketBase` client, constructed on first call.
+ * Subsequent calls return the same instance.
+ *
+ * Call sites: every consumer that previously imported `{ pb }` now
+ * imports `{ getPb }` and calls `getPb()` once at the top of the
+ * function / effect / hook. Returns the REAL PocketBase instance — no
+ * Proxy — so `instanceof PocketBase`, detached methods, and
+ * `this`-sensitive call chains all work without surprise.
  */
-export const pbIsMisconfigured = resolvedUrl === PROD_INVALID_URL;
+export function getPb(): PocketBase {
+  if (cachedClient) return cachedClient;
+  const url = getRuntimeConfig().pocketbaseUrl;
+  cachedUrl = url;
+  cachedClient = new PocketBase(url);
+  return cachedClient;
+}
 
-export const pb = new PocketBase(resolvedUrl);
+/**
+ * `true` iff the current runtime URL is the prod sentinel — hooks can
+ * short-circuit with a clear misconfig error instead of waiting for a
+ * DNS failure. Function form (not a const boolean) because the URL is
+ * resolved lazily on first `getPb()` call; a module-load boolean would
+ * have to snapshot at import time, which is exactly the bug this
+ * refactor removes.
+ */
+export function pbIsMisconfigured(): boolean {
+  if (cachedUrl === null) getPb();
+  return cachedUrl === PROD_INVALID_URL;
+}

--- a/showcase/shell-dashboard/src/lib/runtime-config-serialize.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config-serialize.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { serializeRuntimeConfig } from "./runtime-config-serialize";
+
+// Pin a security-critical path: the inline-injected runtime config
+// lands inside a <script>...</script> block in the root layout. A
+// hostile env value containing the closing-script substring would
+// otherwise break out and let the attacker inject arbitrary HTML.
+// JSON.stringify does NOT escape `<` by default, so we MUST escape
+// it to `<` here. U+2028 / U+2029 must also be escaped because
+// the JS string literal parser treats them as line terminators in
+// older engines.
+//
+// shell-dashboard's variant builds the regexes via the RegExp
+// constructor (`new RegExp("\\uXXXX", "g")`) — this test re-asserts
+// the same XSS / parser-hazard properties hold for that variant.
+//
+// Tokenizer note: we build the test inputs via String.fromCharCode
+// so the literal U+2028 / U+2029 codepoints never appear in this
+// source file (some editors / build pipelines reject them).
+
+const LS = String.fromCharCode(0x2028);
+const PS = String.fromCharCode(0x2029);
+
+describe("serializeRuntimeConfig (shell-dashboard)", () => {
+    it("escapes `<` so the closing-script substring cannot appear in the output", () => {
+        const malicious = { shellUrl: "</script><script>alert(1)</script>" };
+        const serialized = serializeRuntimeConfig(malicious);
+        expect(serialized).not.toContain("</script>");
+        expect(serialized).toContain("\\u003c");
+    });
+
+    it("escapes U+2028 (LINE SEPARATOR) to \\u2028", () => {
+        const cfg = { shellUrl: `before${LS}after` };
+        const serialized = serializeRuntimeConfig(cfg);
+        expect(serialized).not.toContain(LS);
+        expect(serialized).toContain("\\u2028");
+    });
+
+    it("escapes U+2029 (PARAGRAPH SEPARATOR) to \\u2029", () => {
+        const cfg = { shellUrl: `before${PS}after` };
+        const serialized = serializeRuntimeConfig(cfg);
+        expect(serialized).not.toContain(PS);
+        expect(serialized).toContain("\\u2029");
+    });
+
+    it("round-trips a normal config via JSON.parse", () => {
+        const cfg = {
+            pocketbaseUrl: "https://pb.example.com",
+            shellUrl: "https://shell.example.com",
+            opsBaseUrl: "https://ops.example.com",
+        };
+        const serialized = serializeRuntimeConfig(cfg);
+        expect(JSON.parse(serialized)).toEqual(cfg);
+    });
+
+    it("does not double-escape already-safe characters", () => {
+        const cfg = { shellUrl: "https://shell.copilotkit.ai" };
+        const serialized = serializeRuntimeConfig(cfg);
+        expect(serialized).toBe(JSON.stringify(cfg));
+    });
+});

--- a/showcase/shell-dashboard/src/lib/runtime-config-serialize.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config-serialize.test.ts
@@ -22,40 +22,40 @@ const LS = String.fromCharCode(0x2028);
 const PS = String.fromCharCode(0x2029);
 
 describe("serializeRuntimeConfig (shell-dashboard)", () => {
-    it("escapes `<` so the closing-script substring cannot appear in the output", () => {
-        const malicious = { shellUrl: "</script><script>alert(1)</script>" };
-        const serialized = serializeRuntimeConfig(malicious);
-        expect(serialized).not.toContain("</script>");
-        expect(serialized).toContain("\\u003c");
-    });
+  it("escapes `<` so the closing-script substring cannot appear in the output", () => {
+    const malicious = { shellUrl: "</script><script>alert(1)</script>" };
+    const serialized = serializeRuntimeConfig(malicious);
+    expect(serialized).not.toContain("</script>");
+    expect(serialized).toContain("\\u003c");
+  });
 
-    it("escapes U+2028 (LINE SEPARATOR) to \\u2028", () => {
-        const cfg = { shellUrl: `before${LS}after` };
-        const serialized = serializeRuntimeConfig(cfg);
-        expect(serialized).not.toContain(LS);
-        expect(serialized).toContain("\\u2028");
-    });
+  it("escapes U+2028 (LINE SEPARATOR) to \\u2028", () => {
+    const cfg = { shellUrl: `before${LS}after` };
+    const serialized = serializeRuntimeConfig(cfg);
+    expect(serialized).not.toContain(LS);
+    expect(serialized).toContain("\\u2028");
+  });
 
-    it("escapes U+2029 (PARAGRAPH SEPARATOR) to \\u2029", () => {
-        const cfg = { shellUrl: `before${PS}after` };
-        const serialized = serializeRuntimeConfig(cfg);
-        expect(serialized).not.toContain(PS);
-        expect(serialized).toContain("\\u2029");
-    });
+  it("escapes U+2029 (PARAGRAPH SEPARATOR) to \\u2029", () => {
+    const cfg = { shellUrl: `before${PS}after` };
+    const serialized = serializeRuntimeConfig(cfg);
+    expect(serialized).not.toContain(PS);
+    expect(serialized).toContain("\\u2029");
+  });
 
-    it("round-trips a normal config via JSON.parse", () => {
-        const cfg = {
-            pocketbaseUrl: "https://pb.example.com",
-            shellUrl: "https://shell.example.com",
-            opsBaseUrl: "https://ops.example.com",
-        };
-        const serialized = serializeRuntimeConfig(cfg);
-        expect(JSON.parse(serialized)).toEqual(cfg);
-    });
+  it("round-trips a normal config via JSON.parse", () => {
+    const cfg = {
+      pocketbaseUrl: "https://pb.example.com",
+      shellUrl: "https://shell.example.com",
+      opsBaseUrl: "https://ops.example.com",
+    };
+    const serialized = serializeRuntimeConfig(cfg);
+    expect(JSON.parse(serialized)).toEqual(cfg);
+  });
 
-    it("does not double-escape already-safe characters", () => {
-        const cfg = { shellUrl: "https://shell.copilotkit.ai" };
-        const serialized = serializeRuntimeConfig(cfg);
-        expect(serialized).toBe(JSON.stringify(cfg));
-    });
+  it("does not double-escape already-safe characters", () => {
+    const cfg = { shellUrl: "https://shell.copilotkit.ai" };
+    const serialized = serializeRuntimeConfig(cfg);
+    expect(serialized).toBe(JSON.stringify(cfg));
+  });
 });

--- a/showcase/shell-dashboard/src/lib/runtime-config-serialize.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config-serialize.ts
@@ -22,8 +22,8 @@
 // Canonical OWASP-recommended escape for inline JSON in HTML.
 
 export function serializeRuntimeConfig(cfg: unknown): string {
-    return JSON.stringify(cfg)
-        .replace(new RegExp("<", "g"), "\\u003c")
-        .replace(new RegExp(" ", "g"), "\\u2028")
-        .replace(new RegExp(" ", "g"), "\\u2029");
+  return JSON.stringify(cfg)
+    .replace(new RegExp("<", "g"), "\\u003c")
+    .replace(new RegExp(" ", "g"), "\\u2028")
+    .replace(new RegExp(" ", "g"), "\\u2029");
 }

--- a/showcase/shell-dashboard/src/lib/runtime-config-serialize.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config-serialize.ts
@@ -1,0 +1,29 @@
+// Serialize the runtime config for inline injection into the root
+// layout's `<script>...</script>` block. Three substrings would
+// otherwise break out of (or corrupt) the parser:
+//
+//   - `<` — guards against the `</script>` breakout (XSS). JSON.stringify
+//     does NOT escape `<` by default, so a URL containing `</script>`
+//     (e.g. a hostile env value) would terminate the inline script and
+//     inject HTML. Escape every `<` to `<` so the substring
+//     `</script>` can never appear.
+//   - U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) — legal
+//     inside JSON strings, but a syntax error inside a JS string literal
+//     in older engines / when the page is parsed as `text/javascript`.
+//     Escape both.
+//
+// Tokenizer note: writing the literal U+2028 / U+2029 codepoints inside
+// a /regex/ literal is a parse error in TypeScript / many JS engines
+// because both codepoints are line terminators that prematurely
+// terminate the regex literal. Constructing via the RegExp constructor
+// with `\u` escapes — resolved at runtime by the regex engine —
+// sidesteps the tokenizer entirely.
+//
+// Canonical OWASP-recommended escape for inline JSON in HTML.
+
+export function serializeRuntimeConfig(cfg: unknown): string {
+    return JSON.stringify(cfg)
+        .replace(new RegExp("<", "g"), "\\u003c")
+        .replace(new RegExp(" ", "g"), "\\u2028")
+        .replace(new RegExp(" ", "g"), "\\u2029");
+}

--- a/showcase/shell-dashboard/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.client.test.ts
@@ -2,56 +2,56 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getRuntimeConfig } from "./runtime-config.client";
 
 describe("client getRuntimeConfig (shell-dashboard)", () => {
-    const originalWindow = globalThis.window;
+  const originalWindow = globalThis.window;
 
-    beforeEach(() => {
-        // jsdom provides `window` by default in this vitest config.
-        // Reset any prior injection.
-        delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
-            .__SHOWCASE_CONFIG__;
-    });
+  beforeEach(() => {
+    // jsdom provides `window` by default in this vitest config.
+    // Reset any prior injection.
+    delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
+      .__SHOWCASE_CONFIG__;
+  });
 
-    afterEach(() => {
-        (globalThis as { window?: Window }).window = originalWindow;
-    });
+  afterEach(() => {
+    (globalThis as { window?: Window }).window = originalWindow;
+  });
 
-    it("returns the injected config", () => {
-        (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
-            {
-                pocketbaseUrl: "https://pb.example.com",
-                shellUrl: "https://shell.example.com",
-                opsBaseUrl: "https://ops.example.com",
-            };
-        expect(getRuntimeConfig()).toEqual({
-            pocketbaseUrl: "https://pb.example.com",
-            shellUrl: "https://shell.example.com",
-            opsBaseUrl: "https://ops.example.com",
-        });
+  it("returns the injected config", () => {
+    (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
+      {
+        pocketbaseUrl: "https://pb.example.com",
+        shellUrl: "https://shell.example.com",
+        opsBaseUrl: "https://ops.example.com",
+      };
+    expect(getRuntimeConfig()).toEqual({
+      pocketbaseUrl: "https://pb.example.com",
+      shellUrl: "https://shell.example.com",
+      opsBaseUrl: "https://ops.example.com",
     });
+  });
 
-    it("throws when __SHOWCASE_CONFIG__ is missing (wiring bug)", () => {
-        expect(() => getRuntimeConfig()).toThrow(
-            /window\.__SHOWCASE_CONFIG__ is missing/,
-        );
-    });
+  it("throws when __SHOWCASE_CONFIG__ is missing (wiring bug)", () => {
+    expect(() => getRuntimeConfig()).toThrow(
+      /window\.__SHOWCASE_CONFIG__ is missing/,
+    );
+  });
 
-    it("returns SSR sentinel placeholder when window is undefined", () => {
-        // Simulate SSR by removing window. "use client" component
-        // bodies execute on the server during SSR, so this reader
-        // MUST be SSR-safe (returns parseable-URL placeholders so
-        // `new URL()` in consumers doesn't throw) and NOT throw —
-        // otherwise the whole server-rendered HTML 500s.
-        const w = globalThis.window;
-        // @ts-expect-error — deliberately removing window for the test
-        delete globalThis.window;
-        try {
-            const cfg = getRuntimeConfig();
-            // URL fields must be parseable.
-            expect(() => new URL(cfg.pocketbaseUrl)).not.toThrow();
-            expect(() => new URL(cfg.shellUrl)).not.toThrow();
-            expect(() => new URL(cfg.opsBaseUrl)).not.toThrow();
-        } finally {
-            (globalThis as { window?: typeof w }).window = w;
-        }
-    });
+  it("returns SSR sentinel placeholder when window is undefined", () => {
+    // Simulate SSR by removing window. "use client" component
+    // bodies execute on the server during SSR, so this reader
+    // MUST be SSR-safe (returns parseable-URL placeholders so
+    // `new URL()` in consumers doesn't throw) and NOT throw —
+    // otherwise the whole server-rendered HTML 500s.
+    const w = globalThis.window;
+    // @ts-expect-error — deliberately removing window for the test
+    delete globalThis.window;
+    try {
+      const cfg = getRuntimeConfig();
+      // URL fields must be parseable.
+      expect(() => new URL(cfg.pocketbaseUrl)).not.toThrow();
+      expect(() => new URL(cfg.shellUrl)).not.toThrow();
+      expect(() => new URL(cfg.opsBaseUrl)).not.toThrow();
+    } finally {
+      (globalThis as { window?: typeof w }).window = w;
+    }
+  });
 });

--- a/showcase/shell-dashboard/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.client.test.ts
@@ -38,18 +38,18 @@ describe("client getRuntimeConfig (shell-dashboard)", () => {
     it("returns SSR sentinel placeholder when window is undefined", () => {
         // Simulate SSR by removing window. "use client" component
         // bodies execute on the server during SSR, so this reader
-        // MUST be SSR-safe (returns empty-string placeholders that
-        // get replaced on the next render after hydration), NOT
-        // throw — otherwise the whole server-rendered HTML 500s.
+        // MUST be SSR-safe (returns parseable-URL placeholders so
+        // `new URL()` in consumers doesn't throw) and NOT throw —
+        // otherwise the whole server-rendered HTML 500s.
         const w = globalThis.window;
         // @ts-expect-error — deliberately removing window for the test
         delete globalThis.window;
         try {
-            expect(getRuntimeConfig()).toEqual({
-                pocketbaseUrl: "",
-                shellUrl: "",
-                opsBaseUrl: "",
-            });
+            const cfg = getRuntimeConfig();
+            // URL fields must be parseable.
+            expect(() => new URL(cfg.pocketbaseUrl)).not.toThrow();
+            expect(() => new URL(cfg.shellUrl)).not.toThrow();
+            expect(() => new URL(cfg.opsBaseUrl)).not.toThrow();
         } finally {
             (globalThis as { window?: typeof w }).window = w;
         }

--- a/showcase/shell-dashboard/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.client.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRuntimeConfig } from "./runtime-config.client";
+
+describe("client getRuntimeConfig (shell-dashboard)", () => {
+    const originalWindow = globalThis.window;
+
+    beforeEach(() => {
+        // jsdom provides `window` by default in this vitest config.
+        // Reset any prior injection.
+        delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
+            .__SHOWCASE_CONFIG__;
+    });
+
+    afterEach(() => {
+        (globalThis as { window?: Window }).window = originalWindow;
+    });
+
+    it("returns the injected config", () => {
+        (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
+            {
+                pocketbaseUrl: "https://pb.example.com",
+                shellUrl: "https://shell.example.com",
+                opsBaseUrl: "https://ops.example.com",
+            };
+        expect(getRuntimeConfig()).toEqual({
+            pocketbaseUrl: "https://pb.example.com",
+            shellUrl: "https://shell.example.com",
+            opsBaseUrl: "https://ops.example.com",
+        });
+    });
+
+    it("throws when __SHOWCASE_CONFIG__ is missing (wiring bug)", () => {
+        expect(() => getRuntimeConfig()).toThrow(
+            /window\.__SHOWCASE_CONFIG__ is missing/,
+        );
+    });
+
+    it("throws on the server (no window)", () => {
+        // Simulate SSR by removing window.
+        const w = globalThis.window;
+        // @ts-expect-error — deliberately removing window for the test
+        delete globalThis.window;
+        try {
+            expect(() => getRuntimeConfig()).toThrow(
+                /called on the server/,
+            );
+        } finally {
+            (globalThis as { window?: typeof w }).window = w;
+        }
+    });
+});

--- a/showcase/shell-dashboard/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.client.test.ts
@@ -35,15 +35,21 @@ describe("client getRuntimeConfig (shell-dashboard)", () => {
         );
     });
 
-    it("throws on the server (no window)", () => {
-        // Simulate SSR by removing window.
+    it("returns SSR sentinel placeholder when window is undefined", () => {
+        // Simulate SSR by removing window. "use client" component
+        // bodies execute on the server during SSR, so this reader
+        // MUST be SSR-safe (returns empty-string placeholders that
+        // get replaced on the next render after hydration), NOT
+        // throw — otherwise the whole server-rendered HTML 500s.
         const w = globalThis.window;
         // @ts-expect-error — deliberately removing window for the test
         delete globalThis.window;
         try {
-            expect(() => getRuntimeConfig()).toThrow(
-                /called on the server/,
-            );
+            expect(getRuntimeConfig()).toEqual({
+                pocketbaseUrl: "",
+                shellUrl: "",
+                opsBaseUrl: "",
+            });
         } finally {
             (globalThis as { window?: typeof w }).window = w;
         }

--- a/showcase/shell-dashboard/src/lib/runtime-config.client.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.client.ts
@@ -1,0 +1,47 @@
+// Client-side runtime config reader. Reads from
+// window.__SHOWCASE_CONFIG__ which the root layout injects via an
+// inline <script> tag BEFORE React hydrates (see app/layout.tsx). This
+// is the ONLY public API for these URLs in client code — never read
+// process.env.NEXT_PUBLIC_* directly (the ESLint rule in B12 enforces
+// this).
+
+import type { RuntimeConfig } from "./runtime-config";
+
+export type { RuntimeConfig };
+
+declare global {
+    interface Window {
+        __SHOWCASE_CONFIG__?: RuntimeConfig;
+    }
+}
+
+/**
+ * Returns the runtime config injected by the root server layout.
+ *
+ * Throws when called during SSR (no window). The intended call sites
+ * are client components and hooks ("use client"), which only execute
+ * after hydration — by which point the inline <script> has populated
+ * window.__SHOWCASE_CONFIG__. If a server component needs the same
+ * values, it MUST import runtime-config.ts (the server variant) — not
+ * this file.
+ */
+export function getRuntimeConfig(): RuntimeConfig {
+    if (typeof window === "undefined") {
+        throw new Error(
+            "[runtime-config.client] getRuntimeConfig() called on the server. " +
+                "Server code must import from './runtime-config' instead.",
+        );
+    }
+    const cfg = window.__SHOWCASE_CONFIG__;
+    if (!cfg) {
+        // The root layout always emits the <script> tag, so a missing
+        // value here is a wiring bug (e.g. a route bypassed the layout,
+        // or the injection script ran with empty inputs). Surface it
+        // loudly rather than silently returning empty strings.
+        throw new Error(
+            "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
+                "The root layout must inject runtime config before client mount.",
+        );
+    }
+    return cfg;
+}

--- a/showcase/shell-dashboard/src/lib/runtime-config.client.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.client.ts
@@ -16,21 +16,36 @@ declare global {
 }
 
 /**
+ * Sentinel returned during SSR when `window` is unavailable. "use client"
+ * components in the Next.js App Router are server-side rendered on the
+ * initial request (that's how the HTML is streamed before hydration),
+ * which means their function bodies execute on the server too. We can't
+ * throw here without breaking SSR — instead we return a placeholder, and
+ * post-hydration the next render reads the real values out of
+ * window.__SHOWCASE_CONFIG__. Server components that need the live env
+ * values MUST import getRuntimeConfig from runtime-config.ts (the server
+ * variant), not this file.
+ */
+const SSR_PLACEHOLDER: RuntimeConfig = {
+    pocketbaseUrl: "",
+    shellUrl: "",
+    opsBaseUrl: "",
+};
+
+/**
  * Returns the runtime config injected by the root server layout.
  *
- * Throws when called during SSR (no window). The intended call sites
- * are client components and hooks ("use client"), which only execute
- * after hydration — by which point the inline <script> has populated
- * window.__SHOWCASE_CONFIG__. If a server component needs the same
- * values, it MUST import runtime-config.ts (the server variant) — not
- * this file.
+ * During SSR (no window) returns a sentinel placeholder; client code
+ * re-reads after hydration and gets the real values. If the inline
+ * <script> never runs (a route bypassed the layout, or injection ran
+ * with empty inputs), the post-hydration read throws — surfacing the
+ * wiring bug loudly rather than silently rendering empty URLs.
  */
 export function getRuntimeConfig(): RuntimeConfig {
     if (typeof window === "undefined") {
-        throw new Error(
-            "[runtime-config.client] getRuntimeConfig() called on the server. " +
-                "Server code must import from './runtime-config' instead.",
-        );
+        // SSR phase — "use client" component bodies execute here too.
+        // Return placeholder; hydration will re-render with real values.
+        return SSR_PLACEHOLDER;
     }
     const cfg = window.__SHOWCASE_CONFIG__;
     if (!cfg) {

--- a/showcase/shell-dashboard/src/lib/runtime-config.client.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.client.ts
@@ -2,8 +2,7 @@
 // window.__SHOWCASE_CONFIG__ which the root layout injects via an
 // inline <script> tag BEFORE React hydrates (see app/layout.tsx). This
 // is the ONLY public API for these URLs in client code — never read
-// process.env.NEXT_PUBLIC_* directly (the ESLint rule in B12 enforces
-// this).
+// process.env.NEXT_PUBLIC_* directly (an ESLint rule enforces this).
 
 import type { RuntimeConfig } from "./runtime-config";
 
@@ -26,10 +25,18 @@ declare global {
  * values MUST import getRuntimeConfig from runtime-config.ts (the server
  * variant), not this file.
  */
+// URL fields use a parseable `https://ssr-placeholder.invalid/` sentinel
+// — NOT the empty string — because consumer components may call
+// `new URL(cfg.someUrl)` inline during render, and `new URL("")` throws
+// a TypeError that escapes the SSR response as a 500. The `.invalid`
+// TLD is reserved by RFC 2606 so the URL also can't accidentally
+// resolve. Post-hydration the next render reads the real value out of
+// window.__SHOWCASE_CONFIG__.
+const SSR_PLACEHOLDER_URL = "https://ssr-placeholder.invalid/";
 const SSR_PLACEHOLDER: RuntimeConfig = {
-    pocketbaseUrl: "",
-    shellUrl: "",
-    opsBaseUrl: "",
+    pocketbaseUrl: SSR_PLACEHOLDER_URL,
+    shellUrl: SSR_PLACEHOLDER_URL,
+    opsBaseUrl: SSR_PLACEHOLDER_URL,
 };
 
 /**

--- a/showcase/shell-dashboard/src/lib/runtime-config.client.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.client.ts
@@ -9,9 +9,9 @@ import type { RuntimeConfig } from "./runtime-config";
 export type { RuntimeConfig };
 
 declare global {
-    interface Window {
-        __SHOWCASE_CONFIG__?: RuntimeConfig;
-    }
+  interface Window {
+    __SHOWCASE_CONFIG__?: RuntimeConfig;
+  }
 }
 
 /**
@@ -34,9 +34,9 @@ declare global {
 // window.__SHOWCASE_CONFIG__.
 const SSR_PLACEHOLDER_URL = "https://ssr-placeholder.invalid/";
 const SSR_PLACEHOLDER: RuntimeConfig = {
-    pocketbaseUrl: SSR_PLACEHOLDER_URL,
-    shellUrl: SSR_PLACEHOLDER_URL,
-    opsBaseUrl: SSR_PLACEHOLDER_URL,
+  pocketbaseUrl: SSR_PLACEHOLDER_URL,
+  shellUrl: SSR_PLACEHOLDER_URL,
+  opsBaseUrl: SSR_PLACEHOLDER_URL,
 };
 
 /**
@@ -49,21 +49,21 @@ const SSR_PLACEHOLDER: RuntimeConfig = {
  * wiring bug loudly rather than silently rendering empty URLs.
  */
 export function getRuntimeConfig(): RuntimeConfig {
-    if (typeof window === "undefined") {
-        // SSR phase — "use client" component bodies execute here too.
-        // Return placeholder; hydration will re-render with real values.
-        return SSR_PLACEHOLDER;
-    }
-    const cfg = window.__SHOWCASE_CONFIG__;
-    if (!cfg) {
-        // The root layout always emits the <script> tag, so a missing
-        // value here is a wiring bug (e.g. a route bypassed the layout,
-        // or the injection script ran with empty inputs). Surface it
-        // loudly rather than silently returning empty strings.
-        throw new Error(
-            "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
-                "The root layout must inject runtime config before client mount.",
-        );
-    }
-    return cfg;
+  if (typeof window === "undefined") {
+    // SSR phase — "use client" component bodies execute here too.
+    // Return placeholder; hydration will re-render with real values.
+    return SSR_PLACEHOLDER;
+  }
+  const cfg = window.__SHOWCASE_CONFIG__;
+  if (!cfg) {
+    // The root layout always emits the <script> tag, so a missing
+    // value here is a wiring bug (e.g. a route bypassed the layout,
+    // or the injection script ran with empty inputs). Surface it
+    // loudly rather than silently returning empty strings.
+    throw new Error(
+      "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
+        "The root layout must inject runtime config before client mount.",
+    );
+  }
+  return cfg;
 }

--- a/showcase/shell-dashboard/src/lib/runtime-config.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.test.ts
@@ -5,143 +5,142 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Component"). The function is a no-op for our purposes (it tells Next
 // not to cache; in a unit test there is no cache to opt out of).
 vi.mock("next/cache", () => ({
-    unstable_noStore: () => {},
+  unstable_noStore: () => {},
 }));
 
 import { getRuntimeConfig } from "./runtime-config";
 
 describe("server getRuntimeConfig (shell-dashboard)", () => {
-    const ORIGINAL_ENV = { ...process.env };
+  const ORIGINAL_ENV = { ...process.env };
 
-    beforeEach(() => {
-        // Reset to a known empty slate; explicit per-test sets follow.
-        for (const k of [
-            "POCKETBASE_URL",
-            "SHELL_URL",
-            "OPS_BASE_URL",
-            "NEXT_PUBLIC_POCKETBASE_URL",
-            "NEXT_PUBLIC_SHELL_URL",
-            "NEXT_PUBLIC_OPS_BASE_URL",
-            "NODE_ENV",
-        ]) {
-            delete (process.env as Record<string, string | undefined>)[k];
-        }
+  beforeEach(() => {
+    // Reset to a known empty slate; explicit per-test sets follow.
+    for (const k of [
+      "POCKETBASE_URL",
+      "SHELL_URL",
+      "OPS_BASE_URL",
+      "NEXT_PUBLIC_POCKETBASE_URL",
+      "NEXT_PUBLIC_SHELL_URL",
+      "NEXT_PUBLIC_OPS_BASE_URL",
+      "NODE_ENV",
+    ]) {
+      delete (process.env as Record<string, string | undefined>)[k];
+    }
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, ORIGINAL_ENV);
+  });
+
+  it("returns env values when all are set (production)", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.POCKETBASE_URL =
+      "https://pocketbase-staging-eec0.up.railway.app";
+    process.env.SHELL_URL = "https://showcase.staging.copilotkit.ai";
+    process.env.OPS_BASE_URL = "https://harness-staging-2ee4.up.railway.app";
+    expect(getRuntimeConfig()).toEqual({
+      pocketbaseUrl: "https://pocketbase-staging-eec0.up.railway.app",
+      shellUrl: "https://showcase.staging.copilotkit.ai",
+      opsBaseUrl: "https://harness-staging-2ee4.up.railway.app",
     });
+  });
 
-    afterEach(() => {
-        Object.assign(process.env, ORIGINAL_ENV);
+  it("strips trailing slashes", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.POCKETBASE_URL = "https://pb.example.com/";
+    process.env.SHELL_URL = "https://shell.example.com//";
+    process.env.OPS_BASE_URL = "https://ops.example.com///";
+    const cfg = getRuntimeConfig();
+    expect(cfg.pocketbaseUrl).toBe("https://pb.example.com");
+    expect(cfg.shellUrl).toBe("https://shell.example.com");
+    expect(cfg.opsBaseUrl).toBe("https://ops.example.com");
+  });
+
+  it("falls back to dev defaults when unset in non-production", () => {
+    (process.env as Record<string, string>).NODE_ENV = "development";
+    const cfg = getRuntimeConfig();
+    expect(cfg.pocketbaseUrl).toBe("http://127.0.0.1:8090");
+    expect(cfg.shellUrl).toBe("http://localhost:3000");
+    expect(cfg.opsBaseUrl).toBe("http://localhost:9020");
+  });
+
+  it("falls back to sentinels and console.errors in production", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
     });
+    const cfg = getRuntimeConfig();
+    spy.mockRestore();
+    expect(cfg.pocketbaseUrl).toBe("http://pocketbase.invalid");
+    expect(cfg.shellUrl).toBe("about:blank#shell-url-missing");
+    expect(cfg.opsBaseUrl).toBe("http://ops.invalid");
+    expect(errs.some((m) => m.includes("POCKETBASE_URL"))).toBe(true);
+    expect(errs.some((m) => m.includes("SHELL_URL"))).toBe(true);
+    expect(errs.some((m) => m.includes("OPS_BASE_URL"))).toBe(true);
+  });
 
-    it("returns env values when all are set (production)", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.POCKETBASE_URL = "https://pocketbase-staging-eec0.up.railway.app";
-        process.env.SHELL_URL = "https://showcase.staging.copilotkit.ai";
-        process.env.OPS_BASE_URL = "https://harness-staging-2ee4.up.railway.app";
-        expect(getRuntimeConfig()).toEqual({
-            pocketbaseUrl: "https://pocketbase-staging-eec0.up.railway.app",
-            shellUrl: "https://showcase.staging.copilotkit.ai",
-            opsBaseUrl: "https://harness-staging-2ee4.up.railway.app",
-        });
-    });
+  it("reads live process.env on each call (no module-load freeze)", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.POCKETBASE_URL = "https://first.example.com";
+    process.env.SHELL_URL = "https://shell.example.com";
+    process.env.OPS_BASE_URL = "https://ops.example.com";
+    expect(getRuntimeConfig().pocketbaseUrl).toBe("https://first.example.com");
+    process.env.POCKETBASE_URL = "https://second.example.com";
+    expect(getRuntimeConfig().pocketbaseUrl).toBe("https://second.example.com");
+  });
 
-    it("strips trailing slashes", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.POCKETBASE_URL = "https://pb.example.com/";
-        process.env.SHELL_URL = "https://shell.example.com//";
-        process.env.OPS_BASE_URL = "https://ops.example.com///";
-        const cfg = getRuntimeConfig();
-        expect(cfg.pocketbaseUrl).toBe("https://pb.example.com");
-        expect(cfg.shellUrl).toBe("https://shell.example.com");
-        expect(cfg.opsBaseUrl).toBe("https://ops.example.com");
-    });
+  it("accepts NEXT_PUBLIC_* fallbacks when bare names are unset", () => {
+    // Deploy-config contract: shell-dashboard reads bare names first,
+    // but tolerates NEXT_PUBLIC_-prefixed variants so a Railway
+    // service that follows the shell-docs naming convention still
+    // wires through. See the readUrl fallback chain in
+    // runtime-config.ts.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_POCKETBASE_URL = "https://alt-pb.example.com";
+    process.env.NEXT_PUBLIC_SHELL_URL = "https://alt-shell.example.com";
+    process.env.NEXT_PUBLIC_OPS_BASE_URL = "https://alt-ops.example.com";
+    const cfg = getRuntimeConfig();
+    expect(cfg.pocketbaseUrl).toBe("https://alt-pb.example.com");
+    expect(cfg.shellUrl).toBe("https://alt-shell.example.com");
+    expect(cfg.opsBaseUrl).toBe("https://alt-ops.example.com");
+  });
 
-    it("falls back to dev defaults when unset in non-production", () => {
-        (process.env as Record<string, string>).NODE_ENV = "development";
-        const cfg = getRuntimeConfig();
-        expect(cfg.pocketbaseUrl).toBe("http://127.0.0.1:8090");
-        expect(cfg.shellUrl).toBe("http://localhost:3000");
-        expect(cfg.opsBaseUrl).toBe("http://localhost:9020");
-    });
+  it("bare names take precedence over NEXT_PUBLIC_ variants when both set", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.POCKETBASE_URL = "https://primary-pb.example.com";
+    process.env.SHELL_URL = "https://primary-shell.example.com";
+    process.env.OPS_BASE_URL = "https://primary-ops.example.com";
+    process.env.NEXT_PUBLIC_POCKETBASE_URL = "https://alt-pb.example.com";
+    process.env.NEXT_PUBLIC_SHELL_URL = "https://alt-shell.example.com";
+    process.env.NEXT_PUBLIC_OPS_BASE_URL = "https://alt-ops.example.com";
+    const cfg = getRuntimeConfig();
+    expect(cfg.pocketbaseUrl).toBe("https://primary-pb.example.com");
+    expect(cfg.shellUrl).toBe("https://primary-shell.example.com");
+    expect(cfg.opsBaseUrl).toBe("https://primary-ops.example.com");
+  });
 
-    it("falls back to sentinels and console.errors in production", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        const errs: string[] = [];
-        const spy = vi
-            .spyOn(console, "error")
-            .mockImplementation((m: string) => {
-                errs.push(m);
-            });
-        const cfg = getRuntimeConfig();
-        spy.mockRestore();
-        expect(cfg.pocketbaseUrl).toBe("http://pocketbase.invalid");
-        expect(cfg.shellUrl).toBe("about:blank#shell-url-missing");
-        expect(cfg.opsBaseUrl).toBe("http://ops.invalid");
-        expect(errs.some((m) => m.includes("POCKETBASE_URL"))).toBe(true);
-        expect(errs.some((m) => m.includes("SHELL_URL"))).toBe(true);
-        expect(errs.some((m) => m.includes("OPS_BASE_URL"))).toBe(true);
-    });
+  it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
+    // Confirm the Edge wrapper passes `{ noStore: false }`.
+    // Reach into the mocked module to assert noStore was NOT called
+    // on this path, while the default getRuntimeConfig() above DID
+    // call it.
+    const cacheMod = await import("next/cache");
+    const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.POCKETBASE_URL = "https://edge.example.com";
+    process.env.SHELL_URL = "https://edge-shell.example.com";
+    process.env.OPS_BASE_URL = "https://edge-ops.example.com";
 
-    it("reads live process.env on each call (no module-load freeze)", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.POCKETBASE_URL = "https://first.example.com";
-        process.env.SHELL_URL = "https://shell.example.com";
-        process.env.OPS_BASE_URL = "https://ops.example.com";
-        expect(getRuntimeConfig().pocketbaseUrl).toBe("https://first.example.com");
-        process.env.POCKETBASE_URL = "https://second.example.com";
-        expect(getRuntimeConfig().pocketbaseUrl).toBe("https://second.example.com");
-    });
+    const { getRuntimeConfigEdge } = await import("./runtime-config");
+    const cfg = getRuntimeConfigEdge();
+    expect(cfg.pocketbaseUrl).toBe("https://edge.example.com");
+    expect(noStoreSpy).not.toHaveBeenCalled();
 
-    it("accepts NEXT_PUBLIC_* fallbacks when bare names are unset", () => {
-        // Deploy-config contract: shell-dashboard reads bare names first,
-        // but tolerates NEXT_PUBLIC_-prefixed variants so a Railway
-        // service that follows the shell-docs naming convention still
-        // wires through. See the readUrl fallback chain in
-        // runtime-config.ts.
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.NEXT_PUBLIC_POCKETBASE_URL = "https://alt-pb.example.com";
-        process.env.NEXT_PUBLIC_SHELL_URL = "https://alt-shell.example.com";
-        process.env.NEXT_PUBLIC_OPS_BASE_URL = "https://alt-ops.example.com";
-        const cfg = getRuntimeConfig();
-        expect(cfg.pocketbaseUrl).toBe("https://alt-pb.example.com");
-        expect(cfg.shellUrl).toBe("https://alt-shell.example.com");
-        expect(cfg.opsBaseUrl).toBe("https://alt-ops.example.com");
-    });
-
-    it("bare names take precedence over NEXT_PUBLIC_ variants when both set", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.POCKETBASE_URL = "https://primary-pb.example.com";
-        process.env.SHELL_URL = "https://primary-shell.example.com";
-        process.env.OPS_BASE_URL = "https://primary-ops.example.com";
-        process.env.NEXT_PUBLIC_POCKETBASE_URL = "https://alt-pb.example.com";
-        process.env.NEXT_PUBLIC_SHELL_URL = "https://alt-shell.example.com";
-        process.env.NEXT_PUBLIC_OPS_BASE_URL = "https://alt-ops.example.com";
-        const cfg = getRuntimeConfig();
-        expect(cfg.pocketbaseUrl).toBe("https://primary-pb.example.com");
-        expect(cfg.shellUrl).toBe("https://primary-shell.example.com");
-        expect(cfg.opsBaseUrl).toBe("https://primary-ops.example.com");
-    });
-
-    it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
-        // Confirm the Edge wrapper passes `{ noStore: false }`.
-        // Reach into the mocked module to assert noStore was NOT called
-        // on this path, while the default getRuntimeConfig() above DID
-        // call it.
-        const cacheMod = await import("next/cache");
-        const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.POCKETBASE_URL = "https://edge.example.com";
-        process.env.SHELL_URL = "https://edge-shell.example.com";
-        process.env.OPS_BASE_URL = "https://edge-ops.example.com";
-
-        const { getRuntimeConfigEdge } = await import("./runtime-config");
-        const cfg = getRuntimeConfigEdge();
-        expect(cfg.pocketbaseUrl).toBe("https://edge.example.com");
-        expect(noStoreSpy).not.toHaveBeenCalled();
-
-        // And confirm the default entrypoint DOES call noStore().
-        noStoreSpy.mockClear();
-        getRuntimeConfig();
-        expect(noStoreSpy).toHaveBeenCalledTimes(1);
-        noStoreSpy.mockRestore();
-    });
+    // And confirm the default entrypoint DOES call noStore().
+    noStoreSpy.mockClear();
+    getRuntimeConfig();
+    expect(noStoreSpy).toHaveBeenCalledTimes(1);
+    noStoreSpy.mockRestore();
+  });
 });

--- a/showcase/shell-dashboard/src/lib/runtime-config.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub next/cache.unstable_noStore — vitest runs outside Next's runtime
+// so the real implementation throws ("called outside a Server
+// Component"). The function is a no-op for our purposes (it tells Next
+// not to cache; in a unit test there is no cache to opt out of).
+vi.mock("next/cache", () => ({
+    unstable_noStore: () => {},
+}));
+
+import { getRuntimeConfig } from "./runtime-config";
+
+describe("server getRuntimeConfig (shell-dashboard)", () => {
+    const ORIGINAL_ENV = { ...process.env };
+
+    beforeEach(() => {
+        // Reset to a known empty slate; explicit per-test sets follow.
+        for (const k of [
+            "POCKETBASE_URL",
+            "SHELL_URL",
+            "OPS_BASE_URL",
+            "NODE_ENV",
+        ]) {
+            delete (process.env as Record<string, string | undefined>)[k];
+        }
+    });
+
+    afterEach(() => {
+        Object.assign(process.env, ORIGINAL_ENV);
+    });
+
+    it("returns env values when all are set (production)", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.POCKETBASE_URL = "https://pocketbase-staging-eec0.up.railway.app";
+        process.env.SHELL_URL = "https://showcase.staging.copilotkit.ai";
+        process.env.OPS_BASE_URL = "https://harness-staging-2ee4.up.railway.app";
+        expect(getRuntimeConfig()).toEqual({
+            pocketbaseUrl: "https://pocketbase-staging-eec0.up.railway.app",
+            shellUrl: "https://showcase.staging.copilotkit.ai",
+            opsBaseUrl: "https://harness-staging-2ee4.up.railway.app",
+        });
+    });
+
+    it("strips trailing slashes", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.POCKETBASE_URL = "https://pb.example.com/";
+        process.env.SHELL_URL = "https://shell.example.com//";
+        process.env.OPS_BASE_URL = "https://ops.example.com///";
+        const cfg = getRuntimeConfig();
+        expect(cfg.pocketbaseUrl).toBe("https://pb.example.com");
+        expect(cfg.shellUrl).toBe("https://shell.example.com");
+        expect(cfg.opsBaseUrl).toBe("https://ops.example.com");
+    });
+
+    it("falls back to dev defaults when unset in non-production", () => {
+        (process.env as Record<string, string>).NODE_ENV = "development";
+        const cfg = getRuntimeConfig();
+        expect(cfg.pocketbaseUrl).toBe("http://127.0.0.1:8090");
+        expect(cfg.shellUrl).toBe("http://localhost:3000");
+        expect(cfg.opsBaseUrl).toBe("http://localhost:9020");
+    });
+
+    it("falls back to sentinels and console.errors in production", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        const errs: string[] = [];
+        const spy = vi
+            .spyOn(console, "error")
+            .mockImplementation((m: string) => {
+                errs.push(m);
+            });
+        const cfg = getRuntimeConfig();
+        spy.mockRestore();
+        expect(cfg.pocketbaseUrl).toBe("http://pocketbase.invalid");
+        expect(cfg.shellUrl).toBe("about:blank#shell-url-missing");
+        expect(cfg.opsBaseUrl).toBe("http://ops.invalid");
+        expect(errs.some((m) => m.includes("POCKETBASE_URL"))).toBe(true);
+        expect(errs.some((m) => m.includes("SHELL_URL"))).toBe(true);
+        expect(errs.some((m) => m.includes("OPS_BASE_URL"))).toBe(true);
+    });
+
+    it("reads live process.env on each call (no module-load freeze)", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.POCKETBASE_URL = "https://first.example.com";
+        process.env.SHELL_URL = "https://shell.example.com";
+        process.env.OPS_BASE_URL = "https://ops.example.com";
+        expect(getRuntimeConfig().pocketbaseUrl).toBe("https://first.example.com");
+        process.env.POCKETBASE_URL = "https://second.example.com";
+        expect(getRuntimeConfig().pocketbaseUrl).toBe("https://second.example.com");
+    });
+
+    it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
+        // Confirm the Edge wrapper passes `{ noStore: false }`.
+        // Reach into the mocked module to assert noStore was NOT called
+        // on this path, while the default getRuntimeConfig() above DID
+        // call it.
+        const cacheMod = await import("next/cache");
+        const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.POCKETBASE_URL = "https://edge.example.com";
+        process.env.SHELL_URL = "https://edge-shell.example.com";
+        process.env.OPS_BASE_URL = "https://edge-ops.example.com";
+
+        const { getRuntimeConfigEdge } = await import("./runtime-config");
+        const cfg = getRuntimeConfigEdge();
+        expect(cfg.pocketbaseUrl).toBe("https://edge.example.com");
+        expect(noStoreSpy).not.toHaveBeenCalled();
+
+        // And confirm the default entrypoint DOES call noStore().
+        noStoreSpy.mockClear();
+        getRuntimeConfig();
+        expect(noStoreSpy).toHaveBeenCalledTimes(1);
+        noStoreSpy.mockRestore();
+    });
+});

--- a/showcase/shell-dashboard/src/lib/runtime-config.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.test.ts
@@ -19,6 +19,9 @@ describe("server getRuntimeConfig (shell-dashboard)", () => {
             "POCKETBASE_URL",
             "SHELL_URL",
             "OPS_BASE_URL",
+            "NEXT_PUBLIC_POCKETBASE_URL",
+            "NEXT_PUBLIC_SHELL_URL",
+            "NEXT_PUBLIC_OPS_BASE_URL",
             "NODE_ENV",
         ]) {
             delete (process.env as Record<string, string | undefined>)[k];
@@ -86,6 +89,36 @@ describe("server getRuntimeConfig (shell-dashboard)", () => {
         expect(getRuntimeConfig().pocketbaseUrl).toBe("https://first.example.com");
         process.env.POCKETBASE_URL = "https://second.example.com";
         expect(getRuntimeConfig().pocketbaseUrl).toBe("https://second.example.com");
+    });
+
+    it("accepts NEXT_PUBLIC_* fallbacks when bare names are unset", () => {
+        // Deploy-config contract: shell-dashboard reads bare names first,
+        // but tolerates NEXT_PUBLIC_-prefixed variants so a Railway
+        // service that follows the shell-docs naming convention still
+        // wires through. See the readUrl fallback chain in
+        // runtime-config.ts.
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.NEXT_PUBLIC_POCKETBASE_URL = "https://alt-pb.example.com";
+        process.env.NEXT_PUBLIC_SHELL_URL = "https://alt-shell.example.com";
+        process.env.NEXT_PUBLIC_OPS_BASE_URL = "https://alt-ops.example.com";
+        const cfg = getRuntimeConfig();
+        expect(cfg.pocketbaseUrl).toBe("https://alt-pb.example.com");
+        expect(cfg.shellUrl).toBe("https://alt-shell.example.com");
+        expect(cfg.opsBaseUrl).toBe("https://alt-ops.example.com");
+    });
+
+    it("bare names take precedence over NEXT_PUBLIC_ variants when both set", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.POCKETBASE_URL = "https://primary-pb.example.com";
+        process.env.SHELL_URL = "https://primary-shell.example.com";
+        process.env.OPS_BASE_URL = "https://primary-ops.example.com";
+        process.env.NEXT_PUBLIC_POCKETBASE_URL = "https://alt-pb.example.com";
+        process.env.NEXT_PUBLIC_SHELL_URL = "https://alt-shell.example.com";
+        process.env.NEXT_PUBLIC_OPS_BASE_URL = "https://alt-ops.example.com";
+        const cfg = getRuntimeConfig();
+        expect(cfg.pocketbaseUrl).toBe("https://primary-pb.example.com");
+        expect(cfg.shellUrl).toBe("https://primary-shell.example.com");
+        expect(cfg.opsBaseUrl).toBe("https://primary-ops.example.com");
     });
 
     it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {

--- a/showcase/shell-dashboard/src/lib/runtime-config.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.ts
@@ -16,12 +16,12 @@
 import { unstable_noStore as noStore } from "next/cache";
 
 export interface RuntimeConfig {
-    /** PocketBase backend used by the Status tab live-readers. */
-    pocketbaseUrl: string;
-    /** Showcase shell host — used to build Demo / Code / docs-shell links. */
-    shellUrl: string;
-    /** Ops API base URL — server-side rewrite target for /api/ops/*. */
-    opsBaseUrl: string;
+  /** PocketBase backend used by the Status tab live-readers. */
+  pocketbaseUrl: string;
+  /** Showcase shell host — used to build Demo / Code / docs-shell links. */
+  shellUrl: string;
+  /** Ops API base URL — server-side rewrite target for /api/ops/*. */
+  opsBaseUrl: string;
 }
 
 const PROD_INVALID_POCKETBASE_URL = "http://pocketbase.invalid";
@@ -46,33 +46,33 @@ const PROD_INVALID_SHELL_URL = "about:blank#shell-url-missing";
  * below makes this explicit at the call site.
  */
 export function getRuntimeConfig(
-    opts: { noStore?: boolean } = {},
+  opts: { noStore?: boolean } = {},
 ): RuntimeConfig {
-    if (opts.noStore !== false) noStore();
-    const isProd = process.env.NODE_ENV === "production";
+  if (opts.noStore !== false) noStore();
+  const isProd = process.env.NODE_ENV === "production";
 
-    const pocketbaseUrl = readUrl(
-        "POCKETBASE_URL",
-        isProd ? PROD_INVALID_POCKETBASE_URL : "http://127.0.0.1:8090",
-        isProd,
-    );
-    const shellUrl = readUrl(
-        "SHELL_URL",
-        isProd ? PROD_INVALID_SHELL_URL : "http://localhost:3000",
-        isProd,
-    );
-    const opsBaseUrl = readUrl(
-        "OPS_BASE_URL",
-        // shell-dashboard's next.config.ts validates OPS_BASE_URL at
-        // start time, so reaching the fallback here means something
-        // is wrong with the launch sequence. Use a sentinel that
-        // produces visible breakage rather than silently routing to
-        // a guessed host.
-        isProd ? "http://ops.invalid" : "http://localhost:9020",
-        isProd,
-    );
+  const pocketbaseUrl = readUrl(
+    "POCKETBASE_URL",
+    isProd ? PROD_INVALID_POCKETBASE_URL : "http://127.0.0.1:8090",
+    isProd,
+  );
+  const shellUrl = readUrl(
+    "SHELL_URL",
+    isProd ? PROD_INVALID_SHELL_URL : "http://localhost:3000",
+    isProd,
+  );
+  const opsBaseUrl = readUrl(
+    "OPS_BASE_URL",
+    // shell-dashboard's next.config.ts validates OPS_BASE_URL at
+    // start time, so reaching the fallback here means something
+    // is wrong with the launch sequence. Use a sentinel that
+    // produces visible breakage rather than silently routing to
+    // a guessed host.
+    isProd ? "http://ops.invalid" : "http://localhost:9020",
+    isProd,
+  );
 
-    return { pocketbaseUrl, shellUrl, opsBaseUrl };
+  return { pocketbaseUrl, shellUrl, opsBaseUrl };
 }
 
 /**
@@ -87,7 +87,7 @@ export function getRuntimeConfig(
  * and the build fails with "module not found in edge runtime."
  */
 export function getRuntimeConfigEdge(): RuntimeConfig {
-    return getRuntimeConfig({ noStore: false });
+  return getRuntimeConfig({ noStore: false });
 }
 
 // Env-name tolerance: deploy configs in the wild use either the bare
@@ -96,9 +96,9 @@ export function getRuntimeConfigEdge(): RuntimeConfig {
 // fallback to the alternate so a Railway service variable set under
 // the "wrong" name still works without redeploy.
 function altEnvName(envKey: string): string {
-    return envKey.startsWith("NEXT_PUBLIC_")
-        ? envKey.slice("NEXT_PUBLIC_".length)
-        : `NEXT_PUBLIC_${envKey}`;
+  return envKey.startsWith("NEXT_PUBLIC_")
+    ? envKey.slice("NEXT_PUBLIC_".length)
+    : `NEXT_PUBLIC_${envKey}`;
 }
 
 // Length-aware env coalesce: a deliberately-empty primary (e.g. an
@@ -106,27 +106,27 @@ function altEnvName(envKey: string): string {
 // mask a populated alternate. Treat empty-string as "unset" and fall
 // through to the alternate.
 function readEnvPair(envKey: string): string | undefined {
-    const primary = process.env[envKey];
-    if (primary && primary.length > 0) return primary;
-    const alt = process.env[altEnvName(envKey)];
-    if (alt && alt.length > 0) return alt;
-    return undefined;
+  const primary = process.env[envKey];
+  if (primary && primary.length > 0) return primary;
+  const alt = process.env[altEnvName(envKey)];
+  if (alt && alt.length > 0) return alt;
+  return undefined;
 }
 
 function readUrl(envKey: string, fallback: string, isProd: boolean): string {
-    const value = readEnvPair(envKey);
-    if (value !== undefined) return value.replace(/\/+$/, "");
-    if (isProd) {
-        // eslint-disable-next-line no-console
-        console.error(
-            `[shell-dashboard runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
-                `using sentinel ${fallback}. Set the env var on the Railway service.`,
-        );
-    } else {
-        // eslint-disable-next-line no-console
-        console.warn(
-            `[shell-dashboard runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
-        );
-    }
-    return fallback.replace(/\/+$/, "");
+  const value = readEnvPair(envKey);
+  if (value !== undefined) return value.replace(/\/+$/, "");
+  if (isProd) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[shell-dashboard runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
+        `using sentinel ${fallback}. Set the env var on the Railway service.`,
+    );
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[shell-dashboard runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
+    );
+  }
+  return fallback.replace(/\/+$/, "");
 }

--- a/showcase/shell-dashboard/src/lib/runtime-config.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.ts
@@ -6,8 +6,8 @@
 // `unstable_noStore()` opts the calling segment out of Next.js's static
 // cache so reads always reflect the live env. Without it, a server
 // component that uses this could be statically rendered at build time
-// and freeze the URLs back into the artifact (the exact bug we are
-// fixing). See Next.js App Router docs on Dynamic Rendering.
+// and freeze the URLs back into the artifact — defeating the runtime
+// switch. See Next.js App Router docs on Dynamic Rendering.
 //
 // This module MUST NOT be imported from client components. The matching
 // client-side reader lives in runtime-config.client.ts and reads from
@@ -90,8 +90,19 @@ export function getRuntimeConfigEdge(): RuntimeConfig {
     return getRuntimeConfig({ noStore: false });
 }
 
+// Env-name tolerance: deploy configs in the wild use either the bare
+// name (e.g. `OPS_BASE_URL`) or the `NEXT_PUBLIC_*`-prefixed name. We
+// accept either — the primary (passed-in) name wins, with transparent
+// fallback to the alternate so a Railway service variable set under
+// the "wrong" name still works without redeploy.
+function altEnvName(envKey: string): string {
+    return envKey.startsWith("NEXT_PUBLIC_")
+        ? envKey.slice("NEXT_PUBLIC_".length)
+        : `NEXT_PUBLIC_${envKey}`;
+}
+
 function readUrl(envKey: string, fallback: string, isProd: boolean): string {
-    const value = process.env[envKey];
+    const value = process.env[envKey] ?? process.env[altEnvName(envKey)];
     if (value && value.length > 0) return value.replace(/\/+$/, "");
     if (isProd) {
         // eslint-disable-next-line no-console

--- a/showcase/shell-dashboard/src/lib/runtime-config.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.ts
@@ -1,0 +1,109 @@
+// Server-only runtime config reader. Reads from process.env at REQUEST
+// time (not at module load) so a single built artifact can serve
+// different URL values across staging vs prod by changing the Railway
+// service's env vars — no rebuild required.
+//
+// `unstable_noStore()` opts the calling segment out of Next.js's static
+// cache so reads always reflect the live env. Without it, a server
+// component that uses this could be statically rendered at build time
+// and freeze the URLs back into the artifact (the exact bug we are
+// fixing). See Next.js App Router docs on Dynamic Rendering.
+//
+// This module MUST NOT be imported from client components. The matching
+// client-side reader lives in runtime-config.client.ts and reads from
+// window.__SHOWCASE_CONFIG__ which the root layout injects.
+
+import { unstable_noStore as noStore } from "next/cache";
+
+export interface RuntimeConfig {
+    /** PocketBase backend used by the Status tab live-readers. */
+    pocketbaseUrl: string;
+    /** Showcase shell host — used to build Demo / Code / docs-shell links. */
+    shellUrl: string;
+    /** Ops API base URL — server-side rewrite target for /api/ops/*. */
+    opsBaseUrl: string;
+}
+
+const PROD_INVALID_POCKETBASE_URL = "http://pocketbase.invalid";
+const PROD_INVALID_SHELL_URL = "about:blank#shell-url-missing";
+
+/**
+ * Resolve the runtime config for shell-dashboard. Called once per request
+ * by the root layout and by any other server component that needs it.
+ *
+ * Fail-loud strategy mirrors the prior build-time pb.ts logic: in
+ * production, missing env vars produce sentinel URLs (visible breakage)
+ * AND a console.error; in dev, we fall back to localhost so iteration is
+ * frictionless.
+ *
+ * `opts.noStore` (default `true`) controls whether to call
+ * `unstable_noStore()`. The Node.js server runtime needs the opt-out so
+ * Next.js does not statically prerender callers and freeze the URLs into
+ * the build artifact. The Edge runtime (middleware) MUST pass
+ * `{ noStore: false }` — `unstable_noStore()` is unavailable there, and
+ * middleware always runs per-request by definition so there is no
+ * static cache to opt out of. The thin `getRuntimeConfigEdge()` wrapper
+ * below makes this explicit at the call site.
+ */
+export function getRuntimeConfig(
+    opts: { noStore?: boolean } = {},
+): RuntimeConfig {
+    if (opts.noStore !== false) noStore();
+    const isProd = process.env.NODE_ENV === "production";
+
+    const pocketbaseUrl = readUrl(
+        "POCKETBASE_URL",
+        isProd ? PROD_INVALID_POCKETBASE_URL : "http://127.0.0.1:8090",
+        isProd,
+    );
+    const shellUrl = readUrl(
+        "SHELL_URL",
+        isProd ? PROD_INVALID_SHELL_URL : "http://localhost:3000",
+        isProd,
+    );
+    const opsBaseUrl = readUrl(
+        "OPS_BASE_URL",
+        // shell-dashboard's next.config.ts validates OPS_BASE_URL at
+        // start time (B10), so reaching the fallback here means
+        // something is wrong with the launch sequence. Use a sentinel
+        // that produces visible breakage rather than silently routing
+        // to a guessed host.
+        isProd ? "http://ops.invalid" : "http://localhost:9020",
+        isProd,
+    );
+
+    return { pocketbaseUrl, shellUrl, opsBaseUrl };
+}
+
+/**
+ * Edge-runtime variant. Identical semantics to `getRuntimeConfig()`
+ * except `unstable_noStore()` is skipped — `next/cache`'s no-store
+ * helper is not available in the Edge runtime, and middleware always
+ * runs per-request by definition so there is no static cache to opt
+ * out of. Thin wrapper to keep the body single-sourced.
+ *
+ * Middleware (`src/middleware.ts`) MUST import this rather than
+ * `getRuntimeConfig` — otherwise the Edge bundle pulls in `next/cache`
+ * and the build fails with "module not found in edge runtime."
+ */
+export function getRuntimeConfigEdge(): RuntimeConfig {
+    return getRuntimeConfig({ noStore: false });
+}
+
+function readUrl(envKey: string, fallback: string, isProd: boolean): string {
+    const value = process.env[envKey];
+    if (value && value.length > 0) return value.replace(/\/+$/, "");
+    if (isProd) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
+                `using sentinel ${fallback}. Set the env var on the Railway service.`,
+        );
+    } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `[runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
+        );
+    }
+    return fallback.replace(/\/+$/, "");
+}

--- a/showcase/shell-dashboard/src/lib/runtime-config.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.ts
@@ -64,10 +64,10 @@ export function getRuntimeConfig(
     const opsBaseUrl = readUrl(
         "OPS_BASE_URL",
         // shell-dashboard's next.config.ts validates OPS_BASE_URL at
-        // start time (B10), so reaching the fallback here means
-        // something is wrong with the launch sequence. Use a sentinel
-        // that produces visible breakage rather than silently routing
-        // to a guessed host.
+        // start time, so reaching the fallback here means something
+        // is wrong with the launch sequence. Use a sentinel that
+        // produces visible breakage rather than silently routing to
+        // a guessed host.
         isProd ? "http://ops.invalid" : "http://localhost:9020",
         isProd,
     );
@@ -101,19 +101,31 @@ function altEnvName(envKey: string): string {
         : `NEXT_PUBLIC_${envKey}`;
 }
 
+// Length-aware env coalesce: a deliberately-empty primary (e.g. an
+// operator clearing `OPS_BASE_URL=""` on a Railway service) must NOT
+// mask a populated alternate. Treat empty-string as "unset" and fall
+// through to the alternate.
+function readEnvPair(envKey: string): string | undefined {
+    const primary = process.env[envKey];
+    if (primary && primary.length > 0) return primary;
+    const alt = process.env[altEnvName(envKey)];
+    if (alt && alt.length > 0) return alt;
+    return undefined;
+}
+
 function readUrl(envKey: string, fallback: string, isProd: boolean): string {
-    const value = process.env[envKey] ?? process.env[altEnvName(envKey)];
-    if (value && value.length > 0) return value.replace(/\/+$/, "");
+    const value = readEnvPair(envKey);
+    if (value !== undefined) return value.replace(/\/+$/, "");
     if (isProd) {
         // eslint-disable-next-line no-console
         console.error(
-            `[runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
+            `[shell-dashboard runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
                 `using sentinel ${fallback}. Set the env var on the Railway service.`,
         );
     } else {
         // eslint-disable-next-line no-console
         console.warn(
-            `[runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
+            `[shell-dashboard runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
         );
     }
     return fallback.replace(/\/+$/, "");

--- a/showcase/shell-dashboard/tests/runtime-env-switch.spike.test.ts
+++ b/showcase/shell-dashboard/tests/runtime-env-switch.spike.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { execSync, spawn, type ChildProcess } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { setTimeout as wait } from "node:timers/promises";
 
 // This test boots `next build` ONCE then `next start` TWICE with two
@@ -34,98 +35,96 @@ const SHELL_DASHBOARD_DIR = import.meta.dirname + "/..";
 const BUILD_TIME_OPS_PLACEHOLDER = "http://build-placeholder.invalid";
 
 describe("Option B: one artifact, two env values, no rebuild", () => {
-    beforeAll(() => {
-        // Build ONCE. Pass a placeholder OPS_BASE_URL only so
-        // next.config.ts:rewrites() can construct its proxy entry.
-        // No POCKETBASE_URL / SHELL_URL — those are read at request
-        // time by getRuntimeConfig() and must not be required at build.
-        //
-        // Use `npm run build` (not `npx next build` directly) so the
-        // `prebuild` script runs and the generated data fixtures
-        // (`src/data/registry.json`, `catalog.json`, `docs-status.json`)
-        // exist before webpack walks the import tree.
-        execSync("npm run build", {
-            cwd: SHELL_DASHBOARD_DIR,
-            stdio: "inherit",
-            env: {
-                ...process.env,
-                NODE_ENV: "production",
-                OPS_BASE_URL: BUILD_TIME_OPS_PLACEHOLDER,
-            },
-        });
-    }, 180_000);
-
-    async function bootAndProbe(
-        port: number,
-        env: Record<string, string>,
-    ): Promise<{ pocketbaseUrl: string; shellUrl: string; opsBaseUrl: string }> {
-        const proc: ChildProcess = spawn(
-            "npx",
-            ["next", "start", "-p", String(port)],
-            {
-                cwd: SHELL_DASHBOARD_DIR,
-                env: { ...process.env, NODE_ENV: "production", ...env },
-                stdio: "pipe",
-                detached: false,
-            },
-        );
-        try {
-            // Wait for the server to be ready by polling /.
-            const deadline = Date.now() + 30_000;
-            while (Date.now() < deadline) {
-                try {
-                    const res = await fetch(`http://localhost:${port}/`);
-                    if (res.ok) break;
-                } catch {
-                    // not up yet
-                }
-                await wait(500);
-            }
-            const html = await (await fetch(`http://localhost:${port}/`)).text();
-            // Extract the inlined runtime config from the injected
-            // <script id="__showcase_config__">. The injection pattern
-            // is `window.__SHOWCASE_CONFIG__={"...":"..."};`.
-            const match = html.match(
-                /window\.__SHOWCASE_CONFIG__=(\{[^<]*?\});/,
-            );
-            if (!match) throw new Error("no __SHOWCASE_CONFIG__ in HTML");
-            // The serialized payload has < escaped as < — JSON.parse
-            // accepts it as-is for our keys (URLs don't contain <).
-            const parsed = JSON.parse(match[1]);
-            return parsed;
-        } finally {
-            proc.kill("SIGTERM");
-            // Drain — give the OS a beat to release the port before the
-            // next iteration binds it.
-            await wait(500);
-        }
-    }
-
-    it("serves env-A URLs on the first boot", async () => {
-        const cfg = await bootAndProbe(PORT_A, {
-            POCKETBASE_URL: "https://pb-env-a.example.com",
-            SHELL_URL: "https://shell-env-a.example.com",
-            OPS_BASE_URL: "https://ops-env-a.example.com",
-        });
-        expect(cfg.pocketbaseUrl).toBe("https://pb-env-a.example.com");
-        expect(cfg.shellUrl).toBe("https://shell-env-a.example.com");
-        expect(cfg.opsBaseUrl).toBe("https://ops-env-a.example.com");
-    }, 60_000);
-
-    it("serves env-B URLs on the second boot of THE SAME ARTIFACT", async () => {
-        const cfg = await bootAndProbe(PORT_B, {
-            POCKETBASE_URL: "https://pb-env-b.example.com",
-            SHELL_URL: "https://shell-env-b.example.com",
-            OPS_BASE_URL: "https://ops-env-b.example.com",
-        });
-        expect(cfg.pocketbaseUrl).toBe("https://pb-env-b.example.com");
-        expect(cfg.shellUrl).toBe("https://shell-env-b.example.com");
-        expect(cfg.opsBaseUrl).toBe("https://ops-env-b.example.com");
-    }, 60_000);
-
-    afterAll(() => {
-        // Nothing to clean — the .next/ artifact is intentionally
-        // left in place for inspection; the test doesn't touch it
-        // between runs.
+  beforeAll(() => {
+    // Build ONCE. Pass a placeholder OPS_BASE_URL only so
+    // next.config.ts:rewrites() can construct its proxy entry.
+    // No POCKETBASE_URL / SHELL_URL — those are read at request
+    // time by getRuntimeConfig() and must not be required at build.
+    //
+    // Use `npm run build` (not `npx next build` directly) so the
+    // `prebuild` script runs and the generated data fixtures
+    // (`src/data/registry.json`, `catalog.json`, `docs-status.json`)
+    // exist before webpack walks the import tree.
+    execSync("npm run build", {
+      cwd: SHELL_DASHBOARD_DIR,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        NODE_ENV: "production",
+        OPS_BASE_URL: BUILD_TIME_OPS_PLACEHOLDER,
+      },
     });
+  }, 180_000);
+
+  async function bootAndProbe(
+    port: number,
+    env: Record<string, string>,
+  ): Promise<{ pocketbaseUrl: string; shellUrl: string; opsBaseUrl: string }> {
+    const proc: ChildProcess = spawn(
+      "npx",
+      ["next", "start", "-p", String(port)],
+      {
+        cwd: SHELL_DASHBOARD_DIR,
+        env: { ...process.env, NODE_ENV: "production", ...env },
+        stdio: "pipe",
+        detached: false,
+      },
+    );
+    try {
+      // Wait for the server to be ready by polling /.
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        try {
+          const res = await fetch(`http://localhost:${port}/`);
+          if (res.ok) break;
+        } catch {
+          // not up yet
+        }
+        await wait(500);
+      }
+      const html = await (await fetch(`http://localhost:${port}/`)).text();
+      // Extract the inlined runtime config from the injected
+      // <script id="__showcase_config__">. The injection pattern
+      // is `window.__SHOWCASE_CONFIG__={"...":"..."};`.
+      const match = html.match(/window\.__SHOWCASE_CONFIG__=(\{[^<]*?\});/);
+      if (!match) throw new Error("no __SHOWCASE_CONFIG__ in HTML");
+      // The serialized payload has < escaped as < — JSON.parse
+      // accepts it as-is for our keys (URLs don't contain <).
+      const parsed = JSON.parse(match[1]);
+      return parsed;
+    } finally {
+      proc.kill("SIGTERM");
+      // Drain — give the OS a beat to release the port before the
+      // next iteration binds it.
+      await wait(500);
+    }
+  }
+
+  it("serves env-A URLs on the first boot", async () => {
+    const cfg = await bootAndProbe(PORT_A, {
+      POCKETBASE_URL: "https://pb-env-a.example.com",
+      SHELL_URL: "https://shell-env-a.example.com",
+      OPS_BASE_URL: "https://ops-env-a.example.com",
+    });
+    expect(cfg.pocketbaseUrl).toBe("https://pb-env-a.example.com");
+    expect(cfg.shellUrl).toBe("https://shell-env-a.example.com");
+    expect(cfg.opsBaseUrl).toBe("https://ops-env-a.example.com");
+  }, 60_000);
+
+  it("serves env-B URLs on the second boot of THE SAME ARTIFACT", async () => {
+    const cfg = await bootAndProbe(PORT_B, {
+      POCKETBASE_URL: "https://pb-env-b.example.com",
+      SHELL_URL: "https://shell-env-b.example.com",
+      OPS_BASE_URL: "https://ops-env-b.example.com",
+    });
+    expect(cfg.pocketbaseUrl).toBe("https://pb-env-b.example.com");
+    expect(cfg.shellUrl).toBe("https://shell-env-b.example.com");
+    expect(cfg.opsBaseUrl).toBe("https://ops-env-b.example.com");
+  }, 60_000);
+
+  afterAll(() => {
+    // Nothing to clean — the .next/ artifact is intentionally
+    // left in place for inspection; the test doesn't touch it
+    // between runs.
+  });
 });

--- a/showcase/shell-dashboard/tests/runtime-env-switch.spike.test.ts
+++ b/showcase/shell-dashboard/tests/runtime-env-switch.spike.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+import { setTimeout as wait } from "node:timers/promises";
+
+// This test boots `next build` ONCE then `next start` TWICE with two
+// different POCKETBASE_URL / SHELL_URL / OPS_BASE_URL value sets,
+// curls the served HTML on each, and asserts the injected
+// __SHOWCASE_CONFIG__ JSON matches the env values for that boot.
+//
+// If no-rebuild env switching ever regresses (someone re-bakes a URL
+// into the bundle), this test fails because the first boot's URL
+// values leak into the second boot's HTML.
+//
+// One nuance vs the original spike: shell-dashboard's next.config.ts
+// `rewrites()` reads OPS_BASE_URL and Next.js evaluates rewrites at
+// build time (not only at start). So we DO pass an OPS_BASE_URL at
+// build — but the value is a sentinel placeholder that no boot uses.
+// The properties under test (the inlined __SHOWCASE_CONFIG__ script
+// emitted by `src/app/layout.tsx`) are read from process.env at
+// request time by `getRuntimeConfig()` and therefore reflect the
+// per-boot env values, NOT the build-time placeholder.
+
+const PORT_A = 3801;
+const PORT_B = 3802;
+
+// `__dirname` is undefined under ESM (vitest runs ESM); use Node
+// 20.11+'s `import.meta.dirname` for the path-to-shell-dashboard
+// resolution.
+const SHELL_DASHBOARD_DIR = import.meta.dirname + "/..";
+
+// Sentinel used ONLY to satisfy next.config.ts rewrites() during
+// `next build`. Per-boot env vars below override this for the
+// __SHOWCASE_CONFIG__ injection that the test actually asserts on.
+const BUILD_TIME_OPS_PLACEHOLDER = "http://build-placeholder.invalid";
+
+describe("Option B: one artifact, two env values, no rebuild", () => {
+    beforeAll(() => {
+        // Build ONCE. Pass a placeholder OPS_BASE_URL only so
+        // next.config.ts:rewrites() can construct its proxy entry.
+        // No POCKETBASE_URL / SHELL_URL — those are read at request
+        // time by getRuntimeConfig() and must not be required at build.
+        //
+        // Use `npm run build` (not `npx next build` directly) so the
+        // `prebuild` script runs and the generated data fixtures
+        // (`src/data/registry.json`, `catalog.json`, `docs-status.json`)
+        // exist before webpack walks the import tree.
+        execSync("npm run build", {
+            cwd: SHELL_DASHBOARD_DIR,
+            stdio: "inherit",
+            env: {
+                ...process.env,
+                NODE_ENV: "production",
+                OPS_BASE_URL: BUILD_TIME_OPS_PLACEHOLDER,
+            },
+        });
+    }, 180_000);
+
+    async function bootAndProbe(
+        port: number,
+        env: Record<string, string>,
+    ): Promise<{ pocketbaseUrl: string; shellUrl: string; opsBaseUrl: string }> {
+        const proc: ChildProcess = spawn(
+            "npx",
+            ["next", "start", "-p", String(port)],
+            {
+                cwd: SHELL_DASHBOARD_DIR,
+                env: { ...process.env, NODE_ENV: "production", ...env },
+                stdio: "pipe",
+                detached: false,
+            },
+        );
+        try {
+            // Wait for the server to be ready by polling /.
+            const deadline = Date.now() + 30_000;
+            while (Date.now() < deadline) {
+                try {
+                    const res = await fetch(`http://localhost:${port}/`);
+                    if (res.ok) break;
+                } catch {
+                    // not up yet
+                }
+                await wait(500);
+            }
+            const html = await (await fetch(`http://localhost:${port}/`)).text();
+            // Extract the inlined runtime config from the injected
+            // <script id="__showcase_config__">. The injection pattern
+            // is `window.__SHOWCASE_CONFIG__={"...":"..."};`.
+            const match = html.match(
+                /window\.__SHOWCASE_CONFIG__=(\{[^<]*?\});/,
+            );
+            if (!match) throw new Error("no __SHOWCASE_CONFIG__ in HTML");
+            // The serialized payload has < escaped as < — JSON.parse
+            // accepts it as-is for our keys (URLs don't contain <).
+            const parsed = JSON.parse(match[1]);
+            return parsed;
+        } finally {
+            proc.kill("SIGTERM");
+            // Drain — give the OS a beat to release the port before the
+            // next iteration binds it.
+            await wait(500);
+        }
+    }
+
+    it("serves env-A URLs on the first boot", async () => {
+        const cfg = await bootAndProbe(PORT_A, {
+            POCKETBASE_URL: "https://pb-env-a.example.com",
+            SHELL_URL: "https://shell-env-a.example.com",
+            OPS_BASE_URL: "https://ops-env-a.example.com",
+        });
+        expect(cfg.pocketbaseUrl).toBe("https://pb-env-a.example.com");
+        expect(cfg.shellUrl).toBe("https://shell-env-a.example.com");
+        expect(cfg.opsBaseUrl).toBe("https://ops-env-a.example.com");
+    }, 60_000);
+
+    it("serves env-B URLs on the second boot of THE SAME ARTIFACT", async () => {
+        const cfg = await bootAndProbe(PORT_B, {
+            POCKETBASE_URL: "https://pb-env-b.example.com",
+            SHELL_URL: "https://shell-env-b.example.com",
+            OPS_BASE_URL: "https://ops-env-b.example.com",
+        });
+        expect(cfg.pocketbaseUrl).toBe("https://pb-env-b.example.com");
+        expect(cfg.shellUrl).toBe("https://shell-env-b.example.com");
+        expect(cfg.opsBaseUrl).toBe("https://ops-env-b.example.com");
+    }, 60_000);
+
+    afterAll(() => {
+        // Nothing to clean — the .next/ artifact is intentionally
+        // left in place for inspection; the test doesn't touch it
+        // between runs.
+    });
+});

--- a/showcase/shell-dashboard/vitest.config.ts
+++ b/showcase/shell-dashboard/vitest.config.ts
@@ -8,7 +8,15 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.test.{ts,tsx}"],
+    // Default unit tests live under src/; the spike-replay integration
+    // test for runtime env switching (B13) lives under tests/ because it
+    // spawns `next build` + two `next start` invocations and is too heavy
+    // for the per-file unit suite. The `.spike.test.ts` suffix scopes the
+    // tests/-rooted include narrowly so visual snapshots stay out.
+    include: [
+      "src/**/*.test.{ts,tsx}",
+      "tests/**/*.spike.test.ts",
+    ],
     exclude: ["tests/visual/**", "node_modules/**"],
   },
   resolve: {

--- a/showcase/shell-dashboard/vitest.config.ts
+++ b/showcase/shell-dashboard/vitest.config.ts
@@ -13,10 +13,7 @@ export default defineConfig({
     // spawns `next build` + two `next start` invocations and is too heavy
     // for the per-file unit suite. The `.spike.test.ts` suffix scopes the
     // tests/-rooted include narrowly so visual snapshots stay out.
-    include: [
-      "src/**/*.test.{ts,tsx}",
-      "tests/**/*.spike.test.ts",
-    ],
+    include: ["src/**/*.test.{ts,tsx}", "tests/**/*.spike.test.ts"],
     exclude: ["tests/visual/**", "node_modules/**"],
   },
   resolve: {

--- a/showcase/shell-docs/.env.example
+++ b/showcase/shell-docs/.env.example
@@ -1,18 +1,56 @@
 # shell-docs environment variables.
 #
-# Both NEXT_PUBLIC_* values below are read at REQUEST time (not at
-# build time) — a single built artifact can serve staging and prod by
-# pointing them at different hosts. Missing values in production log a
-# FATAL-CONFIG warning and fall back to the canonical prod host. In dev,
-# missing values fall back to localhost defaults so you can run
-# `next dev` without a .env.local.
+# All values below are read at REQUEST time (not at build time) — a
+# single built artifact can serve staging and prod by pointing them at
+# different hosts. See src/lib/runtime-config.ts for the authoritative
+# resolution rules; the summary below is a quick reference.
+#
+# URL-FATAL semantics: missing in production logs a `FATAL-CONFIG:`
+# error (Sentry-alerted) and falls back to a sentinel URL (visible
+# breakage) or — for fields with a working prod default — a non-fatal
+# warn and the default. Analytics-KEY semantics: missing is the empty
+# string with NO log (consumers no-op on empty).
+#
+# Severity by field:
+#   FATAL-CONFIG on miss:  NEXT_PUBLIC_BASE_URL, NEXT_PUBLIC_SHELL_URL
+#   Non-fatal warn on miss (working prod default):
+#                          NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL,
+#                          NEXT_PUBLIC_POSTHOG_HOST
+#   Silent ("" empty default, no log):
+#                          NEXT_PUBLIC_POSTHOG_KEY,
+#                          NEXT_PUBLIC_SCARF_PIXEL_ID,
+#                          NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID,
+#                          NEXT_PUBLIC_REB2B_KEY,
+#                          NEXT_PUBLIC_REO_KEY
 
 # Canonical base URL used by sitemap.ts, robots.ts, and the per-page
 # canonical metadata. In production this points at the docs host so
 # crawlers index every framework variant at its self-canonical URL.
+# FATAL on miss in prod, falls back to the canonical prod host
+# (https://docs.copilotkit.ai).
 NEXT_PUBLIC_BASE_URL=https://docs.copilotkit.ai
 
 # URL of the showcase shell host, which owns /integrations and /matrix.
 # Used by the top-nav cross-host links and InlineDemo. Replace with your
-# deployment's shell host.
+# deployment's shell host. FATAL on miss in prod, falls back to the
+# sentinel `about:blank#shell-url-missing` (visible breakage).
 NEXT_PUBLIC_SHELL_URL=https://www.copilotkit.ai
+
+# Intelligence platform signup URL — drives the signup-link CTA and the
+# ops-platform-cta. Non-fatal warn on miss in prod; falls back to
+# https://dashboard.operations.copilotkit.ai/ which is a real working
+# host, so absence is recoverable.
+# NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL=https://dashboard.operations.copilotkit.ai/
+
+# PostHog host — analytics destination for `posthog-js`. Non-fatal warn
+# on miss in prod; falls back to https://eu.i.posthog.com (the EU cloud
+# default that matches prior middleware behavior).
+# NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+
+# Analytics keys — empty string disables that analytics channel.
+# Legitimately absent in non-production envs; NO log on miss.
+# NEXT_PUBLIC_POSTHOG_KEY=
+# NEXT_PUBLIC_SCARF_PIXEL_ID=
+# NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID=
+# NEXT_PUBLIC_REB2B_KEY=
+# NEXT_PUBLIC_REO_KEY=

--- a/showcase/shell-docs/.env.example
+++ b/showcase/shell-docs/.env.example
@@ -1,9 +1,11 @@
 # shell-docs environment variables.
 #
-# Both NEXT_PUBLIC_* values below are required for `next build`
-# (next.config.ts throws when either is missing during a production
-# build). In dev, missing values fall back to localhost defaults so
-# you can run `next dev` without a .env.local.
+# Both NEXT_PUBLIC_* values below are read at REQUEST time (not at
+# build time) — a single built artifact can serve staging and prod by
+# pointing them at different hosts. Missing values in production log a
+# FATAL-CONFIG warning and fall back to the canonical prod host. In dev,
+# missing values fall back to localhost defaults so you can run
+# `next dev` without a .env.local.
 
 # Canonical base URL used by sitemap.ts, robots.ts, and the per-page
 # canonical metadata. In production this points at the docs host so

--- a/showcase/shell-docs/Dockerfile
+++ b/showcase/shell-docs/Dockerfile
@@ -1,29 +1,6 @@
 FROM node:20-slim AS builder
 ARG COMMIT_SHA=unknown
 ARG BRANCH=unknown
-# NEXT_PUBLIC_BASE_URL is required at `next build` time (see next.config.ts).
-ARG NEXT_PUBLIC_BASE_URL
-ENV NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL}
-# NEXT_PUBLIC_SHELL_URL is required at `next build` time for links back to
-# the showcase shell host.
-ARG NEXT_PUBLIC_SHELL_URL
-ENV NEXT_PUBLIC_SHELL_URL=${NEXT_PUBLIC_SHELL_URL}
-# Client-side analytics keys. `NEXT_PUBLIC_*` vars are inlined into the
-# client JS bundle at `next build` time — Railway's runtime env doesn't
-# reach this build step, so values must come through as `--build-arg`s
-# from the GHA workflow (`showcase_build.yml` Prepare build args step).
-# Missing values leave the bundle with empty strings; analytics silently
-# no-op in the browser.
-ARG NEXT_PUBLIC_POSTHOG_KEY
-ENV NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY}
-ARG NEXT_PUBLIC_REB2B_KEY
-ENV NEXT_PUBLIC_REB2B_KEY=${NEXT_PUBLIC_REB2B_KEY}
-ARG NEXT_PUBLIC_SCARF_PIXEL_ID
-ENV NEXT_PUBLIC_SCARF_PIXEL_ID=${NEXT_PUBLIC_SCARF_PIXEL_ID}
-ARG NEXT_PUBLIC_REO_KEY
-ENV NEXT_PUBLIC_REO_KEY=${NEXT_PUBLIC_REO_KEY}
-ARG NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID
-ENV NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID=${NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID}
 WORKDIR /app
 
 # Copy only what shell-docs + scripts need

--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -1,57 +1,15 @@
 import type { NextConfig } from "next";
 
-// NEXT_PUBLIC_BASE_URL is inlined automatically by Next.js at build time
-// because of the NEXT_PUBLIC_ prefix. Do NOT re-declare it in an `env` block —
-// doing so bakes the build-time value into server code and overrides runtime env.
-//
-// Consumers in production: src/app/sitemap.ts, src/app/robots.ts, and the
-// per-page `generateMetadata()` canonical URLs in the catch-all routes
-// (src/app/[[...slug]]/page.tsx, src/app/[framework]/[[...slug]]/page.tsx,
-// src/app/reference/[...slug]/page.tsx, src/app/ag-ui/[[...slug]]/page.tsx).
-// All read it through `getBaseUrl()` in src/lib/sitemap-helpers.ts, which
-// falls back to https://docs.copilotkit.ai when unset.
-//
-// Fail fast during an actual `next build` if the variable is missing, so we
-// never ship broken absolute URLs. Other invocations that also load this
-// config (e.g. `next lint`, `next dev`) only warn, because failing them on a
-// missing value would be noise — consumers are expected to handle the dev
-// fallback themselves (e.g. `process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3003"`).
-//
-// Use NEXT_PHASE — the Next.js-canonical signal for production builds —
-// rather than sniffing process.argv, which is fragile (e.g. broken under
-// wrappers, turbo runs, or when invoked programmatically).
-const isNextBuild = process.env.NEXT_PHASE === "phase-production-build";
-
-if (!process.env.NEXT_PUBLIC_BASE_URL) {
-  if (isNextBuild) {
-    throw new Error(
-      "NEXT_PUBLIC_BASE_URL is required for `next build` of showcase/shell-docs. " +
-        "Set it in the environment (e.g. https://your-domain.example) before running the build.",
-    );
-  }
-  // eslint-disable-next-line no-console
-  console.warn(
-    "[shell-docs] NEXT_PUBLIC_BASE_URL is not set; consumers should fall back to a sensible dev default (e.g. http://localhost:3003).",
-  );
-}
-
-// NEXT_PUBLIC_SHELL_URL points at the shell (showcase) host, which owns
-// `/integrations` and `/matrix` — the live integration explorer and
-// feature-matrix pages. Components use it directly in cross-host hrefs
-// (e.g. the top-nav "Integrations" link). Same validation pattern as
-// NEXT_PUBLIC_BASE_URL above: fail at `next build` if missing; warn in dev.
-if (!process.env.NEXT_PUBLIC_SHELL_URL) {
-  if (isNextBuild) {
-    throw new Error(
-      "NEXT_PUBLIC_SHELL_URL is required for `next build` of showcase/shell-docs. " +
-        "Set it to the shell host before running the build.",
-    );
-  }
-  // eslint-disable-next-line no-console
-  console.warn(
-    "[shell-docs] NEXT_PUBLIC_SHELL_URL is not set; consumers should fall back to a sensible dev default (e.g. http://localhost:3000).",
-  );
-}
+// Under Option B (runtime URL injection), NEXT_PUBLIC_BASE_URL and
+// NEXT_PUBLIC_SHELL_URL are read at REQUEST time by the server
+// `getRuntimeConfig()` reader and injected into the client via
+// `window.__SHOWCASE_CONFIG__` from the root layout. They are NOT
+// build-time inputs — a single built artifact can serve staging and
+// prod by changing the Railway env vars. The previous build-time
+// `next build` validation (which threw if either var was unset) is
+// therefore removed: it would prevent the very deploy pattern Option
+// B exists to enable. Missing values are surfaced loudly at runtime
+// via `console.error` from `runtime-config.ts` instead.
 
 const nextConfig: NextConfig = {
   images: {

--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -1,15 +1,13 @@
 import type { NextConfig } from "next";
 
-// Under Option B (runtime URL injection), NEXT_PUBLIC_BASE_URL and
-// NEXT_PUBLIC_SHELL_URL are read at REQUEST time by the server
-// `getRuntimeConfig()` reader and injected into the client via
-// `window.__SHOWCASE_CONFIG__` from the root layout. They are NOT
-// build-time inputs — a single built artifact can serve staging and
-// prod by changing the Railway env vars. The previous build-time
-// `next build` validation (which threw if either var was unset) is
-// therefore removed: it would prevent the very deploy pattern Option
-// B exists to enable. Missing values are surfaced loudly at runtime
-// via `console.error` from `runtime-config.ts` instead.
+// NEXT_PUBLIC_BASE_URL and NEXT_PUBLIC_SHELL_URL are read at REQUEST
+// time by the server `getRuntimeConfig()` reader and injected into the
+// client via `window.__SHOWCASE_CONFIG__` from the root layout. They
+// are NOT build-time inputs — a single built artifact can serve staging
+// and prod by changing the Railway env vars. Any previous build-time
+// validation that threw on unset env vars would prevent that exact
+// deploy pattern. Missing values are surfaced loudly at runtime via
+// `console.error` from `runtime-config.ts` instead.
 
 const nextConfig: NextConfig = {
   images: {

--- a/showcase/shell-docs/src/app/layout.tsx
+++ b/showcase/shell-docs/src/app/layout.tsx
@@ -10,7 +10,45 @@ import { ShellSearchProvider } from "@/components/search-trigger";
 import { PostHogProvider } from "@/lib/providers/posthog-provider";
 import { ScarfPixel } from "@/lib/providers/scarf-pixel";
 import { getIntegrations } from "@/lib/registry";
+import { getRuntimeConfig } from "@/lib/runtime-config";
 import "./globals.css";
+
+/**
+ * Serialize the runtime config for inline injection. We must
+ * JSON.stringify-then-escape because the value lands inside a
+ * `<script>...</script>` tag, where three substrings would otherwise
+ * break out of (or corrupt) the parser:
+ *
+ *   - `<` — guards against the `</script>` breakout (XSS). JSON.stringify
+ *     does NOT escape `<` by default, so a URL containing `</script>`
+ *     (e.g. a hostile env value) would terminate the inline script and
+ *     inject HTML. Escape every `<` to `<` so the substring
+ *     `</script>` can never appear.
+ *   - ` ` (LINE SEPARATOR) and ` ` (PARAGRAPH SEPARATOR) —
+ *     legal inside JSON strings, but a syntax error inside a JS string
+ *     literal in older engines / when the page is parsed as
+ *     `text/javascript`. Escape both.
+ *
+ * The regex sources below are written with explicit ` ` / ` `
+ * ECMAScript-Unicode escapes — the regex engine resolves the escape at
+ * runtime, so the literal codepoint is matched.
+ *
+ * Canonical OWASP-recommended escape for inline JSON in HTML.
+ */
+const LS_RE = new RegExp("\u2028", "g");
+const PS_RE = new RegExp("\u2029", "g");
+
+// Tokenizer note: writing the literal U+2028 / U+2029 codepoints inside
+// a /regex/ literal is impossible because TS treats them as line
+// terminators and the regex becomes unterminated. Constructing via
+// new RegExp("\uXXXX", "g") sidesteps the tokenizer entirely: the
+// regex engine resolves the escape at runtime.
+function serializeRuntimeConfig(cfg: unknown): string {
+  return JSON.stringify(cfg)
+    .replace(/</g, "\\u003c")
+    .replace(LS_RE, "\\u2028")
+    .replace(PS_RE, "\\u2029");
+}
 
 // Top-level route segments in src/app/ that must not be mistaken for
 // framework slugs by FrameworkProvider.urlFramework. If an integration
@@ -78,8 +116,14 @@ export default function RootLayout({
         ? "unknown"
         : rawSha.slice(0, 7);
 
-  const REO_KEY = process.env.NEXT_PUBLIC_REO_KEY;
-  const REB2B_KEY = process.env.NEXT_PUBLIC_REB2B_KEY;
+  // Server-side: read live env at request time. `unstable_noStore()`
+  // inside getRuntimeConfig opts this segment out of the static
+  // cache so the inline <script> below always reflects the current
+  // Railway env vars.
+  const runtimeConfig = getRuntimeConfig();
+  const injection = `window.__SHOWCASE_CONFIG__=${serializeRuntimeConfig(runtimeConfig)};`;
+  const REO_KEY = runtimeConfig.reoKey;
+  const REB2B_KEY = runtimeConfig.reb2bKey;
 
   return (
     // suppressHydrationWarning is required because the inline theme-init
@@ -95,6 +139,19 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <head>
+        {/* MUST be the first child of <head>. Every client component
+         * reads window.__SHOWCASE_CONFIG__ during hydration; populating
+         * it from a raw inline <script> guarantees the value is set
+         * before the parser reaches any next-script beforeInteractive
+         * block (those run after the parser passes our inline script).
+         * Using a plain <script> rather than next/script also avoids
+         * the deferred-execution semantics of `strategy="beforeInteractive"`
+         * — `beforeInteractive` runs before hydration but AFTER raw
+         * parse-time scripts. */}
+        <script
+          id="__showcase_config__"
+          dangerouslySetInnerHTML={{ __html: injection }}
+        />
         {/* Apply the persisted theme before first paint to avoid a
          * light-flash on dark-preferring loads. Reads `localStorage.theme`
          * and falls back to `prefers-color-scheme` when the persisted

--- a/showcase/shell-docs/src/app/layout.tsx
+++ b/showcase/shell-docs/src/app/layout.tsx
@@ -11,44 +11,13 @@ import { PostHogProvider } from "@/lib/providers/posthog-provider";
 import { ScarfPixel } from "@/lib/providers/scarf-pixel";
 import { getIntegrations } from "@/lib/registry";
 import { getRuntimeConfig } from "@/lib/runtime-config";
+import { serializeRuntimeConfig } from "@/lib/runtime-config-serialize";
 import "./globals.css";
 
-/**
- * Serialize the runtime config for inline injection. We must
- * JSON.stringify-then-escape because the value lands inside a
- * `<script>...</script>` tag, where three substrings would otherwise
- * break out of (or corrupt) the parser:
- *
- *   - `<` — guards against the `</script>` breakout (XSS). JSON.stringify
- *     does NOT escape `<` by default, so a URL containing `</script>`
- *     (e.g. a hostile env value) would terminate the inline script and
- *     inject HTML. Escape every `<` to `<` so the substring
- *     `</script>` can never appear.
- *   - ` ` (LINE SEPARATOR) and ` ` (PARAGRAPH SEPARATOR) —
- *     legal inside JSON strings, but a syntax error inside a JS string
- *     literal in older engines / when the page is parsed as
- *     `text/javascript`. Escape both.
- *
- * The regex sources below are written with explicit ` ` / ` `
- * ECMAScript-Unicode escapes — the regex engine resolves the escape at
- * runtime, so the literal codepoint is matched.
- *
- * Canonical OWASP-recommended escape for inline JSON in HTML.
- */
-const LS_RE = new RegExp("\u2028", "g");
-const PS_RE = new RegExp("\u2029", "g");
-
-// Tokenizer note: writing the literal U+2028 / U+2029 codepoints inside
-// a /regex/ literal is impossible because TS treats them as line
-// terminators and the regex becomes unterminated. Constructing via
-// new RegExp("\uXXXX", "g") sidesteps the tokenizer entirely: the
-// regex engine resolves the escape at runtime.
-function serializeRuntimeConfig(cfg: unknown): string {
-  return JSON.stringify(cfg)
-    .replace(/</g, "\\u003c")
-    .replace(LS_RE, "\\u2028")
-    .replace(PS_RE, "\\u2029");
-}
+// serializeRuntimeConfig is extracted to `lib/runtime-config-serialize.ts`
+// so it can be unit-tested for the OWASP escape behavior (XSS via
+// `</script>`, U+2028/U+2029 line-terminator injection) without
+// importing the layout into the test runner.
 
 // Top-level route segments in src/app/ that must not be mistaken for
 // framework slugs by FrameworkProvider.urlFramework. If an integration

--- a/showcase/shell-docs/src/app/robots.ts
+++ b/showcase/shell-docs/src/app/robots.ts
@@ -5,6 +5,11 @@
 import type { MetadataRoute } from "next";
 import { getBaseUrl } from "@/lib/sitemap-helpers";
 
+// Force-dynamic so the emitted sitemap URL reflects the live
+// NEXT_PUBLIC_BASE_URL at request time — see app/sitemap.ts for the
+// same rationale.
+export const dynamic = "force-dynamic";
+
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = getBaseUrl();
   return {

--- a/showcase/shell-docs/src/app/sitemap.ts
+++ b/showcase/shell-docs/src/app/sitemap.ts
@@ -30,7 +30,7 @@ import { getDocsFolder, getIntegrations } from "@/lib/registry";
 // the LIVE NEXT_PUBLIC_BASE_URL via getRuntimeConfig(). Without this
 // Next.js would statically prerender the sitemap at build time and
 // freeze whichever value `process.env.NEXT_PUBLIC_BASE_URL` had at
-// `next build` — defeating the Option B runtime-config switch.
+// `next build` — defeating the runtime-config switch.
 export const dynamic = "force-dynamic";
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/showcase/shell-docs/src/app/sitemap.ts
+++ b/showcase/shell-docs/src/app/sitemap.ts
@@ -26,6 +26,13 @@ import {
 } from "@/lib/sitemap-helpers";
 import { getDocsFolder, getIntegrations } from "@/lib/registry";
 
+// Force-dynamic so the sitemap is regenerated per request and reads
+// the LIVE NEXT_PUBLIC_BASE_URL via getRuntimeConfig(). Without this
+// Next.js would statically prerender the sitemap at build time and
+// freeze whichever value `process.env.NEXT_PUBLIC_BASE_URL` had at
+// `next build` — defeating the Option B runtime-config switch.
+export const dynamic = "force-dynamic";
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = getBaseUrl();
   const now = new Date();

--- a/showcase/shell-docs/src/components/ai/page-actions.tsx
+++ b/showcase/shell-docs/src/components/ai/page-actions.tsx
@@ -22,20 +22,23 @@ import ClaudeIcon from "@/components/icons/claude";
 import ClaudeCodeIcon from "@/components/icons/claude-code";
 import CodexIcon from "@/components/icons/codex";
 import WindsurfIcon from "@/components/icons/windsurf";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
 /**
- * Resolve the canonical base URL on the client. Inlined here (instead of
- * imported from `@/lib/sitemap-helpers`) because that module also pulls
- * in `fs` / `path` / `gray-matter` for sitemap generation — Node-only
- * deps that fail the Next.js client bundle when this `"use client"`
- * component reaches for them. The env var contract is identical:
- * `NEXT_PUBLIC_BASE_URL` (set in production), prod fallback otherwise,
- * with trailing slash stripped so callers can concatenate
+ * Resolve the canonical base URL on the client. Reads from
+ * window.__SHOWCASE_CONFIG__ (populated by the root layout's inline
+ * <script>) so the rendered absolute URL reflects the current deploy's
+ * NEXT_PUBLIC_BASE_URL without rebuilding the artifact. The runtime
+ * reader already strips trailing slashes so callers can concatenate
  * `${BASE}${path}` safely.
+ *
+ * Still inlined here (rather than reaching into `@/lib/sitemap-helpers`)
+ * because that module also pulls in `fs` / `path` / `gray-matter` for
+ * sitemap generation — Node-only deps that fail the client bundle when
+ * a `"use client"` component reaches for them.
  */
 function getClientBaseUrl(): string {
-  const raw = process.env.NEXT_PUBLIC_BASE_URL || "https://docs.copilotkit.ai";
-  return raw.replace(/\/+$/, "");
+  return getRuntimeConfig().baseUrl;
 }
 
 // Module-scoped cache of resolved markdown bodies. Survives navigations

--- a/showcase/shell-docs/src/components/ai/page-actions.tsx
+++ b/showcase/shell-docs/src/components/ai/page-actions.tsx
@@ -294,6 +294,11 @@ export function ViewOptionsPopover({
             href={item.href}
             rel="noreferrer noopener"
             target="_blank"
+            // item.href embeds `getClientBaseUrl()` (the SSR placeholder
+            // during server-render, real value post-hydration), so React
+            // would log a hydration mismatch on every popover anchor.
+            // Suppression scopes to this attribute mismatch only.
+            suppressHydrationWarning
             // Fire a PostHog event keyed by `target` (github, windsurf,
             // claude, chatgpt, codex, view-as-markdown, etc.) so the
             // analytics dashboard can attribute LLM-routing intent to

--- a/showcase/shell-docs/src/components/integration-grid.tsx
+++ b/showcase/shell-docs/src/components/integration-grid.tsx
@@ -46,6 +46,11 @@ export function IntegrationGrid({
         <a
           href={`${shellHost}/integrations`}
           style={{ color: "var(--accent)" }}
+          // shellHost is the SSR placeholder during server-render and the
+          // real value post-hydration (runtime-config.client.ts). React
+          // would otherwise log a hydration mismatch on this href every
+          // pageload; suppression scopes to THIS attribute mismatch only.
+          suppressHydrationWarning
         >
           Integrations
         </a>{" "}

--- a/showcase/shell-docs/src/components/integration-grid.tsx
+++ b/showcase/shell-docs/src/components/integration-grid.tsx
@@ -2,8 +2,7 @@
 
 import React from "react";
 import { useFramework } from "./framework-provider";
-
-const SHELL_HOST = process.env.NEXT_PUBLIC_SHELL_URL ?? "http://localhost:3000";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
 export function IntegrationGrid({
   path,
@@ -17,6 +16,13 @@ export function IntegrationGrid({
 
   // On a framework-scoped route the user already chose a backend — hide.
   if (framework) return null;
+
+  // Shell host is now read at runtime from window.__SHOWCASE_CONFIG__
+  // (set by the root layout) so the rendered <a href> reflects the
+  // current deploy's NEXT_PUBLIC_SHELL_URL without a rebuild. Pulled
+  // after the early-return so we never call into the client reader on
+  // renders that produce no DOM.
+  const shellHost = getRuntimeConfig().shellUrl;
 
   return (
     <>
@@ -38,7 +44,7 @@ export function IntegrationGrid({
       >
         See{" "}
         <a
-          href={`${SHELL_HOST}/integrations`}
+          href={`${shellHost}/integrations`}
           style={{ color: "var(--accent)" }}
         >
           Integrations

--- a/showcase/shell-docs/src/components/react/__tests__/signup-link.ssr.test.tsx
+++ b/showcase/shell-docs/src/components/react/__tests__/signup-link.ssr.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SignupLink } from "../signup-link";
+import { OpsPlatformCTA } from "../ops-platform-cta";
+
+// These tests exercise the SSR path of "use client" components whose
+// render-time bodies call `new URL(getRuntimeConfig().<url>)`. During
+// SSR the client reader returns the SSR_PLACEHOLDER (no window); if any
+// URL field there is the empty string, `new URL("")` throws and the
+// whole server-rendered HTML response 500s. The placeholder MUST be a
+// parseable URL.
+
+describe("client component SSR safety (shell-docs)", () => {
+  beforeEach(() => {
+    // Force SSR path — getRuntimeConfig() in runtime-config.client.ts
+    // returns the SSR_PLACEHOLDER when `typeof window === "undefined"`.
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  it("SignupLink SSR-renders without throwing", () => {
+    expect(() =>
+      renderToStaticMarkup(
+        React.createElement(SignupLink, { surface: "test" }, "Sign up"),
+      ),
+    ).not.toThrow();
+  });
+
+  it("SignupLink SSR href parses as a URL", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SignupLink, { surface: "test" }, "Sign up"),
+    );
+    const match = html.match(/href="([^"]+)"/);
+    expect(match).not.toBeNull();
+    expect(() => new URL(match![1])).not.toThrow();
+  });
+
+  it("OpsPlatformCTA SSR-renders without throwing", () => {
+    expect(() =>
+      renderToStaticMarkup(
+        React.createElement(OpsPlatformCTA, {
+          title: "Test",
+          surface: "test-surface",
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("OpsPlatformCTA SSR href parses as a URL", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OpsPlatformCTA, {
+        title: "Test",
+        surface: "test-surface",
+      }),
+    );
+    const match = html.match(/href="([^"]+)"/);
+    expect(match).not.toBeNull();
+    expect(() => new URL(match![1])).not.toThrow();
+  });
+});

--- a/showcase/shell-docs/src/components/react/ops-platform-cta.tsx
+++ b/showcase/shell-docs/src/components/react/ops-platform-cta.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CopilotKitMark } from "@/components/copilotkit-mark";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
 // Icons inlined as SVG so this component avoids a lucide-react dep
 // (shell-docs deliberately keeps icon usage minimal — see mdx-registry's
@@ -47,11 +48,6 @@ function Info({ className }: { className?: string }) {
   );
 }
 
-const DEFAULT_SIGNUP_URL = "https://dashboard.operations.copilotkit.ai/";
-
-const SIGNUP_URL =
-  process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL || DEFAULT_SIGNUP_URL;
-
 export type OpsPlatformCTAVariant = "tile" | "inline" | "card" | "info";
 
 export interface OpsPlatformCTAProps {
@@ -73,7 +69,12 @@ export interface OpsPlatformCTAProps {
 }
 
 function buildHref(surface: string): string {
-  const url = new URL(SIGNUP_URL);
+  // Signup URL is read at render time from the runtime config injected
+  // by the root layout — see signup-link.tsx and lib/runtime-config.ts
+  // for the full plumbing rationale. Keeps a single artifact retargetable
+  // across Railway envs without rebuild.
+  const signupUrl = getRuntimeConfig().intelligenceSignupUrl;
+  const url = new URL(signupUrl);
   url.searchParams.set("utm_source", "docs");
   url.searchParams.set("utm_medium", "cta");
   url.searchParams.set("utm_campaign", "intelligence");

--- a/showcase/shell-docs/src/components/react/signup-link.tsx
+++ b/showcase/shell-docs/src/components/react/signup-link.tsx
@@ -2,11 +2,7 @@
 
 import posthog from "posthog-js";
 import { useCallback } from "react";
-
-const DEFAULT_SIGNUP_URL = "https://dashboard.operations.copilotkit.ai/";
-
-const SIGNUP_URL =
-  process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL || DEFAULT_SIGNUP_URL;
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
 export interface SignupLinkProps {
   /** Stable identifier for analytics, e.g. "docs_langgraph_quickstart_step1" */
@@ -15,7 +11,12 @@ export interface SignupLinkProps {
 }
 
 function buildHref(surface: string): string {
-  const url = new URL(SIGNUP_URL);
+  // Read the signup URL at render time from the runtime config injected
+  // by the root layout so a single built artifact can point at staging
+  // vs prod by changing the Railway env var. The reader already returns
+  // a fallback when NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL is unset.
+  const signupUrl = getRuntimeConfig().intelligenceSignupUrl;
+  const url = new URL(signupUrl);
   url.searchParams.set("utm_source", "docs");
   url.searchParams.set("utm_medium", "cta");
   url.searchParams.set("utm_campaign", "intelligence");

--- a/showcase/shell-docs/src/components/search-modal.tsx
+++ b/showcase/shell-docs/src/components/search-modal.tsx
@@ -8,11 +8,14 @@ import { DEFAULT_FRAMEWORK, useFramework } from "./framework-provider";
 import { FrameworkLogo } from "./icons/framework-icons";
 import { compareByDisplayOrder } from "@/lib/framework-order";
 import type { Registry } from "@/lib/registry";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
 // Integrations explorer + per-integration demo pages live on the shell
 // host (showcase.copilotkit.ai), not on shell-docs. Search results that
-// surface an integration or one of its demos route there directly.
-const SHELL_HOST = process.env.NEXT_PUBLIC_SHELL_URL ?? "http://localhost:3000";
+// surface an integration or one of its demos route there directly. The
+// shell host is now read at runtime from window.__SHOWCASE_CONFIG__
+// (set by the root layout) so a single built artifact can serve
+// staging vs prod without rebuilding — see lib/runtime-config.client.
 
 type SearchResultType =
   | "integration"
@@ -125,9 +128,9 @@ function frameworkDocsHref(framework: string, topic: string): string {
   return topic ? `/${framework}/${topic}` : `/${framework}`;
 }
 
-function normalizeHref(href: string): string {
+function normalizeHref(href: string, shellHost: string): string {
   if (href === "/integrations" || href === "/matrix") {
-    return `${SHELL_HOST}${href}`;
+    return `${shellHost}${href}`;
   }
   if (href.startsWith("/docs/")) {
     return href.slice("/docs".length) || "/";
@@ -274,6 +277,13 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
     [setStoredFramework],
   );
 
+  // Read the shell host once per render from the runtime config injected
+  // into window by the root layout. Pulled inside the component (not at
+  // module top) because the value only exists after hydration and the
+  // client reader throws on the server. Threaded into normalizeHref()
+  // and the integration href below so neither one re-reads window.
+  const shellHost = getRuntimeConfig().shellUrl;
+
   const results = useMemo(() => {
     if (!query.trim()) return [];
 
@@ -339,7 +349,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
           docsGroups.set(docsTopic, {
             topic: docsTopic,
             entry: p,
-            href: normalizeHref(p.href),
+            href: normalizeHref(p.href, shellHost),
           });
         }
         continue;
@@ -352,7 +362,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
           title: p.title,
           subtitle: p.subtitle,
           section: p.section,
-          href: normalizeHref(p.href),
+          href: normalizeHref(p.href, shellHost),
         });
       }
     }
@@ -387,7 +397,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
             type: "integration",
             title: i.name,
             subtitle: (i.description || "").slice(0, 80),
-            href: `${SHELL_HOST}/integrations/${i.slug}`,
+            href: `${shellHost}/integrations/${i.slug}`,
           });
         }
       }
@@ -408,7 +418,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
     return dedupeResults(items)
       .sort((a, b) => scoreResult(a, q) - scoreResult(b, q))
       .slice(0, 12);
-  }, [query, registryData, selectedFramework, frameworkOptions]);
+  }, [query, registryData, selectedFramework, frameworkOptions, shellHost]);
 
   useEffect(() => {
     setSelectedIndex((idx) =>

--- a/showcase/shell-docs/src/lib/hooks/use-google-analytics.test.ts
+++ b/showcase/shell-docs/src/lib/hooks/use-google-analytics.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// React's Rules of Hooks forbid calling hooks AFTER a conditional return.
+// Doing so means a render where GA_ID is empty calls 0 hooks, and a
+// subsequent render after hydration where GA_ID is populated calls
+// usePathname() + two useEffects — different hook counts across renders
+// of the same component instance trigger "Rendered more hooks than
+// during the previous render" and tear the page down on the client.
+//
+// The pattern this file enforces: all hook calls live BEFORE any
+// conditional early return; the GA_ID truthiness gate moves INSIDE the
+// effect bodies (mirroring the pattern used in posthog-provider.tsx).
+//
+// Source-level assertion because the project has no jsdom / no
+// react-test-renderer; a true cross-render reproduction needs one of
+// those. Source assertion is sufficient: rules-of-hooks linting is the
+// same check React itself runs at runtime — we're just running it
+// against the file's textual structure.
+
+describe("useGoogleAnalytics: hooks unconditional (rules of hooks)", () => {
+  const sourcePath = resolve(__dirname, "./use-google-analytics.tsx");
+  const source = readFileSync(sourcePath, "utf8");
+
+  // Strip leading "use client" / imports / comments so the bodyOnly
+  // string is just the function body region we care about.
+  const fnStart = source.indexOf("export function useGoogleAnalytics");
+  // Guard against a refactor that renames the export so this test
+  // doesn't silently start passing on an unrelated file shape.
+  expect(fnStart, "expected useGoogleAnalytics export").toBeGreaterThan(-1);
+  const body = source.slice(fnStart);
+
+  it("does not early-return before calling hooks", () => {
+    // Find the index of the first 'return;' (the bug-shape early
+    // return) and the first hook call. If the early return precedes
+    // any hook, that's the bug.
+    const earlyReturn = body.search(/if\s*\(\s*!GA_ID\s*\)\s*[{\s]*return\s*;/);
+    const firstUsePathname = body.indexOf("usePathname(");
+    const firstUseEffect = body.indexOf("useEffect(");
+
+    // If there's no bug-shape early return at all, the test trivially
+    // passes (the hook authoring is clean).
+    if (earlyReturn === -1) {
+      expect(true).toBe(true);
+      return;
+    }
+
+    expect(
+      firstUsePathname,
+      "usePathname() must be called before any conditional return",
+    ).toBeLessThan(earlyReturn);
+    expect(
+      firstUseEffect,
+      "useEffect() must be called before any conditional return",
+    ).toBeLessThan(earlyReturn);
+  });
+});

--- a/showcase/shell-docs/src/lib/hooks/use-google-analytics.test.ts
+++ b/showcase/shell-docs/src/lib/hooks/use-google-analytics.test.ts
@@ -33,16 +33,28 @@ describe("useGoogleAnalytics: hooks unconditional (rules of hooks)", () => {
 
   it("does not early-return before calling hooks", () => {
     // Find the index of the first 'return;' (the bug-shape early
-    // return) and the first hook call. If the early return precedes
-    // any hook, that's the bug.
+    // return) and the first hook call.
     const earlyReturn = body.search(/if\s*\(\s*!GA_ID\s*\)\s*[{\s]*return\s*;/);
     const firstUsePathname = body.indexOf("usePathname(");
     const firstUseEffect = body.indexOf("useEffect(");
 
-    // If there's no bug-shape early return at all, the test trivially
-    // passes (the hook authoring is clean).
+    // First, the hook calls MUST exist in the source — otherwise a
+    // refactor that deleted all hooks would silently satisfy the
+    // "hooks-before-early-return" check (everything is `-1`, and the
+    // tautology branch trivially passed).
+    expect(
+      firstUsePathname,
+      "usePathname() must be called by useGoogleAnalytics",
+    ).toBeGreaterThan(-1);
+    expect(
+      firstUseEffect,
+      "useEffect() must be called by useGoogleAnalytics",
+    ).toBeGreaterThan(-1);
+
     if (earlyReturn === -1) {
-      expect(true).toBe(true);
+      // No bug-shape early return at all — the hook authoring is clean
+      // and the hooks exist. The presence-checks above are the
+      // meaningful assertions in this case (no tautology).
       return;
     }
 

--- a/showcase/shell-docs/src/lib/hooks/use-google-analytics.tsx
+++ b/showcase/shell-docs/src/lib/hooks/use-google-analytics.tsx
@@ -4,9 +4,13 @@ import { usePathname } from "next/navigation";
 import { useEffect } from "react";
 import ReactGA from "react-ga4";
 import { normalizePathnameForAnalytics } from "@/lib/analytics-utils";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
 export function useGoogleAnalytics() {
-  const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID;
+  // Tracking ID is read at render time from the runtime config injected
+  // by the root layout. Empty string disables GA — the early return
+  // below already gates on truthiness.
+  const GA_ID = getRuntimeConfig().googleAnalyticsTrackingId;
 
   if (!GA_ID) {
     return;

--- a/showcase/shell-docs/src/lib/hooks/use-google-analytics.tsx
+++ b/showcase/shell-docs/src/lib/hooks/use-google-analytics.tsx
@@ -8,22 +8,22 @@ import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
 export function useGoogleAnalytics() {
   // Tracking ID is read at render time from the runtime config injected
-  // by the root layout. Empty string disables GA — the early return
-  // below already gates on truthiness.
+  // by the root layout. Empty string disables GA — but the gating MUST
+  // live INSIDE the effect bodies, not as an early return, otherwise
+  // React's rules-of-hooks are violated (hooks below the conditional
+  // return would be skipped on renders where GA is disabled, which
+  // changes hook order between renders and crashes React).
   const GA_ID = getRuntimeConfig().googleAnalyticsTrackingId;
-
-  if (!GA_ID) {
-    return;
-  }
-
   const pathname = usePathname();
 
   useEffect(() => {
+    if (!GA_ID) return;
     ReactGA.initialize([{ trackingId: GA_ID }]);
-  }, []);
+  }, [GA_ID]);
 
   useEffect(() => {
+    if (!GA_ID) return;
     const normalizedPathname = normalizePathnameForAnalytics(pathname);
     ReactGA.send({ hitType: "pageview", page: normalizedPathname });
-  }, [pathname]);
+  }, [pathname, GA_ID]);
 }

--- a/showcase/shell-docs/src/lib/providers/posthog-provider.tsx
+++ b/showcase/shell-docs/src/lib/providers/posthog-provider.tsx
@@ -4,8 +4,8 @@ import { PostHogProvider as PostHogProviderBase } from "posthog-js/react";
 import posthog from "posthog-js";
 import { useEffect, useState, useRef } from "react";
 import { usePathname } from "next/navigation";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
-const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 // Reverse-proxied via /ingest/* rewrites in next.config.ts so requests
 // flow through the docs host instead of *.i.posthog.com — bypasses
 // ad blockers / tracking-protection that target the PostHog hostname.
@@ -25,6 +25,11 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const [sessionId, setSessionId] = useState<string | null>(null);
   const isInitializedRef = useRef(false);
+
+  // Pull the PostHog key from the runtime config injected by the root
+  // layout — empty string means "analytics disabled in this env" and
+  // the init/capture branches below already gate on truthiness.
+  const POSTHOG_KEY = getRuntimeConfig().posthogKey;
 
   // Read session_id from URL only on client side to avoid hydration mismatch
   useEffect(() => {

--- a/showcase/shell-docs/src/lib/providers/scarf-pixel.tsx
+++ b/showcase/shell-docs/src/lib/providers/scarf-pixel.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import React from "react";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
 export function ScarfPixel() {
-  const SCARF_PIXEL_ID = process.env.NEXT_PUBLIC_SCARF_PIXEL_ID;
+  // Pixel ID from the runtime config injected by the root layout —
+  // empty string disables the pixel (consumer no-ops on falsy).
+  const SCARF_PIXEL_ID = getRuntimeConfig().scarfPixelId;
   if (!SCARF_PIXEL_ID) return null;
   return (
     <img

--- a/showcase/shell-docs/src/lib/runtime-config-serialize.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config-serialize.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { serializeRuntimeConfig } from "./runtime-config-serialize";
+
+// Pin a security-critical path: the inline-injected runtime config
+// lands inside a <script>...</script> block in the root layout. A
+// hostile env value containing the closing-script substring would
+// otherwise break out and let the attacker inject arbitrary HTML.
+// JSON.stringify does NOT escape `<` by default, so we MUST escape
+// it to `<` here. U+2028 / U+2029 must also be escaped because
+// the JS string literal parser treats them as line terminators in
+// older engines.
+//
+// Tokenizer note: we build the test inputs via String.fromCharCode
+// so the literal U+2028 / U+2029 codepoints never appear in this
+// source file (some editors / build pipelines reject them).
+
+const LS = String.fromCharCode(0x2028);
+const PS = String.fromCharCode(0x2029);
+
+describe("serializeRuntimeConfig (shell-docs)", () => {
+  it("escapes `<` so the closing-script substring cannot appear in the output", () => {
+    const malicious = { baseUrl: "</script><script>alert(1)</script>" };
+    const serialized = serializeRuntimeConfig(malicious);
+    expect(serialized).not.toContain("</script>");
+    expect(serialized).toContain("\\u003c");
+  });
+
+  it("escapes U+2028 (LINE SEPARATOR) to \\u2028", () => {
+    const cfg = { baseUrl: `before${LS}after` };
+    const serialized = serializeRuntimeConfig(cfg);
+    expect(serialized).not.toContain(LS);
+    expect(serialized).toContain("\\u2028");
+  });
+
+  it("escapes U+2029 (PARAGRAPH SEPARATOR) to \\u2029", () => {
+    const cfg = { baseUrl: `before${PS}after` };
+    const serialized = serializeRuntimeConfig(cfg);
+    expect(serialized).not.toContain(PS);
+    expect(serialized).toContain("\\u2029");
+  });
+
+  it("round-trips a normal config via JSON.parse", () => {
+    const cfg = {
+      baseUrl: "https://docs.example.com",
+      shellUrl: "https://shell.example.com",
+      posthogKey: "phc_real",
+    };
+    const serialized = serializeRuntimeConfig(cfg);
+    // The browser receives `window.__SHOWCASE_CONFIG__=<serialized>;`
+    // and evaluates it. JSON.parse accepts the escaped output
+    // identically (the JS engine resolves < / <LS> / <PS>).
+    expect(JSON.parse(serialized)).toEqual(cfg);
+  });
+
+  it("does not double-escape already-safe characters", () => {
+    const cfg = { baseUrl: "https://docs.copilotkit.ai" };
+    const serialized = serializeRuntimeConfig(cfg);
+    expect(serialized).toBe(JSON.stringify(cfg));
+  });
+});

--- a/showcase/shell-docs/src/lib/runtime-config-serialize.ts
+++ b/showcase/shell-docs/src/lib/runtime-config-serialize.ts
@@ -1,0 +1,31 @@
+// Serialize the runtime config for inline injection into the root
+// layout's `<script>...</script>` block. Three substrings would
+// otherwise break out of (or corrupt) the parser:
+//
+//   - `<` — guards against the `</script>` breakout (XSS). JSON.stringify
+//     does NOT escape `<` by default, so a URL containing `</script>`
+//     (e.g. a hostile env value) would terminate the inline script and
+//     inject HTML. Escape every `<` to `<` so the substring
+//     `</script>` can never appear.
+//   - U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) — legal
+//     inside JSON strings, but a syntax error inside a JS string literal
+//     in older engines / when the page is parsed as `text/javascript`.
+//     Escape both.
+//
+// Tokenizer note: writing the literal U+2028 / U+2029 codepoints inside
+// a /regex/ literal is impossible because TS / pre-ES2019 engines treat
+// them as line terminators and the regex literal becomes unterminated.
+// Constructing via new RegExp("\uXXXX", "g") sidesteps the tokenizer
+// entirely — the regex engine resolves the escape at runtime.
+//
+// Canonical OWASP-recommended escape for inline JSON in HTML.
+
+const LS_RE = new RegExp(" ", "g");
+const PS_RE = new RegExp(" ", "g");
+
+export function serializeRuntimeConfig(cfg: unknown): string {
+  return JSON.stringify(cfg)
+    .replace(/</g, "\\u003c")
+    .replace(LS_RE, "\\u2028")
+    .replace(PS_RE, "\\u2029");
+}

--- a/showcase/shell-docs/src/lib/runtime-config-serialize.ts
+++ b/showcase/shell-docs/src/lib/runtime-config-serialize.ts
@@ -2,30 +2,31 @@
 // layout's `<script>...</script>` block. Three substrings would
 // otherwise break out of (or corrupt) the parser:
 //
-//   - `<` — guards against the `</script>` breakout (XSS). JSON.stringify
+//   - `<` -- guards against the `</script>` breakout (XSS). JSON.stringify
 //     does NOT escape `<` by default, so a URL containing `</script>`
 //     (e.g. a hostile env value) would terminate the inline script and
 //     inject HTML. Escape every `<` to `<` so the substring
 //     `</script>` can never appear.
-//   - U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) — legal
+//   - U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) -- legal
 //     inside JSON strings, but a syntax error inside a JS string literal
 //     in older engines / when the page is parsed as `text/javascript`.
 //     Escape both.
 //
-// Tokenizer note: writing the literal U+2028 / U+2029 codepoints inside
-// a /regex/ literal is impossible because TS / pre-ES2019 engines treat
-// them as line terminators and the regex literal becomes unterminated.
-// Constructing via new RegExp("\uXXXX", "g") sidesteps the tokenizer
-// entirely — the regex engine resolves the escape at runtime.
+// Tokenizer note: the U+2028 / U+2029 codepoints in the RegExp argument
+// are written as six-character ASCII backslash-u escape sequences,
+// resolved at runtime by the regex engine, NOT as the literal Unicode
+// codepoints. A formatter or editor that silently normalizes line
+// terminators could otherwise strip the literal codepoints, leaving a
+// regex that matches nothing and a security-critical XSS escape that
+// silently no-ops. The escape-string form is robust to any such
+// formatter pass. This file MUST NOT contain the literal U+2028 or
+// U+2029 bytes anywhere in its source.
 //
 // Canonical OWASP-recommended escape for inline JSON in HTML.
 
-const LS_RE = new RegExp(" ", "g");
-const PS_RE = new RegExp(" ", "g");
-
 export function serializeRuntimeConfig(cfg: unknown): string {
   return JSON.stringify(cfg)
-    .replace(/</g, "\\u003c")
-    .replace(LS_RE, "\\u2028")
-    .replace(PS_RE, "\\u2029");
+    .replace(new RegExp("<", "g"), "\\u003c")
+    .replace(new RegExp("\\u2028", "g"), "\\u2028")
+    .replace(new RegExp("\\u2029", "g"), "\\u2029");
 }

--- a/showcase/shell-docs/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.client.test.ts
@@ -47,20 +47,22 @@ describe("client getRuntimeConfig (shell-docs)", () => {
   it("returns SSR sentinel placeholder when window is undefined", () => {
     // Simulate SSR by removing window. "use client" component bodies
     // execute on the server during SSR, so this reader MUST be SSR-safe
-    // (returns empty-string placeholders that get replaced on the next
-    // render after hydration), NOT throw — otherwise the whole
-    // server-rendered HTML 500s.
+    // (returns parseable-URL placeholders for URL fields so `new URL()`
+    // calls in consumers don't throw, and empty strings for analytics
+    // keys so `if (key)` truthiness gates fail-closed) — NOT throw,
+    // otherwise the whole server-rendered HTML 500s.
     delete (globalThis as { window?: WindowWithConfig }).window;
-    expect(getRuntimeConfig()).toEqual({
-      baseUrl: "",
-      shellUrl: "",
-      intelligenceSignupUrl: "",
-      posthogKey: "",
-      posthogHost: "",
-      scarfPixelId: "",
-      googleAnalyticsTrackingId: "",
-      reb2bKey: "",
-      reoKey: "",
-    });
+    const cfg = getRuntimeConfig();
+    // URL fields must be parseable so `new URL()` in consumers doesn't throw.
+    expect(() => new URL(cfg.baseUrl)).not.toThrow();
+    expect(() => new URL(cfg.shellUrl)).not.toThrow();
+    expect(() => new URL(cfg.intelligenceSignupUrl)).not.toThrow();
+    expect(() => new URL(cfg.posthogHost)).not.toThrow();
+    // Analytics keys stay empty so `if (key)` gates fail-closed on SSR.
+    expect(cfg.posthogKey).toBe("");
+    expect(cfg.scarfPixelId).toBe("");
+    expect(cfg.googleAnalyticsTrackingId).toBe("");
+    expect(cfg.reb2bKey).toBe("");
+    expect(cfg.reoKey).toBe("");
   });
 });

--- a/showcase/shell-docs/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.client.test.ts
@@ -44,8 +44,23 @@ describe("client getRuntimeConfig (shell-docs)", () => {
     );
   });
 
-  it("throws on the server (no window)", () => {
+  it("returns SSR sentinel placeholder when window is undefined", () => {
+    // Simulate SSR by removing window. "use client" component bodies
+    // execute on the server during SSR, so this reader MUST be SSR-safe
+    // (returns empty-string placeholders that get replaced on the next
+    // render after hydration), NOT throw — otherwise the whole
+    // server-rendered HTML 500s.
     delete (globalThis as { window?: WindowWithConfig }).window;
-    expect(() => getRuntimeConfig()).toThrow(/called on the server/);
+    expect(getRuntimeConfig()).toEqual({
+      baseUrl: "",
+      shellUrl: "",
+      intelligenceSignupUrl: "",
+      posthogKey: "",
+      posthogHost: "",
+      scarfPixelId: "",
+      googleAnalyticsTrackingId: "",
+      reb2bKey: "",
+      reoKey: "",
+    });
   });
 });

--- a/showcase/shell-docs/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.client.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRuntimeConfig, type RuntimeConfig } from "./runtime-config.client";
+
+// shell-docs's vitest runs with `environment: "node"` (no jsdom) — we
+// simulate the browser by attaching a minimal `window` to globalThis
+// before each test and removing it after, so we exercise BOTH the
+// server-path throw (no window) and the client-path read.
+
+type WindowWithConfig = { __SHOWCASE_CONFIG__?: RuntimeConfig };
+
+const FULL_CONFIG: RuntimeConfig = {
+  baseUrl: "https://docs.example.com",
+  shellUrl: "https://shell.example.com",
+  intelligenceSignupUrl: "https://signup.example.com",
+  posthogKey: "phc_test",
+  posthogHost: "https://eu.i.posthog.com",
+  scarfPixelId: "scarf-id",
+  googleAnalyticsTrackingId: "G-TEST",
+  reb2bKey: "rb2b-key",
+  reoKey: "reo-key",
+};
+
+describe("client getRuntimeConfig (shell-docs)", () => {
+  beforeEach(() => {
+    // Attach a fresh stub `window` for each test. The cast is unavoidable
+    // here because globalThis.window is typed against the DOM lib and we
+    // are deliberately providing only the shape we need.
+    (globalThis as { window?: WindowWithConfig }).window = {};
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: WindowWithConfig }).window;
+  });
+
+  it("returns the injected config", () => {
+    (globalThis as { window?: WindowWithConfig }).window!.__SHOWCASE_CONFIG__ =
+      FULL_CONFIG;
+    expect(getRuntimeConfig()).toEqual(FULL_CONFIG);
+  });
+
+  it("throws when __SHOWCASE_CONFIG__ is missing (wiring bug)", () => {
+    expect(() => getRuntimeConfig()).toThrow(
+      /window\.__SHOWCASE_CONFIG__ is missing/,
+    );
+  });
+
+  it("throws on the server (no window)", () => {
+    delete (globalThis as { window?: WindowWithConfig }).window;
+    expect(() => getRuntimeConfig()).toThrow(/called on the server/);
+  });
+});

--- a/showcase/shell-docs/src/lib/runtime-config.client.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.client.ts
@@ -15,21 +15,42 @@ declare global {
 }
 
 /**
+ * Sentinel returned during SSR when `window` is unavailable. "use client"
+ * components in the Next.js App Router are server-side rendered on the
+ * initial request (that's how the HTML is streamed before hydration),
+ * which means their function bodies execute on the server too. We can't
+ * throw here without breaking SSR — instead we return a placeholder, and
+ * post-hydration the next render reads the real values out of
+ * window.__SHOWCASE_CONFIG__. Server components that need the live env
+ * values MUST import getRuntimeConfig from runtime-config.ts (the server
+ * variant), not this file.
+ */
+const SSR_PLACEHOLDER: RuntimeConfig = {
+  baseUrl: "",
+  shellUrl: "",
+  intelligenceSignupUrl: "",
+  posthogKey: "",
+  posthogHost: "",
+  scarfPixelId: "",
+  googleAnalyticsTrackingId: "",
+  reb2bKey: "",
+  reoKey: "",
+};
+
+/**
  * Returns the runtime config injected by the root server layout.
  *
- * Throws when called during SSR (no window). The intended call sites
- * are client components and hooks ("use client"), which only execute
- * after hydration — by which point the inline <script> has populated
- * window.__SHOWCASE_CONFIG__. If a server component needs the same
- * values, it MUST import runtime-config.ts (the server variant) — not
- * this file.
+ * During SSR (no window) returns a sentinel placeholder; client code
+ * re-reads after hydration and gets the real values. If the inline
+ * <script> never runs (a route bypassed the layout, or injection ran
+ * with empty inputs), the post-hydration read throws — surfacing the
+ * wiring bug loudly rather than silently rendering empty URLs.
  */
 export function getRuntimeConfig(): RuntimeConfig {
   if (typeof window === "undefined") {
-    throw new Error(
-      "[runtime-config.client] getRuntimeConfig() called on the server. " +
-        "Server code must import from './runtime-config' instead.",
-    );
+    // SSR phase — "use client" component bodies execute here too.
+    // Return placeholder; hydration will re-render with real values.
+    return SSR_PLACEHOLDER;
   }
   const cfg = window.__SHOWCASE_CONFIG__;
   if (!cfg) {

--- a/showcase/shell-docs/src/lib/runtime-config.client.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.client.ts
@@ -1,0 +1,46 @@
+// Client-side runtime config reader for shell-docs. Reads from
+// window.__SHOWCASE_CONFIG__ which the root layout injects via an
+// inline <script> tag BEFORE React hydrates (see app/layout.tsx).
+// This is the ONLY public API for these URLs/keys in client code —
+// never read process.env.NEXT_PUBLIC_* directly.
+
+import type { RuntimeConfig } from "./runtime-config";
+
+export type { RuntimeConfig };
+
+declare global {
+  interface Window {
+    __SHOWCASE_CONFIG__?: RuntimeConfig;
+  }
+}
+
+/**
+ * Returns the runtime config injected by the root server layout.
+ *
+ * Throws when called during SSR (no window). The intended call sites
+ * are client components and hooks ("use client"), which only execute
+ * after hydration — by which point the inline <script> has populated
+ * window.__SHOWCASE_CONFIG__. If a server component needs the same
+ * values, it MUST import runtime-config.ts (the server variant) — not
+ * this file.
+ */
+export function getRuntimeConfig(): RuntimeConfig {
+  if (typeof window === "undefined") {
+    throw new Error(
+      "[runtime-config.client] getRuntimeConfig() called on the server. " +
+        "Server code must import from './runtime-config' instead.",
+    );
+  }
+  const cfg = window.__SHOWCASE_CONFIG__;
+  if (!cfg) {
+    // The root layout always emits the <script> tag, so a missing
+    // value here is a wiring bug (e.g. a route bypassed the layout,
+    // or the injection script ran with empty inputs). Surface it
+    // loudly rather than silently returning empty strings.
+    throw new Error(
+      "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
+        "The root layout must inject runtime config before client mount.",
+    );
+  }
+  return cfg;
+}

--- a/showcase/shell-docs/src/lib/runtime-config.client.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.client.ts
@@ -24,13 +24,27 @@ declare global {
  * window.__SHOWCASE_CONFIG__. Server components that need the live env
  * values MUST import getRuntimeConfig from runtime-config.ts (the server
  * variant), not this file.
+ *
+ * URL fields use a parseable `https://ssr-placeholder.invalid/` sentinel
+ * — NOT the empty string — because consumer components call
+ * `new URL(cfg.someUrl)` inline during render, and `new URL("")` throws
+ * a TypeError that escapes the SSR response as a 500. The `.invalid`
+ * TLD is reserved by RFC 2606 so the URL also can't accidentally
+ * resolve. The post-hydration re-read swaps in the real value and the
+ * href is fixed up before any user interaction (consumers also use
+ * `suppressHydrationWarning` to silence the benign href diff).
+ *
+ * Analytics-KEY fields STAY the empty string because every consumer
+ * gates side-effects on `if (key)` truthiness — populating them with a
+ * sentinel would erroneously start analytics during SSR.
  */
+const SSR_PLACEHOLDER_URL = "https://ssr-placeholder.invalid/";
 const SSR_PLACEHOLDER: RuntimeConfig = {
-  baseUrl: "",
-  shellUrl: "",
-  intelligenceSignupUrl: "",
+  baseUrl: SSR_PLACEHOLDER_URL,
+  shellUrl: SSR_PLACEHOLDER_URL,
+  intelligenceSignupUrl: SSR_PLACEHOLDER_URL,
   posthogKey: "",
-  posthogHost: "",
+  posthogHost: SSR_PLACEHOLDER_URL,
   scarfPixelId: "",
   googleAnalyticsTrackingId: "",
   reb2bKey: "",

--- a/showcase/shell-docs/src/lib/runtime-config.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.test.ts
@@ -43,7 +43,11 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   });
 
   it("returns env values when all are set (production)", () => {
-    process.env.NODE_ENV = "production";
+    // NODE_ENV is typed as `"development" | "production" | "test"` and
+    // marked read-only in modern @types/node. The runtime-config reader
+    // only checks the string value, so writing through a record cast is
+    // safe and matches the pattern used in other shell-docs tests.
+    (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.NEXT_PUBLIC_BASE_URL = "https://docs.copilotkit.ai";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://showcase.copilotkit.ai";
     process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
@@ -69,7 +73,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   });
 
   it("strips trailing slashes from URLs", () => {
-    process.env.NODE_ENV = "production";
+    (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.NEXT_PUBLIC_BASE_URL = "https://docs.example.com/";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://shell.example.com//";
     process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
@@ -84,7 +88,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   });
 
   it("falls back to dev defaults when URLs are unset in non-production", () => {
-    process.env.NODE_ENV = "development";
+    (process.env as Record<string, string>).NODE_ENV = "development";
     const cfg = getRuntimeConfig();
     expect(cfg.baseUrl).toBe("http://localhost:3003");
     expect(cfg.shellUrl).toBe("http://localhost:3000");
@@ -95,7 +99,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   });
 
   it("falls back to prod sentinels and console.errors when URLs unset in production", () => {
-    process.env.NODE_ENV = "production";
+    (process.env as Record<string, string>).NODE_ENV = "production";
     const errs: string[] = [];
     const spy = vi
       .spyOn(console, "error")
@@ -120,7 +124,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   });
 
   it("returns empty strings for missing analytics keys with no console output", () => {
-    process.env.NODE_ENV = "production";
+    (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.NEXT_PUBLIC_BASE_URL = "https://docs.copilotkit.ai";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://showcase.copilotkit.ai";
 
@@ -149,7 +153,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   });
 
   it("reads live process.env on each call (no module-load freeze)", () => {
-    process.env.NODE_ENV = "production";
+    (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.NEXT_PUBLIC_BASE_URL = "https://first.example.com";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://shell.example.com";
     process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
@@ -165,7 +169,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
     const cacheMod = await import("next/cache");
     const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
-    process.env.NODE_ENV = "production";
+    (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.NEXT_PUBLIC_BASE_URL = "https://edge.example.com";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://edge-shell.example.com";
     process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =

--- a/showcase/shell-docs/src/lib/runtime-config.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.test.ts
@@ -15,6 +15,13 @@ const URL_KEYS = [
   "NEXT_PUBLIC_SHELL_URL",
   "NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL",
   "NEXT_PUBLIC_POSTHOG_HOST",
+  // Alt (bare) names — shell-docs tolerates these as a fallback so a
+  // Railway service following the shell / shell-dashboard naming
+  // convention still wires through.
+  "BASE_URL",
+  "SHELL_URL",
+  "INTELLIGENCE_SIGNUP_URL",
+  "POSTHOG_HOST",
 ] as const;
 const ANALYTICS_KEYS = [
   "NEXT_PUBLIC_POSTHOG_KEY",
@@ -98,16 +105,23 @@ describe("server getRuntimeConfig (shell-docs)", () => {
     expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
   });
 
-  it("falls back to prod sentinels and console.errors when URLs unset in production", () => {
+  it("falls back to prod sentinels and logs by severity when URLs unset in production", () => {
     (process.env as Record<string, string>).NODE_ENV = "production";
     const errs: string[] = [];
-    const spy = vi
+    const infos: string[] = [];
+    const errSpy = vi
       .spyOn(console, "error")
       .mockImplementation((m: string) => {
         errs.push(m);
       });
+    const infoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation((m: string) => {
+        infos.push(m);
+      });
     const cfg = getRuntimeConfig();
-    spy.mockRestore();
+    errSpy.mockRestore();
+    infoSpy.mockRestore();
 
     expect(cfg.baseUrl).toBe("https://docs.copilotkit.ai");
     expect(cfg.shellUrl).toBe("about:blank#shell-url-missing");
@@ -115,12 +129,28 @@ describe("server getRuntimeConfig (shell-docs)", () => {
       "https://dashboard.operations.copilotkit.ai",
     );
     expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+    // baseUrl + shellUrl are FATAL-CONFIG severity (no legitimate prod
+    // default exists for shellUrl; baseUrl mismatches break sitemap+OG).
     expect(errs.some((m) => m.includes("NEXT_PUBLIC_BASE_URL"))).toBe(true);
     expect(errs.some((m) => m.includes("NEXT_PUBLIC_SHELL_URL"))).toBe(true);
+    // intelligenceSignupUrl + posthogHost have working prod defaults
+    // (dashboard.operations.copilotkit.ai, EU posthog cloud), so they
+    // log at info severity — not fatal — to avoid alert noise on
+    // deploys that intentionally use the default.
+    expect(
+      infos.some((m) => m.includes("NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL")),
+    ).toBe(true);
+    expect(infos.some((m) => m.includes("NEXT_PUBLIC_POSTHOG_HOST"))).toBe(
+      true,
+    );
+    // Confirm NO false-positive FATAL-CONFIG was logged for the
+    // recoverable cases.
     expect(
       errs.some((m) => m.includes("NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL")),
-    ).toBe(true);
-    expect(errs.some((m) => m.includes("NEXT_PUBLIC_POSTHOG_HOST"))).toBe(true);
+    ).toBe(false);
+    expect(errs.some((m) => m.includes("NEXT_PUBLIC_POSTHOG_HOST"))).toBe(
+      false,
+    );
   });
 
   it("returns empty strings for missing analytics keys with no console output", () => {
@@ -164,6 +194,46 @@ describe("server getRuntimeConfig (shell-docs)", () => {
 
     process.env.NEXT_PUBLIC_BASE_URL = "https://second.example.com";
     expect(getRuntimeConfig().baseUrl).toBe("https://second.example.com");
+  });
+
+  it("accepts bare-name fallbacks when NEXT_PUBLIC_* variants are unset", () => {
+    // Deploy-config contract: shell-docs reads NEXT_PUBLIC_* first,
+    // but tolerates the bare-name variant so a Railway service that
+    // follows the shell / shell-dashboard naming convention still
+    // wires through. See the readUrl fallback chain in
+    // runtime-config.ts.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://alt-docs.example.com";
+    process.env.SHELL_URL = "https://alt-shell.example.com";
+    process.env.INTELLIGENCE_SIGNUP_URL = "https://alt-signup.example.com";
+    process.env.POSTHOG_HOST = "https://alt-ph.example.com";
+
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("https://alt-docs.example.com");
+    expect(cfg.shellUrl).toBe("https://alt-shell.example.com");
+    expect(cfg.intelligenceSignupUrl).toBe("https://alt-signup.example.com");
+    expect(cfg.posthogHost).toBe("https://alt-ph.example.com");
+  });
+
+  it("NEXT_PUBLIC_* takes precedence over bare-name when both set", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://primary-docs.example.com";
+    process.env.BASE_URL = "https://alt-docs.example.com";
+    process.env.NEXT_PUBLIC_SHELL_URL = "https://primary-shell.example.com";
+    process.env.SHELL_URL = "https://alt-shell.example.com";
+    process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
+      "https://primary-signup.example.com";
+    process.env.INTELLIGENCE_SIGNUP_URL = "https://alt-signup.example.com";
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://primary-ph.example.com";
+    process.env.POSTHOG_HOST = "https://alt-ph.example.com";
+
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("https://primary-docs.example.com");
+    expect(cfg.shellUrl).toBe("https://primary-shell.example.com");
+    expect(cfg.intelligenceSignupUrl).toBe(
+      "https://primary-signup.example.com",
+    );
+    expect(cfg.posthogHost).toBe("https://primary-ph.example.com");
   });
 
   it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {

--- a/showcase/shell-docs/src/lib/runtime-config.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub next/cache.unstable_noStore — vitest runs outside Next's runtime
+// so the real implementation throws ("called outside a Server
+// Component"). The function is a no-op for our purposes (it tells Next
+// not to cache; in a unit test there is no cache to opt out of).
+vi.mock("next/cache", () => ({
+  unstable_noStore: () => {},
+}));
+
+import { getRuntimeConfig, getRuntimeConfigEdge } from "./runtime-config";
+
+const URL_KEYS = [
+  "NEXT_PUBLIC_BASE_URL",
+  "NEXT_PUBLIC_SHELL_URL",
+  "NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL",
+  "NEXT_PUBLIC_POSTHOG_HOST",
+] as const;
+const ANALYTICS_KEYS = [
+  "NEXT_PUBLIC_POSTHOG_KEY",
+  "NEXT_PUBLIC_SCARF_PIXEL_ID",
+  "NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID",
+  "NEXT_PUBLIC_REB2B_KEY",
+  "NEXT_PUBLIC_REO_KEY",
+] as const;
+
+describe("server getRuntimeConfig (shell-docs)", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    for (const k of [...URL_KEYS, ...ANALYTICS_KEYS, "NODE_ENV"] as const) {
+      delete (process.env as Record<string, string | undefined>)[k];
+    }
+  });
+
+  afterEach(() => {
+    // Restore the snapshot — replace, don't merge, so per-test sets
+    // don't leak into the next test.
+    for (const k of Object.keys(process.env)) {
+      delete (process.env as Record<string, string | undefined>)[k];
+    }
+    Object.assign(process.env, ORIGINAL_ENV);
+  });
+
+  it("returns env values when all are set (production)", () => {
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://docs.copilotkit.ai";
+    process.env.NEXT_PUBLIC_SHELL_URL = "https://showcase.copilotkit.ai";
+    process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
+      "https://dashboard.operations.copilotkit.ai/";
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://eu.i.posthog.com";
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_real";
+    process.env.NEXT_PUBLIC_SCARF_PIXEL_ID = "scarf-id";
+    process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID = "G-XYZ";
+    process.env.NEXT_PUBLIC_REB2B_KEY = "rb2b-key";
+    process.env.NEXT_PUBLIC_REO_KEY = "reo-key";
+
+    expect(getRuntimeConfig()).toEqual({
+      baseUrl: "https://docs.copilotkit.ai",
+      shellUrl: "https://showcase.copilotkit.ai",
+      intelligenceSignupUrl: "https://dashboard.operations.copilotkit.ai",
+      posthogKey: "phc_real",
+      posthogHost: "https://eu.i.posthog.com",
+      scarfPixelId: "scarf-id",
+      googleAnalyticsTrackingId: "G-XYZ",
+      reb2bKey: "rb2b-key",
+      reoKey: "reo-key",
+    });
+  });
+
+  it("strips trailing slashes from URLs", () => {
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://docs.example.com/";
+    process.env.NEXT_PUBLIC_SHELL_URL = "https://shell.example.com//";
+    process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
+      "https://signup.example.com///";
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://posthog.example.com/";
+
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("https://docs.example.com");
+    expect(cfg.shellUrl).toBe("https://shell.example.com");
+    expect(cfg.intelligenceSignupUrl).toBe("https://signup.example.com");
+    expect(cfg.posthogHost).toBe("https://posthog.example.com");
+  });
+
+  it("falls back to dev defaults when URLs are unset in non-production", () => {
+    process.env.NODE_ENV = "development";
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("http://localhost:3003");
+    expect(cfg.shellUrl).toBe("http://localhost:3000");
+    expect(cfg.intelligenceSignupUrl).toBe(
+      "https://dashboard.operations.copilotkit.ai",
+    );
+    expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+  });
+
+  it("falls back to prod sentinels and console.errors when URLs unset in production", () => {
+    process.env.NODE_ENV = "production";
+    const errs: string[] = [];
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation((m: string) => {
+        errs.push(m);
+      });
+    const cfg = getRuntimeConfig();
+    spy.mockRestore();
+
+    expect(cfg.baseUrl).toBe("https://docs.copilotkit.ai");
+    expect(cfg.shellUrl).toBe("about:blank#shell-url-missing");
+    expect(cfg.intelligenceSignupUrl).toBe(
+      "https://dashboard.operations.copilotkit.ai",
+    );
+    expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+    expect(errs.some((m) => m.includes("NEXT_PUBLIC_BASE_URL"))).toBe(true);
+    expect(errs.some((m) => m.includes("NEXT_PUBLIC_SHELL_URL"))).toBe(true);
+    expect(
+      errs.some((m) => m.includes("NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL")),
+    ).toBe(true);
+    expect(errs.some((m) => m.includes("NEXT_PUBLIC_POSTHOG_HOST"))).toBe(true);
+  });
+
+  it("returns empty strings for missing analytics keys with no console output", () => {
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://docs.copilotkit.ai";
+    process.env.NEXT_PUBLIC_SHELL_URL = "https://showcase.copilotkit.ai";
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cfg = getRuntimeConfig();
+    warnSpy.mockRestore();
+    errSpy.mockRestore();
+
+    expect(cfg.posthogKey).toBe("");
+    expect(cfg.scarfPixelId).toBe("");
+    expect(cfg.googleAnalyticsTrackingId).toBe("");
+    expect(cfg.reb2bKey).toBe("");
+    expect(cfg.reoKey).toBe("");
+
+    // None of the analytics-key env names should have produced a log.
+    const allOutput = [
+      ...warnSpy.mock.calls.flat(),
+      ...errSpy.mock.calls.flat(),
+    ]
+      .map(String)
+      .join("\n");
+    for (const k of ANALYTICS_KEYS) {
+      expect(allOutput).not.toContain(k);
+    }
+  });
+
+  it("reads live process.env on each call (no module-load freeze)", () => {
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://first.example.com";
+    process.env.NEXT_PUBLIC_SHELL_URL = "https://shell.example.com";
+    process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
+      "https://signup.example.com";
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://ph.example.com";
+
+    expect(getRuntimeConfig().baseUrl).toBe("https://first.example.com");
+
+    process.env.NEXT_PUBLIC_BASE_URL = "https://second.example.com";
+    expect(getRuntimeConfig().baseUrl).toBe("https://second.example.com");
+  });
+
+  it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
+    const cacheMod = await import("next/cache");
+    const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://edge.example.com";
+    process.env.NEXT_PUBLIC_SHELL_URL = "https://edge-shell.example.com";
+    process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
+      "https://edge-signup.example.com";
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://edge-ph.example.com";
+
+    const cfg = getRuntimeConfigEdge();
+    expect(cfg.baseUrl).toBe("https://edge.example.com");
+    expect(noStoreSpy).not.toHaveBeenCalled();
+
+    // And confirm the default entrypoint DOES call noStore().
+    noStoreSpy.mockClear();
+    getRuntimeConfig();
+    expect(noStoreSpy).toHaveBeenCalledTimes(1);
+    noStoreSpy.mockRestore();
+  });
+});

--- a/showcase/shell-docs/src/lib/runtime-config.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.test.ts
@@ -108,20 +108,20 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   it("falls back to prod sentinels and logs by severity when URLs unset in production", () => {
     (process.env as Record<string, string>).NODE_ENV = "production";
     const errs: string[] = [];
-    const infos: string[] = [];
+    const warns: string[] = [];
     const errSpy = vi
       .spyOn(console, "error")
       .mockImplementation((m: string) => {
         errs.push(m);
       });
-    const infoSpy = vi
-      .spyOn(console, "info")
+    const warnSpy = vi
+      .spyOn(console, "warn")
       .mockImplementation((m: string) => {
-        infos.push(m);
+        warns.push(m);
       });
     const cfg = getRuntimeConfig();
     errSpy.mockRestore();
-    infoSpy.mockRestore();
+    warnSpy.mockRestore();
 
     expect(cfg.baseUrl).toBe("https://docs.copilotkit.ai");
     expect(cfg.shellUrl).toBe("about:blank#shell-url-missing");
@@ -135,14 +135,24 @@ describe("server getRuntimeConfig (shell-docs)", () => {
     expect(errs.some((m) => m.includes("NEXT_PUBLIC_SHELL_URL"))).toBe(true);
     // intelligenceSignupUrl + posthogHost have working prod defaults
     // (dashboard.operations.copilotkit.ai, EU posthog cloud), so they
-    // log at info severity — not fatal — to avoid alert noise on
-    // deploys that intentionally use the default.
+    // log via console.warn WITHOUT the `FATAL-CONFIG:` prefix — visible
+    // in prod log streams but not raising ops alerts.
     expect(
-      infos.some((m) => m.includes("NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL")),
+      warns.some((m) => m.includes("NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL")),
     ).toBe(true);
-    expect(infos.some((m) => m.includes("NEXT_PUBLIC_POSTHOG_HOST"))).toBe(
+    expect(warns.some((m) => m.includes("NEXT_PUBLIC_POSTHOG_HOST"))).toBe(
       true,
     );
+    // The recoverable warns must NOT carry the `FATAL-CONFIG:` prefix —
+    // that prefix is what ops alert routing pattern-matches on.
+    expect(
+      warns.some(
+        (m) =>
+          m.includes("FATAL-CONFIG:") &&
+          (m.includes("NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL") ||
+            m.includes("NEXT_PUBLIC_POSTHOG_HOST")),
+      ),
+    ).toBe(false);
     // Confirm NO false-positive FATAL-CONFIG was logged for the
     // recoverable cases.
     expect(

--- a/showcase/shell-docs/src/lib/runtime-config.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.ts
@@ -1,0 +1,156 @@
+// Server-only runtime config reader for shell-docs. Reads from
+// process.env at REQUEST time (not at module load) so a single built
+// artifact can serve different URL/key values across staging vs prod by
+// changing the Railway service's env vars — no rebuild required.
+//
+// `unstable_noStore()` opts the calling segment out of Next.js's static
+// cache so reads always reflect the live env. Without it, a server
+// component that uses this could be statically rendered at build time
+// and freeze the URLs back into the artifact (the exact bug Option B
+// fixes).
+//
+// This module MUST NOT be imported from client components. The matching
+// client-side reader lives in runtime-config.client.ts and reads from
+// window.__SHOWCASE_CONFIG__ which the root layout injects.
+
+import { unstable_noStore as noStore } from "next/cache";
+
+export interface RuntimeConfig {
+  /** Canonical docs base URL — sitemap, robots, canonical links. */
+  baseUrl: string;
+  /** Showcase shell host — search-modal, integration-grid, cross-host hrefs. */
+  shellUrl: string;
+  /** Intelligence platform signup URL — signup-link, ops-platform-cta. */
+  intelligenceSignupUrl: string;
+  /** Analytics keys (empty string = analytics disabled in that channel). */
+  posthogKey: string;
+  posthogHost: string;
+  scarfPixelId: string;
+  googleAnalyticsTrackingId: string;
+  reb2bKey: string;
+  reoKey: string;
+}
+
+const PROD_BASE_URL_FALLBACK = "https://docs.copilotkit.ai";
+const PROD_INVALID_SHELL_URL = "about:blank#shell-url-missing";
+const PROD_DEFAULT_SIGNUP_URL = "https://dashboard.operations.copilotkit.ai/";
+const PROD_DEFAULT_POSTHOG_HOST = "https://eu.i.posthog.com";
+
+/**
+ * Resolve the runtime config for shell-docs. Called once per request by
+ * the root layout and by any other server component / route that needs
+ * it (sitemap, robots, middleware via the Edge wrapper).
+ *
+ * Fail-loud strategy:
+ *   - URL fields in production: missing env vars produce sentinel
+ *     URLs (or, for `baseUrl`, the canonical prod host — preserves
+ *     existing sitemap behavior) AND a console.error.
+ *   - URL fields in dev: localhost fallbacks + console.warn.
+ *   - Analytics keys: empty string fallback in BOTH envs with no log —
+ *     analytics keys are legitimately absent in non-production envs and
+ *     consumers already no-op on empty.
+ *
+ * `opts.noStore` (default `true`) controls whether to call
+ * `unstable_noStore()`. The Node.js server runtime needs the opt-out
+ * so Next.js does not statically prerender callers and freeze the URLs
+ * into the build artifact. The Edge runtime (middleware) MUST pass
+ * `{ noStore: false }` — `unstable_noStore()` is unavailable there,
+ * and middleware always runs per-request by definition so there is no
+ * static cache to opt out of. The thin `getRuntimeConfigEdge()`
+ * wrapper below makes this explicit at the call site.
+ */
+export function getRuntimeConfig(
+  opts: { noStore?: boolean } = {},
+): RuntimeConfig {
+  if (opts.noStore !== false) noStore();
+  const isProd = process.env.NODE_ENV === "production";
+
+  const baseUrl = readUrl(
+    "NEXT_PUBLIC_BASE_URL",
+    // baseUrl preserves the prior `https://docs.copilotkit.ai` prod
+    // fallback (matches the legacy getBaseUrl() behavior in
+    // sitemap-helpers.ts) so a misconfigured deploy still emits a
+    // reasonable sitemap rather than a sentinel URL. Logged either way.
+    isProd ? PROD_BASE_URL_FALLBACK : "http://localhost:3003",
+    isProd,
+  );
+  const shellUrl = readUrl(
+    "NEXT_PUBLIC_SHELL_URL",
+    isProd ? PROD_INVALID_SHELL_URL : "http://localhost:3000",
+    isProd,
+  );
+  const intelligenceSignupUrl = readUrl(
+    "NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL",
+    // Both prod and dev fall back to the canonical signup host — the
+    // historical behavior of the consumer modules (signup-link.tsx,
+    // ops-platform-cta.tsx) was to use this URL whenever the env was
+    // unset. Logged in prod only.
+    PROD_DEFAULT_SIGNUP_URL,
+    isProd,
+  );
+  const posthogHost = readUrl(
+    "NEXT_PUBLIC_POSTHOG_HOST",
+    PROD_DEFAULT_POSTHOG_HOST,
+    isProd,
+  );
+
+  return {
+    baseUrl,
+    shellUrl,
+    intelligenceSignupUrl,
+    posthogKey: readKey("NEXT_PUBLIC_POSTHOG_KEY"),
+    posthogHost,
+    scarfPixelId: readKey("NEXT_PUBLIC_SCARF_PIXEL_ID"),
+    googleAnalyticsTrackingId: readKey(
+      "NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID",
+    ),
+    reb2bKey: readKey("NEXT_PUBLIC_REB2B_KEY"),
+    reoKey: readKey("NEXT_PUBLIC_REO_KEY"),
+  };
+}
+
+/**
+ * Edge-runtime variant. Identical semantics to `getRuntimeConfig()`
+ * except `unstable_noStore()` is skipped — `next/cache`'s no-store
+ * helper is not available in the Edge runtime, and middleware always
+ * runs per-request by definition so there is no static cache to opt
+ * out of. Thin wrapper to keep the body single-sourced.
+ *
+ * Middleware (`src/middleware.ts`) MUST import this rather than
+ * `getRuntimeConfig` — otherwise the Edge bundle pulls in `next/cache`
+ * and the build fails with "module not found in edge runtime."
+ */
+export function getRuntimeConfigEdge(): RuntimeConfig {
+  return getRuntimeConfig({ noStore: false });
+}
+
+function readUrl(envKey: string, fallback: string, isProd: boolean): string {
+  const value = process.env[envKey];
+  if (value && value.length > 0) return value.replace(/\/+$/, "");
+  if (isProd) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
+        `using fallback ${fallback}. Set the env var on the Railway service.`,
+    );
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
+    );
+  }
+  return fallback.replace(/\/+$/, "");
+}
+
+/**
+ * Read an analytics key. Empty/missing values are returned as the empty
+ * string with NO log — analytics keys are legitimately absent in
+ * non-production envs (the consumer providers no-op when the key is
+ * empty), and the existing shell-docs/Dockerfile documents the same
+ * behavior. Adding a prod warn here would create alert noise on
+ * intentionally analytics-disabled environments.
+ */
+function readKey(envKey: string): string {
+  const value = process.env[envKey];
+  return value && value.length > 0 ? value : "";
+}

--- a/showcase/shell-docs/src/lib/runtime-config.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.ts
@@ -6,8 +6,8 @@
 // `unstable_noStore()` opts the calling segment out of Next.js's static
 // cache so reads always reflect the live env. Without it, a server
 // component that uses this could be statically rendered at build time
-// and freeze the URLs back into the artifact (the exact bug Option B
-// fixes).
+// and freeze the URLs back into the artifact — which is the entire
+// reason this module exists.
 //
 // This module MUST NOT be imported from client components. The matching
 // client-side reader lives in runtime-config.client.ts and reads from
@@ -73,25 +73,30 @@ export function getRuntimeConfig(
     // reasonable sitemap rather than a sentinel URL. Logged either way.
     isProd ? PROD_BASE_URL_FALLBACK : "http://localhost:3003",
     isProd,
+    "fatal",
   );
   const shellUrl = readUrl(
     "NEXT_PUBLIC_SHELL_URL",
     isProd ? PROD_INVALID_SHELL_URL : "http://localhost:3000",
     isProd,
+    "fatal",
   );
+  // intelligenceSignupUrl: prod fallback IS a real working host
+  // (dashboard.operations.copilotkit.ai), not a sentinel — so absence is
+  // recoverable. Demote from FATAL-CONFIG to an info-level log to stop
+  // generating false-positive alerts on deploys that intentionally rely
+  // on the default. Same logic for posthogHost (EU cloud is the default).
   const intelligenceSignupUrl = readUrl(
     "NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL",
-    // Both prod and dev fall back to the canonical signup host — the
-    // historical behavior of the consumer modules (signup-link.tsx,
-    // ops-platform-cta.tsx) was to use this URL whenever the env was
-    // unset. Logged in prod only.
     PROD_DEFAULT_SIGNUP_URL,
     isProd,
+    "info",
   );
   const posthogHost = readUrl(
     "NEXT_PUBLIC_POSTHOG_HOST",
     PROD_DEFAULT_POSTHOG_HOST,
     isProd,
+    "info",
   );
 
   return {
@@ -124,15 +129,42 @@ export function getRuntimeConfigEdge(): RuntimeConfig {
   return getRuntimeConfig({ noStore: false });
 }
 
-function readUrl(envKey: string, fallback: string, isProd: boolean): string {
-  const value = process.env[envKey];
+// Env-name tolerance: deploy configs in the wild use either the bare
+// name (e.g. `BASE_URL`) or the `NEXT_PUBLIC_*`-prefixed name. We accept
+// either — the primary (passed-in) name wins, and we transparently fall
+// back to the alternate so a Railway service variable set under the
+// "wrong" name still works without redeploy. The pair is computed by
+// stripping/adding the `NEXT_PUBLIC_` prefix.
+function altEnvName(envKey: string): string {
+  return envKey.startsWith("NEXT_PUBLIC_")
+    ? envKey.slice("NEXT_PUBLIC_".length)
+    : `NEXT_PUBLIC_${envKey}`;
+}
+
+function readUrl(
+  envKey: string,
+  fallback: string,
+  isProd: boolean,
+  severity: "fatal" | "info" = "fatal",
+): string {
+  const value = process.env[envKey] ?? process.env[altEnvName(envKey)];
   if (value && value.length > 0) return value.replace(/\/+$/, "");
   if (isProd) {
-    // eslint-disable-next-line no-console
-    console.error(
-      `[runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
-        `using fallback ${fallback}. Set the env var on the Railway service.`,
-    );
+    if (severity === "fatal") {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
+          `using fallback ${fallback}. Set the env var on the Railway service.`,
+      );
+    } else {
+      // info-level: legitimate prod default exists; absence is
+      // recoverable so we log but do not raise the FATAL-CONFIG flag
+      // that triggers ops alerts.
+      // eslint-disable-next-line no-console
+      console.info(
+        `[runtime-config] ${envKey} unset; using prod default ${fallback}`,
+      );
+    }
   } else {
     // eslint-disable-next-line no-console
     console.warn(
@@ -151,6 +183,6 @@ function readUrl(envKey: string, fallback: string, isProd: boolean): string {
  * intentionally analytics-disabled environments.
  */
 function readKey(envKey: string): string {
-  const value = process.env[envKey];
+  const value = process.env[envKey] ?? process.env[altEnvName(envKey)];
   return value && value.length > 0 ? value : "";
 }

--- a/showcase/shell-docs/src/lib/runtime-config.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.ts
@@ -42,9 +42,16 @@ const PROD_DEFAULT_POSTHOG_HOST = "https://eu.i.posthog.com";
  * it (sitemap, robots, middleware via the Edge wrapper).
  *
  * Fail-loud strategy:
- *   - URL fields in production: missing env vars produce sentinel
- *     URLs (or, for `baseUrl`, the canonical prod host — preserves
- *     existing sitemap behavior) AND a console.error.
+ *   - URL fields in production (severity=fatal): missing env vars
+ *     produce sentinel URLs (or, for `baseUrl`, the canonical prod host
+ *     — preserves existing sitemap behavior) AND a console.error
+ *     prefixed `FATAL-CONFIG:` (the prefix is what Sentry pattern-
+ *     matches for ops alerts).
+ *   - URL fields in production with a working default (severity=info,
+ *     e.g. intelligenceSignupUrl, posthogHost): console.warn WITHOUT
+ *     the `FATAL-CONFIG:` prefix — visible in prod log streams (warn
+ *     clears aggregation thresholds; info does not) but does not raise
+ *     ops alerts.
  *   - URL fields in dev: localhost fallbacks + console.warn.
  *   - Analytics keys: empty string fallback in BOTH envs with no log —
  *     analytics keys are legitimately absent in non-production envs and
@@ -83,9 +90,11 @@ export function getRuntimeConfig(
   );
   // intelligenceSignupUrl: prod fallback IS a real working host
   // (dashboard.operations.copilotkit.ai), not a sentinel — so absence is
-  // recoverable. Demote from FATAL-CONFIG to an info-level log to stop
-  // generating false-positive alerts on deploys that intentionally rely
-  // on the default. Same logic for posthogHost (EU cloud is the default).
+  // recoverable. Demote from FATAL-CONFIG to a non-fatal warn (no
+  // `FATAL-CONFIG:` prefix → no Sentry alert) so absence does not
+  // generate false-positive alerts, but the line still clears prod
+  // log-aggregation thresholds and stays operator-visible. Same logic
+  // for posthogHost (EU cloud is the default).
   const intelligenceSignupUrl = readUrl(
     "NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL",
     PROD_DEFAULT_SIGNUP_URL,
@@ -141,34 +150,48 @@ function altEnvName(envKey: string): string {
     : `NEXT_PUBLIC_${envKey}`;
 }
 
+// Length-aware env coalesce: a deliberately-empty primary (e.g. an
+// operator clearing `NEXT_PUBLIC_SHELL_URL=""` on a Railway service)
+// must NOT mask a populated alternate. Treat empty-string as "unset"
+// and fall through to the alternate.
+function readEnvPair(envKey: string): string | undefined {
+  const primary = process.env[envKey];
+  if (primary && primary.length > 0) return primary;
+  const alt = process.env[altEnvName(envKey)];
+  if (alt && alt.length > 0) return alt;
+  return undefined;
+}
+
 function readUrl(
   envKey: string,
   fallback: string,
   isProd: boolean,
   severity: "fatal" | "info" = "fatal",
 ): string {
-  const value = process.env[envKey] ?? process.env[altEnvName(envKey)];
-  if (value && value.length > 0) return value.replace(/\/+$/, "");
+  const value = readEnvPair(envKey);
+  if (value !== undefined) return value.replace(/\/+$/, "");
   if (isProd) {
     if (severity === "fatal") {
       // eslint-disable-next-line no-console
       console.error(
-        `[runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
+        `[shell-docs runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
           `using fallback ${fallback}. Set the env var on the Railway service.`,
       );
     } else {
-      // info-level: legitimate prod default exists; absence is
+      // warn-level: legitimate prod default exists; absence is
       // recoverable so we log but do not raise the FATAL-CONFIG flag
-      // that triggers ops alerts.
+      // that triggers ops alerts. console.warn (not console.info) so
+      // the line clears prod log-aggregation thresholds and stays
+      // visible to operators.
       // eslint-disable-next-line no-console
-      console.info(
-        `[runtime-config] ${envKey} unset; using prod default ${fallback}`,
+      console.warn(
+        `[shell-docs runtime-config] ${envKey} unset; using prod default ${fallback}`,
       );
     }
   } else {
     // eslint-disable-next-line no-console
     console.warn(
-      `[runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
+      `[shell-docs runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
     );
   }
   return fallback.replace(/\/+$/, "");
@@ -183,6 +206,6 @@ function readUrl(
  * intentionally analytics-disabled environments.
  */
 function readKey(envKey: string): string {
-  const value = process.env[envKey] ?? process.env[altEnvName(envKey)];
-  return value && value.length > 0 ? value : "";
+  const value = readEnvPair(envKey);
+  return value !== undefined ? value : "";
 }

--- a/showcase/shell-docs/src/lib/sitemap-helpers.ts
+++ b/showcase/shell-docs/src/lib/sitemap-helpers.ts
@@ -14,6 +14,7 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
+import { getRuntimeConfig } from "./runtime-config";
 
 export const DOCS_CONTENT_DIR = path.join(process.cwd(), "src/content/docs");
 export const REFERENCE_CONTENT_DIR = path.join(
@@ -173,13 +174,14 @@ export function getAgUiPages(): MdxEntry[] {
 }
 
 /**
- * Resolve the canonical base URL. Reads `NEXT_PUBLIC_BASE_URL` (set in
- * production to `https://docs.copilotkit.ai`) and strips any trailing
- * slash so callers can concatenate `${BASE}/${path}` safely. Falls back
- * to the production host so SSG always yields absolute URLs even when
- * the env var hasn't been wired yet.
+ * Resolve the canonical base URL. Delegates to the server runtime
+ * config reader (which itself reads `NEXT_PUBLIC_BASE_URL` at REQUEST
+ * time, strips trailing slashes, and applies a sensible prod/dev
+ * fallback). Lives behind this thin wrapper so existing sitemap /
+ * robots call sites keep their shape — the runtime-config switch is
+ * what makes a single built artifact serve different hosts across
+ * Railway environments.
  */
 export function getBaseUrl(): string {
-  const raw = process.env.NEXT_PUBLIC_BASE_URL || "https://docs.copilotkit.ai";
-  return raw.replace(/\/+$/, "");
+  return getRuntimeConfig().baseUrl;
 }

--- a/showcase/shell-docs/src/middleware.ts
+++ b/showcase/shell-docs/src/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextFetchEvent, NextRequest } from "next/server";
 import { seoRedirects } from "@/lib/seo-redirects";
 import { stripRouteGroupSegmentsFromPathname } from "@/lib/route-groups";
+import { getRuntimeConfigEdge } from "@/lib/runtime-config";
 import registry from "@/data/registry.json";
 
 // ---------------------------------------------------------------------------
@@ -59,8 +60,15 @@ for (const entry of seoRedirects) {
 // PostHog tracking via fetch (Edge Runtime compatible — no posthog-node SDK)
 // ---------------------------------------------------------------------------
 
-const POSTHOG_HOST =
-  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
+// PostHog host is read at REQUEST time from the Edge runtime-config
+// reader (which is the same body as the Node reader but skips the
+// `unstable_noStore()` call that the Edge bundle can't import). This
+// keeps a single built artifact retargetable across Railway envs by
+// changing NEXT_PUBLIC_POSTHOG_HOST. The reader applies the same
+// `https://eu.i.posthog.com` fallback used before.
+function getPosthogHost(): string {
+  return getRuntimeConfigEdge().posthogHost;
+}
 const DISTINCT_ID_COOKIE = "ph_distinct_id";
 // ~2 years — long enough to meaningfully track returning visitors.
 const DISTINCT_ID_COOKIE_MAX_AGE = 60 * 60 * 24 * 365 * 2;
@@ -79,7 +87,7 @@ function trackRedirect(id: string, fromPath: string, toPath: string): void {
   }
 
   // Fire-and-forget — don't await
-  fetch(`${POSTHOG_HOST}/capture/`, {
+  fetch(`${getPosthogHost()}/capture/`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -106,7 +114,7 @@ async function capturePageView(
   }
 
   try {
-    const response = await fetch(`${POSTHOG_HOST}/capture/`, {
+    const response = await fetch(`${getPosthogHost()}/capture/`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/showcase/shell-dojo/Dockerfile
+++ b/showcase/shell-dojo/Dockerfile
@@ -27,6 +27,8 @@ RUN cd scripts && node node_modules/tsx/dist/cli.mjs generate-registry.ts \
 
 FROM node:20-slim AS runner
 WORKDIR /app
+ARG COMMIT_SHA=unknown
+ARG BRANCH=unknown
 ENV NODE_ENV=production
 ENV PORT=10000
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}

--- a/showcase/shell-dojo/src/app/layout.tsx
+++ b/showcase/shell-dojo/src/app/layout.tsx
@@ -18,7 +18,9 @@ export const metadata: Metadata = {
  *     containing `</script>` (e.g. a hostile env value) would
  *     terminate the inline script and inject HTML. Escape every
  *     `<` to `<` so the substring `</script>` can never appear.
- *   - ` ` (LINE SEPARATOR) and ` ` (PARAGRAPH SEPARATOR) —
+ *   - `
+` (LINE SEPARATOR) and `
+` (PARAGRAPH SEPARATOR) —
  *     legal inside JSON strings, but a syntax error inside a JS
  *     string literal in older engines / when the page is parsed as
  *     `text/javascript`. Escape both.

--- a/showcase/shell-dojo/src/app/layout.tsx
+++ b/showcase/shell-dojo/src/app/layout.tsx
@@ -1,19 +1,62 @@
 import "./globals.css";
 import type { Metadata } from "next";
+import { getRuntimeConfig } from "@/lib/runtime-config";
 
 export const metadata: Metadata = {
   title: "CopilotKit Interactive Dojo",
   description: "Interactive showcase of CopilotKit integrations",
 };
 
+/**
+ * Serialize the runtime config for inline injection. We must
+ * JSON.stringify-then-escape because the value lands inside a
+ * `<script>...</script>` tag, where four substrings would otherwise
+ * break out of (or corrupt) the parser:
+ *
+ *   - `<` — guards against the `</script>` breakout (XSS).
+ *     `JSON.stringify` does NOT escape `<` by default, so a URL
+ *     containing `</script>` (e.g. a hostile env value) would
+ *     terminate the inline script and inject HTML. Escape every
+ *     `<` to `<` so the substring `</script>` can never appear.
+ *   - ` ` (LINE SEPARATOR) and ` ` (PARAGRAPH SEPARATOR) —
+ *     legal inside JSON strings, but a syntax error inside a JS
+ *     string literal in older engines / when the page is parsed as
+ *     `text/javascript`. Escape both.
+ *
+ * Canonical OWASP-recommended escape for inline JSON in HTML.
+ */
+function serializeRuntimeConfig(cfg: unknown): string {
+  return JSON.stringify(cfg)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // Server-side: read live env at request time. `unstable_noStore()`
+  // inside getRuntimeConfig opts this segment out of the static cache
+  // so the inline <script> below always reflects the current Railway
+  // env vars. shell-dojo's RuntimeConfig is empty today; the
+  // injection stays for pattern symmetry across all four shells.
+  const runtimeConfig = getRuntimeConfig();
+  const injection = `window.__SHOWCASE_CONFIG__=${serializeRuntimeConfig(runtimeConfig)};`;
+
   return (
     <html lang="en">
       <head>
+        {/* First child of <head> — MUST execute before every other
+            head-level script so client code can read
+            window.__SHOWCASE_CONFIG__ during module init. Keep this
+            ahead of the fonts <link> and any future next/script
+            beforeInteractive blocks. */}
+        <script
+          id="__showcase_config__"
+          dangerouslySetInnerHTML={{ __html: injection }}
+        />
         <link
           href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&family=Spline+Sans+Mono:wght@400;500;600&display=swap"
           rel="stylesheet"

--- a/showcase/shell-dojo/src/app/layout.tsx
+++ b/showcase/shell-dojo/src/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 /**
  * Serialize the runtime config for inline injection. We must
  * JSON.stringify-then-escape because the value lands inside a
- * `<script>...</script>` tag, where four substrings would otherwise
+ * `<script>...</script>` tag, where three substrings would otherwise
  * break out of (or corrupt) the parser:
  *
  *   - `<` — guards against the `</script>` breakout (XSS).

--- a/showcase/shell-dojo/src/lib/runtime-config.client.ts
+++ b/showcase/shell-dojo/src/lib/runtime-config.client.ts
@@ -21,21 +21,35 @@ declare global {
 }
 
 /**
+ * Sentinel returned during SSR when `window` is unavailable. "use client"
+ * components in the Next.js App Router are server-side rendered on the
+ * initial request (that's how the HTML is streamed before hydration),
+ * which means their function bodies execute on the server too. We can't
+ * throw here without breaking SSR — instead we return a placeholder, and
+ * post-hydration the next render reads the real values out of
+ * window.__SHOWCASE_CONFIG__. Server components that need the live env
+ * values MUST import getRuntimeConfig from runtime-config.ts (the server
+ * variant), not this file.
+ *
+ * shell-dojo's RuntimeConfig is currently `{}` — the placeholder is the
+ * empty object that matches the interface.
+ */
+const SSR_PLACEHOLDER: RuntimeConfig = {};
+
+/**
  * Returns the runtime config injected by the root server layout.
  *
- * Throws when called during SSR (no window). The intended call sites
- * are client components and hooks ("use client"), which only execute
- * after hydration — by which point the inline <script> has populated
- * window.__SHOWCASE_CONFIG__. If a server component needs the same
- * values, it MUST import runtime-config.ts (the server variant) — not
- * this file.
+ * During SSR (no window) returns a sentinel placeholder; client code
+ * re-reads after hydration and gets the real values. If the inline
+ * <script> never runs (a route bypassed the layout, or injection ran
+ * with empty inputs), the post-hydration read throws — surfacing the
+ * wiring bug loudly rather than silently rendering empty URLs.
  */
 export function getRuntimeConfig(): RuntimeConfig {
     if (typeof window === "undefined") {
-        throw new Error(
-            "[runtime-config.client] getRuntimeConfig() called on the server. " +
-                "Server code must import from './runtime-config' instead.",
-        );
+        // SSR phase — "use client" component bodies execute here too.
+        // Return placeholder; hydration will re-render with real values.
+        return SSR_PLACEHOLDER;
     }
     const cfg = window.__SHOWCASE_CONFIG__;
     if (!cfg) {

--- a/showcase/shell-dojo/src/lib/runtime-config.client.ts
+++ b/showcase/shell-dojo/src/lib/runtime-config.client.ts
@@ -1,0 +1,52 @@
+// Client-side runtime config reader. Reads from
+// window.__SHOWCASE_CONFIG__ which the root layout injects via an
+// inline <script> tag BEFORE React hydrates (see app/layout.tsx). This
+// is the ONLY public API for these URLs in client code — never read
+// process.env.NEXT_PUBLIC_* directly (the ESLint rule in B12 enforces
+// this).
+//
+// shell-dojo's `RuntimeConfig` is intentionally empty today (no URL
+// consumers); the module exists to keep the pattern symmetric across
+// shells. When a URL is added on the server side, this reader picks it
+// up via the shared interface.
+
+import type { RuntimeConfig } from "./runtime-config";
+
+export type { RuntimeConfig };
+
+declare global {
+    interface Window {
+        __SHOWCASE_CONFIG__?: RuntimeConfig;
+    }
+}
+
+/**
+ * Returns the runtime config injected by the root server layout.
+ *
+ * Throws when called during SSR (no window). The intended call sites
+ * are client components and hooks ("use client"), which only execute
+ * after hydration — by which point the inline <script> has populated
+ * window.__SHOWCASE_CONFIG__. If a server component needs the same
+ * values, it MUST import runtime-config.ts (the server variant) — not
+ * this file.
+ */
+export function getRuntimeConfig(): RuntimeConfig {
+    if (typeof window === "undefined") {
+        throw new Error(
+            "[runtime-config.client] getRuntimeConfig() called on the server. " +
+                "Server code must import from './runtime-config' instead.",
+        );
+    }
+    const cfg = window.__SHOWCASE_CONFIG__;
+    if (!cfg) {
+        // The root layout always emits the <script> tag, so a missing
+        // value here is a wiring bug (e.g. a route bypassed the layout,
+        // or the injection script ran with empty inputs). Surface it
+        // loudly rather than silently returning empty strings.
+        throw new Error(
+            "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
+                "The root layout must inject runtime config before client mount.",
+        );
+    }
+    return cfg;
+}

--- a/showcase/shell-dojo/src/lib/runtime-config.client.ts
+++ b/showcase/shell-dojo/src/lib/runtime-config.client.ts
@@ -14,9 +14,9 @@ import type { RuntimeConfig } from "./runtime-config";
 export type { RuntimeConfig };
 
 declare global {
-    interface Window {
-        __SHOWCASE_CONFIG__?: RuntimeConfig;
-    }
+  interface Window {
+    __SHOWCASE_CONFIG__?: RuntimeConfig;
+  }
 }
 
 /**
@@ -45,21 +45,21 @@ const SSR_PLACEHOLDER: RuntimeConfig = {};
  * wiring bug loudly rather than silently rendering empty URLs.
  */
 export function getRuntimeConfig(): RuntimeConfig {
-    if (typeof window === "undefined") {
-        // SSR phase — "use client" component bodies execute here too.
-        // Return placeholder; hydration will re-render with real values.
-        return SSR_PLACEHOLDER;
-    }
-    const cfg = window.__SHOWCASE_CONFIG__;
-    if (!cfg) {
-        // The root layout always emits the <script> tag, so a missing
-        // value here is a wiring bug (e.g. a route bypassed the layout,
-        // or the injection script ran with empty inputs). Surface it
-        // loudly rather than silently returning empty strings.
-        throw new Error(
-            "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
-                "The root layout must inject runtime config before client mount.",
-        );
-    }
-    return cfg;
+  if (typeof window === "undefined") {
+    // SSR phase — "use client" component bodies execute here too.
+    // Return placeholder; hydration will re-render with real values.
+    return SSR_PLACEHOLDER;
+  }
+  const cfg = window.__SHOWCASE_CONFIG__;
+  if (!cfg) {
+    // The root layout always emits the <script> tag, so a missing
+    // value here is a wiring bug (e.g. a route bypassed the layout,
+    // or the injection script ran with empty inputs). Surface it
+    // loudly rather than silently returning empty strings.
+    throw new Error(
+      "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
+        "The root layout must inject runtime config before client mount.",
+    );
+  }
+  return cfg;
 }

--- a/showcase/shell-dojo/src/lib/runtime-config.client.ts
+++ b/showcase/shell-dojo/src/lib/runtime-config.client.ts
@@ -2,8 +2,7 @@
 // window.__SHOWCASE_CONFIG__ which the root layout injects via an
 // inline <script> tag BEFORE React hydrates (see app/layout.tsx). This
 // is the ONLY public API for these URLs in client code — never read
-// process.env.NEXT_PUBLIC_* directly (the ESLint rule in B12 enforces
-// this).
+// process.env.NEXT_PUBLIC_* directly (an ESLint rule enforces this).
 //
 // shell-dojo's `RuntimeConfig` is intentionally empty today (no URL
 // consumers); the module exists to keep the pattern symmetric across

--- a/showcase/shell-dojo/src/lib/runtime-config.ts
+++ b/showcase/shell-dojo/src/lib/runtime-config.ts
@@ -6,20 +6,20 @@
 // `unstable_noStore()` opts the calling segment out of Next.js's static
 // cache so reads always reflect the live env. Without it, a server
 // component that uses this could be statically rendered at build time
-// and freeze the URLs back into the artifact (the exact bug we are
-// fixing). See Next.js App Router docs on Dynamic Rendering.
+// and freeze the URLs back into the artifact — defeating the runtime
+// switch. See Next.js App Router docs on Dynamic Rendering.
 //
 // This module MUST NOT be imported from client components. The matching
 // client-side reader lives in runtime-config.client.ts and reads from
 // window.__SHOWCASE_CONFIG__ which the root layout injects.
 //
-// shell-dojo today has no URL consumers (audit B0 reported zero
-// process.env.NEXT_PUBLIC_* reads). The `RuntimeConfig` interface is
-// intentionally an empty object literal — it exists to keep the
-// runtime-config / layout-injection pattern symmetric across all four
-// shells. Adding a URL later means adding a field here, reading it
-// from process.env via `readUrl`, and the client-side reader picks it
-// up automatically through the shared interface.
+// shell-dojo today has no URL consumers (zero process.env.NEXT_PUBLIC_*
+// reads in this shell). The `RuntimeConfig` interface is intentionally
+// an empty object literal — it exists to keep the runtime-config /
+// layout-injection pattern symmetric across the shells. Adding a URL
+// later means adding a field here, reading it from process.env via
+// `readUrl`, and the client-side reader picks it up automatically
+// through the shared interface.
 
 import { unstable_noStore as noStore } from "next/cache";
 

--- a/showcase/shell-dojo/src/lib/runtime-config.ts
+++ b/showcase/shell-dojo/src/lib/runtime-config.ts
@@ -39,8 +39,8 @@ export interface RuntimeConfig {}
  * future URL values into the build artifact.
  */
 export function getRuntimeConfig(
-    opts: { noStore?: boolean } = {},
+  opts: { noStore?: boolean } = {},
 ): RuntimeConfig {
-    if (opts.noStore !== false) noStore();
-    return {};
+  if (opts.noStore !== false) noStore();
+  return {};
 }

--- a/showcase/shell-dojo/src/lib/runtime-config.ts
+++ b/showcase/shell-dojo/src/lib/runtime-config.ts
@@ -1,0 +1,46 @@
+// Server-only runtime config reader. Reads from process.env at REQUEST
+// time (not at module load) so a single built artifact can serve
+// different URL values across staging vs prod by changing the Railway
+// service's env vars — no rebuild required.
+//
+// `unstable_noStore()` opts the calling segment out of Next.js's static
+// cache so reads always reflect the live env. Without it, a server
+// component that uses this could be statically rendered at build time
+// and freeze the URLs back into the artifact (the exact bug we are
+// fixing). See Next.js App Router docs on Dynamic Rendering.
+//
+// This module MUST NOT be imported from client components. The matching
+// client-side reader lives in runtime-config.client.ts and reads from
+// window.__SHOWCASE_CONFIG__ which the root layout injects.
+//
+// shell-dojo today has no URL consumers (audit B0 reported zero
+// process.env.NEXT_PUBLIC_* reads). The `RuntimeConfig` interface is
+// intentionally an empty object literal — it exists to keep the
+// runtime-config / layout-injection pattern symmetric across all four
+// shells. Adding a URL later means adding a field here, reading it
+// from process.env via `readUrl`, and the client-side reader picks it
+// up automatically through the shared interface.
+
+import { unstable_noStore as noStore } from "next/cache";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface RuntimeConfig {}
+
+/**
+ * Resolve the runtime config for shell-dojo. Called once per request
+ * by the root layout. Currently returns an empty object since
+ * shell-dojo has no URL-dependent consumers; the module exists to keep
+ * the pattern symmetric across shells (see shell-dashboard's
+ * runtime-config.ts for the full template).
+ *
+ * `opts.noStore` (default `true`) controls whether to call
+ * `unstable_noStore()`. The Node.js server runtime needs the opt-out
+ * so Next.js does not statically prerender callers and freeze any
+ * future URL values into the build artifact.
+ */
+export function getRuntimeConfig(
+    opts: { noStore?: boolean } = {},
+): RuntimeConfig {
+    if (opts.noStore !== false) noStore();
+    return {};
+}

--- a/showcase/shell/Dockerfile
+++ b/showcase/shell/Dockerfile
@@ -30,6 +30,8 @@ RUN cd scripts && node node_modules/tsx/dist/cli.mjs generate-registry.ts \
 
 FROM node:20-slim AS runner
 WORKDIR /app
+ARG COMMIT_SHA=unknown
+ARG BRANCH=unknown
 ENV NODE_ENV=production
 ENV PORT=10000
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}

--- a/showcase/shell/next.config.ts
+++ b/showcase/shell/next.config.ts
@@ -70,8 +70,11 @@ const DOCS_HOST = "https://docs.showcase.copilotkit.ai";
 
 const nextConfig: NextConfig = {
   env: {
-    NEXT_PUBLIC_BASE_URL:
-      process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000",
+    // NEXT_PUBLIC_BASE_URL intentionally NOT listed here: it must be
+    // read at request time via runtime-config (otherwise `next build`
+    // re-bakes the build-time value into every chunk). NEXT_PUBLIC_LOCAL_BACKENDS
+    // is fine to bake because it is computed from `shared/local-ports.json`
+    // (a JSON file on disk, not an env var) and only used in local-dev.
     NEXT_PUBLIC_LOCAL_BACKENDS: localBackendsEnv(),
   },
   serverExternalPackages: ["@copilotkit/runtime", "@copilotkitnext/runtime"],

--- a/showcase/shell/package-lock.json
+++ b/showcase/shell/package-lock.json
@@ -8,14 +8,14 @@
       "name": "@copilotkit/showcase-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@copilotkit/react-core": "next",
+        "@copilotkit/react-core": "latest",
         "@copilotkitnext/agent": "next",
         "@copilotkitnext/react": "next",
         "@copilotkitnext/runtime": "next",
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.11.1",
-        "hono": "^4.0.0",
-        "next": "^15.0.0",
+        "hono": "^4.6.0",
+        "next": "^15.5.15",
         "next-mdx-remote": "^5.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -31,10 +31,12 @@
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-syntax-highlighter": "^15.5.0",
+        "jsdom": "^29.0.2",
         "postcss": "^8.5.0",
         "tailwindcss": "^4.0.0",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -450,6 +452,57 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -487,6 +540,19 @@
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.11.0",
@@ -1910,10 +1976,173 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2360,6 +2589,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3412,6 +3659,25 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.5.15",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
@@ -3553,6 +3819,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@preact/signals-core": {
@@ -4236,6 +4512,288 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
@@ -4596,6 +5154,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -4669,6 +5291,28 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3": {
@@ -4933,6 +5577,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5078,6 +5729,119 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -5214,6 +5978,16 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -5252,6 +6026,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -5397,6 +6181,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -5590,6 +6384,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -5643,6 +6444,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/csstype": {
@@ -6180,6 +6995,58 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -6204,6 +7071,13 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -6392,6 +7266,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -6631,6 +7512,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
@@ -6752,6 +7643,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fetch-blob": {
@@ -7496,6 +8405,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -7731,6 +8653,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -7779,6 +8708,111 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/json-bigint": {
@@ -8242,6 +9276,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/lucide": {
@@ -8724,6 +9768,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -9690,9 +10741,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -9878,6 +10929,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -10013,6 +11075,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -10050,9 +11125,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -10070,7 +11145,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10125,6 +11200,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode.js": {
@@ -10820,6 +11905,40 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
     "node_modules/roughjs": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
@@ -10933,6 +12052,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -11171,6 +12303,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-polyfill": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/signal-polyfill/-/signal-polyfill-0.2.2.tgz",
@@ -11220,6 +12359,13 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -11228,6 +12374,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamdown": {
       "version": "1.6.11",
@@ -11366,6 +12519,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
@@ -11397,6 +12557,13 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
@@ -11406,6 +12573,53 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.0.tgz",
+      "integrity": "sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.0"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.1.tgz",
+      "integrity": "sha512-sc2nGvGbixlJRHwTh/qQdPXTxJU1UDJboGPQm4d/01YUJ9r/u6aeIulQvEaxUlvKDN7hb1qCLjax+jhVAPLa/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -11413,6 +12627,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -11532,6 +12759,16 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -11912,6 +13149,174 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -11961,6 +13366,19 @@
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -11986,6 +13404,16 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -12009,6 +13437,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wonka": {
@@ -12043,6 +13488,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/showcase/shell/package.json
+++ b/showcase/shell/package.json
@@ -6,7 +6,9 @@
     "dev": "tsx ../scripts/generate-registry.ts && tsx ../scripts/bundle-demo-content.ts && tsx ../scripts/bundle-starter-content.ts && tsx ../scripts/generate-search-index.ts && npx -y concurrently -k -n bundle,next \"tsx ../scripts/bundle-demo-content.ts --watch\" \"next dev\"",
     "build": "tsx ../scripts/generate-registry.ts && tsx ../scripts/bundle-demo-content.ts && tsx ../scripts/bundle-starter-content.ts && tsx ../scripts/generate-search-index.ts && next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@copilotkit/react-core": "latest",
@@ -32,9 +34,11 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-syntax-highlighter": "^15.5.0",
+    "jsdom": "^29.0.2",
     "postcss": "^8.5.0",
     "tailwindcss": "^4.0.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.4"
   }
 }

--- a/showcase/shell/src/app/layout.tsx
+++ b/showcase/shell/src/app/layout.tsx
@@ -3,7 +3,42 @@ import { Plus_Jakarta_Sans, Spline_Sans_Mono } from "next/font/google";
 import { BrandNav } from "@/components/brand-nav";
 import { FrameworkProvider } from "@/components/framework-provider";
 import { getIntegrations } from "@/lib/registry";
+import { getRuntimeConfig } from "@/lib/runtime-config";
 import "./globals.css";
+
+/**
+ * Serialize the runtime config for inline injection. We must
+ * JSON.stringify-then-escape because the value lands inside a
+ * `<script>...</script>` tag, where three substrings would otherwise
+ * break out of (or corrupt) the parser:
+ *
+ *   - `<` — guards against the `</script>` breakout (XSS).
+ *     `JSON.stringify` does NOT escape `<` by default, so a URL
+ *     containing `</script>` (e.g. a hostile env value) would
+ *     terminate the inline script and inject HTML. Escape every
+ *     `<` to `<` so the substring `</script>` can never appear.
+ *   - ` ` (LINE SEPARATOR) and ` ` (PARAGRAPH SEPARATOR) —
+ *     legal inside JSON strings, but a syntax error inside a JS
+ *     string literal in older engines / when the page is parsed as
+ *     `text/javascript`. Escape both.
+ *
+ * IMPORTANT: the regex sources below use explicit ` ` / ` `
+ * ECMAScript-Unicode escapes — the regex engine resolves the escape at
+ * compile time, so `/ /` matches the actual U+2028 codepoint.
+ * Using a literal U+2028 / U+2029 character in the regex source would
+ * break the parser (those codepoints terminate a regex literal in
+ * pre-ES2019 engines, and are visually invisible — easy to ship
+ * accidentally). Reviewers MUST confirm these regexes are written with
+ * ` ` / ` ` escapes literally.
+ *
+ * Canonical OWASP-recommended escape for inline JSON in HTML.
+ */
+function serializeRuntimeConfig(cfg: unknown): string {
+  return JSON.stringify(cfg)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
 
 const plusJakartaSans = Plus_Jakarta_Sans({
   subsets: ["latin"],
@@ -41,11 +76,28 @@ export default function RootLayout({
   // options are wired up in the docs page-level server components.
   const knownFrameworks = getIntegrations().map((i) => i.slug);
 
+  // Server-side: read live env at request time. `unstable_noStore()`
+  // inside getRuntimeConfig opts this segment out of the static cache
+  // so the inline <script> below always reflects the current Railway
+  // env vars rather than baked-in build-time values.
+  const runtimeConfig = getRuntimeConfig();
+  const injection = `window.__SHOWCASE_CONFIG__=${serializeRuntimeConfig(runtimeConfig)};`;
+
   return (
     <html
       lang="en"
       className={`${plusJakartaSans.variable} ${splineSansMono.variable}`}
     >
+      <head>
+        {/* Must be the first (and currently only) child of <head>:
+         * every client component reads window.__SHOWCASE_CONFIG__
+         * during hydration; it must be populated by the time the
+         * parser reaches <body>. */}
+        <script
+          id="__showcase_config__"
+          dangerouslySetInnerHTML={{ __html: injection }}
+        />
+      </head>
       <body className="min-h-screen">
         <FrameworkProvider knownFrameworks={knownFrameworks}>
           <BrandNav />

--- a/showcase/shell/src/app/layout.tsx
+++ b/showcase/shell/src/app/layout.tsx
@@ -17,19 +17,26 @@ import "./globals.css";
  *     containing `</script>` (e.g. a hostile env value) would
  *     terminate the inline script and inject HTML. Escape every
  *     `<` to `<` so the substring `</script>` can never appear.
- *   - ` ` (LINE SEPARATOR) and ` ` (PARAGRAPH SEPARATOR) —
+ *   - `
+` (LINE SEPARATOR) and `
+` (PARAGRAPH SEPARATOR) —
  *     legal inside JSON strings, but a syntax error inside a JS
  *     string literal in older engines / when the page is parsed as
  *     `text/javascript`. Escape both.
  *
- * IMPORTANT: the regex sources below use explicit ` ` / ` `
+ * IMPORTANT: the regex sources below use explicit `
+` / `
+`
  * ECMAScript-Unicode escapes — the regex engine resolves the escape at
- * compile time, so `/ /` matches the actual U+2028 codepoint.
+ * compile time, so `/
+/` matches the actual U+2028 codepoint.
  * Using a literal U+2028 / U+2029 character in the regex source would
  * break the parser (those codepoints terminate a regex literal in
  * pre-ES2019 engines, and are visually invisible — easy to ship
  * accidentally). Reviewers MUST confirm these regexes are written with
- * ` ` / ` ` escapes literally.
+ * `
+` / `
+` escapes literally.
  *
  * Canonical OWASP-recommended escape for inline JSON in HTML.
  */

--- a/showcase/shell/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell/src/lib/runtime-config.client.test.ts
@@ -33,13 +33,20 @@ describe("client getRuntimeConfig (shell)", () => {
         );
     });
 
-    it("throws on the server (no window)", () => {
-        // Simulate SSR by removing window.
+    it("returns SSR sentinel placeholder when window is undefined", () => {
+        // Simulate SSR by removing window. "use client" component
+        // bodies execute on the server during SSR, so this reader
+        // MUST be SSR-safe (returns empty-string placeholders that
+        // get replaced on the next render after hydration), NOT
+        // throw — otherwise the whole server-rendered HTML 500s.
         const w = globalThis.window;
         // @ts-expect-error — deliberately removing window for the test
         delete globalThis.window;
         try {
-            expect(() => getRuntimeConfig()).toThrow(/called on the server/);
+            expect(getRuntimeConfig()).toEqual({
+                baseUrl: "",
+                posthogHost: "",
+            });
         } finally {
             (globalThis as { window?: typeof w }).window = w;
         }

--- a/showcase/shell/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell/src/lib/runtime-config.client.test.ts
@@ -36,17 +36,17 @@ describe("client getRuntimeConfig (shell)", () => {
     it("returns SSR sentinel placeholder when window is undefined", () => {
         // Simulate SSR by removing window. "use client" component
         // bodies execute on the server during SSR, so this reader
-        // MUST be SSR-safe (returns empty-string placeholders that
-        // get replaced on the next render after hydration), NOT
-        // throw — otherwise the whole server-rendered HTML 500s.
+        // MUST be SSR-safe (returns parseable-URL placeholders so
+        // `new URL()` in consumers doesn't throw) and NOT throw —
+        // otherwise the whole server-rendered HTML 500s.
         const w = globalThis.window;
         // @ts-expect-error — deliberately removing window for the test
         delete globalThis.window;
         try {
-            expect(getRuntimeConfig()).toEqual({
-                baseUrl: "",
-                posthogHost: "",
-            });
+            const cfg = getRuntimeConfig();
+            // URL fields must be parseable.
+            expect(() => new URL(cfg.baseUrl)).not.toThrow();
+            expect(() => new URL(cfg.posthogHost)).not.toThrow();
         } finally {
             (globalThis as { window?: typeof w }).window = w;
         }

--- a/showcase/shell/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell/src/lib/runtime-config.client.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRuntimeConfig } from "./runtime-config.client";
+
+describe("client getRuntimeConfig (shell)", () => {
+    const originalWindow = globalThis.window;
+
+    beforeEach(() => {
+        // jsdom provides `window` by default in this vitest config.
+        // Reset any prior injection.
+        delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
+            .__SHOWCASE_CONFIG__;
+    });
+
+    afterEach(() => {
+        (globalThis as { window?: Window }).window = originalWindow;
+    });
+
+    it("returns the injected config", () => {
+        (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
+            {
+                baseUrl: "https://showcase.example.com",
+                posthogHost: "https://eu.i.posthog.com",
+            };
+        expect(getRuntimeConfig()).toEqual({
+            baseUrl: "https://showcase.example.com",
+            posthogHost: "https://eu.i.posthog.com",
+        });
+    });
+
+    it("throws when __SHOWCASE_CONFIG__ is missing (wiring bug)", () => {
+        expect(() => getRuntimeConfig()).toThrow(
+            /window\.__SHOWCASE_CONFIG__ is missing/,
+        );
+    });
+
+    it("throws on the server (no window)", () => {
+        // Simulate SSR by removing window.
+        const w = globalThis.window;
+        // @ts-expect-error — deliberately removing window for the test
+        delete globalThis.window;
+        try {
+            expect(() => getRuntimeConfig()).toThrow(/called on the server/);
+        } finally {
+            (globalThis as { window?: typeof w }).window = w;
+        }
+    });
+});

--- a/showcase/shell/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell/src/lib/runtime-config.client.test.ts
@@ -2,53 +2,53 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getRuntimeConfig } from "./runtime-config.client";
 
 describe("client getRuntimeConfig (shell)", () => {
-    const originalWindow = globalThis.window;
+  const originalWindow = globalThis.window;
 
-    beforeEach(() => {
-        // jsdom provides `window` by default in this vitest config.
-        // Reset any prior injection.
-        delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
-            .__SHOWCASE_CONFIG__;
-    });
+  beforeEach(() => {
+    // jsdom provides `window` by default in this vitest config.
+    // Reset any prior injection.
+    delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
+      .__SHOWCASE_CONFIG__;
+  });
 
-    afterEach(() => {
-        (globalThis as { window?: Window }).window = originalWindow;
-    });
+  afterEach(() => {
+    (globalThis as { window?: Window }).window = originalWindow;
+  });
 
-    it("returns the injected config", () => {
-        (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
-            {
-                baseUrl: "https://showcase.example.com",
-                posthogHost: "https://eu.i.posthog.com",
-            };
-        expect(getRuntimeConfig()).toEqual({
-            baseUrl: "https://showcase.example.com",
-            posthogHost: "https://eu.i.posthog.com",
-        });
+  it("returns the injected config", () => {
+    (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
+      {
+        baseUrl: "https://showcase.example.com",
+        posthogHost: "https://eu.i.posthog.com",
+      };
+    expect(getRuntimeConfig()).toEqual({
+      baseUrl: "https://showcase.example.com",
+      posthogHost: "https://eu.i.posthog.com",
     });
+  });
 
-    it("throws when __SHOWCASE_CONFIG__ is missing (wiring bug)", () => {
-        expect(() => getRuntimeConfig()).toThrow(
-            /window\.__SHOWCASE_CONFIG__ is missing/,
-        );
-    });
+  it("throws when __SHOWCASE_CONFIG__ is missing (wiring bug)", () => {
+    expect(() => getRuntimeConfig()).toThrow(
+      /window\.__SHOWCASE_CONFIG__ is missing/,
+    );
+  });
 
-    it("returns SSR sentinel placeholder when window is undefined", () => {
-        // Simulate SSR by removing window. "use client" component
-        // bodies execute on the server during SSR, so this reader
-        // MUST be SSR-safe (returns parseable-URL placeholders so
-        // `new URL()` in consumers doesn't throw) and NOT throw —
-        // otherwise the whole server-rendered HTML 500s.
-        const w = globalThis.window;
-        // @ts-expect-error — deliberately removing window for the test
-        delete globalThis.window;
-        try {
-            const cfg = getRuntimeConfig();
-            // URL fields must be parseable.
-            expect(() => new URL(cfg.baseUrl)).not.toThrow();
-            expect(() => new URL(cfg.posthogHost)).not.toThrow();
-        } finally {
-            (globalThis as { window?: typeof w }).window = w;
-        }
-    });
+  it("returns SSR sentinel placeholder when window is undefined", () => {
+    // Simulate SSR by removing window. "use client" component
+    // bodies execute on the server during SSR, so this reader
+    // MUST be SSR-safe (returns parseable-URL placeholders so
+    // `new URL()` in consumers doesn't throw) and NOT throw —
+    // otherwise the whole server-rendered HTML 500s.
+    const w = globalThis.window;
+    // @ts-expect-error — deliberately removing window for the test
+    delete globalThis.window;
+    try {
+      const cfg = getRuntimeConfig();
+      // URL fields must be parseable.
+      expect(() => new URL(cfg.baseUrl)).not.toThrow();
+      expect(() => new URL(cfg.posthogHost)).not.toThrow();
+    } finally {
+      (globalThis as { window?: typeof w }).window = w;
+    }
+  });
 });

--- a/showcase/shell/src/lib/runtime-config.client.ts
+++ b/showcase/shell/src/lib/runtime-config.client.ts
@@ -25,9 +25,17 @@ declare global {
  * values MUST import getRuntimeConfig from runtime-config.ts (the server
  * variant), not this file.
  */
+// URL fields use a parseable `https://ssr-placeholder.invalid/` sentinel
+// — NOT the empty string — because consumer components may call
+// `new URL(cfg.someUrl)` inline during render, and `new URL("")` throws
+// a TypeError that escapes the SSR response as a 500. The `.invalid`
+// TLD is reserved by RFC 2606 so the URL also can't accidentally
+// resolve. Post-hydration the next render reads the real value out of
+// window.__SHOWCASE_CONFIG__.
+const SSR_PLACEHOLDER_URL = "https://ssr-placeholder.invalid/";
 const SSR_PLACEHOLDER: RuntimeConfig = {
-    baseUrl: "",
-    posthogHost: "",
+    baseUrl: SSR_PLACEHOLDER_URL,
+    posthogHost: SSR_PLACEHOLDER_URL,
 };
 
 /**

--- a/showcase/shell/src/lib/runtime-config.client.ts
+++ b/showcase/shell/src/lib/runtime-config.client.ts
@@ -15,21 +15,35 @@ declare global {
 }
 
 /**
+ * Sentinel returned during SSR when `window` is unavailable. "use client"
+ * components in the Next.js App Router are server-side rendered on the
+ * initial request (that's how the HTML is streamed before hydration),
+ * which means their function bodies execute on the server too. We can't
+ * throw here without breaking SSR — instead we return a placeholder, and
+ * post-hydration the next render reads the real values out of
+ * window.__SHOWCASE_CONFIG__. Server components that need the live env
+ * values MUST import getRuntimeConfig from runtime-config.ts (the server
+ * variant), not this file.
+ */
+const SSR_PLACEHOLDER: RuntimeConfig = {
+    baseUrl: "",
+    posthogHost: "",
+};
+
+/**
  * Returns the runtime config injected by the root server layout.
  *
- * Throws when called during SSR (no window). The intended call sites
- * are client components and hooks ("use client"), which only execute
- * after hydration — by which point the inline <script> has populated
- * window.__SHOWCASE_CONFIG__. If a server component needs the same
- * values, it MUST import runtime-config.ts (the server variant) — not
- * this file.
+ * During SSR (no window) returns a sentinel placeholder; client code
+ * re-reads after hydration and gets the real values. If the inline
+ * <script> never runs (a route bypassed the layout, or injection ran
+ * with empty inputs), the post-hydration read throws — surfacing the
+ * wiring bug loudly rather than silently rendering empty URLs.
  */
 export function getRuntimeConfig(): RuntimeConfig {
     if (typeof window === "undefined") {
-        throw new Error(
-            "[runtime-config.client] getRuntimeConfig() called on the server. " +
-                "Server code must import from './runtime-config' instead.",
-        );
+        // SSR phase — "use client" component bodies execute here too.
+        // Return placeholder; hydration will re-render with real values.
+        return SSR_PLACEHOLDER;
     }
     const cfg = window.__SHOWCASE_CONFIG__;
     if (!cfg) {

--- a/showcase/shell/src/lib/runtime-config.client.ts
+++ b/showcase/shell/src/lib/runtime-config.client.ts
@@ -1,0 +1,46 @@
+// Client-side runtime config reader. Reads from
+// window.__SHOWCASE_CONFIG__ which the root layout injects via an
+// inline <script> tag BEFORE React hydrates (see app/layout.tsx). This
+// is the ONLY public API for these URLs in client code — never read
+// process.env.NEXT_PUBLIC_* directly.
+
+import type { RuntimeConfig } from "./runtime-config";
+
+export type { RuntimeConfig };
+
+declare global {
+    interface Window {
+        __SHOWCASE_CONFIG__?: RuntimeConfig;
+    }
+}
+
+/**
+ * Returns the runtime config injected by the root server layout.
+ *
+ * Throws when called during SSR (no window). The intended call sites
+ * are client components and hooks ("use client"), which only execute
+ * after hydration — by which point the inline <script> has populated
+ * window.__SHOWCASE_CONFIG__. If a server component needs the same
+ * values, it MUST import runtime-config.ts (the server variant) — not
+ * this file.
+ */
+export function getRuntimeConfig(): RuntimeConfig {
+    if (typeof window === "undefined") {
+        throw new Error(
+            "[runtime-config.client] getRuntimeConfig() called on the server. " +
+                "Server code must import from './runtime-config' instead.",
+        );
+    }
+    const cfg = window.__SHOWCASE_CONFIG__;
+    if (!cfg) {
+        // The root layout always emits the <script> tag, so a missing
+        // value here is a wiring bug (e.g. a route bypassed the layout,
+        // or the injection script ran with empty inputs). Surface it
+        // loudly rather than silently returning empty strings.
+        throw new Error(
+            "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
+                "The root layout must inject runtime config before client mount.",
+        );
+    }
+    return cfg;
+}

--- a/showcase/shell/src/lib/runtime-config.client.ts
+++ b/showcase/shell/src/lib/runtime-config.client.ts
@@ -9,9 +9,9 @@ import type { RuntimeConfig } from "./runtime-config";
 export type { RuntimeConfig };
 
 declare global {
-    interface Window {
-        __SHOWCASE_CONFIG__?: RuntimeConfig;
-    }
+  interface Window {
+    __SHOWCASE_CONFIG__?: RuntimeConfig;
+  }
 }
 
 /**
@@ -34,8 +34,8 @@ declare global {
 // window.__SHOWCASE_CONFIG__.
 const SSR_PLACEHOLDER_URL = "https://ssr-placeholder.invalid/";
 const SSR_PLACEHOLDER: RuntimeConfig = {
-    baseUrl: SSR_PLACEHOLDER_URL,
-    posthogHost: SSR_PLACEHOLDER_URL,
+  baseUrl: SSR_PLACEHOLDER_URL,
+  posthogHost: SSR_PLACEHOLDER_URL,
 };
 
 /**
@@ -48,21 +48,21 @@ const SSR_PLACEHOLDER: RuntimeConfig = {
  * wiring bug loudly rather than silently rendering empty URLs.
  */
 export function getRuntimeConfig(): RuntimeConfig {
-    if (typeof window === "undefined") {
-        // SSR phase — "use client" component bodies execute here too.
-        // Return placeholder; hydration will re-render with real values.
-        return SSR_PLACEHOLDER;
-    }
-    const cfg = window.__SHOWCASE_CONFIG__;
-    if (!cfg) {
-        // The root layout always emits the <script> tag, so a missing
-        // value here is a wiring bug (e.g. a route bypassed the layout,
-        // or the injection script ran with empty inputs). Surface it
-        // loudly rather than silently returning empty strings.
-        throw new Error(
-            "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
-                "The root layout must inject runtime config before client mount.",
-        );
-    }
-    return cfg;
+  if (typeof window === "undefined") {
+    // SSR phase — "use client" component bodies execute here too.
+    // Return placeholder; hydration will re-render with real values.
+    return SSR_PLACEHOLDER;
+  }
+  const cfg = window.__SHOWCASE_CONFIG__;
+  if (!cfg) {
+    // The root layout always emits the <script> tag, so a missing
+    // value here is a wiring bug (e.g. a route bypassed the layout,
+    // or the injection script ran with empty inputs). Surface it
+    // loudly rather than silently returning empty strings.
+    throw new Error(
+      "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
+        "The root layout must inject runtime config before client mount.",
+    );
+  }
+  return cfg;
 }

--- a/showcase/shell/src/lib/runtime-config.test.ts
+++ b/showcase/shell/src/lib/runtime-config.test.ts
@@ -5,138 +5,136 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Component"). The function is a no-op for our purposes (it tells Next
 // not to cache; in a unit test there is no cache to opt out of).
 vi.mock("next/cache", () => ({
-    unstable_noStore: () => {},
+  unstable_noStore: () => {},
 }));
 
 import { getRuntimeConfig } from "./runtime-config";
 
 describe("server getRuntimeConfig (shell)", () => {
-    const ORIGINAL_ENV = { ...process.env };
+  const ORIGINAL_ENV = { ...process.env };
 
-    beforeEach(() => {
-        for (const k of [
-            "BASE_URL",
-            "POSTHOG_HOST",
-            "NEXT_PUBLIC_BASE_URL",
-            "NEXT_PUBLIC_POSTHOG_HOST",
-            "NODE_ENV",
-        ]) {
-            delete (process.env as Record<string, string | undefined>)[k];
-        }
+  beforeEach(() => {
+    for (const k of [
+      "BASE_URL",
+      "POSTHOG_HOST",
+      "NEXT_PUBLIC_BASE_URL",
+      "NEXT_PUBLIC_POSTHOG_HOST",
+      "NODE_ENV",
+    ]) {
+      delete (process.env as Record<string, string | undefined>)[k];
+    }
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, ORIGINAL_ENV);
+  });
+
+  it("returns env values when all are set (production)", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    process.env.POSTHOG_HOST = "https://eu.i.posthog.com";
+    expect(getRuntimeConfig()).toEqual({
+      baseUrl: "https://showcase.copilotkit.ai",
+      posthogHost: "https://eu.i.posthog.com",
     });
+  });
 
-    afterEach(() => {
-        Object.assign(process.env, ORIGINAL_ENV);
+  it("strips trailing slashes", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.example.com/";
+    process.env.POSTHOG_HOST = "https://eu.i.posthog.com//";
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("https://showcase.example.com");
+    expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+  });
+
+  it("falls back to dev defaults when unset in non-production", () => {
+    (process.env as Record<string, string>).NODE_ENV = "development";
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("http://localhost:3000");
+    expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+  });
+
+  it("falls back to sentinel and console.errors in production (BASE_URL only)", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
     });
+    const cfg = getRuntimeConfig();
+    spy.mockRestore();
+    expect(cfg.baseUrl).toBe("about:blank#shell-base-url-missing");
+    // POSTHOG_HOST falls back silently (analytics key — legitimately absent in some envs).
+    expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+    expect(errs.some((m) => m.includes("BASE_URL"))).toBe(true);
+    expect(errs.some((m) => m.includes("POSTHOG_HOST"))).toBe(false);
+  });
 
-    it("returns env values when all are set (production)", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.BASE_URL = "https://showcase.copilotkit.ai";
-        process.env.POSTHOG_HOST = "https://eu.i.posthog.com";
-        expect(getRuntimeConfig()).toEqual({
-            baseUrl: "https://showcase.copilotkit.ai",
-            posthogHost: "https://eu.i.posthog.com",
-        });
-    });
+  it("reads live process.env on each call (no module-load freeze)", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://first.example.com";
+    process.env.POSTHOG_HOST = "https://eu.i.posthog.com";
+    expect(getRuntimeConfig().baseUrl).toBe("https://first.example.com");
+    process.env.BASE_URL = "https://second.example.com";
+    expect(getRuntimeConfig().baseUrl).toBe("https://second.example.com");
+  });
 
-    it("strips trailing slashes", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.BASE_URL = "https://showcase.example.com/";
-        process.env.POSTHOG_HOST = "https://eu.i.posthog.com//";
-        const cfg = getRuntimeConfig();
-        expect(cfg.baseUrl).toBe("https://showcase.example.com");
-        expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
-    });
+  it("accepts NEXT_PUBLIC_BASE_URL as a fallback when BASE_URL is unset", () => {
+    // Deploy-config contract: the shell reads the bare name first,
+    // but tolerates the NEXT_PUBLIC_-prefixed variant so a Railway
+    // service that follows the shell-docs convention still wires
+    // through. See the readUrl fallback chain in runtime-config.ts.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
+    // BASE_URL deliberately unset.
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("https://alt.example.com");
+  });
 
-    it("falls back to dev defaults when unset in non-production", () => {
-        (process.env as Record<string, string>).NODE_ENV = "development";
-        const cfg = getRuntimeConfig();
-        expect(cfg.baseUrl).toBe("http://localhost:3000");
-        expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
-    });
+  it("BASE_URL takes precedence over NEXT_PUBLIC_BASE_URL when both set", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://primary.example.com";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("https://primary.example.com");
+  });
 
-    it("falls back to sentinel and console.errors in production (BASE_URL only)", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        const errs: string[] = [];
-        const spy = vi
-            .spyOn(console, "error")
-            .mockImplementation((m: string) => {
-                errs.push(m);
-            });
-        const cfg = getRuntimeConfig();
-        spy.mockRestore();
-        expect(cfg.baseUrl).toBe("about:blank#shell-base-url-missing");
-        // POSTHOG_HOST falls back silently (analytics key — legitimately absent in some envs).
-        expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
-        expect(errs.some((m) => m.includes("BASE_URL"))).toBe(true);
-        expect(errs.some((m) => m.includes("POSTHOG_HOST"))).toBe(false);
-    });
+  it("empty-string primary does not mask a set alternate (length-aware fallback)", () => {
+    // A deliberately-empty BASE_URL must NOT win over a populated
+    // NEXT_PUBLIC_BASE_URL. The prior `??` form treated `""` as
+    // "set", masking the alternate; the length-aware form falls
+    // through to the alternate when the primary is empty.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("https://alt.example.com");
+  });
 
-    it("reads live process.env on each call (no module-load freeze)", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.BASE_URL = "https://first.example.com";
-        process.env.POSTHOG_HOST = "https://eu.i.posthog.com";
-        expect(getRuntimeConfig().baseUrl).toBe("https://first.example.com");
-        process.env.BASE_URL = "https://second.example.com";
-        expect(getRuntimeConfig().baseUrl).toBe("https://second.example.com");
-    });
+  it("accepts NEXT_PUBLIC_POSTHOG_HOST as a fallback when POSTHOG_HOST is unset", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://alt-ph.example.com";
+    process.env.BASE_URL = "https://shell.example.com";
+    const cfg = getRuntimeConfig();
+    expect(cfg.posthogHost).toBe("https://alt-ph.example.com");
+  });
 
-    it("accepts NEXT_PUBLIC_BASE_URL as a fallback when BASE_URL is unset", () => {
-        // Deploy-config contract: the shell reads the bare name first,
-        // but tolerates the NEXT_PUBLIC_-prefixed variant so a Railway
-        // service that follows the shell-docs convention still wires
-        // through. See the readUrl fallback chain in runtime-config.ts.
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
-        // BASE_URL deliberately unset.
-        const cfg = getRuntimeConfig();
-        expect(cfg.baseUrl).toBe("https://alt.example.com");
-    });
+  it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
+    const cacheMod = await import("next/cache");
+    const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://edge.example.com";
+    process.env.POSTHOG_HOST = "https://edge-posthog.example.com";
 
-    it("BASE_URL takes precedence over NEXT_PUBLIC_BASE_URL when both set", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.BASE_URL = "https://primary.example.com";
-        process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
-        const cfg = getRuntimeConfig();
-        expect(cfg.baseUrl).toBe("https://primary.example.com");
-    });
+    const { getRuntimeConfigEdge } = await import("./runtime-config");
+    const cfg = getRuntimeConfigEdge();
+    expect(cfg.baseUrl).toBe("https://edge.example.com");
+    expect(noStoreSpy).not.toHaveBeenCalled();
 
-    it("empty-string primary does not mask a set alternate (length-aware fallback)", () => {
-        // A deliberately-empty BASE_URL must NOT win over a populated
-        // NEXT_PUBLIC_BASE_URL. The prior `??` form treated `""` as
-        // "set", masking the alternate; the length-aware form falls
-        // through to the alternate when the primary is empty.
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.BASE_URL = "";
-        process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
-        const cfg = getRuntimeConfig();
-        expect(cfg.baseUrl).toBe("https://alt.example.com");
-    });
-
-    it("accepts NEXT_PUBLIC_POSTHOG_HOST as a fallback when POSTHOG_HOST is unset", () => {
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://alt-ph.example.com";
-        process.env.BASE_URL = "https://shell.example.com";
-        const cfg = getRuntimeConfig();
-        expect(cfg.posthogHost).toBe("https://alt-ph.example.com");
-    });
-
-    it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
-        const cacheMod = await import("next/cache");
-        const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
-        (process.env as Record<string, string>).NODE_ENV = "production";
-        process.env.BASE_URL = "https://edge.example.com";
-        process.env.POSTHOG_HOST = "https://edge-posthog.example.com";
-
-        const { getRuntimeConfigEdge } = await import("./runtime-config");
-        const cfg = getRuntimeConfigEdge();
-        expect(cfg.baseUrl).toBe("https://edge.example.com");
-        expect(noStoreSpy).not.toHaveBeenCalled();
-
-        // And confirm the default entrypoint DOES call noStore().
-        noStoreSpy.mockClear();
-        getRuntimeConfig();
-        expect(noStoreSpy).toHaveBeenCalledTimes(1);
-        noStoreSpy.mockRestore();
-    });
+    // And confirm the default entrypoint DOES call noStore().
+    noStoreSpy.mockClear();
+    getRuntimeConfig();
+    expect(noStoreSpy).toHaveBeenCalledTimes(1);
+    noStoreSpy.mockRestore();
+  });
 });

--- a/showcase/shell/src/lib/runtime-config.test.ts
+++ b/showcase/shell/src/lib/runtime-config.test.ts
@@ -14,7 +14,13 @@ describe("server getRuntimeConfig (shell)", () => {
     const ORIGINAL_ENV = { ...process.env };
 
     beforeEach(() => {
-        for (const k of ["BASE_URL", "POSTHOG_HOST", "NODE_ENV"]) {
+        for (const k of [
+            "BASE_URL",
+            "POSTHOG_HOST",
+            "NEXT_PUBLIC_BASE_URL",
+            "NEXT_PUBLIC_POSTHOG_HOST",
+            "NODE_ENV",
+        ]) {
             delete (process.env as Record<string, string | undefined>)[k];
         }
     });
@@ -73,6 +79,34 @@ describe("server getRuntimeConfig (shell)", () => {
         expect(getRuntimeConfig().baseUrl).toBe("https://first.example.com");
         process.env.BASE_URL = "https://second.example.com";
         expect(getRuntimeConfig().baseUrl).toBe("https://second.example.com");
+    });
+
+    it("accepts NEXT_PUBLIC_BASE_URL as a fallback when BASE_URL is unset", () => {
+        // Deploy-config contract: the shell reads the bare name first,
+        // but tolerates the NEXT_PUBLIC_-prefixed variant so a Railway
+        // service that follows the shell-docs convention still wires
+        // through. See the readUrl fallback chain in runtime-config.ts.
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
+        // BASE_URL deliberately unset.
+        const cfg = getRuntimeConfig();
+        expect(cfg.baseUrl).toBe("https://alt.example.com");
+    });
+
+    it("BASE_URL takes precedence over NEXT_PUBLIC_BASE_URL when both set", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.BASE_URL = "https://primary.example.com";
+        process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
+        const cfg = getRuntimeConfig();
+        expect(cfg.baseUrl).toBe("https://primary.example.com");
+    });
+
+    it("accepts NEXT_PUBLIC_POSTHOG_HOST as a fallback when POSTHOG_HOST is unset", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://alt-ph.example.com";
+        process.env.BASE_URL = "https://shell.example.com";
+        const cfg = getRuntimeConfig();
+        expect(cfg.posthogHost).toBe("https://alt-ph.example.com");
     });
 
     it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {

--- a/showcase/shell/src/lib/runtime-config.test.ts
+++ b/showcase/shell/src/lib/runtime-config.test.ts
@@ -101,6 +101,18 @@ describe("server getRuntimeConfig (shell)", () => {
         expect(cfg.baseUrl).toBe("https://primary.example.com");
     });
 
+    it("empty-string primary does not mask a set alternate (length-aware fallback)", () => {
+        // A deliberately-empty BASE_URL must NOT win over a populated
+        // NEXT_PUBLIC_BASE_URL. The prior `??` form treated `""` as
+        // "set", masking the alternate; the length-aware form falls
+        // through to the alternate when the primary is empty.
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.BASE_URL = "";
+        process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
+        const cfg = getRuntimeConfig();
+        expect(cfg.baseUrl).toBe("https://alt.example.com");
+    });
+
     it("accepts NEXT_PUBLIC_POSTHOG_HOST as a fallback when POSTHOG_HOST is unset", () => {
         (process.env as Record<string, string>).NODE_ENV = "production";
         process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://alt-ph.example.com";

--- a/showcase/shell/src/lib/runtime-config.test.ts
+++ b/showcase/shell/src/lib/runtime-config.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub next/cache.unstable_noStore — vitest runs outside Next's runtime
+// so the real implementation throws ("called outside a Server
+// Component"). The function is a no-op for our purposes (it tells Next
+// not to cache; in a unit test there is no cache to opt out of).
+vi.mock("next/cache", () => ({
+    unstable_noStore: () => {},
+}));
+
+import { getRuntimeConfig } from "./runtime-config";
+
+describe("server getRuntimeConfig (shell)", () => {
+    const ORIGINAL_ENV = { ...process.env };
+
+    beforeEach(() => {
+        for (const k of ["BASE_URL", "POSTHOG_HOST", "NODE_ENV"]) {
+            delete (process.env as Record<string, string | undefined>)[k];
+        }
+    });
+
+    afterEach(() => {
+        Object.assign(process.env, ORIGINAL_ENV);
+    });
+
+    it("returns env values when all are set (production)", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.BASE_URL = "https://showcase.copilotkit.ai";
+        process.env.POSTHOG_HOST = "https://eu.i.posthog.com";
+        expect(getRuntimeConfig()).toEqual({
+            baseUrl: "https://showcase.copilotkit.ai",
+            posthogHost: "https://eu.i.posthog.com",
+        });
+    });
+
+    it("strips trailing slashes", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.BASE_URL = "https://showcase.example.com/";
+        process.env.POSTHOG_HOST = "https://eu.i.posthog.com//";
+        const cfg = getRuntimeConfig();
+        expect(cfg.baseUrl).toBe("https://showcase.example.com");
+        expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+    });
+
+    it("falls back to dev defaults when unset in non-production", () => {
+        (process.env as Record<string, string>).NODE_ENV = "development";
+        const cfg = getRuntimeConfig();
+        expect(cfg.baseUrl).toBe("http://localhost:3000");
+        expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+    });
+
+    it("falls back to sentinel and console.errors in production (BASE_URL only)", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        const errs: string[] = [];
+        const spy = vi
+            .spyOn(console, "error")
+            .mockImplementation((m: string) => {
+                errs.push(m);
+            });
+        const cfg = getRuntimeConfig();
+        spy.mockRestore();
+        expect(cfg.baseUrl).toBe("about:blank#shell-base-url-missing");
+        // POSTHOG_HOST falls back silently (analytics key — legitimately absent in some envs).
+        expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+        expect(errs.some((m) => m.includes("BASE_URL"))).toBe(true);
+        expect(errs.some((m) => m.includes("POSTHOG_HOST"))).toBe(false);
+    });
+
+    it("reads live process.env on each call (no module-load freeze)", () => {
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.BASE_URL = "https://first.example.com";
+        process.env.POSTHOG_HOST = "https://eu.i.posthog.com";
+        expect(getRuntimeConfig().baseUrl).toBe("https://first.example.com");
+        process.env.BASE_URL = "https://second.example.com";
+        expect(getRuntimeConfig().baseUrl).toBe("https://second.example.com");
+    });
+
+    it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
+        const cacheMod = await import("next/cache");
+        const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
+        (process.env as Record<string, string>).NODE_ENV = "production";
+        process.env.BASE_URL = "https://edge.example.com";
+        process.env.POSTHOG_HOST = "https://edge-posthog.example.com";
+
+        const { getRuntimeConfigEdge } = await import("./runtime-config");
+        const cfg = getRuntimeConfigEdge();
+        expect(cfg.baseUrl).toBe("https://edge.example.com");
+        expect(noStoreSpy).not.toHaveBeenCalled();
+
+        // And confirm the default entrypoint DOES call noStore().
+        noStoreSpy.mockClear();
+        getRuntimeConfig();
+        expect(noStoreSpy).toHaveBeenCalledTimes(1);
+        noStoreSpy.mockRestore();
+    });
+});

--- a/showcase/shell/src/lib/runtime-config.ts
+++ b/showcase/shell/src/lib/runtime-config.ts
@@ -89,19 +89,31 @@ function altEnvName(envKey: string): string {
         : `NEXT_PUBLIC_${envKey}`;
 }
 
+// Length-aware env coalesce: a deliberately-empty primary (e.g. an
+// operator clearing `BASE_URL=""` on a Railway service) must NOT mask a
+// populated alternate. Treat empty-string as "unset" and fall through to
+// the alternate.
+function readEnvPair(envKey: string): string | undefined {
+    const primary = process.env[envKey];
+    if (primary && primary.length > 0) return primary;
+    const alt = process.env[altEnvName(envKey)];
+    if (alt && alt.length > 0) return alt;
+    return undefined;
+}
+
 function readUrl(envKey: string, fallback: string, isProd: boolean): string {
-    const value = process.env[envKey] ?? process.env[altEnvName(envKey)];
-    if (value && value.length > 0) return value.replace(/\/+$/, "");
+    const value = readEnvPair(envKey);
+    if (value !== undefined) return value.replace(/\/+$/, "");
     if (isProd) {
         // eslint-disable-next-line no-console
         console.error(
-            `[runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
+            `[shell runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
                 `using sentinel ${fallback}. Set the env var on the Railway service.`,
         );
     } else {
         // eslint-disable-next-line no-console
         console.warn(
-            `[runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
+            `[shell runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
         );
     }
     return fallback.replace(/\/+$/, "");
@@ -110,7 +122,7 @@ function readUrl(envKey: string, fallback: string, isProd: boolean): string {
 // Analytics keys (POSTHOG_HOST etc.) are legitimately absent on
 // non-production envs; do NOT log a FATAL-CONFIG warning when missing.
 function readKey(envKey: string, fallback: string): string {
-    const value = process.env[envKey] ?? process.env[altEnvName(envKey)];
-    if (value && value.length > 0) return value.replace(/\/+$/, "");
+    const value = readEnvPair(envKey);
+    if (value !== undefined) return value.replace(/\/+$/, "");
     return fallback.replace(/\/+$/, "");
 }

--- a/showcase/shell/src/lib/runtime-config.ts
+++ b/showcase/shell/src/lib/runtime-config.ts
@@ -14,10 +14,10 @@
 import { unstable_noStore as noStore } from "next/cache";
 
 export interface RuntimeConfig {
-    /** Canonical shell base URL — used for canonical hrefs, OG metadata, etc. */
-    baseUrl: string;
-    /** PostHog host — middleware ships seo_redirect events here. */
-    posthogHost: string;
+  /** Canonical shell base URL — used for canonical hrefs, OG metadata, etc. */
+  baseUrl: string;
+  /** PostHog host — middleware ships seo_redirect events here. */
+  posthogHost: string;
 }
 
 const PROD_INVALID_BASE_URL = "about:blank#shell-base-url-missing";
@@ -42,25 +42,22 @@ const PROD_INVALID_BASE_URL = "about:blank#shell-base-url-missing";
  * below makes this explicit at the call site.
  */
 export function getRuntimeConfig(
-    opts: { noStore?: boolean } = {},
+  opts: { noStore?: boolean } = {},
 ): RuntimeConfig {
-    if (opts.noStore !== false) noStore();
-    const isProd = process.env.NODE_ENV === "production";
+  if (opts.noStore !== false) noStore();
+  const isProd = process.env.NODE_ENV === "production";
 
-    const baseUrl = readUrl(
-        "BASE_URL",
-        isProd ? PROD_INVALID_BASE_URL : "http://localhost:3000",
-        isProd,
-    );
-    // PostHog host: legitimately absent on non-production deploys; never
-    // log a FATAL-CONFIG for it. The historic default (`eu.i.posthog.com`)
-    // matches the previous middleware behavior.
-    const posthogHost = readKey(
-        "POSTHOG_HOST",
-        "https://eu.i.posthog.com",
-    );
+  const baseUrl = readUrl(
+    "BASE_URL",
+    isProd ? PROD_INVALID_BASE_URL : "http://localhost:3000",
+    isProd,
+  );
+  // PostHog host: legitimately absent on non-production deploys; never
+  // log a FATAL-CONFIG for it. The historic default (`eu.i.posthog.com`)
+  // matches the previous middleware behavior.
+  const posthogHost = readKey("POSTHOG_HOST", "https://eu.i.posthog.com");
 
-    return { baseUrl, posthogHost };
+  return { baseUrl, posthogHost };
 }
 
 /**
@@ -75,7 +72,7 @@ export function getRuntimeConfig(
  * and the build fails with "module not found in edge runtime."
  */
 export function getRuntimeConfigEdge(): RuntimeConfig {
-    return getRuntimeConfig({ noStore: false });
+  return getRuntimeConfig({ noStore: false });
 }
 
 // Env-name tolerance: deploy configs in the wild use either the bare
@@ -84,9 +81,9 @@ export function getRuntimeConfigEdge(): RuntimeConfig {
 // to the alternate so a Railway service variable set under the "wrong"
 // name still works without redeploy.
 function altEnvName(envKey: string): string {
-    return envKey.startsWith("NEXT_PUBLIC_")
-        ? envKey.slice("NEXT_PUBLIC_".length)
-        : `NEXT_PUBLIC_${envKey}`;
+  return envKey.startsWith("NEXT_PUBLIC_")
+    ? envKey.slice("NEXT_PUBLIC_".length)
+    : `NEXT_PUBLIC_${envKey}`;
 }
 
 // Length-aware env coalesce: a deliberately-empty primary (e.g. an
@@ -94,35 +91,35 @@ function altEnvName(envKey: string): string {
 // populated alternate. Treat empty-string as "unset" and fall through to
 // the alternate.
 function readEnvPair(envKey: string): string | undefined {
-    const primary = process.env[envKey];
-    if (primary && primary.length > 0) return primary;
-    const alt = process.env[altEnvName(envKey)];
-    if (alt && alt.length > 0) return alt;
-    return undefined;
+  const primary = process.env[envKey];
+  if (primary && primary.length > 0) return primary;
+  const alt = process.env[altEnvName(envKey)];
+  if (alt && alt.length > 0) return alt;
+  return undefined;
 }
 
 function readUrl(envKey: string, fallback: string, isProd: boolean): string {
-    const value = readEnvPair(envKey);
-    if (value !== undefined) return value.replace(/\/+$/, "");
-    if (isProd) {
-        // eslint-disable-next-line no-console
-        console.error(
-            `[shell runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
-                `using sentinel ${fallback}. Set the env var on the Railway service.`,
-        );
-    } else {
-        // eslint-disable-next-line no-console
-        console.warn(
-            `[shell runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
-        );
-    }
-    return fallback.replace(/\/+$/, "");
+  const value = readEnvPair(envKey);
+  if (value !== undefined) return value.replace(/\/+$/, "");
+  if (isProd) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[shell runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
+        `using sentinel ${fallback}. Set the env var on the Railway service.`,
+    );
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[shell runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
+    );
+  }
+  return fallback.replace(/\/+$/, "");
 }
 
 // Analytics keys (POSTHOG_HOST etc.) are legitimately absent on
 // non-production envs; do NOT log a FATAL-CONFIG warning when missing.
 function readKey(envKey: string, fallback: string): string {
-    const value = readEnvPair(envKey);
-    if (value !== undefined) return value.replace(/\/+$/, "");
-    return fallback.replace(/\/+$/, "");
+  const value = readEnvPair(envKey);
+  if (value !== undefined) return value.replace(/\/+$/, "");
+  return fallback.replace(/\/+$/, "");
 }

--- a/showcase/shell/src/lib/runtime-config.ts
+++ b/showcase/shell/src/lib/runtime-config.ts
@@ -1,0 +1,105 @@
+// Server-side runtime config for the showcase shell.
+//
+// This module reads URL / analytics env values at REQUEST time. It must
+// only be imported from server components (and from middleware via the
+// Edge-safe wrapper below). Importing it from a client component would
+// cause Next.js to inline `next/cache` into the client bundle (build
+// fails) and would freeze the URLs back into the artifact (the exact
+// bug we are fixing). See Next.js App Router docs on Dynamic Rendering.
+//
+// This module MUST NOT be imported from client components. The matching
+// client-side reader lives in runtime-config.client.ts and reads from
+// window.__SHOWCASE_CONFIG__ which the root layout injects.
+
+import { unstable_noStore as noStore } from "next/cache";
+
+export interface RuntimeConfig {
+    /** Canonical shell base URL — used for canonical hrefs, OG metadata, etc. */
+    baseUrl: string;
+    /** PostHog host — middleware ships seo_redirect events here. */
+    posthogHost: string;
+}
+
+const PROD_INVALID_BASE_URL = "about:blank#shell-base-url-missing";
+
+/**
+ * Resolve the runtime config for shell. Called once per request by the
+ * root layout and by middleware (via the Edge wrapper below).
+ *
+ * Fail-loud strategy mirrors shell-dashboard: in production, missing
+ * URL env vars produce sentinel URLs (visible breakage) AND a
+ * console.error; in dev, we fall back to localhost so iteration is
+ * frictionless. Analytics keys (posthogHost) use the dev fallback
+ * unconditionally — historic POSTHOG_HOST default is the EU cloud.
+ *
+ * `opts.noStore` (default `true`) controls whether to call
+ * `unstable_noStore()`. The Node.js server runtime needs the opt-out so
+ * Next.js does not statically prerender callers and freeze the URLs into
+ * the build artifact. The Edge runtime (middleware) MUST pass
+ * `{ noStore: false }` — `unstable_noStore()` is unavailable there, and
+ * middleware always runs per-request by definition so there is no
+ * static cache to opt out of. The thin `getRuntimeConfigEdge()` wrapper
+ * below makes this explicit at the call site.
+ */
+export function getRuntimeConfig(
+    opts: { noStore?: boolean } = {},
+): RuntimeConfig {
+    if (opts.noStore !== false) noStore();
+    const isProd = process.env.NODE_ENV === "production";
+
+    const baseUrl = readUrl(
+        "BASE_URL",
+        isProd ? PROD_INVALID_BASE_URL : "http://localhost:3000",
+        isProd,
+    );
+    // PostHog host: legitimately absent on non-production deploys; never
+    // log a FATAL-CONFIG for it. The historic default (`eu.i.posthog.com`)
+    // matches the previous middleware behavior.
+    const posthogHost = readKey(
+        "POSTHOG_HOST",
+        "https://eu.i.posthog.com",
+    );
+
+    return { baseUrl, posthogHost };
+}
+
+/**
+ * Edge-runtime variant. Identical semantics to `getRuntimeConfig()`
+ * except `unstable_noStore()` is skipped — `next/cache`'s no-store
+ * helper is not available in the Edge runtime, and middleware always
+ * runs per-request by definition so there is no static cache to opt
+ * out of. Thin wrapper to keep the body single-sourced.
+ *
+ * Middleware (`src/middleware.ts`) MUST import this rather than
+ * `getRuntimeConfig` — otherwise the Edge bundle pulls in `next/cache`
+ * and the build fails with "module not found in edge runtime."
+ */
+export function getRuntimeConfigEdge(): RuntimeConfig {
+    return getRuntimeConfig({ noStore: false });
+}
+
+function readUrl(envKey: string, fallback: string, isProd: boolean): string {
+    const value = process.env[envKey];
+    if (value && value.length > 0) return value.replace(/\/+$/, "");
+    if (isProd) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
+                `using sentinel ${fallback}. Set the env var on the Railway service.`,
+        );
+    } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `[runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
+        );
+    }
+    return fallback.replace(/\/+$/, "");
+}
+
+// Analytics keys (POSTHOG_HOST etc.) are legitimately absent on
+// non-production envs; do NOT log a FATAL-CONFIG warning when missing.
+function readKey(envKey: string, fallback: string): string {
+    const value = process.env[envKey];
+    if (value && value.length > 0) return value.replace(/\/+$/, "");
+    return fallback.replace(/\/+$/, "");
+}

--- a/showcase/shell/src/lib/runtime-config.ts
+++ b/showcase/shell/src/lib/runtime-config.ts
@@ -4,8 +4,8 @@
 // only be imported from server components (and from middleware via the
 // Edge-safe wrapper below). Importing it from a client component would
 // cause Next.js to inline `next/cache` into the client bundle (build
-// fails) and would freeze the URLs back into the artifact (the exact
-// bug we are fixing). See Next.js App Router docs on Dynamic Rendering.
+// fails) and would freeze the URLs back into the artifact — defeating
+// the runtime switch. See Next.js App Router docs on Dynamic Rendering.
 //
 // This module MUST NOT be imported from client components. The matching
 // client-side reader lives in runtime-config.client.ts and reads from
@@ -78,8 +78,19 @@ export function getRuntimeConfigEdge(): RuntimeConfig {
     return getRuntimeConfig({ noStore: false });
 }
 
+// Env-name tolerance: deploy configs in the wild use either the bare
+// name (e.g. `BASE_URL`) or the `NEXT_PUBLIC_*`-prefixed name. We accept
+// either — the primary (passed-in) name wins, with transparent fallback
+// to the alternate so a Railway service variable set under the "wrong"
+// name still works without redeploy.
+function altEnvName(envKey: string): string {
+    return envKey.startsWith("NEXT_PUBLIC_")
+        ? envKey.slice("NEXT_PUBLIC_".length)
+        : `NEXT_PUBLIC_${envKey}`;
+}
+
 function readUrl(envKey: string, fallback: string, isProd: boolean): string {
-    const value = process.env[envKey];
+    const value = process.env[envKey] ?? process.env[altEnvName(envKey)];
     if (value && value.length > 0) return value.replace(/\/+$/, "");
     if (isProd) {
         // eslint-disable-next-line no-console
@@ -99,7 +110,7 @@ function readUrl(envKey: string, fallback: string, isProd: boolean): string {
 // Analytics keys (POSTHOG_HOST etc.) are legitimately absent on
 // non-production envs; do NOT log a FATAL-CONFIG warning when missing.
 function readKey(envKey: string, fallback: string): string {
-    const value = process.env[envKey];
+    const value = process.env[envKey] ?? process.env[altEnvName(envKey)];
     if (value && value.length > 0) return value.replace(/\/+$/, "");
     return fallback.replace(/\/+$/, "");
 }

--- a/showcase/shell/src/middleware.ts
+++ b/showcase/shell/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { seoRedirects } from "@/lib/seo-redirects";
+import { getRuntimeConfigEdge } from "@/lib/runtime-config";
 import registry from "@/data/registry.json";
 
 // ---------------------------------------------------------------------------
@@ -38,9 +39,6 @@ for (const entry of seoRedirects) {
 // PostHog tracking via fetch (Edge Runtime compatible — no posthog-node SDK)
 // ---------------------------------------------------------------------------
 
-const POSTHOG_HOST =
-  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
-
 let posthogKeyWarned = false;
 
 function trackRedirect(id: string, fromPath: string, toPath: string): void {
@@ -55,8 +53,13 @@ function trackRedirect(id: string, fromPath: string, toPath: string): void {
     return;
   }
 
+  // Read the PostHog host from the Edge-safe runtime config (live
+  // process.env at request time, no `next/cache` import — see
+  // getRuntimeConfigEdge in src/lib/runtime-config.ts).
+  const posthogHost = getRuntimeConfigEdge().posthogHost;
+
   // Fire-and-forget — don't await
-  fetch(`${POSTHOG_HOST}/capture/`, {
+  fetch(`${posthogHost}/capture/`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({

--- a/showcase/shell/vitest.config.ts
+++ b/showcase/shell/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+    test: {
+        environment: "jsdom",
+        globals: true,
+        include: ["src/**/*.test.{ts,tsx}"],
+        exclude: ["node_modules/**"],
+    },
+    resolve: {
+        alias: {
+            "@": path.resolve(__dirname, "./src"),
+        },
+    },
+});

--- a/showcase/shell/vitest.config.ts
+++ b/showcase/shell/vitest.config.ts
@@ -2,15 +2,15 @@ import { defineConfig } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
-    test: {
-        environment: "jsdom",
-        globals: true,
-        include: ["src/**/*.test.{ts,tsx}"],
-        exclude: ["node_modules/**"],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}"],
+    exclude: ["node_modules/**"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
     },
-    resolve: {
-        alias: {
-            "@": path.resolve(__dirname, "./src"),
-        },
-    },
+  },
 });

--- a/showcase/tests/env-routing.spec.ts
+++ b/showcase/tests/env-routing.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type Route } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+import type { Route } from "@playwright/test";
 
 /**
  * Env-routing test (B14): for each shell × env combination, assert that
@@ -29,15 +30,15 @@ import { test, expect, type Route } from "@playwright/test";
 type _Route = Route;
 
 interface EnvSet {
-    name: "staging" | "prod";
-    expected: {
-        baseUrl?: string;
-        shellUrl?: string;
-        pocketbaseUrl?: string;
-        opsBaseUrl?: string;
-    };
-    /** Hosts (regex) that backend fetches MAY hit. Anything else fails. */
-    backendAllowlist: RegExp[];
+  name: "staging" | "prod";
+  expected: {
+    baseUrl?: string;
+    shellUrl?: string;
+    pocketbaseUrl?: string;
+    opsBaseUrl?: string;
+  };
+  /** Hosts (regex) that backend fetches MAY hit. Anything else fails. */
+  backendAllowlist: RegExp[];
 }
 
 // Third-party hosts shared by both envs (analytics, fonts, CDN, HubSpot,
@@ -46,140 +47,140 @@ interface EnvSet {
 // real page loads (see plan-B B14 host-inventory step); broader
 // patterns would let env leaks slip through.
 const SHARED_THIRDPARTY_ALLOWLIST: RegExp[] = [
-    // Analytics + product telemetry
-    /^eu\.i\.posthog\.com$/,
-    /^eu-assets\.i\.posthog\.com$/,
-    /^static\.scarf\.sh$/,
-    /^www\.google-analytics\.com$/,
-    /^region1\.google-analytics\.com$/,
-    // Fonts (next/font/google preconnects to both)
-    /^fonts\.googleapis\.com$/,
-    /^fonts\.gstatic\.com$/,
-    // Marketing + visitor identification (shell-docs)
-    /^js\.hs-scripts\.com$/,
-    /^static\.reo\.dev$/,
-    /^b2bjsstore\.s3\.us-west-2\.amazonaws\.com$/,
-    // Shared image/video CDN (cdn.copilotkit.ai, next.config.ts)
-    /^cdn\.copilotkit\.ai$/,
+  // Analytics + product telemetry
+  /^eu\.i\.posthog\.com$/,
+  /^eu-assets\.i\.posthog\.com$/,
+  /^static\.scarf\.sh$/,
+  /^www\.google-analytics\.com$/,
+  /^region1\.google-analytics\.com$/,
+  // Fonts (next/font/google preconnects to both)
+  /^fonts\.googleapis\.com$/,
+  /^fonts\.gstatic\.com$/,
+  // Marketing + visitor identification (shell-docs)
+  /^js\.hs-scripts\.com$/,
+  /^static\.reo\.dev$/,
+  /^b2bjsstore\.s3\.us-west-2\.amazonaws\.com$/,
+  // Shared image/video CDN (cdn.copilotkit.ai, next.config.ts)
+  /^cdn\.copilotkit\.ai$/,
 ];
 
 const STAGING: EnvSet = {
-    name: "staging",
-    expected: {
-        baseUrl: "https://docs.staging.copilotkit.ai",
-        shellUrl: "https://showcase.staging.copilotkit.ai",
-        pocketbaseUrl: "https://pocketbase-staging-eec0.up.railway.app",
-        opsBaseUrl: "https://harness-staging-2ee4.up.railway.app",
-    },
-    backendAllowlist: [
-        // Staging ingress: ONLY *.staging.copilotkit.ai (e.g.
-        // docs.staging.copilotkit.ai, showcase.staging.copilotkit.ai,
-        // dashboard.showcase.staging.copilotkit.ai). Anchored at both
-        // ends so `something.docs.staging.copilotkit.ai` does NOT slip
-        // through.
-        /^(docs|showcase|dashboard\.showcase)\.staging\.copilotkit\.ai$/,
-        // Railway public domains for the staging deploys this
-        // workstream wires. Pinned to the EXACT host suffixes that
-        // appear in the B15 env-var list — not a wildcard
-        // `-staging-[a-z0-9]+` pattern that would also match other
-        // unrelated staging services in the workspace.
-        /^pocketbase-staging-eec0\.up\.railway\.app$/,
-        /^harness-staging-2ee4\.up\.railway\.app$/,
-        ...SHARED_THIRDPARTY_ALLOWLIST,
-    ],
+  name: "staging",
+  expected: {
+    baseUrl: "https://docs.staging.copilotkit.ai",
+    shellUrl: "https://showcase.staging.copilotkit.ai",
+    pocketbaseUrl: "https://pocketbase-staging-eec0.up.railway.app",
+    opsBaseUrl: "https://harness-staging-2ee4.up.railway.app",
+  },
+  backendAllowlist: [
+    // Staging ingress: ONLY *.staging.copilotkit.ai (e.g.
+    // docs.staging.copilotkit.ai, showcase.staging.copilotkit.ai,
+    // dashboard.showcase.staging.copilotkit.ai). Anchored at both
+    // ends so `something.docs.staging.copilotkit.ai` does NOT slip
+    // through.
+    /^(docs|showcase|dashboard\.showcase)\.staging\.copilotkit\.ai$/,
+    // Railway public domains for the staging deploys this
+    // workstream wires. Pinned to the EXACT host suffixes that
+    // appear in the B15 env-var list — not a wildcard
+    // `-staging-[a-z0-9]+` pattern that would also match other
+    // unrelated staging services in the workspace.
+    /^pocketbase-staging-eec0\.up\.railway\.app$/,
+    /^harness-staging-2ee4\.up\.railway\.app$/,
+    ...SHARED_THIRDPARTY_ALLOWLIST,
+  ],
 };
 
 const PROD: EnvSet = {
-    name: "prod",
-    expected: {
-        baseUrl: "https://docs.copilotkit.ai",
-        shellUrl: "https://showcase.copilotkit.ai",
-        pocketbaseUrl: "https://showcase-pocketbase-production.up.railway.app",
-        opsBaseUrl: "https://showcase-harness-production.up.railway.app",
-    },
-    backendAllowlist: [
-        // Prod ingress: bare-domain marketing + docs + showcase +
-        // dashboard hosts. ONLY these — anchored at both ends so
-        // `something.docs.copilotkit.ai` doesn't slip through.
-        /^(www|docs|showcase|dashboard\.showcase)\.copilotkit\.ai$/,
-        // Railway public domains used by prod (exact suffix match per
-        // the build-args at showcase_build.yml:197-198).
-        /^showcase-pocketbase-production\.up\.railway\.app$/,
-        /^showcase-harness-production\.up\.railway\.app$/,
-        ...SHARED_THIRDPARTY_ALLOWLIST,
-    ],
+  name: "prod",
+  expected: {
+    baseUrl: "https://docs.copilotkit.ai",
+    shellUrl: "https://showcase.copilotkit.ai",
+    pocketbaseUrl: "https://showcase-pocketbase-production.up.railway.app",
+    opsBaseUrl: "https://showcase-harness-production.up.railway.app",
+  },
+  backendAllowlist: [
+    // Prod ingress: bare-domain marketing + docs + showcase +
+    // dashboard hosts. ONLY these — anchored at both ends so
+    // `something.docs.copilotkit.ai` doesn't slip through.
+    /^(www|docs|showcase|dashboard\.showcase)\.copilotkit\.ai$/,
+    // Railway public domains used by prod (exact suffix match per
+    // the build-args at showcase_build.yml:197-198).
+    /^showcase-pocketbase-production\.up\.railway\.app$/,
+    /^showcase-harness-production\.up\.railway\.app$/,
+    ...SHARED_THIRDPARTY_ALLOWLIST,
+  ],
 };
 
 interface ShellTarget {
-    shell: "shell" | "shell-docs" | "shell-dashboard" | "shell-dojo";
-    urlFor: (env: EnvSet) => string;
-    expectedFields: Array<keyof EnvSet["expected"]>;
+  shell: "shell" | "shell-docs" | "shell-dashboard" | "shell-dojo";
+  urlFor: (env: EnvSet) => string;
+  expectedFields: Array<keyof EnvSet["expected"]>;
 }
 
 const TARGETS: ShellTarget[] = [
-    {
-        shell: "shell",
-        urlFor: (e) =>
-            e.name === "staging"
-                ? "https://showcase.staging.copilotkit.ai/"
-                : "https://showcase.copilotkit.ai/",
-        expectedFields: ["baseUrl"],
-    },
-    {
-        shell: "shell-docs",
-        urlFor: (e) =>
-            e.name === "staging"
-                ? "https://docs.staging.copilotkit.ai/"
-                : "https://docs.copilotkit.ai/",
-        expectedFields: ["baseUrl", "shellUrl"],
-    },
-    {
-        shell: "shell-dashboard",
-        urlFor: (e) =>
-            e.name === "staging"
-                ? "https://dashboard.showcase.staging.copilotkit.ai/"
-                : "https://dashboard.showcase.copilotkit.ai/",
-        expectedFields: ["pocketbaseUrl", "shellUrl", "opsBaseUrl"],
-    },
-    // shell-dojo — uncomment when a public env-routed host is wired
-    // (no public ingress today per the B15 service inventory).
+  {
+    shell: "shell",
+    urlFor: (e) =>
+      e.name === "staging"
+        ? "https://showcase.staging.copilotkit.ai/"
+        : "https://showcase.copilotkit.ai/",
+    expectedFields: ["baseUrl"],
+  },
+  {
+    shell: "shell-docs",
+    urlFor: (e) =>
+      e.name === "staging"
+        ? "https://docs.staging.copilotkit.ai/"
+        : "https://docs.copilotkit.ai/",
+    expectedFields: ["baseUrl", "shellUrl"],
+  },
+  {
+    shell: "shell-dashboard",
+    urlFor: (e) =>
+      e.name === "staging"
+        ? "https://dashboard.showcase.staging.copilotkit.ai/"
+        : "https://dashboard.showcase.copilotkit.ai/",
+    expectedFields: ["pocketbaseUrl", "shellUrl", "opsBaseUrl"],
+  },
+  // shell-dojo — uncomment when a public env-routed host is wired
+  // (no public ingress today per the B15 service inventory).
 ];
 
 for (const env of [STAGING, PROD]) {
-    for (const target of TARGETS) {
-        test(`${target.shell} on ${env.name}: runtime config + backend allowlist`, async ({
-            page,
-        }) => {
-            const offenders: string[] = [];
-            page.on("request", (req) => {
-                const url = new URL(req.url());
-                // Same-origin requests don't cross env lines.
-                if (url.origin === new URL(target.urlFor(env)).origin) return;
-                // Data: and blob: aren't network hosts.
-                if (url.protocol === "data:" || url.protocol === "blob:") return;
-                const allowed = env.backendAllowlist.some((re) => re.test(url.host));
-                if (!allowed) offenders.push(req.url());
-            });
+  for (const target of TARGETS) {
+    test(`${target.shell} on ${env.name}: runtime config + backend allowlist`, async ({
+      page,
+    }) => {
+      const offenders: string[] = [];
+      page.on("request", (req) => {
+        const url = new URL(req.url());
+        // Same-origin requests don't cross env lines.
+        if (url.origin === new URL(target.urlFor(env)).origin) return;
+        // Data: and blob: aren't network hosts.
+        if (url.protocol === "data:" || url.protocol === "blob:") return;
+        const allowed = env.backendAllowlist.some((re) => re.test(url.host));
+        if (!allowed) offenders.push(req.url());
+      });
 
-            await page.goto(target.urlFor(env), { waitUntil: "networkidle" });
+      await page.goto(target.urlFor(env), { waitUntil: "networkidle" });
 
-            // Assert __SHOWCASE_CONFIG__ matches the expected env.
-            const cfg = await page.evaluate(
-                () =>
-                    (window as Window & { __SHOWCASE_CONFIG__?: unknown })
-                        .__SHOWCASE_CONFIG__,
-            );
-            expect(cfg).toBeDefined();
-            for (const field of target.expectedFields) {
-                expect((cfg as Record<string, string>)[field]).toBe(
-                    env.expected[field],
-                );
-            }
+      // Assert __SHOWCASE_CONFIG__ matches the expected env.
+      const cfg = await page.evaluate(
+        () =>
+          (window as Window & { __SHOWCASE_CONFIG__?: unknown })
+            .__SHOWCASE_CONFIG__,
+      );
+      expect(cfg).toBeDefined();
+      for (const field of target.expectedFields) {
+        expect((cfg as Record<string, string>)[field]).toBe(
+          env.expected[field],
+        );
+      }
 
-            expect(
-                offenders,
-                `${target.shell} on ${env.name} hit non-allowlisted hosts:\n${offenders.join("\n")}`,
-            ).toEqual([]);
-        });
-    }
+      expect(
+        offenders,
+        `${target.shell} on ${env.name} hit non-allowlisted hosts:\n${offenders.join("\n")}`,
+      ).toEqual([]);
+    });
+  }
 }

--- a/showcase/tests/env-routing.spec.ts
+++ b/showcase/tests/env-routing.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect, type Route } from "@playwright/test";
+
+/**
+ * Env-routing test (B14): for each shell × env combination, assert that
+ *   (a) the inlined `window.__SHOWCASE_CONFIG__` matches the env's
+ *       expected URL set, and
+ *   (b) every backend fetch host matches a tight per-env allowlist.
+ *
+ * Runs against live deployments after B15 wires the per-env Railway env
+ * vars. Failures indicate either a runtime-config wiring regression
+ * (the artifact serves stale URLs) or an unsanctioned third-party host
+ * appearing in a page load (silent dep introducing a tracker, etc.).
+ *
+ * Allowlists below are derived from the plan-B host inventory (real
+ * page-load captures across the four shells). Treat the inventory as a
+ * floor — extend it when a captured load surfaces a new legitimate
+ * host, never contract it. An over-broad allowlist masks env-leak bugs.
+ *
+ * This file is intentionally scoped narrowly to env-routing assertions
+ * and uses its own Playwright config at
+ * `showcase/playwright.env-routing.config.ts` (the existing
+ * `showcase/tests/playwright.config.ts` is the integrations smoke
+ * harness with `testDir: ./e2e`).
+ */
+
+// Tell ts-prune / unused-import linters that Route is intentionally
+// imported for future use (per-request interception in follow-on
+// suites that will inspect specific URLs rather than only hosts).
+type _Route = Route;
+
+interface EnvSet {
+    name: "staging" | "prod";
+    expected: {
+        baseUrl?: string;
+        shellUrl?: string;
+        pocketbaseUrl?: string;
+        opsBaseUrl?: string;
+    };
+    /** Hosts (regex) that backend fetches MAY hit. Anything else fails. */
+    backendAllowlist: RegExp[];
+}
+
+// Third-party hosts shared by both envs (analytics, fonts, CDN, HubSpot,
+// REB2B, Reo). Same keys/hosts in staging and prod — these are NOT
+// env-routing signals. Pinned tightly to the EXACT hosts captured in
+// real page loads (see plan-B B14 host-inventory step); broader
+// patterns would let env leaks slip through.
+const SHARED_THIRDPARTY_ALLOWLIST: RegExp[] = [
+    // Analytics + product telemetry
+    /^eu\.i\.posthog\.com$/,
+    /^eu-assets\.i\.posthog\.com$/,
+    /^static\.scarf\.sh$/,
+    /^www\.google-analytics\.com$/,
+    /^region1\.google-analytics\.com$/,
+    // Fonts (next/font/google preconnects to both)
+    /^fonts\.googleapis\.com$/,
+    /^fonts\.gstatic\.com$/,
+    // Marketing + visitor identification (shell-docs)
+    /^js\.hs-scripts\.com$/,
+    /^static\.reo\.dev$/,
+    /^b2bjsstore\.s3\.us-west-2\.amazonaws\.com$/,
+    // Shared image/video CDN (cdn.copilotkit.ai, next.config.ts)
+    /^cdn\.copilotkit\.ai$/,
+];
+
+const STAGING: EnvSet = {
+    name: "staging",
+    expected: {
+        baseUrl: "https://docs.staging.copilotkit.ai",
+        shellUrl: "https://showcase.staging.copilotkit.ai",
+        pocketbaseUrl: "https://pocketbase-staging-eec0.up.railway.app",
+        opsBaseUrl: "https://harness-staging-2ee4.up.railway.app",
+    },
+    backendAllowlist: [
+        // Staging ingress: ONLY *.staging.copilotkit.ai (e.g.
+        // docs.staging.copilotkit.ai, showcase.staging.copilotkit.ai,
+        // dashboard.showcase.staging.copilotkit.ai). Anchored at both
+        // ends so `something.docs.staging.copilotkit.ai` does NOT slip
+        // through.
+        /^(docs|showcase|dashboard\.showcase)\.staging\.copilotkit\.ai$/,
+        // Railway public domains for the staging deploys this
+        // workstream wires. Pinned to the EXACT host suffixes that
+        // appear in the B15 env-var list — not a wildcard
+        // `-staging-[a-z0-9]+` pattern that would also match other
+        // unrelated staging services in the workspace.
+        /^pocketbase-staging-eec0\.up\.railway\.app$/,
+        /^harness-staging-2ee4\.up\.railway\.app$/,
+        ...SHARED_THIRDPARTY_ALLOWLIST,
+    ],
+};
+
+const PROD: EnvSet = {
+    name: "prod",
+    expected: {
+        baseUrl: "https://docs.copilotkit.ai",
+        shellUrl: "https://showcase.copilotkit.ai",
+        pocketbaseUrl: "https://showcase-pocketbase-production.up.railway.app",
+        opsBaseUrl: "https://showcase-harness-production.up.railway.app",
+    },
+    backendAllowlist: [
+        // Prod ingress: bare-domain marketing + docs + showcase +
+        // dashboard hosts. ONLY these — anchored at both ends so
+        // `something.docs.copilotkit.ai` doesn't slip through.
+        /^(www|docs|showcase|dashboard\.showcase)\.copilotkit\.ai$/,
+        // Railway public domains used by prod (exact suffix match per
+        // the build-args at showcase_build.yml:197-198).
+        /^showcase-pocketbase-production\.up\.railway\.app$/,
+        /^showcase-harness-production\.up\.railway\.app$/,
+        ...SHARED_THIRDPARTY_ALLOWLIST,
+    ],
+};
+
+interface ShellTarget {
+    shell: "shell" | "shell-docs" | "shell-dashboard" | "shell-dojo";
+    urlFor: (env: EnvSet) => string;
+    expectedFields: Array<keyof EnvSet["expected"]>;
+}
+
+const TARGETS: ShellTarget[] = [
+    {
+        shell: "shell",
+        urlFor: (e) =>
+            e.name === "staging"
+                ? "https://showcase.staging.copilotkit.ai/"
+                : "https://showcase.copilotkit.ai/",
+        expectedFields: ["baseUrl"],
+    },
+    {
+        shell: "shell-docs",
+        urlFor: (e) =>
+            e.name === "staging"
+                ? "https://docs.staging.copilotkit.ai/"
+                : "https://docs.copilotkit.ai/",
+        expectedFields: ["baseUrl", "shellUrl"],
+    },
+    {
+        shell: "shell-dashboard",
+        urlFor: (e) =>
+            e.name === "staging"
+                ? "https://dashboard.showcase.staging.copilotkit.ai/"
+                : "https://dashboard.showcase.copilotkit.ai/",
+        expectedFields: ["pocketbaseUrl", "shellUrl", "opsBaseUrl"],
+    },
+    // shell-dojo — uncomment when a public env-routed host is wired
+    // (no public ingress today per the B15 service inventory).
+];
+
+for (const env of [STAGING, PROD]) {
+    for (const target of TARGETS) {
+        test(`${target.shell} on ${env.name}: runtime config + backend allowlist`, async ({
+            page,
+        }) => {
+            const offenders: string[] = [];
+            page.on("request", (req) => {
+                const url = new URL(req.url());
+                // Same-origin requests don't cross env lines.
+                if (url.origin === new URL(target.urlFor(env)).origin) return;
+                // Data: and blob: aren't network hosts.
+                if (url.protocol === "data:" || url.protocol === "blob:") return;
+                const allowed = env.backendAllowlist.some((re) => re.test(url.host));
+                if (!allowed) offenders.push(req.url());
+            });
+
+            await page.goto(target.urlFor(env), { waitUntil: "networkidle" });
+
+            // Assert __SHOWCASE_CONFIG__ matches the expected env.
+            const cfg = await page.evaluate(
+                () =>
+                    (window as Window & { __SHOWCASE_CONFIG__?: unknown })
+                        .__SHOWCASE_CONFIG__,
+            );
+            expect(cfg).toBeDefined();
+            for (const field of target.expectedFields) {
+                expect((cfg as Record<string, string>)[field]).toBe(
+                    env.expected[field],
+                );
+            }
+
+            expect(
+                offenders,
+                `${target.shell} on ${env.name} hit non-allowlisted hosts:\n${offenders.join("\n")}`,
+            ).toEqual([]);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- Establishes a two-stage push-to-main deploy pipeline for the showcase fleet: build GHCR images and redeploy STAGING (which floats `:latest`); PROD is digest-pinned (`@sha256:`) and promote-only via a gated workflow.
- Introduces a single source of truth (SSOT) for Railway env/service IDs, image refs, per-env domains, and probe configs, consumed by Ruby tooling, TypeScript pipeline scripts, and CI workflows.
- Adds a Ruby `bin/railway` promote command with per-service targeting, `--digest` pinning, and fleet-scoped preflight gates (P1 GHCR digest existence, P2 staging-latest SUCCESS, P3 staging-green live re-probe, P5 mutation correctness, P6 parity matrix).
- Migrates the four Next.js shells (shell, shell-dashboard, shell-docs, shell-dojo) to runtime URL config (\"Option B\"): server-side reads of `NEXT_PUBLIC_*` at request time + `window.__SHOWCASE_CONFIG__` injection, with an oxlint rule guarding against build-time public-env reads.
- Hardens the image-ref gate (per-env: prod `@sha256`, staging `:latest`), adds untracked-service hard-fail and `gateIgnore` opt-out, and rolls five additional services into the gate.
- Adds verify-deploy probe drivers, per-env verify matrix resolution, per-slot build-result artifacts, and end-to-end fail-loud boundaries across the pipeline scripts.

## Key changes

### Deploy model and workflows
- `showcase_build.yml`, `showcase_build_check.yml`, `showcase_deploy.yml`, `showcase_promote.yml` updated/added for the new two-stage flow.
- Push-to-main redeploy retargeted from prod to staging; redeploy-summary upload is now mandatory and bridged into the build workflow artifact.
- New prod promote workflow (`showcase_promote.yml`) gates on the Ruby preflight suite.

### Railway envs SSOT
- `showcase/scripts/railway-envs.ts` + generated `railway-envs.generated.json` as the canonical source of env/service IDs, per-env domains, probe config, dispatch-name uniqueness invariant, and `gateIgnore` per service.
- CI `--check` mode verifies the generated artifact is in sync with the TS source.
- Ruby `bin/railway` reads `EXPECTED_DOMAINS` from the TS SSOT artifact.
- Snapshot schema v2 adds `healthcheck`/`region`/`replicas`/`restartPolicy` for the parity matrix.

### TS pipeline scripts (`showcase/scripts/`)
- `redeploy-env.ts` for explicit per-env Railway redeploys with per-service JSON summary emission.
- `resolve-verify-matrix.ts` for SSOT-driven verify matrix resolution (skips verify when redeploy success-set is empty; pinned by a contract test).
- `verify-deploy.ts` parameterized per-env probe + baseline driver implementations.
- `verify-railway-image-refs.ts` per-env gate (prod `@sha256`, staging `:latest`), untracked-service hard-fail, malformed-ref negatives, per-service shape tests.
- `aggregate-build-results.ts` per-slot build-result artifacts, fail-loud on missing slot file, GHA heredoc output.
- `emit-railway-envs-json.ts` SSOT artifact emitter with hermetic, fail-loud read errors.
- Shared `scripts/lib/`: unified Railway GraphQL endpoint (backboard.railway.app), shared token resolver preferring `user.accessToken`, whitespace/type-safe narrowing, sanitized GraphQL error bodies.

### Ruby promote (`showcase/bin/railway` + `lib/`)
- `PromoteCommand` refactored for testable preflight; single-service targeting via `--digest`.
- `Railway::Auth.ghcr_token` + `GHCR.manifest_exists` (P1 GHCR digest gate).
- P2 staging-latest-deployment SUCCESS check.
- P3 require-staging-green live re-probe via `verify-deploy --env staging`.
- P5 mutation-correctness verification (boolean + re-query retry).
- P6 parity matrix (healthcheck/region/replicas/restartPolicy).
- Promote resolves staging tag to GHCR digest once, pins prod, verifies redeploy, fails loud on partial promote.

### Runtime URL config across Next shells (\"Option B\")
- `shell`, `shell-dashboard`, `shell-docs`, `shell-dojo`: new `runtime-config.ts` (server) + `runtime-config.client.ts` (client) modules; `__SHOWCASE_CONFIG__` injected via root layout; middleware and URL consumers migrated.
- Dropped build-time `NEXT_PUBLIC_*` build-args from CI and Dockerfiles; re-declared `COMMIT_SHA`/`BRANCH` ARG in runner stages where needed.
- `shell-docs` sitemap/robots made dynamic; analytics + middleware routed through runtime config; `signup-link` and CTA components migrated with SSR tests.
- New oxlint rule rejects `NEXT_PUBLIC_*` reads from shell source.
- Playwright env-routing spec per shell per env; no-rebuild env-switch integration test.

### Test hardening
- vitest coverage for runtime-config server/client, SSR safety, env-name tolerance.
- Contract tests pin verify-matrix SSOT shape and CLI behavior.
- Per-service image-ref gate shape tests; malformed-ref negatives.

## Test plan

- [ ] CI: \`build-checks\` green on this branch
- [ ] CI: \`validate-showcase\` green (SSOT \`--check\` passes)
- [ ] CI: Python tests green
- [ ] CI: oxlint passes (no NEXT_PUBLIC_* reads in shells)
- [ ] Local: \`bundle exec rspec\` (Ruby promote suite) green
- [ ] Local: \`pnpm -C showcase/scripts test\` (vitest) green
- [ ] Local: \`pnpm -C showcase/shell test\` and sibling shells green (runtime-config + SSR)
- [ ] Local: \`docker buildx build\` succeeds for each shell with the trimmed build-args
- [ ] Local: Playwright env-routing spec passes against a running shell
- [ ] Manual: dry-run \`bin/railway promote --digest <sha256>\` against a staging service; P1–P6 gates report as expected