### PR TITLE
fix(showcase): unify dashboard staleness and fix false-green chips

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
@@ -292,13 +292,15 @@ describe("CellMatrix", () => {
   it("filters to rows with regressions when filter=regressions", () => {
     // Uses buildCellModel D3/D4/D5 depth model (not the old D0-D6 ladder).
     //
-    // lgp/agentic-chat: e2e row GREEN (D3 passes), chat row GREEN (D4 passes),
-    //   but "agentic-chat" has a CATALOG_TO_D5_KEY mapping so ceiling=5.
-    //   No D5 PB rows → D5 status=null → achieved=4 < ceiling=5 → REGRESSION.
+    // lgp/agentic-chat: e2e GREEN (D3), chat GREEN (D4), and an EMITTED RED
+    //   D5 row. "agentic-chat" maps to a CATALOG_TO_D5_KEY so ceiling=5;
+    //   achieved=4 < ceiling=5 AND the next rung (D5) has emitted data
+    //   (status='red') → genuine REGRESSION (unification C requires emitted
+    //   data above achievedDepth, so a no-data D5 would NOT count).
     //
-    // lgp/no-d5-feature: e2e row GREEN (D3 passes), chat row GREEN (D4 passes),
-    //   "no-d5-feature" has NO CATALOG_TO_D5_KEY mapping → ceiling=4.
-    //   achieved=4 === ceiling=4 → NOT a regression.
+    // lgp/no-d5-feature: e2e GREEN (D3), chat GREEN (D4), "no-d5-feature" has
+    //   NO CATALOG_TO_D5_KEY mapping → ceiling=4. achieved=4 === ceiling=4 →
+    //   NOT a regression.
     const regressFeatures = [
       { id: "agentic-chat", name: "Agentic Chat", category: "chat-ui" },
       { id: "no-d5-feature", name: "No D5 Feature", category: "platform" },
@@ -331,6 +333,9 @@ describe("CellMatrix", () => {
       row("e2e:lgp/agentic-chat", "e2e", "green"),
       row("e2e:lgp/no-d5-feature", "e2e", "green"),
       row("chat:lgp", "chat", "green"),
+      // Emitted RED D5 keeps agentic-chat a genuine regression under the
+      // refined (unification C) rule — a missing D5 row would be no-data.
+      row("d5:lgp/agentic-chat", "d5", "red"),
     ]);
     const oneIntegration = [
       { slug: "lgp", name: "LangGraph Python", tier: "reference" as const },
@@ -347,7 +352,7 @@ describe("CellMatrix", () => {
         referenceSlug="lgp"
       />,
     );
-    // agentic-chat: achieved=4 < ceiling=5 → regression → visible
+    // agentic-chat: achieved=4 < ceiling=5, D5 emitted red → regression → visible
     expect(queryByText("Agentic Chat")).not.toBeNull();
     // no-d5-feature: achieved=4 === ceiling=4 → at ceiling → hidden
     expect(queryByText("No D5 Feature")).toBeNull();

--- a/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
@@ -8,6 +8,7 @@ import { CellMatrix } from "../cell-matrix";
 import type { CatalogCell } from "../depth-utils";
 import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
 import type { FeatureCategory } from "@/lib/registry";
+import { E2E_STALE_AFTER_MS } from "@/lib/staleness";
 
 // Mock localStorage
 const storageMap = new Map<string, string>();
@@ -597,5 +598,117 @@ describe("CellMatrix", () => {
     // Click same cell again to toggle off
     fireEvent.click(getByTestId("cell-btn-lgp-agentic-chat"));
     expect(queryByTestId("cell-drilldown")).toBeNull();
+  });
+
+  it("filter pass and render path share ONE `now` across a staleness boundary", () => {
+    // The filter pass and the render-path buildCellModel must agree on which
+    // green rows are stale. The e2e:lgp/agentic-chat row's observed_at sits
+    // EXACTLY on the e2e staleness boundary relative to the FIRST clock tick:
+    // a `now` at the base reads fresh (D3 green → achievedDepth 4, a
+    // regression that the filter includes), but a `now` advanced past the
+    // boundary reads stale (D3 amber → gate fails → achievedDepth 0). We stub
+    // Date.now to advance on EACH call, straddling the boundary. With a single
+    // hoisted `now` (called once per render) the filter and render see the
+    // same pre-boundary tick, so the included row renders at depth 4. Pre-fix
+    // the render path called Date.now() again, landing past the boundary and
+    // rendering depth 0 — a chip/filter disagreement.
+    const base = 1_700_000_000_000;
+    // observed_at is exactly E2E_STALE_AFTER_MS before `base`: at now=base it
+    // is NOT stale (now - observed === maxAge, and isStale uses strict `>`),
+    // but at now=base+1 (or later) it IS stale.
+    const observedAt = new Date(base - E2E_STALE_AFTER_MS).toISOString();
+    // Fresh timestamp for D4 (chat) — its window is 1h, far tighter than the
+    // 6h e2e window, so it must NOT sit on the e2e boundary or it would read
+    // stale-degraded at base and cap achievedDepth below 4 regardless.
+    const freshObservedAt = new Date(base).toISOString();
+    let tick = 0;
+    // First call → base (fresh); every subsequent call → well past boundary.
+    const nowSpy = vi
+      .spyOn(Date, "now")
+      .mockImplementation(() => (tick++ === 0 ? base : base + 60_000));
+
+    try {
+      const boundaryCells: CatalogCell[] = [
+        {
+          id: "lgp/agentic-chat",
+          integration: "lgp",
+          integration_name: "LangGraph Python",
+          feature: "agentic-chat",
+          feature_name: "Agentic Chat",
+          status: "wired",
+          max_depth: 3,
+          category: "chat-ui",
+          category_name: "Chat & UI",
+        },
+      ];
+      const boundaryFeatures = [
+        { id: "agentic-chat", name: "Agentic Chat", category: "chat-ui" },
+      ];
+      const oneIntegration = [
+        { slug: "lgp", name: "LangGraph Python", tier: "reference" as const },
+      ];
+      // D3 green (boundary observed_at), D4 green, D5 emitted red → fresh-read
+      // achievedDepth 4 < ceiling 5 with emitted D5 data = a regression the
+      // filter INCLUDES. A stale-read collapses D3 to amber (achievedDepth 0).
+      const live: LiveStatusMap = new Map();
+      for (const r of [
+        {
+          id: "id-e2e",
+          key: "e2e:lgp/agentic-chat",
+          dimension: "e2e",
+          state: "green" as const,
+          signal: {},
+          observed_at: observedAt,
+          transitioned_at: observedAt,
+          fail_count: 0,
+          first_failure_at: null,
+        },
+        {
+          id: "id-chat",
+          key: "chat:lgp",
+          dimension: "chat",
+          state: "green" as const,
+          signal: {},
+          observed_at: freshObservedAt,
+          transitioned_at: freshObservedAt,
+          fail_count: 0,
+          first_failure_at: null,
+        },
+        {
+          id: "id-d5",
+          key: "d5:lgp/agentic-chat",
+          dimension: "d5",
+          state: "red" as const,
+          signal: {},
+          observed_at: observedAt,
+          transitioned_at: observedAt,
+          fail_count: 1,
+          first_failure_at: observedAt,
+        },
+      ] satisfies StatusRow[]) {
+        live.set(r.key, r);
+      }
+
+      const { getAllByTestId } = render(
+        <CellMatrix
+          cells={boundaryCells}
+          categories={[{ id: "chat-ui", name: "Chat & UI" }]}
+          features={boundaryFeatures}
+          integrations={oneIntegration}
+          liveStatus={live}
+          defaultOpenCategories={new Set(["chat-ui"])}
+          filter="regressions"
+          referenceSlug="lgp"
+        />,
+      );
+
+      // The cell was included by the filter (fresh read). The render-path chip
+      // must reflect the SAME fresh `now`: depth 4, NOT the stale depth 0.
+      const chips = getAllByTestId("depth-chip");
+      expect(chips.length).toBe(1);
+      expect(chips[0].getAttribute("data-depth")).toBe("4");
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });

--- a/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
@@ -233,6 +233,69 @@ describe("computeColumnTallyDetail", () => {
     expect(result.unknown).toBe(false);
   });
 
+  it("green D3+D4 + red D5 → red bucket with dimension 'health'", () => {
+    // Exercises the feature-grid `dimension:"health"` branch: a D5 row that
+    // exists with a non-null, non-green status classifies the failure as a
+    // live-conversation ("health") failure, not a page-load ("e2e") one. The
+    // broken D5 ladder makes chipColor red.
+    const integration = makeIntegration("h-int", ["agentic-chat"]);
+    const features = [makeFeature("agentic-chat", "Feature A")];
+    const liveStatus: LiveStatusMap = new Map([
+      [
+        "e2e:h-int/agentic-chat",
+        makeRow("e2e:h-int/agentic-chat", "e2e", "green"),
+      ],
+      // chat green → D4 green (tools absent, worst-state skips it)
+      ["chat:h-int", makeRow("chat:h-int", "chat", "green")],
+      // d5 red → ladder broken at D5 → chipColor red, dimension health
+      ["d5:h-int/agentic-chat", makeRow("d5:h-int/agentic-chat", "d5", "red")],
+    ]);
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "live",
+    );
+
+    expect(result.unknown).toBe(false);
+    expect(result.green).toEqual([]);
+    expect(result.amber).toEqual([]);
+    expect(result.red).toEqual([
+      { label: "Feature A", dimension: "health", featureId: "agentic-chat" },
+    ]);
+  });
+
+  it("green D3 + red D4 → red bucket with dimension 'health'", () => {
+    // A red D4 (real-time chat/tools) row exists with a non-null, non-green
+    // status → the failing D1-D4 gate paints the chip red, and the
+    // `dimension:"health"` branch classifies it as a live-roundtrip failure.
+    const integration = makeIntegration("h2-int", ["agentic-chat"]);
+    const features = [makeFeature("agentic-chat", "Feature A")];
+    const liveStatus: LiveStatusMap = new Map([
+      [
+        "e2e:h2-int/agentic-chat",
+        makeRow("e2e:h2-int/agentic-chat", "e2e", "green"),
+      ],
+      // chat red → D4 red → gate fails → chipColor red, dimension health
+      ["chat:h2-int", makeRow("chat:h2-int", "chat", "red")],
+    ]);
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "live",
+    );
+
+    expect(result.unknown).toBe(false);
+    expect(result.green).toEqual([]);
+    expect(result.amber).toEqual([]);
+    expect(result.red).toEqual([
+      { label: "Feature A", dimension: "health", featureId: "agentic-chat" },
+    ]);
+  });
+
   it("not_supported_features are gray and excluded", () => {
     const integration = {
       ...makeIntegration("ns-int", ["agentic-chat", "tool-rendering"]),

--- a/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
@@ -161,6 +161,22 @@ describe("deriveDepth", () => {
     expect(result.achieved).toBe(4);
   });
 
+  it("D4 worst-state wins: green chat + red tools does NOT achieve D4", () => {
+    // Unification D: D4 was `chatGreen || toolsGreen` (OR), which credited
+    // D4 even when one half was red. Match cell-model's resolveD4 worst-
+    // state-wins — a red tools row pulls D4 down so achieved caps at D3.
+    const c = cell("lgp", "agentic-chat");
+    const live = mapOf([
+      row("health:lgp", "health", "green"),
+      row("agent:lgp", "agent", "green"),
+      row("e2e:lgp/agentic-chat", "e2e", "green"),
+      row("chat:lgp", "chat", "green"),
+      row("tools:lgp", "tools", "red"),
+    ]);
+    const result = deriveDepth(c, live);
+    expect(result.achieved).toBe(3);
+  });
+
   it("short-circuits: D1 red means D0 even if D2+ green", () => {
     const c = cell("lgp", "agentic-chat");
     const live = mapOf([

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -53,6 +53,10 @@ vi.mock("@/data/docs-status.json", () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
+// A recent timestamp so green rows are not treated as stale by the
+// staleness downgrade in resolveCell (compares against Date.now()).
+const FRESH_OBSERVED_AT = new Date().toISOString();
+
 function makeStatusRow(
   dimension: string,
   slug: string,
@@ -68,8 +72,8 @@ function makeStatusRow(
     dimension,
     state,
     signal: null,
-    observed_at: "2026-04-20T00:00:00Z",
-    transitioned_at: "2026-04-20T00:00:00Z",
+    observed_at: FRESH_OBSERVED_AT,
+    transitioned_at: FRESH_OBSERVED_AT,
     fail_count: 0,
     first_failure_at: null,
   };

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -251,7 +251,21 @@ describe("Overlay selector integration — real UI components", () => {
   // 3. Health only — the critical case (no docs indicators must appear)
   // -------------------------------------------------------------------------
   it("health only: API/RT/CV badges visible, NO docs indicators", () => {
-    const ctx = makeCtx();
+    // `agentic-chat` is a real CATALOG_TO_D5_KEY entry, so its d5 row resolves
+    // green and the CV badge renders. An UNMAPPED feature's CV badge is gray
+    // "?" and hidden by design (resolveD5Row returns null for unmapped
+    // features, matching resolveD5 / isD5Green) — "don't show tests that
+    // don't exist".
+    const ctx = makeCtx({
+      feature: {
+        id: "agentic-chat",
+        name: "Agentic Chat",
+        category: "chat-ui",
+        description: "Agentic chat feature",
+        kind: "primary",
+      },
+      liveStatus: buildLiveStatusMap("next", "agentic-chat"),
+    });
     const { getByTestId, getByText, queryByText, queryByTestId } = render(
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
     );
@@ -324,7 +338,20 @@ describe("Overlay selector integration — real UI components", () => {
   // 6. Health + Docs — both badges AND docs indicators visible
   // -------------------------------------------------------------------------
   it("health + docs: badges AND docs indicators both visible", () => {
-    const ctx = makeCtx();
+    // `agentic-chat` is a real CATALOG_TO_D5_KEY entry so the CV badge has a
+    // resolved (green) d5 row to render; an unmapped feature's CV badge is
+    // hidden by design. The docs-status mock also covers `agentic-chat`, so
+    // the docs-og / docs-shell indicators still resolve.
+    const ctx = makeCtx({
+      feature: {
+        id: "agentic-chat",
+        name: "Agentic Chat",
+        category: "chat-ui",
+        description: "Agentic chat feature",
+        kind: "primary",
+      },
+      liveStatus: buildLiveStatusMap("next", "agentic-chat"),
+    });
     const { getByTestId, getByText, queryByText, queryByTestId } = render(
       <ComposedCell ctx={ctx} overlays={overlaySet("health", "docs")} />,
     );

--- a/showcase/shell-dashboard/src/components/cell-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/cell-matrix.tsx
@@ -282,6 +282,9 @@ export function CellMatrix({
   // Filter features based on mode
   const filterFeatureRow = (featureId: string): boolean => {
     if (filter === "all" || filter === "reference") return true;
+    // Single `now` per filter pass so the gaps `resolveCell` and the
+    // regressions `buildCellModel` agree on which green rows are stale.
+    const now = Date.now();
     if (filter === "wired") {
       return visibleIntegrations.some((int) => {
         const cell = cellIndex.get(`${int.slug}/${featureId}`);
@@ -298,7 +301,9 @@ export function CellMatrix({
         if (cell.status === "unsupported") return false;
         // Red probes = functional gap (cell exists but failing)
         if (cell.feature !== null) {
-          const cellState = resolveCell(liveStatus, int.slug, cell.feature);
+          const cellState = resolveCell(liveStatus, int.slug, cell.feature, {
+            now,
+          });
           if (cellState.rollup === "red") return true;
         }
         return false;
@@ -309,12 +314,16 @@ export function CellMatrix({
         const cell = cellIndex.get(`${int.slug}/${featureId}`);
         if (!cell) return false;
         const isNotSupported = cell.status === "unsupported";
-        const model = buildCellModel(liveStatus, {
-          slug: int.slug,
-          featureId,
-          isSupported: !isNotSupported,
-          isWired: cell.status === "wired" || cell.status === "stub",
-        });
+        const model = buildCellModel(
+          liveStatus,
+          {
+            slug: int.slug,
+            featureId,
+            isSupported: !isNotSupported,
+            isWired: cell.status === "wired" || cell.status === "stub",
+          },
+          now,
+        );
         return model.isRegression;
       });
     }

--- a/showcase/shell-dashboard/src/components/cell-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/cell-matrix.tsx
@@ -87,6 +87,14 @@ interface CategorySectionProps {
   selectedCell: SelectedCell | null;
   onCellClick: (cell: SelectedCell | null) => void;
   connection: ConnectionStatus;
+  /**
+   * Single reference time shared with the parent's filter pass so the
+   * render-path `buildCellModel` and the filter `buildCellModel`/`resolveCell`
+   * agree on which green rows are stale — a cell the filter included can no
+   * longer render a different staleness state because its render `now` crossed
+   * a window boundary milliseconds later.
+   */
+  now: number;
 }
 
 function CategorySection({
@@ -100,6 +108,7 @@ function CategorySection({
   selectedCell,
   onCellClick,
   connection,
+  now,
 }: CategorySectionProps) {
   const { isOpen, toggle } = useCollapsible({
     name: cat.name,
@@ -144,12 +153,16 @@ function CategorySection({
             {visibleIntegrations.map((int) => {
               const cell = cellIndex.get(`${int.slug}/${feature.id}`);
               const isNotSupported = cell?.status === "unsupported";
-              const model = buildCellModel(liveStatus, {
-                slug: int.slug,
-                featureId: feature.id,
-                isSupported: !isNotSupported,
-                isWired: cell?.status === "wired" || cell?.status === "stub",
-              });
+              const model = buildCellModel(
+                liveStatus,
+                {
+                  slug: int.slug,
+                  featureId: feature.id,
+                  isSupported: !isNotSupported,
+                  isWired: cell?.status === "wired" || cell?.status === "stub",
+                },
+                now,
+              );
               const cellStatus = !model.supported
                 ? "unsupported"
                 : (cell?.status ?? "unshipped");
@@ -269,6 +282,15 @@ export function CellMatrix({
     return idx;
   }, [cells]);
 
+  // Single reference time captured once per data update (keyed on
+  // `liveStatus`) and shared by the filter pass AND the render-path
+  // `buildCellModel` below. Threading ONE `now` keeps the chip and the
+  // badges in lockstep: a cell the filter included renders the SAME
+  // staleness state, instead of re-deriving against a fresh `Date.now()`
+  // that may have crossed a window boundary milliseconds later. Mirrors
+  // the single-`now` discipline in cells-view.tsx's stats pass.
+  const now = useMemo(() => Date.now(), [liveStatus]);
+
   // Group features by category
   const featuresByCategory = useMemo(() => {
     return categories
@@ -282,9 +304,10 @@ export function CellMatrix({
   // Filter features based on mode
   const filterFeatureRow = (featureId: string): boolean => {
     if (filter === "all" || filter === "reference") return true;
-    // Single `now` per filter pass so the gaps `resolveCell` and the
-    // regressions `buildCellModel` agree on which green rows are stale.
-    const now = Date.now();
+    // Reuse the single `now` hoisted to CellMatrix scope so the gaps
+    // `resolveCell` / regressions `buildCellModel` filter pass and the
+    // render-path `buildCellModel` (in CategorySection) all agree on which
+    // green rows are stale.
     if (filter === "wired") {
       return visibleIntegrations.some((int) => {
         const cell = cellIndex.get(`${int.slug}/${featureId}`);
@@ -378,6 +401,7 @@ export function CellMatrix({
                 selectedCell={selectedCell}
                 onCellClick={handleCellClick}
                 connection={connection}
+                now={now}
               />
             );
           })}

--- a/showcase/shell-dashboard/src/components/cells-view.tsx
+++ b/showcase/shell-dashboard/src/components/cells-view.tsx
@@ -9,12 +9,10 @@ import { useMemo, useState } from "react";
 import { StatsBar } from "./stats-bar";
 import { CoverageBar } from "./coverage-bar";
 import { ChipsExplainer } from "./chips-explainer";
-import { FilterChips, type FilterMode } from "./filter-chips";
-import {
-  CellMatrix,
-  type IntegrationInfo,
-  type FeatureInfo,
-} from "./cell-matrix";
+import { FilterChips } from "./filter-chips";
+import type { FilterMode } from "./filter-chips";
+import { CellMatrix } from "./cell-matrix";
+import type { IntegrationInfo, FeatureInfo } from "./cell-matrix";
 import { deriveDepth } from "./depth-utils";
 import { resolveCell } from "@/lib/live-status";
 import type { LiveStatusMap, ConnectionStatus } from "@/lib/live-status";
@@ -131,9 +129,12 @@ export function CellsView({ catalog, liveStatus, connection }: CellsViewProps) {
     let maxDepth = 0;
     let regressions = 0;
     let failures = 0;
+    // Single `now` for the whole pass so `deriveDepth` and `resolveCell`
+    // agree on which green rows are stale.
+    const now = Date.now();
     for (const cell of catalog.cells) {
       if (cell.status !== "unshipped" && cell.status !== "unsupported") {
-        const d = deriveDepth(cell, liveStatus);
+        const d = deriveDepth(cell, liveStatus, now);
         if (d.achieved > maxDepth) maxDepth = d.achieved;
         if (d.isRegression) regressions++;
         // Count cells with red rollup as failures
@@ -142,6 +143,7 @@ export function CellsView({ catalog, liveStatus, connection }: CellsViewProps) {
             liveStatus,
             cell.integration,
             cell.feature,
+            { now },
           );
           if (cellState.rollup === "red") failures++;
         }

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -17,12 +17,13 @@
  * Short-circuits: if any level is not green, stop there.
  */
 import { keyFor, CATALOG_TO_D5_KEY } from "@/lib/live-status";
-import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
+import type { LiveStatusMap } from "@/lib/live-status";
 import {
   E2E_STALE_AFTER_MS,
   D4_STALE_AFTER_MS,
   LIVENESS_STALE_AFTER_MS,
-} from "@/lib/cell-model";
+  isStale,
+} from "@/lib/staleness";
 
 /** Minimal catalog cell shape consumed by depth derivation. */
 export interface CatalogCell {
@@ -82,14 +83,7 @@ function isGreenAndFresh(
 ): boolean {
   const row = live.get(key);
   if (row?.state !== "green") return false;
-  return !isRowStale(row, now, maxAgeMs);
-}
-
-/** Row is stale if `observed_at` is older than `maxAgeMs` relative to `now`. */
-function isRowStale(row: StatusRow, now: number, maxAgeMs: number): boolean {
-  const observedMs = Date.parse(row.observed_at);
-  if (Number.isNaN(observedMs)) return false;
-  return now - observedMs > maxAgeMs;
+  return !isStale(row, now, maxAgeMs);
 }
 
 /**

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -87,6 +87,29 @@ function isGreenAndFresh(
 }
 
 /**
+ * Check whether D4 (real-time chat/tools) is green for a given slug, using
+ * worst-state-wins semantics that mirror `cell-model.ts` `resolveD4`: D4 is
+ * green only when at least one of `chat:<slug>` / `tools:<slug>` is present
+ * AND every present row is green-and-fresh. A present red/degraded/stale row
+ * pulls D4 down even if its sibling is green — the old `chatGreen ||
+ * toolsGreen` OR wrongly credited D4 when one half was failing.
+ */
+function isD4Green(live: LiveStatusMap, slug: string, now: number): boolean {
+  const chatRow = live.get(keyFor("chat", slug)) ?? null;
+  const toolsRow = live.get(keyFor("tools", slug)) ?? null;
+  // Neither present → D4 has no evidence, not achieved.
+  if (!chatRow && !toolsRow) return false;
+  // Every present row must be green-and-fresh (worst-state wins).
+  for (const present of [chatRow, toolsRow]) {
+    if (!present) continue;
+    if (!isGreenAndFresh(live, present.key, now, D4_STALE_AFTER_MS)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Check whether all D5 PB rows for a given (slug, catalogFeatureId) are green
  * AND fresh. Returns false if the feature has no D5 mapping or any mapped row
  * is missing/non-green/stale. The staleness gate mirrors `cell-model.ts` so a
@@ -235,20 +258,13 @@ export function deriveDepth(
   }
   achieved = 3;
 
-  // D4: chat:<slug> OR tools:<slug> green (real-time window)
-  const chatGreen = isGreenAndFresh(
-    live,
-    keyFor("chat", cell.integration),
-    now,
-    D4_STALE_AFTER_MS,
-  );
-  const toolsGreen = isGreenAndFresh(
-    live,
-    keyFor("tools", cell.integration),
-    now,
-    D4_STALE_AFTER_MS,
-  );
-  if (!(chatGreen || toolsGreen)) {
+  // D4: chat:<slug> + tools:<slug>, worst-state wins (real-time window).
+  // Mirrors cell-model.ts `resolveD4`: a present green chat with a present
+  // red tools yields a NOT-green D4 (the old `chatGreen || toolsGreen` OR
+  // credited D4 even when one half was failing). A present row that is not
+  // green-and-fresh pulls D4 down; D4 is achieved only when at least one
+  // chat/tools row is present and EVERY present row is green-and-fresh.
+  if (!isD4Green(live, cell.integration, now)) {
     return {
       achieved,
       maxPossible,

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -718,6 +718,41 @@ describe("buildCellModel", () => {
       });
       expect(notWired.isRegression).toBe(false);
     });
+
+    // ── refinement (unification C): the next rung above achievedDepth must
+    //    have EMITTED data (exists && status !== null) for a cell to count
+    //    as a regression. A mapped-but-unemitted D5 (status === null) is
+    //    no-data, not a slide-back. ──
+    it("is FALSE when the next rung (D5) is mapped but has no emitted data", () => {
+      // D3 green + D4 green, D5 mapped but NO d5 rows emitted →
+      // achieved=4, ceiling=5, d5.exists=true but d5.status===null.
+      // No data above achieved → NOT a regression.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.achievedDepth).toBe(4);
+      expect(model.ceilingDepth).toBe(5);
+      expect(model.d5?.exists).toBe(true);
+      expect(model.d5?.status).toBeNull();
+      expect(model.isRegression).toBe(false);
+    });
+
+    it("is TRUE when the next rung (D5) is below ceiling AND emitted red data", () => {
+      // D3 green + D4 green + D5 red → achieved=4, ceiling=5, and d5 has
+      // emitted (status==='red'). A real slide-back → regression.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.achievedDepth).toBe(4);
+      expect(model.ceilingDepth).toBe(5);
+      expect(model.d5?.status).toBe("red");
+      expect(model.isRegression).toBe(true);
+    });
   });
 
   // ── e2e staleness downgrade (false-green D3 bug) ────────────────────

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -405,9 +405,32 @@ export function buildCellModel(
     chipColor = "red";
   }
 
-  // isRegression: a cell has slid below its own ceiling — tests exist
-  // (ceilingDepth > 0) but the contiguous passing depth is short of them.
-  const isRegression = ceilingDepth > 0 && achievedDepth < ceilingDepth;
+  // isRegression: a cell has slid below its own ceiling. Beyond
+  // `achievedDepth < ceilingDepth`, the NEXT rung above `achievedDepth` must
+  // have EMITTED data — `exists && status !== null` — for the slide-back to
+  // be real. A mapped-but-unemitted D5 (e.g. achieved=4, ceiling=5, but
+  // `d5.status === null` because no d5 rows have ticked) is no-data, not a
+  // regression: flagging it would paint every D5-mapped cell amber the moment
+  // its D5 driver hasn't run yet. A present RED/AMBER next rung (status !==
+  // null) still counts — that is a genuine failure below the ceiling.
+  //
+  // Next-rung map by achievedDepth: 0→d3, 3→d4, 4→d5, 5→d6.
+  const nextRung: TestLevel | null =
+    achievedDepth === 0
+      ? d3
+      : achievedDepth === 3
+        ? d4
+        : achievedDepth === 4
+          ? d5
+          : achievedDepth === 5
+            ? d6
+            : null;
+  const isRegression =
+    ceilingDepth > 0 &&
+    achievedDepth < ceilingDepth &&
+    nextRung !== null &&
+    nextRung.exists &&
+    nextRung.status !== null;
 
   return {
     supported: true,

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -9,6 +9,16 @@
 
 import type { LiveStatusMap, StatusRow, State } from "./live-status";
 import { keyFor, CATALOG_TO_D5_KEY } from "./live-status";
+import { E2E_STALE_AFTER_MS, D4_STALE_AFTER_MS, isStale } from "./staleness";
+
+// Re-export the staleness windows so existing consumers that import them from
+// this module (e.g. `cell-model.test.ts`) keep resolving — the canonical
+// definitions now live in `./staleness`.
+export {
+  E2E_STALE_AFTER_MS,
+  D4_STALE_AFTER_MS,
+  LIVENESS_STALE_AFTER_MS,
+} from "./staleness";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -16,39 +26,6 @@ import { keyFor, CATALOG_TO_D5_KEY } from "./live-status";
 
 export type TestStatus = "green" | "red" | "amber" | null;
 export type ChipColor = "green" | "amber" | "red" | "gray";
-
-/**
- * Staleness window for the `e2e:` dimension. The e2e-demos driver writes
- * `e2e:<slug>/<feature>` rows hourly (`schedule: "10 * * * *"`, see
- * harness/config/probes/e2e-demos.yml). When the driver stops writing
- * (a wedged browser pool, a dead probe pipeline), the last row freezes —
- * a green row then reads as a healthy D3 forever, masking the outage as a
- * false-green. Mirroring the original ">6h stale" model (see
- * live-status.ts), a green e2e row whose `observed_at` is older than this
- * window is downgraded to `degraded` (amber) so the staleness surfaces
- * instead of presenting as green. 6h tolerates several missed hourly ticks
- * before flagging, avoiding flapping on a single skipped run.
- */
-export const E2E_STALE_AFTER_MS = 6 * 60 * 60 * 1000;
-
-/**
- * Staleness window for the D4 (real-time chat/tools) dimension. The
- * `chat:<slug>`/`tools:<slug>` drivers write on their own cadence; a
- * frozen-green D4 row from a stalled driver must NOT credit D4 forever. A
- * green D4 row older than this window is downgraded to `degraded` (amber) so
- * the staleness surfaces, mirroring the D3/D5/D6 downgrade. Not env-tunable.
- */
-export const D4_STALE_AFTER_MS = 60 * 60 * 1000;
-
-/**
- * Staleness window for the D1/D2 (liveness — `health:<slug>`/`agent:<slug>`)
- * dimensions. Tighter than the e2e window because liveness probes are the
- * most frequently written signals; a frozen-green liveness row is a strong
- * stalled-driver indicator. Consumed by `depth-utils.ts` (cell-model has no
- * D1/D2 resolution — D3's failure implicitly covers the D1/D2 gate). Not
- * env-tunable.
- */
-export const LIVENESS_STALE_AFTER_MS = 45 * 60 * 1000;
 
 export interface TestLevel {
   exists: boolean;
@@ -238,17 +215,6 @@ function resolveD5(
     status: stateToTestStatus(worstState),
     row: worstRow,
   };
-}
-
-/**
- * Determine whether a row's `observed_at` is older than `maxAgeMs` relative
- * to `now`. An unparseable/missing timestamp is treated as NOT stale —
- * staleness must be a positive signal, never inferred from bad data.
- */
-function isStale(row: StatusRow, now: number, maxAgeMs: number): boolean {
-  const observedMs = Date.parse(row.observed_at);
-  if (Number.isNaN(observedMs)) return false;
-  return now - observedMs > maxAgeMs;
 }
 
 /**

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -412,9 +412,15 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
     // Pre-fix regression: only `red` could replace `worst`, so a degraded
     // row encountered after a green row was silently dropped and the
     // badge stayed green. With the fix, degraded > green wins.
+    // All 5 mapped sub-rows are present (STRICT requires a full family before
+    // a non-red fold is credited) so the fold — not missing handling — is
+    // what's under test.
     const liveGreenFirst = mapOf([
       row("d5:agno/beautiful-chat-toggle-theme", "d5", "green"),
       row("d5:agno/beautiful-chat-pie-chart", "d5", "degraded"),
+      row("d5:agno/beautiful-chat-bar-chart", "d5", "green"),
+      row("d5:agno/beautiful-chat-search-flights", "d5", "green"),
+      row("d5:agno/beautiful-chat-schedule-meeting", "d5", "green"),
     ]);
     expect(resolveCell(liveGreenFirst, "agno", "beautiful-chat").d5.tone).toBe(
       "amber",
@@ -423,6 +429,9 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
     const liveDegradedFirst = mapOf([
       row("d5:agno/beautiful-chat-toggle-theme", "d5", "degraded"),
       row("d5:agno/beautiful-chat-pie-chart", "d5", "green"),
+      row("d5:agno/beautiful-chat-bar-chart", "d5", "green"),
+      row("d5:agno/beautiful-chat-search-flights", "d5", "green"),
+      row("d5:agno/beautiful-chat-schedule-meeting", "d5", "green"),
     ]);
     expect(
       resolveCell(liveDegradedFirst, "agno", "beautiful-chat").d5.tone,
@@ -446,6 +455,71 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
       row("d5:agno/beautiful-chat-schedule-meeting", "d5", "green"),
     ]);
     expect(resolveCell(live, "agno", "beautiful-chat").d5.tone).toBe("green");
+  });
+
+  // ── STRICT missing-sub-row handling (mirrors cell-model.ts resolveD5) ──
+  // A multi-key family is credited green ONLY when EVERY mapped sub-row is
+  // present and (post-stale) green. A missing mapped sub-row makes the family
+  // unverified → no-data (gray "?"), NOT a green badge. A present red still
+  // dominates no-data and surfaces red. This matches buildCellModel's D5.
+  it("d5 multi-key fan-out: one present-green + missing sub-rows → NOT green (gray no-data)", () => {
+    // beautiful-chat maps to 5 sub-keys; emit only 1 (one present-green,
+    // four missing). Pre-fix this rendered a false-green d5 badge while
+    // buildCellModel's D5 rendered gray.
+    const live = mapOf([
+      row("d5:agno/beautiful-chat-toggle-theme", "d5", "green"),
+      // pie-chart, bar-chart, search-flights, schedule-meeting omitted.
+    ]);
+    const c = resolveCell(live, "agno", "beautiful-chat");
+    expect(c.d5.tone).not.toBe("green");
+    expect(c.d5.tone).toBe("gray");
+    expect(c.d5.label).toBe("?");
+    expect(c.d5.row).toBeNull();
+  });
+
+  it("d5 multi-key fan-out: present-red + a missing sub-row → red (red dominates no-data)", () => {
+    const live = mapOf([
+      row("d5:agno/beautiful-chat-toggle-theme", "d5", "green"),
+      row("d5:agno/beautiful-chat-pie-chart", "d5", "red"),
+      // bar-chart, search-flights, schedule-meeting omitted.
+    ]);
+    const c = resolveCell(live, "agno", "beautiful-chat");
+    expect(c.d5.tone).toBe("red");
+    expect(c.d5.label).toBe("✗");
+  });
+
+  it("d5 multi-key fan-out: stale-green sub-row listed FIRST folds to amber (order-independent)", () => {
+    // Mirrors cell-model.test.ts's staleFirst coverage to pin order-
+    // independence of the stale fold. A stale-green sub-row listed FIRST must
+    // still force the full (otherwise-fresh-green) family to amber — the fold
+    // does not depend on CATALOG_TO_D5_KEY order. All 5 sub-rows present so
+    // STRICT missing handling is satisfied and the fold is what's exercised.
+    const NOW = Date.parse("2026-05-30T00:00:00Z");
+    const staleAt = new Date(
+      NOW - (E2E_STALE_AFTER_MS + 60 * 60 * 1000),
+    ).toISOString();
+    const freshAt = new Date(NOW).toISOString();
+    const live = mapOf([
+      // Stale-green listed FIRST.
+      row("d5:agno/beautiful-chat-toggle-theme", "d5", "green", {
+        observed_at: staleAt,
+      }),
+      row("d5:agno/beautiful-chat-pie-chart", "d5", "green", {
+        observed_at: freshAt,
+      }),
+      row("d5:agno/beautiful-chat-bar-chart", "d5", "green", {
+        observed_at: freshAt,
+      }),
+      row("d5:agno/beautiful-chat-search-flights", "d5", "green", {
+        observed_at: freshAt,
+      }),
+      row("d5:agno/beautiful-chat-schedule-meeting", "d5", "green", {
+        observed_at: freshAt,
+      }),
+    ]);
+    const c = resolveCell(live, "agno", "beautiful-chat", { now: NOW });
+    expect(c.d5.tone).not.toBe("green");
+    expect(c.d5.tone).toBe("amber");
   });
 });
 
@@ -525,13 +599,24 @@ describe("resolveCell — staleness downgrade (unification A)", () => {
 
   it("stale-green d5 badge downgrades to amber (per-sub-row fold, 6h window)", () => {
     // resolveD5Row applies the per-sub-row stale fold BEFORE worst-state, so
-    // any stale-green sub-row forces the family amber.
+    // any stale-green sub-row forces the family amber. All 5 mapped sub-rows
+    // are present so STRICT missing handling is satisfied and the stale fold
+    // is what's under test.
     const live = mapOf([
       row("d5:agno/beautiful-chat-toggle-theme", "d5", "green", {
         observed_at: freshAt(0),
       }),
       row("d5:agno/beautiful-chat-pie-chart", "d5", "green", {
         observed_at: freshAt(E2E_STALE_AFTER_MS + 60 * 60 * 1000),
+      }),
+      row("d5:agno/beautiful-chat-bar-chart", "d5", "green", {
+        observed_at: freshAt(0),
+      }),
+      row("d5:agno/beautiful-chat-search-flights", "d5", "green", {
+        observed_at: freshAt(0),
+      }),
+      row("d5:agno/beautiful-chat-schedule-meeting", "d5", "green", {
+        observed_at: freshAt(0),
       }),
     ]);
     const c = resolveCell(live, "agno", "beautiful-chat", { now: NOW });
@@ -560,6 +645,23 @@ describe("resolveCell — staleness downgrade (unification A)", () => {
     const c = resolveCell(live, "agno", "ac", { now: NOW });
     expect(c.smoke.tone).toBe("amber");
     expect(c.d2.tone).toBe("amber");
+  });
+
+  it("stale-green badge returns the EFFECTIVE (downgraded) row, not the raw green row", () => {
+    // buildBadge must return row: effRow so .row.state agrees with .tone.
+    // Pre-fix the badge had tone:"amber" while badge.row.state==="green" —
+    // a latent false-green any consumer reading .row.state would hit.
+    const live = mapOf([
+      row("e2e:agno/ac", "e2e", "green", {
+        observed_at: freshAt(E2E_STALE_AFTER_MS + 60 * 60 * 1000),
+      }),
+    ]);
+    const c = resolveCell(live, "agno", "ac", { now: NOW });
+    expect(c.e2e.tone).toBe("amber");
+    expect(c.e2e.row?.state).toBe("degraded");
+    expect(c.e2e.row?.state).not.toBe("green");
+    // Drilldown metadata preserved by the spread.
+    expect(c.e2e.row?.key).toBe("e2e:agno/ac");
   });
 
   it("stale RED row is left as-is (only green is downgraded)", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -7,6 +7,12 @@ import {
 } from "./live-status";
 import type { LiveStatusMap, StatusRow } from "./live-status";
 import { formatTs } from "./format-ts";
+import { E2E_STALE_AFTER_MS, LIVENESS_STALE_AFTER_MS } from "./staleness";
+
+// A recent timestamp so green rows are not treated as stale by the
+// staleness downgrade in resolveCell (which compares against Date.now()).
+// Mirrors the FRESH_OBSERVED_AT pattern in compute-tally-detail.test.tsx.
+const FRESH_OBSERVED_AT = new Date().toISOString();
 
 function row(
   key: string,
@@ -20,10 +26,10 @@ function row(
     dimension,
     state,
     signal: {},
-    observed_at: "2026-04-20T00:00:00Z",
-    transitioned_at: "2026-04-20T00:00:00Z",
+    observed_at: FRESH_OBSERVED_AT,
+    transitioned_at: FRESH_OBSERVED_AT,
     fail_count: state === "red" ? 1 : 0,
-    first_failure_at: state === "red" ? "2026-04-20T00:00:00Z" : null,
+    first_failure_at: state === "red" ? FRESH_OBSERVED_AT : null,
     ...overrides,
   };
 }
@@ -440,6 +446,131 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
       row("d5:agno/beautiful-chat-schedule-meeting", "d5", "green"),
     ]);
     expect(resolveCell(live, "agno", "beautiful-chat").d5.tone).toBe("green");
+  });
+});
+
+describe("resolveCell — staleness downgrade (unification A)", () => {
+  // A fixed `now` so the stale/fresh boundary is deterministic.
+  const NOW = Date.parse("2026-05-30T00:00:00Z");
+  const freshAt = (ageMs: number): string =>
+    new Date(NOW - ageMs).toISOString();
+
+  it("stale-green e2e → rollup not-green + e2e badge amber", () => {
+    // e2e uses the 6h window. A green e2e row older than that must downgrade
+    // to amber so the frozen-green driver no longer credits D3.
+    const live = mapOf([
+      row("health:agno", "health", "green", { observed_at: freshAt(0) }),
+      row("e2e:agno/ac", "e2e", "green", {
+        observed_at: freshAt(E2E_STALE_AFTER_MS + 60 * 60 * 1000),
+      }),
+    ]);
+    const c = resolveCell(live, "agno", "ac", { now: NOW });
+    expect(c.rollup).not.toBe("green");
+    expect(c.rollup).toBe("amber");
+    expect(c.e2e.tone).toBe("amber");
+  });
+
+  it("fresh-green e2e + fresh-green health → stays green", () => {
+    const live = mapOf([
+      row("health:agno", "health", "green", { observed_at: freshAt(0) }),
+      row("e2e:agno/ac", "e2e", "green", { observed_at: freshAt(0) }),
+    ]);
+    const c = resolveCell(live, "agno", "ac", { now: NOW });
+    expect(c.rollup).toBe("green");
+    expect(c.e2e.tone).toBe("green");
+    expect(c.health.tone).toBe("green");
+  });
+
+  it("stale-green health → rollup not-green + health badge amber (45m window)", () => {
+    // health uses the tighter liveness window. A green health row just past
+    // 45m downgrades; an e2e row inside its 6h window stays green.
+    const live = mapOf([
+      row("health:agno", "health", "green", {
+        observed_at: freshAt(LIVENESS_STALE_AFTER_MS + 60 * 1000),
+      }),
+      row("e2e:agno/ac", "e2e", "green", { observed_at: freshAt(0) }),
+    ]);
+    const c = resolveCell(live, "agno", "ac", { now: NOW });
+    expect(c.rollup).not.toBe("green");
+    expect(c.rollup).toBe("amber");
+    expect(c.health.tone).toBe("amber");
+  });
+
+  it("per-dimension windows: e2e green at 1h is NOT stale (under 6h)", () => {
+    // 1h is well within the e2e window — must stay green.
+    const live = mapOf([
+      row("health:agno", "health", "green", { observed_at: freshAt(0) }),
+      row("e2e:agno/ac", "e2e", "green", {
+        observed_at: freshAt(60 * 60 * 1000),
+      }),
+    ]);
+    const c = resolveCell(live, "agno", "ac", { now: NOW });
+    expect(c.rollup).toBe("green");
+    expect(c.e2e.tone).toBe("green");
+  });
+
+  it("per-dimension windows: health green at 1h IS stale (over 45m)", () => {
+    // 1h exceeds the liveness window — health must downgrade even though the
+    // same age would be fresh for e2e.
+    const live = mapOf([
+      row("health:agno", "health", "green", {
+        observed_at: freshAt(60 * 60 * 1000),
+      }),
+      row("e2e:agno/ac", "e2e", "green", { observed_at: freshAt(0) }),
+    ]);
+    const c = resolveCell(live, "agno", "ac", { now: NOW });
+    expect(c.health.tone).toBe("amber");
+    expect(c.rollup).toBe("amber");
+  });
+
+  it("stale-green d5 badge downgrades to amber (per-sub-row fold, 6h window)", () => {
+    // resolveD5Row applies the per-sub-row stale fold BEFORE worst-state, so
+    // any stale-green sub-row forces the family amber.
+    const live = mapOf([
+      row("d5:agno/beautiful-chat-toggle-theme", "d5", "green", {
+        observed_at: freshAt(0),
+      }),
+      row("d5:agno/beautiful-chat-pie-chart", "d5", "green", {
+        observed_at: freshAt(E2E_STALE_AFTER_MS + 60 * 60 * 1000),
+      }),
+    ]);
+    const c = resolveCell(live, "agno", "beautiful-chat", { now: NOW });
+    expect(c.d5.tone).toBe("amber");
+  });
+
+  it("stale-green d6 badge downgrades to amber (6h window)", () => {
+    const live = mapOf([
+      row("d6:agno", "d6", "green", {
+        observed_at: freshAt(E2E_STALE_AFTER_MS + 60 * 60 * 1000),
+      }),
+    ]);
+    const c = resolveCell(live, "agno", "ac", { now: NOW });
+    expect(c.d6.tone).toBe("amber");
+  });
+
+  it("stale-green smoke / d2 badges downgrade to amber (45m window)", () => {
+    const live = mapOf([
+      row("smoke:agno", "smoke", "green", {
+        observed_at: freshAt(LIVENESS_STALE_AFTER_MS + 60 * 1000),
+      }),
+      row("agent:agno", "agent", "green", {
+        observed_at: freshAt(LIVENESS_STALE_AFTER_MS + 60 * 1000),
+      }),
+    ]);
+    const c = resolveCell(live, "agno", "ac", { now: NOW });
+    expect(c.smoke.tone).toBe("amber");
+    expect(c.d2.tone).toBe("amber");
+  });
+
+  it("stale RED row is left as-is (only green is downgraded)", () => {
+    const live = mapOf([
+      row("e2e:agno/ac", "e2e", "red", {
+        observed_at: freshAt(E2E_STALE_AFTER_MS + 60 * 60 * 1000),
+      }),
+    ]);
+    const c = resolveCell(live, "agno", "ac", { now: NOW });
+    expect(c.e2e.tone).toBe("red");
+    expect(c.rollup).toBe("red");
   });
 });
 

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -356,20 +356,24 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
     // (e2e is also required); rollup is "gray" and the red d5/d6 rows
     // must not promote it to red.
     // D6 uses integration-scoped aggregate keys (d6:<slug>), not per-feature.
+    // `agentic-chat` is a real CATALOG_TO_D5_KEY entry (single-key family);
+    // its d5 row resolves through resolveD5Row's mapped path.
     const live = mapOf([
       row("health:agno", "health", "green"),
-      row("d5:agno/ac", "d5", "red"),
+      row("d5:agno/agentic-chat", "d5", "red"),
       row("d6:agno", "d6", "red"),
     ]);
-    const c = resolveCell(live, "agno", "ac");
+    const c = resolveCell(live, "agno", "agentic-chat");
     expect(c.rollup).toBe("gray");
     expect(c.d5.tone).toBe("red");
     expect(c.d6.tone).toBe("red");
   });
 
   it("d5 degraded renders amber tone with '~' label (not green check)", () => {
-    const live = mapOf([row("d5:agno/ac", "d5", "degraded")]);
-    const c = resolveCell(live, "agno", "ac");
+    // `agentic-chat` is a mapped single-key D5 family; a degraded sub-row
+    // folds through resolveD5Row's worst-state path to amber.
+    const live = mapOf([row("d5:agno/agentic-chat", "d5", "degraded")]);
+    const c = resolveCell(live, "agno", "agentic-chat");
     expect(c.d5.tone).toBe("amber");
     expect(c.d5.label).toBe("~");
   });
@@ -486,6 +490,25 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
     const c = resolveCell(live, "agno", "beautiful-chat");
     expect(c.d5.tone).toBe("red");
     expect(c.d5.label).toBe("✗");
+  });
+
+  // ── unmapped feature: no direct-key fallback (mirrors cell-model.ts
+  //    resolveD5 / depth-utils.ts isD5Green) ──
+  // A feature NOT in CATALOG_TO_D5_KEY has no CV test, so its D5 badge must
+  // be gray "?" even when a direct `d5:<slug>/<featureId>` row exists in the
+  // map. Pre-fix, resolveD5Row fell back to the direct key and rendered the
+  // row's tone (green), contradicting the coverage chip (resolveD5 returns
+  // exists:false) and deriveDepth (isD5Green returns false). The fallback was
+  // removed from isD5Green because it "could resolve true from stale/shared
+  // PB rows, granting D5 to cells without CV tests" — resolveD5Row must match.
+  it("d5 unmapped feature: present direct-key row does NOT render green (matches chip)", () => {
+    // `some-unmapped-feature` is intentionally absent from CATALOG_TO_D5_KEY.
+    const live = mapOf([row("d5:agno/some-unmapped-feature", "d5", "green")]);
+    const c = resolveCell(live, "agno", "some-unmapped-feature");
+    expect(c.d5.tone).not.toBe("green");
+    expect(c.d5.tone).toBe("gray");
+    expect(c.d5.label).toBe("?");
+    expect(c.d5.row).toBeNull();
   });
 
   it("d5 multi-key fan-out: stale-green sub-row listed FIRST folds to amber (order-independent)", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -229,6 +229,12 @@ function resolveD5Row(
   now: number = Date.now(),
 ): StatusRow | null {
   const d5Keys = CATALOG_TO_D5_KEY[featureId];
+  // Unmapped feature: fall back to a direct `d5:<slug>/<featureId>` row. This
+  // is a different code path from the mapped fan-out — some features
+  // legitimately have a direct d5 key — so we return it as-is (it still flows
+  // through buildBadge's staleness pass). cell-model.ts `resolveD5` returns
+  // "not exists" for unmapped features, but here the direct-key fallback is
+  // intentional and does not affect the mapped-family STRICT semantics below.
   if (!d5Keys) {
     return live.get(keyFor("d5", slug, featureId)) ?? null;
   }
@@ -236,16 +242,33 @@ function resolveD5Row(
   // comparison (mirrors cell-model.ts `resolveD5`): any stale-green sub-row
   // folds in as degraded so it can never win the all-green tie and mask a
   // fresh-green sibling. D5 uses the e2e (6h) window.
+  //
+  // STRICT on missing sub-rows (mirrors cell-model.ts `resolveD5` and
+  // depth-utils.ts `isD5Green`'s `every(...)`): a multi-key family is credited
+  // green ONLY when EVERY mapped sub-row is present. A missing mapped sub-row
+  // (`anyMissing`) forces the family out of green and resolves to `null`
+  // (no-data → gray badge) UNLESS a present sub-row is red — a present red
+  // signals a real failure and dominates no-data.
   let worst: StatusRow | null = null;
   let worstState: State | null = null;
+  let anyMissing = false;
   for (const d5Key of d5Keys) {
     const row = live.get(keyFor("d5", slug, d5Key)) ?? null;
-    if (!row) continue;
+    if (!row) {
+      anyMissing = true;
+      continue;
+    }
     const eff = effectiveState(row, now, E2E_STALE_AFTER_MS);
     if (worstState === null || D5_STATE_RANK[eff] > D5_STATE_RANK[worstState]) {
       worst = row;
       worstState = eff;
     }
+  }
+  // A missing mapped sub-row makes the family unverified: collapse a
+  // present green/degraded fold to no-data (null). A present red still
+  // dominates (returns the red row).
+  if (anyMissing && worstState !== "red") {
+    return null;
   }
   return worst;
 }
@@ -412,9 +435,12 @@ export interface ResolveCellOptions {
  * Build a `BadgeRender` for one dimension, applying the stale-green→degraded
  * downgrade: a green row older than `maxAgeMs` renders amber with the "stale"
  * tooltip, so a frozen-green driver no longer presents as healthy. The
- * downgrade affects only the rendered tone/label/tooltip — `.row` retains the
- * ORIGINAL row so consumers still have the raw producer data. A missing row,
- * or a non-green row, passes through unchanged.
+ * returned `.row` is the EFFECTIVE (downgraded) row so `.row.state` agrees
+ * with `.tone` — a consumer reading `.row.state` sees `degraded`, not a
+ * latent false-green. Only `.state` is rewritten; the spread preserves all
+ * other producer fields (`fail_count`, `first_failure_at`, `observed_at`,
+ * `signal`) so drilldown metadata is unaffected. A missing row, or a
+ * non-green row, passes through unchanged.
  */
 function buildBadge(
   dim: LiveDimension,
@@ -431,7 +457,7 @@ function buildBadge(
     tone: rowTone(effRow),
     label: formatLabel(dim, effRow),
     tooltip: formatTooltip(dim, effRow, connection),
-    row,
+    row: effRow,
   };
 }
 

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -13,6 +13,11 @@
  */
 
 import { formatTs } from "./format-ts";
+import {
+  E2E_STALE_AFTER_MS,
+  LIVENESS_STALE_AFTER_MS,
+  isStale,
+} from "./staleness";
 
 export type State = "green" | "red" | "degraded";
 
@@ -204,21 +209,42 @@ const D5_STATE_RANK: Readonly<Record<State, number>> = {
   green: 1,
 };
 
+/**
+ * Effective state for staleness folding: a green row whose `observed_at` is
+ * older than `maxAgeMs` folds in as `degraded`, so a frozen-green driver can
+ * never win the all-green tie and mask a fresh-green sibling. Only green is
+ * downgraded — a stale red/degraded row already signals a problem. Mirrors
+ * `cell-model.ts`'s per-row stale-green downgrade.
+ */
+function effectiveState(row: StatusRow, now: number, maxAgeMs: number): State {
+  return row.state === "green" && isStale(row, now, maxAgeMs)
+    ? "degraded"
+    : row.state;
+}
+
 function resolveD5Row(
   live: LiveStatusMap,
   slug: string,
   featureId: string,
+  now: number = Date.now(),
 ): StatusRow | null {
   const d5Keys = CATALOG_TO_D5_KEY[featureId];
   if (!d5Keys) {
     return live.get(keyFor("d5", slug, featureId)) ?? null;
   }
+  // Per-sub-row stale-green→degraded fold applied BEFORE the worst-state
+  // comparison (mirrors cell-model.ts `resolveD5`): any stale-green sub-row
+  // folds in as degraded so it can never win the all-green tie and mask a
+  // fresh-green sibling. D5 uses the e2e (6h) window.
   let worst: StatusRow | null = null;
+  let worstState: State | null = null;
   for (const d5Key of d5Keys) {
     const row = live.get(keyFor("d5", slug, d5Key)) ?? null;
     if (!row) continue;
-    if (!worst || D5_STATE_RANK[row.state] > D5_STATE_RANK[worst.state]) {
+    const eff = effectiveState(row, now, E2E_STALE_AFTER_MS);
+    if (worstState === null || D5_STATE_RANK[eff] > D5_STATE_RANK[worstState]) {
       worst = row;
+      worstState = eff;
     }
   }
   return worst;
@@ -373,6 +399,40 @@ export interface ResolveCellOptions {
    * overridden to "dashboard offline (§5.3)".
    */
   connection?: ConnectionStatus;
+  /**
+   * Reference time for staleness downgrade, defaulting to `Date.now()`.
+   * Co-rendering call sites thread the SAME `now` they pass to
+   * `buildCellModel` so the chip and the badges agree on which green rows
+   * are stale.
+   */
+  now?: number;
+}
+
+/**
+ * Build a `BadgeRender` for one dimension, applying the stale-green→degraded
+ * downgrade: a green row older than `maxAgeMs` renders amber with the "stale"
+ * tooltip, so a frozen-green driver no longer presents as healthy. The
+ * downgrade affects only the rendered tone/label/tooltip — `.row` retains the
+ * ORIGINAL row so consumers still have the raw producer data. A missing row,
+ * or a non-green row, passes through unchanged.
+ */
+function buildBadge(
+  dim: LiveDimension,
+  row: StatusRow | null,
+  now: number,
+  maxAgeMs: number,
+  connection: ConnectionStatus,
+): BadgeRender {
+  const effRow: StatusRow | null =
+    row && row.state === "green" && isStale(row, now, maxAgeMs)
+      ? { ...row, state: "degraded" }
+      : row;
+  return {
+    tone: rowTone(effRow),
+    label: formatLabel(dim, effRow),
+    tooltip: formatTooltip(dim, effRow, connection),
+    row,
+  };
 }
 
 /**
@@ -394,6 +454,7 @@ export function resolveCell(
   opts: ResolveCellOptions = {},
 ): CellState {
   const connection: ConnectionStatus = opts.connection ?? "live";
+  const now: number = opts.now ?? Date.now();
 
   const healthRow = live.get(keyFor("health", slug)) ?? null;
   const e2eRow = live.get(keyFor("e2e", slug, featureId)) ?? null;
@@ -415,15 +476,25 @@ export function resolveCell(
   // (alert engine routes them independently, same model as smoke). A
   // missing row resolves to a gray "?" badge, which is the expected
   // resting state for D6 cells outside their weekly-rotation slot.
-  const d5Row = resolveD5Row(live, slug, featureId);
+  const d5Row = resolveD5Row(live, slug, featureId, now);
   // D6 probe writes aggregate keys d6:<slug>, not per-cell d6:<slug>/<featureId>.
   const d6Row = live.get(keyFor("d6", slug)) ?? null;
 
   // Rollup contributors: health + e2e (Decision #7: smokeRow dropped).
-  const contributors: Array<StatusRow | null> = [healthRow, e2eRow];
-  const toneSet = contributors.map(rowTone);
-  const hasAnyRed = toneSet.includes("red");
-  const hasAnyAmber = toneSet.includes("amber");
+  // Each contributor's stale-green is downgraded to degraded BEFORE tone
+  // derivation, using its own window — health uses the liveness (45m) window,
+  // e2e uses the e2e (6h) window — so a frozen-green driver can no longer
+  // roll the cell up to green. Only green is downgraded; a stale red/degraded
+  // row already signals a problem and is left as-is.
+  const healthEff = healthRow
+    ? effectiveState(healthRow, now, LIVENESS_STALE_AFTER_MS)
+    : null;
+  const e2eEff = e2eRow
+    ? effectiveState(e2eRow, now, E2E_STALE_AFTER_MS)
+    : null;
+  const contributorStates: Array<State | null> = [healthEff, e2eEff];
+  const hasAnyRed = contributorStates.includes("red");
+  const hasAnyAmber = contributorStates.includes("degraded");
   // `allGreen` is gated on `connection !== "error"` to avoid the stale-green
   // lie (spec §5.3): when the SSE stream has gone dark, any cached green
   // rows are by definition stale and must NOT be presented as authoritative
@@ -436,9 +507,7 @@ export function resolveCell(
   // e2e probe has actually ticked, which is a different flavour of the
   // stale-green lie.
   const allGreen =
-    connection !== "error" &&
-    healthRow?.state === "green" &&
-    e2eRow?.state === "green";
+    connection !== "error" && healthEff === "green" && e2eEff === "green";
 
   let rollup: BadgeTone;
   if (hasAnyRed) {
@@ -455,43 +524,27 @@ export function resolveCell(
     rollup = "gray";
   }
 
+  // Per-badge stale-green downgrade windows: e2e/d5/d6 use the e2e (6h)
+  // window; health/d2(agent)/smoke use the tighter liveness (45m) window.
   return {
-    e2e: {
-      tone: rowTone(e2eRow),
-      label: formatLabel("e2e", e2eRow),
-      tooltip: formatTooltip("e2e", e2eRow, connection),
-      row: e2eRow,
-    },
-    smoke: {
-      tone: rowTone(smokeRow),
-      label: formatLabel("smoke", smokeRow),
-      tooltip: formatTooltip("smoke", smokeRow, connection),
-      row: smokeRow,
-    },
-    health: {
-      tone: rowTone(healthRow),
-      label: formatLabel("health", healthRow),
-      tooltip: formatTooltip("health", healthRow, connection),
-      row: healthRow,
-    },
-    d2: {
-      tone: rowTone(agentRow),
-      label: formatLabel("agent", agentRow),
-      tooltip: formatTooltip("agent", agentRow, connection),
-      row: agentRow,
-    },
-    d5: {
-      tone: rowTone(d5Row),
-      label: formatLabel("d5", d5Row),
-      tooltip: formatTooltip("d5", d5Row, connection),
-      row: d5Row,
-    },
-    d6: {
-      tone: rowTone(d6Row),
-      label: formatLabel("d6", d6Row),
-      tooltip: formatTooltip("d6", d6Row, connection),
-      row: d6Row,
-    },
+    e2e: buildBadge("e2e", e2eRow, now, E2E_STALE_AFTER_MS, connection),
+    smoke: buildBadge(
+      "smoke",
+      smokeRow,
+      now,
+      LIVENESS_STALE_AFTER_MS,
+      connection,
+    ),
+    health: buildBadge(
+      "health",
+      healthRow,
+      now,
+      LIVENESS_STALE_AFTER_MS,
+      connection,
+    ),
+    d2: buildBadge("agent", agentRow, now, LIVENESS_STALE_AFTER_MS, connection),
+    d5: buildBadge("d5", d5Row, now, E2E_STALE_AFTER_MS, connection),
+    d6: buildBadge("d6", d6Row, now, E2E_STALE_AFTER_MS, connection),
     rollup,
   };
 }

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -229,14 +229,16 @@ function resolveD5Row(
   now: number = Date.now(),
 ): StatusRow | null {
   const d5Keys = CATALOG_TO_D5_KEY[featureId];
-  // Unmapped feature: fall back to a direct `d5:<slug>/<featureId>` row. This
-  // is a different code path from the mapped fan-out — some features
-  // legitimately have a direct d5 key — so we return it as-is (it still flows
-  // through buildBadge's staleness pass). cell-model.ts `resolveD5` returns
-  // "not exists" for unmapped features, but here the direct-key fallback is
-  // intentional and does not affect the mapped-family STRICT semantics below.
-  if (!d5Keys) {
-    return live.get(keyFor("d5", slug, featureId)) ?? null;
+  // Unmapped / empty-map feature: no CV test exists, so return null (gray
+  // no-data badge) to match cell-model.ts `resolveD5` (returns exists:false)
+  // and depth-utils.ts `isD5Green` (returns false). There is NO direct-key
+  // fallback — a feature with real D5 coverage must be in CATALOG_TO_D5_KEY.
+  // A direct `d5:<slug>/<featureId>` fallback was removed because it could
+  // resolve a green badge from a stale/shared PB row, granting D5 to a cell
+  // the chip and depth derivation both treat as having no CV test, so the
+  // badge and chip would visibly contradict each other.
+  if (!d5Keys || d5Keys.length === 0) {
+    return null;
   }
   // Per-sub-row stale-green→degraded fold applied BEFORE the worst-state
   // comparison (mirrors cell-model.ts `resolveD5`): any stale-green sub-row

--- a/showcase/shell-dashboard/src/lib/staleness.ts
+++ b/showcase/shell-dashboard/src/lib/staleness.ts
@@ -1,0 +1,61 @@
+/**
+ * Staleness windows + the shared `isStale` predicate — the single source of
+ * truth for "a green row from a stalled driver must not credit its depth".
+ *
+ * Extracted from `cell-model.ts` (which owned the constants and a private
+ * `isStale`) and `components/depth-utils.ts` (which carried a byte-identical
+ * private `isRowStale` duplicate). Centralizing here lets `cell-model.ts`,
+ * `components/depth-utils.ts`, and `lib/live-status.ts` all share one
+ * implementation without forming an import cycle — this module imports only a
+ * type from `live-status.ts`, so there is no runtime dependency edge.
+ */
+
+import type { StatusRow } from "./live-status";
+
+/**
+ * Staleness window for the `e2e:` dimension. The e2e-demos driver writes
+ * `e2e:<slug>/<feature>` rows hourly (`schedule: "10 * * * *"`, see
+ * harness/config/probes/e2e-demos.yml). When the driver stops writing
+ * (a wedged browser pool, a dead probe pipeline), the last row freezes —
+ * a green row then reads as a healthy D3 forever, masking the outage as a
+ * false-green. Mirroring the original ">6h stale" model (see
+ * live-status.ts), a green e2e row whose `observed_at` is older than this
+ * window is downgraded to `degraded` (amber) so the staleness surfaces
+ * instead of presenting as green. 6h tolerates several missed hourly ticks
+ * before flagging, avoiding flapping on a single skipped run.
+ */
+export const E2E_STALE_AFTER_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Staleness window for the D4 (real-time chat/tools) dimension. The
+ * `chat:<slug>`/`tools:<slug>` drivers write on their own cadence; a
+ * frozen-green D4 row from a stalled driver must NOT credit D4 forever. A
+ * green D4 row older than this window is downgraded to `degraded` (amber) so
+ * the staleness surfaces, mirroring the D3/D5/D6 downgrade. Not env-tunable.
+ */
+export const D4_STALE_AFTER_MS = 60 * 60 * 1000;
+
+/**
+ * Staleness window for the D1/D2 (liveness — `health:<slug>`/`agent:<slug>`)
+ * dimensions. Tighter than the e2e window because liveness probes are the
+ * most frequently written signals; a frozen-green liveness row is a strong
+ * stalled-driver indicator. Consumed by `depth-utils.ts` (cell-model has no
+ * D1/D2 resolution — D3's failure implicitly covers the D1/D2 gate). Not
+ * env-tunable.
+ */
+export const LIVENESS_STALE_AFTER_MS = 45 * 60 * 1000;
+
+/**
+ * Determine whether a row's `observed_at` is older than `maxAgeMs` relative
+ * to `now`. An unparseable/missing timestamp is treated as NOT stale —
+ * staleness must be a positive signal, never inferred from bad data.
+ */
+export function isStale(
+  row: StatusRow,
+  now: number,
+  maxAgeMs: number,
+): boolean {
+  const observedMs = Date.parse(row.observed_at);
+  if (Number.isNaN(observedMs)) return false;
+  return now - observedMs > maxAgeMs;
+}


### PR DESCRIPTION
## Summary

Unifies how the showcase status dashboard decides whether a demo's data is "too old to trust," and removes two ways a chip/badge could show green when the underlying data was stale or absent.

- **Shared staleness helper** (`lib/staleness.ts`): one `isStale` + per-driver windows (e2e 6h, D4 1h, liveness 45m), so the chip, badges, depth, and filters all apply the same freshness rule instead of three private copies.
- **Stale-green → amber**: `resolveCell` and `resolveD5Row` downgrade frozen-green rows so a driver that stopped reporting no longer reads as healthy.
- **Honest D5 coverage**: `resolveD5Row` now returns `null` for unmapped/empty-map features, matching the chip (`resolveD5`) and depth (`isD5Green`). Previously an unmapped feature with a stray `d5:<slug>/<featureId>` row rendered a green badge while the chip showed gray — a visible contradiction.
- **No phantom regressions**: `isRegression` requires emitted data on the rung above the achieved depth before flagging a regression.
- **D4 worst-state-wins**: `deriveDepth` folds chat/tools to the worst state rather than OR-ing green.
- **One clock per render**: a single `now` (memoized on `liveStatus`) is threaded through the cell-matrix render path so the chip, the regressions/gaps filter, and the badges all judge staleness against the same instant; previously the render path used a fresh `Date.now()` per cell and could disagree across a window boundary.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 681 passed, 1 skipped
- [x] `npm run build` — clean
- [x] New red-green tests: stale-green downgrade (order-independent), STRICT missing-sub-row, unmapped-feature → gray (not green), and shared-`now` agreement across a staleness-window boundary