### PR TITLE
feat(ui): stable cross-framework testids — default tool renderer + error/loading indicators

### DIFF
--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat-message-view-cursor.testid.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat-message-view-cursor.testid.spec.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Verifies the angular cursor component renders the stable
+ * `copilot-loading-cursor` testid so e2e tests can deterministically detect
+ * the "still loading" state. Mirrors the convention already in place on the
+ * v2 react-core Cursor.
+ */
+
+const cursorPath = resolve(__dirname, "../copilot-chat-message-view-cursor.ts");
+const cursorSrc = readFileSync(cursorPath, "utf-8");
+
+describe("angular stable testids", () => {
+  it("CopilotChatMessageViewCursor renders the copilot-loading-cursor testid", () => {
+    expect(cursorSrc).toMatch(/data-testid="copilot-loading-cursor"/);
+  });
+});

--- a/packages/angular/src/lib/components/chat/copilot-chat-message-view-cursor.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-message-view-cursor.ts
@@ -19,7 +19,7 @@ import { cn } from "../../utils";
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
-    <div [class]="computedClass()"></div>
+    <div data-testid="copilot-loading-cursor" [class]="computedClass()"></div>
   `,
 })
 export class CopilotChatMessageViewCursor {

--- a/packages/react-core/src/components/toast/testids.test.ts
+++ b/packages/react-core/src/components/toast/testids.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Verifies stable `data-testid` markers exist on the error banner surfaces
+ * (BannerErrorDisplay + UsageBanner) so e2e tests can deterministically
+ * distinguish "errored out" vs "still loading" states. Without these, e2e
+ * probes hit ~30-60s timeouts instead of failing fast.
+ */
+
+const toastProviderPath = resolve(__dirname, "toast-provider.tsx");
+const usageBannerPath = resolve(__dirname, "../usage-banner.tsx");
+
+const toastProviderSrc = readFileSync(toastProviderPath, "utf-8");
+const usageBannerSrc = readFileSync(usageBannerPath, "utf-8");
+
+describe("react-core stable testids", () => {
+  it("BannerErrorDisplay renders the copilot-error-banner testid", () => {
+    expect(toastProviderSrc).toMatch(/data-testid="copilot-error-banner"/);
+  });
+
+  it("UsageBanner renders the copilot-error-banner testid", () => {
+    expect(usageBannerSrc).toMatch(/data-testid="copilot-error-banner"/);
+  });
+});

--- a/packages/react-core/src/components/toast/toast-provider.tsx
+++ b/packages/react-core/src/components/toast/toast-provider.tsx
@@ -1,6 +1,7 @@
-import { GraphQLError } from "@copilotkit/runtime-client-gql";
+import type { GraphQLError } from "@copilotkit/runtime-client-gql";
 import React, { createContext, useContext, useState, useCallback } from "react";
-import { PartialBy, CopilotKitError, Severity } from "@copilotkit/shared";
+import type { PartialBy, CopilotKitError } from "@copilotkit/shared";
+import { Severity } from "@copilotkit/shared";
 
 interface Toast {
   id: string;
@@ -154,6 +155,7 @@ function BannerErrorDisplay({
 
   return (
     <div
+      data-testid="copilot-error-banner"
       style={{
         position: "fixed",
         bottom: "20px",
@@ -383,7 +385,7 @@ export function ToastProvider({
         return;
       }
 
-      const id = toast.id ?? Math.random().toString(36).substring(2, 9);
+      const id = toast.id ?? Math.random().toString(36).slice(2, 9);
 
       setToasts((currentToasts) => {
         if (currentToasts.find((toast) => toast.id === id))

--- a/packages/react-core/src/components/usage-banner.tsx
+++ b/packages/react-core/src/components/usage-banner.tsx
@@ -195,7 +195,7 @@ export function UsageBanner({
         `}
       </style>
 
