### PR TITLE
Showcase polish hardening (validators, promote specs, fixtures, token)

### DIFF
--- a/showcase/bin/spec/test_promote_fleet_target_invariant.rb
+++ b/showcase/bin/spec/test_promote_fleet_target_invariant.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+# bin/railway promote — fleet_*/target_* accessor invariant regression.
+#
+# This is the PINNING test for the convention enforced by the
+# fleet_staging/fleet_prod/target_staging/target_prod accessors. The
+# accessors only exist because TWO prior bugs were caused by a
+# fleet-scoped invariant reading the post-narrowing snapshot ivar:
+#
+#   (1) check_expected_prod_domains read the narrowed prod → fleet-wide
+#       public hosts looked "missing" on every single-service promote →
+#       spurious WARN → workflow refused without --confirm-divergence.
+#   (2) check_service_set_parity diffed narrowed staging vs narrowed prod
+#       (always equal post-narrow) → the invariant became a tautology
+#       and the "target-absent-from-prod" silent-skip path was no longer
+#       gated by a REFUSE.
+#
+# The fix replaced raw ivar reads in run_with_preflight_only with calls
+# to fleet_*/target_* accessors. This test pins the contract that those
+# accessors must point at DIFFERENT views when a single-service narrow
+# has been applied — i.e. flipping a fleet-scoped read to the target
+# view (or vice versa) must produce a regression we can see.
+#
+# Concretely: with a healthy fleet narrowed to a single domain-less
+# service, the promote must succeed silently; but if we monkey-patch
+# fleet_prod to return target_prod (the WRONG view), the same fixture
+# must produce the historic spurious "WARN: production missing expected
+# custom domains" finding. Symmetrically, swapping fleet_staging to
+# target_staging makes the service-set-parity check tautological — we
+# pin that the un-swapped version still catches a real fleet-shape
+# divergence (target-absent-from-prod surfaces as REFUSE).
+#
+# Sister spec: test_promote_single_service_fleet_invariants.rb pins the
+# behavioral CONTRACT (rc=0 on healthy fleet, REFUSE on absent target).
+# This spec pins that the accessor INDIRECTION is what enforces that
+# contract, so a future "simplify back to raw ivars" rewrite trips a
+# red light.
+
+require_relative "spec_helper"
+require "stringio"
+
+class PromoteFleetTargetInvariantTest < Minitest::Test
+    # Reuse the inline fakes pattern from
+    # test_promote_single_service_fleet_invariants.rb — kept inline so
+    # this spec is self-contained and unaffected by changes in sibling
+    # fixtures.
+    class FakeGQLBenign
+        attr_reader :calls
+        def initialize
+            @calls = []
+            @pinned_by_service = {}
+            @ts_counter = 0
+        end
+        def query(q, vars = {})
+            @calls << [q, vars]
+            sid = vars[:serviceId]
+            if q.include?("serviceInstanceUpdate")
+                @pinned_by_service[sid] = vars[:image]
+                { "serviceInstanceUpdate" => true }
+            elsif q.include?("serviceInstanceRedeploy")
+                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("ServiceInstanceRecheck")
+                pinned = @pinned_by_service[sid]
+                if pinned.nil?
+                    {
+                        "serviceInstance" => {
+                            "id" => "i",
+                            "source" => { "image" => "ghcr.io/copilotkit/old@sha256:OLD" },
+                            "updatedAt" => "2026-05-28T00:00:00Z",
+                        },
+                    }
+                else
+                    @ts_counter += 1
+                    {
+                        "serviceInstance" => {
+                            "id" => "i",
+                            "source" => { "image" => pinned },
+                            "updatedAt" => "2026-05-29T00:00:#{format('%02d', @ts_counter)}Z",
+                        },
+                    }
+                end
+            else
+                { "deployments" => { "edges" => [] } }
+            end
+        end
+
+        def pinned_services
+            @calls.select { |q, _| q.include?("serviceInstanceUpdate") }
+                  .map { |_, vars| [vars[:serviceId], vars[:image]] }
+        end
+    end
+
+    class FakeGHCR
+        def initialize(resolve_map: {})
+            @resolve_map = resolve_map
+        end
+        def resolve_digest(ref)
+            return ref.split("@", 2).last if ref.include?("@sha256:")
+            @resolve_map[ref] || "sha256:default_digest_for_#{ref.sub(/[^a-z0-9]/i, '_')[0, 16]}"
+        end
+        def manifest_exists(_ref); :exists; end
+        def parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+    end
+
+    def make_staging_service(name)
+        {
+            "name" => name, "service_id" => "svc-#{name}",
+            "image" => "ghcr.io/copilotkit/#{name}:latest",
+            "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+        }
+    end
+
+    def make_prod_service(name, custom_domains: [])
+        {
+            "name" => name, "service_id" => "prod-#{name}",
+            "image" => "ghcr.io/copilotkit/#{name}@sha256:OLD#{name.gsub(/[^a-z0-9]/i, '')}",
+            "env_keys" => [],
+            "start_command" => "node server.js", "healthcheck_path" => "/health",
+            "region" => "us-west", "replicas" => 1, "restart_policy" => "ON_FAILURE",
+            "custom_domains" => custom_domains,
+        }
+    end
+
+    # A healthy fleet whose UNION of prod custom_domains covers the
+    # SSOT-published EXPECTED_DOMAINS[PRODUCTION_ENV_ID] set. The
+    # targeted service ("aimock") is intentionally domain-less so that
+    # the NARROWED prod view (target_prod) does NOT carry the public
+    # hosts — the post-narrowing view is precisely the broken view a
+    # fleet-scoped check must NOT see.
+    def install_fleet_fixture(cmd, gql, ghcr, target: "aimock")
+        domain_services_prod = [
+            make_prod_service("dashboard", custom_domains: ["dashboard.showcase.copilotkit.ai"]),
+            make_prod_service("docs",      custom_domains: ["docs.copilotkit.ai"]),
+            make_prod_service("dojo",      custom_domains: ["dojo.showcase.copilotkit.ai"]),
+            make_prod_service("webhooks",  custom_domains: ["hooks.showcase.copilotkit.ai"]),
+            make_prod_service("shell",     custom_domains: ["showcase.copilotkit.ai"]),
+            make_prod_service(target),
+            make_prod_service("harness"),
+        ]
+        staging_services = (domain_services_prod.map { |s| s["name"] }).uniq.map { |n| make_staging_service(n) }
+
+        cmd.instance_variable_set(:@staging_snapshot, { "services" => staging_services })
+        cmd.instance_variable_set(:@prod_snapshot,    { "services" => domain_services_prod })
+        cmd.instance_variable_set(:@gql, gql)
+        cmd.instance_variable_set(:@ghcr, ghcr)
+
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |service_id|
+            name = service_id.sub(/^svc-/, "")
+            ghcr_obj = instance_variable_get(:@ghcr)
+            digest = ghcr_obj.resolve_digest("ghcr.io/copilotkit/#{name}:latest")
+            [{ "id" => "d", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/#{name}@#{digest}" } }]
+        end
+        cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
+    end
+
+    def build_cmd(argv)
+        # CRITICAL: mirror real workflow — no --confirm-divergence.
+        Railway::PromoteCommand.new(argv + ["--non-interactive", "--yes"])
+    end
+
+    def with_fast_sleeper
+        original = Railway::PromoteCommand.const_get(:RETRY_DELAY_SEC)
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, 0)
+        yield
+    ensure
+        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
+        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, original)
+    end
+
+    # ── Positive: with the CORRECT accessor wiring, a healthy
+    # single-service promote produces neither spurious domain WARN nor
+    # spurious set-parity REFUSE. This is the "green" half of the gate.
+    def test_correct_accessors_produce_no_spurious_fleet_findings
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new(resolve_map: { "ghcr.io/copilotkit/aimock:latest" => "sha256:NEW_AIMOCK" })
+        cmd = build_cmd(["aimock"])
+        install_fleet_fixture(cmd, gql, ghcr, target: "aimock")
+
+        rc = nil
+        out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
+
+        assert_equal 0, rc,
+            "healthy fleet, single-service promote, correct accessors → rc=0. " \
+            "Got rc=#{rc.inspect}; out=\n#{out}"
+        refute_match(/WARN: production missing expected custom domains/, out,
+            "fleet_prod must see the FULL prod fleet — no spurious 'missing " \
+            "fleet domains' WARN should fire when the fleet legitimately " \
+            "carries every EXPECTED_DOMAINS host")
+        refute_match(/REFUSE: services in (?:staging|prod) not in (?:prod|staging)/, out,
+            "fleet_staging/fleet_prod must see the FULL fleet — set-parity " \
+            "must not surface a spurious REFUSE when the fleet is in sync")
+    end
+
+    # ── Gate: if a future refactor flips check_expected_prod_domains to
+    # read the NARROWED view (i.e. target_prod instead of fleet_prod),
+    # the same fixture must produce the historic spurious WARN. We
+    # simulate that flip by monkey-patching fleet_prod on the instance
+    # to return target_prod (the wrong view), then assert the WARN
+    # reappears. This makes the accessor distinction load-bearing.
+    def test_swapping_fleet_prod_to_target_prod_recreates_spurious_domain_warn
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new(resolve_map: { "ghcr.io/copilotkit/aimock:latest" => "sha256:NEW_AIMOCK" })
+        cmd = build_cmd(["aimock"])
+        install_fleet_fixture(cmd, gql, ghcr, target: "aimock")
+
+        # Flip fleet_prod → target_prod (the broken pre-fix wiring).
+        # Use a singleton method that delegates to target_prod so the
+        # narrowing applied by `run` still drives the result.
+        #
+        # We also flip fleet_staging in lockstep so the SET-PARITY
+        # check stays clean (full-fleet staging vs narrowed prod would
+        # mismatch on every other service name and surface as a REFUSE
+        # that short-circuits the WARN). Isolating the BUG #1 symptom
+        # requires both reads to be uniformly broken — which is exactly
+        # the regression we're pinning against (a sweeping refactor
+        # that rewires both accessors at once).
+        cmd.define_singleton_method(:fleet_prod)    { send(:target_prod) }
+        cmd.define_singleton_method(:fleet_staging) { send(:target_staging) }
+
+        rc = nil
+        out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
+
+        assert_match(/WARN: production missing expected custom domains/, out,
+            "swapping fleet_prod to target_prod must reproduce the original " \
+            "BUG #1 symptom (spurious 'missing fleet domains' WARN on a " \
+            "healthy fleet narrowed to a domain-less service). If this " \
+            "assertion fails, the accessor distinction is no longer " \
+            "load-bearing — check_expected_prod_domains may have been " \
+            "moved or its argument source changed."
+        )
+        refute_equal 0, rc,
+            "without --confirm-divergence, the spurious WARN must refuse " \
+            "the promote (matches the historic workflow regression)"
+    end
+
+    # ── Symmetric gate: if a future refactor flips
+    # check_service_set_parity to read the narrowed staging/prod, the
+    # invariant becomes tautological and the target-absent-from-prod
+    # case stops surfacing a REFUSE. Pin that the un-swapped version
+    # catches a real fleet-shape divergence (target only in staging).
+    def test_correct_accessors_catch_target_absent_from_prod
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new(resolve_map: { "ghcr.io/copilotkit/aimock:latest" => "sha256:NEW_AIMOCK" })
+        cmd = build_cmd(["aimock"])
+        install_fleet_fixture(cmd, gql, ghcr, target: "aimock")
+
+        # Surgically remove "aimock" from prod ONLY (full fleet keeps
+        # all other services + all expected domains). Staging keeps
+        # "aimock". After narrowing both snapshots to "aimock", a check
+        # reading the narrowed view would see [aimock] vs [] — which
+        # superficially seems to also catch the divergence — but the
+        # POINT of using fleet_* is so that the SAME check fires
+        # regardless of whether the run is full-fleet or single-service.
+        full_prod = cmd.instance_variable_get(:@prod_snapshot)
+        full_prod = full_prod.merge("services" => full_prod["services"].reject { |s| s["name"] == "aimock" })
+        cmd.instance_variable_set(:@prod_snapshot, full_prod)
+
+        rc = nil
+        out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
+
+        refute_equal 0, rc,
+            "target absent from prod must FAIL LOUD (nonzero rc). Got " \
+            "rc=#{rc.inspect}; out=\n#{out}"
+        assert_match(/REFUSE: services in staging not in prod/, out,
+            "fleet_staging vs fleet_prod must surface the staging-only " \
+            "target as a clear REFUSE")
+    end
+end

--- a/showcase/bin/spec/test_rollback_commit_injection.rb
+++ b/showcase/bin/spec/test_rollback_commit_injection.rb
@@ -14,6 +14,21 @@ require_relative "spec_helper"
 class RollbackCommitInjectionTest < Minitest::Test
     # Capture every IO.popen invocation issued during the test so we can both
     # stub out git AND assert that injection attempts never reach a subprocess.
+    #
+    # Hardening notes:
+    #   * `expected_subcmds` is the set of git subcommands the test
+    #     explicitly configured (via PopenSpy.responses or PopenSpy.exits).
+    #     Any `git <subcmd>` call NOT in that set raises UnexpectedPopen
+    #     instead of silently returning nil — so a future code path that
+    #     starts shelling out to e.g. `git rev-parse` is caught loudly
+    #     at the boundary rather than producing a confusing downstream
+    #     YAML.safe_load failure on an empty string.
+    #   * `exits` yields an honest `$?.exitstatus` for the configured code
+    #     by shelling to a tiny `ruby -e "exit N"` — `true`/`false` only
+    #     produce 0/1 and so failed to surface bugs sensitive to the
+    #     specific code (e.g. git's 128 for "bad object").
+    class UnexpectedPopen < StandardError; end
+
     module PopenSpy
         @calls = []
         @responses = {}
@@ -31,6 +46,32 @@ class RollbackCommitInjectionTest < Minitest::Test
 
             def record(args)
                 @calls << args
+            end
+
+            # Subcommands the current test has explicitly accounted for.
+            # A response of "" or an exit of 0 counts as an explicit
+            # opt-in: the test author has thought about that subcmd.
+            def expected_subcmds
+                (@responses.keys + @exits.keys).uniq
+            end
+
+            # Set $?.exitstatus to `code` by running a real, short-lived
+            # subprocess that exits with that code. Using `system("true")`
+            # / `system("false")` only ever yields 0 or 1 — too lossy for
+            # bug-fidelity assertions (e.g. git's exit 128 on bad object).
+            def stamp_exit_status!(code)
+                # `ruby -e "exit N"` is portable across CI runners and
+                # avoids relying on shell builtins. Suppress stderr just
+                # in case (shouldn't print anything, but defensive).
+                # Fail loud if the spawn itself fails: `system` returns
+                # `nil` on exec failure (command-not-found / interpreter
+                # unresolvable), in which case `$?` reflects a
+                # ~127 exec failure rather than the configured code and
+                # silently corrupts the spy contract. `false` (the
+                # child ran and exited non-zero with the configured
+                # code) is the happy path here and must NOT raise.
+                result = system(RbConfig.ruby, "-e", "exit #{Integer(code)}", out: File::NULL, err: File::NULL)
+                raise "stamp_exit_status! failed to spawn #{RbConfig.ruby}" if result.nil?
             end
         end
     end
@@ -67,6 +108,13 @@ class RollbackCommitInjectionTest < Minitest::Test
         #   IO.popen(["git", "ls-tree", ...], err: [:child, :out]) { |io| io.read }
         # We intercept that and return canned output keyed by the first non-git
         # subcommand ("ls-tree" or "show").
+        #
+        # Hardening: any `git <subcmd>` NOT in PopenSpy.expected_subcmds
+        # raises UnexpectedPopen. That makes "a new subprocess shows up
+        # in the code path" a loud failure instead of a silent nil read.
+        # Non-git popens fall through to the real implementation (we
+        # want to keep e.g. minitest's own bookkeeping intact, though
+        # nothing currently relies on it).
         @original_popen = IO.method(:popen)
         spy = PopenSpy
         IO.singleton_class.send(:define_method, :popen) do |*args, **kwargs, &block|
@@ -74,12 +122,21 @@ class RollbackCommitInjectionTest < Minitest::Test
             argv = args.first
             if argv.is_a?(Array) && argv.first == "git"
                 subcmd = argv[1]
+                unless spy.expected_subcmds.include?(subcmd)
+                    raise UnexpectedPopen,
+                        "PopenSpy received an UNEXPECTED `git #{subcmd}` invocation. " \
+                        "The test only configured: #{spy.expected_subcmds.inspect}. " \
+                        "If this is a legitimate new subprocess, opt in by setting " \
+                        "PopenSpy.responses[#{subcmd.inspect}] (and/or exits) in " \
+                        "the test setup. Full argv: #{argv.inspect}"
+                end
                 response = spy.responses[subcmd] || ""
-                # Set $? to the per-subcommand desired status. Use a real
-                # subprocess (true/false) so $?.exitstatus reflects 0 or 1
-                # the way the real `git` call would.
-                exit_code = spy.exits[subcmd]
-                system(exit_code == 0 || exit_code.nil? ? "true" : "false")
+                # Stamp $?.exitstatus with the configured code (default 0).
+                # Critical for tests asserting on the *specific* exit code
+                # (e.g. git's 128 for "fatal: bad object") rather than a
+                # generic 0/1 success/fail.
+                exit_code = spy.exits[subcmd] || 0
+                spy.stamp_exit_status!(exit_code)
                 # Mimic the block form used by the production code.
                 if block
                     require "stringio"
@@ -234,5 +291,60 @@ class RollbackCommitInjectionTest < Minitest::Test
         assert_empty PopenSpy.calls.select { |c| c.first.is_a?(Array) && c.first.first == "git" },
             "no git subprocess should be spawned for unknown --env"
         refute FakeRestore.ran
+    end
+
+    # ── PopenSpy self-test: hardening guarantees ──────────────────────────
+    #
+    # These tests pin the spy's own contract so it can't silently rot.
+    # The spy is the only thing standing between a future subprocess
+    # addition and a test that "passes" with a wrong answer.
+
+    # If the production code adds a NEW git subprocess (e.g. rev-parse)
+    # without the test opting in, the spy must raise — not silently
+    # return nil/"" which would corrupt downstream assertions.
+    def test_popen_spy_raises_on_unexpected_git_subcommand
+        # Only "ls-tree" and "show" are configured here.
+        PopenSpy.responses["ls-tree"] = ""
+        PopenSpy.responses["show"] = ""
+
+        # Direct invocation simulates the "new subprocess slipped in"
+        # scenario without needing to add a real call site to railway.
+        err = assert_raises(UnexpectedPopen) do
+            IO.popen(["git", "rev-parse", "HEAD"], err: [:child, :out]) { |io| io.read }
+        end
+        assert_match(/UNEXPECTED `git rev-parse`/, err.message,
+            "spy must name the offending subcommand in its error")
+        assert_match(/ls-tree/, err.message,
+            "spy must list the configured subcommands so the operator " \
+            "can decide whether to opt the new one in")
+    end
+
+    # Exit-code fidelity: configuring `exits["show"] = 128` must yield
+    # an honest `$?.exitstatus == 128`, not a generic 1. The git-show
+    # failure-gate test depends on this fidelity to be a meaningful
+    # regression test of the gate (a gate keyed on `!= 0` would pass
+    # against a fake 1, but a gate keyed on `== 128` would not).
+    def test_popen_spy_stamps_real_exit_status_for_configured_code
+        PopenSpy.responses["show"] = "fatal: whatever\n"
+        PopenSpy.exits["show"] = 128
+
+        IO.popen(["git", "show", "abc1234:foo"], err: [:child, :out]) { |io| io.read }
+        assert_equal 128, $?.exitstatus,
+            "PopenSpy.stamp_exit_status! must reflect the *configured* " \
+            "exit code in $?.exitstatus (got #{$?.exitstatus.inspect}). " \
+            "Without this, tests asserting on specific git exit codes " \
+            "(e.g. 128 for bad object) are vacuous."
+    end
+
+    # Default behaviour: when `exits[subcmd]` is unset, the call must
+    # behave like a successful git invocation (`$?.exitstatus == 0`).
+    def test_popen_spy_defaults_to_exit_zero_when_exits_unset
+        PopenSpy.responses["ls-tree"] = "snap.yaml\n"
+
+        IO.popen(["git", "ls-tree", "abc1234"], err: [:child, :out]) { |io| io.read }
+        assert_equal 0, $?.exitstatus,
+            "default exit status for an un-configured subcmd response " \
+            "must be 0 (success), matching how real git behaves on a " \
+            "successful call"
     end
 end

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# Snapshot-ivar enforcement lint.
+#
+# Background: PromoteCommand has two snapshot "views" — the FULL un-narrowed
+# fleet snapshot and the (optionally) target-narrowed snapshot. Two prior
+# regressions came from a `check_*` method reading the wrong raw ivar
+# (`@staging_snapshot` / `@prod_snapshot`) inside a fleet-scoped invariant
+# and accidentally evaluating it against the narrowed view, producing
+# spurious WARN/REFUSE findings on single-service promotes.
+#
+# The fix introduced four accessors — `fleet_staging`, `fleet_prod`,
+# `target_staging`, `target_prod` — and the convention is that ALL reads of
+# the four backing ivars go through one of those accessors. This lint test
+# pins the convention as an executable invariant: any direct read of
+# `@staging_snapshot`, `@prod_snapshot`, `@full_staging_snapshot`, or
+# `@full_prod_snapshot` outside the explicit allowlist below FAILS the
+# suite.
+#
+# The allowlist is keyed by `<line-number>:<exact-line-content>` and the
+# check requires BOTH to match. NOTE: the allowlist is keyed by both line
+# number and stripped content. Any line shift in bin/railway above the
+# allowlisted region requires renumbering every entry by hand; the
+# `test_allowlist_entries_match_current_file_content` self-check fails
+# loud when this drifts. Nothing refreshes the allowlist mechanically —
+# this dual self-check + offender-sweep is intentional, so a new
+# offender (even one with identical surrounding text) fails the suite.
+#
+# To intentionally add a NEW legitimate write/accessor site, also add its
+# `<line>:<content>` entry to ALLOWED_LINES.
+
+require_relative "spec_helper"
+
+class SnapshotIvarLintTest < Minitest::Test
+    RAILWAY_PATH = File.expand_path("../railway", __dir__)
+
+    # The four protected ivars. Anything matching one of these names is a
+    # candidate offender unless it appears on an allowlisted line.
+    IVAR_PATTERN = /@(?:full_)?(?:staging|prod)_snapshot\b/.freeze
+
+    # Allowlist: every legitimate site that mentions one of the four
+    # ivars. Format = "<1-indexed line>:<stripped line content>". When the
+    # railway file legitimately changes, update this list to match.
+    #
+    # Categories (must remain in sync with bin/railway):
+    #   - run             : initial @full_*_snapshot capture at promote start
+    #   - capture_snapshots
+    #                      : the single test-seam assignment site
+    #   - narrow_snapshots_to_single_service!
+    #                      : the narrowing reads + writes of @{staging,prod}_snapshot
+    #   - fleet_staging / fleet_prod / target_staging / target_prod
+    #                      : the four accessors themselves (the ONLY sanctioned reads)
+    #   - comments        : block/inline comments that name the ivar in
+    #                       prose (do not perform a read)
+    ALLOWED_LINES = [
+        # `run` — capture full-fleet view before optional narrowing.
+        '1149:@full_staging_snapshot = @staging_snapshot',
+        '1150:@full_prod_snapshot    = @prod_snapshot',
+
+        # Doc comment above narrow_snapshots_to_single_service!.
+        '1158:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+
+        # narrow_snapshots_to_single_service! — the WRITE site.
+        '1166:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1171:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1172:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1173:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+
+        # Doc comment above capture_snapshots.
+        '1177:# @staging_snapshot / @prod_snapshot directly.',
+
+        # capture_snapshots — single test-seam assignment site.
+        '1179:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1180:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+
+        # Doc comment above the accessor block (explains test seam).
+        '1204:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+
+        # The four accessor bodies — the ONLY sanctioned reads.
+        '1216:@full_staging_snapshot || @staging_snapshot',
+        '1220:@full_prod_snapshot || @prod_snapshot',
+        '1224:@staging_snapshot',
+        '1228:@prod_snapshot',
+    ].freeze
+
+    def setup
+        @lines = File.readlines(RAILWAY_PATH).each_with_index.map { |l, i| [i + 1, l.chomp] }
+        @allowed = ALLOWED_LINES.each_with_object({}) do |entry, h|
+            lineno, content = entry.split(":", 2)
+            h[Integer(lineno)] = content
+        end
+    end
+
+    def test_allowlist_entries_match_current_file_content
+        # Defensive: prove the allowlist itself is correct. If someone
+        # reformats bin/railway and the allowlist drifts, surface that as
+        # a clear assertion rather than a spurious lint failure later.
+        @allowed.each do |lineno, expected|
+            actual = @lines.find { |n, _| n == lineno }
+            assert actual, "allowlist references line #{lineno} but railway has no such line"
+            assert_equal expected, actual[1].strip,
+                "allowlist content for line #{lineno} does not match railway file " \
+                "(allowlist=#{expected.inspect}, file=#{actual[1].strip.inspect}). " \
+                "If the file legitimately changed, update ALLOWED_LINES."
+        end
+    end
+
+    def test_no_direct_ivar_reads_outside_allowlist
+        offenders = []
+        @lines.each do |lineno, content|
+            next unless content =~ IVAR_PATTERN
+            next if @allowed.key?(lineno) && @allowed[lineno] == content.strip
+            offenders << "  #{RAILWAY_PATH}:#{lineno}: #{content.strip}"
+        end
+
+        assert_empty offenders, <<~MSG
+            Direct read of @{,full_}{staging,prod}_snapshot found outside the
+            sanctioned write/accessor sites. ALL reads must go through one
+            of the four accessors:
+
+                fleet_staging  / fleet_prod   — FLEET-shape invariants
+                target_staging / target_prod  — per-service checks
+
+            Offenders:
+            #{offenders.join("\n")}
+
+            If this site is a legitimate new write or accessor, add its
+            "<line>:<stripped content>" entry to ALLOWED_LINES in
+            #{__FILE__} and document why.
+        MSG
+    end
+end

--- a/showcase/harness/src/probes/aimock-fixture-coverage.test.ts
+++ b/showcase/harness/src/probes/aimock-fixture-coverage.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { promises as fs } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -277,10 +278,12 @@ function isCovered(prompt: string, fixtures: Fixture[]): boolean {
  * monolithic feature-parity.json used).
  *
  * Missing fixture DIRECTORIES are a hard error (the reorg layout is
- * load-bearing). Files present but lacking a `fixtures` array are silently
- * skipped (defensive against schema drift; no such files exist today).
+ * load-bearing). Files present but lacking a `fixtures` array are ALSO a
+ * hard error — fail loud against schema drift rather than silently skipping.
+ * Malformed JSON is rethrown with the offending file path so operators can
+ * identify the source file immediately.
  */
