### PR TITLE
fix(shell-docs): stop framework-scoping cross-framework + reserved links

### DIFF
--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -37,7 +37,8 @@ import type { MdxFrameworkOverviewProps } from "@/components/content/landing-pag
 import { FrameworkSetup } from "@/lib/setup-concept";
 import { docsComponents } from "@/lib/mdx-registry";
 import { transformerMeta } from "@/lib/rehype-code-meta";
-import { getIntegration, getTabDefault } from "@/lib/registry";
+import { getIntegration, getIntegrations, getTabDefault } from "@/lib/registry";
+import { RESERVED_ROUTE_SLUGS } from "@/app/layout";
 import type { NavNode } from "@/lib/docs-render";
 import { navTreeToPageTree } from "@/lib/page-tree-bridge";
 import { tocHeadingsToFumadocs } from "@/lib/toc-bridge";
@@ -55,6 +56,31 @@ import {
   filterFrameworkScopedBlocks,
   slugify,
 } from "@/lib/toc";
+
+// First-URL-segment sets used by the framework-scoped link rewriter to
+// skip absolute MDX links that are NOT meant to be re-scoped:
+// - cross-framework slugs (registered integrations + docs-only frameworks)
+// - reserved top-level routes that don't live under any framework
+//
+// Computed at module load so the rewriter's per-link check is O(1).
+// `frameworkOverride` is still allowed to match `CROSS_FRAMEWORK_SLUGS`
+// (the link rewriter handles "same framework" via its own check), so a
+// page authored at `/built-in-agent/...` clicking `/built-in-agent/...`
+// stays correctly scoped.
+const CROSS_FRAMEWORK_SLUGS: ReadonlySet<string> = new Set<string>([
+  ...getIntegrations().map((i) => i.slug),
+  // Docs-only frameworks have no registry entry but DO own a
+  // `/<slug>/...` URL subtree. Mirror the list in
+  // app/[framework]/[[...slug]]/page.tsx so the rewriter doesn't
+  // capture inbound links into these scopes.
+  "a2a",
+  "agent-spec",
+  "deepagents",
+]);
+
+const RESERVED_ROUTE_SLUG_SET: ReadonlySet<string> = new Set<string>(
+  RESERVED_ROUTE_SLUGS as readonly string[],
+);
 
 export interface DocsPageViewProps {
   /** Slug path relative to `CONTENT_DIR` (no leading slash). */
@@ -457,10 +483,31 @@ export async function DocsPageView({
                             !!href &&
                             (href === `/${frameworkOverride}` ||
                               href.startsWith(`/${frameworkOverride}/`));
+                          // Cross-framework (`/a2a/...`,
+                          // `/langgraph-python/...`) and top-level
+                          // reserved-route (`/reference`, `/ag-ui`,
+                          // `/api`, `/docs`) links must keep their
+                          // absolute path. Without these guards, an
+                          // MDX link like `/a2a/generative-ui/...`
+                          // rendered on a BIA page becomes
+                          // `/built-in-agent/a2a/...` and 404s.
+                          const firstSegment =
+                            href?.startsWith("/") && !isProtocolRelative
+                              ? href.slice(1).split(/[/?#]/, 1)[0]
+                              : undefined;
+                          const targetsAnotherFramework =
+                            firstSegment !== undefined &&
+                            CROSS_FRAMEWORK_SLUGS.has(firstSegment) &&
+                            firstSegment !== frameworkOverride;
+                          const targetsReservedRoute =
+                            firstSegment !== undefined &&
+                            RESERVED_ROUTE_SLUG_SET.has(firstSegment);
                           const resolved =
                             href?.startsWith("/") &&
                             !isProtocolRelative &&
-                            !alreadyScoped
+                            !alreadyScoped &&
+                            !targetsAnotherFramework &&
+                            !targetsReservedRoute
                               ? `/${frameworkOverride}${href}`
                               : href;
                           return (

--- a/showcase/shell-docs/src/content/snippets/shared/generative-ui/a2ui.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/generative-ui/a2ui.mdx
@@ -88,9 +88,9 @@ Check out the [A2UI Composer](https://a2ui-editor.ag-ui.com/gallery) to create a
 
 ## Learn More
 
-- [Generative UI Specs Overview](/generative-ui/specs) - Compare all supported specifications
-- [Generative UI Guide](/generative-ui) - Build with Generative UI in CopilotKit
+- [Generative UI Specs Overview](/concepts/generative-ui-overview) - Compare all supported specifications
+- [Generative UI Guide](/generative-ui/tool-based) - Build with Generative UI in CopilotKit
 - [A2UI Site](https://a2ui.org/) - Visit the A2UI site
-- [AG-UI Protocol](/ag-ui-protocol) - Learn about the protocol that supports A2UI
-- [Open-JSON-UI](/generative-ui/specs/open-json-ui) - OpenAI's alternative approach
-- [MCP Apps](/generative-ui/specs/mcp-apps) - Iframe-based Generative UI extending MCP
+- [AG-UI Protocol](/agentic-protocols/ag-ui) - Learn about the protocol that supports A2UI
+- [Open-JSON-UI](/generative-ui/open-json-ui) - OpenAI's alternative approach
+- [MCP Apps](/generative-ui/mcp-apps) - Iframe-based Generative UI extending MCP

--- a/showcase/shell-docs/src/lib/seo-redirects.ts
+++ b/showcase/shell-docs/src/lib/seo-redirects.ts
@@ -156,17 +156,29 @@ function generateFrameworkRenames(): RedirectEntry[] {
   const entries: RedirectEntry[] = [];
   for (const fw of FRAMEWORKS) {
     const fwDest = canonicalSlug(fw);
-    // S13: concepts/* collapses to framework root
-    entries.push({
-      id: `S13w×${fw}`,
-      source: `/${fw}/concepts/:path*`,
-      destination: `/${fwDest}`,
-    });
-    entries.push({
-      id: `S13e×${fw}`,
-      source: `/${fw}/concepts`,
-      destination: `/${fwDest}`,
-    });
+    // S13: concepts/* collapses to framework root.
+    //
+    // Originally added to retire legacy `/langgraph/concepts/*` URLs
+    // (LangGraph had authored concept pages pre-cutover that the
+    // shell-docs IA removed). Only emit this when the framework slug
+    // actually renamed (legacy ≠ canonical) — for canonical-slug
+    // frameworks (`mastra`, `ag2`, `agno`, etc.) the legacy docs never
+    // had `/<fw>/concepts/*` pages, AND shell-docs now serves the
+    // agnostic `/concepts/*` content under every framework's scope
+    // (e.g. `/mastra/concepts/architecture`). Leaving the unconditional
+    // rule in place would 301 those valid agnostic-content URLs away.
+    if (fw !== fwDest) {
+      entries.push({
+        id: `S13w×${fw}`,
+        source: `/${fw}/concepts/:path*`,
+        destination: `/${fwDest}`,
+      });
+      entries.push({
+        id: `S13e×${fw}`,
+        source: `/${fw}/concepts`,
+        destination: `/${fwDest}`,
+      });
+    }
 
     for (const rename of SUBPATH_RENAMES) {
       entries.push({


### PR DESCRIPTION
Three coupled bugs surfaced from the BIA-as-default cutover, all hitting
the A2UI snippet rendered on /built-in-agent/generative-ui/a2ui:

1. Framework-scoped link rewriter (docs-page-view) blindly prefixed
   every root-relative MDX href with the active framework slug, so
   `/a2a/generative-ui/declarative-a2ui` rendered as
   `/built-in-agent/a2a/generative-ui/declarative-a2ui` (404). Now skip
   the rewrite when the first URL segment matches a known framework
   slug (registry integrations + docs-only a2a/agent-spec/deepagents)
   or a reserved top-level route (/docs, /ag-ui, /reference, /api).

2. Snippet `shared/generative-ui/a2ui.mdx` "Learn More" block linked at
   legacy paths (`/generative-ui/specs`, `/ag-ui-protocol`,
   `/generative-ui/specs/*`) that the IA retired. Updated to canonical
   destinations (`/concepts/generative-ui-overview`,
   `/agentic-protocols/ag-ui`, `/generative-ui/<spec>`) so the
   framework-prefix rewriter produces valid framework-scoped URLs.

3. S13 redirect (concepts/* -> framework root) was generated for every
   legacy framework slug including those whose canonical slug didn't
   change (mastra, ag2, agno, ...). The legacy docs never had
   /<canonical-slug>/concepts/* pages so the rule never had legitimate
   work for them — but shell-docs serves agnostic /concepts/* under
   every framework's scope now, and the unconditional rule was 301'ing
   those valid URLs to the framework root. Restricted to renamed
   frameworks only.

Verified locally: every link rendered on /built-in-agent/generative-ui/a2ui
now resolves to 200; /<unchanged-slug-fw>/concepts/architecture still
serves; /langgraph/concepts/* still collapses to /langgraph-python.