### PR TITLE
fix(showcase): harden deploy pipeline — rollback, Host brand, CI alerts

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -666,14 +666,28 @@ jobs:
 
   notify:
     name: Notify on failure
-    # Cover the whole build→aggregate→redeploy pipeline. `needs: [build]`
+    # Cover the whole detect→build→aggregate→redeploy pipeline. `needs: [build]`
     # alone meant a failure in aggregate-build-results or redeploy-staging
-    # produced ZERO Slack signal (verify just never ran). `if: failure()`
-    # already skips when none of the needs failed — so this still no-ops
-    # for the "no changes → build skipped" path, since skipped != failure.
-    # If `notify-all-builds-failed` also fires (genuine all-failed case),
-    # both alerts firing for the same event is acceptable per the alert SOP.
-    needs: [build, aggregate-build-results, redeploy-staging]
+    # produced ZERO Slack signal (verify just never ran). Likewise, a red
+    # in detect-changes, check-lockfile, or verify-image-refs would skip
+    # `build` (skipped != failure) so the original `needs: [build]` form
+    # also missed those pre-build red paths. Adding the early-stage jobs
+    # to `needs` extends the alert surface to the full workflow, matching
+    # the workflow-level notify pattern in showcase_promote.yml.
+    # `if: failure()` already skips when none of the needs failed — so
+    # this still no-ops for the "no changes → build skipped" path, since
+    # skipped != failure. If `notify-all-builds-failed` also fires
+    # (genuine all-failed case), both alerts firing for the same event is
+    # acceptable per the alert SOP.
+    needs:
+      [
+        detect-changes,
+        check-lockfile,
+        verify-image-refs,
+        build,
+        aggregate-build-results,
+        redeploy-staging,
+      ]
     if: failure()
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -31,8 +31,12 @@ on:
         required: false
         type: string
 
+# Serialize ALL promotes on a single input-agnostic group so concurrent runs
+# (e.g. `all` + a single-service promote) can't pin the same Railway service
+# at once; `cancel-in-progress: false` ensures an in-flight prod promote is
+# never cancelled by a newer run queued behind it.
 concurrency:
-  group: showcase-promote-${{ inputs.service }}
+  group: showcase-promote
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -661,5 +661,7 @@ jobs:
             }
       - name: Log (no Slack — webhook unset)
         if: steps.state.outputs.state == 'failure' && env.SLACK_WEBHOOK == ''
+        env:
+          REF: ${{ github.ref }}
         run: |
-          echo "::warning::showcase_validate failed on ${{ github.ref }} but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."
+          echo "::warning::showcase_validate failed on $REF but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -603,3 +603,63 @@ jobs:
             echo "::warning::No showcase/integrations/*/tests/python/ directories found"
           fi
           exit "$failed"
+
+  notify:
+    # Slack #oss-alerts on any red. Never #engr (engr is sacred — release alerts only).
+    # Mirrors the workflow-level notify pattern in showcase_promote.yml so
+    # red runs surface uniformly across the showcase pipeline. The validate
+    # job has its own inline (and richer) push-only notifier that extracts
+    # the failing step + error excerpt; this job is the workflow-level
+    # safety net that also covers the python-unit-tests matrix job — which
+    # otherwise had no Slack signal at all. Webhook empty-guard mirrors
+    # promote.yml so an unset SLACK_WEBHOOK_OSS_ALERTS secret does not
+    # break the shell or red the workflow on this step.
+    needs: [validate, python-unit-tests]
+    if: always() && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      actions: read
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+    steps:
+      - name: Compute state
+        id: state
+        env:
+          VALIDATE: ${{ needs.validate.result }}
+          PYTEST: ${{ needs.python-unit-tests.result }}
+        run: |
+          set -euo pipefail
+          if [ "$VALIDATE" = "success" ] && [ "$PYTEST" = "success" ]; then
+            STATE="success"; ICON=":white_check_mark:"
+          else
+            STATE="failure"; ICON=":x:"
+          fi
+          {
+            echo "state=$STATE"
+            echo "icon=$ICON"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post to #oss-alerts
+        if: steps.state.outputs.state == 'failure' && env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ${{ toJSON(format(
+                '{0} *showcase_validate failed on {1}*\nvalidate={2} python-unit-tests={3}\n<{4}/{5}/actions/runs/{6}|View run>',
+                steps.state.outputs.icon,
+                github.ref,
+                needs.validate.result,
+                needs.python-unit-tests.result,
+                github.server_url,
+                github.repository,
+                github.run_id
+              )) }}
+            }
+      - name: Log (no Slack — webhook unset)
+        if: steps.state.outputs.state == 'failure' && env.SLACK_WEBHOOK == ''
+        run: |
+          echo "::warning::showcase_validate failed on ${{ github.ref }} but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -906,13 +906,33 @@ module Railway
             env = options[:env]
             sha = options[:sha]
 
+            # Input validation BEFORE invoking git — these values flow into
+            # subprocess invocations and an attacker-controlled `--sha` or
+            # `--env` must not be able to inject shell or git arguments.
+            # `sha` must look like a git object name (7-40 lowercase hex).
+            # `env` must resolve via Railway.env_id_for, which constrains it
+            # to the known set ("staging"/"stage"/"production"/"prod"); on miss
+            # it calls Railway.die! itself.
+            unless sha.is_a?(String) && sha.match?(/\A[0-9a-f]{7,40}\z/)
+                Railway.die!("--sha must be a 7-40 char lowercase hex git SHA " \
+                    "(got #{sha.inspect}).")
+            end
+            Railway.env_id_for(env)  # dies with "Unknown env: ..." if invalid.
+
             # We look in showcase/.railway-snapshots/*-<env>.yaml at SHA, take last.
