### PR TITLE
fix(showcase/harness): isolate d6 feature-timeout cascade

### DIFF
--- a/showcase/harness/config/probes/d6-all-pills-e2e.yml
+++ b/showcase/harness/config/probes/d6-all-pills-e2e.yml
@@ -13,12 +13,16 @@
 # -- Cadence: hourly at :40 --
 #
 # Avoids e2e-demos at :10, D5 at :05/:20/:35/:50. With BROWSER_POOL_SIZE=10
-# and FEATURE_CONCURRENCY=4, estimated runtime ~7-10 min.
+# and FEATURE_CONCURRENCY_D6=2 (lowered from 4 because 4 concurrent
+# hung 5-min contexts on the shared per-service Chromium OOM-killed
+# the subprocess and cascaded "browser closed" across the rest of
+# that service's features — see drivers/d6-all-pills.ts), estimated
+# runtime ~10-14 min.
 #
 # -- timeout_ms: 600_000 (10 min) --
 # -- max_concurrency: 8 --
 #
-# 8 services x 4 features = 32 concurrent contexts on 10 browsers.
+# 8 services x 2 features = 16 concurrent contexts on 10 browsers.
 kind: e2e_d6
 id: d6-all-pills-e2e
 schedule: "40 * * * *"

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   createE2eFullDriver,
   createPooledE2eFullLauncher,
@@ -137,8 +137,8 @@ describe("e2e-full driver", () => {
       expect(typeof createPooledE2eFullLauncher).toBe("function");
     });
 
