### PR TITLE
showcase(D6): reclassify manifest not_supported_features as skipped-incapable (stop counting incapable demos as red)

### DIFF
--- a/showcase/harness/src/cli/targets.ts
+++ b/showcase/harness/src/cli/targets.ts
@@ -23,6 +23,13 @@ interface Manifest {
   name: string;
   demos: Array<{ id: string; features?: string[] }>;
   features?: string[];
+  /**
+   * Features the integration's framework architecturally cannot support
+   * (e.g. lacks graph-interrupt API). Propagated to D6 driver inputs so
+   * the harness reclassifies probe failures on these features as
+   * `skipped-incapable` instead of counting them as red.
+   */
+  not_supported_features?: string[];
   deployed?: boolean;
 }
 
@@ -88,6 +95,12 @@ export interface FullInput {
   backendUrl: string;
   name: string;
   demos: string[];
+  /**
+   * Manifest `not_supported_features` set — forwarded so the driver
+   * reclassifies failing probes on these features as `skipped-incapable`
+   * instead of red. Empty/undefined when the manifest omits the field.
+   */
+  notSupportedFeatures?: string[];
   shape: "package";
 }
 
@@ -178,6 +191,15 @@ export function loadManifest(slug: string, config: LocalConfig): Manifest {
     );
   }
 
+  if (
+    manifest.not_supported_features !== undefined &&
+    !Array.isArray(manifest.not_supported_features)
+  ) {
+    throw new Error(
+      `Invalid "not_supported_features" in manifest for ${slug}: expected array`,
+    );
+  }
+
   return {
     slug: manifest.slug as string,
     name: (manifest.name as string) ?? slug,
@@ -186,6 +208,9 @@ export function loadManifest(slug: string, config: LocalConfig): Manifest {
       : [],
     features: Array.isArray(manifest.features)
       ? (manifest.features as string[])
+      : undefined,
+    not_supported_features: Array.isArray(manifest.not_supported_features)
+      ? (manifest.not_supported_features as string[])
       : undefined,
     deployed: manifest.deployed as boolean | undefined,
   };
@@ -329,6 +354,7 @@ export function buildFullInputs(
         backendUrl: getPackageUrl(slug, config),
         name: manifest.name,
         demos: features,
+        notSupportedFeatures: manifest.not_supported_features,
         shape: "package" as const,
       };
     })