-            list_cmd = %(git ls-tree -r --name-only #{sha} -- 'showcase/.railway-snapshots/*-#{env}.yaml')
-            entries = `#{list_cmd}`.lines.map(&:strip).reject(&:empty?).sort
+            # IO.popen with an argv array (no shell string) so sha/env are
+            # passed as literal argv to git — never parsed by a shell.
+            pathspec = "showcase/.railway-snapshots/*-#{env}.yaml"
+            ls_out = IO.popen(["git", "ls-tree", "-r", "--name-only", sha, "--", pathspec],
+                err: [:child, :out]) { |io| io.read }
+            Railway.die!("git ls-tree failed for #{sha}") unless $?.exitstatus == 0
+            entries = ls_out.lines.map(&:strip).reject(&:empty?).sort
             Railway.die!("No snapshot for env=#{env} at #{sha}.") if entries.empty?
             path = entries.last
 
-            yaml = `git show #{sha}:#{path}`
+            yaml = IO.popen(["git", "show", "#{sha}:#{path}"],
+                err: [:child, :out]) { |io| io.read }
+            Railway.die!("git show failed for #{sha}:#{path}") unless $?.exitstatus == 0
             Railway.die!("git show failed for #{sha}:#{path}") if yaml.nil? || yaml.empty?
 
             snap = YAML.safe_load(yaml, permitted_classes: [Time, Symbol], aliases: false)
@@ -1120,10 +1140,12 @@ module Railway
             #       fires in the target-absent-from-prod case.
             #
             # We therefore retain references to the full snapshots and
-            # only narrow when the per-service branch is taken. The
-            # fleet-scoped checks always read @full_*_snapshot; everything
-            # else reads @staging_snapshot/@prod_snapshot (narrowed when
-            # a positional service is given, full otherwise).
+            # only narrow when the per-service branch is taken. Reads go
+            # through the fleet_*/target_* accessors below so the
+            # fleet-scoped vs per-service distinction is enforced by
+            # method name (not by comment, as it was before — two prior
+            # regressions came from reading the wrong ivar in a
+            # fleet-scoped check).
             @full_staging_snapshot = @staging_snapshot
             @full_prod_snapshot    = @prod_snapshot
             if options[:service]
@@ -1136,9 +1158,9 @@ module Railway
         # Narrow @staging_snapshot and @prod_snapshot to only the named
         # service. Staging presence is mandatory (validated against SSOT
         # already); prod absence is tolerated here so the fleet-scoped
-        # service-set-parity REFUSE (now reading @full_prod_snapshot) can
-        # surface as the user-facing error rather than a silent rc=0
-        # 'success' (find_service returns nil, so execute_promotion would
+        # service-set-parity REFUSE (comparing fleet_staging vs fleet_prod) can surface as
+        # the user-facing error rather than a silent rc=0 'success'
+        # (find_service returns nil, so execute_promotion would
         # otherwise skip the absent service with no mutation).
         def narrow_snapshots_to_single_service!(name)
             staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }
@@ -1158,27 +1180,71 @@ module Railway
             @prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)
         end
 
+        # ── Snapshot accessors ─────────────────────────────────────────────
+        #
+        # The fleet-vs-target distinction is load-bearing. A "fleet" view
+        # is the FULL un-narrowed snapshot (every service in the env). A
+        # "target" view is the snapshot scoped to whatever this promote
+        # run actually targets — narrowed to one service when the
+        # operator passed a positional service argument, equal to the
+        # fleet view otherwise.
+        #
+        # Use:
+        #   fleet_staging / fleet_prod   — for FLEET-SHAPE invariants
+        #     (service-set parity, expected prod domain set). These
+        #     answer questions about the env itself, not the promote
+        #     target, and must produce the same verdict regardless of
+        #     whether this run is full-fleet or single-service.
+        #   target_staging / target_prod — for PER-SERVICE checks
+        #     (P1..P3/P6, critical env-key parity, execute_promotion,
+        #     resolved_prod_image). These iterate the services we are
+        #     actually about to promote.
+        #
+        # The `|| @*` fallback preserves the existing test seam: legacy
+        # promote tests stub @staging_snapshot/@prod_snapshot directly
+        # and invoke run_with_preflight_only without going through `run`
+        # (which is what sets @full_*). For those tests full == narrowed
+        # by construction (full-fleet semantics), so falling back to the
+        # target view is correct.
+        # Below: fleet_* / target_* accessors are intentionally private to this
+        # class (PromoteCommand-internal views of the snapshots). A matching
+        # `public` toggle after target_prod restores default visibility for the
+        # subsequent run_with_preflight_only / check_* methods.
+        private
+
+        def fleet_staging
+            @full_staging_snapshot || @staging_snapshot
+        end
+
+        def fleet_prod
+            @full_prod_snapshot || @prod_snapshot
+        end
+
+        def target_staging
+            @staging_snapshot
+        end
+
+        def target_prod
+            @prod_snapshot
+        end
+
+        public
+
         # All preconditions, then (if clean) the actual promote.
         def run_with_preflight_only
             findings = []
 
-            findings.concat(check_p1_ghcr_digests(@staging_snapshot))
-            findings.concat(check_p2_staging_deployments(@staging_snapshot))
-            findings.concat(check_p3_staging_live_green(@staging_snapshot))
-            findings.concat(check_p6_parity(@staging_snapshot, @prod_snapshot))
+            findings.concat(check_p1_ghcr_digests(target_staging))
+            findings.concat(check_p2_staging_deployments(target_staging))
+            findings.concat(check_p3_staging_live_green(target_staging))
+            findings.concat(check_p6_parity(target_staging, target_prod))
             # FLEET-SCOPED invariants — must see the FULL fleet so they
             # produce the same verdict regardless of whether this run is
             # full-fleet or restricted to a single service. See `run` for
