### PR TITLE
fix(react-core): mount interrupt card on consecutive interrupts in one thread

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useInterrupt } from "../use-interrupt";
 import { useCopilotKit } from "../../context";
 import { useAgent } from "../use-agent";
@@ -57,6 +57,12 @@ describe("useInterrupt", () => {
     });
 
     mockUseAgent.mockReturnValue({ agent: mockAgent });
+  });
+
+  afterEach(() => {
+    // F21: clean up the test-only global installed by the 2nd-interrupt
+    // BugHarness so it cannot leak across tests.
+    delete (globalThis as { __forceRerender?: () => void }).__forceRerender;
   });
 
   function Harness({
@@ -520,5 +526,108 @@ describe("useInterrupt", () => {
     expect(tail.some((v) => v === null)).toBe(false);
 
     unmount();
+  });
+
+  it("falls back to null result when sync handler throws (no crash)", () => {
+    // F3: a synchronous throw from the consumer's handler must NOT escape the
+    // hook's effect and crash the React tree. The JSDoc on `handler` states
+    // "Rejecting/throwing falls back to `result = null`" — this enforces the
+    // sync branch matches the documented contract.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = vi.fn(() => {
+      throw new Error("sync-boom");
+    });
+
+    expect(() => {
+      render(<Harness renderInChat={false} handler={handler} />);
+      emitInterrupt("sync-throw");
+    }).not.toThrow();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("interrupt").textContent).toContain(
+      "no-result:sync-throw",
+    );
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("logs and falls back to null when async handler rejects", async () => {
+    // F3 (companion): the async rejection path was previously swallowed
+    // silently. It must log via console.error so the failure is diagnosable
+    // while still honoring the documented null-fallback.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <Harness
+        renderInChat={false}
+        handler={() => Promise.reject(new Error("async-boom"))}
+      />,
+    );
+
+    emitInterrupt("async-throw");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("interrupt").textContent).toContain(
+        "no-result:async-throw",
+      );
+    });
+
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("runs handler exactly once when resolve identity changes mid-interrupt", () => {
+    // F4: the handler effect must not re-invoke the consumer handler when
+    // only `resolve`'s identity churns (e.g. because the underlying agent or
+    // copilotkit reference changes). Pin the handler effect to `pendingEvent`
+    // so a single interrupt → a single handler invocation, regardless of how
+    // many times resolve's identity flips while the interrupt is pending.
+    const handler = vi.fn(({ event }) => `handled:${String(event.value)}`);
+
+    // We render twice with two different `agent` identities. The second
+    // useAgent return updates the mock so `resolve` (deps: [agent, copilotkit])
+    // gets a new identity. The handler effect must NOT re-run for the same
+    // pendingEvent.
+    const agentA = { ...mockAgent, id: "agent-a" };
+    const agentB = { ...mockAgent, id: "agent-b" };
+    mockUseAgent.mockReturnValue({ agent: agentA });
+
+    const { rerender } = render(
+      <Harness renderInChat={false} handler={handler} />,
+    );
+
+    emitInterrupt("once");
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Swap the agent identity to churn resolve's identity, then re-render.
+    mockUseAgent.mockReturnValue({ agent: agentB });
+    act(() => {
+      rerender(<Harness renderInChat={false} handler={handler} />);
+    });
+
+    // pendingEvent unchanged → handler must NOT fire again.
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats interrupt as disabled when enabled predicate throws", () => {
+    // F5: a throwing enabled predicate must NOT crash the tree at either
+    // call site (handler effect or element memo). On throw the interrupt is
+    // treated as disabled — no handler invocation, no element rendered.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = vi.fn(() => "should-not-run");
+    const enabled = vi.fn(() => {
+      throw new Error("predicate-boom");
+    });
+
+    expect(() => {
+      render(
+        <Harness renderInChat={false} enabled={enabled} handler={handler} />,
+      );
+      emitInterrupt("filtered");
+    }).not.toThrow();
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("interrupt")).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
@@ -227,7 +227,13 @@ describe("useInterrupt", () => {
     expect(screen.queryByTestId("interrupt")).toBeNull();
   });
 
-  it("resolve clears UI and resumes agent with response payload", () => {
+  it("resolve resumes agent with response payload and keeps card mounted until run starts", () => {
+    // The card MUST stay mounted across resolve() so the resume-run's first
+    // tokens stream into the interrupt UI; onRunStartedEvent (fired by the
+    // resume run) is the legitimate clear path. Previously the hook
+    // synchronously cleared pendingEvent inside resolve, which forced
+    // consumers to wrap resolve() in a 500ms setTimeout to keep the card
+    // mounted long enough.
     render(<Harness renderInChat={false} />);
 
     emitInterrupt("approve-me");
@@ -235,7 +241,8 @@ describe("useInterrupt", () => {
       screen.getByTestId("interrupt").click();
     });
 
-    expect(screen.queryByTestId("interrupt")).toBeNull();
+    // Card still mounted — the resume run will clear it via onRunStartedEvent.
+    expect(screen.queryByTestId("interrupt")).not.toBeNull();
     expect(runAgentMock).toHaveBeenCalledTimes(1);
     expect(runAgentMock).toHaveBeenCalledWith({
       agent: mockAgent,
@@ -246,6 +253,12 @@ describe("useInterrupt", () => {
         },
       },
     });
+
+    // Once the resume run actually starts, the card unmounts.
+    act(() => {
+      handlers.onRunStartedEvent?.();
+    });
+    expect(screen.queryByTestId("interrupt")).toBeNull();
   });
 
   it("does not render and does not run handler when enabled returns false", () => {
@@ -393,5 +406,119 @@ describe("useInterrupt", () => {
     });
 
     expect(screen.getByTestId("interrupt").textContent).toContain("second");
+  });
+
+  it("renders the second interrupt card in the same thread", async () => {
+    // Reproduces the 2nd-interrupt bug: in a single thread, after resolving
+    // the first interrupt and a new run completes with another interrupt,
+    // the chat subscriber must latch a NON-null element carrying the 2nd
+    // interrupt's value. The bug is the publish effect's cleanup pushing
+    // null on every dep churn (config.render is a new identity every render),
+    // so the LAST publish observed by the chat subscriber after the 2nd
+    // interrupt arrives is `null` rather than the new element.
+    //
+    // We simulate the real consumer pattern: an inline render lambda whose
+    // identity changes on every parent render. We force extra parent renders
+    // after the 2nd interrupt arrives so the publish effect's cleanup runs
+    // AFTER the last non-null publish (which is what unmounts the card in
+    // production).
+    function BugHarness() {
+      const [, setNonce] = React.useState(0);
+      // Expose a way to force re-renders to mimic parent re-rendering after
+      // the interrupt has been published.
+      (globalThis as { __forceRerender?: () => void }).__forceRerender = () =>
+        setNonce((n) => n + 1);
+
+      useInterrupt({
+        // Inline render lambda → new identity every render.
+        render: ({ event, resolve }) => (
+          <button
+            data-testid="interrupt"
+            onClick={() => resolve({ approved: true, value: event.value })}
+          >
+            {String(event.value)}
+          </button>
+        ),
+      });
+      return <div />;
+    }
+
+    const { unmount } = render(<BugHarness />);
+
+    // --- Interrupt #1 ---
+    act(() => {
+      handlers.onCustomEvent?.({
+        event: { name: "on_interrupt", value: "first" },
+      });
+      handlers.onRunFinalized?.();
+    });
+
+    await waitFor(() => {
+      const last1 = setInterruptElementMock.mock.calls.at(-1)?.[0];
+      expect(last1).not.toBeNull();
+      expect(React.isValidElement(last1)).toBe(true);
+    });
+
+    // Resolve the first interrupt (mimic clicking the card's resolve button).
+    const firstElement = setInterruptElementMock.mock.calls
+      .map((c) => c[0])
+      .filter((el) => el != null)
+      .at(-1) as React.ReactElement<{ onClick: () => void }>;
+    act(() => {
+      firstElement.props.onClick();
+    });
+
+    // --- Resume run starts + 2nd interrupt arrives in same thread ---
+    act(() => {
+      handlers.onRunStartedEvent?.();
+    });
+    act(() => {
+      handlers.onCustomEvent?.({
+        event: { name: "on_interrupt", value: "second" },
+      });
+      handlers.onRunFinalized?.();
+    });
+
+    // Force a parent re-render AFTER the 2nd interrupt published. This
+    // mimics a parent component re-rendering (e.g. due to chat-subscriber
+    // state churn) while the interrupt is still pending. With the bug,
+    // config.render's new identity causes the element memo to recompute,
+    // which re-runs the publish effect — and its cleanup pushes a stale
+    // `null` AFTER the latest non-null element, leaving the chat subscriber
+    // latched to null. The card never mounts.
+    act(() => {
+      (globalThis as { __forceRerender?: () => void }).__forceRerender?.();
+    });
+
+    // After all renders settle, the chat subscriber must LAST see a non-null
+    // element carrying the 2nd interrupt's value.
+    await waitFor(() => {
+      const last = setInterruptElementMock.mock.calls.at(-1)?.[0];
+      expect(last).not.toBeNull();
+      expect(React.isValidElement(last)).toBe(true);
+      const el = last as React.ReactElement<{ children: React.ReactNode }>;
+      expect(String(el.props.children)).toContain("second");
+    });
+
+    // Stronger assertion: after the 2nd interrupt finalized, NO publish call
+    // should clear the element to null. The publish effect must not nullify
+    // on dep churn — only on true unmount (covered separately).
+    const callsAfterSecondFinalize = setInterruptElementMock.mock.calls
+      .map((c, i) => ({ value: c[0], index: i }))
+      .filter((c) => {
+        if (c.value == null) return false;
+        const el = c.value as React.ReactElement<{
+          children: React.ReactNode;
+        }>;
+        return String(el.props.children).includes("second");
+      });
+    const firstSecondIdx = callsAfterSecondFinalize[0]?.index ?? -1;
+    expect(firstSecondIdx).toBeGreaterThanOrEqual(0);
+    const tail = setInterruptElementMock.mock.calls
+      .slice(firstSecondIdx)
+      .map((c) => c[0]);
+    expect(tail.some((v) => v === null)).toBe(false);
+
+    unmount();
   });
 });

--- a/packages/react-core/src/v2/hooks/use-interrupt.tsx
+++ b/packages/react-core/src/v2/hooks/use-interrupt.tsx
@@ -220,7 +220,10 @@ export function useInterrupt<
 
   const resolve = useCallback(
     (response: unknown) => {
-      setPendingEvent(null);
+      // Do NOT synchronously clear pendingEvent here — onRunStartedEvent
+      // already clears it when the resume run begins. Clearing synchronously
+      // unmounts the card before commit, which previously forced consumers
+      // to wrap their resolve() in a 500ms setTimeout to keep the UI alive.
       copilotkit.runAgent({
         agent,
         forwardedProps: {
@@ -234,6 +237,18 @@ export function useInterrupt<
     [agent, copilotkit],
   );
 
+  // Stabilize consumer-supplied callbacks behind refs so inline lambdas
+  // (a new identity every parent render) do NOT churn the element memo
+  // identity or the handler effect. Without this, every dep-churn cycle
+  // would re-run the publish effect's cleanup, racing a stale `null` past
+  // the new element and unmounting the in-chat card on each render.
+  const renderRef = useRef(config.render);
+  renderRef.current = config.render;
+  const enabledRef = useRef(config.enabled);
+  enabledRef.current = config.enabled;
+  const handlerRef = useRef(config.handler);
+  handlerRef.current = config.handler;
+
   useEffect(() => {
     // No interrupt to process — reset any stale handler result from a previous interrupt
     if (!pendingEvent) {
@@ -241,11 +256,11 @@ export function useInterrupt<
       return;
     }
     // Interrupt exists but the consumer's filter rejects it — treat as no-op
-    if (config.enabled && !config.enabled(pendingEvent)) {
+    if (enabledRef.current && !enabledRef.current(pendingEvent)) {
       setHandlerResult(null);
       return;
     }
-    const handler = config.handler;
+    const handler = handlerRef.current;
     // No handler provided — skip straight to rendering with a null result
     if (!handler) {
       setHandlerResult(null);
@@ -274,27 +289,36 @@ export function useInterrupt<
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingEvent, config.enabled, config.handler, resolve]);
+  }, [pendingEvent, resolve]);
 
   const element = useMemo(() => {
     if (!pendingEvent) return null;
-    if (config.enabled && !config.enabled(pendingEvent)) return null;
+    if (enabledRef.current && !enabledRef.current(pendingEvent)) return null;
 
-    return config.render({
+    return renderRef.current({
       event: pendingEvent,
       result: handlerResult,
       resolve,
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingEvent, handlerResult, config.enabled, config.render, resolve]);
+  }, [pendingEvent, handlerResult, resolve]);
 
-  // Publish to core for in-chat rendering
+  // Publish to core for in-chat rendering. Publish-only — do NOT nullify
+  // on dep churn; the element memo already returns null when pendingEvent
+  // is null (the legitimate clear path: onRunStartedEvent / onRunFailed).
   useEffect(() => {
     if (config.renderInChat === false) return;
     copilotkit.setInterruptElement(element);
-    return () => copilotkit.setInterruptElement(null);
   }, [element, config.renderInChat, copilotkit]);
+
+  // Nullify on true unmount only. Separate effect with empty deps so the
+  // cleanup runs exactly once when the component is removed from the tree.
+  useEffect(() => {
+    if (config.renderInChat === false) return;
+    return () => {
+      copilotkit.setInterruptElement(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Only return element when rendering outside chat
   if (config.renderInChat === false) {

--- a/packages/react-core/src/v2/hooks/use-interrupt.tsx
+++ b/packages/react-core/src/v2/hooks/use-interrupt.tsx
@@ -248,6 +248,29 @@ export function useInterrupt<
   enabledRef.current = config.enabled;
   const handlerRef = useRef(config.handler);
   handlerRef.current = config.handler;
+  // F4: mirror `resolve` behind a ref so the handler effect does not depend
+  // on resolve's identity. Without this, churn in [agent, copilotkit]
+  // (resolve's deps) would re-run the effect for the same pendingEvent and
+  // double-invoke the consumer handler.
+  const resolveRef = useRef(resolve);
+  resolveRef.current = resolve;
+
+  // F5: predicate evaluator that treats a throw as "disabled" (false) and
+  // logs the error. Called from both the handler effect and the element
+  // memo, neither of which may crash the React tree on a consumer bug.
+  const isEnabled = (event: InterruptEvent): boolean => {
+    const predicate = enabledRef.current;
+    if (!predicate) return true;
+    try {
+      return predicate(event);
+    } catch (err) {
+      console.error(
+        "[CopilotKit] useInterrupt enabled predicate threw; treating interrupt as disabled:",
+        err,
+      );
+      return false;
+    }
+  };
 
   useEffect(() => {
     // No interrupt to process — reset any stale handler result from a previous interrupt
@@ -255,8 +278,9 @@ export function useInterrupt<
       setHandlerResult(null);
       return;
     }
-    // Interrupt exists but the consumer's filter rejects it — treat as no-op
-    if (enabledRef.current && !enabledRef.current(pendingEvent)) {
+    // Interrupt exists but the consumer's filter rejects it — treat as no-op.
+    // F5: a throw from the predicate is treated as "disabled".
+    if (!isEnabled(pendingEvent)) {
       setHandlerResult(null);
       return;
     }
@@ -268,10 +292,25 @@ export function useInterrupt<
     }
 
     let cancelled = false;
-    const maybePromise = handler({
-      event: pendingEvent,
-      resolve,
-    });
+    // F3: a synchronous throw from the consumer handler must not escape the
+    // effect. Honor the documented contract ("Rejecting/throwing falls back
+    // to `result = null`") at the sync branch too.
+    let maybePromise: ReturnType<typeof handler>;
+    try {
+      maybePromise = handler({
+        event: pendingEvent,
+        resolve: resolveRef.current,
+      });
+    } catch (err) {
+      console.error(
+        "[CopilotKit] useInterrupt handler threw; result will be null:",
+        err,
+      );
+      if (!cancelled) setHandlerResult(null);
+      return () => {
+        cancelled = true;
+      };
+    }
 
     // If the handler returns a promise/thenable, wait for resolution before setting result.
     if (isPromiseLike(maybePromise)) {
@@ -279,7 +318,13 @@ export function useInterrupt<
         .then((resolved) => {
           if (!cancelled) setHandlerResult(resolved);
         })
-        .catch(() => {
+        .catch((err) => {
+          // F3 (companion): log the async failure so it isn't silently
+          // swallowed, while preserving the documented null-fallback.
+          console.error(
+            "[CopilotKit] useInterrupt handler rejected; result will be null:",
+            err,
+          );
           if (!cancelled) setHandlerResult(null);
         });
     } else {
@@ -289,11 +334,15 @@ export function useInterrupt<
     return () => {
       cancelled = true;
     };
-  }, [pendingEvent, resolve]);
+    // F4: depend ONLY on pendingEvent. resolve is read via resolveRef so
+    // identity churn in [agent, copilotkit] cannot double-fire the handler.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingEvent]);
 
   const element = useMemo(() => {
     if (!pendingEvent) return null;
-    if (enabledRef.current && !enabledRef.current(pendingEvent)) return null;
+    // F5: throwing predicate → disabled.
+    if (!isEnabled(pendingEvent)) return null;
 
     return renderRef.current({
       event: pendingEvent,


### PR DESCRIPTION
## Summary

Fixes the **2nd-interrupt bug** in `@copilotkit/react-core`'s v2 `useInterrupt` hook: in a single thread the first interrupt's card mounted, but the second interrupt's card never appeared.

This PR is intended to bundle into the in-flight **v1.59.2** release.

Clears blocker:
- LGP `gen-ui-interrupt` 2nd-interrupt failure
- MAF `interrupt-headless` cross-integration failure

## Root cause

Three coordinated issues in `packages/react-core/src/v2/hooks/use-interrupt.tsx` combined into a publish-cleanup race:

1. The `element` `useMemo` depended on `config.render` and `config.enabled`. Consumers pass these as inline lambdas, so their identity changes on every parent render. The element identity churned every render.
2. The publish effect did `setInterruptElement(element)` with a cleanup that pushed `null`. On dep churn, the cleanup ran AFTER the previous publish; chat subscribers latched `null` between renders, leaving the card unmounted.
3. `resolve` synchronously called `setPendingEvent(null)`, unmounting the card before the resume run's first tokens streamed. Consumers worked around this with a 500ms `setTimeout` wrapper around `resolve()`.

## Fix (3 coordinated changes, all in `use-interrupt.tsx`)

- Stabilize `render`, `enabled`, `handler` behind refs so the element memo and handler effect depend only on `pendingEvent` / `handlerResult` / `resolve`. Mirrors the v1 `useLangGraphInterrupt` wrapper's stabilization pattern.
- Split the publish effect into a **publish-only** effect (no nullify on churn) plus a separate **unmount-only** cleanup effect with empty deps.
- Drop the synchronous `setPendingEvent(null)` from `resolve` — `onRunStartedEvent` is the legitimate clear path when the resume run begins. This removes the need for consumer `setTimeout` workarounds.

The `element` memo still returns `null` when `pendingEvent` is `null`, so the legitimate clear paths (`onRunStartedEvent` / `onRunFailed`) continue to work.

## Red-green test

Added `renders the second interrupt card in the same thread` to `__tests__/use-interrupt.test.tsx`. Drives two interrupts in one thread through the chat-render path with an inline-render consumer, forces a parent re-render after the 2nd interrupt arrives, and asserts that no stale `null` follows the last non-null publish.

Verified RED on the unfixed file (assertion fails on the trailing `null`) → GREEN after the 3 coordinated changes.

The existing `resolve clears UI` test was updated to assert the new contract: card stays mounted across `resolve()` and unmounts when the resume run's `onRunStartedEvent` fires.

## Test plan

- [x] `pnpm --filter @copilotkit/react-core exec vitest run src/v2/hooks/__tests__/use-interrupt.test.tsx` — 16/16 green
- [x] Full `@copilotkit/react-core` vitest suite — 1184/1184 green
- [x] `pnpm --filter @copilotkit/react-core exec tsc --noEmit` — zero new errors vs baseline; touched files (`use-interrupt.tsx`, `use-langgraph-interrupt.ts`, `v2/headless.ts`) have zero errors
- [x] `pnpm nx build react-core` — green
- [x] Full pre-commit hook (`nx run-many -t test --projects=packages/**`) — green