### PR TITLE
fix(showcase/harness): prevent d6 BrowserPool PID-exhaustion crash

### DIFF
--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -20,6 +20,8 @@ import {
 } from "../helpers/d5-registry.js";
 import type { D5Script } from "../helpers/d5-registry.js";
 import { logger } from "../../logger.js";
+import type { Browser } from "playwright";
+import type { BrowserPool } from "../helpers/browser-pool.js";
 import type {
   ProbeContext,
   ProbeResult,
@@ -527,4 +529,114 @@ describe("e2e-full driver", () => {
       expect(() => sem.release()).toThrow();
     });
   });
+
+  // --------------------------------------------------------------------
+  // Defensive re-acquire on disconnected browser. The pool's own
+  // acquire() skips zombies whose `disconnected` event has already
+  // fired, but a browser can also die in the narrow window AFTER
+  // acquire() returns it but BEFORE the caller hands it to
+  // `browser.newContext()` — most commonly during the D6 service
+  // fan-out's Chromium-spawn burst when fork() returns EAGAIN. The
+  // launcher must release-and-re-acquire so the entire service's
+  // ~40 features don't all fail with "Target page, context or
+  // browser has been closed".
+  // --------------------------------------------------------------------
+  describe("createPooledE2eFullLauncher", () => {
+    it("releases and re-acquires when acquire() returns a disconnected browser", async () => {
+      const dead = makeFakeBrowserish(false);
+      const fresh = makeFakeBrowserish(true);
+      const acquired: FakeBrowserish[] = [];
+      const released: FakeBrowserish[] = [];
+      let nextIdx = 0;
+      const queue = [dead, fresh];
+      const fakePool = {
+        async acquire() {
+          const b = queue[nextIdx++]!;
+          acquired.push(b);
+          return b as unknown as Browser;
+        },
+        release(b: unknown) {
+          released.push(b as FakeBrowserish);
+        },
+        stats() {
+          return { size: 1, available: 0, inUse: 1, totalRecycles: 0 };
+        },
+      };
+      const warnings: Array<{ event: string; meta?: unknown }> = [];
+      const warnLogger = {
+        warn: (event: string, meta?: Record<string, unknown>) =>
+          warnings.push({ event, meta }),
+      };
+      const launcher = createPooledE2eFullLauncher(
+        fakePool as unknown as BrowserPool,
+        warnLogger,
+      );
+      const browser = await launcher();
+      // Must have acquired twice (dead, then fresh) and released the
+      // dead instance back to the pool exactly once.
+      expect(acquired).toHaveLength(2);
+      expect(acquired[0]).toBe(dead);
+      expect(acquired[1]).toBe(fresh);
+      expect(released).toHaveLength(1);
+      expect(released[0]).toBe(dead);
+      // The launcher must return a usable E2eFullBrowser; smoke-test
+      // newContext() to confirm we got back the FRESH instance.
+      await browser.newContext();
+      // Diagnostic warn surfaced so operators can correlate.
+      expect(warnings.map((w) => w.event)).toContain(
+        "probe.e2e-full.pool-acquire-dead",
+      );
+    });
+
+    it("does not re-acquire when the first acquire returns a healthy browser", async () => {
+      const healthy = makeFakeBrowserish(true);
+      const acquired: FakeBrowserish[] = [];
+      const released: FakeBrowserish[] = [];
+      const fakePool = {
+        async acquire() {
+          acquired.push(healthy);
+          return healthy as unknown as Browser;
+        },
+        release(b: unknown) {
+          released.push(b as FakeBrowserish);
+        },
+        stats() {
+          return { size: 1, available: 0, inUse: 1, totalRecycles: 0 };
+        },
+      };
+      const launcher = createPooledE2eFullLauncher(
+        fakePool as unknown as BrowserPool,
+      );
+      await launcher();
+      expect(acquired).toHaveLength(1);
+      expect(released).toHaveLength(0);
+    });
+  });
 });