-async function loadAllFixtures(dirs: string[]): Promise<Fixture[]> {
+export async function loadAllFixtures(dirs: string[]): Promise<Fixture[]> {
   const out: Fixture[] = [];
   for (const dir of dirs) {
     let entries: string[];
@@ -290,17 +293,27 @@ async function loadAllFixtures(dirs: string[]): Promise<Fixture[]> {
       // Missing dir is a hard error — the reorg layout is load-bearing.
       throw new Error(
         `aimock fixture dir not found: ${dir} (${(err as Error).message})`,
+        { cause: err },
       );
     }
     const jsonFiles = entries.filter((e) => e.endsWith(".json"));
     for (const file of jsonFiles) {
       const fullPath = path.join(dir, file);
-      const raw = await fs.readFile(fullPath, "utf8");
-      const parsed = JSON.parse(raw) as Partial<FeatureParityFile>;
+      let parsed: Partial<FeatureParityFile>;
+      try {
+        const raw = await fs.readFile(fullPath, "utf8");
+        parsed = JSON.parse(raw) as Partial<FeatureParityFile>;
+      } catch (err) {
+        const msg = (err as Error).message;
+        throw new Error(`failed to parse fixture file ${fullPath}: ${msg}`, {
+          cause: err,
+        });
+      }
       if (!parsed || !Array.isArray(parsed.fixtures)) {
-        // Skip files that don't carry a fixtures array (defensive — no
-        // such files exist today but the schema is informally enforced).
-        continue;
+        // Schema drift is a hard error — every fixture file MUST carry a
+        // `fixtures` array. Matches the "missing dir is a hard error"
+        // stance above.
+        throw new Error(`fixture file missing 'fixtures' array: ${fullPath}`);
       }
       out.push(...parsed.fixtures);
     }
@@ -360,5 +373,51 @@ describe("aimock feature-parity fixture coverage for langgraph-python E2E specs"
     // trivially. Floor chosen from the current count (roughly 50+) with
     // margin for future pruning.
     expect(allPrompts.length).toBeGreaterThanOrEqual(30);
+  });
+});
+
+/**
+ * Fail-loud coverage for the two throw branches in `loadAllFixtures`.
+ *
+ * These tests exist because the loader was hardened to throw (rather than
+ * silently `continue`) on (a) malformed JSON and (b) a file missing the
+ * `fixtures` array. Without these tests, a future revert to silent-skip
+ * would pass CI green. Each test isolates a temp dir, writes the offending
+ * file, calls the helper directly, and asserts the rejection message
+ * mentions both the failure mode and the file path.
+ */
+describe("loadAllFixtures fail-loud", () => {
+  it("throws with file path when a fixture file has malformed JSON", async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "aimock-fixture-malformed-"),
+    );
+    try {
+      const badPath = path.join(tmpDir, "bad.json");
+      await fs.writeFile(badPath, "{ not valid json", "utf8");
+
+      await expect(loadAllFixtures([tmpDir])).rejects.toThrow(
+        /failed to parse fixture file/,
+      );
+      await expect(loadAllFixtures([tmpDir])).rejects.toThrow(badPath);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws with file path when a fixture file is missing the 'fixtures' array", async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "aimock-fixture-missing-"),
+    );
+    try {
+      const badPath = path.join(tmpDir, "no-fixtures.json");
+      await fs.writeFile(badPath, JSON.stringify({ notFixtures: [] }), "utf8");
+
+      await expect(loadAllFixtures([tmpDir])).rejects.toThrow(
+        /missing 'fixtures' array/,
+      );
+      await expect(loadAllFixtures([tmpDir])).rejects.toThrow(badPath);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/showcase/scripts/__tests__/verify-deploy.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.test.ts
@@ -181,6 +181,40 @@ describe("asHost validator", () => {
   it("rejects fragment '#'", () => {
     expect(() => asHost("docs.example.com#frag")).toThrow(/fragment|#/);
   });
+
+  it("rejects ASCII control characters (newline, CR, NUL, tab inside)", () => {
+    // These would survive the trim() check (because the offending
+    // char is interior, not leading/trailing) but must still be
+    // caught by the explicit control-char rule. NUL is the classic
+    // injection vector; newline/CR can cause header smuggling at any
+    // downstream `https://${host}/...` composition.
+    expect(() => asHost("docs.example\ncom")).toThrow(/control/i);
+    expect(() => asHost("docs.example\rcom")).toThrow(/control/i);
+    expect(() => asHost("docs.example\x00com")).toThrow(/control/i);
+    expect(() => asHost("docs.example\x7fcom")).toThrow(/control/i);
+    expect(() => asHost("docs.example\tcom")).toThrow(/control/i);
+  });
+
+  it("rejects a ':port' suffix", () => {
+    // domainFor() returns bare hostnames; ports are not part of the
+    // verify-pipeline contract. Reject with a precise diagnostic.
+    expect(() => asHost("docs.example.com:8080")).toThrow(/port/i);
+    expect(() => asHost("localhost:3000")).toThrow(/port/i);
+  });
+
+  it("rejects characters outside the DNS-label charset", () => {
+    // Underscore, unicode — none are in [A-Za-z0-9.-]. Leading/trailing
+    // whitespace is caught earlier by the trim check; interior
+    // whitespace is rejected here by the charset rule. `:` is caught
+    // by the port suffix check.
+    expect(() => asHost("docs_example.com")).toThrow(/charset|DNS/);
+    expect(() => asHost("docs.exämple.com")).toThrow(/charset|DNS/);
+    expect(() => asHost("docs!example.com")).toThrow(/charset|DNS/);
+    // Pure positive: real SSOT-shape hostnames still pass.
+    expect(() => asHost("docs.example.com")).not.toThrow();
+    expect(() => asHost("a-b.c-d.example")).not.toThrow();
+    expect(() => asHost("harness-staging-2ee4.up.railway.app")).not.toThrow();
+  });
 });
 
 describe("runVerify driver dispatch", () => {

--- a/showcase/scripts/deploy-to-railway.ts
+++ b/showcase/scripts/deploy-to-railway.ts
@@ -39,10 +39,19 @@ const SHOWCASE = {
  * the script's exit-1 contract for operator/config errors. The shared
  * helper never calls process.exit — exit-code mapping lives HERE so the
  * helper stays unit-testable.
+ *
+ * Memoized at module scope so the Railway config isn't re-read and the
+ * deprecation warning isn't re-emitted on every GraphQL request. A
+ * failure is NOT cached — the first call's error still maps to exit 1
+ * (or rethrows for non-RailwayTokenError), so a transient/operator
+ * error remains fail-loud and a subsequent run gets a fresh resolution.
  */
+let cachedToken: string | undefined;
 function getToken(): string {
+  if (cachedToken) return cachedToken;
   try {
-    return resolveRailwayToken().token;
+    cachedToken = resolveRailwayToken().token;
+    return cachedToken;
   } catch (e) {
     if (e instanceof RailwayTokenError) {
       console.error(e.message);
@@ -206,8 +215,8 @@ async function createService(slug: string): Promise<void> {
     // GITHUB_ACTOR for CI contexts). Fail loud rather than baking a
     // personal handle into the script.
     const ghcrUser = (
-      process.env.GHCR_USERNAME ??
-      process.env.GITHUB_ACTOR ??
+      process.env.GHCR_USERNAME ||
+      process.env.GITHUB_ACTOR ||
       ""
     ).trim();
     if (!ghcrUser) {

--- a/showcase/scripts/verify-deploy.ts
+++ b/showcase/scripts/verify-deploy.ts
@@ -95,32 +95,50 @@ export function parseArgs(argv: string[]): ParsedArgs {
  * A `Host` is a bare hostname literal (no scheme, no path, no slash) —
  * exactly the shape `domainFor()` is documented to return. The brand is
  * structural only: at runtime a `Host` IS a string, so it is assignable
- * to any `string`-typed parameter (e.g. `checkHealthcheck200(host, ...)`)
- * with no runtime cost. The point is to prevent the inverse direction —
- * a caller cannot hand a `ProbeTarget` a scheme-included or path-bearing
- * string without going through `asHost()`, which validates fail-loud.
+ * to any `string`-typed parameter with no runtime cost. The point is to
+ * prevent the inverse direction — a caller cannot hand a `ProbeTarget` a
+ * scheme-included or path-bearing string without going through
+ * `asHost()`, which validates fail-loud.
+ *
+ * The brand uses a non-exported `unique symbol`, so a stray
+ * `"foo" as Host` cast from outside this module is a type error — the
+ * brand symbol is not in scope. `asHost()` is the sole legitimate
+ * constructor.
  *
  * Co-located with `ProbeTarget` (the only structural consumer) rather
  * than in `railway-envs.ts` to keep the brand at the verify-pipeline
  * boundary; `domainFor()` keeps its `string` return type and we validate
  * + brand at the point of ingress in `resolveProbeTargets`.
  */
-export type Host = string & { readonly __brand: "Host" };
+declare const HostBrand: unique symbol;
+export type Host = string & { readonly [HostBrand]: true };
 
 /**
- * Validate + brand a bare hostname literal as a `Host`. Throws on any
- * scheme separator (`://`), any slash (path component), leading/trailing
- * whitespace, or any of `@` (userinfo), `?` (query), `#` (fragment) — the
- * verify-deploy pipeline never wants any of these — drivers always build
- * URLs as `https://${host}${path}`, so a host carrying any of those would
- * produce malformed URLs at the driver boundary.
+ * Validate + brand a bare hostname literal as a `Host`. Rejects, with a
+ * precise diagnostic per case:
+ *   - any scheme separator (`://`)
+ *   - any slash (path component)
+ *   - the empty string
+ *   - leading/trailing whitespace
+ *   - `@` (userinfo), `?` (query), `#` (fragment)
+ *   - any ASCII control character (`\x00-\x1f`, `\x7f` — e.g. `\n`, `\r`)
+ *   - any `:` character (typically a `:port` suffix — bare hostnames
+ *     from `domainFor` never contain a colon; ports are not part of
+ *     the contract)
+ *   - any character outside the DNS-label charset `[A-Za-z0-9.-]`
+ *     (positive shape check — rejects unicode, `_`, `!`, etc.)
+ *
+ * The verify-deploy pipeline never wants any of these — drivers always
+ * build URLs as `https://${host}${path}`, so a host carrying any of
+ * the above would produce malformed URLs at the driver boundary.
  *
  * Overlap with `domainFor()` is partial, not full: `domainFor` re-checks
  * scheme + empty on the normal SSOT path, but does NOT check path/slash
- * or the whitespace/userinfo/query/fragment cases that `asHost` rejects.
- * The override seam in `resolveProbeTargets` (test-only path that bypasses
- * `domainFor` entirely) is what makes the `asHost` call mandatory — it is
- * the sole ingress that gets to skip `domainFor`'s checks.
+ * or the whitespace/userinfo/query/fragment/control/port/charset cases
+ * that `asHost` rejects. The override seam in `resolveProbeTargets`
+ * (test-only path that bypasses `domainFor` entirely) is what makes the
+ * `asHost` call mandatory — it is the sole ingress that gets to skip
+ * `domainFor`'s checks.
  */
 export function asHost(value: string): Host {
   if (value.includes("://")) {
@@ -152,6 +170,29 @@ export function asHost(value: string): Host {
   if (value.includes("#")) {
     throw new Error(
       `asHost: host must not include a fragment "#" (got "${value}")`,
+    );
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(value)) {
+    throw new Error(
+      `asHost: host must not include control characters (got ${JSON.stringify(value)})`,
+    );
+  }
+  // Port suffix: verify-pipeline hosts from `domainFor` are bare
+  // hostnames. A `:port` here would produce `https://host:port/path`
+  // — well-formed but outside the contract — so reject it loudly so
+  // callers feed a bare hostname (the SSOT shape).
+  if (value.includes(":")) {
+    throw new Error(
+      `asHost: host must not include a port suffix (got "${value}")`,
+    );
+  }
+  // Positive DNS-label charset check. Anchored so any single invalid
+  // character (space, `_`, unicode, etc.) is rejected. Combined with
+  // the negative rules above, this leaves only `[A-Za-z0-9.-]+`.
+  if (!/^[A-Za-z0-9.-]+$/.test(value)) {
+    throw new Error(
+      `asHost: host must match DNS-label charset [A-Za-z0-9.-] (got "${value}")`,
     );
   }
   return value as Host;
@@ -208,10 +249,11 @@ export function resolveProbeTargets(opts: ResolveOpts): ProbeTarget[] {
     // receives a `Host` (not a raw `string`). On the normal path
     // `domainFor` already enforces scheme + empty checks, and `asHost`
     // re-validates those (cheap redundancy). The checks that ONLY exist
-    // here — path/slash, leading/trailing whitespace, `@`/`?`/`#` — are
-    // mandatory because the override seam below (`overrideDomains`,
-    // test-only) bypasses `domainFor` entirely; `asHost` is the sole
-    // gate that catches those for both paths.
+    // here — path/slash, leading/trailing whitespace, `@`/`?`/`#`,
+    // control chars, port suffix, DNS-label charset — are mandatory
+    // because the override seam above (`overrideDomains`, test-only)
+    // bypasses `domainFor` entirely; `asHost` is the sole gate that
+    // catches those for both paths.
     const host = asHost(rawHost);
     targets.push({ name, host, driver: entry.probe.driver });
   }

--- a/showcase/shell-dashboard/src/lib/runtime-config.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.test.ts
@@ -120,7 +120,7 @@ describe("server getRuntimeConfig (shell-dashboard)", () => {
     expect(cfg.opsBaseUrl).toBe("https://primary-ops.example.com");
   });
 
-  it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
+  it("getRuntimeConfigForMiddleware skips noStore() (Edge runtime path)", async () => {
     // Confirm the Edge wrapper passes `{ noStore: false }`.
     // Reach into the mocked module to assert noStore was NOT called
     // on this path, while the default getRuntimeConfig() above DID
@@ -132,8 +132,8 @@ describe("server getRuntimeConfig (shell-dashboard)", () => {
     process.env.SHELL_URL = "https://edge-shell.example.com";
     process.env.OPS_BASE_URL = "https://edge-ops.example.com";
 
-    const { getRuntimeConfigEdge } = await import("./runtime-config");
-    const cfg = getRuntimeConfigEdge();
+    const { getRuntimeConfigForMiddleware } = await import("./runtime-config");
+    const cfg = getRuntimeConfigForMiddleware();
     expect(cfg.pocketbaseUrl).toBe("https://edge.example.com");
     expect(noStoreSpy).not.toHaveBeenCalled();
 

--- a/showcase/shell-dashboard/src/lib/runtime-config.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.ts
@@ -42,7 +42,7 @@ const PROD_INVALID_SHELL_URL = "about:blank#shell-url-missing";
  * the build artifact. The Edge runtime (middleware) MUST pass
  * `{ noStore: false }` — `unstable_noStore()` is unavailable there, and
  * middleware always runs per-request by definition so there is no
- * static cache to opt out of. The thin `getRuntimeConfigEdge()` wrapper
+ * static cache to opt out of. The thin `getRuntimeConfigForMiddleware()` wrapper
  * below makes this explicit at the call site.
  */
 export function getRuntimeConfig(
@@ -86,7 +86,7 @@ export function getRuntimeConfig(
  * `getRuntimeConfig` — otherwise the Edge bundle pulls in `next/cache`
  * and the build fails with "module not found in edge runtime."
  */
-export function getRuntimeConfigEdge(): RuntimeConfig {
+export function getRuntimeConfigForMiddleware(): RuntimeConfig {
   return getRuntimeConfig({ noStore: false });
 }
 

--- a/showcase/shell-docs/src/lib/runtime-config.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.test.ts
@@ -8,7 +8,7 @@ vi.mock("next/cache", () => ({
   unstable_noStore: () => {},
 }));
 
-import { getRuntimeConfig, getRuntimeConfigEdge } from "./runtime-config";
+import { getRuntimeConfig, getRuntimeConfigForMiddleware } from "./runtime-config";
 
 const URL_KEYS = [
   "NEXT_PUBLIC_BASE_URL",
@@ -246,7 +246,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
     expect(cfg.posthogHost).toBe("https://primary-ph.example.com");
   });
 
-  it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
+  it("getRuntimeConfigForMiddleware skips noStore() (Edge runtime path)", async () => {
     const cacheMod = await import("next/cache");
     const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
     (process.env as Record<string, string>).NODE_ENV = "production";
@@ -256,7 +256,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
       "https://edge-signup.example.com";
     process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://edge-ph.example.com";
 
-    const cfg = getRuntimeConfigEdge();
+    const cfg = getRuntimeConfigForMiddleware();
     expect(cfg.baseUrl).toBe("https://edge.example.com");
     expect(noStoreSpy).not.toHaveBeenCalled();
 

--- a/showcase/shell-docs/src/lib/runtime-config.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.test.ts
@@ -8,7 +8,10 @@ vi.mock("next/cache", () => ({
   unstable_noStore: () => {},
 }));
 
-import { getRuntimeConfig, getRuntimeConfigForMiddleware } from "./runtime-config";
+import {
+  getRuntimeConfig,
+  getRuntimeConfigForMiddleware,
+} from "./runtime-config";
 
 const URL_KEYS = [
   "NEXT_PUBLIC_BASE_URL",

--- a/showcase/shell-docs/src/lib/runtime-config.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.ts
@@ -63,7 +63,7 @@ const PROD_DEFAULT_POSTHOG_HOST = "https://eu.i.posthog.com";
  * into the build artifact. The Edge runtime (middleware) MUST pass
  * `{ noStore: false }` — `unstable_noStore()` is unavailable there,
  * and middleware always runs per-request by definition so there is no
- * static cache to opt out of. The thin `getRuntimeConfigEdge()`
+ * static cache to opt out of. The thin `getRuntimeConfigForMiddleware()`
  * wrapper below makes this explicit at the call site.
  */
 export function getRuntimeConfig(
@@ -134,7 +134,7 @@ export function getRuntimeConfig(
  * `getRuntimeConfig` — otherwise the Edge bundle pulls in `next/cache`
  * and the build fails with "module not found in edge runtime."
  */
-export function getRuntimeConfigEdge(): RuntimeConfig {
+export function getRuntimeConfigForMiddleware(): RuntimeConfig {
   return getRuntimeConfig({ noStore: false });
 }
 

--- a/showcase/shell-docs/src/middleware.ts
+++ b/showcase/shell-docs/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextFetchEvent, NextRequest } from "next/server";
 import { seoRedirects } from "@/lib/seo-redirects";
 import { stripRouteGroupSegmentsFromPathname } from "@/lib/route-groups";
-import { getRuntimeConfigEdge } from "@/lib/runtime-config";
+import { getRuntimeConfigForMiddleware } from "@/lib/runtime-config";
 import registry from "@/data/registry.json";
 
 // ---------------------------------------------------------------------------
@@ -67,7 +67,7 @@ for (const entry of seoRedirects) {
 // changing NEXT_PUBLIC_POSTHOG_HOST. The reader applies the same
 // `https://eu.i.posthog.com` fallback used before.
 function getPosthogHost(): string {
-  return getRuntimeConfigEdge().posthogHost;
+  return getRuntimeConfigForMiddleware().posthogHost;
 }
 const DISTINCT_ID_COOKIE = "ph_distinct_id";
 // ~2 years — long enough to meaningfully track returning visitors.

--- a/showcase/shell/src/lib/runtime-config.test.ts
+++ b/showcase/shell/src/lib/runtime-config.test.ts
@@ -119,15 +119,15 @@ describe("server getRuntimeConfig (shell)", () => {
     expect(cfg.posthogHost).toBe("https://alt-ph.example.com");
   });
 
-  it("getRuntimeConfigEdge skips noStore() (Edge runtime path)", async () => {
+  it("getRuntimeConfigForMiddleware skips noStore() (Edge runtime path)", async () => {
     const cacheMod = await import("next/cache");
     const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
     (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.BASE_URL = "https://edge.example.com";
     process.env.POSTHOG_HOST = "https://edge-posthog.example.com";
 
-    const { getRuntimeConfigEdge } = await import("./runtime-config");
-    const cfg = getRuntimeConfigEdge();
+    const { getRuntimeConfigForMiddleware } = await import("./runtime-config");
+    const cfg = getRuntimeConfigForMiddleware();
     expect(cfg.baseUrl).toBe("https://edge.example.com");
     expect(noStoreSpy).not.toHaveBeenCalled();
 

--- a/showcase/shell/src/lib/runtime-config.ts
+++ b/showcase/shell/src/lib/runtime-config.ts
@@ -38,7 +38,7 @@ const PROD_INVALID_BASE_URL = "about:blank#shell-base-url-missing";
  * the build artifact. The Edge runtime (middleware) MUST pass
  * `{ noStore: false }` — `unstable_noStore()` is unavailable there, and
  * middleware always runs per-request by definition so there is no
- * static cache to opt out of. The thin `getRuntimeConfigEdge()` wrapper
+ * static cache to opt out of. The thin `getRuntimeConfigForMiddleware()` wrapper
  * below makes this explicit at the call site.
  */
 export function getRuntimeConfig(
@@ -71,7 +71,7 @@ export function getRuntimeConfig(
  * `getRuntimeConfig` — otherwise the Edge bundle pulls in `next/cache`
  * and the build fails with "module not found in edge runtime."
  */
-export function getRuntimeConfigEdge(): RuntimeConfig {
+export function getRuntimeConfigForMiddleware(): RuntimeConfig {
   return getRuntimeConfig({ noStore: false });
 }
 

--- a/showcase/shell/src/middleware.ts
+++ b/showcase/shell/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { seoRedirects } from "@/lib/seo-redirects";
-import { getRuntimeConfigEdge } from "@/lib/runtime-config";
+import { getRuntimeConfigForMiddleware } from "@/lib/runtime-config";
 import registry from "@/data/registry.json";
 
 // ---------------------------------------------------------------------------
@@ -55,8 +55,8 @@ function trackRedirect(id: string, fromPath: string, toPath: string): void {
 
   // Read the PostHog host from the Edge-safe runtime config (live
   // process.env at request time, no `next/cache` import — see
-  // getRuntimeConfigEdge in src/lib/runtime-config.ts).
-  const posthogHost = getRuntimeConfigEdge().posthogHost;
+  // getRuntimeConfigForMiddleware in src/lib/runtime-config.ts).
+  const posthogHost = getRuntimeConfigForMiddleware().posthogHost;
 
   // Fire-and-forget — don't await
   fetch(`${posthogHost}/capture/`, {


### PR DESCRIPTION
## Summary

Polish/hardening sweep over the showcase deploy + promote tooling — the deferred follow-up items from the deploy-pipeline closeout. Five focused, low-coupling changes:

- **asHost validator + Host brand** — reject ASCII control chars, colon/port suffix, and any non-DNS-charset character; switch the `Host` brand from a string-literal `__brand` to a non-exported `unique symbol` so an out-of-module `as Host` cast is a type error. `asHost` remains the sole runtime constructor.
- **Railway promote snapshot invariants** — a regression spec that fails if a fleet-scoped check reads the narrowed single-service snapshot (the historic spurious-WARN/REFUSE bug), an executable lint banning direct `@*_snapshot` reads outside the sanctioned accessors, and PopenSpy hardening (`UnexpectedPopen` + honest exit-code stamping).
- **aimock fixture loader fail-loud** — throw (with the offending path + caught error as `cause`) on malformed JSON or a missing `fixtures` array instead of silently skipping; covering tests for both throw branches.
- **deploy-to-railway cleanup** — memoize the Railway token (failures never cached), and resolve the GHCR username with `||` so an empty `GHCR_USERNAME` falls through to `GITHUB_ACTOR`.
- **rename** `getRuntimeConfigEdge` → `getRuntimeConfigForMiddleware` across shell, shell-docs, shell-dashboard (definitions, middleware call sites, tests). No behavior change.

## Test plan

- [x] `verify-deploy` vitest (99) incl. new asHost rejection cases
- [x] aimock fixture-coverage vitest (3) incl. red-green throw-branch tests
- [x] ruby promote spec suite (111 runs / 392 assertions / 0 failures)
- [x] shell / shell-docs / shell-dashboard runtime-config vitest (46)
- [x] tsc, oxfmt, oxlint clean on changed files