### PR TITLE
fix(sdk-python): strip copilotkit_forwarded_headers from LLM prompt

### DIFF
--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -509,7 +509,9 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         # via ``_extract_forwarded_headers_from_config``).
         if isinstance(app_context, dict):
             app_context = {
-                k: v for k, v in app_context.items() if k != "copilotkit_forwarded_headers"
+                k: v
+                for k, v in app_context.items()
+                if k != "copilotkit_forwarded_headers"
             }
 
         # Check if app_context is missing or empty

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -154,6 +154,10 @@ _RESERVED_STATE_KEYS = frozenset(
     {
         "messages",
         "copilotkit",
+        # Transport-layer plumbing: forwarded request headers conveyed via a
+        # separate ContextVar to the httpx hook. MUST never be rendered into
+        # the LLM prompt — neither via App Context nor via expose_state.
+        "copilotkit_forwarded_headers",
         "ag-ui",
         "tools",
         "structured_response",
@@ -218,7 +222,17 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         if self._expose_state is False:
             return None
         if isinstance(self._expose_state, frozenset):
-            keys: list[str] = [k for k in self._expose_state if k in state]
+            # Allowlist branch: honor user intent for other reserved keys
+            # (e.g. ``thread_id``) so the override test in this suite still
+            # passes, but hard-exclude ``copilotkit_forwarded_headers`` —
+            # rendering it would leak the raw forwarded request headers into
+            # the LLM prompt, which is what the reserved-keys comment above
+            # promises will never happen "via App Context nor via expose_state".
+            keys: list[str] = [
+                k
+                for k in self._expose_state
+                if k in state and k != "copilotkit_forwarded_headers"
+            ]
         else:
             keys = [
                 k
@@ -486,6 +500,17 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         app_context = copilotkit_state.get("context") or getattr(
             runtime, "context", None
         )
+
+        # Strip the reserved transport-layer key ``copilotkit_forwarded_headers``
+        # so it is never rendered into the LLM prompt. langgraph-api auto-copies
+        # ``config.configurable`` into ``runtime.context``, which means the
+        # forwarded-headers wrapper dict shows up here even though it is only
+        # meant for the httpx hook (which reads it from a separate ContextVar
+        # via ``_extract_forwarded_headers_from_config``).
+        if isinstance(app_context, dict):
+            app_context = {
+                k: v for k, v in app_context.items() if k != "copilotkit_forwarded_headers"
+            }
 
         # Check if app_context is missing or empty
         if not app_context:

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -304,6 +304,74 @@ def test_expose_state_emits_valid_json_payload():
     assert parsed == {"liked": ["a", "b"], "count": 3, "nested": {"k": "v"}}
 
 
+def test_expose_state_true_never_surfaces_forwarded_headers():
+    """``copilotkit_forwarded_headers`` is a transport-layer plumbing key — it
+    must NEVER reach the LLM prompt via the ``expose_state`` path either, even
+    when ``expose_state=True`` would otherwise serialize every non-reserved
+    top-level state key.
+    """
+    middleware = CopilotKitMiddleware(expose_state=True)
+    request = _make_request(
+        state={
+            "messages": [],
+            "liked": ["a"],
+            "copilotkit_forwarded_headers": {
+                "x-aimock-context": "showcase/d6",
+                "x-aimock-strict": "true",
+            },
+        }
+    )
+
+    seen, _ = _run_wrap(middleware, request)
+
+    body = seen.system_message.content if seen.system_message else ""
+    # The genuine user key is still surfaced.
+    assert '"liked"' in body
+    # The transport-layer wrapper and its header values are not.
+    assert "copilotkit_forwarded_headers" not in body, (
+        "copilotkit_forwarded_headers must never appear in expose_state output"
+    )
+    assert "x-aimock-context" not in body, (
+        "forwarded header values must never appear in expose_state output"
+    )
+    assert "x-aimock-strict" not in body
+    assert "showcase/d6" not in body
+
+
+def test_expose_state_allowlist_never_surfaces_forwarded_headers():
+    """``copilotkit_forwarded_headers`` must NEVER reach the LLM prompt via the
+    ``expose_state`` path — including the explicit allowlist form. The sibling
+    ``test_expose_state_allowlist_can_override_reserved_keys`` pins that users
+    CAN allowlist other reserved keys (e.g. ``thread_id``) on purpose; this key
+    is the one exception, because it is a transport-layer wrapper for forwarded
+    request headers and rendering it would leak the raw headers into the prompt.
+    """
+    middleware = CopilotKitMiddleware(
+        expose_state=frozenset({"copilotkit_forwarded_headers"})
+    )
+    request = _make_request(
+        state={
+            "messages": [],
+            "copilotkit_forwarded_headers": {
+                "x-aimock-context": "showcase/d6",
+                "x-aimock-strict": "true",
+            },
+        }
+    )
+
+    seen, _ = _run_wrap(middleware, request)
+
+    body = seen.system_message.content if seen.system_message else ""
+    assert "copilotkit_forwarded_headers" not in body, (
+        "copilotkit_forwarded_headers must never appear in allowlist output"
+    )
+    assert "x-aimock-context" not in body, (
+        "forwarded header values must never appear in allowlist output"
+    )
+    assert "x-aimock-strict" not in body
+    assert "showcase/d6" not in body
+
+
 # ---------------------------------------------------------------------------
 # Async wrapper parity
 # ---------------------------------------------------------------------------
@@ -408,6 +476,80 @@ def test_before_agent_uses_runtime_context_when_state_context_empty():
     assert result is not None
     sys_contents = _system_contents(result["messages"])
     assert any("/dashboard" in s for s in sys_contents)
+
+
+def test_before_agent_strips_copilotkit_forwarded_headers_from_runtime_context():
+    """``copilotkit_forwarded_headers`` is a transport-layer plumbing key that
+    langgraph-api auto-copies from ``configurable`` into ``context``. It must
+    never be rendered into the LLM prompt as App Context — the forwarded-headers
+    httpx conveyance path reads it from a separate ContextVar.
+
+    When that key is the ONLY thing in ``runtime.context``, ``before_agent``
+    must treat it as empty App Context and not inject an "App Context:" system
+    message at all.
+    """
+    middleware = CopilotKitMiddleware()
+    state = {"messages": [HumanMessage("hi")], "copilotkit": {}}
+    runtime = MagicMock(
+        name="runtime",
+        context={
+            "copilotkit_forwarded_headers": {
+                "x-aimock-context": "showcase/d6",
+                "x-aimock-strict": "true",
+            }
+        },
+    )
+
+    result = middleware.before_agent(state, runtime)
+
+    # Contract: when ``runtime.context`` contains ONLY
+    # ``copilotkit_forwarded_headers``, the strip leaves an empty App Context,
+    # so ``before_agent`` MUST short-circuit and return None (no App Context
+    # system message). A non-None result here means the strip regressed and
+    # the transport-layer wrapper is being injected into the prompt.
+    #
+    # NOTE: an earlier version of this test guarded the leak assertions with
+    # ``if result is not None``, which silently passed if the strip stopped
+    # short-circuiting — exactly the regression we need to catch. Assert
+    # explicitly instead.
+    assert result is None, (
+        "expected short-circuit (no App Context message) when only "
+        "copilotkit_forwarded_headers is present in runtime.context"
+    )
+
+
+def test_before_agent_strips_forwarded_headers_but_keeps_real_app_context():
+    """When ``runtime.context`` contains both a genuine app key AND the
+    transport-only ``copilotkit_forwarded_headers`` wrapper, the App Context
+    system message must still be injected with the real key, but the forwarded
+    headers must be filtered out.
+    """
+    middleware = CopilotKitMiddleware()
+    state = {"messages": [HumanMessage("hi")], "copilotkit": {}}
+    runtime = MagicMock(
+        name="runtime",
+        context={
+            "user_tier": "pro",
+            "copilotkit_forwarded_headers": {
+                "x-aimock-context": "showcase/d6",
+            },
+        },
+    )
+
+    result = middleware.before_agent(state, runtime)
+
+    assert result is not None
+    sys_contents = _system_contents(result["messages"])
+    # The genuine app context is still surfaced.
+    assert any("App Context:" in s for s in sys_contents)
+    assert any("user_tier" in s and "pro" in s for s in sys_contents)
+    # The transport-layer wrapper is stripped from the rendered prompt.
+    assert not any(
+        "copilotkit_forwarded_headers" in s for s in sys_contents
+    ), "copilotkit_forwarded_headers must be filtered out of the App Context message"
+    assert not any(
+        "x-aimock-context" in s for s in sys_contents
+    ), "forwarded header values must never appear in a system prompt"
 
 
 # ---------------------------------------------------------------------------

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -544,12 +544,12 @@ def test_before_agent_strips_forwarded_headers_but_keeps_real_app_context():
     assert any("App Context:" in s for s in sys_contents)
     assert any("user_tier" in s and "pro" in s for s in sys_contents)
     # The transport-layer wrapper is stripped from the rendered prompt.
-    assert not any(
-        "copilotkit_forwarded_headers" in s for s in sys_contents
-    ), "copilotkit_forwarded_headers must be filtered out of the App Context message"
-    assert not any(
-        "x-aimock-context" in s for s in sys_contents
-    ), "forwarded header values must never appear in a system prompt"
+    assert not any("copilotkit_forwarded_headers" in s for s in sys_contents), (
+        "copilotkit_forwarded_headers must be filtered out of the App Context message"
+    )
+    assert not any("x-aimock-context" in s for s in sys_contents), (
+        "forwarded header values must never appear in a system prompt"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause**: `langgraph-api` auto-copies the entire `config.configurable` dict into `runtime.context`. That dict carries the CopilotKit-internal transport key `copilotkit_forwarded_headers`, populated solely to drive the httpx header-forwarding hook. The middleware's `before_agent` step renders `runtime.context` into the LLM prompt as an "App Context" system message, and the `expose_state` path can surface the same key via the state note — both leak transport headers into the prompt body.
- **Symptom**: under strict fixture matching (D6 / aimock), the leaked headers change the request payload and the match fails (503). Prompts are also polluted with transport metadata that the user never set.
- **Fix**: hard-exclude `copilotkit_forwarded_headers` from both render paths. The App Context renderer strips the reserved key before serialization; the `expose_state` allowlist applies the same exclusion so an explicit allow cannot reintroduce the leak. The httpx header-forwarding hook is unchanged — the key still reaches downstream as an HTTP header. Pure conveyance, no body pollution.

## Why

This is part of the D6 langgraph-python header-conveyance work. Header conveyance to aimock already works via the httpx hook, but the same forwarded-headers dict was leaking into the prompt body via langgraph-api's `configurable` → `context` auto-copy. That broke aimock strict fixture matching and polluted prompts. The reserved key `copilotkit_forwarded_headers` is now transport-only.

## Test plan

- Red-green unit tests added for both paths:
  - App Context renderer strips `copilotkit_forwarded_headers`.
  - `expose_state` default-deny strips it; explicit-allow allowlist also strips it.
- Full `sdk-python` suite green: **181 passed, 11 skipped, 0 failed**.
- Middleware test file: **51 passed**.
- Proven end-to-end locally via the D6 1-pill (`langgraph-python:agentic-chat`, 3/3 turns green). aimock journal confirms the header arrives on the request, no App Context leak appears in the prompt body, and the fixture matches.

## Known follow-ups (NOT in this PR)

- The OpenAI Responses API (`/v1/responses`) path does not currently carry forwarded headers — a separate, pre-existing conveyance gap affecting reasoning-model demos. Tracked separately.
- Full D6 rollout also requires the `@copilotkit/runtime` release carrying `@ag-ui/langgraph` 0.0.34. Not bundled here.

This PR does **not** claim full D6 parity — it closes the prompt-leak half of the conveyance work.