### PR TITLE
fix(docs): address 404ing links due to docs cutover

### DIFF
--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -433,7 +433,7 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/learn/tutorials/multi-conversation-chat",
-        destination: "/tutorials/multi-conversation-chat",
+        destination: "/",
         permanent: true,
       },
       {
@@ -507,11 +507,11 @@ const nextConfig: NextConfig = {
         destination: "/coding-agents",
         permanent: false,
       },
-      // Orphaned broken stub.
+      // Old guide now belongs in the v2 hook reference.
       {
         source: "/copilot-suggestions",
-        destination: "/",
-        permanent: false,
+        destination: "/reference/v2/hooks/useSuggestions",
+        permanent: true,
       },
       // AI-slop placeholder pulled from nav until properly authored;
       // file stays on disk for rewrite.
@@ -520,14 +520,6 @@ const nextConfig: NextConfig = {
         destination: "/generative-ui",
         permanent: false,
       },
-      // ~1-year-old migration target, no longer a meaningful jump-off
-      // point.
-      {
-        source: "/migrate/1.10.X",
-        destination: "/migrate/v2",
-        permanent: false,
-      },
-
       // ag-ui-middleware moved into the agentic-protocols group so it
       // appears in the sidebar under AG-UI rather than as an orphan
       // root page. 302 (not 301) since the new home is recent and we

--- a/showcase/shell-docs/src/components/docs-landing-next.tsx
+++ b/showcase/shell-docs/src/components/docs-landing-next.tsx
@@ -18,6 +18,7 @@ const backendDescriptions: Record<string, string> = {
     "Python LangGraph agents with the broadest feature coverage.",
   "langgraph-typescript": "TypeScript LangGraph agents over the AG-UI adapter.",
   "langgraph-fastapi": "Python LangGraph agents exposed through FastAPI.",
+  deepagents: "LangChain Deep Agents connected to CopilotKit product UI.",
   "google-adk": "Gemini-powered Google ADK agents connected through AG-UI.",
   mastra: "TypeScript-native agents, tools, memory, and workflows.",
   "crewai-crews": "CrewAI crews wired into CopilotKit product interfaces.",

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/meta.json
@@ -23,6 +23,7 @@
     "mcp-servers",
     "model-selection",
     "advanced-configuration",
+    "telemetry",
     "---Backend---",
     "copilot-runtime", "custom-agent", "ag-ui",
     "---Premium Features---",

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/telemetry.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/telemetry.mdx
@@ -1,0 +1,24 @@
+---
+title: Anonymous Telemetry
+---
+
+We use anonymous telemetry (metadata-only) to learn how to improve CopilotKit.
+
+- Open-source telemetry is **completely anonymous**
+- We **do not collect any data** about end-users (the users interacting with your copilot)
+- We **do not collect any application data** flowing through your system, only CopilotKit metadata
+- We do not sell or share any data with third parties
+- We do not use cookies or trackers in open-source telemetry
+- To minimize the frequency of data sent, we apply batching and sampling to telemetry
+
+## How to opt out of anonymous telemetry
+
+Set `COPILOTKIT_TELEMETRY_DISABLED=true` in your runtime environment. This disables telemetry for both the CopilotRuntime and the Inspector dev-console. We also respect [Do Not Track (DNT)](https://consoledonottrack.com/).
+
+## How to adjust telemetry sample rate
+
+The default sample rate is `0.05` (5%). You can adjust it by setting the `COPILOTKIT_TELEMETRY_SAMPLE_RATE` to any value between 0 and 1.
+
+## Get in touch
+
+If you have any questions or concerns, please reach out at [hello@copilotkit.ai](mailto:hello@copilotkit.ai).

--- a/showcase/shell-docs/src/content/docs/meta.json
+++ b/showcase/shell-docs/src/content/docs/meta.json
@@ -66,7 +66,7 @@
     },
     {
       "title": "Migrate",
-      "pages": ["migrate/v2", "migrate/1.8.2"]
+      "pages": ["migrate/v2", "migrate/1.10.X", "migrate/1.8.2"]
     }
   ]
 }

