### PR TITLE
chore(examples): update LangGraph threads CopilotKit pins

### DIFF
--- a/examples/integrations/langgraph-python-threads/apps/app/package.json
+++ b/examples/integrations/langgraph-python-threads/apps/app/package.json
@@ -8,9 +8,9 @@
     "start": "node server.mjs"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.52",
-    "@copilotkit/a2ui-renderer": "1.57.0",
-    "@copilotkit/react-core": "1.57.0",
+    "@ag-ui/client": "0.0.53",
+    "@copilotkit/a2ui-renderer": "1.59.1",
+    "@copilotkit/react-core": "1.59.1",
     "@hono/node-server": "^1.19.14",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-label": "^2.1.8",

--- a/examples/integrations/langgraph-python-threads/apps/bff/package.json
+++ b/examples/integrations/langgraph-python-threads/apps/bff/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/server.js"
   },
   "dependencies": {
-    "@copilotkit/runtime": "1.57.0",
+    "@copilotkit/runtime": "1.59.1",
     "@hono/node-server": "^1.13.6",
     "express": "5.2.1",
     "hono": "^4.7.11",

--- a/examples/integrations/langgraph-python-threads/package-lock.json
+++ b/examples/integrations/langgraph-python-threads/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "copilotkit-langgraph-template",
+      "hasInstallScript": true,
       "workspaces": [
         "apps/*"
       ],
@@ -24,10 +25,9 @@
       "name": "@repo/app",
       "version": "0.1.0",
       "dependencies": {
-        "@ag-ui/client": "0.0.52",
-        "@copilotkit/a2ui-renderer": "1.57.0",
-        "@copilotkit/react-core": "1.57.0",
-        "@copilotkit/react-ui": "1.57.0",
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/a2ui-renderer": "1.59.1",
+        "@copilotkit/react-core": "1.59.1",
         "@hono/node-server": "^1.19.14",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-label": "^2.1.8",
@@ -56,416 +56,11 @@
         "vite": "^7.1.12"
       }
     },
