### PR TITLE
fix(showcase): harden dashboard chip semantics + browser-pool capacity logging

### DIFF
--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -128,6 +128,41 @@ function makeFakeLogger(): {
   };
 }
 
+interface LeveledLog extends CapturedLog {
+  level: "info" | "warn" | "error";
+}
+
+/**
+ * Fake logger that captures the SEVERITY each event was emitted at. Unlike
+ * `makeFakeLogger` (info-only), this exposes `warn`/`error` so routing-by-
+ * severity is observable: a capacity-loss event logged via `logger.error(...)`
+ * must show up with `level: "error"`, never `level: "info"`.
+ */
+function makeLeveledLogger(): {
+  logger: {
+    info: (msg: string, meta?: Record<string, unknown>) => void;
+    warn: (msg: string, meta?: Record<string, unknown>) => void;
+    error: (msg: string, meta?: Record<string, unknown>) => void;
+  };
+  events: LeveledLog[];
+} {
+  const events: LeveledLog[] = [];
+  return {
+    logger: {
+      info(msg, meta) {
+        events.push({ level: "info", event: msg, meta });
+      },
+      warn(msg, meta) {
+        events.push({ level: "warn", event: msg, meta });
+      },
+      error(msg, meta) {
+        events.push({ level: "error", event: msg, meta });
+      },
+    },
+    events,
+  };
+}
+
 /**
  * Flush pending microtasks `times` times so post-recycle state settles
  * enough to observe without tearing the pool down. It does NOT advance real
@@ -695,6 +730,135 @@ describe("BrowserPool dead-instance detection", () => {
     // Two live slots recovered, never double-published into available.
     expect(pool.stats().size).toBe(2);
     expect(pool.stats().available).toBeLessThanOrEqual(2);
+
+    await pool.shutdown();
+    await Promise.allSettled([a, b]);
+  });
+
+  it("routes capacity-loss events to error and per-attempt failures to warn", async () => {
+    // Single-slot pool. The browser crashes and EVERY immediate relaunch
+    // attempt fails (calls 2..4 — RELAUNCH_MAX_ATTEMPTS=3), so each per-attempt
+    // close/relaunch failure must log at warn while the terminal capacity-loss
+    // event (`recycle-relaunch-failed`) must log at error.
+    const { launchBrowser, launched } = makeFakeLauncher({
+      failAtCalls: [2, 3, 4],
+    });
+    const { logger, events } = makeLeveledLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    await pool.init();
+    expect(launched).toHaveLength(1);
+
+    launched[0]!.__crash();
+    await waitFor(() => pool.stats().size === 0, 3_000);
+
+    // Terminal capacity-loss after all retries → error.
+    const recycleFailed = events.find(
+      (e) => e.event === "browser-pool.recycle-relaunch-failed",
+    );
+    expect(recycleFailed).toBeDefined();
+    expect(recycleFailed?.level).toBe("error");
+
+    // The capacity-loss event must NOT also have been emitted at info.
+    expect(
+      events.some(
+        (e) =>
+          e.event === "browser-pool.recycle-relaunch-failed" &&
+          e.level === "info",
+      ),
+    ).toBe(false);
+
+    await pool.shutdown();
+  });
+
+  it("routes per-attempt relaunch-failed (lazy recovery) to warn", async () => {
+    // Single-slot pool. Crash + all immediate retries fail (calls 2..4) parks
+    // the slot. A first acquire's lazy relaunchPendingSlots attempt (call 5)
+    // ALSO fails → `relaunch-failed` must log at warn (per-attempt, not a
+    // terminal capacity loss).
+    const { launchBrowser, launched } = makeFakeLauncher({
+      failAtCalls: [2, 3, 4, 5],
+    });
+    const { logger, events } = makeLeveledLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    await pool.init();
+
+    launched[0]!.__crash();
+    await waitFor(() => pool.stats().size === 0, 3_000);
+
+    // First acquire drives a relaunchPendingSlots attempt (call 5) which fails.
+    await expect(pool.acquire(50)).rejects.toThrow(
+      "BrowserPool acquire timeout",
+    );
+
+    const relaunchFailed = events.find(
+      (e) => e.event === "browser-pool.relaunch-failed",
+    );
+    expect(relaunchFailed).toBeDefined();
+    expect(relaunchFailed?.level).toBe("warn");
+
+    await pool.shutdown();
+  });
+
+  it("emits an error when reinit ends with an empty pool (every relaunch failed)", async () => {
+    // 1-slot pool. After init (call 1), every subsequent launch fails. The
+    // backstop reinit() can only run when this.slots is truly empty, so we
+    // construct a never-launched pool: init throws nothing (call 1 succeeds),
+    // but to reach the empty-pool reinit path we use a 1-slot pool whose ONLY
+    // slot was never created because init's launch failed. Use failAt=1 so
+    // init launches nothing, leaving this.slots empty; the next acquire drives
+    // reinit, whose launch (call 2) also fails, ending the pool empty → error.
+    const { launchBrowser } = makeFakeLauncher({ failAtCalls: [1, 2, 3] });
+    const { logger, events } = makeLeveledLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    // init's only launch (call 1) throws — init sets `launchBrowser` BEFORE the
+    // launch loop, so after catching the throw `this.slots` is empty but the
+    // pool can still reinit. (init does not swallow launch errors by design.)
+    await expect(pool.init()).rejects.toThrow("simulated launch failure");
+    expect(pool.stats().size).toBe(0);
+
+    // acquire drives the empty-pool reinit backstop; its launch (call 2) fails,
+    // so reinitInner's loop ends with this.slots.length === 0 → error emit.
+    await expect(pool.acquire(50)).rejects.toThrow(
+      "BrowserPool acquire timeout",
+    );
+
+    const reinitEmpty = events.find(
+      (e) => e.event === "browser-pool.reinit-empty",
+    );
+    expect(reinitEmpty).toBeDefined();
+    expect(reinitEmpty?.level).toBe("error");
+
+    await pool.shutdown();
+  });
+
+  it("does not overshoot poolSize when two concurrent acquires hit an empty pool", async () => {
+    // Empty pool (init launches nothing). Two concurrent acquire() calls both
+    // see this.slots.length === 0. WITHOUT a reiniting guard, BOTH drive
+    // reinit() and each launches up to poolSize browsers — overshoot. WITH the
+    // guard, the second acquire skips reinit and falls through to the waiter
+    // queue, so at most poolSize browsers are launched.
+    const poolSize = 2;
+    // init = call 1 fails (so this.slots stays empty); reinit launches succeed.
+    const { launchBrowser, launched } = makeFakeLauncher({ failAtCalls: [1] });
+    const { logger } = makeLeveledLogger();
+    const pool = new BrowserPool(poolSize, 100, logger, launchBrowser);
+    // init's first launch (call 1) throws, leaving this.slots empty but with
+    // `launchBrowser` already set so reinit can run. init does not swallow.
+    await expect(pool.init()).rejects.toThrow("simulated launch failure");
+    expect(pool.stats().size).toBe(0);
+
+    const a = pool.acquire(5_000);
+    const b = pool.acquire(5_000);
+
+    const first = await Promise.race([a, b]);
+    expect(first).toBeDefined();
+    expect((first as unknown as FakeBrowser).isConnected()).toBe(true);
+
+    await drainMicrotasks(30);
+
+    // The guard ensures only ONE reinit ran: at most poolSize browsers exist.
+    expect(launched.length).toBeLessThanOrEqual(poolSize);
+    expect(pool.stats().size).toBeLessThanOrEqual(poolSize);
 
     await pool.shutdown();
     await Promise.allSettled([a, b]);

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -42,11 +42,17 @@ export interface BrowserPoolStats {
 
 /**
  * Minimal logger surface the pool uses for lifecycle events. Matches the
- * harness-wide `Logger` interface but only the `info` method is required.
- * Optional so existing callers (tests, legacy boot paths) don't break.
+ * harness-wide `Logger` interface but only the `info` method is required;
+ * `warn`/`error` are OPTIONAL so existing callers (tests, legacy boot paths)
+ * that inject a bare-`info` fake still type-check. The concrete harness logger
+ * implements all three (warn/error route to stderr → Sentry), so capacity-loss
+ * events emitted via `error` reach the alert pipeline instead of being buried
+ * at info. Call the optional methods safely: `this.logger?.warn?.(...)`.
  */
 interface PoolLogger {
   info(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+  error?(msg: string, meta?: Record<string, unknown>): void;
 }
 
 /**
@@ -73,6 +79,15 @@ export class BrowserPool {
   // the same slot — which would leak one process and/or publish the slot to
   // `available` twice.
   private relaunchingSlots = new Set<Slot>();
+  // Re-entry guard for the empty-pool reinit backstop, mirroring the
+  // relaunchingSlots/recyclingSlots idiom. Two concurrent acquire() calls
+  // against a truly-empty pool (this.slots.length === 0) would each drive
+  // reinit() and each launch up to poolSize browsers — overshooting capacity.
+  // Setting this synchronously before reinit's first await makes the second
+  // acquire skip reinit and fall through to the waiter queue, where the first
+  // reinit's handOff serves it. Cleared in a finally so a thrown reinit can't
+  // wedge the guard set forever.
+  private reiniting = false;
   private isShutdown = false;
   private readonly logger?: PoolLogger;
   private readonly injectedLaunchBrowser?: LaunchBrowser;
@@ -156,7 +171,7 @@ export class BrowserPool {
     try {
       await browser.close();
     } catch (err) {
-      this.logger?.info("browser-pool.close-failed", {
+      this.logger?.warn?.("browser-pool.close-failed", {
         slotIndex,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -178,7 +193,7 @@ export class BrowserPool {
     // contained — a recovery launch failing is non-fatal to the pool.
     return promise
       .catch((err: unknown) => {
-        this.logger?.info("browser-pool.recovery-failed", {
+        this.logger?.error?.("browser-pool.recovery-failed", {
           error: err instanceof Error ? err.message : String(err),
         });
       })
@@ -200,10 +215,20 @@ export class BrowserPool {
    */
   private async reinit(): Promise<void> {
     if (this.isShutdown || this.launchBrowser === undefined) return;
-    // Track the whole reinit so a shutdown racing this launch loop drains it
-    // before closing slots, rather than leaking a browser that resolves after
-    // shutdown already awaited the in-flight set.
-    await this.track(this.reinitInner());
+    // Set the concurrent-entry guard SYNCHRONOUSLY before the first `await`
+    // (before `this.track(...)`) so a second acquire reaching its empty-pool
+    // check while this reinit is in flight skips reinit and parks a waiter
+    // instead of launching its own duplicate set of browsers. Cleared in the
+    // `finally` so a thrown reinit can't leave the guard latched forever.
+    this.reiniting = true;
+    try {
+      // Track the whole reinit so a shutdown racing this launch loop drains it
+      // before closing slots, rather than leaking a browser that resolves after
+      // shutdown already awaited the in-flight set.
+      await this.track(this.reinitInner());
+    } finally {
+      this.reiniting = false;
+    }
   }
 
   private async reinitInner(): Promise<void> {
@@ -229,11 +254,24 @@ export class BrowserPool {
         this.handOff(slot, browser);
       } catch (err) {
         // Best effort — keep trying the remaining slots. If none succeed
-        // the pool stays empty and the next acquire retries reinit.
-        this.logger?.info("browser-pool.reinit-failed", {
+        // the pool stays empty and the next acquire retries reinit. Per-attempt
+        // failure is a warn: a single slot failing to relaunch is recoverable
+        // (other slots may succeed, or a later acquire retries).
+        this.logger?.warn?.("browser-pool.reinit-failed", {
           error: err instanceof Error ? err.message : String(err),
         });
       }
+    }
+
+    // The genuine empty-pool capacity-loss signal: reinit ran but every launch
+    // failed, so the pool ends with zero slots. Unlike the per-attempt warn
+    // above, this is the terminal "pool ended empty" outage and must reach the
+    // error/Sentry pipeline. Per-attempt reinit-failed stays warn (recoverable);
+    // this distinct end-of-loop emit fires once when the backstop drained empty.
+    if (this.slots.length === 0) {
+      this.logger?.error?.("browser-pool.reinit-empty", {
+        poolSize: this.poolSize,
+      });
     }
   }
 
@@ -309,8 +347,10 @@ export class BrowserPool {
           slotIndex: this.slots.indexOf(slot),
         });
       } catch (err) {
-        // Still failing — leave it pending for the next acquire to retry.
-        this.logger?.info("browser-pool.relaunch-failed", {
+        // Still failing — leave it pending for the next acquire to retry. This
+        // is a per-attempt failure (the slot stays parked and recoverable), so
+        // warn rather than error.
+        this.logger?.warn?.("browser-pool.relaunch-failed", {
           slotIndex: this.slots.indexOf(slot),
           error: err instanceof Error ? err.message : String(err),
         });
@@ -333,9 +373,9 @@ export class BrowserPool {
     // `relaunchPendingSlots()`, not here. (`stats().size` may read 0 in that
     // state, but `size` does not gate this backstop — `this.slots.length`
     // does.)
-    if (this.slots.length === 0) {
+    if (this.slots.length === 0 && !this.reiniting) {
       await this.reinit();
-    } else {
+    } else if (this.slots.length > 0) {
       // Lazily relaunch any slot whose last relaunch failed. This is the
       // recovery path for a transient launch failure: the slot was kept
       // (capacity preserved) but parked as `relaunchPending`; the next
@@ -343,6 +383,11 @@ export class BrowserPool {
       // normal available-slot scan.
       await this.relaunchPendingSlots();
     }
+    // The remaining case — `slots.length === 0 && this.reiniting` — is the
+    // concurrent-acquire skip: another acquire's reinit is already launching
+    // up to poolSize browsers, so this call does NOT launch its own duplicate
+    // set. It falls through to the waiter-queue path below; the in-flight
+    // reinit's `handOff` serves this waiter as soon as a fresh browser lands.
 
     // Skip zombie slots whose browser has disconnected but whose disconnect
     // handler hasn't yet completed the recycle. Without this loop, a single
@@ -601,7 +646,10 @@ export class BrowserPool {
       // launch (see relaunchPendingSlots), and the empty-pool backstop in
       // acquire() re-initializes if every slot ends up pending/lost.
       slot.relaunchPending = true;
-      this.logger?.info("browser-pool.recycle-relaunch-failed", {
+      // Capacity loss after exhausting ALL immediate retries — the slot is now
+      // parked dead and only a later lazy acquire can recover it. This is a
+      // genuine capacity-loss signal that must reach error/Sentry, not info.
+      this.logger?.error?.("browser-pool.recycle-relaunch-failed", {
         slotIndex: this.slots.indexOf(slot),
         attempts: RELAUNCH_MAX_ATTEMPTS,
         poolSize: this.slots.length,
@@ -623,7 +671,7 @@ export class BrowserPool {
     // never surface as an unhandled rejection.
     recyclePromise
       .catch((err: unknown) => {
-        this.logger?.info("browser-pool.recycle-failed", {
+        this.logger?.error?.("browser-pool.recycle-failed", {
           slotIndex: this.slots.indexOf(slot),
           error: err instanceof Error ? err.message : String(err),
         });

--- a/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
@@ -95,16 +95,36 @@ describe("computeColumnTallyDetail", () => {
   });
 
   it("green D6 cells land in green bucket", () => {
-    const integration = makeIntegration("my-int", ["feat-a", "feat-b"]);
+    // Use feature IDs with a D5 mapping (agentic-chat, tool-rendering) so the
+    // verification ladder is contiguous to D5. Green requires an intact
+    // ladder: a green D6 cannot paint green over a missing/red D5.
+    const integration = makeIntegration("my-int", [
+      "agentic-chat",
+      "tool-rendering",
+    ]);
     const features = [
-      makeFeature("feat-a", "Feature A"),
-      makeFeature("feat-b", "Feature B"),
+      makeFeature("agentic-chat", "Feature A"),
+      makeFeature("tool-rendering", "Feature B"),
     ];
 
-    // Both features have green D3 + green D6 → chipColor=green (D6-ceiling)
+    // Both features: green D3 + green D5 + green D6 → chipColor=green.
     const liveStatus: LiveStatusMap = new Map([
-      ["e2e:my-int/feat-a", makeRow("e2e:my-int/feat-a", "e2e", "green")],
-      ["e2e:my-int/feat-b", makeRow("e2e:my-int/feat-b", "e2e", "green")],
+      [
+        "e2e:my-int/agentic-chat",
+        makeRow("e2e:my-int/agentic-chat", "e2e", "green"),
+      ],
+      [
+        "e2e:my-int/tool-rendering",
+        makeRow("e2e:my-int/tool-rendering", "e2e", "green"),
+      ],
+      [
+        "d5:my-int/agentic-chat",
+        makeRow("d5:my-int/agentic-chat", "d5", "green"),
+      ],
+      [
+        "d5:my-int/tool-rendering",
+        makeRow("d5:my-int/tool-rendering", "d5", "green"),
+      ],
       ["d6:my-int", makeRow("d6:my-int", "d6", "green")],
     ]);
 
@@ -117,8 +137,8 @@ describe("computeColumnTallyDetail", () => {
 
     expect(result.unknown).toBe(false);
     expect(result.green).toEqual([
-      { label: "Feature A", dimension: "e2e", featureId: "feat-a" },
-      { label: "Feature B", dimension: "e2e", featureId: "feat-b" },
+      { label: "Feature A", dimension: "e2e", featureId: "agentic-chat" },
+      { label: "Feature B", dimension: "e2e", featureId: "tool-rendering" },
     ]);
     expect(result.amber).toEqual([]);
     expect(result.red).toEqual([]);
@@ -154,16 +174,23 @@ describe("computeColumnTallyDetail", () => {
   });
 
   it("features without demos are gray (unwired) and excluded", () => {
-    // Integration only has demo for feat-1, not feat-2
-    const integration = makeIntegration("partial", ["feat-1"]);
+    // Integration only has a demo for agentic-chat, not tool-rendering.
+    const integration = makeIntegration("partial", ["agentic-chat"]);
     const features = [
-      makeFeature("feat-1", "Feature 1"),
-      makeFeature("feat-2", "Feature 2"),
+      makeFeature("agentic-chat", "Feature 1"),
+      makeFeature("tool-rendering", "Feature 2"),
     ];
 
-    // D3=green + D6=green → chipColor=green (D6-ceiling algorithm)
+    // agentic-chat: green D3 + green D5 + green D6 → green (intact ladder).
     const liveStatus: LiveStatusMap = new Map([
-      ["e2e:partial/feat-1", makeRow("e2e:partial/feat-1", "e2e", "green")],
+      [
+        "e2e:partial/agentic-chat",
+        makeRow("e2e:partial/agentic-chat", "e2e", "green"),
+      ],
+      [
+        "d5:partial/agentic-chat",
+        makeRow("d5:partial/agentic-chat", "d5", "green"),
+      ],
       ["d6:partial", makeRow("d6:partial", "d6", "green")],
     ]);
 
@@ -175,9 +202,10 @@ describe("computeColumnTallyDetail", () => {
     );
 
     expect(result.unknown).toBe(false);
-    // feat-1: wired + D3=green + D6=green → green; feat-2: unwired → gray
+    // agentic-chat: wired + intact green ladder → green; tool-rendering:
+    // unwired → gray.
     expect(result.green).toEqual([
-      { label: "Feature 1", dimension: "e2e", featureId: "feat-1" },
+      { label: "Feature 1", dimension: "e2e", featureId: "agentic-chat" },
     ]);
     expect(result.amber).toEqual([]);
     expect(result.red).toEqual([]);
@@ -207,18 +235,28 @@ describe("computeColumnTallyDetail", () => {
 
   it("not_supported_features are gray and excluded", () => {
     const integration = {
-      ...makeIntegration("ns-int", ["feat-a", "feat-b"]),
-      not_supported_features: ["feat-b"],
+      ...makeIntegration("ns-int", ["agentic-chat", "tool-rendering"]),
+      not_supported_features: ["tool-rendering"],
     };
     const features = [
-      makeFeature("feat-a", "Feature A"),
-      makeFeature("feat-b", "Feature B"),
+      makeFeature("agentic-chat", "Feature A"),
+      makeFeature("tool-rendering", "Feature B"),
     ];
 
-    // D3=green + D6=green → chipColor=green for supported features
+    // agentic-chat: green D3 + green D5 + green D6 → green (intact ladder).
     const liveStatus: LiveStatusMap = new Map([
-      ["e2e:ns-int/feat-a", makeRow("e2e:ns-int/feat-a", "e2e", "green")],
-      ["e2e:ns-int/feat-b", makeRow("e2e:ns-int/feat-b", "e2e", "green")],
+      [
+        "e2e:ns-int/agentic-chat",
+        makeRow("e2e:ns-int/agentic-chat", "e2e", "green"),
+      ],
+      [
+        "e2e:ns-int/tool-rendering",
+        makeRow("e2e:ns-int/tool-rendering", "e2e", "green"),
+      ],
+      [
+        "d5:ns-int/agentic-chat",
+        makeRow("d5:ns-int/agentic-chat", "d5", "green"),
+      ],
       ["d6:ns-int", makeRow("d6:ns-int", "d6", "green")],
     ]);
 
@@ -230,9 +268,10 @@ describe("computeColumnTallyDetail", () => {
     );
 
     expect(result.unknown).toBe(false);
-    // feat-a: D3+D6 green → green; feat-b: unsupported → gray → excluded
+    // agentic-chat: intact green ladder → green; tool-rendering: unsupported
+    // → gray → excluded.
     expect(result.green).toEqual([
-      { label: "Feature A", dimension: "e2e", featureId: "feat-a" },
+      { label: "Feature A", dimension: "e2e", featureId: "agentic-chat" },
     ]);
     expect(result.amber).toEqual([]);
     expect(result.red).toEqual([]);

--- a/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
@@ -435,6 +435,108 @@ describe("deriveDepth", () => {
     });
   });
 
+  // ── D1/D2/D4 staleness downgrade (per-driver windows) ──
+  // Liveness (D1/D2) and real-time (D4) green rows from a stalled driver
+  // must not credit their depth. D1/D2 use LIVENESS_STALE_AFTER_MS (45m),
+  // D4 uses D4_STALE_AFTER_MS (1h); both mirror cell-model.ts.
+  describe("D1/D2/D4 staleness downgrade", () => {
+    const NOW = Date.parse("2026-05-30T12:00:00Z");
+    // Stale past every window in use (e2e 6h is the widest).
+    const STALE_AT = new Date(NOW - 7 * 60 * 60 * 1000).toISOString();
+    const FRESH_AT = new Date(NOW - 60 * 1000).toISOString();
+    // Older than 45m (D1/D2 window) but within the D4 1h window — proves the
+    // windows are independent: D1/D2 downgrade here while D4 would not.
+    const STALE_LIVENESS_AT = new Date(NOW - 50 * 60 * 1000).toISOString();
+    // Older than 1h (D4 window).
+    const STALE_D4_AT = new Date(NOW - 70 * 60 * 1000).toISOString();
+
+    it("does not credit D1 when its green health row is stale", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([
+        row("health:lgp", "health", "green", STALE_LIVENESS_AT),
+        row("agent:lgp", "agent", "green", FRESH_AT),
+      ]);
+      const result = deriveDepth(c, live, NOW);
+      // Stale green health → D1 not credited → achieved caps at D0.
+      expect(result.achieved).toBe(0);
+    });
+
+    it("credits D1 when its green health row is fresh", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([row("health:lgp", "health", "green", FRESH_AT)]);
+      const result = deriveDepth(c, live, NOW);
+      expect(result.achieved).toBe(1);
+    });
+
+    it("does not credit D2 when its green agent row is stale", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([
+        row("health:lgp", "health", "green", FRESH_AT),
+        row("agent:lgp", "agent", "green", STALE_LIVENESS_AT),
+      ]);
+      const result = deriveDepth(c, live, NOW);
+      // Stale green agent → D2 not credited → caps at D1.
+      expect(result.achieved).toBe(1);
+    });
+
+    it("credits D2 when its green agent row is fresh", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([
+        row("health:lgp", "health", "green", FRESH_AT),
+        row("agent:lgp", "agent", "green", FRESH_AT),
+      ]);
+      const result = deriveDepth(c, live, NOW);
+      expect(result.achieved).toBe(2);
+    });
+
+    it("does not credit D4 when its green chat row is stale", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([
+        row("health:lgp", "health", "green", FRESH_AT),
+        row("agent:lgp", "agent", "green", FRESH_AT),
+        row("e2e:lgp/agentic-chat", "e2e", "green", FRESH_AT),
+        row("chat:lgp", "chat", "green", STALE_D4_AT),
+      ]);
+      const result = deriveDepth(c, live, NOW);
+      // Stale green chat → D4 not credited → caps at D3.
+      expect(result.achieved).toBe(3);
+    });
+
+    it("credits D4 when its green chat row is fresh", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([
+        row("health:lgp", "health", "green", FRESH_AT),
+        row("agent:lgp", "agent", "green", FRESH_AT),
+        row("e2e:lgp/agentic-chat", "e2e", "green", FRESH_AT),
+        row("chat:lgp", "chat", "green", FRESH_AT),
+      ]);
+      const result = deriveDepth(c, live, NOW);
+      expect(result.achieved).toBe(4);
+    });
+
+    it("D1/D2 window is tighter than D4: a 50m-old D4 row would still count", () => {
+      // A chat row 50m old is stale for liveness (45m) but fresh for D4 (1h).
+      // This guards against collapsing the two windows into one constant.
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([
+        row("health:lgp", "health", "green", FRESH_AT),
+        row("agent:lgp", "agent", "green", FRESH_AT),
+        row("e2e:lgp/agentic-chat", "e2e", "green", FRESH_AT),
+        row("chat:lgp", "chat", "green", STALE_LIVENESS_AT),
+      ]);
+      const result = deriveDepth(c, live, NOW);
+      // 50m < D4's 1h window → D4 still credited.
+      expect(result.achieved).toBe(4);
+    });
+
+    it("leaves a stale RED liveness row red (no false-credit either way)", () => {
+      const c = cell("lgp", "agentic-chat");
+      const live = mapOf([row("health:lgp", "health", "red", STALE_AT)]);
+      const result = deriveDepth(c, live, NOW);
+      expect(result.achieved).toBe(0);
+    });
+  });
+
   it("returns D4 for feature with no D5 mapping", () => {
     const c = cell("lgp", "unknown-feature");
     const live = mapOf([

--- a/showcase/shell-dashboard/src/components/__tests__/parity-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/parity-matrix.test.tsx
@@ -30,6 +30,11 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+// Fresh timestamp so green rows are not tripped by the D1/D2/D4 staleness
+// downgrade (deriveDepth defaults `now` to Date.now()). These tests assert
+// achieved depth, not staleness, so the rows must read as recently observed.
+const FRESH_OBSERVED_AT = new Date().toISOString();
+
 function row(
   key: string,
   dimension: string,
@@ -41,8 +46,8 @@ function row(
     dimension,
     state,
     signal: {},
-    observed_at: "2026-04-20T00:00:00Z",
-    transitioned_at: "2026-04-20T00:00:00Z",
+    observed_at: FRESH_OBSERVED_AT,
+    transitioned_at: FRESH_OBSERVED_AT,
     fail_count: 0,
     first_failure_at: null,
   };

--- a/showcase/shell-dashboard/src/components/cell-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/cell-matrix.tsx
@@ -315,9 +315,7 @@ export function CellMatrix({
           isSupported: !isNotSupported,
           isWired: cell.status === "wired" || cell.status === "stub",
         });
-        return (
-          model.ceilingDepth > 0 && model.achievedDepth < model.ceilingDepth
-        );
+        return model.isRegression;
       });
     }
     return true;

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -18,7 +18,11 @@
  */
 import { keyFor, CATALOG_TO_D5_KEY } from "@/lib/live-status";
 import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
-import { E2E_STALE_AFTER_MS } from "@/lib/cell-model";
+import {
+  E2E_STALE_AFTER_MS,
+  D4_STALE_AFTER_MS,
+  LIVENESS_STALE_AFTER_MS,
+} from "@/lib/cell-model";
 
 /** Minimal catalog cell shape consumed by depth derivation. */
 export interface CatalogCell {
@@ -59,26 +63,26 @@ export interface DepthResult {
   unsupported: boolean;
 }
 
-function isGreen(live: LiveStatusMap, key: string): boolean {
-  const row = live.get(key);
-  return row?.state === "green";
-}
-
 /**
  * A row counts as green only when it is green AND fresh. A frozen-green row
  * from a stalled driver must NOT credit its depth — otherwise the depth ladder
  * reads a dead probe pipeline as a false-green (e.g. a D3 e2e signal whose
  * driver stopped writing). Mirrors the staleness downgrade `cell-model.ts`
- * applies to D3/D5/D6 so both consumers agree.
+ * applies to every dimension so both consumers agree.
+ *
+ * Each dimension supplies its own staleness window: D1/D2 (liveness) use
+ * `LIVENESS_STALE_AFTER_MS`, D4 uses `D4_STALE_AFTER_MS`, and D3/D5/D6 use the
+ * default `E2E_STALE_AFTER_MS`.
  */
 function isGreenAndFresh(
   live: LiveStatusMap,
   key: string,
   now: number,
+  maxAgeMs: number = E2E_STALE_AFTER_MS,
 ): boolean {
   const row = live.get(key);
   if (row?.state !== "green") return false;
-  return !isRowStale(row, now, E2E_STALE_AFTER_MS);
+  return !isRowStale(row, now, maxAgeMs);
 }
 
 /** Row is stale if `observed_at` is older than `maxAgeMs` relative to `now`. */
@@ -179,8 +183,15 @@ export function deriveDepth(
   // D0: cell exists (wired or stub) — always true if we reach here.
   let achieved: AchievedDepth = 0;
 
-  // D1: health:<slug> green
-  if (!isGreen(live, keyFor("health", cell.integration))) {
+  // D1: health:<slug> green (liveness window)
+  if (
+    !isGreenAndFresh(
+      live,
+      keyFor("health", cell.integration),
+      now,
+      LIVENESS_STALE_AFTER_MS,
+    )
+  ) {
     return {
       achieved,
       maxPossible,
@@ -190,8 +201,15 @@ export function deriveDepth(
   }
   achieved = 1;
 
-  // D2: agent:<slug> green
-  if (!isGreen(live, keyFor("agent", cell.integration))) {
+  // D2: agent:<slug> green (liveness window)
+  if (
+    !isGreenAndFresh(
+      live,
+      keyFor("agent", cell.integration),
+      now,
+      LIVENESS_STALE_AFTER_MS,
+    )
+  ) {
     return {
       achieved,
       maxPossible,
@@ -223,9 +241,19 @@ export function deriveDepth(
   }
   achieved = 3;
 
-  // D4: chat:<slug> OR tools:<slug> green (integration-scoped)
-  const chatGreen = isGreen(live, keyFor("chat", cell.integration));
-  const toolsGreen = isGreen(live, keyFor("tools", cell.integration));
+  // D4: chat:<slug> OR tools:<slug> green (real-time window)
+  const chatGreen = isGreenAndFresh(
+    live,
+    keyFor("chat", cell.integration),
+    now,
+    D4_STALE_AFTER_MS,
+  );
+  const toolsGreen = isGreenAndFresh(
+    live,
+    keyFor("tools", cell.integration),
+    now,
+    D4_STALE_AFTER_MS,
+  );
   if (!(chatGreen || toolsGreen)) {
     return {
       achieved,

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildCellModel, E2E_STALE_AFTER_MS } from "../cell-model";
+import {
+  buildCellModel,
+  E2E_STALE_AFTER_MS,
+  D4_STALE_AFTER_MS,
+} from "../cell-model";
 import type { CellModelInput } from "../cell-model";
 import type { LiveStatusMap, StatusRow, State } from "../live-status";
 import { keyFor } from "../live-status";
@@ -144,8 +148,9 @@ describe("buildCellModel", () => {
       expect(model.achievedDepth).toBe(3);
       // ceilingDepth requires contiguity: D4 doesn't exist → stops at 3
       expect(model.ceilingDepth).toBe(3);
-      // D6-ceiling: D5 exists but not green, D6 absent → red
-      expect(model.chipColor).toBe("red");
+      // Contiguous-ladder: D5 exists but has no data (status null), D6
+      // absent → unverified ladder → gray (no-data, not a failure).
+      expect(model.chipColor).toBe("gray");
     });
   });
 
@@ -343,7 +348,7 @@ describe("buildCellModel", () => {
 
   // ── No live data at all → D0 gray ──────────────────────────────────
   describe("no live data", () => {
-    it("returns red chip when D5 exists but no data (D6-ceiling)", () => {
+    it("returns gray chip when D5 exists but no data (unverified ladder)", () => {
       const model = buildCellModel(
         mapOf([]),
         wiredInput("agno", "agentic-chat"),
@@ -356,8 +361,9 @@ describe("buildCellModel", () => {
       // ceilingDepth requires contiguity: D5 only counts if D3+D4 exist
       expect(model.ceilingDepth).toBe(0);
       expect(model.achievedDepth).toBe(0);
-      // D6-ceiling: D5 exists (but not green), D6 absent → red
-      expect(model.chipColor).toBe("red");
+      // Contiguous-ladder: D5 has no data (status null), D6 absent →
+      // unverified ladder → gray (no-data, not a failure).
+      expect(model.chipColor).toBe("gray");
     });
 
     it("returns ceilingDepth=0 when no tests exist at all", () => {
@@ -517,6 +523,60 @@ describe("buildCellModel", () => {
       expect(model.d6!.status).toBe("red");
       // Neither D5 nor D6 green, both exist → red
       expect(model.chipColor).toBe("red");
+    });
+
+    it("D5 red + D6 green → red (contiguous-ladder gate)", () => {
+      // A red D5 below a green D6 must NOT paint green: the verification
+      // ladder is broken at D5, so D6's aggregate pass is not trustworthy
+      // evidence of this cell's health. Red wins.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "red"),
+        row(keyFor("d6", "agno"), "d6", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d5!.status).toBe("red");
+      expect(model.d6!.status).toBe("green");
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("D5 null + D6 green → gray (unverified ladder)", () => {
+      // A no-data D5 below a green D6 must NOT paint green: the ladder is
+      // unverified at D5, so D6 cannot credit the cell. Treat as no-data.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d6", "agno"), "d6", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d5!.exists).toBe(true);
+      expect(model.d5!.status).toBeNull();
+      expect(model.d6!.status).toBe("green");
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("D5 null + D6 red → red", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d6", "agno"), "d6", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d5!.status).toBeNull();
+      expect(model.d6!.status).toBe("red");
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("D5 null + D6 missing → gray (no data)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d5!.status).toBeNull();
+      expect(model.d6!.exists).toBe(false);
+      expect(model.chipColor).toBe("gray");
     });
 
     it("D6 uses aggregate key not per-cell", () => {
@@ -802,6 +862,77 @@ describe("buildCellModel", () => {
         expect(model.achievedDepth).toBe(4);
         expect(model.chipColor).toBe("red");
       });
+    });
+  });
+
+  // ── D4 staleness downgrade (per-driver window) ─────────────────────
+  // The chat/tools drivers write `chat:<slug>`/`tools:<slug>` rows on their
+  // own cadence. A frozen-green D4 row from a stalled driver must downgrade
+  // to amber the same way D3/D5/D6 do, using the D4-specific window.
+  describe("D4 staleness downgrade", () => {
+    const NOW = Date.parse("2026-05-30T12:00:00Z");
+
+    function rowAtAge(
+      key: string,
+      dimension: string,
+      ageMs: number,
+      state: State = "green",
+    ) {
+      const observedAt = new Date(NOW - ageMs).toISOString();
+      return row(key, dimension, state, {
+        observed_at: observedAt,
+        transitioned_at: observedAt,
+      });
+    }
+
+    const STALE = D4_STALE_AFTER_MS + 60 * 1000;
+    const FRESH = 60 * 1000;
+
+    it("downgrades a stale green D4 (chat) row to amber", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", STALE, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", FRESH, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      // Stale green D4 must NOT present as healthy.
+      expect(model.d4?.status).toBe("amber");
+      // D4 stale-amber fails the gate → chain caps at D3.
+      expect(model.achievedDepth).toBe(3);
+      // Gate fails (D4 not green) → red.
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("keeps a fresh green D4 row green", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", FRESH, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d4?.status).toBe("green");
+      expect(model.achievedDepth).toBe(5);
+    });
+
+    it("leaves a stale RED D4 row red (staleness only downgrades green)", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", STALE, "red"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d4?.status).toBe("red");
     });
   });
 });

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -669,14 +669,54 @@ describe("buildCellModel", () => {
     });
   });
 
-  // ── isRegression is always false (stub for future) ─────────────────
+  // ── isRegression: achievedDepth below ceilingDepth ─────────────────
   describe("isRegression", () => {
-    it("is always false in current implementation", () => {
+    it("is true when achievedDepth < ceilingDepth (D3 red, tests exist)", () => {
+      // D3 red → achievedDepth=0; D3 exists → ceilingDepth=3 → regression.
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.achievedDepth).toBe(0);
+      expect(model.ceilingDepth).toBe(3);
+      expect(model.isRegression).toBe(true);
+    });
+
+    it("is false when achievedDepth === ceilingDepth (cell at its ceiling)", () => {
+      // D3 green, no D4/D5 mapped → achieved=3, ceiling=3 → no regression.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "no-d5-feature"), "e2e", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "no-d5-feature"));
+      expect(model.achievedDepth).toBe(3);
+      expect(model.ceilingDepth).toBe(3);
       expect(model.isRegression).toBe(false);
+    });
+
+    it("is false when ceilingDepth === 0 (no tests exist at all)", () => {
+      const model = buildCellModel(
+        mapOf([]),
+        wiredInput("agno", "no-d5-feature"),
+      );
+      expect(model.ceilingDepth).toBe(0);
+      expect(model.isRegression).toBe(false);
+    });
+
+    it("is false for unsupported and not-wired cells", () => {
+      const unsupported = buildCellModel(mapOf([]), {
+        slug: "agno",
+        featureId: "agentic-chat",
+        isSupported: false,
+        isWired: false,
+      });
+      expect(unsupported.isRegression).toBe(false);
+      const notWired = buildCellModel(mapOf([]), {
+        slug: "agno",
+        featureId: "agentic-chat",
+        isSupported: true,
+        isWired: false,
+      });
+      expect(notWired.isRegression).toBe(false);
     });
   });
 

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -344,6 +344,64 @@ describe("buildCellModel", () => {
       // D6-ceiling: D5 green but D6 absent → amber
       expect(model.chipColor).toBe("amber");
     });
+
+    it("does not credit D5 green when one mapped sub-row is MISSING (strict)", () => {
+      // beautiful-chat maps to 5 sub-keys; emit only 4 (bar-chart missing).
+      // A missing mapped sub-row means the family is unverified, so D5 must
+      // NOT be credited green — it returns status:null (no-data), matching
+      // `isD5Green`'s `every(...)`. achievedDepth caps below 5; A1 renders
+      // the unverified ladder gray.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "beautiful-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-toggle-theme"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-pie-chart"), "d5", "green"),
+        // beautiful-chat-bar-chart intentionally omitted.
+        row(
+          keyFor("d5", "agno", "beautiful-chat-search-flights"),
+          "d5",
+          "green",
+        ),
+        row(
+          keyFor("d5", "agno", "beautiful-chat-schedule-meeting"),
+          "d5",
+          "green",
+        ),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
+      expect(model.d5!.exists).toBe(true);
+      // Missing sub-row → no-data, NOT green and NOT red.
+      expect(model.d5!.status).toBeNull();
+      expect(model.achievedDepth).toBe(4);
+      // Unverified ladder (D5 null), D6 absent → gray.
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("still reports red when a present sub-row is red even if another is missing", () => {
+      // A present red sub-row signals a real failure regardless of a missing
+      // sibling — red dominates no-data.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "beautiful-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-toggle-theme"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-pie-chart"), "d5", "red"),
+        // bar-chart missing; one present sub-row is red.
+        row(
+          keyFor("d5", "agno", "beautiful-chat-search-flights"),
+          "d5",
+          "green",
+        ),
+        row(
+          keyFor("d5", "agno", "beautiful-chat-schedule-meeting"),
+          "d5",
+          "green",
+        ),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
+      expect(model.d5!.status).toBe("red");
+      expect(model.achievedDepth).toBe(4);
+      expect(model.chipColor).toBe("red");
+    });
   });
 
   // ── No live data at all → D0 gray ──────────────────────────────────

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -31,6 +31,25 @@ export type ChipColor = "green" | "amber" | "red" | "gray";
  */
 export const E2E_STALE_AFTER_MS = 6 * 60 * 60 * 1000;
 
+/**
+ * Staleness window for the D4 (real-time chat/tools) dimension. The
+ * `chat:<slug>`/`tools:<slug>` drivers write on their own cadence; a
+ * frozen-green D4 row from a stalled driver must NOT credit D4 forever. A
+ * green D4 row older than this window is downgraded to `degraded` (amber) so
+ * the staleness surfaces, mirroring the D3/D5/D6 downgrade. Not env-tunable.
+ */
+export const D4_STALE_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Staleness window for the D1/D2 (liveness — `health:<slug>`/`agent:<slug>`)
+ * dimensions. Tighter than the e2e window because liveness probes are the
+ * most frequently written signals; a frozen-green liveness row is a strong
+ * stalled-driver indicator. Consumed by `depth-utils.ts` (cell-model has no
+ * D1/D2 resolution — D3's failure implicitly covers the D1/D2 gate). Not
+ * env-tunable.
+ */
+export const LIVENESS_STALE_AFTER_MS = 45 * 60 * 1000;
+
 export interface TestLevel {
   exists: boolean;
   status: TestStatus;
@@ -89,8 +108,16 @@ const STATE_RANK: Readonly<Record<State, number>> = {
  *
  * D4 checks both `chat:<slug>` and `tools:<slug>`. When both exist the
  * worst-state wins — a green chat + red tools yields red D4, not green.
+ *
+ * Staleness applies the same downgrade as `resolveD3`, but PER ROW and
+ * BEFORE the worst-state fold (mirroring `resolveD5`): a green chat/tools
+ * row whose `observed_at` is older than `D4_STALE_AFTER_MS` is treated as
+ * `degraded` while folding. Folding raw states first would let a fresh-green
+ * row win the all-green tie and hide a stale-green sibling, re-introducing
+ * the false-green. Only green is downgraded; a stale red/degraded row already
+ * signals a problem.
  */
-function resolveD4(live: LiveStatusMap, slug: string): TestLevel {
+function resolveD4(live: LiveStatusMap, slug: string, now: number): TestLevel {
   const chatRow = live.get(keyFor("chat", slug)) ?? null;
   const toolsRow = live.get(keyFor("tools", slug)) ?? null;
 
@@ -98,21 +125,29 @@ function resolveD4(live: LiveStatusMap, slug: string): TestLevel {
     return { exists: false, status: null, row: null };
   }
 
-  // Pick the worst row when both exist.
-  let winner: StatusRow;
-  if (chatRow && toolsRow) {
-    winner =
-      STATE_RANK[toolsRow.state] > STATE_RANK[chatRow.state]
-        ? toolsRow
-        : chatRow;
-  } else {
-    winner = (chatRow ?? toolsRow)!;
+  // Fold to the worst effective state across present rows, applying the
+  // per-row stale-green→degraded downgrade before comparing.
+  let winner: StatusRow | null = null;
+  let worstState: State | null = null;
+  for (const candidate of [chatRow, toolsRow]) {
+    if (!candidate) continue;
+    const effectiveState: State =
+      candidate.state === "green" && isStale(candidate, now, D4_STALE_AFTER_MS)
+        ? "degraded"
+        : candidate.state;
+    if (
+      worstState === null ||
+      STATE_RANK[effectiveState] > STATE_RANK[worstState]
+    ) {
+      winner = candidate;
+      worstState = effectiveState;
+    }
   }
 
   return {
     exists: true,
-    status: stateToTestStatus(winner.state),
-    row: winner,
+    status: stateToTestStatus(worstState!),
+    row: winner!,
   };
 }
 
@@ -312,7 +347,7 @@ export function buildCellModel(
 
   // ── Wired + supported: resolve each depth independently ───────────
   const d3 = resolveD3(live, slug, featureId, now);
-  const d4 = resolveD4(live, slug);
+  const d4 = resolveD4(live, slug, now);
   const d5 = resolveD5(live, slug, featureId, now);
   const d6 = resolveD6(live, slug, now);
 
@@ -347,23 +382,46 @@ export function buildCellModel(
     }
   }
 
-  // chipColor derivation — D6-ceiling algorithm:
-  // NOTE: D1/D2 (liveness) failure causes D3 (e2e-demos) to also fail,
-  // so checking d3.status implicitly covers the D1/D2 gate.
+  // chipColor derivation — contiguous-ladder algorithm.
+  //
+  // Green is the strict reward for an INTACT verification ladder; a higher
+  // level (D6) can never paint over a broken/unverified lower level (D5).
+  // NOTE: D1/D2 (liveness) failure causes D3 (e2e-demos) to also fail, so
+  // checking d3.status implicitly covers the D1/D2 gate.
+  //
+  // Decision table over (d1d4GateFails, d5.exists, d5.status, d6.status):
+  //   gate fails                                  → red  (gate dominates)
+  //   D5 unmapped (!d5.exists), no D6             → gray (ceiling is D4)
+  //   D5 green + D6 green                         → green
+  //   D5 green + D6 red/amber/missing             → amber
+  //   D5 red/amber + (any D6)                     → red  (broken ladder)
+  //   D5 null  + D6 red                           → red
+  //   D5 null  + D6 green/amber/missing           → gray (unverified ladder)
   const d1d4GateFails =
     (d3.exists && d3.status !== "green") ||
     (d4.exists && d4.status !== "green");
 
   let chipColor: ChipColor;
   if (d1d4GateFails) {
+    // A failing/stale D1-D4 gate dominates everything below it.
     chipColor = "red";
-  } else if (d6.status === "green") {
-    chipColor = "green";
+  } else if (!d5.exists) {
+    // D5 is not mapped for this feature → ceiling is D4 and D6 is not its
+    // gate. Green requires a contiguous D5, so an unmapped D5 never paints
+    // green. With the gate passing this resolves to gray (cell sits at its
+    // D4 ceiling with no further verification), unless a present D6 row is
+    // explicitly failing — which still surfaces as red.
+    chipColor = d6.exists && d6.status !== "green" ? "red" : "gray";
   } else if (d5.status === "green") {
-    chipColor = "amber";
-  } else if (!d5.exists && !d6.exists) {
-    chipColor = "gray";
+    // Mapped D5 is green → ladder intact up to D5. D6 decides green vs amber.
+    chipColor = d6.status === "green" ? "green" : "amber";
+  } else if (d5.status === null) {
+    // Mapped D5 has no data → ladder unverified. A red D6 still signals a
+    // real failure; otherwise treat as no-data (gray), never green.
+    chipColor = d6.status === "red" ? "red" : "gray";
   } else {
+    // Mapped D5 is red or stale-amber → ladder broken at D5. Red wins over
+    // any D6 outcome (including a green aggregate).
     chipColor = "red";
   }
 

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -169,15 +169,13 @@ function resolveD4(live: LiveStatusMap, slug: string, now: number): TestLevel {
  * independent of `CATALOG_TO_D5_KEY` order. Only green is downgraded; a stale
  * red/degraded sub-row already signals a problem.
  *
- * NOTE on missing sub-rows: this fold only considers sub-rows that are PRESENT
- * — a missing row is SKIPPED (`if (!row) continue;`), not treated as failing.
- * So a multi-key family with only some sub-rows emitted can still be credited
- * green from those present rows. This DIVERGES from `depth-utils.ts`
- * `isD5Green`, which uses `d5Keys.every(...)` and therefore requires every
- * mapped key to be present AND green-and-fresh; a missing row makes the whole
- * family non-green there. The per-row stale-green→degraded downgrade IS
- * mirrored between the two; only the partial-emission (missing-row) handling
- * differs.
+ * STRICT on missing sub-rows: a multi-key family is credited green ONLY when
+ * EVERY mapped sub-row is present and green-and-fresh — a missing mapped
+ * sub-row forces the family out of green and resolves to `status: null`
+ * (no-data/unverified), so `achievedDepth` caps below 5 and the chip renders
+ * gray. A present RED sub-row still yields red (red dominates no-data). This
+ * matches `depth-utils.ts` `isD5Green`, which uses `d5Keys.every(...)`; both
+ * consumers now agree on partial-emission handling.
  */
 function resolveD5(
   live: LiveStatusMap,
@@ -194,9 +192,16 @@ function resolveD5(
 
   let worstRow: StatusRow | null = null;
   let worstState: State | null = null;
+  let anyMissing = false;
   for (const d5Key of d5Keys) {
     const row = live.get(keyFor("d5", slug, d5Key)) ?? null;
-    if (!row) continue;
+    if (!row) {
+      // STRICT: a missing mapped sub-row means the family is unverified —
+      // it can no longer be credited green. Mirrors `isD5Green`'s
+      // `every(...)` in depth-utils.ts so both consumers agree.
+      anyMissing = true;
+      continue;
+    }
     // Per-row staleness downgrade applied BEFORE the fold: a green sub-row
     // that is stale folds in as `degraded` so it can never win the all-green
     // tie and mask a fresh-green sibling.
@@ -216,6 +221,15 @@ function resolveD5(
   if (!worstRow || worstState === null) {
     // Keys are mapped but no rows emitted yet — test exists but has no
     // data. Treat as exists=true so ceilingDepth reflects it.
+    return { exists: true, status: null, row: null };
+  }
+
+  // STRICT missing-sub-row handling: when a mapped sub-row is absent the
+  // family is unverified. A present RED sub-row still signals a real failure
+  // (red dominates no-data), but a present green/degraded fold must NOT be
+  // credited — collapse it to no-data (status: null) so achievedDepth caps
+  // below 5 and the chip renders gray, not a false-green/amber.
+  if (anyMissing && worstState !== "red") {
     return { exists: true, status: null, row: null };
   }
 

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -439,6 +439,10 @@ export function buildCellModel(
     chipColor = "red";
   }
 
+  // isRegression: a cell has slid below its own ceiling — tests exist
+  // (ceilingDepth > 0) but the contiguous passing depth is short of them.
+  const isRegression = ceilingDepth > 0 && achievedDepth < ceilingDepth;
+
   return {
     supported: true,
     d3,
@@ -448,6 +452,6 @@ export function buildCellModel(
     achievedDepth,
     ceilingDepth,
     chipColor,
-    isRegression: false,
+    isRegression,
   };
 }


### PR DESCRIPTION
## Summary
Follow-up hardening for the showcase Coverage dashboard and harness browser-pool (deferred items from #5112):

- **Gate the green chip on a contiguous depth ladder.** A green `d6:<slug>` aggregate over a red/absent/no-data D5 no longer renders green; a never-run D5 reads gray (pending) instead of red. Decision table over `(d1d4Gate, d5.exists, d5.status, d6.exists, d6.status)` preserves all prior intended outcomes.
- **Staleness-gate D1/D2/D4 with per-driver windows.** D4 (`chat`/`tools`, 15-min cadence) uses a 1h window; D1/D2 (`health`/`agent`, 5-min cadence) use 45m — applied in both `resolveD4` and the deprecated `deriveDepth`, so a frozen-green liveness/round-trip row no longer credits depth (mirrors the D3/D5/D6 staleness already shipped).
- **`resolveD5` strict on missing mapped sub-rows.** A missing pill in a multi-key family (e.g. `beautiful-chat`) is unverified, not passing → returns `status: null` (caps depth, reads gray), matching `isD5Green`.
- **Compute `CellModel.isRegression`** (`ceilingDepth > 0 && achievedDepth < ceilingDepth`) and drive the Coverage regressions filter from the model field.
- **Harness:** widen `PoolLogger` to `warn`/`error` and route capacity-loss events (exhausted relaunch, recovery failure, empty-pool reinit) to the proper severity so they reach the warn/error pipeline; add a `reinit()` concurrent-entry guard.

## Test plan
- [ ] `showcase/shell-dashboard`: `npm test` (661 pass) incl. new chip-contiguity, per-driver-staleness, strict-D5, and isRegression cases (red-green).
- [ ] `showcase/harness`: `npx nx test showcase-harness` (1657 pass) incl. logger-severity-routing and reinit-guard tests.
- [ ] Both packages: typecheck + build green.