--- a/showcase/harness/src/probes/discovery/railway-services.ts
+++ b/showcase/harness/src/probes/discovery/railway-services.ts
@@ -90,6 +90,15 @@ export interface RailwayServiceInfo {
    */
   demos: readonly string[];
   /**
+   * Features the integration's framework architecturally cannot support
+   * (`not_supported_features` from `registry.json`/manifest). Empty when
+   * the slug is missing from the registry, the registry is unreadable,
+   * or the manifest omits `not_supported_features`. The D6 driver reads
+   * this to reclassify probe failures on those features as
+   * `skipped-incapable` rather than counting them as red.
+   */
+  notSupportedFeatures: readonly string[];
+  /**
    * ISO-8601 timestamp of the latest deployment's creation, sourced from
    * Railway's `latestDeployment.createdAt`. Downstream drivers (e2e-deep)
    * use this to skip services that deployed very recently (deploy-churn
@@ -290,23 +299,40 @@ const VariablesSchema = z.object({
 });
 
 /**
- * Read `registry.json` and build a `slug -> demos[].id[]` map. Mirrors
- * the parsing logic in `drivers/e2e-readiness.ts`'s `defaultDemosResolver`
- * so behaviour stays consistent across the two readers — the discovery
- * source feeds the invoker's pre-dispatch sort while the driver's
- * resolver feeds the per-service fan-out at execute time.
+ * Per-integration discovery data sourced from `registry.json`.
+ *
+ * `demos` are the demo IDs (filtered to those with a route); consumed
+ * by the invoker's pre-dispatch sort and downstream drivers.
+ * `notSupportedFeatures` is the integration's manifest
+ * `not_supported_features` set; consumed by the D6 driver to
+ * reclassify probe failures on those features as `skipped-incapable`
+ * rather than red.
+ */
+interface RegistryIntegrationInfo {
+  demos: string[];
+  notSupportedFeatures: string[];
+}
+
+/**
+ * Read `registry.json` and build a `slug -> {demos, notSupportedFeatures}`
+ * map. Mirrors the parsing logic in `drivers/e2e-readiness.ts`'s
+ * `defaultDemosResolver` so behaviour stays consistent across the two
+ * readers — the discovery source feeds the invoker's pre-dispatch sort
+ * + downstream NSF reclassification, while the driver's resolver feeds
+ * the per-service fan-out at execute time.
  *
  * Path resolution: honours `env.REGISTRY_JSON_PATH` for tests/dev,
  * falling back to the production runtime path `/app/data/registry.json`
  * (mirrors the driver's default). Read failures are non-fatal: we log
  * `discovery.railway-services.registry-read-failed` once and return an
- * empty Map so every service emits with `demos: []`. A missing registry
- * must NEVER abort the tick — sibling probes (smoke, image-drift, ...)
- * still need their service list even when the registry isn't mounted.
+ * empty Map so every service emits with `demos: []` /
+ * `notSupportedFeatures: []`. A missing registry must NEVER abort the
+ * tick — sibling probes (smoke, image-drift, ...) still need their
+ * service list even when the registry isn't mounted.
  */
 async function loadDemosMap(
   ctx: DiscoveryContext,
-): Promise<Map<string, string[]>> {
+): Promise<Map<string, RegistryIntegrationInfo>> {
   const override = ctx.env.REGISTRY_JSON_PATH;
   // Production fallback path. Previously wrapped in `path.resolve()`,
   // which is a no-op for an absolute path; dropped the wrap to keep
@@ -389,9 +415,10 @@ async function loadDemosMap(
     integrations?: Array<{
       slug?: string;
       demos?: Array<{ id?: string; route?: string }>;
+      not_supported_features?: unknown;
     }>;
   };
-  const map = new Map<string, string[]>();
+  const map = new Map<string, RegistryIntegrationInfo>();
   for (const it of parsed.integrations ?? []) {
     if (!it.slug) continue;
     const demos: string[] = [];
@@ -399,7 +426,13 @@ async function loadDemosMap(
       if (typeof d.id === "string" && typeof d.route === "string")
         demos.push(d.id);
     }
-    map.set(it.slug, demos);
+    const nsf: string[] = [];
+    if (Array.isArray(it.not_supported_features)) {
+      for (const f of it.not_supported_features) {
+        if (typeof f === "string") nsf.push(f);
+      }
+    }
+    map.set(it.slug, { demos, notSupportedFeatures: nsf });
   }
   return map;
 }
@@ -593,6 +626,7 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
         });
       }
 
+      const registryInfo = demosMap.get(deriveSlugFromServiceName(svc.name));
       return {
         name: svc.name,
         imageRef,
@@ -600,7 +634,8 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
         env,
         shape: classifyShape(svc.name, { logger: ctx.logger }),
         deployedDigest,
-        demos: demosMap.get(deriveSlugFromServiceName(svc.name)) ?? [],
+        demos: registryInfo?.demos ?? [],
+        notSupportedFeatures: registryInfo?.notSupportedFeatures ?? [],
         deployedAt,
       };
     }

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -327,6 +327,120 @@ describe("e2e-full driver", () => {
     });
   });
 
