### PR TITLE
fix(showcase/harness): emit d6:<slug> aggregate row so dashboard D6 column populates

### DIFF
--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -254,6 +254,79 @@ describe("e2e-full driver", () => {
     });
   });
 
+  // Regression guard: the dashboard reads the integration-scoped aggregate
+  // row `d6:<slug>` (see shell-dashboard/src/lib/live-status.ts:420 and
+  // shell-dashboard/src/components/depth-utils.ts:218). The cron driver
+  // path (input.key = "d6-all-pills-e2e:<name>") does NOT propagate that
+  // key as its primary result, so the driver must explicitly side-emit
+  // a `d6:<slug>` row carrying the aggregate signal — matching the
+  // CLI path's shape (cli/targets.ts:328 -> key: `d6:${slug}`).
+  describe("aggregate d6:<slug> side row (dashboard read contract)", () => {
+    it("emits d6:<slug> green aggregate when all features pass", async () => {
+      registerD5Script(makeScript(["agentic-chat"]));
+
+      const sideEmits: ProbeResult<unknown>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r);
+        },
+      };
+
+      const driver = createE2eFullDriver({
+        launcher: async () => makeBrowser(),
+        scriptLoader: noopScriptLoader(),
+      });
+      // Use the cron-shape key (d6-all-pills-e2e:<name>) — the bug only
+      // manifests on this path because the CLI path's primary key is
+      // already d6:<slug>.
+      const result = await driver.run(makeCtx({ writer }), {
+        key: "d6-all-pills-e2e:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: ["agentic-chat"],
+      });
+
+      expect(result.state).toBe("green");
+
+      const aggRow = sideEmits.find((r) => r.key === "d6:test-slug");
+      expect(aggRow).toBeDefined();
+      expect(aggRow!.state).toBe("green");
+      const aggSignal = aggRow!.signal as E2eFullAggregateSignal;
+      expect(aggSignal.slug).toBe("test-slug");
+      expect(aggSignal.passed).toBe(1);
+      expect(aggSignal.failed).toEqual([]);
+      expect(aggSignal.total).toBe(1);
+    });
+
+    it("emits d6:<slug> red aggregate when any feature fails (missing script)", async () => {
+      // No script registered — agentic-chat will fail with missing-script red.
+      const sideEmits: ProbeResult<unknown>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r);
+        },
+      };
+
+      const driver = createE2eFullDriver({
+        launcher: async () => makeBrowser(),
+        scriptLoader: noopScriptLoader(),
+      });
+      const result = await driver.run(makeCtx({ writer }), {
+        key: "d6-all-pills-e2e:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: ["agentic-chat"],
+      });
+
+      expect(result.state).toBe("red");
+
+      const aggRow = sideEmits.find((r) => r.key === "d6:test-slug");
+      expect(aggRow).toBeDefined();
+      expect(aggRow!.state).toBe("red");
+      const aggSignal = aggRow!.signal as E2eFullAggregateSignal;
+      expect(aggSignal.slug).toBe("test-slug");
+      expect(aggSignal.failed).toContain("agentic-chat");
+    });
+  });
+
   describe("deploy-churn grace window", () => {
     it("skips with green when deploy is recent", async () => {
       registerD5Script(makeScript(["agentic-chat"]));

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -501,7 +501,7 @@ export function createE2eFullDriver(
       const requestedFeatures = featureSource.filter(isKnownFeatureType);
 
       if (requestedFeatures.length === 0) {
-        return {
+        const aggregateResult: ProbeResult<E2eFullAggregateSignal> = {
           key: input.key,
           state: "green",
           signal: {
@@ -516,6 +516,8 @@ export function createE2eFullDriver(
           },
           observedAt,
         };
+        await emitAggregate(ctx, slug, aggregateResult);
+        return aggregateResult;
       }
 
       // Deploy-churn grace window
@@ -548,7 +550,7 @@ export function createE2eFullDriver(
               });
             }
 
-            return {
+            const aggregateResult: ProbeResult<E2eFullAggregateSignal> = {
               key: input.key,
               state: "green",
               signal: {
@@ -563,6 +565,8 @@ export function createE2eFullDriver(
               },
               observedAt,
             };
+            await emitAggregate(ctx, slug, aggregateResult);
+            return aggregateResult;
           }
         }
       }
@@ -644,7 +648,7 @@ export function createE2eFullDriver(
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.warn("probe.e2e-full.launcher-error", { slug, err: msg });
-          return {
+          const aggregateResult: ProbeResult<E2eFullAggregateSignal> = {
             key: input.key,
             state: "red",
             signal: {
@@ -660,6 +664,8 @@ export function createE2eFullDriver(
             },
             observedAt,
           };
+          await emitAggregate(ctx, slug, aggregateResult);
+          return aggregateResult;
         }
 
         // Emit red side rows for missing-script features upfront.
@@ -695,7 +701,7 @@ export function createE2eFullDriver(
 
         // If nothing is runnable but we have missing scripts, that's a red.
         if (runnable.length === 0 && missingScript.length > 0) {
-          return {
+          const aggregateResult: ProbeResult<E2eFullAggregateSignal> = {
             key: input.key,
             state: "red",
             signal: {
@@ -712,11 +718,13 @@ export function createE2eFullDriver(
             },
             observedAt,
           };
+          await emitAggregate(ctx, slug, aggregateResult);
+          return aggregateResult;
         }
 
         // If nothing is runnable and everything was filtered, green.
         if (runnable.length === 0) {
-          return {
+          const aggregateResult: ProbeResult<E2eFullAggregateSignal> = {
             key: input.key,
             state: "green",
             signal: {
@@ -731,6 +739,8 @@ export function createE2eFullDriver(
             },
             observedAt,
           };
+          await emitAggregate(ctx, slug, aggregateResult);
+          return aggregateResult;
         }
 
         // Run features with bounded parallelism.
@@ -1001,7 +1011,7 @@ export function createE2eFullDriver(
           state: aggregateGreen ? "green" : "red",
           durationMs: Date.now() - serviceStart,
         });
-        return {
+        const aggregateResult: ProbeResult<E2eFullAggregateSignal> = {
           key: input.key,
           state: aggregateGreen ? "green" : "red",
           signal: {
@@ -1017,6 +1027,12 @@ export function createE2eFullDriver(
           },
           observedAt,
         };
+        // Unconditional dashboard-contract emit: even if features failed
+        // or timed out, the dashboard's D6 column needs a `d6:<slug>` row
+        // to display red (vs blank). Placed after the loop so per-feature
+        // timeouts inside the loop can never skip it.
+        await emitAggregate(ctx, slug, aggregateResult);
+        return aggregateResult;
       } finally {
         clearTimeout(timeoutHandle);
         if (externalAbort) {
@@ -1344,6 +1360,45 @@ async function sideEmit(
   } catch (err) {
     ctx.logger.error("probe.e2e-full.side-emit-writer-failed", {
       key: result.key,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Emit the integration-scoped aggregate `d6:<slug>` side row consumed
+ * by the showcase dashboard. The dashboard reads this exact key (see
+ * `shell-dashboard/src/lib/live-status.ts` and
+ * `shell-dashboard/src/components/depth-utils.ts`). The CLI driver path
+ * (cli/targets.ts -> `key: d6:<slug>`) produces this shape as its
+ * primary return; the cron path's primary key is
+ * `d6-all-pills-e2e:<name>`, so without this explicit side-emit the
+ * dashboard's D6 column stays permanently blank.
+ *
+ * Best-effort and isolated from primary-return semantics: failures here
+ * are logged by `ctx.writer.write` but never propagate to the caller.
+ */
+async function emitAggregate(
+  ctx: ProbeContext,
+  slug: string,
+  result: ProbeResult<E2eFullAggregateSignal>,
+): Promise<void> {
+  if (!ctx.writer) {
+    ctx.logger.warn("probe.e2e-full.aggregate-writer-missing", {
+      key: `d6:${slug}`,
+    });
+    return;
+  }
+  try {
+    await ctx.writer.write({
+      key: `d6:${slug}`,
+      state: result.state,
+      signal: result.signal,
+      observedAt: result.observedAt,
+    });
+  } catch (err) {
+    ctx.logger.error("probe.e2e-full.aggregate-emit-failed", {
+      key: `d6:${slug}`,
       err: err instanceof Error ? err.message : String(err),
     });
   }


### PR DESCRIPTION
## Bug

The showcase dashboard reads integration-scoped aggregate rows keyed `d6:<slug>` to populate the D6 column:

- `shell-dashboard/src/lib/live-status.ts:420` reads `d6:<slug>` to derive each integration's D6 state.
- `shell-dashboard/src/components/depth-utils.ts:218` uses the same key when mapping cells to depths.

The CLI driver path (`showcase/harness/src/cli/targets.ts`) invokes the e2e-full driver with `key: d6:<slug>`, so the driver's primary return lands under the right key. But the **cron** probe driver runs with `key: d6-all-pills-e2e:<name>` (per the probe YAML / docstring), so its primary return never writes a `d6:<slug>` row. The driver only emits per-feature side rows keyed `d6:<slug>/<featureType>` — never the integration-scoped aggregate.

Result: in staging/prod the D6 column is permanently blank even though the docstring and probe YAML promise the aggregate row.

## Fix

Add an `emitAggregate` helper (mirroring the existing `sideEmit`) that writes a `d6:<slug>` row carrying the same `E2eFullAggregateSignal` shape as the primary return, and call it at every primary-return point in `showcase/harness/src/probes/drivers/d6-all-pills.ts`:

- Post-loop aggregate (placed AFTER the feature loop so a per-feature timeout cannot skip it; emits red when any feature failed, so the dashboard shows red rather than blank).
- No-features-declared early return.
- Deploy-churn grace-window skip.
- Launcher-error early return.
- All-runnable-filtered-out early returns (both the missing-script red and the all-filtered green branches).

`emitAggregate` is best-effort — writer errors are logged but never propagate to the caller, matching `sideEmit` semantics.

## Red-green test evidence

Two new regression tests added to `showcase/harness/src/probes/drivers/d6-all-pills.test.ts` under `aggregate d6:<slug> side row (dashboard read contract)`:

- Exercises the cron-shape key (`d6-all-pills-e2e:<slug>`).
- Asserts the emitted `d6:<slug>` side row carries the right state — green when all features pass, red when any fails — and the correct aggregate signal.

Both tests confirmed failing before the fix and passing after (red-green). Full harness suite **1648/1648** passes; `tsc --noEmit` clean; oxfmt + oxlint clean on the touched files.

## Effect

Makes the dashboard D6 column populate from cron runs. It will go **red first** for integrations whose underlying D6 parity work hasn't landed yet, and **green** as each integration's parity lands — i.e. the column finally reflects reality instead of staying blank.