### PR TITLE
fix(showcase/harness): exclude bare-named infra services from aimock-wiring probe

### DIFF
--- a/showcase/harness/src/probes/aimock-wiring.test.ts
+++ b/showcase/harness/src/probes/aimock-wiring.test.ts
@@ -113,6 +113,50 @@ describe("aimock-wiring probe", () => {
     expect(r.signal.wiredCount).toBe(0);
   });
 
+  it("excludes BARE-named Railway infra services (no `showcase-` prefix)", async () => {
+    // Regression: actual deployed Railway service names are bare
+    // (`harness`, `shell`, `dashboard`, `docs`, `dojo`, `pocketbase`,
+    // `webhooks`, `aimock`) but EXCLUDE_SERVICES only listed the
+    // `showcase-`-prefixed form, so the probe counted all infra services
+    // as unwired and went red on staging/prod despite aimock being
+    // correctly wired. Both forms must be treated as excluded.
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [
+          { name: "aimock" },
+          { name: "harness" },
+          { name: "shell" },
+          { name: "dashboard" },
+          { name: "docs" },
+          { name: "dojo" },
+          { name: "pocketbase" },
+          { name: "webhooks" },
+        ],
+        // None of these have aimock base URLs — all are non-LLM infra
+        // and must be excluded regardless of bare-vs-prefixed naming.
+        getServiceEnv: async () => ({}),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("green");
+    expect(r.signal.unwired).toEqual([]);
+    expect(r.signal.wiredCount).toBe(0);
+  });
+
+  it("excludes bare-named ms-agent-harness-dotnet (non-LLM infra)", async () => {
+    const r = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [{ name: "ms-agent-harness-dotnet" }],
+        getServiceEnv: async () => ({}),
+      },
+      ctx,
+    );
+    expect(r.state).toBe("green");
+    expect(r.signal.unwired).toEqual([]);
+  });
+
   it("does NOT false-exclude services that merely share a prefix with infra names", async () => {
     // Regression: a prefix-based match on `showcase-aimock` would incorrectly
     // exclude `showcase-aimock-pinger-mock-for-test` (or any hypothetical

--- a/showcase/harness/src/probes/aimock-wiring.ts
+++ b/showcase/harness/src/probes/aimock-wiring.ts
@@ -43,23 +43,37 @@ export const SEALED_SENTINEL = "__SEALED__";
  */
 
 /**
- * Exact service names we do NOT check for aimock wiring. The aimock service
+ * Service names we do NOT check for aimock wiring. The aimock service
  * itself has no upstream to route through, and shell/pocketbase/harness are pure
  * infra with no LLM callers.
  *
- * Exact match (not prefix) is load-bearing: prefix-matching on "showcase-aimock"
- * would false-exclude a hypothetical "showcase-aimock-pinger-mock-for-test"
- * AND prevent it from showing up as unwired. Keep this list in sync with the
- * Railway service roster whenever new infra services are added.
+ * Entries are stored in their `showcase-`-prefixed form. The exclusion check
+ * (`isExcluded`) normalizes inputs by stripping a leading `showcase-` so a
+ * bare deployed name (e.g. `harness`, `shell`, `aimock`) matches the same
+ * canonical entry as the prefixed form (`showcase-harness`, …). This is
+ * load-bearing: actual deployed Railway service names in the production
+ * project are BARE — without the strip, every bare infra service would have
+ * been counted as unwired (no `*_BASE_URL` overrides because they are not
+ * LLM callers) and the probe would have stayed red forever.
+ *
+ * Match is still effectively EXACT post-strip (not prefix): a hypothetical
+ * `showcase-aimock-pinger-mock-for-test` strips to `aimock-pinger-mock-for-test`,
+ * which is NOT in the set, so it would correctly surface as unwired. Keep
+ * this list in sync with the Railway service roster whenever new infra
+ * services are added.
  */
 const EXCLUDE_SERVICES: ReadonlySet<string> = new Set([
   "showcase-aimock",
   "showcase-shell",
   "showcase-shell-dashboard",
+  "showcase-dashboard",
   "showcase-shell-docs",
+  "showcase-docs",
   "showcase-shell-dojo",
+  "showcase-dojo",
   "showcase-pocketbase",
   "showcase-harness",
+  "showcase-webhooks",
   "showcase-ms-agent-harness-dotnet",
   "showcase-starter-ag2",
   "showcase-starter-agno",
@@ -169,7 +183,15 @@ export interface AimockWiringSignal {
 const ERRORED_PREVIEW_MAX = 5;
 
 function isExcluded(name: string): boolean {
-  return EXCLUDE_SERVICES.has(name);
+  // Match either the literal name or its `showcase-`-prefixed form. Railway
+  // service names in the production project are BARE (`harness`, `shell`,
+  // `aimock`, …) while EXCLUDE_SERVICES is keyed by the `showcase-`-prefixed
+  // form for historical reasons (the legacy local-dev project named services
+  // with that prefix). Comparing both forms keeps the set robust to either
+  // naming convention without forcing operators to maintain two parallel
+  // sets that can drift.
+  if (EXCLUDE_SERVICES.has(name)) return true;
+  return EXCLUDE_SERVICES.has(`showcase-${name}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

The `aimock-wiring` probe was reporting a false red on staging/prod even though aimock IS correctly wired for every real LLM-calling integration service.

**Root cause:** The probe's `EXCLUDE_SERVICES` set listed all infra services with a `showcase-` prefix (e.g. `showcase-harness`, `showcase-shell`, `showcase-aimock`), but the actual deployed Railway service names in the production project are **bare** (`harness`, `shell`, `dashboard`, `docs`, `dojo`, `pocketbase`, `webhooks`, `aimock`). The exact-match `isExcluded` check therefore failed to exclude them, the non-LLM infra services were counted as unwired (correctly missing `*_BASE_URL` overrides), and the probe stayed red despite aimock-staging being healthy and every integration pointing at it.

**Fix:** `isExcluded` now matches both forms — a bare input resolves against the `showcase-`-prefixed entry in the set, and vice versa. Both naming conventions canonicalize to the same set entry, so there are no parallel lists to drift. Also rounded out the infra roster by adding `showcase-webhooks`, `showcase-dashboard`, `showcase-docs`, and `showcase-dojo`. Hypothetical pinger-style names like `showcase-aimock-pinger-mock-for-test` still correctly surface as unwired (existing regression test continues to pass).

The driver wrapper (`drivers/aimock-wiring.ts`) delegates entirely to the probe and needed no change.

## Evidence

- **Red-green:** two new tests assert bare names (`harness`, `shell`, `dashboard`, `docs`, `dojo`, `pocketbase`, `webhooks`, `aimock`, `ms-agent-harness-dotnet`) are excluded. Failed pre-fix, pass post-fix.
- **Full suite:** 27/27 probe + 16/16 driver tests pass (43 total).
- **External state:** aimock-staging healthy; every LLM-calling integration's Railway env points at the correct aimock URL (verified by inspecting Railway service configs prior to this change).

## Effect

This makes the `aimock-wiring` probe go green on the next tick. **No Railway env changes needed** — the wiring was always correct; only the probe's exclusion logic was wrong.

## Test plan

- [x] Red-green tests added
- [x] `npx oxfmt --check` clean on touched files
- [x] `npx oxlint` clean (0 warnings, 0 errors)
- [x] `tsc --noEmit` clean
- [x] 43/43 probe + driver tests pass
- [ ] CI green
- [ ] Probe goes green on next staging tick post-merge