-    "apps/app/node_modules/@ag-ui/core": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.53.tgz",
-      "integrity": "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "apps/app/node_modules/@ag-ui/encoder": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.53.tgz",
-      "integrity": "sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/proto": "0.0.53"
-      }
-    },
-    "apps/app/node_modules/@ag-ui/proto": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.53.tgz",
-      "integrity": "sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/a2ui-renderer": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.57.0.tgz",
-      "integrity": "sha512-5Fn48h02oj1e0gGHc+lSnKvh4yrP4MPS4lpnBMSnif/kUzuNcyxGblnBRdxfjZo8gWj9Un8Who5Wy513CdToMg==",
-      "license": "MIT",
-      "dependencies": {
-        "@a2ui/web_core": "0.9.0",
-        "clsx": "^2.1.1",
-        "zod": "^3.25.75",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.57.0.tgz",
-      "integrity": "sha512-fCh9/71uJO0yT2b/0o/Rf4moDEYP8nfpJZxy6/xfEJxUsz0NIb8vnQgGO1iE2l2BWTVP2Gg2iGn/Pe9K0YfF1g==",
-      "dependencies": {
-        "@ag-ui/client": "0.0.53",
-        "@copilotkit/shared": "1.57.0",
-        "@tanstack/pacer": "^0.20.1",
-        "phoenix": "^1.8.4",
-        "rxjs": "7.8.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/core/node_modules/@ag-ui/client": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
-      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/proto": "0.0.53",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/core/node_modules/@tanstack/pacer": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/pacer/-/pacer-0.20.1.tgz",
-      "integrity": "sha512-ZNQ1bIL6eUXVKdic0tiImvBVkWrg/IoSK6VIacTrO3d3HAGnd70qFJNJagR/YOJIOw4EKGWnodwpYZkN1pWuVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/devtools-event-client": "^0.4.3",
-        "@tanstack/store": "^0.9.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/react-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.57.0.tgz",
-      "integrity": "sha512-q+Vs+Dyu+ng1/JziWurTLMjev/f0FOz3NCGXT/aSQ2/Xm0ZLF6WzUbJnTRd2R7xdyY8y8UAez0cgnuxbFbXVDA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ag-ui/client": "0.0.53",
-        "@ag-ui/core": "0.0.53",
-        "@copilotkit/a2ui-renderer": "1.57.0",
-        "@copilotkit/core": "1.57.0",
-        "@copilotkit/runtime-client-gql": "1.57.0",
-        "@copilotkit/shared": "1.57.0",
-        "@copilotkit/web-inspector": "1.57.0",
-        "@jetbrains/websandbox": "^1.1.3",
-        "@lit-labs/react": "^2.0.2",
-        "@radix-ui/react-dropdown-menu": "^2.1.15",
-        "@radix-ui/react-slot": "^1.2.3",
-        "@radix-ui/react-tooltip": "^1.2.7",
-        "@scarf/scarf": "^1.3.0",
-        "@tanstack/react-virtual": "^3.13.0",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "katex": "^0.16.22",
-        "lucide-react": "^0.525.0",
-        "react-markdown": "^8.0.7",
-        "rxjs": "7.8.1",
-        "streamdown": "^1.3.0",
-        "tailwind-merge": "^3.3.1",
-        "tw-animate-css": "^1.3.5",
-        "untruncate-json": "^0.0.1",
-        "use-stick-to-bottom": "^1.1.1",
-        "zod-to-json-schema": "^3.24.5"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^18 || ^19 || ^19.0.0-rc",
-        "zod": ">=3.0.0"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/react-core/node_modules/@ag-ui/client": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
-      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/proto": "0.0.53",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/react-core/node_modules/lucide-react": {
-      "version": "0.525.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
-      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/react-ui": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/react-ui/-/react-ui-1.57.0.tgz",
-      "integrity": "sha512-a7YvBi3d7LuHownG0xMRIgVfgGA62hqiQQ3pPvFwTEamCmmc9qDZIzo589KTRDBYLsWFnvb25v3jEQz1KWWUXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@copilotkit/react-core": "1.57.0",
-        "@copilotkit/runtime-client-gql": "1.57.0",
-        "@copilotkit/shared": "1.57.0",
-        "@headlessui/react": "^2.2.9",
-        "react-markdown": "^10.1.0",
-        "react-syntax-highlighter": "^15.6.1",
-        "rehype-raw": "^7.0.0",
-        "remark-gfm": "^4.0.1",
-        "remark-math": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/react-ui/node_modules/react-markdown": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
-      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "hast-util-to-jsx-runtime": "^2.0.0",
-        "html-url-attributes": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.0.0",
-        "unified": "^11.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18",
-        "react": ">=18"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/runtime-client-gql": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.57.0.tgz",
-      "integrity": "sha512-gQebShiQ2ywjKstC+AwK8W91n49YtqxbhNIfpUFCg6uzlK++CQ2ma9u6tsvJphitsaLfBrhJDJto4BzXzg1wPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@copilotkit/shared": "1.57.0",
-        "@urql/core": "^5.0.3",
-        "untruncate-json": "^0.0.1",
-        "urql": "^4.1.0"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/shared": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.57.0.tgz",
-      "integrity": "sha512-X6uqeAWLDh08LUj4a0gpC9mrlmlyaviuybsnGJQPzAJonYIehYH63bEksj6xFgIA1FfkmEzK2XTxUnbrtpMd3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@ag-ui/client": "0.0.53",
-        "@copilotkit/license-verifier": "0.2.0",
-        "@segment/analytics-node": "^2.1.2",
-        "@standard-schema/spec": "^1.0.0",
-        "chalk": "4.1.2",
-        "graphql": "^16.8.1",
-        "partial-json": "^0.1.7",
-        "uuid": "^11.1.0",
-        "zod": "^3.23.3",
-        "zod-to-json-schema": "^3.23.5"
-      },
-      "peerDependencies": {
-        "@ag-ui/core": ">=0.0.48"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/shared/node_modules/@ag-ui/client": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
-      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/proto": "0.0.53",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/web-inspector": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.57.0.tgz",
-      "integrity": "sha512-V05eKxqWNFnyhoNct7qc21AjFipxzK8RQNA72tRgnug38hodSNr6haqQGOcacjLD+tpe17KDEMO45QYm9YuExQ==",
-      "dependencies": {
-        "@ag-ui/client": "0.0.53",
-        "@copilotkit/core": "1.57.0",
-        "lit": "^3.2.0",
-        "lucide": "^0.525.0",
-        "marked": "^12.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "apps/app/node_modules/@copilotkit/web-inspector/node_modules/@ag-ui/client": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
-      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/proto": "0.0.53",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "apps/app/node_modules/@tanstack/store": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
-      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "apps/app/node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "apps/app/node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "apps/app/node_modules/remark-parse": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
-      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "apps/app/node_modules/remark-rehype": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
-      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "unified": "^11.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "apps/app/node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "apps/app/node_modules/unified": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
-      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "bail": "^2.0.0",
-        "devlop": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^4.0.0",
-        "trough": "^2.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "apps/app/node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "apps/app/node_modules/vfile": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "apps/bff": {
       "name": "@repo/bff",
       "version": "0.1.0",
       "dependencies": {
-        "@copilotkit/runtime": "1.57.0",
+        "@copilotkit/runtime": "1.59.1",
         "@hono/node-server": "^1.13.6",
         "express": "5.2.1",
         "hono": "^4.7.11",
@@ -488,61 +83,31 @@
         "rxjs": "7.8.1"
       }
     },
-    "apps/bff/node_modules/@ag-ui/client": {
-      "version": "0.0.53",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/proto": "0.0.53",
-        "@types/uuid": "^10.0.0",
-        "compare-versions": "^6.1.1",
-        "fast-json-patch": "^3.1.1",
-        "rxjs": "7.8.1",
-        "untruncate-json": "^0.0.1",
-        "uuid": "^11.1.0",
-        "zod": "^3.22.4"
-      }
-    },
-    "apps/bff/node_modules/@ag-ui/core": {
-      "version": "0.0.53",
-      "dependencies": {
-        "zod": "^3.22.4"
-      }
-    },
-    "apps/bff/node_modules/@ag-ui/encoder": {
-      "version": "0.0.53",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@ag-ui/proto": "0.0.53"
-      }
-    },
-    "apps/bff/node_modules/@ag-ui/proto": {
-      "version": "0.0.53",
-      "dependencies": {
-        "@ag-ui/core": "0.0.53",
-        "@bufbuild/protobuf": "^2.2.5",
-        "@protobuf-ts/protoc": "^2.11.1"
-      }
+    "apps/bff/node_modules/@copilotkit/license-verifier": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.4.2.tgz",
+      "integrity": "sha512-0+Rdtg4gOwOBFBpZFxYsjgwBcCLja5z03YC6WA3KEntHYhsnoJ2aqNG6c0we8ZExCNYlEO4M7kHIfG5LXzqMYQ==",
+      "license": "MIT"
     },
     "apps/bff/node_modules/@copilotkit/runtime": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.57.0.tgz",
-      "integrity": "sha512-rvFXgQZkFcojdGubmS51OUYnrXQ/MLFj8TrhEgEKRwHT2wqB7OuA1DAPn1d2bip6LqUOPYsFOFGt9Qhy19narw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.59.1.tgz",
+      "integrity": "sha512-0Rl+8i2xj3dGiy+NG6tnItg0wGgXxOnB8BVkMsHC6PxRQp7am3PqUNrOQTFI67i7bvXfEPNdZINm97djzOvVSQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/a2ui-middleware": "0.0.5",
         "@ag-ui/client": "0.0.53",
         "@ag-ui/core": "0.0.53",
         "@ag-ui/encoder": "0.0.53",
-        "@ag-ui/langgraph": "0.0.31",
+        "@ag-ui/langgraph": "0.0.34",
         "@ag-ui/mcp-apps-middleware": "0.0.3",
         "@ai-sdk/anthropic": "^3.0.49",
         "@ai-sdk/google": "^3.0.33",
         "@ai-sdk/google-vertex": "^3.0.97",
         "@ai-sdk/mcp": "^1.0.21",
         "@ai-sdk/openai": "^3.0.36",
-        "@copilotkit/license-verifier": "0.2.0",
-        "@copilotkit/shared": "1.57.0",
+        "@copilotkit/license-verifier": "~0.4.2",
+        "@copilotkit/shared": "1.59.1",
         "@graphql-yoga/plugin-defer-stream": "^3.3.1",
         "@hono/node-server": "^1.13.5",
         "@modelcontextprotocol/sdk": "^1.18.2",
@@ -679,27 +244,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "apps/bff/node_modules/@copilotkit/shared": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.57.0.tgz",
-      "integrity": "sha512-X6uqeAWLDh08LUj4a0gpC9mrlmlyaviuybsnGJQPzAJonYIehYH63bEksj6xFgIA1FfkmEzK2XTxUnbrtpMd3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@ag-ui/client": "0.0.53",
-        "@copilotkit/license-verifier": "0.2.0",
-        "@segment/analytics-node": "^2.1.2",
-        "@standard-schema/spec": "^1.0.0",
-        "chalk": "4.1.2",
-        "graphql": "^16.8.1",
-        "partial-json": "^0.1.7",
-        "uuid": "^11.1.0",
-        "zod": "^3.23.3",
-        "zod-to-json-schema": "^3.23.5"
-      },
-      "peerDependencies": {
-        "@ag-ui/core": ">=0.0.48"
       }
     },
     "apps/bff/node_modules/@types/node": {
@@ -911,6 +455,8 @@
     },
     "node_modules/@0no-co/graphql.web": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