-            # the @full_*_snapshot rationale. When `run` was bypassed
-            # (test seam — preflight invoked directly without capture),
-            # fall back to the current snapshot views so legacy tests
-            # that only set @staging_snapshot/@prod_snapshot continue to
-            # work (full-fleet semantics = full == narrowed).
-            full_staging = @full_staging_snapshot || @staging_snapshot
-            full_prod    = @full_prod_snapshot    || @prod_snapshot
-            findings.concat(check_service_set_parity(full_staging, full_prod))
-            findings.concat(check_critical_env_key_parity(@staging_snapshot, @prod_snapshot))
-            findings.concat(check_expected_prod_domains(full_prod))
+            # the fleet_* rationale.
+            findings.concat(check_service_set_parity(fleet_staging, fleet_prod))
+            findings.concat(check_critical_env_key_parity(target_staging, target_prod))
+            findings.concat(check_expected_prod_domains(fleet_prod))
 
             # Mandatory parity-NOTE that env var VALUES are not compared.
             puts "NOTE: env var VALUES are not compared between staging and prod " \
@@ -1211,7 +1277,7 @@ module Railway
                 yes: options[:yes],
             )
 
-            execute_promotion(@staging_snapshot, @prod_snapshot)
+            execute_promotion(target_staging, target_prod)
         end
 
         # Resolve a staging service's image to the DIGEST-form ref that should