+
+// Module-scoped helpers for the createPooledE2eFullLauncher tests above —
+// lifted out of the describe so oxlint's consistent-function-scoping is
+// satisfied (the factory captures no parent state).
+interface FakeBrowserish {
+  connected: boolean;
+  newContext(): Promise<{
+    close(): Promise<void>;
+    newPage(): Promise<unknown>;
+  }>;
+  isConnected(): boolean;
+}
+
+function makeFakeBrowserish(connected: boolean): FakeBrowserish {
+  return {
+    connected,
+    isConnected() {
+      return this.connected;
+    },
+    async newContext() {
+      return {
+        close: async () => {},
+        newPage: async () => ({}),
+      };
+    },
+  };
+}

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -333,7 +333,27 @@ export function createPooledE2eFullLauncher(
   logger?: { warn(event: string, meta?: Record<string, unknown>): void },
 ): E2eFullBrowserLauncher {
   return async (abortSignal?: AbortSignal): Promise<E2eFullBrowser> => {
-    const browser = await pool.acquire();
+    let browser = await pool.acquire();
+
+    // Defensive re-acquire: the pool's acquire() skips zombie slots whose
+    // browser is already disconnected, but a browser can also die in the
+    // narrow window AFTER acquire() returns it but BEFORE we hand it to
+    // `browser.newContext()` — most commonly during the D6 service fan-out's
+    // Chromium-spawn burst, when the kernel returns EAGAIN on fork and a
+    // recently-handed-out chromium dies between this caller and its first
+    // newContext call. Without this guard, the dead browser dooms an entire
+    // service's ~40 features ("Target page, context or browser has been
+    // closed" on every single feature). One re-acquire is enough — release
+    // routes the dead instance back into the pool where its `isConnected`
+    // check + `recycleSlot` recovery take over.
+    if (!browser.isConnected()) {
+      logger?.warn("probe.e2e-full.pool-acquire-dead", {
+        poolAvailable: pool.stats().available,
+        poolInUse: pool.stats().inUse,
+      });
+      pool.release(browser);
+      browser = await pool.acquire();
+    }
 
     let forceReleased = false;
     const openContexts = new Set<{ close(): Promise<void> }>();

--- a/showcase/harness/src/probes/loader/probe-invoker.test.ts
+++ b/showcase/harness/src/probes/loader/probe-invoker.test.ts
@@ -3706,4 +3706,119 @@ describe("buildProbeInvoker", () => {
     expect(persisted.total).toBe(persisted.passed + persisted.failed);
     expect(persisted.failed).toBeGreaterThanOrEqual(1);
   });
+
+  // ----------------------------------------------------------------------
+  // Service-startup stagger — protects against the d6 Chromium-spawn
+  // thundering herd that crashes the BrowserPool when many services fan
+  // out into pool.acquire() in the same JS tick. The stagger spaces
+  // worker-zero..N-1's FIRST pull over `(N-1)*staggerMs`, so per-Chromium
+  // thread-spawn bursts don't trip the container's PID/thread ceiling.
+  // ----------------------------------------------------------------------
+  it("staggers worker first-pull start times across the fan-out", async () => {
+    const inputSchema = z.object({ key: z.string() });
+    const startTimes: number[] = [];
+    // Each driver run hangs long enough that every worker's FIRST pull
+    // happens before any of them finish — that's the regime where the
+    // stagger actually matters (it spaces the per-service Chromium
+    // launches, not the steady-state cursor draining).
+    const HOLD_MS = 500;
+    const driver: ProbeDriver<z.infer<typeof inputSchema>, { ok: true }> = {
+      kind: "smoke",
+      inputSchema,
+      async run(ctx, input) {
+        startTimes.push(Date.now());
+        await new Promise((r) => setTimeout(r, HOLD_MS));
+        return {
+          key: input.key,
+          state: "green",
+          signal: { ok: true },
+          observedAt: ctx.now().toISOString(),
+        };
+      },
+    };
+    const targets = Array.from({ length: 4 }, (_, i) => ({
+      key: `smoke:t${i}`,
+    }));
+    const cfg: ProbeConfig = {
+      kind: "smoke",
+      id: "smoke-stagger",
+      schedule: "*/15 * * * *",
+      max_concurrency: 4,
+      targets,
+    };
+    const { writer, writes } = mkWriter();
+    const STAGGER = 50;
+    const invoker = buildProbeInvoker(cfg, {
+      driver,
+      schedulerId: cfg.id,
+      discoveryRegistry: createDiscoveryRegistry(),
+      writer,
+      ...BASE_DEPS,
+      // Override the default 300ms to keep the test fast; uses real timers
+      // so a small positive value is enough to assert ordering.
+      env: { SERVICE_STARTUP_STAGGER_MS: String(STAGGER) } as Readonly<
+        Record<string, string | undefined>
+      >,
+    });
+    await invoker();
+    expect(writes).toHaveLength(4);
+    expect(startTimes).toHaveLength(4);
+    // Worker 0 starts immediately; workers 1..N-1 each delayed by their
+    // index * stagger. Assert monotonic non-decreasing start times and a
+    // spread between first and last that is at least (N-1) * stagger
+    // less a small jitter margin. Use a generous lower bound so this is
+    // not flaky under CI scheduling jitter.
+    for (let i = 1; i < startTimes.length; i++) {
+      expect(startTimes[i]!).toBeGreaterThanOrEqual(startTimes[i - 1]!);
+    }
+    const totalSpread = startTimes[3]! - startTimes[0]!;
+    // (4 workers - 1) * 50ms = 150ms expected spread; allow 60% floor for
+    // CI scheduling jitter on slow runners.
+    expect(totalSpread).toBeGreaterThanOrEqual(Math.floor(3 * STAGGER * 0.6));
+  });
+
+  it("disables stagger when SERVICE_STARTUP_STAGGER_MS=0", async () => {
+    const inputSchema = z.object({ key: z.string() });
+    const startTimes: number[] = [];
+    const driver: ProbeDriver<z.infer<typeof inputSchema>, { ok: true }> = {
+      kind: "smoke",
+      inputSchema,
+      async run(ctx, input) {
+        startTimes.push(Date.now());
+        return {
+          key: input.key,
+          state: "green",
+          signal: { ok: true },
+          observedAt: ctx.now().toISOString(),
+        };
+      },
+    };
+    const targets = Array.from({ length: 4 }, (_, i) => ({
+      key: `smoke:t${i}`,
+    }));
+    const cfg: ProbeConfig = {
+      kind: "smoke",
+      id: "smoke-no-stagger",
+      schedule: "*/15 * * * *",
+      max_concurrency: 4,
+      targets,
+    };
+    const { writer } = mkWriter();
+    const invoker = buildProbeInvoker(cfg, {
+      driver,
+      schedulerId: cfg.id,
+      discoveryRegistry: createDiscoveryRegistry(),
+      writer,
+      ...BASE_DEPS,
+      env: { SERVICE_STARTUP_STAGGER_MS: "0" } as Readonly<
+        Record<string, string | undefined>
+      >,
+    });
+    await invoker();
+    // With stagger=0 every worker pulls its first input in the same
+    // microtask flush — the spread is bounded by JS scheduling latency
+    // for sibling promises, well under any meaningful stagger value.
+    const totalSpread = startTimes[3]! - startTimes[0]!;
+    expect(totalSpread).toBeLessThan(50);
+  });
 });