+      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -932,11 +478,13 @@
       }
     },
     "node_modules/@ag-ui/client": {
-      "version": "0.0.52",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
+      "integrity": "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==",
       "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/proto": "0.0.52",
+        "@ag-ui/core": "0.0.53",
+        "@ag-ui/encoder": "0.0.53",
+        "@ag-ui/proto": "0.0.53",
         "@types/uuid": "^10.0.0",
         "compare-versions": "^6.1.1",
         "fast-json-patch": "^3.1.1",
@@ -954,20 +502,26 @@
       }
     },
     "node_modules/@ag-ui/core": {
-      "version": "0.0.52",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.53.tgz",
+      "integrity": "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==",
       "dependencies": {
         "zod": "^3.22.4"
       }
     },
     "node_modules/@ag-ui/encoder": {
-      "version": "0.0.52",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.53.tgz",
+      "integrity": "sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==",
       "dependencies": {
-        "@ag-ui/core": "0.0.52",
-        "@ag-ui/proto": "0.0.52"
+        "@ag-ui/core": "0.0.53",
+        "@ag-ui/proto": "0.0.53"
       }
     },
     "node_modules/@ag-ui/langgraph": {
-      "version": "0.0.31",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.34.tgz",
+      "integrity": "sha512-3BV3/X9iRXL3EOFq1DxAZffbh2V6bJ2G8aoNJP6wHx40jbPdJT7aDvZb4DmzlFmXVWJ2kzfD4AnvxLAx9ooPLQ==",
       "dependencies": {
         "@langchain/core": "^1.1.40",
         "@langchain/langgraph-sdk": "^1.8.8",
@@ -982,6 +536,8 @@
     },
     "node_modules/@ag-ui/langgraph/node_modules/rxjs": {
       "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -1005,9 +561,11 @@
       }
     },
     "node_modules/@ag-ui/proto": {
-      "version": "0.0.52",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.53.tgz",
+      "integrity": "sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==",
       "dependencies": {
-        "@ag-ui/core": "0.0.52",
+        "@ag-ui/core": "0.0.53",
         "@bufbuild/protobuf": "^2.2.5",
         "@protobuf-ts/protoc": "^2.11.1"
       }
@@ -1459,13 +1017,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "dev": true,
@@ -1514,6 +1065,8 @@
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cfworker/json-schema": {
@@ -1582,8 +1135,187 @@
         "commander": "~13.1.0"
       }
     },