--- a/showcase/shell-docs/src/content/docs/migrate/1.10.X.mdx
+++ b/showcase/shell-docs/src/content/docs/migrate/1.10.X.mdx
@@ -1,0 +1,9 @@
+---
+title: Migrate to 1.10.X
+description: Migration guide for CopilotKit 1.10.X
+icon: "lucide/RefreshCw"
+---
+
+import MigrateTo1100 from "@/snippets/shared/troubleshooting/migrate-to-1.10.X.mdx";
+
+<MigrateTo1100 components={props.components} />

--- a/showcase/shell-docs/src/content/docs/migrate/meta.json
+++ b/showcase/shell-docs/src/content/docs/migrate/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Migrate",
   "icon": "lucide/RefreshCw",
-  "pages": ["v2", "1.8.2"]
+  "pages": ["v2", "1.10.X", "1.8.2"]
 }

--- a/showcase/shell-docs/src/content/reference/hooks/useCapabilities.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useCapabilities.mdx
@@ -1,0 +1,133 @@
+---
+title: "useCapabilities"
+description: "React hook for reading an agent's declared capabilities"
+---
+## Overview
+
+`useCapabilities` returns the [AG-UI `AgentCapabilities`](https://docs.ag-ui.com/concepts/capabilities) declared by an agent. Capabilities describe what an agent supports -- tool calling, streaming, multi-agent coordination, human-in-the-loop, and more.
+
+Capabilities are populated from the runtime `/info` response at connection time. The value is `undefined` until the runtime handshake completes or if the agent doesn't declare capabilities.
+
+## Signature
+
+```tsx
+import { useCapabilities } from "@copilotkit/react-core/v2";
+
+function useCapabilities(agentId?: string): AgentCapabilities | undefined
+```
+
+## Parameters
+
+<PropertyReference name="agentId" type="string" default='"default"'>
+  ID of the agent whose capabilities to read. If omitted, uses the default agent.
+</PropertyReference>
+
+## Return Value
+
+<PropertyReference name="capabilities" type="AgentCapabilities | undefined">
+  The agent's capability declaration, or `undefined` if the agent hasn't reported capabilities yet (e.g., the runtime handshake is still in progress) or doesn't implement `getCapabilities()`.
+
+  When defined, the object contains these optional categories:
+
+  <PropertyReference name="identity" type="IdentityCapabilities">
+    Agent metadata: `name`, `type` (framework), `description`, `version`, `provider`, `documentationUrl`, `metadata`.
+  </PropertyReference>
+
+  <PropertyReference name="transport" type="TransportCapabilities">
+    Supported transports: `streaming`, `websocket`, `httpBinary`, `pushNotifications`, `resumable`.
+  </PropertyReference>
+
+  <PropertyReference name="tools" type="ToolsCapabilities">
+    Tool support: `supported`, `items`, `parallelCalls`, `clientProvided`.
+  </PropertyReference>
+
+  <PropertyReference name="output" type="OutputCapabilities">
+    Output formats: `structuredOutput`, `supportedMimeTypes`.
+  </PropertyReference>
+
+  <PropertyReference name="state" type="StateCapabilities">
+    State management: `snapshots`, `deltas`, `memory`, `persistentState`.
+  </PropertyReference>
+
+  <PropertyReference name="multiAgent" type="MultiAgentCapabilities">
+    Multi-agent coordination: `supported`, `delegation`, `handoffs`, `subAgents`.
+  </PropertyReference>
+
+  <PropertyReference name="reasoning" type="ReasoningCapabilities">
+    Reasoning/thinking visibility: `supported`, `streaming`, `encrypted`.
+  </PropertyReference>
+
+  <PropertyReference name="multimodal" type="MultimodalCapabilities">
+    Multimodal input/output: `input` and `output` sub-objects for images, audio, video, PDF, and file support.
+  </PropertyReference>
+
+  <PropertyReference name="execution" type="ExecutionCapabilities">
+    Code execution: `codeExecution`, `sandboxed`, `maxIterations`, `maxExecutionTime`.
+  </PropertyReference>
+
+  <PropertyReference name="humanInTheLoop" type="HumanInTheLoopCapabilities">
+    Human-in-the-loop: `supported`, `approvals`, `interventions`, `feedback`.
+  </PropertyReference>
+
+  <PropertyReference name="custom" type="Record&lt;string, unknown&gt;">
+    Arbitrary key-value pairs for integration-specific capabilities.
+  </PropertyReference>
+</PropertyReference>
+
+## Usage
+
+### Conditionally render UI based on capabilities
+
+```tsx title="ToolPanel.tsx"
+import { useCapabilities } from "@copilotkit/react-core/v2";
+
+function ToolPanel() {
+  const capabilities = useCapabilities();
+
+  if (!capabilities?.tools?.supported) {
+    return null; // Agent doesn't support tools — hide the panel
+  }
+
+  return (
+    <div>
+      <h3>Tools</h3>
+      {capabilities.tools.clientProvided && (
+        <p>This agent accepts client-provided tools.</p>
+      )}
+    </div>
+  );
+}
+```
+
+### Read capabilities for a specific agent
+
+```tsx title="AgentInfo.tsx"
+import { useCapabilities } from "@copilotkit/react-core/v2";
+
+function AgentInfo({ agentId }: { agentId: string }) {
+  const capabilities = useCapabilities(agentId);
+
+  if (!capabilities) {
+    return <p>Loading capabilities…</p>;
+  }
+
+  return (
+    <ul>
+      <li>Streaming: {capabilities.transport?.streaming ? "Yes" : "No"}</li>
+      <li>Tools: {capabilities.tools?.supported ? "Yes" : "No"}</li>
+      <li>Human-in-the-loop: {capabilities.humanInTheLoop?.supported ? "Yes" : "No"}</li>
+    </ul>
+  );
+}
+```
+
+## Behavior
+
+- **Synchronous read** -- The hook reads `capabilities` directly from the agent instance. There is no separate loading state or async fetch -- the value is `undefined` until the runtime `/info` handshake populates it, then becomes defined.
+- **Re-renders** -- The hook calls `useAgent()` internally, so the component re-renders on agent state, message, and run-status changes (the default `updates` set). If you only need capabilities and want fewer re-renders, read `agent.capabilities` directly via `useAgent({ updates: [] })`.
+- **Stable reference** -- The capabilities object reference only changes when the agent reconnects or the runtime response changes. It does not change on every render.
+
+## Related
+
+- [`useAgent`](/reference/v2/hooks/useAgent) -- access the full agent instance (capabilities are a property of the agent)
+- [AG-UI Protocol](/agentic-protocols/ag-ui) -- the protocol that defines the capabilities schema

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -6,7 +6,12 @@ vi.mock("../registry", () => ({
   getDocsMode: () => "generated",
 }));
 
-import { inlineSnippets, SNIPPET_MAP, SNIPPETS_DIR } from "../docs-render";
+import {
+  inlineSnippets,
+  loadDoc,
+  SNIPPET_MAP,
+  SNIPPETS_DIR,
+} from "../docs-render";
 
 let tempDir = "";
 
@@ -98,6 +103,16 @@ describe("inlineSnippets", () => {
       "RuntimeCard",
       "from slug",
       "pdx-208-runtime-multiline",
+    );
+  });
+});
+
+describe("loadDoc", () => {
+  it("resolves clean URLs to files stored under route-group folders", () => {
+    const doc = loadDoc("integrations/aws-strands/telemetry");
+
+    expect(doc?.filePath).toContain(
+      "integrations/aws-strands/(other)/telemetry/index.mdx",
     );
   });
 });