--- a/showcase/harness/src/probes/loader/probe-invoker.ts
+++ b/showcase/harness/src/probes/loader/probe-invoker.ts
@@ -23,6 +23,47 @@ import type { ProbeRunWriter, ProbeRunSummary } from "../run-history.js";
 const SYNTHETIC_ERROR_MSG_BUDGET = 1200;
 
 /**
+ * Per-worker startup stagger (ms) for the fan-out loop below. When a
+ * probe like d6-all-pills-e2e fans `max_concurrency` workers out across
+ * its discovered services in the same JS tick, each worker
+ * immediately drives a `pool.acquire()` that launches a Chromium
+ * (~50 threads/procs each). With 8 simultaneous workers the kernel
+ * sees ~400 thread spawns inside a 4ms window on top of an already-
+ * warm 10-browser pool, and the container hits its PID/thread ceiling
+ * — fork/pthread_create returns EAGAIN, Chromium processes die, and
+ * per-feature `browser.newContext()` fails with "Target page, context
+ * or browser has been closed" so the whole run aborts at T+2s.
+ *
+ * The fix is to spread the FIRST `pool.acquire()` of each worker out
+ * over `(concurrency - 1) * STAGGER_MS` so the per-Chromium thread-spawn
+ * bursts overlap rather than collide. Subsequent iterations of the same
+ * worker run at full speed — this only delays the initial fan-out
+ * (worker `i` waits `i * stagger` before pulling its first input), so
+ * wall-clock throughput is preserved.
+ *
+ * Env-overridable: `SERVICE_STARTUP_STAGGER_MS` (parsed as int; non-finite
+ * or negative values fall through to the default). Set to `0` to disable.
+ *
+ * Default chosen to spread 8 workers across ~2.1s — small relative to
+ * the 10-minute D6 budget but large enough that each Chromium's
+ * thread-spawn burst (~150ms in practice) is done before the next
+ * starts.
+ */
+const DEFAULT_SERVICE_STARTUP_STAGGER_MS = 300;
+
+function resolveStaggerMs(
+  env: Readonly<Record<string, string | undefined>>,
+): number {
+  const raw = env.SERVICE_STARTUP_STAGGER_MS;
+  if (raw === undefined) return DEFAULT_SERVICE_STARTUP_STAGGER_MS;
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_SERVICE_STARTUP_STAGGER_MS;
+  }
+  return parsed;
+}
+
+/**
  * B7: minimal scheduler surface the invoker needs. Re-typed inline rather
  * than imported from `../scheduler/scheduler.ts` to keep this module
  * dependency-light (the full `Scheduler` interface owns cron + lifecycle
@@ -517,8 +558,22 @@ export function buildProbeInvoker(
     // Hand-rolled bounded pool. Each worker pulls from a shared index so
     // N workers process the M inputs cooperatively — no Promise.all
     // stampede even when M >> N.
+    //
+    // Per-worker startup stagger: worker `i` sleeps `i * staggerMs` before
+    // its first pull so the per-service `pool.acquire()` Chromium-launch
+    // bursts (~50 threads/procs each) don't pile up inside a single JS
+    // tick and trip the container's PID/thread ceiling. See
+    // `DEFAULT_SERVICE_STARTUP_STAGGER_MS` for the full rationale. Only the
+    // FIRST iteration of each worker is staggered — subsequent iterations
+    // run at full speed so wall-clock throughput is unchanged.
+    const staggerMs = resolveStaggerMs(env);
     let cursor = 0;
-    const runOne = async (): Promise<void> => {
+    const runOne = async (workerIndex: number): Promise<void> => {
+      if (staggerMs > 0 && workerIndex > 0) {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, workerIndex * staggerMs),
+        );
+      }
       while (cursor < inputs.length) {
         // Invariant: `idx < inputs.length` from the loop precondition,
         // so `inputs[idx]` is always defined. Non-null assertion avoids
@@ -611,7 +666,7 @@ export function buildProbeInvoker(
       if (resolved.ok) {
         const workers = Array.from(
           { length: Math.min(concurrency, Math.max(inputs.length, 1)) },
-          () => runOne(),
+          (_, i) => runOne(i),
         );
         await Promise.all(workers);
       }


### PR DESCRIPTION
## Summary

The staging \`d6-all-pills-e2e\` probe was aborting at T+2s with every per-feature \`browser.newContext()\` failing with \"Target page, context or browser has been closed.\"

### Root cause

The probe-invoker's worker fan-out launches \`max_concurrency\` workers in the SAME JS tick (a 4ms thundering herd). On d6 (\`max_concurrency: 8\`, ~8 services) each worker's first call drives \`pool.acquire()\` → a Chromium launch (~50 threads/procs each) on top of the already-warm 10-browser pool. The container hits its PID/thread ceiling, the kernel returns EAGAIN on fork/pthread_create, fresh Chromium processes die, and per-feature \`browser.newContext()\` then fails on every single feature — wiping out every service's full ~40-feature matrix. Not OOM, not a code race in the pool's locking.

### Fix

1. **Stagger service startup** in the invoker's worker fan-out (\`probe-invoker.ts\`): worker \`i\` sleeps \`i * SERVICE_STARTUP_STAGGER_MS\` before its FIRST pull, so per-Chromium thread-spawn bursts (~150ms each in practice) overlap rather than collide. Subsequent iterations of each worker run at full speed — wall-clock throughput is preserved. Configurable via \`SERVICE_STARTUP_STAGGER_MS\` env (default 300ms, set 0 to disable).

2. **Defensive re-acquire** in \`createPooledE2eFullLauncher\` (\`d6-all-pills.ts\`): after \`pool.acquire()\`, check \`browser.isConnected()\`; if false, \`pool.release(browser)\` + re-acquire once. Covers the narrow window where a browser dies AFTER acquire returns but BEFORE the caller hands it to \`newContext()\` — so a dead browser doesn't doom an entire service's ~40 features.

\`BROWSER_POOL_SIZE\`, \`max_concurrency\`, and \`FEATURE_CONCURRENCY_D6\` defaults are unchanged — concurrency is preserved; the stagger only spreads the initial-acquire burst.

## Test plan

- [x] \`pnpm typecheck\` passes for \`showcase/harness\`
- [x] Targeted vitest run (\`d6-all-pills.test.ts\`, \`browser-pool.test.ts\`, \`probe-invoker.test.ts\`) passes — added focused coverage for stagger ordering, stagger=0 opt-out, and re-acquire-on-disconnected
- [x] Full harness vitest (1668 tests) passes
- [x] \`oxfmt --write\` + \`oxlint\` on touched files; no new warnings introduced by this change
- [ ] Watch CI to green
- [ ] Verify in staging after merge: d6 runs complete past T+2s and emit non-empty per-service aggregates