-    "node_modules/@copilotkit/license-verifier": {
-      "version": "0.2.0"
+    "node_modules/@copilotkit/a2ui-renderer": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.59.1.tgz",
+      "integrity": "sha512-jRltYlLKqwWREiS430pJ0ukpA1L7hralerVFYlsgtkMhRMf9DzSMl+Gbt48FDGt/QteS7YwsT+nZrUWanOXJXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@a2ui/web_core": "0.9.0",
+        "clsx": "^2.1.1",
+        "zod": "^3.25.75",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@copilotkit/core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.59.1.tgz",
+      "integrity": "sha512-i1cdGADVNR/TkkZcMWGyrInBMutnHlCVxvLoujet9x8OkgMVOF/T6w9Ep7PNNY5Wwlu+i2XwGQPz5bb1/NyUdw==",
+      "dependencies": {
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/shared": "1.59.1",
+        "@tanstack/pacer": "^0.20.1",
+        "phoenix": "^1.8.4",
+        "rxjs": "7.8.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@copilotkit/core/node_modules/@tanstack/pacer": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/pacer/-/pacer-0.20.1.tgz",
+      "integrity": "sha512-ZNQ1bIL6eUXVKdic0tiImvBVkWrg/IoSK6VIacTrO3d3HAGnd70qFJNJagR/YOJIOw4EKGWnodwpYZkN1pWuVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/devtools-event-client": "^0.4.3",
+        "@tanstack/store": "^0.9.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@copilotkit/core/node_modules/@tanstack/store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
+      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@copilotkit/core/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@copilotkit/react-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.59.1.tgz",
+      "integrity": "sha512-vteM29uKKhN1IfS9iKIMDw28IUGMSuUJd3eB6gAJhE2lI4GUr0K02vytUclqHKxR1/vUZpsvqvPJuDLCFO4ujw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/client": "0.0.53",
+        "@ag-ui/core": "0.0.53",
+        "@copilotkit/a2ui-renderer": "1.59.1",
+        "@copilotkit/core": "1.59.1",
+        "@copilotkit/runtime-client-gql": "1.59.1",
+        "@copilotkit/shared": "1.59.1",
+        "@copilotkit/web-inspector": "1.59.1",
+        "@jetbrains/websandbox": "^1.1.3",
+        "@lit-labs/react": "^2.0.2",
+        "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tooltip": "^1.2.7",
+        "@scarf/scarf": "^1.3.0",
+        "@tanstack/react-virtual": "^3.13.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "katex": "^0.16.22",
+        "lucide-react": "^0.525.0",
+        "react-markdown": "^8.0.7",
+        "rxjs": "7.8.1",
+        "streamdown": "^1.3.0",
+        "tailwind-merge": "^3.3.1",
+        "tw-animate-css": "^1.3.5",
+        "untruncate-json": "^0.0.1",
+        "use-stick-to-bottom": "^1.1.1",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc",
+        "zod": ">=3.0.0"
+      }
+    },
+    "node_modules/@copilotkit/react-core/node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@copilotkit/react-core/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@copilotkit/runtime-client-gql": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.59.1.tgz",
+      "integrity": "sha512-JLBDy5Y37LiZhKWIwSm4ETQBOzy3vHDUvbvjtxDzF6kxsddswyXEMtjQUEc93RDwDCh1XuH2FLnd1ha48kmOLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@copilotkit/shared": "1.59.1",
+        "@urql/core": "^5.0.3",
+        "untruncate-json": "^0.0.1",
+        "urql": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@copilotkit/shared": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.59.1.tgz",
+      "integrity": "sha512-vCJB4bao5Tu54mc7D/h/vLfUZsDECl/kgW/GVli2soMzIJW6UAHFhtt2D9MN206xDtE6gXqBnBIMKNG+JO61SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/license-verifier": "~0.4.2",
+        "@segment/analytics-node": "^2.1.2",
+        "@standard-schema/spec": "^1.0.0",
+        "chalk": "4.1.2",
+        "graphql": "^16.8.1",
+        "partial-json": "^0.1.7",
+        "uuid": "^11.1.0",
+        "zod": "^3.23.3",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "peerDependencies": {
+        "@ag-ui/core": ">=0.0.48"
+      }
+    },
+    "node_modules/@copilotkit/shared/node_modules/@copilotkit/license-verifier": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.4.2.tgz",
+      "integrity": "sha512-0+Rdtg4gOwOBFBpZFxYsjgwBcCLja5z03YC6WA3KEntHYhsnoJ2aqNG6c0we8ZExCNYlEO4M7kHIfG5LXzqMYQ==",
+      "license": "MIT"
+    },
+    "node_modules/@copilotkit/web-inspector": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.59.1.tgz",
+      "integrity": "sha512-vA+xhTiXLh7x0IKP84O7neAAZfx6FYzzwGAr1lVPBLDABGb8Ax2ZuSGywMEEtAiu9r5ravPTN+oT71yRNjD4yA==",
+      "dependencies": {
+        "@ag-ui/client": "0.0.53",
+        "@copilotkit/core": "1.59.1",
+        "lit": "^3.2.0",
+        "lucide": "^0.525.0",
+        "marked": "^12.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.8",
@@ -1662,19 +1394,6 @@
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/react": {
-      "version": "0.26.28",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.8",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -1858,24 +1577,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@headlessui/react": {
-      "version": "2.2.10",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react": "^0.26.16",
-        "@react-aria/focus": "^3.20.2",
-        "@react-aria/interactions": "^3.25.0",
-        "@tanstack/react-virtual": "^3.13.9",
-        "use-sync-external-store": "^1.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "license": "MIT",
@@ -1906,27 +1607,6 @@
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
         "mlly": "^1.8.2"
-      }
-    },
-    "node_modules/@internationalized/date": {
-      "version": "3.12.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@internationalized/number": {
-      "version": "3.6.6",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@internationalized/string": {
-      "version": "3.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -1985,14 +1665,13 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.42",
+      "version": "1.1.48",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.48.tgz",
+      "integrity": "sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
         "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
@@ -2001,16 +1680,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@langchain/core/node_modules/langsmith": {
@@ -2045,11 +1714,14 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.2.9",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.2.tgz",
+      "integrity": "sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.1",
-        "@langchain/langgraph-sdk": "~1.8.9",
+        "@langchain/langgraph-checkpoint": "^1.0.2",
+        "@langchain/langgraph-sdk": "~1.9.4",
+        "@langchain/protocol": "^0.0.15",
         "@standard-schema/spec": "1.1.0",
         "uuid": "^10.0.0"
       },
@@ -2057,7 +1729,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.40",
+        "@langchain/core": "^1.1.44",
         "zod": "^3.25.32 || ^4.2.0",
         "zod-to-json-schema": "^3.x"
       },