--- a/showcase/bin/spec/test_rollback_commit_injection.rb
+++ b/showcase/bin/spec/test_rollback_commit_injection.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# RollbackCommitCommand takes attacker-influenced operator input (--sha, --env)
+# and used to interpolate both into shell strings (`git ls-tree ... #{sha}` and
+# `git show #{sha}:#{path}`). A malformed --sha like "abc; touch /tmp/pwn"
+# would be parsed by the shell. These tests pin the invariant:
+#
+#   1. Happy path: a valid hex --sha + known --env locates the snapshot via
+#      IO.popen (argv form, no shell) and hands off to RestoreCommand.
+#   2. Malformed --sha is rejected BEFORE any subprocess is spawned.
+#   3. Unknown --env is rejected BEFORE any subprocess is spawned.
+class RollbackCommitInjectionTest < Minitest::Test
+    # Capture every IO.popen invocation issued during the test so we can both
+    # stub out git AND assert that injection attempts never reach a subprocess.
+    module PopenSpy
+        @calls = []
+        @responses = {}
+        @exits = {}
+
+        class << self
+            attr_reader :calls
+            attr_accessor :responses, :exits
+
+            def reset!
+                @calls = []
+                @responses = {}
+                @exits = {}
+            end
+
+            def record(args)
+                @calls << args
+            end
+        end
+    end
+
+    # A stand-in for RestoreCommand.run so we can detect successful hand-off
+    # without touching Railway's GraphQL API.
+    class FakeRestore
+        @last_argv = nil
+        @ran = false
+        class << self
+            attr_accessor :last_argv, :ran
+            def reset!
+                @last_argv = nil
+                @ran = false
+            end
+        end
+
+        def initialize(argv)
+            @argv = argv
+        end
+
+        def run
+            FakeRestore.last_argv = @argv
+            FakeRestore.ran = true
+        end
+    end
+
+    def setup
+        PopenSpy.reset!
+        FakeRestore.reset!
+
+        # Monkey-patch IO.popen ONLY for the duration of each test.
+        # The real RollbackCommitCommand uses the argv-array form:
+        #   IO.popen(["git", "ls-tree", ...], err: [:child, :out]) { |io| io.read }
+        # We intercept that and return canned output keyed by the first non-git
+        # subcommand ("ls-tree" or "show").
+        @original_popen = IO.method(:popen)
+        spy = PopenSpy
+        IO.singleton_class.send(:define_method, :popen) do |*args, **kwargs, &block|
+            spy.record(args)
+            argv = args.first
+            if argv.is_a?(Array) && argv.first == "git"
+                subcmd = argv[1]
+                response = spy.responses[subcmd] || ""
+                # Set $? to the per-subcommand desired status. Use a real
+                # subprocess (true/false) so $?.exitstatus reflects 0 or 1
+                # the way the real `git` call would.
+                exit_code = spy.exits[subcmd]
+                system(exit_code == 0 || exit_code.nil? ? "true" : "false")
+                # Mimic the block form used by the production code.
+                if block
+                    require "stringio"
+                    block.call(StringIO.new(response))
+                else
+                    response
+                end
+            else
+                # Defer to the real implementation for anything we don't expect.
+                spy.instance_variable_get(:@original_popen)&.call(*args, **kwargs, &block)
+            end
+        end
+
+        # Stub RestoreCommand so the integration boundary never tries to hit
+        # Railway. We swap the constant and restore in teardown.
+        @original_restore = Railway::RestoreCommand
+        Railway.send(:remove_const, :RestoreCommand)
+        Railway.const_set(:RestoreCommand, FakeRestore)
+    end
+
+    def teardown
+        # Restore IO.popen.
+        original = @original_popen
+        IO.singleton_class.send(:define_method, :popen) do |*args, **kwargs, &block|
+            original.call(*args, **kwargs, &block)
+        end
+        # Restore RestoreCommand.
+        Railway.send(:remove_const, :RestoreCommand)
+        Railway.const_set(:RestoreCommand, @original_restore)
+    end
+
+    # ── Happy path ─────────────────────────────────────────────────────────
+
+    def test_valid_sha_and_env_invokes_git_via_argv_and_hands_off_to_restore
+        PopenSpy.responses["ls-tree"] = "showcase/.railway-snapshots/20260101T000000Z-staging.yaml\n"
+        PopenSpy.responses["show"] = "schema_version: 1\nservices: []\n"
+
+        cmd = Railway::RollbackCommitCommand.new(
+            ["--env", "staging", "--sha", "abc1234", "--yes", "--non-interactive", "--dry-run"]
+        )
+        cmd.run
+
+        # 1. RestoreCommand got the expected argv (proves hand-off happened).
+        assert FakeRestore.ran, "expected RestoreCommand to be invoked on happy path"
+        assert_includes FakeRestore.last_argv, "--env"
+        assert_includes FakeRestore.last_argv, "staging"
+        assert_includes FakeRestore.last_argv, "--snapshot"
+        assert_includes FakeRestore.last_argv, "--dry-run"
+
+        # 2. Every git invocation used the argv-array form (no shell string).
+        git_calls = PopenSpy.calls.map(&:first).select { |a| a.is_a?(Array) && a.first == "git" }
+        refute_empty git_calls, "expected at least one git subprocess via IO.popen argv-array"
+        git_calls.each do |argv|
+            assert argv.is_a?(Array), "git call must be an argv array, got #{argv.inspect}"
+            assert argv.all? { |a| a.is_a?(String) }, "all argv elements must be strings"
+        end
+
+        # 3. The sha appears as a literal argv element somewhere (not glued).
+        ls_call = git_calls.find { |a| a[1] == "ls-tree" }
+        assert ls_call, "expected a `git ls-tree` invocation"
+        assert_includes ls_call, "abc1234"
+
+        show_call = git_calls.find { |a| a[1] == "show" }
+        assert show_call, "expected a `git show` invocation"
+        # `git show` takes sha:path as a single token by design; ensure it's
+        # the FULL token (not concatenated with anything else like `; rm -rf`).
+        assert_includes show_call, "abc1234:showcase/.railway-snapshots/20260101T000000Z-staging.yaml"
+    end
+
+    # ── Rejection: malformed --sha ─────────────────────────────────────────
+
+    def test_malformed_sha_is_rejected_before_any_subprocess
+        malicious = "abc; touch /tmp/pwn"
+        cmd = Railway::RollbackCommitCommand.new(["--env", "staging", "--sha", malicious])
+
+        exited = assert_raises(SystemExit) { cmd.run }
+        refute_equal 0, exited.status, "rejection must exit nonzero"
+
+        # No subprocess of any kind should have been launched.
+        assert_empty PopenSpy.calls.select { |c| c.first.is_a?(Array) && c.first.first == "git" },
+            "no git subprocess should be spawned for malformed --sha; got #{PopenSpy.calls.inspect}"
+        refute FakeRestore.ran, "RestoreCommand must not run when --sha is rejected"
+    end
+
+    def test_sha_with_uppercase_is_rejected
+        cmd = Railway::RollbackCommitCommand.new(["--env", "staging", "--sha", "ABC1234"])
+        exited = assert_raises(SystemExit) { cmd.run }
+        refute_equal 0, exited.status, "rejection must exit nonzero"
+        assert_empty PopenSpy.calls.select { |c| c.first.is_a?(Array) && c.first.first == "git" },
+            "no git subprocess should be spawned for uppercase --sha"
+        refute FakeRestore.ran, "RestoreCommand must not run when --sha is rejected"
+    end
+
+    def test_sha_too_short_is_rejected
+        cmd = Railway::RollbackCommitCommand.new(["--env", "staging", "--sha", "abc12"])
+        exited = assert_raises(SystemExit) { cmd.run }
+        refute_equal 0, exited.status, "rejection must exit nonzero"
+        assert_empty PopenSpy.calls.select { |c| c.first.is_a?(Array) && c.first.first == "git" },
+            "no git subprocess should be spawned for too-short --sha"
+        refute FakeRestore.ran, "RestoreCommand must not run when --sha is rejected"
+    end
+
+    # ── Subprocess-failure gating ──────────────────────────────────────────
+
+    # Regression: a failed `git show` previously slipped past the nil/empty
+    # guard because `err: [:child, :out]` merges stderr into stdout, so a
+    # non-zero exit produces a non-empty `yaml` containing git's error text
+    # which then flowed into YAML.safe_load. The fix gates on $?.exitstatus.
+    def test_git_show_nonzero_exit_dies_before_yaml_parse
+        PopenSpy.responses["ls-tree"] = "showcase/.railway-snapshots/20260101T000000Z-staging.yaml\n"
+        # Simulate a corrupt/missing blob: git prints an error to stderr
+        # (merged into stdout via err: [:child, :out]) and exits non-zero.
+        PopenSpy.responses["show"] = "fatal: bad object abc1234:showcase/.railway-snapshots/20260101T000000Z-staging.yaml\n"
+        PopenSpy.exits["show"] = 128
+
+        cmd = Railway::RollbackCommitCommand.new(
+            ["--env", "staging", "--sha", "abc1234", "--yes", "--non-interactive", "--dry-run"]
+        )
+
+        exited = assert_raises(SystemExit) { cmd.run }
+        refute_equal 0, exited.status, "git-show failure must exit nonzero"
+        refute FakeRestore.ran, "RestoreCommand must not run when git show fails"
+    end
+
+    def test_empty_snapshot_listing_dies_before_git_show
+        # ls-tree succeeds but returns no entries → die before any git show.
+        PopenSpy.responses["ls-tree"] = ""
+
+        cmd = Railway::RollbackCommitCommand.new(
+            ["--env", "staging", "--sha", "abc1234", "--yes", "--non-interactive", "--dry-run"]
+        )
+
+        exited = assert_raises(SystemExit) { cmd.run }
+        refute_equal 0, exited.status, "no-snapshot must exit nonzero"
+        refute FakeRestore.ran, "RestoreCommand must not run when no snapshot found"
+
+        # No `git show` should have been spawned.
+        show_calls = PopenSpy.calls.select do |c|
+            c.first.is_a?(Array) && c.first.first == "git" && c.first[1] == "show"
+        end
+        assert_empty show_calls, "no git show should run when ls-tree returns empty"
+    end
+
+    # ── Rejection: unknown --env ───────────────────────────────────────────
+
+    def test_unknown_env_is_rejected_before_any_subprocess
+        cmd = Railway::RollbackCommitCommand.new(["--env", "evil; rm -rf ~", "--sha", "abc1234"])
+
+        exited = assert_raises(SystemExit) { cmd.run }
+        refute_equal 0, exited.status, "rejection must exit nonzero"
+
+        assert_empty PopenSpy.calls.select { |c| c.first.is_a?(Array) && c.first.first == "git" },
+            "no git subprocess should be spawned for unknown --env"
+        refute FakeRestore.ran
+    end
+end