-      <div className="usage-banner">
+      <div className="usage-banner" data-testid="copilot-error-banner">
         <div className="banner-content">
           <div className="banner-message">{message}</div>
           {actions?.primary && (

--- a/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
@@ -40,6 +40,62 @@ describe("useDefaultRenderTool", () => {
     expect(typeof config.render).toBe("function");
   });
 
+  it("forwards toolCallId to custom wildcard render function", () => {
+    // Note: source DefaultRenderProps omits toolCallId, but the wrapper
+    // passes the render through untouched and useRenderTool forwards
+    // toolCallId at runtime. This test locks that behavior.
+    const customRender = vi.fn(
+      (_props: {
+        name: string;
+        parameters: unknown;
+        status: "inProgress" | "executing" | "complete";
+        result: string | undefined;
+      }) => <div data-testid="custom">custom</div>,
+    );
+
+    const Harness: React.FC = () => {
+      useDefaultRenderTool({
+        render: customRender,
+      });
+      return null;
+    };
+
+    render(<Harness />);
+
+    expect(mockUseRenderTool).toHaveBeenCalledTimes(1);
+    const [config] = mockUseRenderTool.mock.calls[0] as [
+      {
+        name: string;
+        render: (props: {
+          name: string;
+          toolCallId: string;
+          parameters: unknown;
+          status: string;
+          result: string | undefined;
+        }) => React.ReactElement;
+      },
+    ];
+
+    config.render({
+      name: "searchDocs",
+      toolCallId: "tc-forwarded-1",
+      parameters: { query: "copilot" },
+      status: "executing",
+      result: undefined,
+    });
+
+    expect(customRender).toHaveBeenCalledTimes(1);
+    // The statically-declared DefaultRenderProps omits toolCallId, but the
+    // hook forwards it at runtime — that's what this test locks. Cast
+    // through unknown to read the runtime-only field.
+    const forwardedProps = customRender.mock.calls[0][0] as unknown as {
+      toolCallId: string;
+    };
+    expect(forwardedProps).toMatchObject({
+      toolCallId: "tc-forwarded-1",
+    });
+  });
+
   it("forwards custom render function and deps", () => {
     const customRender = vi.fn(() => <div data-testid="custom">custom</div>);
     const deps = ["compact"] as const;

--- a/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
@@ -150,4 +150,55 @@ describe("useDefaultRenderTool", () => {
     expect(screen.getByText("Result")).toBeDefined();
     expect(screen.getByText("done")).toBeDefined();
   });
+
+  it("default renderer emits stable copilot-tool-render testid and metadata attrs", () => {
+    const Harness: React.FC = () => {
+      useDefaultRenderTool();
+      return null;
+    };
+
+    render(<Harness />);
+
+    const [config] = mockUseRenderTool.mock.calls[0] as [
+      {
+        render: (props: {
+          name: string;
+          parameters: unknown;
+          status: string;
+          result: string | undefined;
+        }) => React.ReactElement;
+      },
+    ];
+
+    const DefaultRenderer = config.render as React.ComponentType<{
+      name: string;
+      parameters: unknown;
+      status: string;
+      result: string | undefined;
+    }>;
+
+    render(
+      <DefaultRenderer
+        name="searchDocs"
+        parameters={{ query: "copilot" }}
+        status="complete"
+        result="ok"
+      />,
+    );
+
+    const wrapper = screen.getByTestId("copilot-tool-render");
+    expect(wrapper).toBeDefined();
+    expect(wrapper.getAttribute("data-tool-name")).toBe("searchDocs");
+    expect(wrapper.getAttribute("data-status")).toBe("complete");
+    expect(wrapper.getAttribute("data-args")).toBe(
+      JSON.stringify({ query: "copilot" }),
+    );
+    expect(wrapper.getAttribute("data-result")).toBe("ok");
+    expect(screen.getByTestId("copilot-tool-render-name").textContent).toBe(
+      "searchDocs",
+    );
+    expect(screen.getByTestId("copilot-tool-render-status").textContent).toBe(
+      "Done",
+    );
+  });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
@@ -118,25 +118,17 @@ describe("useDefaultRenderTool", () => {
 
     const [config] = mockUseRenderTool.mock.calls[0] as [
       {
-        render: (props: {
-          name: string;
-          parameters: unknown;
-          status: string;
-          result: string | undefined;
-        }) => React.ReactElement;
+        render: (props: DefaultRenderProps) => React.ReactElement;
       },
     ];
 
-    const DefaultRenderer = config.render as React.ComponentType<{
-      name: string;
-      parameters: unknown;
-      status: string;
-      result: string | undefined;
-    }>;
+    const DefaultRenderer =
+      config.render as React.ComponentType<DefaultRenderProps>;
 
     render(
       <DefaultRenderer
         name="searchDocs"
+        toolCallId="tc-default-executing"
         parameters={{ query: "copilot" }}
         status="executing"
         result={undefined}
@@ -161,25 +153,17 @@ describe("useDefaultRenderTool", () => {
 
     const [config] = mockUseRenderTool.mock.calls[0] as [
       {
-        render: (props: {
-          name: string;
-          parameters: unknown;
-          status: string;
-          result: string | undefined;
-        }) => React.ReactElement;
+        render: (props: DefaultRenderProps) => React.ReactElement;
       },
     ];
 
-    const DefaultRenderer = config.render as React.ComponentType<{
-      name: string;
-      parameters: unknown;
-      status: string;
-      result: string | undefined;
-    }>;
+    const DefaultRenderer =
+      config.render as React.ComponentType<DefaultRenderProps>;
 
     render(
       <DefaultRenderer
         name="searchDocs"
+        toolCallId="tc-default-complete"
         parameters={{ query: "copilot" }}
         status="complete"
         result="done"
@@ -202,25 +186,17 @@ describe("useDefaultRenderTool", () => {
 
     const [config] = mockUseRenderTool.mock.calls[0] as [
       {
-        render: (props: {
-          name: string;
-          parameters: unknown;
-          status: string;
-          result: string | undefined;
-        }) => React.ReactElement;
+        render: (props: DefaultRenderProps) => React.ReactElement;
       },
     ];
 
-    const DefaultRenderer = config.render as React.ComponentType<{
-      name: string;
-      parameters: unknown;
-      status: string;
-      result: string | undefined;
-    }>;
+    const DefaultRenderer =
+      config.render as React.ComponentType<DefaultRenderProps>;
 
     render(
       <DefaultRenderer
         name="searchDocs"
+        toolCallId="tc-default-testid"
         parameters={{ query: "copilot" }}
         status="complete"
         result="ok"

--- a/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useDefaultRenderTool } from "../use-default-render-tool";
+import type { DefaultRenderProps } from "../use-default-render-tool";
 import { useRenderTool } from "../use-render-tool";
 
 vi.mock("../use-render-tool", () => ({
@@ -41,17 +42,12 @@ describe("useDefaultRenderTool", () => {
   });
 
   it("forwards toolCallId to custom wildcard render function", () => {
-    // Note: source DefaultRenderProps omits toolCallId, but the wrapper
-    // passes the render through untouched and useRenderTool forwards
-    // toolCallId at runtime. This test locks that behavior.
-    const customRender = vi.fn(
-      (_props: {
-        name: string;
-        parameters: unknown;
-        status: "inProgress" | "executing" | "complete";
-        result: string | undefined;
-      }) => <div data-testid="custom">custom</div>,
-    );
+    // DefaultRenderProps declares toolCallId, and useRenderTool forwards
+    // it at runtime via the spread in its render adapter. This test locks
+    // that behavior end-to-end.
+    const customRender = vi.fn((_props: DefaultRenderProps) => (
+      <div data-testid="custom">custom</div>
+    ));
 
     const Harness: React.FC = () => {
       useDefaultRenderTool({
@@ -66,13 +62,7 @@ describe("useDefaultRenderTool", () => {
     const [config] = mockUseRenderTool.mock.calls[0] as [
       {
         name: string;
-        render: (props: {
-          name: string;
-          toolCallId: string;
-          parameters: unknown;
-          status: string;
-          result: string | undefined;
-        }) => React.ReactElement;
+        render: (props: DefaultRenderProps) => React.ReactElement;
       },
     ];
 
@@ -85,12 +75,7 @@ describe("useDefaultRenderTool", () => {
     });
 
     expect(customRender).toHaveBeenCalledTimes(1);
-    // The statically-declared DefaultRenderProps omits toolCallId, but the
-    // hook forwards it at runtime — that's what this test locks. Cast
-    // through unknown to read the runtime-only field.
-    const forwardedProps = customRender.mock.calls[0][0] as unknown as {
-      toolCallId: string;
-    };
+    const forwardedProps = customRender.mock.calls[0][0];
     expect(forwardedProps).toMatchObject({
       toolCallId: "tc-forwarded-1",
     });

--- a/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
@@ -42,9 +42,8 @@ describe("useDefaultRenderTool", () => {
   });
 
   it("forwards toolCallId to custom wildcard render function", () => {
-    // DefaultRenderProps declares toolCallId, and useRenderTool forwards
-    // it at runtime via the spread in its render adapter. This test locks
-    // that behavior end-to-end.
+    // Verifies useDefaultRenderTool passes the user's render through untouched,
+    // so toolCallId given to the registered render reaches the custom render fn.
     const customRender = vi.fn((_props: DefaultRenderProps) => (
       <div data-testid="custom">custom</div>
     ));

--- a/packages/react-core/src/v2/hooks/use-default-render-tool.tsx
+++ b/packages/react-core/src/v2/hooks/use-default-render-tool.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
 import { useRenderTool } from "./use-render-tool";
 
-type DefaultRenderProps = {
+export type DefaultRenderProps = {
   /** The name of the tool being called. */
   name: string;
+  /** The id of the tool call being rendered. */
+  toolCallId: string;
   /** The parsed parameters passed to the tool call. */
   parameters: unknown;
   /** Current execution status of the tool call. */

--- a/packages/react-core/src/v2/hooks/use-render-tool-call.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-tool-call.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useMemo, useSyncExternalStore } from "react";
-import { ToolCall, ToolMessage } from "@ag-ui/core";
+import type { ToolCall, ToolMessage } from "@ag-ui/core";
 import { ToolCallStatus } from "@copilotkit/core";
 import { useCopilotKit } from "../context";
 import { useCopilotChatConfiguration } from "../providers/CopilotChatConfigurationProvider";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
 import { partialJSONParse } from "@copilotkit/shared";
-import { ReactToolCallRenderer } from "../types/react-tool-call-renderer";
+import type { ReactToolCallRenderer } from "../types/react-tool-call-renderer";
 import { DefaultToolCallRenderer } from "./use-default-render-tool";
 
 export interface UseRenderToolCallProps {
@@ -181,9 +181,9 @@ export function useRenderToolCall() {
 
 // Adapter that bridges the ReactToolCallRenderer signature
 // (`{ name, args, status, result, toolCallId }`) to the
-// `DefaultToolCallRenderer` signature (`{ name, parameters, status,
-// result }`) so the latter can be used as a zero-config fallback when
-// no `*` renderer is registered.
+// `DefaultToolCallRenderer` signature (`{ name, toolCallId, parameters,
+// status, result }`) so the latter can be used as a zero-config fallback
+// when no `*` renderer is registered.
 function defaultToolCallRenderAdapter(props: {
   name: string;
   args: unknown;
@@ -200,6 +200,7 @@ function defaultToolCallRenderAdapter(props: {
   return (
     <DefaultToolCallRenderer
       name={props.name}
+      toolCallId={props.toolCallId}
       parameters={props.args}
       status={status}
       result={props.result}

--- a/packages/react-native/src/components/messages/TypingIndicator.tsx
+++ b/packages/react-native/src/components/messages/TypingIndicator.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from "react";
-import { View, Animated, StyleSheet, type ViewStyle } from "react-native";
+import { View, Animated, StyleSheet } from "react-native";
+import type { ViewStyle } from "react-native";
 
 /**
  * Props for the TypingIndicator component.
@@ -75,6 +76,7 @@ export function TypingIndicator({ style }: TypingIndicatorProps) {
 
   return (
     <View
+      testID="copilot-loading-cursor"
       style={[styles.container, style]}
       accessibilityLabel="Typing indicator"
       accessibilityRole="text"

--- a/packages/react-native/src/components/messages/__tests__/TypingIndicator.testid.test.ts
+++ b/packages/react-native/src/components/messages/__tests__/TypingIndicator.testid.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 

--- a/packages/react-native/src/components/messages/__tests__/TypingIndicator.testid.test.ts
+++ b/packages/react-native/src/components/messages/__tests__/TypingIndicator.testid.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Verifies the react-native TypingIndicator renders the stable
+ * `copilot-loading-cursor` testID so e2e tests can deterministically detect
+ * the "still loading" state. Uses RN's `testID` (capital ID) convention.
+ */
+
+const tiPath = resolve(__dirname, "../TypingIndicator.tsx");
+const tiSrc = readFileSync(tiPath, "utf-8");
+
+describe("react-native stable testids", () => {
+  it("TypingIndicator renders the copilot-loading-cursor testID", () => {
+    expect(tiSrc).toMatch(/testID="copilot-loading-cursor"/);
+  });
+});

--- a/packages/react-ui/src/components/chat/Messages.tsx
+++ b/packages/react-ui/src/components/chat/Messages.tsx
@@ -1,12 +1,10 @@
 import React, { useEffect, useMemo, useRef } from "react";
-import { MessagesProps } from "./props";
+import type { MessagesProps } from "./props";
 import { useChatContext } from "./ChatContext";
-import { Message } from "@copilotkit/shared";
+import type { Message } from "@copilotkit/shared";
 import { useCopilotChatInternal } from "@copilotkit/react-core";
-import {
-  LegacyRenderMessage,
-  LegacyRenderProps,
-} from "./messages/LegacyRenderMessage";
+import type { LegacyRenderProps } from "./messages/LegacyRenderMessage";
+import { LegacyRenderMessage } from "./messages/LegacyRenderMessage";
 
 export const Messages = ({
   inProgress,
@@ -85,7 +83,9 @@ export const Messages = ({
       )
     : RenderMessage;
 
-  const LoadingIcon = () => <span>{icons.activityIcon}</span>;
+  const LoadingIcon = () => (
+    <span data-testid="copilot-loading-cursor">{icons.activityIcon}</span>
+  );
 
   return (
     <div className="copilotKitMessages" ref={messagesContainerRef}>

--- a/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
+++ b/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
@@ -1,4 +1,4 @@
-import { AssistantMessageProps } from "../props";
+import type { AssistantMessageProps } from "../props";
 import { useChatContext } from "../ChatContext";
 import { Markdown } from "../Markdown";
 import { useState } from "react";
@@ -48,7 +48,9 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
     }
   };
 
-  const LoadingIcon = () => <span>{icons.activityIcon}</span>;
+  const LoadingIcon = () => (
+    <span data-testid="copilot-loading-cursor">{icons.activityIcon}</span>
+  );
   const content = message?.content || "";
   const subComponent = message?.generativeUI?.() ?? props.subComponent;
   const subComponentPosition = message?.generativeUIPosition ?? "after";

--- a/packages/react-ui/src/components/chat/messages/ErrorMessage.tsx
+++ b/packages/react-ui/src/components/chat/messages/ErrorMessage.tsx
@@ -1,4 +1,4 @@
-import { ErrorMessageProps } from "../props";
+import type { ErrorMessageProps } from "../props";
 import { useChatContext } from "../ChatContext";
 import { Markdown } from "../Markdown";
 import { useState } from "react";
@@ -28,7 +28,10 @@ export const ErrorMessage = (props: ErrorMessageProps) => {
   console.log(error);
 
   return (
-    <div className="copilotKitMessage copilotKitAssistantMessage">
+    <div
+      data-testid="copilot-error-banner"
+      className="copilotKitMessage copilotKitAssistantMessage"
+    >
       <Markdown content={error.message} />
 
       <div

--- a/packages/react-ui/src/components/chat/messages/testids.test.ts
+++ b/packages/react-ui/src/components/chat/messages/testids.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Verifies stable `data-testid` markers exist on the error banner and loading
+ * indicator surfaces so e2e tests can deterministically distinguish "errored
+ * out" vs "still loading" states. Without these, e2e probes hit ~30-60s
+ * timeouts instead of failing fast.
+ */
+
+const errorMessagePath = resolve(__dirname, "ErrorMessage.tsx");
+const assistantMessagePath = resolve(__dirname, "AssistantMessage.tsx");
+const messagesPath = resolve(__dirname, "../Messages.tsx");
+
+const errorMessageSrc = readFileSync(errorMessagePath, "utf-8");
+const assistantMessageSrc = readFileSync(assistantMessagePath, "utf-8");
+const messagesSrc = readFileSync(messagesPath, "utf-8");
+
+describe("react-ui stable testids", () => {
+  it("ErrorMessage renders the copilot-error-banner testid on its root", () => {
+    expect(errorMessageSrc).toMatch(/data-testid="copilot-error-banner"/);
+  });
+
+  it("Messages LoadingIcon renders the copilot-loading-cursor testid", () => {
+    expect(messagesSrc).toMatch(/data-testid="copilot-loading-cursor"/);
+  });
+
+  it("AssistantMessage LoadingIcon renders the copilot-loading-cursor testid", () => {
+    expect(assistantMessageSrc).toMatch(/data-testid="copilot-loading-cursor"/);
+  });
+});

--- a/packages/vue/src/v2/components/chat/CopilotChatMessageView.vue
+++ b/packages/vue/src/v2/components/chat/CopilotChatMessageView.vue
@@ -469,7 +469,7 @@ function resolveToolMessage(
     <slot v-if="showCursor" name="cursor">
       <div
         class="cpk:w-[11px] cpk:h-[11px] cpk:rounded-full cpk:bg-foreground cpk:animate-pulse cpk:ml-1"
-        data-testid="copilot-chat-cursor"
+        data-testid="copilot-loading-cursor"
       />
     </slot>
   </div>

--- a/packages/vue/src/v2/components/chat/__tests__/CopilotChat.e2e.test.ts
+++ b/packages/vue/src/v2/components/chat/__tests__/CopilotChat.e2e.test.ts
@@ -1069,7 +1069,7 @@ describe("CopilotChat E2E - Chat Basics and Streaming Patterns", () => {
       );
 
       await waitFor(() => {
-        const chatLevelCursor = screen.queryByTestId("copilot-chat-cursor");
+        const chatLevelCursor = screen.queryByTestId("copilot-loading-cursor");
         expect(chatLevelCursor).toBeNull();
       });
 
@@ -1098,7 +1098,7 @@ describe("CopilotChat E2E - Chat Basics and Streaming Patterns", () => {
       });
 
       await waitFor(() => {
-        const chatLevelCursor = screen.queryByTestId("copilot-chat-cursor");
+        const chatLevelCursor = screen.queryByTestId("copilot-loading-cursor");
         expect(chatLevelCursor).not.toBeNull();
       });
 

--- a/packages/vue/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.ts
+++ b/packages/vue/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.ts
@@ -179,7 +179,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 async function submitMessageAndWaitForUserMessage(value: string) {
   await waitFor(() => {
-    expect(screen.queryByTestId("copilot-chat-cursor")).toBeNull();
+    expect(screen.queryByTestId("copilot-loading-cursor")).toBeNull();
   });
 
   const input = await screen.findByRole("textbox");

--- a/packages/vue/src/v2/components/chat/__tests__/CopilotChatMessageView.testid.spec.ts
+++ b/packages/vue/src/v2/components/chat/__tests__/CopilotChatMessageView.testid.spec.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Verifies the vue MessageView cursor renders the stable
+ * `copilot-loading-cursor` testid so e2e tests can deterministically detect
+ * the "still loading" state. Aligns with the v2 react-core convention.
+ */
+
+const viewPath = resolve(__dirname, "../CopilotChatMessageView.vue");
+const viewSrc = readFileSync(viewPath, "utf-8");
+
+describe("vue stable testids", () => {
+  it("CopilotChatMessageView cursor renders the copilot-loading-cursor testid", () => {
+    expect(viewSrc).toMatch(/data-testid="copilot-loading-cursor"/);
+  });
+});

--- a/packages/vue/src/v2/hooks/__tests__/use-default-render-tool.test.ts
+++ b/packages/vue/src/v2/hooks/__tests__/use-default-render-tool.test.ts
@@ -211,4 +211,48 @@ describe("useDefaultRenderTool", () => {
     expect(screen.getByText("Result")).toBeDefined();
     expect(screen.getByText("done")).toBeDefined();
   });
+
+  it("default renderer emits stable copilot-tool-render testid and metadata attrs", () => {
+    const Harness = defineComponent({
+      setup() {
+        useDefaultRenderTool();
+        return {};
+      },
+      template: `<div />`,
+    });
+
+    render(Harness);
+
+    const [config] = mockUseRenderTool.mock.calls[0] as [
+      {
+        render: unknown;
+      },
+    ];
+
+    const DefaultRenderer = config.render;
+    render(DefaultRenderer as any, {
+      props: {
+        name: "searchDocs",
+        toolCallId: "tc-testid-1",
+        parameters: { query: "copilot" },
+        status: "complete",
+        result: "ok",
+      },
+    });
+
+    const wrapper = screen.getByTestId("copilot-tool-render");
+    expect(wrapper).toBeDefined();
+    expect(wrapper.getAttribute("data-tool-name")).toBe("searchDocs");
+    expect(wrapper.getAttribute("data-status")).toBe("complete");
+    expect(wrapper.getAttribute("data-args")).toBe(
+      JSON.stringify({ query: "copilot" }),
+    );
+    expect(wrapper.getAttribute("data-result")).toBe("ok");
+    expect(screen.getByTestId("copilot-tool-render-name").textContent).toBe(
+      "searchDocs",
+    );
+    expect(screen.getByTestId("copilot-tool-render-status").textContent).toBe(
+      "Done",
+    );
+  });
 });

--- a/packages/vue/src/v2/hooks/__tests__/use-default-render-tool.test.ts
+++ b/packages/vue/src/v2/hooks/__tests__/use-default-render-tool.test.ts
@@ -46,7 +46,7 @@ describe("useDefaultRenderTool", () => {
 
   it("forwards custom render function and deps", () => {
     const customRender = vi.fn(() => "custom");
-    const deps = ["compact"] as const;
+    const deps = [() => "compact"];
 
     const Harness = defineComponent({
       setup() {
@@ -54,7 +54,7 @@ describe("useDefaultRenderTool", () => {
           {
             render: customRender,
           },
-          deps as unknown as any[],
+          deps,
         );
         return {};
       },

--- a/packages/vue/src/v2/hooks/use-default-render-tool.ts
+++ b/packages/vue/src/v2/hooks/use-default-render-tool.ts
@@ -49,59 +49,91 @@ const DefaultToolCallRenderer = defineComponent({
           ? "Done"
           : props.status;
 
-      return h("div", { style: { marginTop: "8px", paddingBottom: "8px" } }, [
-        h(
-          "div",
-          {
-            style: {
-              borderRadius: "12px",
-              border: "1px solid #e4e4e7",
-              backgroundColor: "#fafafa",
-              padding: "14px 16px",
-            },
-          },
-          [
-            h(
-              "button",
-              {
-                type: "button",
-                onClick: () => {
-                  isExpanded.value = !isExpanded.value;
-                },
-                style: {
-                  width: "100%",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  gap: "10px",
-                  cursor: "pointer",
-                  border: "none",
-                  padding: 0,
-                  margin: 0,
-                  background: "transparent",
-                  textAlign: "left",
-                },
+      return h(
+        "div",
+        {
+          "data-testid": "copilot-tool-render",
+          "data-tool-name": props.name,
+          "data-status": props.status,
+          "data-args": safeStringifyForAttr(props.parameters),
+          "data-result": safeStringifyForAttr(props.result),
+          style: { marginTop: "8px", paddingBottom: "8px" },
+        },
+        [
+          h(
+            "div",
+            {
+              style: {
+                borderRadius: "12px",
+                border: "1px solid #e4e4e7",
+                backgroundColor: "#fafafa",
+                padding: "14px 16px",
               },
-              [
-                h("span", { style: { fontWeight: "600" } }, props.name),
-                h("span", statusLabel),
-              ],
-            ),
-            isExpanded.value
-              ? h("div", { style: { marginTop: "12px" } }, [
-                  h("div", "Arguments"),
-                  h("pre", JSON.stringify(props.parameters ?? {}, null, 2)),
-                  props.result !== undefined
-                    ? h("div", [h("div", "Result"), h("pre", props.result)])
-                    : null,
-                ])
-              : null,
-          ],
-        ),
-      ]);
+            },
+            [
+              h(
+                "button",
+                {
+                  type: "button",
+                  onClick: () => {
+                    isExpanded.value = !isExpanded.value;
+                  },
+                  style: {
+                    width: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: "10px",
+                    cursor: "pointer",
+                    border: "none",
+                    padding: 0,
+                    margin: 0,
+                    background: "transparent",
+                    textAlign: "left",
+                  },
+                },
+                [
+                  h(
+                    "span",
+                    {
+                      "data-testid": "copilot-tool-render-name",
+                      style: { fontWeight: "600" },
+                    },
+                    props.name,
+                  ),
+                  h(
+                    "span",
+                    { "data-testid": "copilot-tool-render-status" },
+                    statusLabel,
+                  ),
+                ],
+              ),
+              isExpanded.value
+                ? h("div", { style: { marginTop: "12px" } }, [
+                    h("div", "Arguments"),
+                    h("pre", JSON.stringify(props.parameters ?? {}, null, 2)),
+                    props.result !== undefined
+                      ? h("div", [h("div", "Result"), h("pre", props.result)])
+                      : null,
+                  ])
+                : null,
+            ],
+          ),
+        ],
+      );
     };
   },
 });
+
+function safeStringifyForAttr(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
 
 export function useDefaultRenderTool(
   config?: {


### PR DESCRIPTION
## Why

Two sibling testid families that e2e tests need across the entire frontend matrix, consolidated into one PR (this PR absorbs #5108). Both are purely additive markers — no behavior, rendering, or styling changes.

### A. Default tool-call renderer (cross-framework parity)

E2E tests for the chat surface (e.g. showcase's `tool-rendering-default-catchall` canonical spec) need a stable selector to count and inspect tool-call cards rendered by the framework's built-in `DefaultToolCallRenderer` when an integration registers zero custom render hooks. `react-core`'s renderer already emits a `data-testid="copilot-tool-render"` wrapper with `data-tool-name`, `data-status`, `data-args` and `data-result`; `vue`'s equivalent renderer was missing them, so the same e2e test counted 0 cards there.

A freshly-built google-adk integration on the showcase reproduced this: cards appeared but without the testids → assertion counted 0; `langgraph-python` passed the same test because its build resolved a `react-core` version that does emit them. This half fixes the framework gap so every framework's built-in renderer emits the same stable selectors.

### B. Error banner + loading indicator (cross-framework, all five packages)

E2E tests for the chat surface today have no stable selector to distinguish "errored out" vs "still loading" states, so probes time out after 30–60s instead of failing fast and pointing to the right cause. This half adds purely additive, framework-spanning `data-testid` markers so a single selector works across every frontend.

## What

### A. Default tool-call renderer

Mirrors `react-core`'s contract onto the `vue` `DefaultToolCallRenderer`:

- `packages/vue/src/v2/hooks/use-default-render-tool.ts`: wrap the card in a `<div>` carrying `data-testid="copilot-tool-render"`, `data-tool-name`, `data-status`, `data-args` and `data-result` (via the same `safeStringifyForAttr` helper shape as react-core); tag the inner name/status spans with `copilot-tool-render-name` and `copilot-tool-render-status`.

Adds `toolCallId` parity to `react-core`'s default-renderer props so both frameworks expose the same prop shape:

- `packages/react-core/src/v2/hooks/use-default-render-tool.tsx`: `DefaultRenderProps` now carries `toolCallId` (vue already exposed it).
- `packages/react-core/src/v2/hooks/use-render-tool-call.tsx`: adapter forwards `toolCallId` into the default renderer.

Locks the contract into unit tests in **both** frameworks so the markers cannot silently disappear in a future refactor:

- `packages/vue/src/v2/hooks/__tests__/use-default-render-tool.test.ts`: new `"default renderer emits stable copilot-tool-render testid and metadata attrs"` test (red-green proven locally by stashing the source change — without it, `getByTestId("copilot-tool-render")` throws).
- `packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx`: mirroring test asserting the same wrapper / `data-*` attrs and inner testids (red-green proven by sentinel-swapping the testid in the renderer source — the new test fails, others pass), plus a regression test that asserts `toolCallId` is forwarded through the adapter.

### B. Error banner + loading indicator

Adds two stable testids on the relevant UI surfaces in every frontend framework package — react-core, react-ui, react-native, angular, vue:

- `copilot-error-banner` on the global error banner UI:
  - `packages/react-core/src/components/toast/toast-provider.tsx` (`BannerErrorDisplay` root)
  - `packages/react-core/src/components/usage-banner.tsx` (`UsageBanner`)
  - `packages/react-ui/src/components/chat/messages/ErrorMessage.tsx` (legacy in-chat ErrorMessage)
- `copilot-loading-cursor` on the flashing-dot / typing indicator:
  - `packages/react-ui/src/components/chat/Messages.tsx` and `messages/AssistantMessage.tsx` (legacy `LoadingIcon` spans)
  - `packages/angular/src/lib/components/chat/copilot-chat-message-view-cursor.ts`
  - `packages/react-native/src/components/messages/TypingIndicator.tsx` (via RN's `testID` convention)
  - `packages/vue/src/v2/components/chat/CopilotChatMessageView.vue`
  - The v2 react-core `CopilotChatMessageView.Cursor` already exposes `copilot-loading-cursor`; this PR broadens that same selector to the other frameworks.

Vue's prior `copilot-chat-cursor` testid is renamed to `copilot-loading-cursor` for cross-framework consistency; the two e2e tests in `packages/vue` that referenced the old name are updated in the same commit.

Adds small static source-asserting tests in each touched package that verify the markers stay in place (red/green proven locally by transiently removing one marker).

## Per-framework audit (default renderer)

| Package | Has built-in default renderer? | `copilot-tool-render` testid before this PR | Status after PR |
|---|---|---|---|
| `react-core` | YES (`DefaultToolCallRenderer`) | YES (already shipping) | `toolCallId` added to `DefaultRenderProps` for vue parity; regression test added |
| `vue` | YES (`DefaultToolCallRenderer` in `use-default-render-tool.ts`) | **NO** | **added** + regression test |
| `angular` | NO (renders only when user registers `*`) | N/A | no change needed |
| `react-native` | NO (deliberately excludes — DOM-only, see `packages/react-native/src/index.ts` comments) | N/A | no change needed |
| `react-ui` | inherits `react-core`'s | N/A | no change needed |

## Consolidation note

This PR supersedes and absorbs #5108. The two testid families touch disjoint files; cherry-picking #5108's single commit onto this branch was clean. Both halves went through the CR loop (converged).

## Scope

Purely additive — no behavior, rendering, or styling changes. The new attributes are inert at runtime; only e2e and unit tests read them. `toolCallId` is now exposed to both frameworks' default renderers as a prop; emission of a `data-tool-call-id` attribute is explicitly out of scope (see Out of scope below).

## Test plan

- [x] `pnpm --filter @copilotkit/vue run test` — 995/995 green
- [x] `pnpm --filter @copilotkit/react-core run test` — 1183/1183 vitest green (the pre-existing `test:scripts` failure on `origin/main` is unrelated)
- [x] `pnpm --filter @copilotkit/react-ui run test` — 36/36 green
- [x] `pnpm --filter @copilotkit/react-native run test` — 246/246 green
- [x] `pnpm --filter @copilotkitnext/angular run test` — 48/48 green
- [x] `pnpm --filter @copilotkit/vue run build` — green
- [x] `pnpm --filter @copilotkit/react-core run build` — green
- [x] `pnpm exec oxlint <touched files>` — 0 warnings, 0 errors
- [x] `pnpm exec oxfmt --check <touched files>` — clean
- [x] Typecheck (`tsc --noEmit`) on all five touched packages — no new errors vs `origin/main` (pre-existing baselines preserved; vue actually drops from 111 → 0 as a side effect of the toolCallId typing tightening)
- [x] Red→green proven for every new test (stash source / sentinel-swap testid / transient marker removal)

## Out of scope (follow-up PR)

The CR loop surfaced several pre-existing issues in the default-tool-renderer code path. They are intentionally NOT addressed here so this PR stays a focused, additive testid + parity change. A follow-up PR will harden them:

- `react-core`: swap the renderer's clickable `<div onClick>` for a `<button>` for keyboard / a11y compliance.
- Exhaustive `ToolCallStatus` enum mapping with explicit logging on unknown values (instead of silent fallback) in both frameworks.
- Emit a `data-tool-call-id` attribute on the wrapper (the prop is now available on both sides; emitting it is a separate, deliberate decision).
- `useDefaultRenderTool`: introduce an opt-in prop-shape adapter so callers can pick the prop contract explicitly rather than implicitly.
- Extract `safeStringifyForAttr` into a shared util and replace remaining unguarded `JSON.stringify` calls in both renderers with it.
- Rewrite the 5 source-grep testid unit tests (cherry-picked from #5108) to render-based assertions instead of `readFileSync` + regex matching.

## Follow-up

- Unblocks the showcase `tool-rendering-default-catchall` D6 canonical spec across the fleet, plus reliable error/loading state assertions in showcase e2e.
- A `react-core` (+ peers) release will follow once this lands (gated, separate change).