@@ -2122,7 +1794,9 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.1",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.3.tgz",
+      "integrity": "sha512-lzamDsWxD/25zIVeEO7Xv38Rq1BCZUQYWx0V6zewHf4LpjzzyxB5N9aZcwdsl+SvHRJASGCnvLleqD9dp3afxg==",
       "license": "MIT",
       "dependencies": {
         "uuid": "^10.0.0"
@@ -2131,7 +1805,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.0.1"
+        "@langchain/core": "^1.1.44"
       }
     },
     "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
@@ -2179,25 +1853,25 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.8.10",
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.10.tgz",
+      "integrity": "sha512-hsvRVAUR2miafkLpl6HjwYkciKxMk4IZdCJz7fO7wzL344RvIBfbNLeXfcPCKF4VP/pR90723M8Am1olW5xvHQ==",
       "license": "MIT",
       "dependencies": {
+        "@langchain/protocol": "^0.0.16",
         "@types/json-schema": "^7.0.15",
         "p-queue": "^9.0.1",
         "p-retry": "^7.1.1",
         "uuid": "^13.0.0"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.16",
+        "@langchain/core": "^1.1.44",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "svelte": "^4.0.0 || ^5.0.0",
         "vue": "^3.0.0"
       },
       "peerDependenciesMeta": {
-        "@langchain/core": {
-          "optional": true
-        },
         "react": {
           "optional": true
         },
@@ -2211,6 +1885,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/@langchain/protocol": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.16.tgz",
+      "integrity": "sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==",
+      "license": "MIT"
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
       "version": "5.0.4",
@@ -2280,6 +1960,12 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@langchain/protocol": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
+      "integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+      "license": "MIT"
+    },
     "node_modules/@lit-labs/react": {
       "version": "2.1.3",
       "license": "BSD-3-Clause",
@@ -2288,7 +1974,9 @@
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.5.1",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/react": {
@@ -2300,6 +1988,8 @@
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
@@ -2395,6 +2085,8 @@
     },
     "node_modules/@protobuf-ts/protoc": {
       "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.11.1.tgz",
+      "integrity": "sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==",
       "license": "Apache-2.0",
       "bin": {
         "protoc": "protoc.js"
@@ -3123,38 +2815,6 @@
       "version": "1.1.1",
       "license": "MIT"
     },
-    "node_modules/@react-aria/focus": {
-      "version": "3.22.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0",
-        "react-aria": "3.48.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/interactions": {
-      "version": "3.28.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-types/shared": "^3.34.0",
-        "@swc/helpers": "^0.5.0",
-        "react-aria": "3.48.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-types/shared": {
-      "version": "3.34.0",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "license": "MIT",
@@ -3361,13 +3021,6 @@
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "license": "MIT"
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
@@ -3857,6 +3510,8 @@
     },
     "node_modules/@urql/core": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.13",
@@ -4315,16 +3970,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001791",
       "dev": true,
@@ -4376,32 +4021,8 @@
         "node": ">=8"
       }
     },
-    "node_modules/character-entities": {
-      "version": "1.2.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "1.1.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-reference-invalid": {
-      "version": "1.1.4",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5233,13 +4854,6 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "license": "MIT"
@@ -5786,17 +5400,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fault": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "format": "^0.2.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "dev": true,
@@ -5884,12 +5487,6 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/format": {
-      "version": "0.2.2",
-      "engines": {
-        "node": ">=0.4.x"
-      }
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -6423,14 +6020,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/hast-util-parse-selector": {
-      "version": "2.2.5",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-raw": {
       "version": "9.1.0",
       "license": "MIT",
@@ -6681,62 +6270,9 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hastscript": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^2.0.0",
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hastscript/node_modules/comma-separated-tokens": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/hastscript/node_modules/property-information": {
-      "version": "5.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/hastscript/node_modules/space-separated-tokens": {
-      "version": "1.1.5",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/help-me": {
       "version": "5.0.0",
       "license": "MIT"
-    },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/highlightjs-vue": {
-      "version": "1.0.0",
-      "license": "CC0-1.0"
     },
     "node_modules/hono": {
       "version": "4.12.15",
@@ -6874,26 +6410,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-alphabetical": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-alphanumerical": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/is-buffer": {
       "version": "2.0.5",
       "funding": [
@@ -6913,14 +6429,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/is-decimal": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-docker": {
@@ -6943,14 +6451,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-hexadecimal": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-inside-container": {
@@ -7173,10 +6673,12 @@
       "license": "MIT"
     },
     "node_modules/langchain": {
-      "version": "1.3.5",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.4.2.tgz",
+      "integrity": "sha512-SLGipy0r4nqQD0aiUOBYLMeGFfB/QiYnMndfZ8sGN89vXDCIXbYqcE7G/4QDDX3nZsM7/emQpoScmlxEX6sDnQ==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph": "^1.2.9",
+        "@langchain/langgraph": "^1.3.2",
         "@langchain/langgraph-checkpoint": "^1.0.1",
         "langsmith": ">=0.5.0 <1.0.0",
         "zod": "^3.25.76 || ^4"
@@ -7185,11 +6687,13 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.42"
+        "@langchain/core": "^1.1.48"
       }
     },
     "node_modules/langchain/node_modules/langsmith": {
-      "version": "0.6.0",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.3.tgz",
+      "integrity": "sha512-Gg+IeRGoF1/aStu80aEnIXJCu+N6+4NoV4tAVFS51ZPRBsRa2KG0LkS7K7/ryZ/yES7O9xdqah5QuuWMIeMjQw==",
       "license": "MIT",
       "dependencies": {
         "p-queue": "6.6.2"
@@ -7336,7 +6840,9 @@
       }
     },
     "node_modules/lit": {
-      "version": "3.3.2",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -7346,6 +6852,8 @@
     },
     "node_modules/lit-element": {
       "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0",
@@ -7354,7 +6862,9 @@
       }
     },
     "node_modules/lit-html": {
-      "version": "3.3.2",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -7415,18 +6925,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lowlight": {
-      "version": "1.20.0",
-      "license": "MIT",
-      "dependencies": {
-        "fault": "^1.0.0",
-        "highlight.js": "~10.7.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "dev": true,
@@ -7437,6 +6935,8 @@
     },
     "node_modules/lucide": {
       "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.525.0.tgz",
+      "integrity": "sha512-sfehWlaE/7NVkcEQ4T9JD3eID8RNMIGJBBUq9wF3UFiJIrcMKRbU3g1KGfDk4svcW7yw8BtDLXaXo02scDtUYQ==",
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -7464,6 +6964,8 @@
     },
     "node_modules/marked": {
       "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -8889,22 +8391,6 @@
       "version": "1.6.0",
       "license": "MIT"
     },
-    "node_modules/parse-entities": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/parse-ms": {
       "version": "4.0.0",
       "dev": true,
@@ -9212,13 +8698,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/prismjs": {
-      "version": "1.30.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/process": {
       "version": "0.11.10",
       "license": "MIT",
@@ -9344,25 +8823,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-aria": {
-      "version": "3.48.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@internationalized/date": "^3.12.1",
-        "@internationalized/number": "^3.6.6",
-        "@internationalized/string": "^3.2.8",
-        "@react-types/shared": "^3.34.0",
-        "@swc/helpers": "^0.5.0",
-        "aria-hidden": "^1.2.3",
-        "clsx": "^2.0.0",
-        "react-stately": "3.46.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/react-dom": {
@@ -9514,21 +8974,6 @@
       "version": "2.6.2",
       "license": "0BSD"
     },
-    "node_modules/react-stately": {
-      "version": "3.46.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@internationalized/date": "^3.12.1",
-        "@internationalized/number": "^3.6.6",
-        "@internationalized/string": "^3.2.8",
-        "@react-types/shared": "^3.34.0",
-        "@swc/helpers": "^0.5.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "license": "MIT",
@@ -9547,21 +8992,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-syntax-highlighter": {
-      "version": "15.6.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "highlight.js": "^10.4.1",
-        "highlightjs-vue": "^1.0.0",
-        "lowlight": "^1.17.0",
-        "prismjs": "^1.30.0",
-        "refractor": "^3.6.0"
-      },
-      "peerDependencies": {
-        "react": ">= 0.14.0"
       }
     },
     "node_modules/react18-json-view": {
@@ -9652,26 +9082,6 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "license": "Apache-2.0"
-    },
-    "node_modules/refractor": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "hastscript": "^6.0.0",
-        "parse-entities": "^2.0.0",
-        "prismjs": "~1.27.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/prismjs": {
-      "version": "1.27.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/regex": {
       "version": "6.1.0",
@@ -11276,10 +10686,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/tabbable": {
-      "version": "6.4.0",
-      "license": "MIT"
-    },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
       "license": "MIT",
@@ -11748,6 +11154,8 @@
     },
     "node_modules/urql": {
       "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/urql/-/urql-4.2.2.tgz",
+      "integrity": "sha512-3GgqNa6iF7bC4hY/ImJKN4REQILcSU9VKcKL8gfELZM8mM5BnLH1BsCc8kBdnVGD1LIFOs4W3O2idNHhON1r0w==",
       "license": "MIT",
       "dependencies": {
         "@urql/core": "^5.1.1",
@@ -12172,6 +11580,8 @@
     },
     "node_modules/wonka": {
       "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.6.tgz",
+      "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
@@ -12225,13 +11635,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {


### PR DESCRIPTION
## Summary
- update the LangGraph Python Threads template CopilotKit packages from 1.57.0 to 1.59.1
- align @ag-ui/client to 0.0.53 so @ag-ui/langgraph and @copilotkit/runtime share the same agent base types
- regenerate the standalone template package-lock.json

## Verification
- npm run build (from examples/integrations/langgraph-python-threads)
- lefthook pre-commit: check-binaries, sync-lockfile, test-and-check-packages