--- a/showcase/shell-docs/src/lib/__tests__/route-groups.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/route-groups.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { stripRouteGroupSegmentsFromPathname } from "../route-groups";
+
+describe("stripRouteGroupSegmentsFromPathname", () => {
+  it("removes route groups from public paths", () => {
+    expect(
+      stripRouteGroupSegmentsFromPathname("/strands/(other)/telemetry"),
+    ).toBe("/strands/telemetry");
+  });
+
+  it("keeps non-route-group paths unchanged", () => {
+    expect(stripRouteGroupSegmentsFromPathname("/strands/telemetry")).toBe(
+      "/strands/telemetry",
+    );
+  });
+});

--- a/showcase/shell-docs/src/lib/__tests__/seo-redirects.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/seo-redirects.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { seoRedirects } from "../seo-redirects";
+
+describe("seoRedirects", () => {
+  it("redirects old DeepAgents integration URLs to the framework root", () => {
+    expect(seoRedirects).toContainEqual({
+      id: "INT-wild×deepagents",
+      source: "/integrations/deepagents/:path*",
+      destination: "/deepagents/:path*",
+    });
+  });
+
+  it("redirects old migration guide slugs to their new pages", () => {
+    expect(seoRedirects).toEqual(
+      expect.arrayContaining([
+        {
+          id: "MG2a",
+          source: "/migration-guides/migrate-to-v2",
+          destination: "/migrate/v2",
+        },
+        {
+          id: "MG3a",
+          source: "/migration-guides/migrate-to-1.10.X",
+          destination: "/migrate/1.10.X",
+        },
+        {
+          id: "MG4a",
+          source: "/migration-guides/migrate-to-1.8.2",
+          destination: "/migrate/1.8.2",
+        },
+      ]),
+    );
+  });
+
+  it("redirects the last old docs URLs to their intended shell locations", () => {
+    expect(seoRedirects).toEqual(
+      expect.arrayContaining([
+        {
+          id: "R13",
+          source: "/copilot-suggestions",
+          destination: "/reference/v2/hooks/useSuggestions",
+        },
+        {
+          id: "R15",
+          source: "/integrations/built-in-agent",
+          destination: "/",
+        },
+        {
+          id: "R16A",
+          source: "/integrations",
+          destination: "/",
+        },
+        {
+          id: "MV-telemetry",
+          source: "/telemetry",
+          destination: "/built-in-agent/telemetry",
+        },
+      ]),
+    );
+  });
+});

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -12,6 +12,7 @@ import path from "path";
 import matter from "gray-matter";
 import { resolveWithinDir } from "./safe-fs";
 import { getDocsMode } from "./registry";
