### PR TITLE
fix(showcase): unbreak main CI (crewai test stub + validate-pins baseline)

### DIFF
--- a/showcase/integrations/crewai-crews/tests/python/test_forwarded_props.py
+++ b/showcase/integrations/crewai-crews/tests/python/test_forwarded_props.py
@@ -227,6 +227,7 @@ def _stub_agent_server_deps():
         "shared_state_read_write",
         "subagents",
         "tool_rendering",
+        "_header_forwarding",
     ):
         sys.modules[f"agents.{name}"] = types.ModuleType(f"agents.{name}")
     setattr(sys.modules["agents.crew"], "LatestAiDevelopment", lambda: object())
@@ -257,6 +258,33 @@ def _stub_agent_server_deps():
     )
     setattr(sys.modules["agents.subagents"], "subagents_flow", object())
     setattr(sys.modules["agents.tool_rendering"], "tool_rendering_flow", object())
+
+    # agent_server imports the header-forwarding helpers at top level and calls
+    # install_global_httpx_hook() at import time, then mounts
+    # HeaderForwardingHTTPMiddleware in the stack. Stub both: a no-arg no-op
+    # callable for the hook, and a BaseHTTPMiddleware subclass for the
+    # middleware. The real middleware's dispatch is a transparent pass-through
+    # (copies x-* headers onto a ContextVar, then `return await
+    # call_next(request)`), so the stub mirrors that pass-through — the bare
+    # BaseHTTPMiddleware.dispatch raises NotImplementedError and would break
+    # the real-agent_server streaming tests that exercise the mounted stack.
+    async def _passthrough_dispatch(self, request, call_next):
+        return await call_next(request)
+
+    setattr(
+        sys.modules["agents._header_forwarding"],
+        "HeaderForwardingHTTPMiddleware",
+        type(
+            "HeaderForwardingHTTPMiddleware",
+            (BaseHTTPMiddleware,),
+            {"dispatch": _passthrough_dispatch},
+        ),
+    )
+    setattr(
+        sys.modules["agents._header_forwarding"],
+        "install_global_httpx_hook",
+        lambda: None,
+    )
 
     # Drop any stale agent_server import — we want the next `import agent_server`
     # to re-run module-init against OUR stubs.

--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the sorted, deduplicated `[FAIL] ...` lines from validate-pins.ts. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the per-package e2e-spec-count floor (single source of truth consumed by both the workflow and validate-parity.ts). NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
   "validatePinsFailCount": 106,
-  "validatePinsFailHash": "4355457a222f8011c361da7a848d7361e897ee588ad0b8c6487b851fd0c23b77",
+  "validatePinsFailHash": "2ef5c41b374aabde7ab29cb1bbeb7445bb2e8629edd28adcc4d50e5c4aa257c7",
   "baselineDemoCount": 9
 }


### PR DESCRIPTION
## Summary
main is red on two CI checks from recent D6 merges; both are mechanical fixes (no production behavior change).

- **Python unit tests (3.10/3.12)** — `crewai-crews/tests/python/test_forwarded_props.py` stubs a fake `agents` package, but the D6 header-conveyance commit added `agents._header_forwarding` (imported at module load in `agent_server.py`) without adding it to the stub list → `ModuleNotFoundError`. Adds the stub (with a pass-through `dispatch` matching the real middleware). Test-only.
- **Validate Showcase (`validate-pins` ratchet)** — the `langgraph-python` `copilotkit 0.1.92→0.1.93` bump rotated one FAIL line's text; FAIL count is unchanged (106), so this is a routine baseline-hash update in `showcase/scripts/fail-baseline.json`. No integration pins changed.

## Test plan
- [ ] `crewai-crews` python tests: `test_forwarded_props.py` 8/8 pass (was 5 failing).
- [ ] `validate-pins` gate: count 106 == baseline, hash matches → green.