### PR TITLE
style(sdk-python): apply ruff format to test_agui_agent.py

### DIFF
--- a/sdk-python/tests/test_agui_agent.py
+++ b/sdk-python/tests/test_agui_agent.py
@@ -650,9 +650,7 @@ class TestAgentMetadata:
         )
         sdk = CopilotKitRemoteEndpoint(agents=[agent], actions=[])
 
-        info = sdk.info(
-            context={"properties": {}, "frontend_url": None, "headers": {}}
-        )
+        info = sdk.info(context={"properties": {}, "frontend_url": None, "headers": {}})
 
         assert info["agents"] == [
             {


### PR DESCRIPTION
Fixes the red `static / quality` format gate on main caused by an unformatted Python test file (pre-existing, unrelated to the showcase pipeline work). Applied ruff 0.15.13 format to `sdk-python/tests/test_agui_agent.py` only.