+import { isRouteGroupSegment } from "./route-groups";
 
 export const CONTENT_DIR = path.join(process.cwd(), "src/content/docs");
 export const SNIPPETS_DIR = path.join(CONTENT_DIR, "..", "snippets");
@@ -1433,6 +1434,74 @@ export interface DocFrontmatter {
   hideTOC?: boolean;
 }
 
+function slugSegments(slugPath: string): string[] | null {
+  const segments = slugPath.split(/[\\/]+/).filter(Boolean);
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    return null;
+  }
+  return segments;
+}
+
+function routeGroupSubdirs(dir: string): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isDirectory() && isRouteGroupSegment(entry.name))
+    .map((entry) => entry.name);
+}
+
+function resolveDocThroughRouteGroups(
+  dir: string,
+  segments: string[],
+): string | null {
+  if (segments.length === 0) {
+    const indexPath = path.join(dir, "index.mdx");
+    return fs.existsSync(indexPath) ? indexPath : null;
+  }
+
+  const [segment, ...rest] = segments;
+  if (rest.length === 0) {
+    const mdxPath = path.join(dir, `${segment}.mdx`);
+    if (fs.existsSync(mdxPath)) return mdxPath;
+    const indexPath = path.join(dir, segment, "index.mdx");
+    if (fs.existsSync(indexPath)) return indexPath;
+  }
+
+  const directDir = path.join(dir, segment);
+  if (fs.existsSync(directDir) && fs.statSync(directDir).isDirectory()) {
+    const direct = resolveDocThroughRouteGroups(directDir, rest);
+    if (direct) return direct;
+  }
+
+  for (const routeGroup of routeGroupSubdirs(dir)) {
+    const grouped = resolveDocThroughRouteGroups(
+      path.join(dir, routeGroup),
+      segments,
+    );
+    if (grouped) return grouped;
+  }
+
+  return null;
+}
+
+function resolveRouteGroupedDocPath(slugPath: string): string | null {
+  const segments = slugSegments(slugPath);
+  if (!segments) return null;
+
+  const filePath = resolveDocThroughRouteGroups(CONTENT_DIR, segments);
+  if (!filePath) return null;
+
+  const resolved = resolveWithinDir(
+    CONTENT_DIR,
+    path.relative(CONTENT_DIR, filePath),
+  );
+  return resolved && fs.existsSync(resolved) ? resolved : null;
+}
+
 /**
  * Load an MDX file by slug and return its raw source + parsed frontmatter
  * metadata for rendering. Returns null when the file doesn't exist.
@@ -1456,7 +1525,12 @@ export function loadDoc(
   } else if (indexResolved && fs.existsSync(indexResolved)) {
     filePath = indexResolved;
   } else {
-    return null;
+    // Route groups such as `(other)` organize the sidebar filesystem but
+    // are not public URL segments. Resolve `/strands/telemetry` to
+    // `integrations/aws-strands/(other)/telemetry/index.mdx`.
+    const routeGroupedPath = resolveRouteGroupedDocPath(slugPath);
+    if (!routeGroupedPath) return null;
+    filePath = routeGroupedPath;
   }
 
   let source: string;

--- a/showcase/shell-docs/src/lib/framework-order.ts
+++ b/showcase/shell-docs/src/lib/framework-order.ts
@@ -11,6 +11,7 @@
 export const FRAMEWORK_DISPLAY_ORDER: readonly string[] = [
   "langgraph-python",
   "langgraph-typescript",
+  "deepagents",
   "google-adk",
   "strands",
   "mastra",

--- a/showcase/shell-docs/src/lib/registry.ts
+++ b/showcase/shell-docs/src/lib/registry.ts
@@ -102,16 +102,44 @@ export interface Registry {
 
 const registry = registryData as Registry;
 
+const DOCS_ONLY_INTEGRATIONS: Integration[] = [
+  {
+    name: "Deep Agents",
+    slug: "deepagents",
+    category: "popular",
+    language: "python",
+    description:
+      "LangChain Deep Agents connected to CopilotKit chat, state, tools, and generative UI.",
+    partner_docs: null,
+    repo: "",
+    copilotkit_version: "",
+    backend_url: "",
+    deployed: true,
+    docs_mode: "generated",
+    sort_order: 13,
+    features: [],
+    demos: [],
+  },
+];
+
+function allIntegrations(): Integration[] {
+  const registeredSlugs = new Set(registry.integrations.map((i) => i.slug));
+  return [
+    ...registry.integrations,
+    ...DOCS_ONLY_INTEGRATIONS.filter((i) => !registeredSlugs.has(i.slug)),
+  ];
+}
+
 export function getRegistry(): Registry {
   return registry;
 }
 
 export function getIntegrations(): Integration[] {
-  return registry.integrations;
+  return allIntegrations();
 }
 
 export function getIntegration(slug: string): Integration | undefined {
-  return registry.integrations.find((i) => i.slug === slug);
+  return allIntegrations().find((i) => i.slug === slug);
 }
 
 /**
@@ -230,7 +258,7 @@ export function getFeatureCategories(): FeatureCategory[] {
 
 export function getIntegrationsByCategory(): Record<string, Integration[]> {
   const grouped: Record<string, Integration[]> = {};
-  for (const integration of registry.integrations) {
+  for (const integration of getIntegrations()) {
     if (!grouped[integration.category]) {
       grouped[integration.category] = [];
     }

--- a/showcase/shell-docs/src/lib/route-groups.ts
+++ b/showcase/shell-docs/src/lib/route-groups.ts
@@ -1,0 +1,10 @@
+export function isRouteGroupSegment(segment: string): boolean {
+  return /^\(.+\)$/.test(segment);
+}
+
+export function stripRouteGroupSegmentsFromPathname(pathname: string): string {
+  const clean = pathname
+    .split("/")
+    .filter((segment) => segment.length > 0 && !isRouteGroupSegment(segment));
+  return `/${clean.join("/")}`;
+}

--- a/showcase/shell-docs/src/lib/seo-redirects.ts
+++ b/showcase/shell-docs/src/lib/seo-redirects.ts
@@ -42,6 +42,7 @@ const FRAMEWORKS = [
   "pydantic-ai",
   "llamaindex",
   "mastra",
+  "deepagents",
   "agent-spec",
   "ag2",
   "microsoft-agent-framework",
@@ -469,15 +470,17 @@ const ROOT_RENAMES: RedirectEntry[] = [
   {
     id: "R13",
     source: "/copilot-suggestions",
-    destination: "/prebuilt-components",
+    destination: "/reference/v2/hooks/useSuggestions",
   },
-  // /direct-to-llm and /integrations/built-in-agent → built-in-agent (BIA canonical)
+  // /direct-to-llm keeps its BIA canonical path, but the retired
+  // /integrations/built-in-agent landing route should go home.
   { id: "R14", source: "/direct-to-llm", destination: "/built-in-agent" },
   {
     id: "R15",
     source: "/integrations/built-in-agent",
-    destination: "/built-in-agent",
+    destination: "/",
   },
+  { id: "R16A", source: "/integrations", destination: "/" },
   { id: "R18", source: "/mcp", destination: "/build-with-agents" },
   { id: "R19", source: "/vibe-coding-mcp", destination: "/build-with-agents" },
   {
@@ -668,12 +671,12 @@ const MOVED_ROOT_REDIRECTS: RedirectEntry[] = [
     source: "/getting-started/quickstart-chatbot",
     destination: "/quickstart",
   },
-  // /telemetry was a one-off legacy page. Send to the home page rather
-  // than 404 since the topic has no current canonical home.
+  // /telemetry was a one-off legacy page. It now lives under the
+  // built-in-agent docs where runtime configuration pages are grouped.
   {
     id: "MV-telemetry",
     source: "/telemetry",
-    destination: "/",
+    destination: "/built-in-agent/telemetry",
   },
   // /reference/hooks/useCoAgent — useCoAgent (v1) was renamed to
   // useAgent (v2). External links still point at the old name.
@@ -858,13 +861,28 @@ const MIGRATION_GUIDES: RedirectEntry[] = [
   { id: "MG1", source: "/migration-guides", destination: "/migrate/v2" },
   { id: "MG2", source: "/migration-guides/v2", destination: "/migrate/v2" },
   {
+    id: "MG2a",
+    source: "/migration-guides/migrate-to-v2",
+    destination: "/migrate/v2",
+  },
+  {
     id: "MG3",
     source: "/migration-guides/1.10.X",
-    destination: "/migrate/v2",
+    destination: "/migrate/1.10.X",
+  },
+  {
+    id: "MG3a",
+    source: "/migration-guides/migrate-to-1.10.X",
+    destination: "/migrate/1.10.X",
   },
   {
     id: "MG4",
     source: "/migration-guides/1.8.2",
+    destination: "/migrate/1.8.2",
+  },
+  {
+    id: "MG4a",
+    source: "/migration-guides/migrate-to-1.8.2",
     destination: "/migrate/1.8.2",
   },
 ];

--- a/showcase/shell-docs/src/middleware.ts
+++ b/showcase/shell-docs/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextFetchEvent, NextRequest } from "next/server";
 import { seoRedirects } from "@/lib/seo-redirects";
+import { stripRouteGroupSegmentsFromPathname } from "@/lib/route-groups";
 import registry from "@/data/registry.json";
 
 // ---------------------------------------------------------------------------
@@ -172,6 +173,14 @@ export function middleware(
   event: NextFetchEvent,
 ): NextResponse {
   const { pathname } = request.nextUrl;
+
+  const routeGroupFreePath = stripRouteGroupSegmentsFromPathname(pathname);
+  if (routeGroupFreePath !== pathname) {
+    trackRedirect("route-group-strip", pathname, routeGroupFreePath);
+    const url = request.nextUrl.clone();
+    url.pathname = routeGroupFreePath;
+    return NextResponse.redirect(url, 301);
+  }
 
   // 1. Redirect lookup.
   //


### PR DESCRIPTION
## Summary
- Redirected the remaining broken legacy docs URLs to their current shell-docs locations, including `copilot-suggestions`, `integrations`, `integrations/built-in-agent`, `telemetry`, and `learn/tutorials/multi-conversation-chat`.
- Ported the missing telemetry page into the built-in-agent docs and added it to the sidebar.
- Added the missing `useCapabilities` reference page, restored `migrate/1.10.X`, and taught shell-docs to resolve docs stored under route-group folders like `(other)`.
- Added DeepAgents to the framework picker and docs navigation so framework redirects resolve cleanly.

## Testing
- `npm run test` passed.
- `npm run typecheck` passed.
- `npm run lint` passed with existing unrelated warnings.
- Verified the local shell-docs preview serves the new canonical pages and returns the expected redirect targets for the legacy URLs.