--- a/showcase/harness/src/probes/aimock-fixture-coverage.test.ts
+++ b/showcase/harness/src/probes/aimock-fixture-coverage.test.ts
@@ -77,10 +77,22 @@ const SPEC_DIR = path.resolve(
   WORKSPACE_ROOT,
   "showcase/integrations/langgraph-python/tests/e2e",
 );
-const FIXTURE_FILE = path.resolve(
-  WORKSPACE_ROOT,
-  "showcase/aimock/feature-parity.json",
-);
+
+/**
+ * After the D4/D6 reorg the monolithic `feature-parity.json` was split into
+ * per-integration files under `showcase/aimock/{d4,d6}/<integration>/*.json`
+ * plus a depth-agnostic `showcase/aimock/shared/*.json` bucket. For the
+ * langgraph-python coverage check we union every fixture from:
+ *   - showcase/aimock/d4/langgraph-python/*.json
+ *   - showcase/aimock/d6/langgraph-python/*.json
+ *   - showcase/aimock/shared/*.json (no-context, matches any integration)
+ * and run the same substring-coverage rule across the union.
+ */
+const FIXTURE_DIRS = [
+  path.resolve(WORKSPACE_ROOT, "showcase/aimock/d4/langgraph-python"),
+  path.resolve(WORKSPACE_ROOT, "showcase/aimock/d6/langgraph-python"),
+  path.resolve(WORKSPACE_ROOT, "showcase/aimock/shared"),
+];
 
 /**
  * Threshold below which a prompt is trivially short enough that its
@@ -259,11 +271,47 @@ function isCovered(prompt: string, fixtures: Fixture[]): boolean {
   return false;
 }
 
+/**
+ * Load and union all fixtures from the per-integration + shared dirs.
+ * Each file is expected to be `{fixtures: [...]}` (the same shape the old
+ * monolithic feature-parity.json used).
+ *
+ * Missing fixture DIRECTORIES are a hard error (the reorg layout is
+ * load-bearing). Files present but lacking a `fixtures` array are silently
+ * skipped (defensive against schema drift; no such files exist today).
+ */
+async function loadAllFixtures(dirs: string[]): Promise<Fixture[]> {
+  const out: Fixture[] = [];
+  for (const dir of dirs) {
+    let entries: string[];
+    try {
+      entries = await fs.readdir(dir);
+    } catch (err) {
+      // Missing dir is a hard error — the reorg layout is load-bearing.
+      throw new Error(
+        `aimock fixture dir not found: ${dir} (${(err as Error).message})`,
+      );
+    }
+    const jsonFiles = entries.filter((e) => e.endsWith(".json"));
+    for (const file of jsonFiles) {
+      const fullPath = path.join(dir, file);
+      const raw = await fs.readFile(fullPath, "utf8");
+      const parsed = JSON.parse(raw) as Partial<FeatureParityFile>;
+      if (!parsed || !Array.isArray(parsed.fixtures)) {
+        // Skip files that don't carry a fixtures array (defensive — no
+        // such files exist today but the schema is informally enforced).
+        continue;
+      }
+      out.push(...parsed.fixtures);
+    }
+  }
+  return out;
+}
+
 describe("aimock feature-parity fixture coverage for langgraph-python E2E specs", () => {
   it("every extracted chat prompt has a matching fixture", async () => {
-    // Load fixtures.
-    const fixtureRaw = await fs.readFile(FIXTURE_FILE, "utf8");
-    const { fixtures } = JSON.parse(fixtureRaw) as FeatureParityFile;
+    // Load fixtures from the D4/D6 per-integration dirs + shared bucket.
+    const fixtures = await loadAllFixtures(FIXTURE_DIRS);
     expect(Array.isArray(fixtures)).toBe(true);
     expect(fixtures.length).toBeGreaterThan(0);
 
@@ -298,8 +346,11 @@ describe("aimock feature-parity fixture coverage for langgraph-python E2E specs"
         .join("\n");
       throw new Error(
         `Found ${uncovered.length} langgraph-python spec prompt(s) without matching aimock fixtures.\n` +
-          `Add a fixture entry (match.userMessage substring + deterministic response) to\n` +
-          `showcase/aimock/feature-parity.json for each:\n\n${listing}\n\n` +
+          `Add a fixture entry (match.userMessage substring + deterministic response) to one of:\n` +
+          `  - showcase/aimock/d4/langgraph-python/<file>.json\n` +
+          `  - showcase/aimock/d6/langgraph-python/<file>.json\n` +
+          `  - showcase/aimock/shared/<file>.json (no-context, depth-agnostic)\n\n` +
+          `${listing}\n\n` +
           `Total prompts scanned: ${allPrompts.length}. Specs scanned: ${specFiles.length}.`,
       );
     }

--- a/showcase/harness/src/probes/scripts/d5-multimodal.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-multimodal.test.ts
@@ -70,8 +70,13 @@ describe("d5-multimodal script", () => {
     };
     const turns = buildTurns(ctx);
     expect(turns).toHaveLength(2);
-    expect(turns[0]!.input).toBe("describe the sample image");
-    expect(turns[1]!.input).toBe("summarize the sample document");
+    // These `input` values are auto-send button sentinels emitted by the
+    // in-app shim when the preFill hook clicks the sample-attachment
+    // buttons — they are NOT natural-language prompts the user types.
+    // Don't "fix" these expectations back to prose; the shim's auto-send
+    // path is what's under test here.
+    expect(turns[0]!.input).toBe("image-sample-button (auto-sent)");
+    expect(turns[1]!.input).toBe("pdf-sample-button (auto-sent)");
   });
 
   it("buildTurns wires preFill on both turns", () => {

--- a/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
@@ -14,6 +14,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { SERVICES } from "../railway-envs";
 import type { ProbeTarget } from "../verify-deploy";
+// Tests construct `ProbeTarget.host` via `asHost(...)` to satisfy the
+// `Host` brand — the same validator the runtime ingress uses.
+import { asHost } from "../verify-deploy";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -178,7 +181,7 @@ describe("envForTarget", () => {
   it("returns 'staging' when host matches the SSOT staging domain", () => {
     const t: ProbeTarget = {
       name: "docs",
-      host: SERVICES.docs.domains.staging,
+      host: asHost(SERVICES.docs.domains.staging),
       driver: "docs",
     };
     expect(envForTarget(t)).toBe("staging");
@@ -187,7 +190,7 @@ describe("envForTarget", () => {
   it("returns 'prod' when host matches the SSOT prod domain", () => {
     const t: ProbeTarget = {
       name: "docs",
-      host: SERVICES.docs.domains.prod,
+      host: asHost(SERVICES.docs.domains.prod),
       driver: "docs",
     };
     expect(envForTarget(t)).toBe("prod");
@@ -195,10 +198,14 @@ describe("envForTarget", () => {
 
   it("returns undefined for unknown host or unknown service", () => {
     expect(
-      envForTarget({ name: "docs", host: "bogus.example", driver: "docs" }),
+      envForTarget({
+        name: "docs",
+        host: asHost("bogus.example"),
+        driver: "docs",
+      }),
     ).toBeUndefined();
     expect(
-      envForTarget({ name: "nonsuch", host: "x", driver: "docs" }),
+      envForTarget({ name: "nonsuch", host: asHost("x"), driver: "docs" }),
     ).toBeUndefined();
   });
 });
@@ -386,7 +393,7 @@ describe("probeBaseline", () => {
     const out = await probeBaseline(
       {
         name: "docs",
-        host: SERVICES.docs.domains.staging,
+        host: asHost(SERVICES.docs.domains.staging),
         driver: "docs",
       },
       {
@@ -401,7 +408,7 @@ describe("probeBaseline", () => {
 
   it("fails loud when env cannot be resolved from host", async () => {
     const out = await probeBaseline(
-      { name: "docs", host: "wrong.example", driver: "docs" },
+      { name: "docs", host: asHost("wrong.example"), driver: "docs" },
       {
         driverLabel: "docs",
         healthcheckPath: "/",
@@ -419,7 +426,7 @@ describe("probeBaseline", () => {
     const out = await probeBaseline(
       {
         name: "docs",
-        host: SERVICES.docs.domains.staging,
+        host: asHost(SERVICES.docs.domains.staging),
         driver: "docs",
       },
       {
@@ -443,7 +450,7 @@ describe("probeBaseline", () => {
     const out = await probeBaseline(
       {
         name: "docs",
-        host: SERVICES.docs.domains.staging,
+        host: asHost(SERVICES.docs.domains.staging),
         driver: "docs",
       },
       {
@@ -465,7 +472,7 @@ describe("probeBaseline", () => {
     const out = await probeBaseline(
       {
         name: "docs",
-        host: SERVICES.docs.domains.staging,
+        host: asHost(SERVICES.docs.domains.staging),
         driver: "docs",
       },
       {
@@ -620,7 +627,7 @@ describe.each(DRIVER_CASES)(
       await withGlobalSeam(fetchImpl, TOKEN, async () => {
         const out = await driver({
           name: service,
-          host: entry.domains.staging,
+          host: asHost(entry.domains.staging),
           driver: label as ProbeTarget["driver"],
         });
         expect(out.ok).toBe(true);
@@ -645,7 +652,7 @@ describe.each(DRIVER_CASES)(
       await withGlobalSeam(fetchImpl, TOKEN, async () => {
         await driver({
           name: service,
-          host: entry.domains.prod,
+          host: asHost(entry.domains.prod),
           driver: label as ProbeTarget["driver"],
         });
       });
@@ -670,7 +677,7 @@ describe.each(DRIVER_CASES)(
       await withGlobalSeam(fetchImpl, TOKEN, async () => {
         await driver({
           name: service,
-          host: entry.domains.staging,
+          host: asHost(entry.domains.staging),
           driver: label as ProbeTarget["driver"],
         });
       });
@@ -688,7 +695,7 @@ describe.each(DRIVER_CASES)(
       await withGlobalSeam(fetchImpl, TOKEN, async () => {
         const out = await driver({
           name: service,
-          host: entry.domains.staging,
+          host: asHost(entry.domains.staging),
           driver: label as ProbeTarget["driver"],
         });
         expect(out.ok).toBe(false);
@@ -707,7 +714,7 @@ describe.each(DRIVER_CASES)(
       await withGlobalSeam(fetchImpl, TOKEN, async () => {
         const out = await driver({
           name: service,
-          host: entry.domains.staging,
+          host: asHost(entry.domains.staging),
           driver: label as ProbeTarget["driver"],
         });
         expect(out.ok).toBe(false);

--- a/showcase/scripts/__tests__/verify-deploy.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseArgs, resolveProbeTargets, runVerify } from "../verify-deploy";
+import {
+  asHost,
+  parseArgs,
+  resolveProbeTargets,
+  runVerify,
+} from "../verify-deploy";
 import type { ProbeRunner } from "../verify-deploy";
 
 describe("verify-deploy argv parsing", () => {
@@ -101,6 +106,80 @@ describe("resolveProbeTargets", () => {
     expect(() =>
       resolveProbeTargets({ env: "staging", services: ["totally-fake"] }),
     ).toThrow(/unknown service/i);
+  });
+
+  it("REFUSES an override domain carrying a scheme (ingress branding wired)", () => {
+    // The override seam in `resolveProbeTargets` bypasses `domainFor`,
+    // so `asHost` is the sole ingress validator on that path. A
+    // scheme-bearing override must surface as a hard throw, proving
+    // the `asHost(rawHost)` call is actually wired in.
+    expect(() =>
+      resolveProbeTargets({
+        env: "staging",
+        services: ["docs"],
+        overrides: {
+          docs: {
+            domains: { staging: "https://docs.test", prod: "docs.test" },
+          },
+        },
+      }),
+    ).toThrow(/scheme/i);
+  });
+
+  it("REFUSES an override domain carrying a path/slash (ingress branding wired)", () => {
+    expect(() =>
+      resolveProbeTargets({
+        env: "staging",
+        services: ["docs"],
+        overrides: {
+          docs: {
+            domains: { staging: "docs.test/path", prod: "docs.test" },
+          },
+        },
+      }),
+    ).toThrow(/path|slash/i);
+  });
+});
+
+describe("asHost validator", () => {
+  it("accepts a bare hostname literal", () => {
+    expect(() => asHost("docs.example.com")).not.toThrow();
+    // Returned value IS a string at runtime (brand is structural).
+    const h = asHost("docs.example.com");
+    expect(typeof h).toBe("string");
+    expect(h).toBe("docs.example.com");
+  });
+
+  it("rejects values with a scheme separator", () => {
+    expect(() => asHost("https://x")).toThrow(/scheme/i);
+    expect(() => asHost("http://docs.example.com")).toThrow(/scheme/i);
+  });
+
+  it("rejects values containing a path or slash", () => {
+    expect(() => asHost("x/y")).toThrow(/path|slash/i);
+    expect(() => asHost("docs.example.com/")).toThrow(/path|slash/i);
+  });
+
+  it("rejects the empty string", () => {
+    expect(() => asHost("")).toThrow(/empty/i);
+  });
+
+  it("rejects leading/trailing whitespace", () => {
+    expect(() => asHost(" docs.example.com")).toThrow(/whitespace/i);
+    expect(() => asHost("docs.example.com ")).toThrow(/whitespace/i);
+    expect(() => asHost("\tdocs.example.com")).toThrow(/whitespace/i);
+  });
+
+  it("rejects userinfo '@'", () => {
+    expect(() => asHost("user@docs.example.com")).toThrow(/userinfo|@/);
+  });
+
+  it("rejects query '?'", () => {
+    expect(() => asHost("docs.example.com?x=1")).toThrow(/query|\?/);
+  });
+
+  it("rejects fragment '#'", () => {
+    expect(() => asHost("docs.example.com#frag")).toThrow(/fragment|#/);
   });
 });
 

--- a/showcase/scripts/deploy-to-railway.ts
+++ b/showcase/scripts/deploy-to-railway.ts
@@ -19,6 +19,8 @@ import path from "path";
 import yaml from "yaml";
 import { fileURLToPath } from "url";
 import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
+import { RailwayTokenError, resolveRailwayToken } from "./lib/railway-token";
+import { PROJECT_ID, PRODUCTION_ENV_ID } from "./railway-envs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -27,27 +29,27 @@ const PACKAGES_DIR = path.join(ROOT, "integrations");
 const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
 
 const SHOWCASE = {
-  projectId: "6f8c6bff-a80d-4f8f-b78d-50b32bcf4479",
-  environmentId: "b14919f4-6417-429f-848d-c6ae2201e04f",
+  projectId: PROJECT_ID,
+  environmentId: PRODUCTION_ENV_ID,
 };
 
+/**
+ * Resolve the Railway bearer token for this run. Wraps the shared
+ * `resolveRailwayToken` envelope and maps any RailwayTokenError onto
+ * the script's exit-1 contract for operator/config errors. The shared
+ * helper never calls process.exit — exit-code mapping lives HERE so the
+ * helper stays unit-testable.
+ */
 function getToken(): string {
-  if (process.env.RAILWAY_TOKEN) return process.env.RAILWAY_TOKEN;
-
-  const configPath = path.join(
-    process.env.HOME || "~",
-    ".railway",
-    "config.json",
-  );
-  if (fs.existsSync(configPath)) {
-    const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    if (config?.user?.token) return config.user.token;
+  try {
+    return resolveRailwayToken().token;
+  } catch (e) {
+    if (e instanceof RailwayTokenError) {
+      console.error(e.message);
+      process.exit(1);
+    }
+    throw e;
   }
-
-  console.error(
-    "No Railway token found. Set RAILWAY_TOKEN or run `railway login`.",
-  );
-  process.exit(1);
 }
 
 async function railwayGql<T = unknown>(
@@ -200,8 +202,22 @@ async function createService(slug: string): Promise<void> {
     region: "us-west1",
   };
   if (githubToken) {
+    // GHCR registry username: read from env (GHCR_USERNAME preferred, then
+    // GITHUB_ACTOR for CI contexts). Fail loud rather than baking a
+    // personal handle into the script.
+    const ghcrUser = (
+      process.env.GHCR_USERNAME ??
+      process.env.GITHUB_ACTOR ??
+      ""
+    ).trim();
+    if (!ghcrUser) {
+      console.error(
+        "GITHUB_TOKEN is set but no GHCR username is available. Set GHCR_USERNAME (or GITHUB_ACTOR in CI) to the username the token is issued to.",
+      );
+      process.exit(1);
+    }
     instanceInput.registryCredentials = {
-      username: "jpr5",
+      username: ghcrUser,
       password: githubToken,
     };
   }

--- a/showcase/scripts/verify-deploy.ts
+++ b/showcase/scripts/verify-deploy.ts
@@ -89,10 +89,78 @@ export function parseArgs(argv: string[]): ParsedArgs {
   return services === undefined ? { env } : { env, services };
 }
 
+/**
+ * Branded host type for `ProbeTarget.host`.
+ *
+ * A `Host` is a bare hostname literal (no scheme, no path, no slash) —
+ * exactly the shape `domainFor()` is documented to return. The brand is
+ * structural only: at runtime a `Host` IS a string, so it is assignable
+ * to any `string`-typed parameter (e.g. `checkHealthcheck200(host, ...)`)
+ * with no runtime cost. The point is to prevent the inverse direction —
+ * a caller cannot hand a `ProbeTarget` a scheme-included or path-bearing
+ * string without going through `asHost()`, which validates fail-loud.
+ *
+ * Co-located with `ProbeTarget` (the only structural consumer) rather
+ * than in `railway-envs.ts` to keep the brand at the verify-pipeline
+ * boundary; `domainFor()` keeps its `string` return type and we validate
+ * + brand at the point of ingress in `resolveProbeTargets`.
+ */
+export type Host = string & { readonly __brand: "Host" };
+
+/**
+ * Validate + brand a bare hostname literal as a `Host`. Throws on any
+ * scheme separator (`://`), any slash (path component), leading/trailing
+ * whitespace, or any of `@` (userinfo), `?` (query), `#` (fragment) — the
+ * verify-deploy pipeline never wants any of these — drivers always build
+ * URLs as `https://${host}${path}`, so a host carrying any of those would
+ * produce malformed URLs at the driver boundary.
+ *
+ * Overlap with `domainFor()` is partial, not full: `domainFor` re-checks
+ * scheme + empty on the normal SSOT path, but does NOT check path/slash
+ * or the whitespace/userinfo/query/fragment cases that `asHost` rejects.
+ * The override seam in `resolveProbeTargets` (test-only path that bypasses
+ * `domainFor` entirely) is what makes the `asHost` call mandatory — it is
+ * the sole ingress that gets to skip `domainFor`'s checks.
+ */
+export function asHost(value: string): Host {
+  if (value.includes("://")) {
+    throw new Error(`asHost: host must not include a scheme (got "${value}")`);
+  }
+  if (value.includes("/")) {
+    throw new Error(
+      `asHost: host must not include a path or slash (got "${value}")`,
+    );
+  }
+  if (value.length === 0) {
+    throw new Error(`asHost: host must not be empty`);
+  }
+  if (value !== value.trim()) {
+    throw new Error(
+      `asHost: host must not have leading/trailing whitespace (got "${value}")`,
+    );
+  }
+  if (value.includes("@")) {
+    throw new Error(
+      `asHost: host must not include userinfo "@" (got "${value}")`,
+    );
+  }
+  if (value.includes("?")) {
+    throw new Error(
+      `asHost: host must not include a query "?" (got "${value}")`,
+    );
+  }
+  if (value.includes("#")) {
+    throw new Error(
+      `asHost: host must not include a fragment "#" (got "${value}")`,
+    );
+  }
+  return value as Host;
+}
+
 export interface ProbeTarget {
-  name: string;
-  host: string;
-  driver: ProbeDriver;
+  readonly name: string;
+  readonly host: Host;
+  readonly driver: ProbeDriver;
 }
 
 export interface ResolveOpts {
@@ -128,14 +196,23 @@ export function resolveProbeTargets(opts: ResolveOpts): ProbeTarget[] {
     if (filter && !filter.has(name)) continue;
     if (!entry.probe[opts.env]) continue;
     const overrideDomains = opts.overrides?.[name]?.domains;
-    const host = overrideDomains
+    const rawHost = overrideDomains
       ? overrideDomains[opts.env]
       : domainFor(name, opts.env);
-    if (!host) {
+    if (!rawHost) {
       throw new Error(
         `Service "${name}" is probe-required for env "${opts.env}" but is missing a ${opts.env} domain.`,
       );
     }
+    // Brand at the verify-pipeline ingress so every downstream driver
+    // receives a `Host` (not a raw `string`). On the normal path
+    // `domainFor` already enforces scheme + empty checks, and `asHost`
+    // re-validates those (cheap redundancy). The checks that ONLY exist
+    // here — path/slash, leading/trailing whitespace, `@`/`?`/`#` — are
+    // mandatory because the override seam below (`overrideDomains`,
+    // test-only) bypasses `domainFor` entirely; `asHost` is the sole
+    // gate that catches those for both paths.
+    const host = asHost(rawHost);
     targets.push({ name, host, driver: entry.probe.driver });
   }
   return targets.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary

Hardening pass over the showcase deploy pipeline and its operator tooling. Five focused areas:

- **`bin/railway` rollback shell-injection fix** — `RollbackCommitCommand` shelled out via backtick subshells interpolating the `--sha`/`--env` flags. Replaced with `IO.popen` argument arrays (no shell), with `--sha` validated against an anchored hex regex and `--env` validated against the known env set before any git invocation. Both `git ls-tree` and `git show` now gate on `$?.exitstatus` before parsing their output (a failed `git show` previously merged stderr into stdout and fed it to `YAML.safe_load`). New spec covers injection rejection, git-show failure, and empty-snapshot paths.
- **Promote snapshot encapsulation** — replaced the bare `@full_*`/`@*` snapshot ivars in `PromoteCommand` with named `fleet_*`/`target_*` accessors so fleet-scoped vs per-service snapshot selection is name-enforced rather than comment-enforced.
- **Branded `Host` type** — `ProbeTarget.host` is now a branded `Host` produced only by `asHost` (rejects scheme, path, empty, whitespace, userinfo, query, fragment), branded at the verify-pipeline ingress; `ProbeTarget` fields are `readonly`.
- **`deploy-to-railway.ts` SSOT migration** — uses the shared `resolveRailwayToken` and sources project/env IDs from the railway-envs SSOT; reads the GHCR username from env (fail-loud) instead of a hardcoded handle.
- **Workflow safety + observability** — collapsed the promote workflow to an input-agnostic concurrency group so promotes can't race the same Railway service; added `#oss-alerts` failure notifications to the build and validate workflows (which previously had silent red paths).
- **Harness probe test fixes** — repointed the aimock fixture-coverage probe to the per-integration D4/D6/shared layout and aligned d5-multimodal assertions to the current auto-send sentinels.

## Test plan

- [ ] CI: Validate Showcase, build-checks, python tests green
- [ ] CI: static/quality (oxfmt + lint + typecheck) green
- [ ] Local: Ruby promote suite (`ruby spec/all_tests.rb`) — 103/342 green
- [ ] Local: showcase-scripts vitest green; harness probe tests green
- [ ] Local: oxfmt --check clean; actionlint clean