### PR TITLE
fix(showcase): self-heal browser pool + flag stale-green e2e rows

### DIFF
--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -117,12 +117,10 @@ function makeFakeLogger(): {
 }
 
 /**
- * `recycleSlot` kicks off an async relaunch via a fire-and-forget IIFE.
- * Tests that observe post-recycle state need to await the in-flight
- * promise to settle. `shutdown()` already awaits `inFlightRecycles`, so
- * this helper is just `await pool.shutdown()` from the test side; here
- * we use a small drain helper for tests that want to observe state
- * without tearing the pool down.
+ * Flush pending microtasks `times` times so post-recycle state settles
+ * enough to observe without tearing the pool down. It does NOT advance real
+ * `setTimeout` backoff timers — tests that depend on backoff elapsing use
+ * `waitFor` instead.
  */
 async function drainMicrotasks(times = 5): Promise<void> {
   for (let i = 0; i < times; i++) {
@@ -316,13 +314,17 @@ describe("BrowserPool dead-instance detection", () => {
     await pool.shutdown();
   });
 
-  it("re-initializes the pool when every slot has been lost (size reaches 0)", async () => {
-    // 2-slot pool. Both browsers crash and EVERY relaunch attempt fails for
-    // both slots, driving the pool to size 0 so the backstop reinit() path
-    // is actually exercised. Each slot makes RELAUNCH_MAX_ATTEMPTS (=3)
-    // launch calls during recycle, so for 2 slots that is launch calls 3..8
-    // (init used calls 1 and 2). Failing 3..8 exhausts all retries and
-    // evicts both slots to leave size 0. Call 9 (the reinit) succeeds.
+  it("recovers a fully-parked pool (all slots relaunchPending, size 0) via the lazy relaunchPendingSlots path on the next acquire", async () => {
+    // 2-slot pool. Both browsers crash and EVERY immediate relaunch attempt
+    // fails for both slots. Each slot makes RELAUNCH_MAX_ATTEMPTS (=3) launch
+    // calls during recycle, so for 2 slots that is launch calls 3..8 (init
+    // used calls 1 and 2). Failing 3..8 exhausts every immediate retry and
+    // parks BOTH slots as `relaunchPending` — they are NOT evicted from
+    // `this.slots` (capacity is preserved), so `stats().size` reads 0 during
+    // the outage while the slots stay parked. Recovery is therefore via the
+    // lazy `relaunchPendingSlots()` path on the next acquire (launch call 9
+    // succeeds), NOT the `reinit()` backstop (which only fires when
+    // `this.slots` is truly empty). This test asserts that actual mechanism.
     const { launchBrowser, launched } = makeFakeLauncher({
       failAtCalls: [3, 4, 5, 6, 7, 8],
     });
@@ -334,17 +336,17 @@ describe("BrowserPool dead-instance detection", () => {
     launched[0]!.__crash();
     launched[1]!.__crash();
     // The recycle uses real setTimeout backoff between attempts, so give it
-    // a wall-clock window to exhaust all retries and park/evict both slots.
+    // a wall-clock window to exhaust all retries and park both slots.
     await waitFor(() => pool.stats().size === 0, 5_000);
 
-    // Precondition: prove the pool actually drained to zero so reinit() is
-    // the path under test (the old [3,4] fixture self-healed on attempt 2
-    // and never reached this state — the test was vacuous).
+    // Precondition: every slot is parked, so live capacity (`size`) reads 0
+    // during the outage. The slots themselves are retained — recovery comes
+    // through the relaunchPending path, not a from-scratch reinit.
     expect(pool.stats().size).toBe(0);
 
-    // With size 0, the next acquire() must trigger the backstop reinit
-    // (launch call 9 succeeds) and hand back a live browser instead of
-    // hanging until timeout.
+    // The next acquire() recovers the parked slots via relaunchPendingSlots
+    // (launch call 9 succeeds) and hands back a live browser instead of
+    // hanging until timeout. `size` returns to non-zero once recovered.
     const acquired = await pool.acquire(5_000);
     expect(acquired).toBeDefined();
     expect((acquired as unknown as FakeBrowser).isConnected()).toBe(true);

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -130,6 +130,26 @@ async function drainMicrotasks(times = 5): Promise<void> {
   }
 }
 
+/**
+ * Poll `predicate` until it returns true or `timeoutMs` elapses. The pool's
+ * recycle/relaunch paths use real `setTimeout` backoff, so state transitions
+ * (slot eviction, relaunchPending parking, deferred recovery) settle over
+ * wall-clock time rather than microtasks. Rejects on timeout so a test that
+ * relies on a precondition fails loudly instead of asserting on stale state.
+ */
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 3_000,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor timed out");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 describe("BrowserPool dead-instance detection", () => {
   it("registers a disconnected listener on each browser at init and recycles when one fires", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
@@ -297,11 +317,14 @@ describe("BrowserPool dead-instance detection", () => {
   });
 
   it("re-initializes the pool when every slot has been lost (size reaches 0)", async () => {
-    // 2-slot pool. Both browsers crash and BOTH relaunches fail (launch
-    // calls 3 and 4), driving the pool to size 0. The next acquire() must
-    // trigger a backstop re-init rather than hanging until timeout.
+    // 2-slot pool. Both browsers crash and EVERY relaunch attempt fails for
+    // both slots, driving the pool to size 0 so the backstop reinit() path
+    // is actually exercised. Each slot makes RELAUNCH_MAX_ATTEMPTS (=3)
+    // launch calls during recycle, so for 2 slots that is launch calls 3..8
+    // (init used calls 1 and 2). Failing 3..8 exhausts all retries and
+    // evicts both slots to leave size 0. Call 9 (the reinit) succeeds.
     const { launchBrowser, launched } = makeFakeLauncher({
-      failAtCalls: [3, 4],
+      failAtCalls: [3, 4, 5, 6, 7, 8],
     });
     const { logger } = makeFakeLogger();
     const pool = new BrowserPool(2, 100, logger, launchBrowser);
@@ -310,18 +333,104 @@ describe("BrowserPool dead-instance detection", () => {
 
     launched[0]!.__crash();
     launched[1]!.__crash();
-    await drainMicrotasks(30);
+    // The recycle uses real setTimeout backoff between attempts, so give it
+    // a wall-clock window to exhaust all retries and park/evict both slots.
+    await waitFor(() => pool.stats().size === 0, 5_000);
 
-    // Both relaunches failed — without a backstop the pool is permanently
-    // empty and every future acquire() times out. With the fix, acquire()
-    // re-initializes the pool (launch calls 5+ succeed) and hands back a
-    // live browser.
+    // Precondition: prove the pool actually drained to zero so reinit() is
+    // the path under test (the old [3,4] fixture self-healed on attempt 2
+    // and never reached this state — the test was vacuous).
+    expect(pool.stats().size).toBe(0);
+
+    // With size 0, the next acquire() must trigger the backstop reinit
+    // (launch call 9 succeeds) and hand back a live browser instead of
+    // hanging until timeout.
     const acquired = await pool.acquire(5_000);
     expect(acquired).toBeDefined();
     expect((acquired as unknown as FakeBrowser).isConnected()).toBe(true);
     expect(pool.stats().size).toBeGreaterThan(0);
 
     await pool.shutdown();
+  });
+
+  it("delivers a fresh browser to a parked waiter once a deferred relaunch succeeds, without a second acquire()", async () => {
+    // Single-slot pool. The browser crashes and EVERY immediate relaunch
+    // attempt fails (launch calls 2..4 — RELAUNCH_MAX_ATTEMPTS=3), so the
+    // slot is parked relaunchPending and the original acquire() is left as a
+    // queued waiter. A LATER launch (call 5) succeeds. The waiter must be
+    // served by the deferred/rescheduled relaunch WITHOUT the test issuing a
+    // second acquire() to drive recovery (guards bug #1 and #3).
+    const { launchBrowser, launched } = makeFakeLauncher({
+      failAtCalls: [2, 3, 4],
+    });
+    const { logger } = makeFakeLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    await pool.init();
+    expect(launched).toHaveLength(1);
+
+    // Hand out the only browser, then crash it while held. The disconnect
+    // recycle relaunches but calls 2..4 all fail, parking the slot.
+    const held = await pool.acquire();
+    expect(held).toBe(launched[0] as unknown as Browser);
+    (held as unknown as FakeBrowser).__crash();
+
+    // Park an acquire as a waiter. With the only slot dead/pending and no
+    // available browser, this returns a pending promise.
+    const waiterPromise = pool.acquire(5_000);
+
+    // Do NOT call acquire() again. The deferred relaunch must reschedule
+    // (call 5 succeeds) and hand the fresh browser directly to the waiter.
+    const recovered = await waiterPromise;
+    expect(recovered).toBeDefined();
+    expect((recovered as unknown as FakeBrowser).isConnected()).toBe(true);
+    expect((recovered as unknown as FakeBrowser).__id).toBe(
+      launched[launched.length - 1]!.__id,
+    );
+
+    await pool.shutdown();
+  });
+
+  it("does not double-publish a relaunchPending slot when recovery is driven concurrently", async () => {
+    // Drive a single slot into relaunchPending (all immediate retries fail),
+    // then trigger TWO concurrent recovery drivers: a deferred relaunch (a
+    // queued waiter schedules it) racing an acquire()-driven relaunch. With a
+    // re-entry guard the slot is launched exactly once and its fresh browser
+    // is handed to exactly one acquirer — never published to `available`
+    // twice nor handed to two probes (guards bug #2).
+    const { launchBrowser, launched } = makeFakeLauncher({
+      failAtCalls: [2, 3, 4],
+    });
+    const { logger } = makeFakeLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    await pool.init();
+
+    const held = await pool.acquire();
+    (held as unknown as FakeBrowser).__crash();
+    // Let the immediate recycle retries (calls 2..4) exhaust and park the
+    // slot as relaunchPending before we drive concurrent recovery.
+    await waitFor(() => pool.stats().available === 0, 3_000).catch(() => {});
+
+    // Two acquirers race for the single recovering slot. The fresh browser
+    // must go to exactly one of them; the loser stays parked as a waiter.
+    const a = pool.acquire(5_000);
+    const b = pool.acquire(5_000);
+
+    const first = await Promise.race([a, b]);
+    expect(first).toBeDefined();
+    expect((first as unknown as FakeBrowser).isConnected()).toBe(true);
+
+    // Exactly one fresh browser (the successful relaunch, call 5) was
+    // created beyond init — no leaked second launch from a re-entrant relaunch.
+    const freshBeyondInit = launched.slice(1);
+    expect(freshBeyondInit.length).toBe(1);
+
+    // The single slot must never appear twice in `available`.
+    expect(pool.stats().available).toBeLessThanOrEqual(1);
+    expect(pool.stats().size).toBe(1);
+
+    await pool.shutdown();
+    // The loser waiter rejects on shutdown; swallow it.
+    await Promise.allSettled([a, b]);
   });
 
   it("shutdown() does not loop the disconnect handler when closing slot browsers", async () => {

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -367,13 +367,15 @@ describe("BrowserPool dead-instance detection", () => {
     await pool.shutdown();
   });
 
-  it("delivers a fresh browser to a parked waiter once a deferred relaunch succeeds, without a second acquire()", async () => {
+  it("recovers a parked slot on the next acquire() after every immediate relaunch failed", async () => {
     // Single-slot pool. The browser crashes and EVERY immediate relaunch
-    // attempt fails (launch calls 2..4 — RELAUNCH_MAX_ATTEMPTS=3), so the
-    // slot is parked relaunchPending and the original acquire() is left as a
-    // queued waiter. A LATER launch (call 5) succeeds. The waiter must be
-    // served by the deferred/rescheduled relaunch WITHOUT the test issuing a
-    // second acquire() to drive recovery (guards bug #1 and #3).
+    // attempt fails (launch calls 2..4 — RELAUNCH_MAX_ATTEMPTS=3), so the slot
+    // is parked relaunchPending. There is no background timer to recover it;
+    // recovery is lazy. A LATER launch (call 5) succeeds, and the NEXT
+    // acquire() must drive `relaunchPendingSlots()` to relaunch the slot and
+    // hand back a fresh, connected browser. This replaces the old
+    // deferred-timer test that asserted a waiter was served WITHOUT a second
+    // acquire() — that behavior intentionally no longer holds.
     const { launchBrowser, launched } = makeFakeLauncher({
       failAtCalls: [2, 3, 4],
     });
@@ -388,13 +390,14 @@ describe("BrowserPool dead-instance detection", () => {
     expect(held).toBe(launched[0] as unknown as Browser);
     (held as unknown as FakeBrowser).__crash();
 
-    // Park an acquire as a waiter. With the only slot dead/pending and no
-    // available browser, this returns a pending promise.
-    const waiterPromise = pool.acquire(5_000);
+    // Wait until the recycle has fully exhausted its immediate retries and
+    // parked the slot — live capacity reads 0 and nothing is recovering it.
+    await waitFor(() => pool.stats().size === 0, 3_000);
 
-    // Do NOT call acquire() again. The deferred relaunch must reschedule
-    // (call 5 succeeds) and hand the fresh browser directly to the waiter.
-    const recovered = await waiterPromise;
+    // The next acquire() drives the lazy recovery: relaunchPendingSlots
+    // re-attempts the launch (call 5 succeeds) and the parked/waiting caller
+    // gets a fresh connected browser.
+    const recovered = await pool.acquire(5_000);
     expect(recovered).toBeDefined();
     expect((recovered as unknown as FakeBrowser).isConnected()).toBe(true);
     expect((recovered as unknown as FakeBrowser).__id).toBe(
@@ -406,11 +409,10 @@ describe("BrowserPool dead-instance detection", () => {
 
   it("does not double-publish a relaunchPending slot when recovery is driven concurrently", async () => {
     // Drive a single slot into relaunchPending (all immediate retries fail),
-    // then trigger TWO concurrent recovery drivers: a deferred relaunch (a
-    // queued waiter schedules it) racing an acquire()-driven relaunch. With a
-    // re-entry guard the slot is launched exactly once and its fresh browser
-    // is handed to exactly one acquirer — never published to `available`
-    // twice nor handed to two probes (guards bug #2).
+    // then trigger TWO concurrent acquire()-driven relaunches racing for the
+    // same slot. With a re-entry guard the slot is launched exactly once and
+    // its fresh browser is handed to exactly one acquirer — never published to
+    // `available` twice nor handed to two probes (guards bug #2).
     const { launchBrowser, launched } = makeFakeLauncher({
       failAtCalls: [2, 3, 4],
     });
@@ -420,14 +422,20 @@ describe("BrowserPool dead-instance detection", () => {
 
     const held = await pool.acquire();
     (held as unknown as FakeBrowser).__crash();
-    // Let the immediate recycle retries (calls 2..4) exhaust and park the
-    // slot as relaunchPending before we drive concurrent recovery. No
-    // `.catch` swallow here — if the precondition never settles, the test
-    // must fail loudly rather than proceed on stale state.
-    await waitFor(() => pool.stats().available === 0, 3_000);
+    // Let the immediate recycle retries (calls 2..4) exhaust and PARK the slot
+    // as relaunchPending before we drive concurrent recovery. We wait on
+    // `size === 0` (slot parked, recycle fully done) rather than
+    // `available === 0` — `available` is already 0 the instant the only
+    // browser was handed out, so it would let the race start while the recycle
+    // is still in flight and the slot is not yet pending. No `.catch` swallow
+    // here — if the precondition never settles, the test must fail loudly
+    // rather than proceed on stale state.
+    await waitFor(() => pool.stats().size === 0, 3_000);
 
-    // Two acquirers race for the single recovering slot. The fresh browser
-    // must go to exactly one of them; the loser stays parked as a waiter.
+    // Two acquirers race for the single recovering slot, each driving
+    // relaunchPendingSlots. The fresh browser must go to exactly one of them;
+    // the loser stays parked as a waiter (it has no timer to recover it and
+    // will reject on shutdown).
     const a = pool.acquire(5_000);
     const b = pool.acquire(5_000);
 
@@ -457,21 +465,19 @@ describe("BrowserPool dead-instance detection", () => {
     await Promise.allSettled([a, b]);
   });
 
-  it("serves a waiter that parks AFTER a recycle has already fully failed, without a second acquire()", async () => {
-    // Bug #1 guard. A single-slot pool. The browser crashes via a
-    // `disconnected` event while NO acquire is waiting and NO waiter is
-    // queued. The recycle exhausts all immediate retries (calls 2..4 fail)
-    // and parks the slot relaunchPending. recycleSlot's own
-    // scheduleDeferredRelaunch(1) early-returns because waiters is empty at
-    // that instant — so nothing has armed the deferred loop.
+  it("recovers a parked slot via a later acquire() even when an intervening acquire()'s relaunch also failed", async () => {
+    // Lazy-recovery guard. A single-slot pool. The browser crashes via a
+    // `disconnected` event while NO acquire is waiting. The recycle exhausts
+    // all immediate retries (calls 2..4 fail) and parks the slot
+    // relaunchPending. There is no background timer — recovery is purely
+    // acquire()-driven.
     //
-    // ONLY THEN does an acquire() run. Its leading relaunchPendingSlots()
-    // attempt (call 5) ALSO fails — so it does NOT serve the waiter inline —
-    // and the acquire falls through and parks a waiter. The ONLY thing that
-    // can now re-arm the deferred loop and eventually serve that waiter (when
-    // call 6 succeeds) is the acquire-kick on the waiter-push path. Pre-fix
-    // (no acquire-kick) nothing re-arms the loop and the waiter hangs until
-    // its acquire timeout. The test issues NO second acquire to drive recovery.
+    // A first acquire()'s leading relaunchPendingSlots() attempt (call 5) ALSO
+    // fails, so that acquire parks a waiter and eventually times out (no timer
+    // re-arms recovery). A LATER acquire() then drives relaunchPendingSlots
+    // again (call 6 succeeds) and gets the fresh connected browser. This proves
+    // the on-demand recovery is robust to a failed intervening relaunch — the
+    // harness probes continuously, so a subsequent probe tick recovers.
     const { launchBrowser, launched } = makeFakeLauncher({
       failAtCalls: [2, 3, 4, 5],
     });
@@ -480,21 +486,25 @@ describe("BrowserPool dead-instance detection", () => {
     await pool.init();
     expect(launched).toHaveLength(1);
 
-    // Crash the idle browser. No waiter is queued, so the recycle's deferred
-    // relaunch kick is a no-op; the slot just parks relaunchPending.
+    // Crash the idle browser. The recycle exhausts immediate retries and parks
+    // the slot relaunchPending (no waiter queued, no timer to recover it).
     launched[0]!.__crash();
     // Wait until the recycle has fully exhausted its immediate retries and
-    // parked the slot — i.e. live capacity reads 0 and recovery is dormant
-    // (no deferred loop armed, because no waiter was queued).
+    // parked the slot — i.e. live capacity reads 0.
     await waitFor(() => pool.stats().size === 0, 3_000);
 
-    // NOW park a waiter. acquire()'s leading relaunchPendingSlots attempt is
-    // call 5, which fails, so the waiter parks unserved. Only the acquire-kick
-    // re-arms the deferred loop; call 6 then succeeds and serves the waiter.
+    // First acquire(): its leading relaunchPendingSlots attempt is call 5,
+    // which fails, so it parks a waiter that hits its (short) timeout — no
+    // timer re-arms recovery, which is the intended lazy behavior.
+    await expect(pool.acquire(50)).rejects.toThrow(
+      "BrowserPool acquire timeout",
+    );
+
+    // A LATER acquire() drives relaunchPendingSlots again; call 6 succeeds and
+    // the parked slot is recovered with a fresh connected browser.
     const recovered = await pool.acquire(5_000);
     expect(recovered).toBeDefined();
     expect((recovered as unknown as FakeBrowser).isConnected()).toBe(true);
-    // The waiter is served by the single successful relaunch (call 6).
     expect((recovered as unknown as FakeBrowser).__id).toBe(
       launched[launched.length - 1]!.__id,
     );

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -25,6 +25,15 @@ interface FakeBrowser {
   newContext(): Promise<{ close(): Promise<void> }>;
   __crash(): void;
   __silentlyDisconnect(): void;
+  /**
+   * Re-fire the `disconnected` event WITHOUT touching `isConnected`. Models a
+   * delayed/duplicate disconnect delivery for an already-dead browser — e.g.
+   * Playwright drains a late `disconnected` for an OLD browser instance after
+   * the slot has already been parked and is being relaunched. `__crash` can
+   * only fire once (it no-ops when already disconnected), so this is the hook
+   * for the "late disconnect races concurrent relaunch" race.
+   */
+  __fireDisconnectLate(): void;
   readonly __closeCount: number;
 }
 
@@ -66,6 +75,9 @@ function makeFakeBrowser(): FakeBrowser {
     },
     __silentlyDisconnect() {
       connected = false;
+    },
+    __fireDisconnectLate() {
+      fire("disconnected");
     },
   };
 }
@@ -409,8 +421,10 @@ describe("BrowserPool dead-instance detection", () => {
     const held = await pool.acquire();
     (held as unknown as FakeBrowser).__crash();
     // Let the immediate recycle retries (calls 2..4) exhaust and park the
-    // slot as relaunchPending before we drive concurrent recovery.
-    await waitFor(() => pool.stats().available === 0, 3_000).catch(() => {});
+    // slot as relaunchPending before we drive concurrent recovery. No
+    // `.catch` swallow here — if the precondition never settles, the test
+    // must fail loudly rather than proceed on stale state.
+    await waitFor(() => pool.stats().available === 0, 3_000);
 
     // Two acquirers race for the single recovering slot. The fresh browser
     // must go to exactly one of them; the loser stays parked as a waiter.
@@ -426,6 +440,14 @@ describe("BrowserPool dead-instance detection", () => {
     const freshBeyondInit = launched.slice(1);
     expect(freshBeyondInit.length).toBe(1);
 
+    // Exact-once: the browser handed to the winning acquirer must BE that
+    // single fresh launch. Asserting only `length === 1` can pass even if the
+    // winner were served some other instance; pinning the id proves the slot
+    // was launched once and that launch is exactly what got served.
+    expect((first as unknown as FakeBrowser).__id).toBe(
+      freshBeyondInit[0]!.__id,
+    );
+
     // The single slot must never appear twice in `available`.
     expect(pool.stats().available).toBeLessThanOrEqual(1);
     expect(pool.stats().size).toBe(1);
@@ -433,6 +455,135 @@ describe("BrowserPool dead-instance detection", () => {
     await pool.shutdown();
     // The loser waiter rejects on shutdown; swallow it.
     await Promise.allSettled([a, b]);
+  });
+
+  it("serves a waiter that parks AFTER a recycle has already fully failed, without a second acquire()", async () => {
+    // Bug #1 guard. A single-slot pool. The browser crashes via a
+    // `disconnected` event while NO acquire is waiting and NO waiter is
+    // queued. The recycle exhausts all immediate retries (calls 2..4 fail)
+    // and parks the slot relaunchPending. recycleSlot's own
+    // scheduleDeferredRelaunch(1) early-returns because waiters is empty at
+    // that instant — so nothing has armed the deferred loop.
+    //
+    // ONLY THEN does an acquire() run. Its leading relaunchPendingSlots()
+    // attempt (call 5) ALSO fails — so it does NOT serve the waiter inline —
+    // and the acquire falls through and parks a waiter. The ONLY thing that
+    // can now re-arm the deferred loop and eventually serve that waiter (when
+    // call 6 succeeds) is the acquire-kick on the waiter-push path. Pre-fix
+    // (no acquire-kick) nothing re-arms the loop and the waiter hangs until
+    // its acquire timeout. The test issues NO second acquire to drive recovery.
+    const { launchBrowser, launched } = makeFakeLauncher({
+      failAtCalls: [2, 3, 4, 5],
+    });
+    const { logger } = makeFakeLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    await pool.init();
+    expect(launched).toHaveLength(1);
+
+    // Crash the idle browser. No waiter is queued, so the recycle's deferred
+    // relaunch kick is a no-op; the slot just parks relaunchPending.
+    launched[0]!.__crash();
+    // Wait until the recycle has fully exhausted its immediate retries and
+    // parked the slot — i.e. live capacity reads 0 and recovery is dormant
+    // (no deferred loop armed, because no waiter was queued).
+    await waitFor(() => pool.stats().size === 0, 3_000);
+
+    // NOW park a waiter. acquire()'s leading relaunchPendingSlots attempt is
+    // call 5, which fails, so the waiter parks unserved. Only the acquire-kick
+    // re-arms the deferred loop; call 6 then succeeds and serves the waiter.
+    const recovered = await pool.acquire(5_000);
+    expect(recovered).toBeDefined();
+    expect((recovered as unknown as FakeBrowser).isConnected()).toBe(true);
+    // The waiter is served by the single successful relaunch (call 6).
+    expect((recovered as unknown as FakeBrowser).__id).toBe(
+      launched[launched.length - 1]!.__id,
+    );
+
+    await pool.shutdown();
+  });
+
+  it("launches exactly one fresh browser when a late disconnect for an OLD browser races relaunchPendingSlots relaunching the same slot", async () => {
+    // Bug #2 guard. A slot parked relaunchPending still holds its OLD (dead)
+    // browser as slot.browser and is still in this.slots. relaunchPendingSlots
+    // begins relaunching it (slot enters relaunchingSlots, NOT recyclingSlots).
+    // While that relaunch is in flight, a LATE `disconnected` fire for the OLD
+    // browser passes the disconnect handler's guards (slot.browser === old,
+    // slots.includes(slot)) and reaches recycleSlot. The OLD guard only
+    // consulted recyclingSlots, so recycleSlot would proceed and launch a
+    // SECOND fresh browser — leaking one process / double-swapping slot.browser.
+    // isSlotBusy (which also checks relaunchingSlots) must make recycleSlot a
+    // no-op so exactly ONE fresh browser is launched and not double-published.
+    //
+    // Deterministic race: gate the relaunchPendingSlots launch so the slot is
+    // mid-relaunch (in relaunchingSlots) when we re-fire the old disconnect.
+    const launched: FakeBrowser[] = [];
+    let callCount = 0;
+    let releaseRelaunch: (() => void) | undefined;
+    const relaunchGate = new Promise<void>((resolve) => {
+      releaseRelaunch = resolve;
+    });
+    // init = call 1; recycle's 3 immediate retries = calls 2..4 (all fail) to
+    // park the slot; the relaunchPendingSlots relaunch = call 5, which we gate.
+    const failCalls = new Set([2, 3, 4]);
+    const launchBrowser: LaunchBrowser = async () => {
+      callCount++;
+      if (failCalls.has(callCount)) {
+        throw new Error("simulated launch failure");
+      }
+      if (callCount === 5) {
+        await relaunchGate;
+      }
+      const b = makeFakeBrowser();
+      launched.push(b);
+      return b as unknown as Browser;
+    };
+    const { logger } = makeFakeLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    await pool.init();
+    expect(launched).toHaveLength(1);
+    const oldBrowser = launched[0]!;
+
+    // Crash the only browser. The disconnect-driven recycle relaunches, but
+    // calls 2..4 all fail, parking the slot relaunchPending. slot.browser is
+    // still oldBrowser (no successful swap), and the slot remains in
+    // this.slots — so a future disconnect for oldBrowser is still routed here.
+    oldBrowser.__crash();
+    await waitFor(() => pool.stats().size === 0, 3_000);
+
+    // Drive relaunchPendingSlots via an acquire(): it picks the pending slot,
+    // adds it to relaunchingSlots, and awaits the gated launch (call 5).
+    const acquirePromise = pool.acquire(5_000);
+    await drainMicrotasks(10);
+
+    // Now fire a LATE disconnect for the OLD browser while the relaunch is
+    // gated and the slot sits in relaunchingSlots (but NOT recyclingSlots).
+    // `__crash` already fired once and no-ops now, so re-fire the event
+    // directly to model the delayed delivery. Without the cross-set guard this
+    // re-enters recycleSlot and launches a second browser; with isSlotBusy it
+    // is a no-op (slot.browser is still oldBrowser, so handler guards pass).
+    oldBrowser.__fireDisconnectLate();
+    await drainMicrotasks(10);
+
+    // Release the gated relaunch; the single fresh browser is delivered.
+    releaseRelaunch!();
+    const acquired = await acquirePromise;
+    expect(acquired).toBeDefined();
+    expect((acquired as unknown as FakeBrowser).isConnected()).toBe(true);
+
+    // Let any erroneously-spawned second recycle settle so a leak would show.
+    await drainMicrotasks(20);
+
+    // Exactly ONE fresh browser beyond init — the late disconnect did not
+    // launch a second. No leaked process, no double-publish.
+    const freshBeyondInit = launched.slice(1);
+    expect(freshBeyondInit.length).toBe(1);
+    expect((acquired as unknown as FakeBrowser).__id).toBe(
+      freshBeyondInit[0]!.__id,
+    );
+    expect(pool.stats().available).toBeLessThanOrEqual(1);
+    expect(pool.stats().size).toBe(1);
+
+    await pool.shutdown();
   });
 
   it("shutdown() does not loop the disconnect handler when closing slot browsers", async () => {

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -596,6 +596,110 @@ describe("BrowserPool dead-instance detection", () => {
     await pool.shutdown();
   });
 
+  it("launches exactly one fresh browser per slot when two pending slots are recovered by two concurrent relaunchPendingSlots invocations", async () => {
+    // Bug #1 guard (multi-slot reachable double-launch). relaunchPendingSlots
+    // snapshots `pending` ONCE then loops. With >=2 pending slots and two
+    // concurrent acquire()-driven invocations:
+    //   - invocation 1 snapshots [A, B], processes A (adds A to
+    //     relaunchingSlots, awaits A's gated launch);
+    //   - invocation 2 starts during that await, snapshots [B] (A is now
+    //     busy), claims B and relaunches it;
+    //   - invocation 1's A launch resolves; its loop advances to B and — with
+    //     NO in-loop re-check — re-adds B and launches a SECOND browser for B,
+    //     overwriting slot.browser (leaking the first) and double-publishing.
+    // The in-loop `if (this.isSlotBusy(slot) || !slot.relaunchPending)
+    // continue;` makes invocation 1 skip B, so EXACTLY ONE fresh browser is
+    // launched per slot.
+    //
+    // Deterministic race: gate every recovery launch (calls 9+) so we can
+    // interleave the two invocations precisely.
+    const launched: FakeBrowser[] = [];
+    let callCount = 0;
+    // One resolver per gated recovery launch; we release them in order.
+    const gateResolvers: Array<() => void> = [];
+    const gateFor = (): Promise<void> =>
+      new Promise<void>((resolve) => {
+        gateResolvers.push(resolve);
+      });
+    // init = calls 1,2; the two slots' immediate recycle retries
+    // (RELAUNCH_MAX_ATTEMPTS=3 each) = calls 3..8, all fail to park both slots.
+    // Recovery relaunches are calls 9 and 10, both gated.
+    const failCalls = new Set([3, 4, 5, 6, 7, 8]);
+    const launchBrowser: LaunchBrowser = async () => {
+      callCount++;
+      if (failCalls.has(callCount)) {
+        throw new Error("simulated launch failure");
+      }
+      if (callCount >= 9) {
+        await gateFor();
+      }
+      const b = makeFakeBrowser();
+      launched.push(b);
+      return b as unknown as Browser;
+    };
+    const { logger } = makeFakeLogger();
+    const pool = new BrowserPool(2, 100, logger, launchBrowser);
+    await pool.init();
+    expect(launched).toHaveLength(2);
+
+    // Park BOTH slots as relaunchPending: crash both, let all immediate
+    // retries (calls 3..8) exhaust. Live capacity drops to 0 while both slots
+    // stay in this.slots.
+    launched[0]!.__crash();
+    launched[1]!.__crash();
+    await waitFor(() => pool.stats().size === 0, 5_000);
+    expect(pool.stats().size).toBe(0);
+
+    // Drive two concurrent relaunchPendingSlots invocations via two acquire()s.
+    const a = pool.acquire(5_000);
+    const b = pool.acquire(5_000);
+
+    // Let both invocations run up to their first gated launch. Invocation 1
+    // snapshots [slotA, slotB], claims slotA, awaits its launch (call 9).
+    // Invocation 2 then snapshots [slotB] (slotA busy), claims slotB, awaits
+    // its launch (call 10). Wait until BOTH gated launches are pending.
+    await waitFor(() => gateResolvers.length >= 2, 3_000);
+
+    // Release both gated launches. Invocation 1's slotA launch (call 9) and
+    // invocation 2's slotB launch (call 10) resolve. Invocation 1's loop then
+    // advances to slotB: WITHOUT the in-loop guard it would launch a SECOND
+    // browser for slotB (a 3rd gated launch, call 11). WITH the guard it skips
+    // slotB (now busy / no longer pending).
+    gateResolvers[0]!();
+    gateResolvers[1]!();
+    await drainMicrotasks(30);
+
+    // Give any erroneous third launch a chance to register its gate so a leak
+    // would surface as a 3rd pending resolver.
+    await drainMicrotasks(30);
+
+    const first = await Promise.race([a, b]);
+    expect(first).toBeDefined();
+    expect((first as unknown as FakeBrowser).isConnected()).toBe(true);
+
+    // Exactly two fresh browsers beyond init — one per slot, no leaked
+    // double-launch for the contended slot. (A third gated launch from the
+    // unguarded re-entry would still be parked on its gate and not yet in
+    // `launched`, so additionally assert no 3rd gate was ever requested.)
+    const freshBeyondInit = launched.slice(2);
+    expect(freshBeyondInit.length).toBe(2);
+    expect(gateResolvers.length).toBe(2);
+
+    // Pin exact-once: both acquirers are served by the two fresh launches, and
+    // each fresh browser maps to a distinct slot (no slot.browser overwrite).
+    const both = await Promise.all([a, b]);
+    const servedIds = both.map((br) => (br as unknown as FakeBrowser).__id);
+    const freshIds = freshBeyondInit.map((br) => br.__id);
+    expect(new Set(servedIds)).toEqual(new Set(freshIds));
+
+    // Two live slots recovered, never double-published into available.
+    expect(pool.stats().size).toBe(2);
+    expect(pool.stats().available).toBeLessThanOrEqual(2);
+
+    await pool.shutdown();
+    await Promise.allSettled([a, b]);
+  });
+
   it("shutdown() does not loop the disconnect handler when closing slot browsers", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
     const { logger, events } = makeFakeLogger();

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { Browser } from "playwright";
-import { BrowserPool, type LaunchBrowser } from "./browser-pool.js";
+import { BrowserPool } from "./browser-pool.js";
+import type { LaunchBrowser } from "./browser-pool.js";
 
 /**
  * Minimal `Browser` stand-in that exposes the surface BrowserPool actually
@@ -74,12 +75,18 @@ interface FakeLauncher {
   launched: FakeBrowser[];
 }
 
-function makeFakeLauncher(opts?: { failAt?: number }): FakeLauncher {
+function makeFakeLauncher(opts?: {
+  failAt?: number;
+  failAtCalls?: number[];
+}): FakeLauncher {
   const launched: FakeBrowser[] = [];
   let callCount = 0;
   const launchBrowser = async (): Promise<Browser> => {
     callCount++;
-    if (opts?.failAt !== undefined && callCount === opts.failAt) {
+    if (
+      (opts?.failAt !== undefined && callCount === opts.failAt) ||
+      opts?.failAtCalls?.includes(callCount)
+    ) {
       throw new Error("simulated launch failure");
     }
     const b = makeFakeBrowser();
@@ -256,6 +263,63 @@ describe("BrowserPool dead-instance detection", () => {
     const next = await pool.acquire();
     expect(next).toBe(launched[1] as unknown as Browser);
     expect((next as unknown as FakeBrowser).isConnected()).toBe(true);
+
+    await pool.shutdown();
+  });
+
+  it("recovers after a transient relaunch failure instead of permanently shrinking the pool to 0", async () => {
+    // Single-slot pool. The browser crashes; the recycle's relaunch fails
+    // ONCE (the 2nd launch call), then a subsequent launch succeeds. The
+    // pool must NOT permanently evict the slot — it must keep capacity and
+    // self-heal so a later acquire() still returns a live browser.
+    const { launchBrowser, launched } = makeFakeLauncher({ failAtCalls: [2] });
+    const { logger } = makeFakeLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    await pool.init();
+    expect(launched).toHaveLength(1);
+
+    // Crash the only browser. The disconnect-driven recycle relaunches, but
+    // launch #2 throws (the simulated transient failure).
+    launched[0]!.__crash();
+    await drainMicrotasks(30);
+
+    // BUG: the old code spliced the slot out of `this.slots` on launch
+    // failure, leaving size 0 forever. The pool must instead retain or
+    // re-create the slot so capacity recovers.
+    const acquired = await pool.acquire(5_000);
+    expect(acquired).toBeDefined();
+    expect((acquired as unknown as FakeBrowser).isConnected()).toBe(true);
+
+    // Pool reports non-zero size again — it healed rather than draining.
+    expect(pool.stats().size).toBeGreaterThan(0);
+
+    await pool.shutdown();
+  });
+
+  it("re-initializes the pool when every slot has been lost (size reaches 0)", async () => {
+    // 2-slot pool. Both browsers crash and BOTH relaunches fail (launch
+    // calls 3 and 4), driving the pool to size 0. The next acquire() must
+    // trigger a backstop re-init rather than hanging until timeout.
+    const { launchBrowser, launched } = makeFakeLauncher({
+      failAtCalls: [3, 4],
+    });
+    const { logger } = makeFakeLogger();
+    const pool = new BrowserPool(2, 100, logger, launchBrowser);
+    await pool.init();
+    expect(launched).toHaveLength(2);
+
+    launched[0]!.__crash();
+    launched[1]!.__crash();
+    await drainMicrotasks(30);
+
+    // Both relaunches failed — without a backstop the pool is permanently
+    // empty and every future acquire() times out. With the fix, acquire()
+    // re-initializes the pool (launch calls 5+ succeed) and hands back a
+    // live browser.
+    const acquired = await pool.acquire(5_000);
+    expect(acquired).toBeDefined();
+    expect((acquired as unknown as FakeBrowser).isConnected()).toBe(true);
+    expect(pool.stats().size).toBeGreaterThan(0);
 
     await pool.shutdown();
   });

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -279,6 +279,17 @@ export class BrowserPool {
     );
     for (const slot of pending) {
       if (this.isShutdown) return;
+      // Re-validate against the once-captured `pending` snapshot before
+      // claiming the slot. A concurrent invocation (a second acquire()-driven
+      // relaunch, or a late `disconnected` re-entering recycleSlot) may have
+      // claimed this slot (isSlotBusy) or already recovered it
+      // (relaunchPending cleared) during a prior iteration's `await`. Without
+      // this check-then-set — with NO `await` between the check and the
+      // `add` — both invocations would launch a fresh browser for the same
+      // slot, the second overwriting `slot.browser` (leaking the first
+      // process) and double-publishing via handOff. Mirrors recycleSlot's
+      // `if (this.isSlotBusy(slot)) return;` guard.
+      if (this.isSlotBusy(slot) || !slot.relaunchPending) continue;
       // Mark before the await so a concurrent invocation skips this slot.
       this.relaunchingSlots.add(slot);
       try {
@@ -503,6 +514,14 @@ export class BrowserPool {
   }
 
   private recycleSlot(slot: Slot): void {
+    // Gate entry on shutdown so a late recycle cannot register a fresh promise
+    // in `inFlightRecycles` AFTER shutdown() snapshotted that set via
+    // `Array.from`, which would let its fresh browser escape the drain. The
+    // disconnect handler already checks isShutdown, but recycleSlot has other
+    // entry points (acquire()'s zombie scan, release()'s dead-slot check), so
+    // harden the function itself. Matches the isShutdown gating reinit() and
+    // relaunchPendingSlots() already do at their entry points.
+    if (this.isShutdown) return;
     // Re-entry guard: a second call for the same slot is a no-op. This must
     // honor BOTH recovery sets (via isSlotBusy), not just recyclingSlots — a
     // slot parked relaunchPending still holds its OLD dead browser in
@@ -597,9 +616,21 @@ export class BrowserPool {
     })();
 
     this.inFlightRecycles.add(recyclePromise);
-    recyclePromise.finally(() => {
-      this.recyclingSlots.delete(slot);
-      this.inFlightRecycles.delete(recyclePromise);
-    });
+    // Absorb any throw with a logged `.catch` before the `.finally`, mirroring
+    // track(). The IIFE swallows its own launch errors today, but a future
+    // synchronous throw (e.g. handOff/attachDisconnectHandler/browserToSlot.set)
+    // must stay contained — a recycle failing is non-fatal to the pool and must
+    // never surface as an unhandled rejection.
+    recyclePromise
+      .catch((err: unknown) => {
+        this.logger?.info("browser-pool.recycle-failed", {
+          slotIndex: this.slots.indexOf(slot),
+          error: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        this.recyclingSlots.delete(slot);
+        this.inFlightRecycles.delete(recyclePromise);
+      });
   }
 }

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -3,6 +3,29 @@ import type { Browser } from "playwright";
 interface Slot {
   browser: Browser;
   contextCount: number;
+  /**
+   * True when this slot's last relaunch attempt failed and the slot is
+   * currently holding a dead browser. A pending slot is kept in
+   * `this.slots` (so capacity is not permanently lost) but is NOT placed
+   * in `available` — `acquire()` lazily re-launches it on demand.
+   */
+  relaunchPending?: boolean;
+}
+
+/**
+ * Number of immediate relaunch attempts (with backoff between them) a
+ * recycle makes before giving up and leaving the slot in the
+ * `relaunchPending` state for a later lazy retry. A single transient
+ * chromium launch failure (OOM spike, fd exhaustion) must not
+ * permanently shrink the pool, so we retry rather than evict.
+ */
+const RELAUNCH_MAX_ATTEMPTS = 3;
+
+/** Base backoff between relaunch attempts; doubles each attempt. */
+const RELAUNCH_BACKOFF_BASE_MS = 250;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 interface Waiter {
@@ -96,9 +119,99 @@ export class BrowserPool {
   // Assigned during init() after the dynamic import resolves.
   private launchBrowser!: LaunchBrowser;
 
+  /**
+   * Backstop re-initialization. Called from `acquire()` when the pool has
+   * drained to zero slots. Re-launches up to `poolSize` browsers, tolerating
+   * partial failure — even one fresh slot lets a waiting probe proceed. A
+   * total failure here surfaces to the caller via the normal acquire
+   * timeout / waiter-reject path rather than wedging the pool forever.
+   */
+  private async reinit(): Promise<void> {
+    if (this.isShutdown || this.launchBrowser === undefined) return;
+    this.logger?.info("browser-pool.reinit", { poolSize: this.poolSize });
+    for (
+      let i = 0;
+      i < this.poolSize && this.slots.length < this.poolSize;
+      i++
+    ) {
+      try {
+        const browser = await this.launchBrowser();
+        if (this.isShutdown) {
+          await browser.close().catch(() => {});
+          return;
+        }
+        const slot: Slot = { browser, contextCount: 0 };
+        this.slots.push(slot);
+        this.browserToSlot.set(browser, slot);
+        this.attachDisconnectHandler(slot, browser);
+        const waiter = this.waiters.shift();
+        if (waiter) {
+          waiter.resolve(browser);
+        } else {
+          this.available.push(slot);
+        }
+      } catch (err) {
+        // Best effort — keep trying the remaining slots. If none succeed
+        // the pool stays empty and the next acquire retries reinit.
+        console.error("[BrowserPool] reinit launch failed:", err);
+      }
+    }
+  }
+
+  /**
+   * Re-attempt the launch for every slot parked as `relaunchPending`. Each
+   * such slot was retained (not evicted) after a failed recycle so capacity
+   * is preserved; here we lazily replace its dead browser with a fresh one.
+   * A still-failing launch leaves the slot pending for the next acquire.
+   */
+  private async relaunchPendingSlots(): Promise<void> {
+    if (this.isShutdown) return;
+    const pending = this.slots.filter((s) => s.relaunchPending);
+    for (const slot of pending) {
+      if (this.isShutdown) return;
+      try {
+        const fresh = await this.launchBrowser();
+        if (this.isShutdown) {
+          await fresh.close().catch(() => {});
+          return;
+        }
+        this.browserToSlot.delete(slot.browser);
+        slot.browser = fresh;
+        slot.contextCount = 0;
+        slot.relaunchPending = false;
+        this.browserToSlot.set(fresh, slot);
+        this.attachDisconnectHandler(slot, fresh);
+        if (!this.available.includes(slot)) {
+          this.available.push(slot);
+        }
+        this.logger?.info("browser-pool.relaunch-recovered", {
+          slotIndex: this.slots.indexOf(slot),
+        });
+      } catch (err) {
+        // Still failing — leave it pending for the next acquire to retry.
+        console.error("[BrowserPool] pending-slot relaunch failed:", err);
+      }
+    }
+  }
+
   async acquire(timeoutMs = 30_000): Promise<Browser> {
     if (this.isShutdown) {
       throw new Error("BrowserPool is shut down");
+    }
+
+    // Backstop: if every slot has been lost (e.g. a burst of crashes whose
+    // relaunches all failed), the pool would otherwise be permanently empty
+    // and every acquire would time out. Re-initialize from scratch so the
+    // pool self-heals instead of draining to nothing.
+    if (this.slots.length === 0) {
+      await this.reinit();
+    } else {
+      // Lazily relaunch any slot whose last relaunch failed. This is the
+      // recovery path for a transient launch failure: the slot was kept
+      // (capacity preserved) but parked as `relaunchPending`; the next
+      // acquire re-attempts the launch before falling through to the
+      // normal available-slot scan.
+      await this.relaunchPendingSlots();
     }
 
     // Skip zombie slots whose browser has disconnected but whose disconnect
@@ -289,49 +402,67 @@ export class BrowserPool {
 
       if (this.isShutdown) return;
 
-      try {
-        const fresh = await this.launchBrowser();
+      // Retry the relaunch a bounded number of times with backoff. A single
+      // transient launch failure (OOM spike, fd exhaustion) must NOT
+      // permanently shrink the pool — the old code spliced the slot out on
+      // the first failure, so one bad launch monotonically drained the pool
+      // to empty and it never self-healed.
+      let lastErr: unknown;
+      for (let attempt = 1; attempt <= RELAUNCH_MAX_ATTEMPTS; attempt++) {
+        if (this.isShutdown) return;
+        try {
+          const fresh = await this.launchBrowser();
 
-        if (this.isShutdown) {
-          // Shutdown was initiated while we were launching. Close the
-          // fresh browser and don't hand it to anyone.
-          await fresh.close().catch(() => {});
+          if (this.isShutdown) {
+            // Shutdown was initiated while we were launching. Close the
+            // fresh browser and don't hand it to anyone.
+            await fresh.close().catch(() => {});
+            return;
+          }
+
+          slot.browser = fresh;
+          slot.contextCount = 0;
+          slot.relaunchPending = false;
+          this.browserToSlot.set(fresh, slot);
+          this.attachDisconnectHandler(slot, fresh);
+
+          const waiter = this.waiters.shift();
+          if (waiter) {
+            waiter.resolve(fresh);
+          } else {
+            this.available.push(slot);
+          }
           return;
-        }
-
-        slot.browser = fresh;
-        slot.contextCount = 0;
-        this.browserToSlot.set(fresh, slot);
-        this.attachDisconnectHandler(slot, fresh);
-
-        const waiter = this.waiters.shift();
-        if (waiter) {
-          waiter.resolve(fresh);
-        } else {
-          this.available.push(slot);
-        }
-      } catch (err) {
-        // Launch failed — remove this slot from the pool entirely so
-        // stats reflect the reduced capacity.
-        const idx = this.slots.indexOf(slot);
-        if (idx !== -1) {
-          this.slots.splice(idx, 1);
-        }
-        console.error(
-          `[BrowserPool] recycleSlot launch failed (slot ${idx}, pool size now ${this.slots.length}):`,
-          err,
-        );
-
-        // If pool is completely exhausted with waiters pending, reject
-        // them all — no remaining slots can ever serve them.
-        if (this.slots.length === 0 && this.waiters.length > 0) {
-          const stale = this.waiters.splice(0);
-          for (const w of stale) {
-            w.reject(
-              new Error("BrowserPool exhausted: all slots failed to launch"),
-            );
+        } catch (err) {
+          lastErr = err;
+          if (attempt < RELAUNCH_MAX_ATTEMPTS) {
+            await delay(RELAUNCH_BACKOFF_BASE_MS * 2 ** (attempt - 1));
           }
         }
+      }
+
+      // All immediate retries failed. Do NOT evict the slot — keep it in
+      // `this.slots` so capacity is preserved and park it as
+      // `relaunchPending`. The next `acquire()` lazily re-attempts the
+      // launch (see relaunchPendingSlots), and the empty-pool backstop in
+      // acquire() re-initializes if every slot ends up pending/lost.
+      slot.relaunchPending = true;
+      console.error(
+        `[BrowserPool] recycleSlot relaunch failed after ${RELAUNCH_MAX_ATTEMPTS} attempts ` +
+          `(slot ${this.slots.indexOf(slot)} parked for lazy retry, pool size ${this.slots.length}):`,
+        lastErr,
+      );
+
+      // A waiter may already be queued (an acquire() that found no live
+      // slot returned a pending promise). Nothing else will wake it, so
+      // schedule a deferred relaunch attempt to serve pending waiters
+      // rather than leaving them to time out. Best-effort and outside the
+      // current recycle promise so it doesn't block shutdown's drain.
+      if (this.waiters.length > 0 && !this.isShutdown) {
+        setTimeout(() => {
+          if (this.isShutdown || this.waiters.length === 0) return;
+          void this.relaunchPendingSlots();
+        }, RELAUNCH_BACKOFF_BASE_MS);
       }
     })();
 

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -24,14 +24,6 @@ const RELAUNCH_MAX_ATTEMPTS = 3;
 /** Base backoff between relaunch attempts; doubles each attempt. */
 const RELAUNCH_BACKOFF_BASE_MS = 250;
 
-/**
- * Upper bound for the deferred-relaunch backoff. The deferred path keeps
- * retrying (not one-shot) while pending slots and queued waiters coexist, so
- * the backoff is capped to avoid an unbounded delay between attempts while a
- * waiter is stranded.
- */
-const RELAUNCH_BACKOFF_MAX_MS = 5_000;
-
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -76,16 +68,11 @@ export class BrowserPool {
   private recyclingSlots = new Set<Slot>();
   // Re-entry guard for the relaunchPending recovery path. A slot is marked
   // here while its lazy relaunch is in flight so two concurrent invocations
-  // (an acquire()-driven call racing the deferred timer) cannot both launch
-  // a browser for the same slot — which would leak one process and/or
-  // publish the slot to `available` twice.
+  // (an acquire()-driven relaunch racing a late `disconnected` fire that
+  // re-enters recycleSlot for the same slot) cannot both launch a browser for
+  // the same slot — which would leak one process and/or publish the slot to
+  // `available` twice.
   private relaunchingSlots = new Set<Slot>();
-  // True while a deferred-relaunch timer loop is live. The loop can be
-  // (re)started from two places — recycleSlot (when all immediate retries
-  // fail with a waiter queued) and acquire() (when a waiter parks while a
-  // slot is still pending). This boolean makes scheduling idempotent so the
-  // two kick sites can never spawn two concurrent timer loops.
-  private deferredRelaunchActive = false;
   private isShutdown = false;
   private readonly logger?: PoolLogger;
   private readonly injectedLaunchBrowser?: LaunchBrowser;
@@ -270,15 +257,16 @@ export class BrowserPool {
    * is preserved; here we lazily replace its dead browser with a fresh one.
    * A still-failing launch leaves the slot pending for the next acquire.
    *
-   * Two concerns this method must own (the deferred timer in recycleSlot and
-   * an acquire()-driven call can run concurrently):
+   * Two concerns this method must own (a late `disconnected` fire for a
+   * pending slot's OLD browser can re-enter `recycleSlot` while an
+   * acquire()-driven call is relaunching the same slot):
    *   - Re-entry: `relaunchingSlots` marks a slot before its `await` so a
    *     racing invocation skips it — otherwise both launch a browser, the
    *     second overwrites `slot.browser` (leaking the first) and/or the slot
    *     is handed to two acquirers.
    *   - Handoff: a fresh browser is delivered to a queued waiter first
-   *     (`handOff`) so the recycle's deferred relaunch actually serves the
-   *     waiter that scheduled it, instead of only pushing to `available`.
+   *     (`handOff`) so the relaunch actually serves the waiter parked by the
+   *     acquire that drove it, instead of only pushing to `available`.
    */
   private async relaunchPendingSlots(): Promise<void> {
     if (this.isShutdown) return;
@@ -319,68 +307,6 @@ export class BrowserPool {
         this.relaunchingSlots.delete(slot);
       }
     }
-  }
-
-  /**
-   * Self-rescheduling deferred relaunch. Re-attempts `relaunchPendingSlots`
-   * with bounded exponential backoff and reschedules itself as long as a
-   * waiter is still parked AND a pending slot remains to serve it. This
-   * replaces the old one-shot timer, which stranded the waiter for its full
-   * acquire timeout if the single deferred attempt also failed.
-   *
-   * Two kick sites drive this loop and must not spawn duplicate timers:
-   *   - `recycleSlot` kicks it the moment all immediate relaunch attempts
-   *     fail with a waiter already queued.
-   *   - `acquire()` kicks it when a waiter parks AFTER a recycle has already
-   *     failed (the recycle's own `scheduleDeferredRelaunch(1)` early-returned
-   *     because no waiter was queued at that instant; nothing else re-arms the
-   *     loop, so that waiter would hang to its acquire timeout).
-   *
-   * The `deferredRelaunchActive` boolean makes scheduling idempotent: it is
-   * set when a loop is armed and cleared only when the loop stops (shutdown,
-   * no waiters, or no pending slot), so the two kick sites can never run two
-   * concurrent timer loops. Stops on shutdown, when no waiters remain, or when
-   * no slot is still pending.
-   */
-  private scheduleDeferredRelaunch(attempt: number): void {
-    if (this.isShutdown || this.waiters.length === 0) return;
-    if (!this.slots.some((s) => s.relaunchPending)) return;
-    // Idempotent guard: a loop is already armed, so the existing timer will
-    // reschedule itself — do not start a second one.
-    if (this.deferredRelaunchActive) return;
-    this.deferredRelaunchActive = true;
-    this.runDeferredRelaunch(attempt);
-  }
-
-  /** Arm a single backoff timer for the active deferred-relaunch loop. */
-  private runDeferredRelaunch(attempt: number): void {
-    const backoff = Math.min(
-      RELAUNCH_BACKOFF_BASE_MS * 2 ** (attempt - 1),
-      RELAUNCH_BACKOFF_MAX_MS,
-    );
-    setTimeout(() => {
-      if (
-        this.isShutdown ||
-        this.waiters.length === 0 ||
-        !this.slots.some((s) => s.relaunchPending)
-      ) {
-        this.deferredRelaunchActive = false;
-        return;
-      }
-      void this.relaunchPendingSlots().finally(() => {
-        // Reschedule only if a waiter is still unserved and a pending slot
-        // remains — otherwise recovery is done or there is nothing to retry.
-        if (
-          !this.isShutdown &&
-          this.waiters.length > 0 &&
-          this.slots.some((s) => s.relaunchPending)
-        ) {
-          this.runDeferredRelaunch(attempt + 1);
-        } else {
-          this.deferredRelaunchActive = false;
-        }
-      });
-    }, backoff);
   }
 
   async acquire(timeoutMs = 30_000): Promise<Browser> {
@@ -450,22 +376,13 @@ export class BrowserPool {
 
       this.waiters.push(waiter);
 
-      // Re-arm the deferred relaunch if this waiter parked AFTER a recycle had
-      // already failed. A recycle triggered by a `disconnected` event or a
-      // zombie-skip can fully exhaust its immediate retries with NO waiter
-      // queued — its own `scheduleDeferredRelaunch(1)` early-returns because
-      // `this.waiters` was empty at that instant. This acquire then parks its
-      // waiter a moment later (the push happens AFTER the synchronous zombie
-      // loop above), and nothing else re-arms the loop, so the waiter would
-      // hang to its acquire timeout even though a pending slot is recoverable.
-      // The idempotent guard inside scheduleDeferredRelaunch ensures this kick
-      // and the recycle-kick can't spawn two concurrent timer loops.
-      if (
-        this.relaunchingSlots.size > 0 ||
-        this.slots.some((s) => s.relaunchPending)
-      ) {
-        this.scheduleDeferredRelaunch(1);
-      }
+      // No timer re-arms recovery here. A parked waiter is served by the next
+      // acquire()/release()-driven relaunch: the harness probes continuously,
+      // so a fresh probe tick drives `relaunchPendingSlots()` (via acquire) or
+      // `handOff` (via release) and serves this waiter. In the degenerate idle
+      // case the waiter hits its bounded `timeoutMs` and the caller retries on
+      // the next tick — the no-eviction + lazy-recovery design already prevents
+      // the pool from draining permanently to 0.
     });
   }
 
@@ -551,7 +468,9 @@ export class BrowserPool {
     return {
       size: liveSlots.length,
       available: availableCount,
-      inUse: liveSlots.length - availableCount,
+      // Clamp to 0 so a future invariant break (availableCount exceeding
+      // liveSlots.length) can never surface as a negative gauge.
+      inUse: Math.max(0, liveSlots.length - availableCount),
       totalRecycles: this.totalRecycles,
     };
   }
@@ -670,12 +589,11 @@ export class BrowserPool {
         error: lastErr instanceof Error ? lastErr.message : String(lastErr),
       });
 
-      // A waiter may already be queued (an acquire() that found no live slot
-      // returned a pending promise). Nothing else will wake it, so kick off a
-      // self-rescheduling deferred relaunch that keeps retrying with bounded
-      // backoff while pending slots AND waiters coexist — a one-shot attempt
-      // would strand the waiter if that single retry also failed.
-      this.scheduleDeferredRelaunch(1);
+      // Leave the slot parked as `relaunchPending` — no timer kick. The next
+      // `acquire()` re-attempts the launch via `relaunchPendingSlots()` and a
+      // release-driven recycle recovers via `handOff`, so a queued waiter is
+      // served by the next probe tick (or, in the degenerate idle case, the
+      // caller retries after the waiter's bounded acquire timeout).
     })();
 
     this.inFlightRecycles.add(recyclePromise);

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -80,6 +80,12 @@ export class BrowserPool {
   // a browser for the same slot — which would leak one process and/or
   // publish the slot to `available` twice.
   private relaunchingSlots = new Set<Slot>();
+  // True while a deferred-relaunch timer loop is live. The loop can be
+  // (re)started from two places — recycleSlot (when all immediate retries
+  // fail with a waiter queued) and acquire() (when a waiter parks while a
+  // slot is still pending). This boolean makes scheduling idempotent so the
+  // two kick sites can never spawn two concurrent timer loops.
+  private deferredRelaunchActive = false;
   private isShutdown = false;
   private readonly logger?: PoolLogger;
   private readonly injectedLaunchBrowser?: LaunchBrowser;
@@ -245,6 +251,20 @@ export class BrowserPool {
   }
 
   /**
+   * A slot is "busy" while either recovery path owns it: `recycleSlot` (which
+   * tracks via `recyclingSlots`) or `relaunchPendingSlotsInner` (which tracks
+   * via `relaunchingSlots`). The two sets guard disjoint entry points, so each
+   * entry point must consult BOTH — otherwise a late `disconnected` fire for a
+   * pending slot's OLD browser would re-enter `recycleSlot` while
+   * `relaunchPendingSlots` is concurrently relaunching the same slot, and both
+   * would launch a fresh browser (the second swap overwrites `slot.browser`,
+   * leaking the first process and/or double-publishing the slot).
+   */
+  private isSlotBusy(slot: Slot): boolean {
+    return this.recyclingSlots.has(slot) || this.relaunchingSlots.has(slot);
+  }
+
+  /**
    * Re-attempt the launch for every slot parked as `relaunchPending`. Each
    * such slot was retained (not evicted) after a failed recycle so capacity
    * is preserved; here we lazily replace its dead browser with a fresh one.
@@ -267,7 +287,7 @@ export class BrowserPool {
 
   private async relaunchPendingSlotsInner(): Promise<void> {
     const pending = this.slots.filter(
-      (s) => s.relaunchPending && !this.relaunchingSlots.has(s),
+      (s) => s.relaunchPending && !this.isSlotBusy(s),
     );
     for (const slot of pending) {
       if (this.isShutdown) return;
@@ -302,23 +322,51 @@ export class BrowserPool {
   }
 
   /**
-   * Self-rescheduling deferred relaunch. A failed recycle schedules this when
-   * a waiter is already queued; it re-attempts `relaunchPendingSlots` with
-   * bounded exponential backoff and reschedules itself as long as a waiter is
-   * still parked AND a pending slot remains to serve it. This replaces the
-   * old one-shot timer, which stranded the waiter for its full acquire
-   * timeout if the single deferred attempt also failed. Stops on shutdown,
-   * when no waiters remain, or when no slot is still pending.
+   * Self-rescheduling deferred relaunch. Re-attempts `relaunchPendingSlots`
+   * with bounded exponential backoff and reschedules itself as long as a
+   * waiter is still parked AND a pending slot remains to serve it. This
+   * replaces the old one-shot timer, which stranded the waiter for its full
+   * acquire timeout if the single deferred attempt also failed.
+   *
+   * Two kick sites drive this loop and must not spawn duplicate timers:
+   *   - `recycleSlot` kicks it the moment all immediate relaunch attempts
+   *     fail with a waiter already queued.
+   *   - `acquire()` kicks it when a waiter parks AFTER a recycle has already
+   *     failed (the recycle's own `scheduleDeferredRelaunch(1)` early-returned
+   *     because no waiter was queued at that instant; nothing else re-arms the
+   *     loop, so that waiter would hang to its acquire timeout).
+   *
+   * The `deferredRelaunchActive` boolean makes scheduling idempotent: it is
+   * set when a loop is armed and cleared only when the loop stops (shutdown,
+   * no waiters, or no pending slot), so the two kick sites can never run two
+   * concurrent timer loops. Stops on shutdown, when no waiters remain, or when
+   * no slot is still pending.
    */
   private scheduleDeferredRelaunch(attempt: number): void {
     if (this.isShutdown || this.waiters.length === 0) return;
+    if (!this.slots.some((s) => s.relaunchPending)) return;
+    // Idempotent guard: a loop is already armed, so the existing timer will
+    // reschedule itself — do not start a second one.
+    if (this.deferredRelaunchActive) return;
+    this.deferredRelaunchActive = true;
+    this.runDeferredRelaunch(attempt);
+  }
+
+  /** Arm a single backoff timer for the active deferred-relaunch loop. */
+  private runDeferredRelaunch(attempt: number): void {
     const backoff = Math.min(
       RELAUNCH_BACKOFF_BASE_MS * 2 ** (attempt - 1),
       RELAUNCH_BACKOFF_MAX_MS,
     );
     setTimeout(() => {
-      if (this.isShutdown || this.waiters.length === 0) return;
-      if (!this.slots.some((s) => s.relaunchPending)) return;
+      if (
+        this.isShutdown ||
+        this.waiters.length === 0 ||
+        !this.slots.some((s) => s.relaunchPending)
+      ) {
+        this.deferredRelaunchActive = false;
+        return;
+      }
       void this.relaunchPendingSlots().finally(() => {
         // Reschedule only if a waiter is still unserved and a pending slot
         // remains — otherwise recovery is done or there is nothing to retry.
@@ -327,7 +375,9 @@ export class BrowserPool {
           this.waiters.length > 0 &&
           this.slots.some((s) => s.relaunchPending)
         ) {
-          this.scheduleDeferredRelaunch(attempt + 1);
+          this.runDeferredRelaunch(attempt + 1);
+        } else {
+          this.deferredRelaunchActive = false;
         }
       });
     }, backoff);
@@ -399,6 +449,23 @@ export class BrowserPool {
       };
 
       this.waiters.push(waiter);
+
+      // Re-arm the deferred relaunch if this waiter parked AFTER a recycle had
+      // already failed. A recycle triggered by a `disconnected` event or a
+      // zombie-skip can fully exhaust its immediate retries with NO waiter
+      // queued — its own `scheduleDeferredRelaunch(1)` early-returns because
+      // `this.waiters` was empty at that instant. This acquire then parks its
+      // waiter a moment later (the push happens AFTER the synchronous zombie
+      // loop above), and nothing else re-arms the loop, so the waiter would
+      // hang to its acquire timeout even though a pending slot is recoverable.
+      // The idempotent guard inside scheduleDeferredRelaunch ensures this kick
+      // and the recycle-kick can't spawn two concurrent timer loops.
+      if (
+        this.relaunchingSlots.size > 0 ||
+        this.slots.some((s) => s.relaunchPending)
+      ) {
+        this.scheduleDeferredRelaunch(1);
+      }
     });
   }
 
@@ -517,12 +584,16 @@ export class BrowserPool {
   }
 
   private recycleSlot(slot: Slot): void {
-    // Re-entry guard: a second call for the same slot (e.g. zombie-skip in
-    // acquire() racing the disconnect handler) is a no-op. Without this,
-    // both call sites would launch a fresh browser and the second would
-    // overwrite `slot.browser` while the first's relaunch was still in
-    // flight, leaking one browser process.
-    if (this.recyclingSlots.has(slot)) return;
+    // Re-entry guard: a second call for the same slot is a no-op. This must
+    // honor BOTH recovery sets (via isSlotBusy), not just recyclingSlots — a
+    // slot parked relaunchPending still holds its OLD dead browser in
+    // `slot.browser` and is still in `this.slots`, so a late `disconnected`
+    // fire for that old browser passes the handler's guards and reaches here
+    // while `relaunchPendingSlots` may already be relaunching the same slot.
+    // Without consulting relaunchingSlots, both would launch a fresh browser
+    // and the second swap would overwrite `slot.browser`, leaking one process
+    // and/or double-publishing the slot.
+    if (this.isSlotBusy(slot)) return;
     this.recyclingSlots.add(slot);
 
     this.totalRecycles++;

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -24,6 +24,14 @@ const RELAUNCH_MAX_ATTEMPTS = 3;
 /** Base backoff between relaunch attempts; doubles each attempt. */
 const RELAUNCH_BACKOFF_BASE_MS = 250;
 
+/**
+ * Upper bound for the deferred-relaunch backoff. The deferred path keeps
+ * retrying (not one-shot) while pending slots and queued waiters coexist, so
+ * the backoff is capped to avoid an unbounded delay between attempts while a
+ * waiter is stranded.
+ */
+const RELAUNCH_BACKOFF_MAX_MS = 5_000;
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -66,6 +74,12 @@ export class BrowserPool {
   private totalRecycles = 0;
   private inFlightRecycles = new Set<Promise<void>>();
   private recyclingSlots = new Set<Slot>();
+  // Re-entry guard for the relaunchPending recovery path. A slot is marked
+  // here while its lazy relaunch is in flight so two concurrent invocations
+  // (an acquire()-driven call racing the deferred timer) cannot both launch
+  // a browser for the same slot — which would leak one process and/or
+  // publish the slot to `available` twice.
+  private relaunchingSlots = new Set<Slot>();
   private isShutdown = false;
   private readonly logger?: PoolLogger;
   private readonly injectedLaunchBrowser?: LaunchBrowser;
@@ -120,6 +134,57 @@ export class BrowserPool {
   private launchBrowser!: LaunchBrowser;
 
   /**
+   * Single waiter-first handoff used by every slot-recovery path (reinit,
+   * recycle success, relaunchPendingSlots). A freshly launched browser must
+   * go to a queued waiter if one exists — otherwise the waiter is stranded
+   * until its acquire timeout while a live browser sits idle in `available`.
+   * Only when there is no waiter does the slot land in `available` (guarded
+   * by `includes` so a slot is never published twice).
+   */
+  private handOff(slot: Slot, browser: Browser): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter.resolve(browser);
+    } else if (!this.available.includes(slot)) {
+      this.available.push(slot);
+    }
+  }
+
+  /**
+   * Close a browser, routing any failure through the structured logger with
+   * the originating slot index instead of silently swallowing it. A close
+   * failure is non-fatal (the process may have already crashed) but must be
+   * visible to the harness log/Sentry pipeline.
+   */
+  private async closeBrowser(
+    browser: Browser,
+    slotIndex: number,
+  ): Promise<void> {
+    try {
+      await browser.close();
+    } catch (err) {
+      this.logger?.info("browser-pool.close-failed", {
+        slotIndex,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Track an in-flight recovery launch (reinit / relaunchPendingSlots) so
+   * `shutdown()` can drain it. Without this, a launch that resolves AFTER
+   * shutdown has awaited `inFlightRecycles` leaks a browser the pool never
+   * closes.
+   */
+  private track(promise: Promise<void>): Promise<void> {
+    this.inFlightRecycles.add(promise);
+    promise.finally(() => {
+      this.inFlightRecycles.delete(promise);
+    });
+    return promise;
+  }
+
+  /**
    * Backstop re-initialization. Called from `acquire()` when the pool has
    * drained to zero slots. Re-launches up to `poolSize` browsers, tolerating
    * partial failure — even one fresh slot lets a waiting probe proceed. A
@@ -128,6 +193,13 @@ export class BrowserPool {
    */
   private async reinit(): Promise<void> {
     if (this.isShutdown || this.launchBrowser === undefined) return;
+    // Track the whole reinit so a shutdown racing this launch loop drains it
+    // before closing slots, rather than leaking a browser that resolves after
+    // shutdown already awaited the in-flight set.
+    await this.track(this.reinitInner());
+  }
+
+  private async reinitInner(): Promise<void> {
     this.logger?.info("browser-pool.reinit", { poolSize: this.poolSize });
     for (
       let i = 0;
@@ -137,23 +209,20 @@ export class BrowserPool {
       try {
         const browser = await this.launchBrowser();
         if (this.isShutdown) {
-          await browser.close().catch(() => {});
+          await this.closeBrowser(browser, this.slots.length);
           return;
         }
         const slot: Slot = { browser, contextCount: 0 };
         this.slots.push(slot);
         this.browserToSlot.set(browser, slot);
         this.attachDisconnectHandler(slot, browser);
-        const waiter = this.waiters.shift();
-        if (waiter) {
-          waiter.resolve(browser);
-        } else {
-          this.available.push(slot);
-        }
+        this.handOff(slot, browser);
       } catch (err) {
         // Best effort — keep trying the remaining slots. If none succeed
         // the pool stays empty and the next acquire retries reinit.
-        console.error("[BrowserPool] reinit launch failed:", err);
+        this.logger?.info("browser-pool.reinit-failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
     }
   }
@@ -163,16 +232,34 @@ export class BrowserPool {
    * such slot was retained (not evicted) after a failed recycle so capacity
    * is preserved; here we lazily replace its dead browser with a fresh one.
    * A still-failing launch leaves the slot pending for the next acquire.
+   *
+   * Two concerns this method must own (the deferred timer in recycleSlot and
+   * an acquire()-driven call can run concurrently):
+   *   - Re-entry: `relaunchingSlots` marks a slot before its `await` so a
+   *     racing invocation skips it — otherwise both launch a browser, the
+   *     second overwrites `slot.browser` (leaking the first) and/or the slot
+   *     is handed to two acquirers.
+   *   - Handoff: a fresh browser is delivered to a queued waiter first
+   *     (`handOff`) so the recycle's deferred relaunch actually serves the
+   *     waiter that scheduled it, instead of only pushing to `available`.
    */
   private async relaunchPendingSlots(): Promise<void> {
     if (this.isShutdown) return;
-    const pending = this.slots.filter((s) => s.relaunchPending);
+    await this.track(this.relaunchPendingSlotsInner());
+  }
+
+  private async relaunchPendingSlotsInner(): Promise<void> {
+    const pending = this.slots.filter(
+      (s) => s.relaunchPending && !this.relaunchingSlots.has(s),
+    );
     for (const slot of pending) {
       if (this.isShutdown) return;
+      // Mark before the await so a concurrent invocation skips this slot.
+      this.relaunchingSlots.add(slot);
       try {
         const fresh = await this.launchBrowser();
         if (this.isShutdown) {
-          await fresh.close().catch(() => {});
+          await this.closeBrowser(fresh, this.slots.indexOf(slot));
           return;
         }
         this.browserToSlot.delete(slot.browser);
@@ -181,17 +268,52 @@ export class BrowserPool {
         slot.relaunchPending = false;
         this.browserToSlot.set(fresh, slot);
         this.attachDisconnectHandler(slot, fresh);
-        if (!this.available.includes(slot)) {
-          this.available.push(slot);
-        }
+        this.handOff(slot, fresh);
         this.logger?.info("browser-pool.relaunch-recovered", {
           slotIndex: this.slots.indexOf(slot),
         });
       } catch (err) {
         // Still failing — leave it pending for the next acquire to retry.
-        console.error("[BrowserPool] pending-slot relaunch failed:", err);
+        this.logger?.info("browser-pool.relaunch-failed", {
+          slotIndex: this.slots.indexOf(slot),
+          error: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        this.relaunchingSlots.delete(slot);
       }
     }
+  }
+
+  /**
+   * Self-rescheduling deferred relaunch. A failed recycle schedules this when
+   * a waiter is already queued; it re-attempts `relaunchPendingSlots` with
+   * bounded exponential backoff and reschedules itself as long as a waiter is
+   * still parked AND a pending slot remains to serve it. This replaces the
+   * old one-shot timer, which stranded the waiter for its full acquire
+   * timeout if the single deferred attempt also failed. Stops on shutdown,
+   * when no waiters remain, or when no slot is still pending.
+   */
+  private scheduleDeferredRelaunch(attempt: number): void {
+    if (this.isShutdown || this.waiters.length === 0) return;
+    const backoff = Math.min(
+      RELAUNCH_BACKOFF_BASE_MS * 2 ** (attempt - 1),
+      RELAUNCH_BACKOFF_MAX_MS,
+    );
+    setTimeout(() => {
+      if (this.isShutdown || this.waiters.length === 0) return;
+      if (!this.slots.some((s) => s.relaunchPending)) return;
+      void this.relaunchPendingSlots().finally(() => {
+        // Reschedule only if a waiter is still unserved and a pending slot
+        // remains — otherwise recovery is done or there is nothing to retry.
+        if (
+          !this.isShutdown &&
+          this.waiters.length > 0 &&
+          this.slots.some((s) => s.relaunchPending)
+        ) {
+          this.scheduleDeferredRelaunch(attempt + 1);
+        }
+      });
+    }, backoff);
   }
 
   async acquire(timeoutMs = 30_000): Promise<Browser> {
@@ -314,9 +436,11 @@ export class BrowserPool {
       await Promise.allSettled(Array.from(this.inFlightRecycles));
     }
 
-    // Close every browser we know about.
-    const closers = this.slots.map((slot) =>
-      slot.browser.close().catch(() => {}),
+    // Close every browser we know about. Route through closeBrowser so a
+    // close failure is logged with its slot index rather than silently
+    // swallowed.
+    const closers = this.slots.map((slot, idx) =>
+      this.closeBrowser(slot.browser, idx),
     );
     await Promise.allSettled(closers);
 
@@ -326,11 +450,17 @@ export class BrowserPool {
   }
 
   stats(): BrowserPoolStats {
+    // `size` counts only live (non-pending) capacity. A slot parked as
+    // `relaunchPending` holds a dead browser and is being recovered lazily,
+    // so it is not usable capacity and must not inflate `size`/`inUse`. This
+    // also makes the empty-pool backstop observable: when every slot is
+    // pending, `size` reads 0 (the condition under which acquire() recovers).
+    const liveSlots = this.slots.filter((s) => !s.relaunchPending);
     const availableCount = this.available.length;
     return {
-      size: this.slots.length,
+      size: liveSlots.length,
       available: availableCount,
-      inUse: this.slots.length - availableCount,
+      inUse: liveSlots.length - availableCount,
       totalRecycles: this.totalRecycles,
     };
   }
@@ -394,11 +524,7 @@ export class BrowserPool {
     const oldBrowser = slot.browser;
 
     const recyclePromise = (async () => {
-      try {
-        await oldBrowser.close();
-      } catch {
-        // Best effort — the browser may have already crashed.
-      }
+      await this.closeBrowser(oldBrowser, slotIdx);
 
       if (this.isShutdown) return;
 
@@ -416,7 +542,7 @@ export class BrowserPool {
           if (this.isShutdown) {
             // Shutdown was initiated while we were launching. Close the
             // fresh browser and don't hand it to anyone.
-            await fresh.close().catch(() => {});
+            await this.closeBrowser(fresh, this.slots.indexOf(slot));
             return;
           }
 
@@ -426,12 +552,7 @@ export class BrowserPool {
           this.browserToSlot.set(fresh, slot);
           this.attachDisconnectHandler(slot, fresh);
 
-          const waiter = this.waiters.shift();
-          if (waiter) {
-            waiter.resolve(fresh);
-          } else {
-            this.available.push(slot);
-          }
+          this.handOff(slot, fresh);
           return;
         } catch (err) {
           lastErr = err;
@@ -447,23 +568,19 @@ export class BrowserPool {
       // launch (see relaunchPendingSlots), and the empty-pool backstop in
       // acquire() re-initializes if every slot ends up pending/lost.
       slot.relaunchPending = true;
-      console.error(
-        `[BrowserPool] recycleSlot relaunch failed after ${RELAUNCH_MAX_ATTEMPTS} attempts ` +
-          `(slot ${this.slots.indexOf(slot)} parked for lazy retry, pool size ${this.slots.length}):`,
-        lastErr,
-      );
+      this.logger?.info("browser-pool.recycle-relaunch-failed", {
+        slotIndex: this.slots.indexOf(slot),
+        attempts: RELAUNCH_MAX_ATTEMPTS,
+        poolSize: this.slots.length,
+        error: lastErr instanceof Error ? lastErr.message : String(lastErr),
+      });
 
-      // A waiter may already be queued (an acquire() that found no live
-      // slot returned a pending promise). Nothing else will wake it, so
-      // schedule a deferred relaunch attempt to serve pending waiters
-      // rather than leaving them to time out. Best-effort and outside the
-      // current recycle promise so it doesn't block shutdown's drain.
-      if (this.waiters.length > 0 && !this.isShutdown) {
-        setTimeout(() => {
-          if (this.isShutdown || this.waiters.length === 0) return;
-          void this.relaunchPendingSlots();
-        }, RELAUNCH_BACKOFF_BASE_MS);
-      }
+      // A waiter may already be queued (an acquire() that found no live slot
+      // returned a pending promise). Nothing else will wake it, so kick off a
+      // self-rescheduling deferred relaunch that keeps retrying with bounded
+      // backoff while pending slots AND waiters coexist — a one-shot attempt
+      // would strand the waiter if that single retry also failed.
+      this.scheduleDeferredRelaunch(1);
     })();
 
     this.inFlightRecycles.add(recyclePromise);

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -178,18 +178,32 @@ export class BrowserPool {
    */
   private track(promise: Promise<void>): Promise<void> {
     this.inFlightRecycles.add(promise);
-    promise.finally(() => {
-      this.inFlightRecycles.delete(promise);
-    });
-    return promise;
+    // Chain the cleanup onto what we return (and await), and absorb any throw
+    // with a logged `.catch` so it can never surface as an unhandled
+    // rejection. The inner methods swallow their own launch errors today, but
+    // a future throw inside reinitInner/relaunchPendingSlotsInner must stay
+    // contained — a recovery launch failing is non-fatal to the pool.
+    return promise
+      .catch((err: unknown) => {
+        this.logger?.info("browser-pool.recovery-failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        this.inFlightRecycles.delete(promise);
+      });
   }
 
   /**
-   * Backstop re-initialization. Called from `acquire()` when the pool has
-   * drained to zero slots. Re-launches up to `poolSize` browsers, tolerating
-   * partial failure — even one fresh slot lets a waiting probe proceed. A
-   * total failure here surfaces to the caller via the normal acquire
-   * timeout / waiter-reject path rather than wedging the pool forever.
+   * Backstop re-initialization for the truly-empty pool. Called from
+   * `acquire()` only when `this.slots` is empty — i.e. nothing was ever
+   * launched (init never ran / launched nothing). This is NOT the all-slots-
+   * crashed recovery path: failed recycles keep their slots in `this.slots`
+   * (parked `relaunchPending`) and are recovered by `relaunchPendingSlots()`,
+   * so they never reach this backstop. Re-launches up to `poolSize` browsers,
+   * tolerating partial failure — even one fresh slot lets a waiting probe
+   * proceed. A total failure here surfaces to the caller via the normal
+   * acquire timeout / waiter-reject path rather than wedging the pool forever.
    */
   private async reinit(): Promise<void> {
     if (this.isShutdown || this.launchBrowser === undefined) return;
@@ -209,7 +223,10 @@ export class BrowserPool {
       try {
         const browser = await this.launchBrowser();
         if (this.isShutdown) {
-          await this.closeBrowser(browser, this.slots.length);
+          // This browser was never added to `this.slots`, so there is no real
+          // originating slot index. Pass -1 rather than a fabricated index
+          // (`this.slots.length`) that would masquerade as a live slot.
+          await this.closeBrowser(browser, -1);
           return;
         }
         const slot: Slot = { browser, contextCount: 0 };
@@ -321,10 +338,14 @@ export class BrowserPool {
       throw new Error("BrowserPool is shut down");
     }
 
-    // Backstop: if every slot has been lost (e.g. a burst of crashes whose
-    // relaunches all failed), the pool would otherwise be permanently empty
-    // and every acquire would time out. Re-initialize from scratch so the
-    // pool self-heals instead of draining to nothing.
+    // Backstop: only when `this.slots` is truly empty — nothing was ever
+    // launched (init() never ran or launched nothing) — does the pool have no
+    // slot to recover, so reinit from scratch. NOTE: a burst of crashes whose
+    // relaunches all fail does NOT empty `this.slots`; those slots are kept
+    // and parked as `relaunchPending`, and are recovered below via
+    // `relaunchPendingSlots()`, not here. (`stats().size` may read 0 in that
+    // state, but `size` does not gate this backstop — `this.slots.length`
+    // does.)
     if (this.slots.length === 0) {
       await this.reinit();
     } else {
@@ -452,9 +473,12 @@ export class BrowserPool {
   stats(): BrowserPoolStats {
     // `size` counts only live (non-pending) capacity. A slot parked as
     // `relaunchPending` holds a dead browser and is being recovered lazily,
-    // so it is not usable capacity and must not inflate `size`/`inUse`. This
-    // also makes the empty-pool backstop observable: when every slot is
-    // pending, `size` reads 0 (the condition under which acquire() recovers).
+    // so it is not usable capacity and must not inflate `size`/`inUse`. When
+    // every slot is pending, `size` reads 0 — that surfaces the outage to
+    // callers, but it is NOT what gates recovery. The parked slots remain in
+    // `this.slots`, so `acquire()` recovers them via `relaunchPendingSlots()`
+    // (the `this.slots.length === 0` reinit backstop is a separate
+    // never-launched case), not via this size reading.
     const liveSlots = this.slots.filter((s) => !s.relaunchPending);
     const availableCount = this.available.length;
     return {

--- a/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
@@ -31,6 +31,10 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+// Recent timestamp so green e2e rows are not treated as stale by the
+// staleness downgrade in cell-model.ts (which compares against Date.now()).
+const FRESH_OBSERVED_AT = new Date().toISOString();
+
 function row(
   key: string,
   dimension: string,
@@ -42,8 +46,8 @@ function row(
     dimension,
     state,
     signal: {},
-    observed_at: "2026-04-20T00:00:00Z",
-    transitioned_at: "2026-04-20T00:00:00Z",
+    observed_at: FRESH_OBSERVED_AT,
+    transitioned_at: FRESH_OBSERVED_AT,
     fail_count: 0,
     first_failure_at: null,
   };

--- a/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
@@ -16,6 +16,10 @@ import { computeColumnTallyDetail } from "@/components/feature-grid";
 /*  Helpers                                                             */
 /* ------------------------------------------------------------------ */
 
+// Recent timestamp so green e2e rows are not treated as stale by the
+// staleness downgrade in cell-model.ts (which compares against Date.now()).
+const FRESH_OBSERVED_AT = new Date().toISOString();
+
 function makeRow(
   key: string,
   dimension: string,
@@ -27,8 +31,8 @@ function makeRow(
     dimension,
     state,
     signal: null,
-    observed_at: "2026-04-28T00:00:00Z",
-    transitioned_at: "2026-04-28T00:00:00Z",
+    observed_at: FRESH_OBSERVED_AT,
+    transitioned_at: FRESH_OBSERVED_AT,
     fail_count: 0,
     first_failure_at: null,
   };

--- a/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
@@ -1,6 +1,8 @@
 /**
- * Unit tests for depth derivation utility.
- * Parameterized: all D0-D6 combos, short-circuit on red, unshipped returns D0.
+ * Unit tests for the depth-derivation utility (deriveDepth).
+ * Covers the D0-D6 ladder walk, short-circuit on non-green, unshipped/
+ * unsupported handling, maxPossible/isRegression computation, multi-key D5
+ * mappings, and D5/D6 staleness downgrades.
  */
 import { describe, it, expect } from "vitest";
 import { deriveDepth } from "../depth-utils";
@@ -368,6 +370,69 @@ describe("deriveDepth", () => {
     ]);
     const result = deriveDepth(c, live);
     expect(result.achieved).toBe(6);
+  });
+
+  // ── D5/D6 staleness mirrors cell-model.ts (both consumers agree) ──
+  describe("D5/D6 staleness downgrade", () => {
+    const NOW = Date.parse("2026-05-30T12:00:00Z");
+    const STALE_AT = new Date(NOW - 7 * 60 * 60 * 1000).toISOString();
+    const FRESH_AT = new Date(NOW - 60 * 1000).toISOString();
+
+    it("does not credit D5 when its green row is stale", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([
+        row("health:lgp", "health", "green", FRESH_AT),
+        row("agent:lgp", "agent", "green", FRESH_AT),
+        row("e2e:lgp/agentic-chat", "e2e", "green", FRESH_AT),
+        row("chat:lgp", "chat", "green", FRESH_AT),
+        row("d5:lgp/agentic-chat", "d5", "green", STALE_AT),
+      ]);
+      const result = deriveDepth(c, live, NOW);
+      // Stale green D5 must not advance past D4.
+      expect(result.achieved).toBe(4);
+    });
+
+    it("credits D5 when its green row is fresh", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([
+        row("health:lgp", "health", "green", FRESH_AT),
+        row("agent:lgp", "agent", "green", FRESH_AT),
+        row("e2e:lgp/agentic-chat", "e2e", "green", FRESH_AT),
+        row("chat:lgp", "chat", "green", FRESH_AT),
+        row("d5:lgp/agentic-chat", "d5", "green", FRESH_AT),
+      ]);
+      const result = deriveDepth(c, live, NOW);
+      expect(result.achieved).toBe(5);
+    });
+
+    it("does not credit D6 when its green row is stale", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([
+        row("health:lgp", "health", "green", FRESH_AT),
+        row("agent:lgp", "agent", "green", FRESH_AT),
+        row("e2e:lgp/agentic-chat", "e2e", "green", FRESH_AT),
+        row("chat:lgp", "chat", "green", FRESH_AT),
+        row("d5:lgp/agentic-chat", "d5", "green", FRESH_AT),
+        row("d6:lgp", "d6", "green", STALE_AT),
+      ]);
+      const result = deriveDepth(c, live, NOW);
+      // Stale green D6 must not advance past D5.
+      expect(result.achieved).toBe(5);
+    });
+
+    it("credits D6 when its green row is fresh", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([
+        row("health:lgp", "health", "green", FRESH_AT),
+        row("agent:lgp", "agent", "green", FRESH_AT),
+        row("e2e:lgp/agentic-chat", "e2e", "green", FRESH_AT),
+        row("chat:lgp", "chat", "green", FRESH_AT),
+        row("d5:lgp/agentic-chat", "d5", "green", FRESH_AT),
+        row("d6:lgp", "d6", "green", FRESH_AT),
+      ]);
+      const result = deriveDepth(c, live, NOW);
+      expect(result.achieved).toBe(6);
+    });
   });
 
   it("returns D4 for feature with no D5 mapping", () => {

--- a/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
@@ -7,10 +7,16 @@ import { deriveDepth } from "../depth-utils";
 import type { CatalogCell } from "../depth-utils";
 import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
 
+// Default `observed_at` is recent so green rows are not treated as stale by
+// the e2e staleness downgrade (see depth-utils.ts / cell-model.ts). Tests
+// that exercise staleness pass an explicit timestamp.
+const FRESH_OBSERVED_AT = new Date().toISOString();
+
 function row(
   key: string,
   dimension: string,
   state: StatusRow["state"],
+  observedAt: string = FRESH_OBSERVED_AT,
 ): StatusRow {
   return {
     id: `id-${key}`,
@@ -18,8 +24,8 @@ function row(
     dimension,
     state,
     signal: {},
-    observed_at: "2026-04-20T00:00:00Z",
-    transitioned_at: "2026-04-20T00:00:00Z",
+    observed_at: observedAt,
+    transitioned_at: observedAt,
     fail_count: 0,
     first_failure_at: null,
   };

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -17,7 +17,8 @@
  * Short-circuits: if any level is not green, stop there.
  */
 import { keyFor, CATALOG_TO_D5_KEY } from "@/lib/live-status";
-import type { LiveStatusMap } from "@/lib/live-status";
+import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
+import { E2E_STALE_AFTER_MS } from "@/lib/cell-model";
 
 /** Minimal catalog cell shape consumed by depth derivation. */
 export interface CatalogCell {
@@ -61,6 +62,30 @@ export interface DepthResult {
 function isGreen(live: LiveStatusMap, key: string): boolean {
   const row = live.get(key);
   return row?.state === "green";
+}
+
+/** Row is stale if `observed_at` is older than `maxAgeMs` relative to `now`. */
+function isRowStale(row: StatusRow, now: number, maxAgeMs: number): boolean {
+  const observedMs = Date.parse(row.observed_at);
+  if (Number.isNaN(observedMs)) return false;
+  return now - observedMs > maxAgeMs;
+}
+
+/**
+ * The e2e (D3) signal counts as green only when a green row exists AND it
+ * has been refreshed within the staleness window. A frozen green row from a
+ * driver that stopped writing must NOT credit D3 — otherwise the depth
+ * ladder reads a dead probe pipeline as a false-green D3. Mirrors the
+ * staleness downgrade in cell-model.ts so both consumers agree.
+ */
+function isE2eGreenAndFresh(
+  live: LiveStatusMap,
+  key: string,
+  now: number,
+): boolean {
+  const row = live.get(key);
+  if (row?.state !== "green") return false;
+  return !isRowStale(row, now, E2E_STALE_AFTER_MS);
 }
 
 /**
@@ -124,6 +149,7 @@ function computeMaxPossible(cell: CatalogCell): AchievedDepth {
 export function deriveDepth(
   cell: CatalogCell,
   live: LiveStatusMap,
+  now: number = Date.now(),
 ): DepthResult {
   const maxPossible = computeMaxPossible(cell);
 
@@ -180,7 +206,13 @@ export function deriveDepth(
       unsupported: false,
     };
   }
-  if (!isGreen(live, keyFor("e2e", cell.integration, cell.feature))) {
+  if (
+    !isE2eGreenAndFresh(
+      live,
+      keyFor("e2e", cell.integration, cell.feature),
+      now,
+    )
+  ) {
     return {
       achieved,
       maxPossible,

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -66,9 +66,10 @@ function isGreen(live: LiveStatusMap, key: string): boolean {
 
 /**
  * A row counts as green only when it is green AND fresh. A frozen-green row
- * from a stalled driver must NOT credit its depth — the same false-green
- * staleness downgrade `cell-model.ts` applies to D3/D5/D6, mirrored here so
- * both consumers agree.
+ * from a stalled driver must NOT credit its depth — otherwise the depth ladder
+ * reads a dead probe pipeline as a false-green (e.g. a D3 e2e signal whose
+ * driver stopped writing). Mirrors the staleness downgrade `cell-model.ts`
+ * applies to D3/D5/D6 so both consumers agree.
  */
 function isGreenAndFresh(
   live: LiveStatusMap,
@@ -85,23 +86,6 @@ function isRowStale(row: StatusRow, now: number, maxAgeMs: number): boolean {
   const observedMs = Date.parse(row.observed_at);
   if (Number.isNaN(observedMs)) return false;
   return now - observedMs > maxAgeMs;
-}
-
-/**
- * The e2e (D3) signal counts as green only when a green row exists AND it
- * has been refreshed within the staleness window. A frozen green row from a
- * driver that stopped writing must NOT credit D3 — otherwise the depth
- * ladder reads a dead probe pipeline as a false-green D3. Mirrors the
- * staleness downgrade in cell-model.ts so both consumers agree.
- */
-function isE2eGreenAndFresh(
-  live: LiveStatusMap,
-  key: string,
-  now: number,
-): boolean {
-  const row = live.get(key);
-  if (row?.state !== "green") return false;
-  return !isRowStale(row, now, E2E_STALE_AFTER_MS);
 }
 
 /**
@@ -228,11 +212,7 @@ export function deriveDepth(
     };
   }
   if (
-    !isE2eGreenAndFresh(
-      live,
-      keyFor("e2e", cell.integration, cell.feature),
-      now,
-    )
+    !isGreenAndFresh(live, keyFor("e2e", cell.integration, cell.feature), now)
   ) {
     return {
       achieved,

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -64,6 +64,22 @@ function isGreen(live: LiveStatusMap, key: string): boolean {
   return row?.state === "green";
 }
 
+/**
+ * A row counts as green only when it is green AND fresh. A frozen-green row
+ * from a stalled driver must NOT credit its depth — the same false-green
+ * staleness downgrade `cell-model.ts` applies to D3/D5/D6, mirrored here so
+ * both consumers agree.
+ */
+function isGreenAndFresh(
+  live: LiveStatusMap,
+  key: string,
+  now: number,
+): boolean {
+  const row = live.get(key);
+  if (row?.state !== "green") return false;
+  return !isRowStale(row, now, E2E_STALE_AFTER_MS);
+}
+
 /** Row is stale if `observed_at` is older than `maxAgeMs` relative to `now`. */
 function isRowStale(row: StatusRow, now: number, maxAgeMs: number): boolean {
   const observedMs = Date.parse(row.observed_at);
@@ -89,13 +105,16 @@ function isE2eGreenAndFresh(
 }
 
 /**
- * Check whether all D5 PB rows for a given (slug, catalogFeatureId) are green.
- * Returns false if the feature has no D5 mapping or any mapped row is missing/non-green.
+ * Check whether all D5 PB rows for a given (slug, catalogFeatureId) are green
+ * AND fresh. Returns false if the feature has no D5 mapping or any mapped row
+ * is missing/non-green/stale. The staleness gate mirrors `cell-model.ts` so a
+ * frozen-green CV row from a stalled driver no longer credits D5.
  */
 function isD5Green(
   live: LiveStatusMap,
   slug: string,
   featureId: string,
+  now: number,
 ): boolean {
   const d5Keys = CATALOG_TO_D5_KEY[featureId];
   // No D5 mapping = no CV test exists for this feature = cannot be D5.
@@ -104,7 +123,9 @@ function isD5Green(
   if (!d5Keys || d5Keys.length === 0) {
     return false;
   }
-  return d5Keys.every((d5Key) => isGreen(live, keyFor("d5", slug, d5Key)));
+  return d5Keys.every((d5Key) =>
+    isGreenAndFresh(live, keyFor("d5", slug, d5Key), now),
+  );
 }
 
 /**
@@ -236,7 +257,7 @@ export function deriveDepth(
   achieved = 4;
 
   // D5: d5:<slug>/<d5FeatureType> green (per-cell, mapped via CATALOG_TO_D5_KEY)
-  if (!isD5Green(live, cell.integration, cell.feature)) {
+  if (!isD5Green(live, cell.integration, cell.feature, now)) {
     return {
       achieved,
       maxPossible,
@@ -247,7 +268,7 @@ export function deriveDepth(
   achieved = 5;
 
   // D6: d6:<slug> green (integration-scoped aggregate)
-  if (isGreen(live, keyFor("d6", cell.integration))) {
+  if (isGreenAndFresh(live, keyFor("d6", cell.integration), now)) {
     achieved = 6;
   }
 

--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -37,6 +37,10 @@ describe("LiveIndicator", () => {
   });
 });
 
+// Recent timestamp so green e2e rows are not treated as stale by the
+// staleness downgrade in cell-model.ts (which compares against Date.now()).
+const FRESH_OBSERVED_AT = new Date().toISOString();
+
 function row(key: string, dim: string, state: StatusRow["state"]): StatusRow {
   return {
     id: key,
@@ -44,8 +48,8 @@ function row(key: string, dim: string, state: StatusRow["state"]): StatusRow {
     dimension: dim,
     state,
     signal: {},
-    observed_at: "2026-04-20T00:00:00Z",
-    transitioned_at: "2026-04-20T00:00:00Z",
+    observed_at: FRESH_OBSERVED_AT,
+    transitioned_at: FRESH_OBSERVED_AT,
     fail_count: 0,
     first_failure_at: null,
   };

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -732,5 +732,76 @@ describe("buildCellModel", () => {
       );
       expect(model.d5?.status).toBe("red");
     });
+
+    // ── Multi-key D5: stale-green sub-row must not be masked by the fold ──
+    // `resolveD5` reduces sub-keys to a "worst" row, but green is the LOWEST
+    // rank — so among all-green sub-rows a fresh-green can win the tie. If
+    // staleness were checked only on the post-fold winner, a stale-green
+    // sibling would be silently masked → false-green. The downgrade must be
+    // per-row (before the fold), so ANY stale-green sub-row forces amber,
+    // independent of CATALOG_TO_D5_KEY ordering.
+    describe("multi-key D5: one stale-green + one fresh-green sub-row", () => {
+      // beautiful-chat maps to 5 D5 sub-keys (see CATALOG_TO_D5_KEY). We make
+      // exactly one stale-green and the rest fresh-green so the only signal
+      // is the stale sibling — which must downgrade the whole family.
+      const STALE_SUBKEY = "beautiful-chat-bar-chart";
+      const FRESH_SUBKEYS = [
+        "beautiful-chat-toggle-theme",
+        "beautiful-chat-pie-chart",
+        "beautiful-chat-search-flights",
+        "beautiful-chat-schedule-meeting",
+      ];
+
+      function buildRows(staleFirst: boolean): StatusRow[] {
+        const base = [
+          rowAtAge(
+            keyFor("e2e", "agno", "beautiful-chat"),
+            "e2e",
+            FRESH,
+            "green",
+          ),
+          rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+        ];
+        const staleRow = rowAtAge(
+          keyFor("d5", "agno", STALE_SUBKEY),
+          "d5",
+          STALE,
+          "green",
+        );
+        const freshRows = FRESH_SUBKEYS.map((sk) =>
+          rowAtAge(keyFor("d5", "agno", sk), "d5", FRESH, "green"),
+        );
+        // Vary insertion order to prove the result does not depend on which
+        // green sub-row the fold encounters first.
+        return staleFirst
+          ? [...base, staleRow, ...freshRows]
+          : [...base, ...freshRows, staleRow];
+      }
+
+      it("downgrades to amber when the stale sub-row is folded FIRST", () => {
+        const model = buildCellModel(
+          mapOf(buildRows(true)),
+          wiredInput("agno", "beautiful-chat"),
+          NOW,
+        );
+        // Stale-green sibling must force the family off green.
+        expect(model.d5?.status).toBe("amber");
+        // Depth ladder must not credit D5.
+        expect(model.achievedDepth).toBe(4);
+        // D5 not green, D6 absent → red.
+        expect(model.chipColor).toBe("red");
+      });
+
+      it("downgrades to amber when the stale sub-row is folded LAST", () => {
+        const model = buildCellModel(
+          mapOf(buildRows(false)),
+          wiredInput("agno", "beautiful-chat"),
+          NOW,
+        );
+        expect(model.d5?.status).toBe("amber");
+        expect(model.achievedDepth).toBe(4);
+        expect(model.chipColor).toBe("red");
+      });
+    });
   });
 });

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildCellModel } from "../cell-model";
+import { buildCellModel, E2E_STALE_AFTER_MS } from "../cell-model";
 import type { CellModelInput } from "../cell-model";
 import type { LiveStatusMap, StatusRow, State } from "../live-status";
 import { keyFor } from "../live-status";
@@ -7,6 +7,11 @@ import { keyFor } from "../live-status";
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
+
+// Default `observed_at` is recent so green rows are not treated as stale by
+// the e2e staleness downgrade (resolveD3). The staleness tests below pass an
+// explicit `observed_at` override to exercise the downgrade.
+const FRESH_OBSERVED_AT = new Date().toISOString();
 
 function row(
   key: string,
@@ -20,10 +25,10 @@ function row(
     dimension,
     state,
     signal: {},
-    observed_at: "2026-04-20T00:00:00Z",
-    transitioned_at: "2026-04-20T00:00:00Z",
+    observed_at: FRESH_OBSERVED_AT,
+    transitioned_at: FRESH_OBSERVED_AT,
     fail_count: state === "red" ? 1 : 0,
-    first_failure_at: state === "red" ? "2026-04-20T00:00:00Z" : null,
+    first_failure_at: state === "red" ? FRESH_OBSERVED_AT : null,
     ...overrides,
   };
 }
@@ -554,6 +559,68 @@ describe("buildCellModel", () => {
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.isRegression).toBe(false);
+    });
+  });
+
+  // ── e2e staleness downgrade (false-green D3 bug) ────────────────────
+  // When the e2e driver stops writing `e2e:<slug>/<feature>` rows, the
+  // last green row freezes and the depth ladder reads it as healthy → a
+  // false-green D3 that masks a dead probe pipeline. A green e2e row older
+  // than the staleness window must be downgraded to degraded (amber).
+  describe("e2e staleness downgrade", () => {
+    const NOW = Date.parse("2026-05-30T12:00:00Z");
+
+    function e2eRowAtAge(ageMs: number, state: State = "green") {
+      const observedAt = new Date(NOW - ageMs).toISOString();
+      return row(keyFor("e2e", "agno", "agentic-chat"), "e2e", state, {
+        observed_at: observedAt,
+        transitioned_at: observedAt,
+      });
+    }
+
+    it("downgrades a stale green e2e row to amber instead of green", () => {
+      const live = mapOf([
+        // e2e last observed well past the staleness window.
+        e2eRowAtAge(E2E_STALE_AFTER_MS + 60 * 60 * 1000, "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      // Stale green must NOT present as a healthy D3.
+      expect(model.d3?.status).toBe("amber");
+      // A stale-amber D3 fails the D1-D4 gate → chip is red, not green.
+      expect(model.chipColor).not.toBe("green");
+      // achievedDepth must not credit D3 when the e2e signal is stale.
+      expect(model.achievedDepth).toBe(0);
+    });
+
+    it("keeps a fresh green e2e row green", () => {
+      const live = mapOf([
+        e2eRowAtAge(60 * 1000, "green"), // observed 1 min ago — fresh
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d3?.status).toBe("green");
+      // Only D3 (e2e) is green here, no D4 row → achievedDepth caps at 3.
+      expect(model.achievedDepth).toBe(3);
+    });
+
+    it("leaves a stale RED e2e row red (staleness only downgrades green)", () => {
+      const live = mapOf([
+        e2eRowAtAge(E2E_STALE_AFTER_MS + 60 * 60 * 1000, "red"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d3?.status).toBe("red");
     });
   });
 });

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -170,7 +170,7 @@ describe("buildCellModel", () => {
     });
   });
 
-  // ── D3+D4 pass, D5 exists but fails → amber chip ───────────────────
+  // ── D3+D4 pass, D5 exists but fails → red chip ─────────────────────
   describe("D3+D4 pass, D5 exists but fails", () => {
     it("returns red chip (D6-ceiling: D5 red, D6 absent)", () => {
       const live = mapOf([
@@ -621,6 +621,116 @@ describe("buildCellModel", () => {
         NOW,
       );
       expect(model.d3?.status).toBe("red");
+    });
+  });
+
+  // ── D5/D6 staleness downgrade (same false-green mode, one dimension up) ──
+  // A frozen-green D5/D6 row from a stalled driver must be downgraded the
+  // same way D3 is, so it no longer credits the depth ladder / ceiling.
+  describe("D5/D6 staleness downgrade", () => {
+    const NOW = Date.parse("2026-05-30T12:00:00Z");
+
+    function rowAtAge(
+      key: string,
+      dimension: string,
+      ageMs: number,
+      state: State = "green",
+    ) {
+      const observedAt = new Date(NOW - ageMs).toISOString();
+      return row(key, dimension, state, {
+        observed_at: observedAt,
+        transitioned_at: observedAt,
+      });
+    }
+
+    const STALE = E2E_STALE_AFTER_MS + 60 * 60 * 1000;
+    const FRESH = 60 * 1000;
+
+    it("downgrades a stale green D5 row to amber (no longer credits D5/ceiling)", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", STALE, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      // Stale green D5 must NOT present as a healthy D5.
+      expect(model.d5?.status).toBe("amber");
+      // Depth ladder must not credit D5 when the signal is stale.
+      expect(model.achievedDepth).toBe(4);
+      // Chip: D5 not green, D6 absent → red (no longer amber-on-green-D5).
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("keeps a fresh green D5 row green", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", FRESH, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d5?.status).toBe("green");
+      expect(model.achievedDepth).toBe(5);
+      // D5 green but no D6 → amber.
+      expect(model.chipColor).toBe("amber");
+    });
+
+    it("downgrades a stale green D6 row to amber (no longer credits D6/green chip)", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", FRESH, "green"),
+        rowAtAge(keyFor("d6", "agno"), "d6", STALE, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      // Stale green D6 must NOT present as a healthy D6.
+      expect(model.d6?.status).toBe("amber");
+      // Depth ladder must not credit D6 when the signal is stale.
+      expect(model.achievedDepth).toBe(5);
+      // D5 green but D6 not green → amber, not green.
+      expect(model.chipColor).toBe("amber");
+    });
+
+    it("keeps a fresh green D6 row green", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", FRESH, "green"),
+        rowAtAge(keyFor("d6", "agno"), "d6", FRESH, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d6?.status).toBe("green");
+      expect(model.achievedDepth).toBe(6);
+      expect(model.chipColor).toBe("green");
+    });
+
+    it("leaves a stale RED D5 row red (staleness only downgrades green)", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", STALE, "red"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d5?.status).toBe("red");
     });
   });
 });

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -131,9 +131,18 @@ function resolveD4(live: LiveStatusMap, slug: string): TestLevel {
  * would let a fresh-green sub-row win the all-green tie and hide a stale-green
  * sibling, re-introducing the false-green. Downgrading each green-but-stale
  * sub-row first means ANY stale-green sub-row forces the family to amber,
- * independent of `CATALOG_TO_D5_KEY` order — matching `depth-utils.ts`
- * `isD5Green`, which requires EVERY sub-key to be green-AND-fresh. Only green
- * is downgraded; a stale red/degraded sub-row already signals a problem.
+ * independent of `CATALOG_TO_D5_KEY` order. Only green is downgraded; a stale
+ * red/degraded sub-row already signals a problem.
+ *
+ * NOTE on missing sub-rows: this fold only considers sub-rows that are PRESENT
+ * — a missing row is SKIPPED (`if (!row) continue;`), not treated as failing.
+ * So a multi-key family with only some sub-rows emitted can still be credited
+ * green from those present rows. This DIVERGES from `depth-utils.ts`
+ * `isD5Green`, which uses `d5Keys.every(...)` and therefore requires every
+ * mapped key to be present AND green-and-fresh; a missing row makes the whole
+ * family non-green there. The per-row stale-green→degraded downgrade IS
+ * mirrored between the two; only the partial-emission (missing-row) handling
+ * differs.
  */
 function resolveD5(
   live: LiveStatusMap,

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -123,15 +123,23 @@ function resolveD4(live: LiveStatusMap, slug: string): TestLevel {
  * Uses `CATALOG_TO_D5_KEY` to map catalog feature IDs to D5 PB row key
  * suffixes. When multiple sub-keys exist (e.g. `beautiful-chat` fans out
  * to 5 pills), worst-state wins.
+ *
+ * Staleness applies the same downgrade as `resolveD3`: a green D5 row whose
+ * `observed_at` is older than `E2E_STALE_AFTER_MS` is downgraded to `amber`
+ * (degraded). When the driver stops writing, a frozen-green row would
+ * otherwise credit D5 forever — the same false-green mode one dimension up.
+ * Only green is downgraded; a stale red/degraded row already signals a
+ * problem and is left as-is.
  */
 function resolveD5(
   live: LiveStatusMap,
   slug: string,
   featureId: string,
+  now: number,
 ): TestLevel {
   const d5Keys = CATALOG_TO_D5_KEY[featureId];
 
-  // No mapping and no fallback row → test doesn't exist for this feature.
+  // No mapping → test doesn't exist for this feature.
   if (!d5Keys || d5Keys.length === 0) {
     return { exists: false, status: null, row: null };
   }
@@ -149,6 +157,10 @@ function resolveD5(
     // Keys are mapped but no rows emitted yet — test exists but has no
     // data. Treat as exists=true so ceilingDepth reflects it.
     return { exists: true, status: null, row: null };
+  }
+
+  if (worst.state === "green" && isStale(worst, now, E2E_STALE_AFTER_MS)) {
+    return { exists: true, status: "amber", row: worst };
   }
 
   return {
@@ -204,11 +216,19 @@ function resolveD3(
  * D6 is an aggregate integration-level signal (`d6:<slug>`), NOT per-cell.
  * The e2e-full driver emits a single row per integration that covers
  * the entire parity comparison against the reference implementation.
+ *
+ * Staleness applies the same downgrade as `resolveD3`: a green D6 row whose
+ * `observed_at` is older than `E2E_STALE_AFTER_MS` is downgraded to `amber`
+ * (degraded), so a frozen-green row from a stalled driver no longer credits
+ * D6 forever. Only green is downgraded; stale red/degraded is left as-is.
  */
-function resolveD6(live: LiveStatusMap, slug: string): TestLevel {
+function resolveD6(live: LiveStatusMap, slug: string, now: number): TestLevel {
   const row = live.get(keyFor("d6", slug)) ?? null;
   if (!row) {
     return { exists: false, status: null, row: null };
+  }
+  if (row.state === "green" && isStale(row, now, E2E_STALE_AFTER_MS)) {
+    return { exists: true, status: "amber", row };
   }
   return {
     exists: true,
@@ -272,8 +292,8 @@ export function buildCellModel(
   // ── Wired + supported: resolve each depth independently ───────────
   const d3 = resolveD3(live, slug, featureId, now);
   const d4 = resolveD4(live, slug);
-  const d5 = resolveD5(live, slug, featureId);
-  const d6 = resolveD6(live, slug);
+  const d5 = resolveD5(live, slug, featureId, now);
+  const d6 = resolveD6(live, slug, now);
 
   // ceilingDepth: highest CONTIGUOUS depth where a test EXISTS.
   // D4 only counts if D3 exists; D5 only counts if D4 counts; D6 only

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -17,6 +17,20 @@ import { keyFor, CATALOG_TO_D5_KEY } from "./live-status";
 export type TestStatus = "green" | "red" | "amber" | null;
 export type ChipColor = "green" | "amber" | "red" | "gray";
 
+/**
+ * Staleness window for the `e2e:` dimension. The e2e-demos driver writes
+ * `e2e:<slug>/<feature>` rows hourly (`schedule: "10 * * * *"`, see
+ * harness/config/probes/e2e-demos.yml). When the driver stops writing
+ * (a wedged browser pool, a dead probe pipeline), the last row freezes —
+ * a green row then reads as a healthy D3 forever, masking the outage as a
+ * false-green. Mirroring the original ">6h stale" model (see
+ * live-status.ts), a green e2e row whose `observed_at` is older than this
+ * window is downgraded to `degraded` (amber) so the staleness surfaces
+ * instead of presenting as green. 6h tolerates several missed hourly ticks
+ * before flagging, avoiding flapping on a single skipped run.
+ */
+export const E2E_STALE_AFTER_MS = 6 * 60 * 60 * 1000;
+
 export interface TestLevel {
   exists: boolean;
   status: TestStatus;
@@ -145,16 +159,37 @@ function resolveD5(
 }
 
 /**
+ * Determine whether a row's `observed_at` is older than `maxAgeMs` relative
+ * to `now`. An unparseable/missing timestamp is treated as NOT stale —
+ * staleness must be a positive signal, never inferred from bad data.
+ */
+function isStale(row: StatusRow, now: number, maxAgeMs: number): boolean {
+  const observedMs = Date.parse(row.observed_at);
+  if (Number.isNaN(observedMs)) return false;
+  return now - observedMs > maxAgeMs;
+}
+
+/**
  * Resolve the D3 (API / e2e) test level for `(slug, featureId)`.
+ *
+ * A green e2e row that has not been refreshed within `E2E_STALE_AFTER_MS`
+ * is downgraded to `amber` (degraded): the driver has stopped writing, so
+ * the frozen-green row is no longer trustworthy evidence of health. Only
+ * green is downgraded — a stale red/degraded row already signals a problem
+ * and is left as-is.
  */
 function resolveD3(
   live: LiveStatusMap,
   slug: string,
   featureId: string,
+  now: number,
 ): TestLevel {
   const row = live.get(keyFor("e2e", slug, featureId)) ?? null;
   if (!row) {
     return { exists: false, status: null, row: null };
+  }
+  if (row.state === "green" && isStale(row, now, E2E_STALE_AFTER_MS)) {
+    return { exists: true, status: "amber", row };
   }
   return {
     exists: true,
@@ -210,6 +245,7 @@ const UNSUPPORTED: CellModel = {
 export function buildCellModel(
   live: LiveStatusMap,
   input: CellModelInput,
+  now: number = Date.now(),
 ): CellModel {
   const { slug, featureId, isSupported, isWired } = input;
 
@@ -234,7 +270,7 @@ export function buildCellModel(
   }
 
   // ── Wired + supported: resolve each depth independently ───────────
-  const d3 = resolveD3(live, slug, featureId);
+  const d3 = resolveD3(live, slug, featureId, now);
   const d4 = resolveD4(live, slug);
   const d5 = resolveD5(live, slug, featureId);
   const d6 = resolveD6(live, slug);

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -124,12 +124,16 @@ function resolveD4(live: LiveStatusMap, slug: string): TestLevel {
  * suffixes. When multiple sub-keys exist (e.g. `beautiful-chat` fans out
  * to 5 pills), worst-state wins.
  *
- * Staleness applies the same downgrade as `resolveD3`: a green D5 row whose
- * `observed_at` is older than `E2E_STALE_AFTER_MS` is downgraded to `amber`
- * (degraded). When the driver stops writing, a frozen-green row would
- * otherwise credit D5 forever — the same false-green mode one dimension up.
- * Only green is downgraded; a stale red/degraded row already signals a
- * problem and is left as-is.
+ * Staleness applies the same downgrade as `resolveD3`, but PER SUB-ROW and
+ * BEFORE the worst-state fold: a green D5 sub-row whose `observed_at` is
+ * older than `E2E_STALE_AFTER_MS` is treated as `degraded` while folding.
+ * This matters because `green` is the LOWEST rank — folding raw states first
+ * would let a fresh-green sub-row win the all-green tie and hide a stale-green
+ * sibling, re-introducing the false-green. Downgrading each green-but-stale
+ * sub-row first means ANY stale-green sub-row forces the family to amber,
+ * independent of `CATALOG_TO_D5_KEY` order — matching `depth-utils.ts`
+ * `isD5Green`, which requires EVERY sub-key to be green-AND-fresh. Only green
+ * is downgraded; a stale red/degraded sub-row already signals a problem.
  */
 function resolveD5(
   live: LiveStatusMap,
@@ -144,29 +148,37 @@ function resolveD5(
     return { exists: false, status: null, row: null };
   }
 
-  let worst: StatusRow | null = null;
+  let worstRow: StatusRow | null = null;
+  let worstState: State | null = null;
   for (const d5Key of d5Keys) {
     const row = live.get(keyFor("d5", slug, d5Key)) ?? null;
     if (!row) continue;
-    if (!worst || STATE_RANK[row.state] > STATE_RANK[worst.state]) {
-      worst = row;
+    // Per-row staleness downgrade applied BEFORE the fold: a green sub-row
+    // that is stale folds in as `degraded` so it can never win the all-green
+    // tie and mask a fresh-green sibling.
+    const effectiveState: State =
+      row.state === "green" && isStale(row, now, E2E_STALE_AFTER_MS)
+        ? "degraded"
+        : row.state;
+    if (
+      worstState === null ||
+      STATE_RANK[effectiveState] > STATE_RANK[worstState]
+    ) {
+      worstRow = row;
+      worstState = effectiveState;
     }
   }
 
-  if (!worst) {
+  if (!worstRow || worstState === null) {
     // Keys are mapped but no rows emitted yet — test exists but has no
     // data. Treat as exists=true so ceilingDepth reflects it.
     return { exists: true, status: null, row: null };
   }
 
-  if (worst.state === "green" && isStale(worst, now, E2E_STALE_AFTER_MS)) {
-    return { exists: true, status: "amber", row: worst };
-  }
-
   return {
     exists: true,
-    status: stateToTestStatus(worst.state),
-    row: worst,
+    status: stateToTestStatus(worstState),
+    row: worstRow,
   };
 }
 


### PR DESCRIPTION
## Summary

Two confirmed bugs in the showcase harness + operator dashboard that together produced a false-green D3 on the dashboard while the e2e probe pipeline was actually dead.

### Bug 1 — Browser-pool death spiral (`showcase/harness/src/probes/helpers/browser-pool.ts`)

When a chromium process crashed, `recycleSlot` relaunched it; if that launch threw, the slot was permanently removed via `slots.splice`. A single transient launch failure (OOM spike, fd exhaustion) thus monotonically shrank the pool to empty with no self-heal, after which every e2e probe failed with `launcher-error` / `BrowserPool acquire timeout`.

Fix:
- The recycle retries the relaunch with bounded backoff (3 attempts, doubling backoff).
- On exhaustion the slot is **kept** (capacity preserved) and parked as `relaunchPending`; the next `acquire()` lazily re-attempts the launch.
- `acquire()` re-initializes the pool as a backstop when every slot has been lost (`slots.length === 0`).
- Existing acquire/release/recycle semantics and logging style preserved.

### Bug 2 — Stale-green e2e rows read as healthy (`shell-dashboard/src/lib/cell-model.ts`, `src/components/depth-utils.ts`)

When the e2e driver stops writing `e2e:<slug>/<feature>` rows, the last row freezes. A green row then reads as a healthy D3 forever, so the depth ladder shows a false-green D3 that masks a dead probe pipeline instead of surfacing it.

Fix:
- `buildCellModel` and `deriveDepth` treat a green e2e row whose `observed_at` is older than `E2E_STALE_AFTER_MS` (6h, matching the original stale-window model) as degraded/amber, so it no longer credits D3.
- Only green is downgraded — a stale red/degraded row already signals a problem and is left as-is.
- An unparseable timestamp is treated as not-stale, so staleness is never inferred from bad data.

## Test plan

- [x] New unit test: pool recovers after a transient relaunch failure (does NOT shrink to 0) and re-inits when emptied — confirmed red→green.
- [x] New unit tests: a stale green `e2e:` row downgrades to amber (not green) and does not credit D3; a fresh green row stays green; a stale red row stays red — confirmed red→green.
- [x] Existing fixtures with hardcoded old `observed_at` updated to default to a recent timestamp so legitimate green rows aren't treated as stale.
- [x] `showcase/harness` full suite: 1646 tests pass.
- [x] `shell-dashboard` full suite: 630 pass (1 env-gated build-spike skipped).
- [x] `packages/**` test graph: 17 projects pass.
- [x] typecheck clean (both packages); oxlint 0 errors; oxfmt clean.

Note: there is a separate operational lever (reduce `BROWSER_POOL_SIZE` / e2e concurrency, raise harness memory) handled outside this PR; this is the code fix only.