+  // NSF (not_supported_features) reclassification: when an integration's
+  // manifest declares a feature in `not_supported_features` (framework
+  // primitive gap, not a regression), the driver must NOT count a failing
+  // probe on that feature as red. Instead, the feature is partitioned
+  // out before script resolution and emitted as a green side row with
+  // `errorClass: "skipped-incapable"`. The aggregate carries them in
+  // `skipped[]` AND an explicit `incapable[]` subset.
+  describe("NSF (not_supported_features) reclassification", () => {
+    it("reclassifies an NSF feature with no registered script as skipped-incapable (green), NOT red", async () => {
+      // No script registered for `gen-ui-interrupt`. Pre-NSF behaviour:
+      // missingScript red. Post-NSF: feature is in notSupportedFeatures
+      // → emitted as green side row, included in skipped[] + incapable[],
+      // never reaches the failed[] list, aggregate stays green.
+      const sideEmits: ProbeResult<unknown>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r);
+        },
+      };
+
+      const driver = createE2eFullDriver({
+        launcher: async () => makeBrowser(),
+        scriptLoader: noopScriptLoader(),
+      });
+      const result = await driver.run(makeCtx({ writer }), {
+        key: "d6-all-pills-e2e:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: ["gen-ui-interrupt"],
+        notSupportedFeatures: ["gen-ui-interrupt"],
+      });
+
+      // Aggregate must be green — the only requested feature is NSF.
+      expect(result.state).toBe("green");
+
+      const signal = result.signal as E2eFullAggregateSignal;
+      expect(signal.failed).toEqual([]);
+      expect(signal.skipped).toContain("gen-ui-interrupt");
+      expect(signal.incapable).toEqual(["gen-ui-interrupt"]);
+
+      // Aggregate side row honors the same reclassification.
+      const aggRow = sideEmits.find((r) => r.key === "d6:test-slug");
+      expect(aggRow).toBeDefined();
+      expect(aggRow!.state).toBe("green");
+
+      // Per-feature side row is green with skipped-incapable class.
+      const ftRow = sideEmits.find(
+        (r) => r.key === "d6:test-slug/gen-ui-interrupt",
+      );
+      expect(ftRow).toBeDefined();
+      expect(ftRow!.state).toBe("green");
+      const ftSignal = ftRow!.signal as E2eFullFeatureSignal;
+      expect(ftSignal.errorClass).toBe("skipped-incapable");
+      expect(ftSignal.note).toContain("not supported");
+    });
+
+    it("keeps capable features running while NSF feature is skipped", async () => {
+      // agentic-chat (capable) passes, gen-ui-interrupt (NSF) is skipped.
+      // Aggregate stays green; passed=1; skipped=[gen-ui-interrupt];
+      // incapable=[gen-ui-interrupt]; failed=[].
+      registerD5Script(makeScript(["agentic-chat"]));
+
+      const sideEmits: ProbeResult<unknown>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r);
+        },
+      };
+
+      const driver = createE2eFullDriver({
+        launcher: async () => makeBrowser(),
+        scriptLoader: noopScriptLoader(),
+      });
+      const result = await driver.run(makeCtx({ writer }), {
+        key: "d6-all-pills-e2e:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: ["agentic-chat", "gen-ui-interrupt"],
+        notSupportedFeatures: ["gen-ui-interrupt"],
+      });
+
+      expect(result.state).toBe("green");
+      const signal = result.signal as E2eFullAggregateSignal;
+      expect(signal.passed).toBe(1);
+      expect(signal.failed).toEqual([]);
+      expect(signal.skipped).toEqual(["gen-ui-interrupt"]);
+      expect(signal.incapable).toEqual(["gen-ui-interrupt"]);
+    });
+
+    it("does NOT affect features outside the NSF set", async () => {
+      // agentic-chat is NOT in NSF but has no script — must still go red.
+      // This guards against accidentally treating NSF as a global allow.
+      const sideEmits: ProbeResult<unknown>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r);
+        },
+      };
+
+      const driver = createE2eFullDriver({
+        launcher: async () => makeBrowser(),
+        scriptLoader: noopScriptLoader(),
+      });
+      const result = await driver.run(makeCtx({ writer }), {
+        key: "d6-all-pills-e2e:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: ["agentic-chat"],
+        notSupportedFeatures: ["gen-ui-interrupt"],
+      });
+
+      expect(result.state).toBe("red");
+      const signal = result.signal as E2eFullAggregateSignal;
+      expect(signal.failed).toContain("agentic-chat");
+    });
+  });
+
   describe("deploy-churn grace window", () => {
     it("skips with green when deploy is recent", async () => {
       registerD5Script(makeScript(["agentic-chat"]));

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -66,6 +66,14 @@ const inputSchema = z
     name: z.string().optional(),
     features: z.array(z.string()).optional(),
     demos: z.array(z.string()).optional(),
+    /**
+     * Integration's manifest `not_supported_features` set. Features in
+     * this list are architecturally incapable on the framework, NOT
+     * regressions. The driver reclassifies them as `skipped-incapable`
+     * (green side-row + `skipped[]` in the aggregate) instead of running
+     * a probe that would always fail and report red.
+     */
+    notSupportedFeatures: z.array(z.string()).optional(),
     shape: showcaseShapeSchema.optional(),
     deployedAt: z.string().optional(),
   })
@@ -100,6 +108,14 @@ export interface E2eFullFeatureSignal {
 /**
  * Aggregate signal carried on the primary `d6:<slug>` row.
  * Green only if ALL features pass.
+ *
+ * `skipped` is a union of three reasons: filtered-by-trigger (operator
+ * intent), deploy-churn (transient deploy state), and incapable
+ * (manifest `not_supported_features` — framework primitive gap). The
+ * driver does NOT distinguish them in the aggregate count because they
+ * all share the "not counted as red" semantic. `incapable` is broken
+ * out separately so dashboard / operators can tell genuine architectural
+ * skips apart from operational ones.
  */
 export interface E2eFullAggregateSignal {
   shape: "package";
@@ -109,6 +125,14 @@ export interface E2eFullAggregateSignal {
   passed: number;
   failed: string[];
   skipped: string[];
+  /**
+   * Subset of `skipped` representing manifest `not_supported_features`
+   * — features the integration's framework architecturally cannot
+   * support. Distinct from operational skips (deploy-churn, trigger
+   * filter). Empty when the manifest declares no NSF or no requested
+   * feature intersects it.
+   */
+  incapable?: string[];
   note?: string;
   errorDesc?: string;
   failureSummary?: string;
@@ -500,6 +524,26 @@ export function createE2eFullDriver(
 
       const requestedFeatures = featureSource.filter(isKnownFeatureType);
 
+      // NSF reclassification: features the integration's manifest
+      // declares in `not_supported_features` are architecturally
+      // incapable on this framework. Partition them out BEFORE script
+      // resolution / runnable filtering so they're never attempted —
+      // a stub demo page would fail every assertion and report red,
+      // but the framework gap is the cause, not a regression. Emit
+      // them as green side-rows with `errorClass: "skipped-incapable"`
+      // and surface in the aggregate via `incapable[]` (a subset of
+      // `skipped[]`).
+      const incapableSet = new Set<string>(input.notSupportedFeatures ?? []);
+      const incapableFeatures: D5FeatureType[] = [];
+      const capableRequestedFeatures: D5FeatureType[] = [];
+      for (const ft of requestedFeatures) {
+        if (incapableSet.has(ft)) {
+          incapableFeatures.push(ft);
+        } else {
+          capableRequestedFeatures.push(ft);
+        }
+      }
+
       if (requestedFeatures.length === 0) {
         const aggregateResult: ProbeResult<E2eFullAggregateSignal> = {
           key: input.key,
@@ -591,9 +635,11 @@ export function createE2eFullDriver(
       // D6 strict missing-script handling: features without a registered
       // script FAIL with red (unlike D5 which skips with green). Missing
       // scripts in D6 are coverage gaps that must surface immediately.
+      // Incapable features (NSF) are excluded from this check entirely
+      // — they're emitted as green side-rows below.
       const missingScript: string[] = [];
       let runnable: D5FeatureType[] = [];
-      for (const ft of requestedFeatures) {
+      for (const ft of capableRequestedFeatures) {
         if (D5_REGISTRY.has(ft)) {
           runnable.push(ft);
         } else {
@@ -658,7 +704,11 @@ export function createE2eFullDriver(
               total: requestedFeatures.length,
               passed: 0,
               failed: [],
-              skipped: [],
+              skipped: [...incapableFeatures.map(String)],
+              incapable:
+                incapableFeatures.length > 0
+                  ? incapableFeatures.map(String)
+                  : undefined,
               errorDesc: "launcher-error",
               failureSummary: truncateUtf8(msg, 1200),
             },
@@ -699,6 +749,26 @@ export function createE2eFullDriver(
           });
         }
 
+        // Emit green side rows for NSF-incapable features. Distinct
+        // `errorClass: "skipped-incapable"` so log scrapers can
+        // distinguish manifest-declared framework gaps from operational
+        // skips. State is green so the dashboard does NOT count these
+        // as red, but the side-row carries the reason for auditability.
+        for (const ft of incapableFeatures) {
+          await sideEmit(ctx, {
+            key: `d6:${slug}/${ft}`,
+            state: "green",
+            signal: {
+              slug,
+              featureType: ft,
+              backendUrl,
+              errorClass: "skipped-incapable",
+              note: "skipped: not supported by integration (manifest.not_supported_features)",
+            },
+            observedAt: ctx.now().toISOString(),
+          });
+        }
+
         // If nothing is runnable but we have missing scripts, that's a red.
         if (runnable.length === 0 && missingScript.length > 0) {
           const aggregateResult: ProbeResult<E2eFullAggregateSignal> = {
@@ -711,7 +781,11 @@ export function createE2eFullDriver(
               total: requestedFeatures.length,
               passed: 0,
               failed: missingScript,
-              skipped: filteredByTrigger,
+              skipped: [...filteredByTrigger, ...incapableFeatures],
+              incapable:
+                incapableFeatures.length > 0
+                  ? incapableFeatures.map(String)
+                  : undefined,
               failureSummary: missingScript
                 .map((ft) => `${ft}: no script registered`)
                 .join("; "),
@@ -734,8 +808,15 @@ export function createE2eFullDriver(
               total: requestedFeatures.length,
               passed: 0,
               failed: [],
-              skipped: filteredByTrigger,
-              note: "all runnable features filtered by trigger",
+              skipped: [...filteredByTrigger, ...incapableFeatures],
+              incapable:
+                incapableFeatures.length > 0
+                  ? incapableFeatures.map(String)
+                  : undefined,
+              note:
+                filteredByTrigger.length > 0
+                  ? "all runnable features filtered by trigger"
+                  : "all requested features are NSF-incapable",
             },
             observedAt,
           };
@@ -1006,7 +1087,8 @@ export function createE2eFullDriver(
           slug,
           passed,
           failed: failed.length,
-          skipped: filteredByTrigger.length,
+          skipped: filteredByTrigger.length + incapableFeatures.length,
+          incapable: incapableFeatures.length,
           total: requestedFeatures.length,
           state: aggregateGreen ? "green" : "red",
           durationMs: Date.now() - serviceStart,
@@ -1021,7 +1103,11 @@ export function createE2eFullDriver(
             total: requestedFeatures.length,
             passed,
             failed,
-            skipped: filteredByTrigger,
+            skipped: [...filteredByTrigger, ...incapableFeatures],
+            incapable:
+              incapableFeatures.length > 0
+                ? incapableFeatures.map(String)
+                : undefined,
             failureSummary:
               featureErrors.length > 0 ? featureErrors.join("; ") : undefined,
           },

--- a/showcase/integrations/ag2/manifest.yaml
+++ b/showcase/integrations/ag2/manifest.yaml
@@ -19,6 +19,8 @@ generative_ui:
   - a2ui-dynamic-schema
 not_supported_features:
   - shared-state-streaming
+  - gen-ui-interrupt
+  - interrupt-headless
 interaction_modalities:
   - sidebar
   - embedded
@@ -54,8 +56,6 @@ features:
   - frontend-tools-async
   - shared-state-read-write
   - subagents
-  - gen-ui-interrupt
-  - interrupt-headless
   - auth
   - agent-config
   - voice

--- a/showcase/integrations/crewai-crews/manifest.yaml
+++ b/showcase/integrations/crewai-crews/manifest.yaml
@@ -23,6 +23,9 @@ managed_platform:
   url: https://crewai.com/amp
 not_supported_features:
   - shared-state-streaming
+  - gen-ui-interrupt
+  - interrupt-headless
+  - mcp-apps
 features:
   - cli-start
   - agentic-chat
@@ -60,9 +63,6 @@ features:
   - byoc-hashbrown
   - byoc-json-render
   - beautiful-chat
-  - mcp-apps
-  - gen-ui-interrupt
-  - interrupt-headless
 a2ui_pattern: schema-loading
 agent_config_pattern: shared-state
 auth_pattern: runtime-onrequest

--- a/showcase/integrations/langroid/manifest.yaml
+++ b/showcase/integrations/langroid/manifest.yaml
@@ -21,6 +21,8 @@ interaction_modalities:
 not_supported_features:
   - shared-state-read-write
   - shared-state-streaming
+  - mcp-apps
+  - tool-rendering-reasoning-chain
 features:
   - cli-start
   - agentic-chat
@@ -48,14 +50,12 @@ features:
   - agent-config
   - tool-rendering-default-catchall
   - tool-rendering-custom-catchall
-  - tool-rendering-reasoning-chain
   - open-gen-ui
   - open-gen-ui-advanced
   - voice
   - multimodal
   - byoc-hashbrown
   - byoc-json-render
-  - mcp-apps
   - beautiful-chat
   - a2ui-fixed-schema
   - gen-ui-interrupt

--- a/showcase/integrations/llamaindex/manifest.yaml
+++ b/showcase/integrations/llamaindex/manifest.yaml
@@ -20,6 +20,9 @@ interaction_modalities:
   - chat
 not_supported_features:
   - shared-state-streaming
+  - gen-ui-interrupt
+  - interrupt-headless
+  - hitl-in-chat-booking
 features:
   - beautiful-chat
   - cli-start
@@ -32,7 +35,6 @@ features:
   - frontend-tools
   - frontend-tools-async
   - hitl-in-chat
-  - hitl-in-chat-booking
   - hitl-in-app
   - hitl
   - tool-rendering
@@ -58,8 +60,6 @@ features:
   - headless-simple
   - headless-complete
   - readonly-state-agent-context
-  - gen-ui-interrupt
-  - interrupt-headless
 a2ui_pattern: schema-loading
 interrupt_pattern: promise-based
 agent_config_pattern: shared-state

--- a/showcase/integrations/mastra/manifest.yaml
+++ b/showcase/integrations/mastra/manifest.yaml
@@ -26,6 +26,11 @@ managed_platform:
   url: https://mastra.ai/cloud
 not_supported_features:
   - shared-state-streaming
+  - gen-ui-interrupt
+  - interrupt-headless
+  - agentic-chat-reasoning
+  - reasoning-default-render
+  - tool-rendering-reasoning-chain
 features:
   - cli-start
   - agentic-chat
@@ -43,8 +48,6 @@ features:
   - headless-simple
   - frontend-tools
   - frontend-tools-async
-  - agentic-chat-reasoning
-  - reasoning-default-render
   - agent-config
   - declarative-gen-ui
   - a2ui-fixed-schema
@@ -63,9 +66,6 @@ features:
   - hitl
   - hitl-in-chat-booking
   - mcp-apps
-  - tool-rendering-reasoning-chain
-  - gen-ui-interrupt
-  - interrupt-headless
 a2ui_pattern: llm-driven
 agent_config_pattern: shared-state
 auth_pattern: runtime-onrequest

--- a/showcase/integrations/spring-ai/manifest.yaml
+++ b/showcase/integrations/spring-ai/manifest.yaml
@@ -29,6 +29,7 @@ interaction_modalities:
 not_supported_features:
   - shared-state-read-write
   - shared-state-streaming
+  - byoc-json-render
 features:
   - cli-start
   - agentic-chat
@@ -65,7 +66,6 @@ features:
   - tool-rendering
   - mcp-apps
   - byoc-hashbrown
-  - byoc-json-render
   - gen-ui-interrupt
   - interrupt-headless
 a2ui_pattern: schema-inline


### PR DESCRIPTION
## Summary

Stops the D6 \`e2e-full\` harness driver from counting framework-incapable demos as RED. When an integration's \`manifest.yaml\` lists a feature under \`not_supported_features\` (NSF), that feature is now reclassified at probe time as \`skipped-incapable\` (a green side-row), not red.

### Reclassification mechanism

- \`showcase/harness/src/probes/drivers/d6-all-pills.ts\` partitions \`requestedFeatures\` into capable + incapable sets BEFORE script resolution / runnable filtering.
- Incapable features emit a side row with \`state: green\` and \`errorClass: \"skipped-incapable\"\`, and surface in the aggregate signal's \`skipped[]\` array plus a new \`incapable[]\` field.
- NSF flows in through two paths:
  - CLI: \`cli/targets.ts\` reads \`not_supported_features\` from the manifest and passes it through \`buildFullInputs\` as \`notSupportedFeatures\` on \`FullInput\`.
  - Discovery: \`probes/discovery/railway-services.ts\` extracts NSF from \`registry.json\` per integration via a new \`RegistryIntegrationInfo\` shape and emits it on each \`RailwayServiceInfo\` record.

### Red-green test

New \`describe(\"NSF (not_supported_features) reclassification\")\` block in \`d6-all-pills.test.ts\` (3 tests) asserts NSF features without a registered script emit \`state=green\`. RED phase was confirmed by stashing the driver changes (test failed with \`expected 'red' to be 'green'\`); GREEN phase: all 21 driver tests pass, full suite 1664/1664 green, typecheck clean.

### Manifests edited

Promoted PARITY_NOTES-documented incapabilities into NSF, moving each entry out of \`features[]\`:

- **mastra**: \`gen-ui-interrupt\`, \`interrupt-headless\`, \`agentic-chat-reasoning\`, \`reasoning-default-render\`, \`tool-rendering-reasoning-chain\`
- **langroid**: \`mcp-apps\`, \`tool-rendering-reasoning-chain\`
- **ag2**: \`gen-ui-interrupt\`, \`interrupt-headless\`
- **crewai-crews**: \`gen-ui-interrupt\`, \`interrupt-headless\`, \`mcp-apps\`
- **llamaindex**: \`gen-ui-interrupt\`, \`interrupt-headless\`, \`hitl-in-chat-booking\`
- **spring-ai**: \`byoc-json-render\`

\`npm run validate-manifests\` passes (no features/NSF overlap).

## DO NOT MERGE

Draft per request — for review only. \`strands\` and \`agno\` already declare their interrupt skips and were verified unchanged. \`validate-pins\` and \`examples\` are untouched.

## Test plan

- [ ] Harness \`npm run typecheck\` clean
- [ ] Harness \`npm test\` 1664/1664 green
- [ ] \`scripts/generate-registry.ts --validate-only\` succeeds across all 19 integrations
- [ ] Confirm CI publishes \`incapable[]\` array on D6 aggregate signals