-    it("exports FEATURE_CONCURRENCY_D6 = 4", () => {
-      expect(FEATURE_CONCURRENCY_D6).toBe(4);
+    it("exports FEATURE_CONCURRENCY_D6 = 2 (lowered from 4 to reduce hung-context memory pressure)", () => {
+      expect(FEATURE_CONCURRENCY_D6).toBe(2);
     });
 
     it("exports e2eFullDriver default instance", () => {
@@ -527,6 +527,164 @@ describe("e2e-full driver", () => {
     it("throws on release without acquire", () => {
       const sem = new Semaphore(1);
       expect(() => sem.release()).toThrow();
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // Between-features browser recycle (cascade isolation).
+  //
+  // A single hung feature (e.g. missing aimock fixture loops to the
+  // 5-min `featureTimeoutMs`) can accumulate enough hung-context
+  // memory to OOM-kill the shared per-service Chromium subprocess.
+  // Once dead, every subsequent `newContext()` on the same handle
+  // throws "Target page, context or browser has been closed" and
+  // wipes the rest of the service's ~40 features with that same
+  // error — destroying per-feature D6 signal.
+  //
+  // Fix: the per-service feature loop checks `browser.isConnected()`
+  // before each feature and recycles (close + relaunch) when dead.
+  // It also recycles proactively after a `feature-timeout` result so
+  // the next feature on this worker does not inherit the pressure.
+  // --------------------------------------------------------------------
+  describe("between-features browser recycle (cascade isolation)", () => {
+    function makeDeadAfterNCallsBrowser(
+      script: PageScript,
+      callsBeforeDeath: number,
+    ): E2eFullBrowser & { connected: boolean; newContextCalls: number } {
+      // Tracks newContext calls. Returns alive contexts for the first
+      // `callsBeforeDeath` calls and flips `connected` to false
+      // immediately after the Nth call returns — mimicking a
+      // Chromium that survives long enough to hand out one context
+      // but is OOM-killed shortly after (e.g. the contended hung-
+      // context memory pressure pattern). Subsequent newContext
+      // calls throw the same error Playwright surfaces when the
+      // underlying chromium has been killed.
+      const b = {
+        connected: true,
+        newContextCalls: 0,
+        async newContext() {
+          b.newContextCalls++;
+          if (b.newContextCalls > callsBeforeDeath) {
+            b.connected = false;
+            throw new Error("Target page, context or browser has been closed");
+          }
+          const ctx = makeContext({ pageScript: script });
+          // Flip to dead immediately AFTER this returned context is
+          // wired up. The next isConnected() check (between
+          // features) will observe the dead handle.
+          if (b.newContextCalls >= callsBeforeDeath) {
+            b.connected = false;
+          }
+          return ctx;
+        },
+        async close() {
+          b.connected = false;
+        },
+        isConnected() {
+          return b.connected;
+        },
+      };
+      return b;
+    }
+
+    // The driver's per-service feature concurrency is env-overridable
+    // via FEATURE_CONCURRENCY_D6; force it to 1 here so the
+    // recycle-between-features semantics is exercised
+    // deterministically (worker 1 finishes before worker 2 starts).
+    // Without this the two workers would run in parallel against the
+    // SAME browser and both grab newContext before the dead check
+    // fires, masking the recycle path.
+    beforeEach(() => {
+      vi.stubEnv("FEATURE_CONCURRENCY_D6", "1");
+    });
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("swaps to a fresh browser when the current handle is disconnected before next feature", async () => {
+      registerD5Script(makeScript(["agentic-chat"]));
+      registerD5Script(makeScript(["tool-rendering"]));
+
+      const sideEmits: ProbeResult<unknown>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r);
+        },
+      };
+
+      // First browser handles exactly 1 newContext call, then "dies"
+      // (mimics OOM-killed Chromium). Second browser is healthy. The
+      // launcher hands them out in sequence; the driver's
+      // between-features check must trigger the second launcher call.
+      const browsers: ReturnType<typeof makeDeadAfterNCallsBrowser>[] = [
+        makeDeadAfterNCallsBrowser({}, 1),
+        makeDeadAfterNCallsBrowser({}, 100),
+      ];
+      let launcherCalls = 0;
+      const driver = createE2eFullDriver({
+        launcher: async () => {
+          const b = browsers[launcherCalls++];
+          if (!b) throw new Error("launcher called more times than expected");
+          return b;
+        },
+        scriptLoader: noopScriptLoader(),
+        featureTimeoutMs: 5_000,
+      });
+
+      await driver.run(makeCtx({ writer }), {
+        key: "d6-all-pills-e2e:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: ["agentic-chat", "tool-rendering"],
+      });
+
+      // The recycle must have triggered at least one extra launcher
+      // call so the second feature got a live browser.
+      expect(launcherCalls).toBeGreaterThanOrEqual(2);
+
+      // Critical assertion: the second feature got newContext off
+      // the FRESH browser, not the dead one.
+      expect(browsers[1]!.newContextCalls).toBeGreaterThanOrEqual(1);
+
+      // Aggregate row exists (driver completed without bailing).
+      const aggRow = sideEmits.find((r) => r.key === "d6:test-slug");
+      expect(aggRow).toBeDefined();
+    });
+
+    it("caps recycle attempts per service to avoid infinite loops on a poisoned pool", async () => {
+      // Every launcher returns a browser that dies on first
+      // newContext. Without a cap the driver would recycle forever
+      // and never make progress. The cap is
+      // MAX_BROWSER_RECYCLES_PER_SERVICE (5) — total launcher calls
+      // = 1 initial + up to 5 recycles = 6 max.
+      registerD5Script(makeScript(["agentic-chat"]));
+      registerD5Script(makeScript(["tool-rendering"]));
+      registerD5Script(makeScript(["shared-state-read"]));
+
+      const writer: ProbeResultWriter = {
+        write: async () => {},
+      };
+
+      let launcherCalls = 0;
+      const driver = createE2eFullDriver({
+        launcher: async () => {
+          launcherCalls++;
+          return makeDeadAfterNCallsBrowser({}, 0);
+        },
+        scriptLoader: noopScriptLoader(),
+        featureTimeoutMs: 5_000,
+      });
+
+      await driver.run(makeCtx({ writer }), {
+        key: "d6-all-pills-e2e:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: ["agentic-chat", "tool-rendering", "shared-state-read"],
+      });
+
+      // Initial acquire + at most MAX_BROWSER_RECYCLES_PER_SERVICE
+      // recycles. Anything significantly beyond that indicates the
+      // cap is broken (e.g. 10+ would mean per-feature unlimited
+      // recycle).
+      expect(launcherCalls).toBeLessThanOrEqual(10);
     });
   });
 

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -179,6 +179,16 @@ export interface E2eFullBrowser {
     extraHTTPHeaders?: Record<string, string>;
   }): Promise<E2eFullBrowserContext>;
   close(): Promise<void>;
+  /**
+   * Optional liveness probe. Pooled launchers and the default Playwright
+   * launcher both expose this; tests/fakes may omit it (treated as alive
+   * by callers via `?? true`). Used by the driver's between-features
+   * cascade-isolation check: a single hung feature can OOM-kill the
+   * shared chromium subprocess, after which every subsequent
+   * `newContext()` on the dead handle throws "browser closed" — recycle
+   * the pooled handle BEFORE the next feature acquires its context.
+   */
+  isConnected?(): boolean;
 }
 
 export type E2eFullBrowserLauncher = (
@@ -204,10 +214,48 @@ const DEFAULT_PAGE_TIMEOUT_MS = 30 * 1000;
 const DEFAULT_FEATURE_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
- * D6 runs 4 features concurrently (vs D5's 2). Higher parallelism
- * because D6 is the full matrix and needs to complete within budget.
+ * D6 per-service feature concurrency.
+ *
+ * Was 4 (matching D6's full-matrix wall-clock budget). Lowered to 2
+ * because 4 concurrent features each holding a 5-min hung context (the
+ * worst case: a feature whose aimock fixture is missing loops to the
+ * `featureTimeoutMs` wall-clock) accumulate enough loaded-page +
+ * SSE/DOM state to OOM-kill the shared Chromium subprocess. Once
+ * Chromium dies, every remaining `newContext()` on that handle fails
+ * with "Target page, context or browser has been closed" and wipes the
+ * rest of the service's ~40 features. Halving the in-flight context
+ * count roughly halves the simultaneous hung-context memory pressure;
+ * wall-clock per service rises modestly but per-feature signal quality
+ * (the actual ask of D6) matters more here.
+ *
+ * Operators can override via `FEATURE_CONCURRENCY_D6` env (see
+ * `resolveFeatureConcurrencyD6`).
  */
-export const FEATURE_CONCURRENCY_D6 = 4;
+export const FEATURE_CONCURRENCY_D6 = 2;
+
+/**
+ * Cap on between-features browser-recycle attempts per service. A
+ * single hung-feature timeout is the expected case (one recycle).
+ * Repeated recycles within one service indicate the pool itself is
+ * unhealthy — bail out rather than spin recycling forever.
+ */
+export const MAX_BROWSER_RECYCLES_PER_SERVICE = 5;
+
+/**
+ * Resolve the effective feature concurrency for a D6 service run.
+ * Reads `FEATURE_CONCURRENCY_D6` from the supplied env map (defaults to
+ * `process.env`) and falls back to the `FEATURE_CONCURRENCY_D6`
+ * constant when unset/invalid. Clamped to >= 1.
+ */
+export function resolveFeatureConcurrencyD6(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.FEATURE_CONCURRENCY_D6;
+  if (raw === undefined || raw === "") return FEATURE_CONCURRENCY_D6;
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return FEATURE_CONCURRENCY_D6;
+  return parsed;
+}
 
 /**
  * Inline counting semaphore — gates concurrent access to a bounded
@@ -325,6 +373,7 @@ const defaultLauncher: E2eFullBrowserLauncher =
         };
       },
       close: () => browser.close(),
+      isConnected: () => browser.isConnected(),
     };
   };
 
@@ -462,6 +511,7 @@ export function createPooledE2eFullLauncher(
         if (forceReleased) return;
         pool.release(browser);
       },
+      isConnected: () => browser.isConnected(),
     };
   };
 }
@@ -844,9 +894,86 @@ export function createE2eFullDriver(
           return aggregateResult;
         }
 
-        // Run features with bounded parallelism.
-        const sem = new Semaphore(FEATURE_CONCURRENCY_D6);
-        const browserRef: E2eFullBrowser = browser!;
+        // Run features with bounded parallelism. Concurrency is
+        // env-overridable (FEATURE_CONCURRENCY_D6) — see resolver
+        // comment near the constant.
+        const featureConcurrency = resolveFeatureConcurrencyD6();
+        const sem = new Semaphore(featureConcurrency);
+
+        // Shared, mutable handle to the current pooled browser. A
+        // single hung feature (e.g. missing aimock fixture loops to
+        // `featureTimeoutMs`) can accumulate enough hung-context
+        // memory to OOM-kill the shared Chromium subprocess; once
+        // dead, every subsequent `newContext()` on the same handle
+        // throws "Target page, context or browser has been closed"
+        // and wipes the rest of the service's features. The
+        // between-features check below detects the dead handle and
+        // single-flight recycles it (release + relauncher) before
+        // the next feature acquires its context, isolating the
+        // cascade to just the feature(s) that hung.
+        const handle: { current: E2eFullBrowser } = { current: browser! };
+        let recycleAttempts = 0;
+        let recycleInFlight: Promise<void> | null = null;
+
+        const recycleBrowser = async (reason: string): Promise<void> => {
+          // Single-flight: if a recycle is already running, await it.
+          // The waiter gets the swapped handle without launching a
+          // duplicate browser.
+          if (recycleInFlight) {
+            await recycleInFlight;
+            return;
+          }
+          if (recycleAttempts >= MAX_BROWSER_RECYCLES_PER_SERVICE) {
+            ctx.logger.warn("probe.e2e-full.recycle-cap-reached", {
+              slug,
+              attempts: recycleAttempts,
+              cap: MAX_BROWSER_RECYCLES_PER_SERVICE,
+              reason,
+            });
+            return;
+          }
+          recycleAttempts++;
+          ctx.logger.warn("probe.e2e-full.between-features-recycle", {
+            slug,
+            attempt: recycleAttempts,
+            cap: MAX_BROWSER_RECYCLES_PER_SERVICE,
+            reason,
+          });
+          recycleInFlight = (async () => {
+            const stale = handle.current;
+            try {
+              await stale.close();
+            } catch (err) {
+              // Stale browser is dead/disconnected — close failure
+              // is expected and non-fatal; the launcher's release
+              // path routes the dead instance back to the pool where
+              // its isConnected check + recycleSlot recovery takes
+              // over.
+              ctx.logger.warn("probe.e2e-full.recycle-close-failed", {
+                slug,
+                err: err instanceof Error ? err.message : String(err),
+              });
+            }
+            try {
+              handle.current = await launcher(abort.signal);
+            } catch (err) {
+              // Relaunch failed (pool empty / chromium spawn EAGAIN /
+              // abort fired). Leave handle.current pointing at the
+              // stale browser; subsequent features will fail-fast on
+              // newContext and we won't infinite-loop because of the
+              // attempts cap above.
+              ctx.logger.warn("probe.e2e-full.recycle-relaunch-failed", {
+                slug,
+                err: err instanceof Error ? err.message : String(err),
+              });
+            }
+          })();
+          try {
+            await recycleInFlight;
+          } finally {
+            recycleInFlight = null;
+          }
+        };
 
         const featurePromises = runnable.map(async (ft) => {
           const sideKey = `d6:${slug}/${ft}`;
@@ -894,6 +1021,18 @@ export function createE2eFullDriver(
               };
             }
 
+            // Between-features cascade isolation: if the shared
+            // pooled browser died during a prior feature (typically a
+            // 5-min hung context that OOM-killed Chromium), recycle
+            // it BEFORE this feature acquires its context. Without
+            // this, `runFeature -> browser.newContext()` would throw
+            // "Target page, context or browser has been closed" and
+            // every remaining feature in the service would fail with
+            // that same error.
+            if (handle.current.isConnected?.() === false) {
+              await recycleBrowser("dead-handle-pre-feature");
+            }
+
             const featureAbort = new AbortController();
             const onParentAbort = (): void => featureAbort.abort();
             if (abort.signal.aborted) featureAbort.abort();
@@ -917,7 +1056,11 @@ export function createE2eFullDriver(
               try {
                 return await Promise.race([
                   runFeature({
-                    browser: browserRef,
+                    // Read handle.current at call-time, not capture-
+                    // time: a between-features recycle may have
+                    // swapped the live browser since this worker was
+                    // scheduled.
+                    browser: handle.current,
                     url,
                     slug,
                     featureType: ft,
@@ -984,6 +1127,21 @@ export function createE2eFullDriver(
               }
             } finally {
               abort.signal.removeEventListener("abort", onParentAbort);
+            }
+
+            // Proactive recycle after a feature-timeout: the hung
+            // context may still be holding memory inside the shared
+            // Chromium even after `featureAbort.abort()` (Playwright's
+            // abort tears down the context asynchronously). Recycling
+            // here drops the pressure before the next feature on this
+            // worker starts, and is cheap on the happy path because
+            // the cap + single-flight guard prevents runaway.
+            if (
+              !featureResult.ok &&
+              featureResult.errorClass === "feature-timeout" &&
+              !abort.signal.aborted
+            ) {
+              await recycleBrowser("post-feature-timeout");
             }
 
             if (featureResult.ok) {


### PR DESCRIPTION
## Root cause

In `d6-all-pills-e2e`, each service acquires ONE pooled browser and runs `FEATURE_CONCURRENCY_D6` (=4) feature workers concurrently via `browser.newContext()`. When a feature's prompt has no matching aimock fixture, the agent hangs/loops until the 300s `featureTimeoutMs`. Four such concurrent hung 5-minute contexts (each holding a loaded page + accumulating SSE/DOM state) create enough memory pressure to OOM-kill the shared Chromium subprocess. After Chromium dies, every subsequent `browser.newContext()` / `newPage()` on that handle fails with `"Target page, context or browser has been closed"` — wiping the rest of that service's ~40 features and destroying per-feature D6 signal.

The per-feature timeout path (`d6-all-pills.ts`) already aborts the hung feature but does NOT recycle the shared browser, so the cascade propagates.

## Fix

1. **Recycle the pooled browser between features when disconnected / after timeout.** The per-service feature loop now checks `browser.isConnected()` before each feature's `newContext()` call and single-flight recycles (close + relaunch) when dead. It also recycles proactively after a `feature-timeout` result so the next feature on this worker does not inherit the pressure. Capped at `MAX_BROWSER_RECYCLES_PER_SERVICE = 5` to prevent infinite-loop on a poisoned pool.

2. **Lower `FEATURE_CONCURRENCY_D6` from 4 to 2** to roughly halve the simultaneous in-flight contexts per service. Worst-case wall-clock per service rises modestly (~10-14 min vs ~7-10 min) but per-feature signal quality — the actual ask of D6 — matters more here. Now env-overridable via `FEATURE_CONCURRENCY_D6`.

## Out of scope

Does NOT change `max_concurrency`, `BROWSER_POOL_SIZE`, or `DEFAULT_FEATURE_TIMEOUT_MS`. The pool's own dead-slot recovery (PR #5133) handles the per-launcher zombie-acquire case; this PR adds the orthogonal between-features-in-one-service recovery.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run src/probes/drivers/d6-all-pills src/probes/helpers/browser-pool` — 43 tests pass, including two new focused tests for the between-features recycle path (one verifies the swap to a fresh browser, one verifies the recycle cap)
- [x] Full harness `pnpm vitest run` — 1670 tests pass
- [x] `oxfmt --write` + `oxlint` on touched files (no new warnings)
- [ ] Production verification: deploy to harness service, observe a D6 run where a fixture-miss happens and confirm subsequent features in the same service still run (`probe.e2e-full.between-features-recycle` log + fresh per-feature results)