### PR TITLE
fix(showcase/harness): serialize browser-pool launches (PID ceiling)

### DIFF
--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -199,7 +199,7 @@ describe("BrowserPool dead-instance detection", () => {
   it("registers a disconnected listener on each browser at init and recycles when one fires", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
     const { logger, events } = makeFakeLogger();
-    const pool = new BrowserPool(2, 100, logger, launchBrowser);
+    const pool = new BrowserPool(2, 100, logger, launchBrowser, 0);
     await pool.init();
     expect(launched).toHaveLength(2);
 
@@ -223,7 +223,7 @@ describe("BrowserPool dead-instance detection", () => {
   it("acquire() skips a silently-disconnected slot and returns the next live one", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
     const { logger, events } = makeFakeLogger();
-    const pool = new BrowserPool(2, 100, logger, launchBrowser);
+    const pool = new BrowserPool(2, 100, logger, launchBrowser, 0);
     await pool.init();
 
     const slot0Browser = launched[0]!;
@@ -245,7 +245,7 @@ describe("BrowserPool dead-instance detection", () => {
 
   it("acquire() recycles every zombie slot and falls through to the waiter path when no live slots remain", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
-    const pool = new BrowserPool(2, 100, undefined, launchBrowser);
+    const pool = new BrowserPool(2, 100, undefined, launchBrowser, 0);
     await pool.init();
 
     launched[0]!.__silentlyDisconnect();
@@ -268,7 +268,7 @@ describe("BrowserPool dead-instance detection", () => {
 
   it("disconnected event during in-use slot triggers a recycle that delivers a fresh browser to the next acquire", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
-    const pool = new BrowserPool(1, 100, undefined, launchBrowser);
+    const pool = new BrowserPool(1, 100, undefined, launchBrowser, 0);
     await pool.init();
 
     const browser = await pool.acquire();
@@ -287,7 +287,7 @@ describe("BrowserPool dead-instance detection", () => {
 
   it("does not double-recycle when both the disconnect event and the on-acquire zombie check fire for the same slot", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
-    const pool = new BrowserPool(1, 100, undefined, launchBrowser);
+    const pool = new BrowserPool(1, 100, undefined, launchBrowser, 0);
     await pool.init();
 
     // Crash fires disconnect AND flips isConnected false.
@@ -307,7 +307,7 @@ describe("BrowserPool dead-instance detection", () => {
   it("release() of a slot whose browser disconnected after acquire still recycles instead of returning a dead browser to available", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
     const { logger, events } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
     await pool.init();
 
     const browser = await pool.acquire();
@@ -339,7 +339,7 @@ describe("BrowserPool dead-instance detection", () => {
     // self-heal so a later acquire() still returns a live browser.
     const { launchBrowser, launched } = makeFakeLauncher({ failAtCalls: [2] });
     const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
     await pool.init();
     expect(launched).toHaveLength(1);
 
@@ -376,7 +376,7 @@ describe("BrowserPool dead-instance detection", () => {
       failAtCalls: [3, 4, 5, 6, 7, 8],
     });
     const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(2, 100, logger, launchBrowser);
+    const pool = new BrowserPool(2, 100, logger, launchBrowser, 0);
     await pool.init();
     expect(launched).toHaveLength(2);
 
@@ -415,7 +415,7 @@ describe("BrowserPool dead-instance detection", () => {
       failAtCalls: [2, 3, 4],
     });
     const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
     await pool.init();
     expect(launched).toHaveLength(1);
 
@@ -452,7 +452,10 @@ describe("BrowserPool dead-instance detection", () => {
       failAtCalls: [2, 3, 4],
     });
     const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    // Stagger 0 keeps the test fast; the launch-serialization gate's
+    // concurrency-1 guarantee (the property under test here, that the slot is
+    // launched exactly once) holds independent of the stagger length.
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
     await pool.init();
 
     const held = await pool.acquire();
@@ -468,14 +471,27 @@ describe("BrowserPool dead-instance detection", () => {
     await waitFor(() => pool.stats().size === 0, 3_000);
 
     // Two acquirers race for the single recovering slot, each driving
-    // relaunchPendingSlots. The fresh browser must go to exactly one of them;
-    // the loser stays parked as a waiter (it has no timer to recover it and
-    // will reject on shutdown).
-    const a = pool.acquire(5_000);
-    const b = pool.acquire(5_000);
+    // relaunchPendingSlots. With the launch-serialization gate, exactly one of
+    // them claims the slot (relaunchingSlots) and drives the single gated
+    // launch; the other skips (slot busy) and parks as a waiter. The freshly
+    // launched browser is handed off to one of the two — the WINNER — and the
+    // LOSER is left parked. The loser uses a SHORT timeout so this test stays
+    // fast: a parked waiter is only rejected by `shutdown()`, and the gate's
+    // extra `await` can let the loser register its waiter AFTER `shutdown()`
+    // has already drained the waiter set, in which case only its own timeout
+    // frees it. We assert the WINNER got exactly the one fresh launch; the
+    // loser's fate (short-timeout reject) is not the property under test.
+    const a = pool.acquire(150);
+    const b = pool.acquire(150);
 
-    const first = await Promise.race([a, b]);
-    expect(first).toBeDefined();
+    const settled = await Promise.allSettled([a, b]);
+    const fulfilled = settled.filter(
+      (s): s is PromiseFulfilledResult<Browser> => s.status === "fulfilled",
+    );
+    // Exactly one acquirer was served (the single slot can serve only one
+    // before being re-held); the other parked and timed out.
+    expect(fulfilled).toHaveLength(1);
+    const first = fulfilled[0]!.value;
     expect((first as unknown as FakeBrowser).isConnected()).toBe(true);
 
     // Exactly one fresh browser (the successful relaunch, call 5) was
@@ -496,8 +512,6 @@ describe("BrowserPool dead-instance detection", () => {
     expect(pool.stats().size).toBe(1);
 
     await pool.shutdown();
-    // The loser waiter rejects on shutdown; swallow it.
-    await Promise.allSettled([a, b]);
   });
 
   it("recovers a parked slot via a later acquire() even when an intervening acquire()'s relaunch also failed", async () => {
@@ -517,7 +531,7 @@ describe("BrowserPool dead-instance detection", () => {
       failAtCalls: [2, 3, 4, 5],
     });
     const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
     await pool.init();
     expect(launched).toHaveLength(1);
 
@@ -583,7 +597,7 @@ describe("BrowserPool dead-instance detection", () => {
       return b as unknown as Browser;
     };
     const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
     await pool.init();
     expect(launched).toHaveLength(1);
     const oldBrowser = launched[0]!;
@@ -646,34 +660,42 @@ describe("BrowserPool dead-instance detection", () => {
     // continue;` makes invocation 1 skip B, so EXACTLY ONE fresh browser is
     // launched per slot.
     //
-    // Deterministic race: gate every recovery launch (calls 9+) so we can
-    // interleave the two invocations precisely.
+    // Deterministic race, ADAPTED for the launch-serialization gate. The gate
+    // funnels EVERY launch through a concurrency-1 serializer, so two recovery
+    // launches can never be in flight (running rawLaunchBrowser) at the same
+    // instant. We therefore gate ONLY the FIRST recovery launch (call 9, slot
+    // A driven by invocation 1). While that launch is gated/held, invocation 2
+    // runs, snapshots pending as [slot B] (slot A is busy in relaunchingSlots),
+    // and CLAIMS slot B (adds it to relaunchingSlots) before its own launch
+    // (call 10) queues behind call 9 in the gate chain. Releasing call 9 lets
+    // invocation 1's loop advance to slot B — where the in-loop guard
+    // `if (this.isSlotBusy(slot) || !slot.relaunchPending) continue;` MUST skip
+    // it (B is busy / no longer pending), so EXACTLY ONE fresh browser is
+    // launched per slot. Stagger 0 keeps the chain advancing fast.
     const launched: FakeBrowser[] = [];
     let callCount = 0;
-    // One resolver per gated recovery launch; we release them in order.
-    const gateResolvers: Array<() => void> = [];
-    const gateFor = (): Promise<void> =>
-      new Promise<void>((resolve) => {
-        gateResolvers.push(resolve);
-      });
+    let releaseCall9: (() => void) | undefined;
+    const call9Gate = new Promise<void>((resolve) => {
+      releaseCall9 = resolve;
+    });
     // init = calls 1,2; the two slots' immediate recycle retries
     // (RELAUNCH_MAX_ATTEMPTS=3 each) = calls 3..8, all fail to park both slots.
-    // Recovery relaunches are calls 9 and 10, both gated.
+    // Recovery relaunches are calls 9 (gated) and 10.
     const failCalls = new Set([3, 4, 5, 6, 7, 8]);
     const launchBrowser: LaunchBrowser = async () => {
       callCount++;
       if (failCalls.has(callCount)) {
         throw new Error("simulated launch failure");
       }
-      if (callCount >= 9) {
-        await gateFor();
+      if (callCount === 9) {
+        await call9Gate;
       }
       const b = makeFakeBrowser();
       launched.push(b);
       return b as unknown as Browser;
     };
     const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(2, 100, logger, launchBrowser);
+    const pool = new BrowserPool(2, 100, logger, launchBrowser, 0);
     await pool.init();
     expect(launched).toHaveLength(2);
 
@@ -686,43 +708,43 @@ describe("BrowserPool dead-instance detection", () => {
     expect(pool.stats().size).toBe(0);
 
     // Drive two concurrent relaunchPendingSlots invocations via two acquire()s.
+    // Invocation 1 (a) snapshots [slotA, slotB], claims slotA, and its slotA
+    // launch (call 9) blocks on the gate. Invocation 2 (b) then runs: it
+    // snapshots [slotB] (slotA busy), claims slotB, and its slotB launch (call
+    // 10) is queued in the serialization chain BEHIND the gated call 9.
     const a = pool.acquire(5_000);
     const b = pool.acquire(5_000);
 
-    // Let both invocations run up to their first gated launch. Invocation 1
-    // snapshots [slotA, slotB], claims slotA, awaits its launch (call 9).
-    // Invocation 2 then snapshots [slotB] (slotA busy), claims slotB, awaits
-    // its launch (call 10). Wait until BOTH gated launches are pending.
-    await waitFor(() => gateResolvers.length >= 2, 3_000);
-
-    // Release both gated launches. Invocation 1's slotA launch (call 9) and
-    // invocation 2's slotB launch (call 10) resolve. Invocation 1's loop then
-    // advances to slotB: WITHOUT the in-loop guard it would launch a SECOND
-    // browser for slotB (a 3rd gated launch, call 11). WITH the guard it skips
-    // slotB (now busy / no longer pending).
-    gateResolvers[0]!();
-    gateResolvers[1]!();
+    // Wait until call 9 is actually in flight (gated) — i.e. invocation 1 has
+    // claimed slotA and reached its launch. By this point invocation 2 has had
+    // the chance to claim slotB. Drain microtasks so invocation 2's synchronous
+    // claim-then-queue has run before we release call 9.
+    await waitFor(() => callCount >= 9, 3_000);
     await drainMicrotasks(30);
 
-    // Give any erroneous third launch a chance to register its gate so a leak
-    // would surface as a 3rd pending resolver.
+    // Release call 9. Invocation 1's slotA launch resolves; its loop advances
+    // to slotB. WITHOUT the in-loop guard it would launch a SECOND browser for
+    // slotB (a 3rd launch, call 11). WITH the guard it skips slotB (busy / no
+    // longer pending). Call 10 (invocation 2's slotB launch) then runs.
+    releaseCall9!();
+
+    // Both acquirers must be served — one per slot — and exactly two fresh
+    // browsers launched beyond init (no leaked third launch for the contended
+    // slot).
+    const both = await Promise.all([a, b]);
+    both.forEach((br) =>
+      expect((br as unknown as FakeBrowser).isConnected()).toBe(true),
+    );
+
     await drainMicrotasks(30);
 
-    const first = await Promise.race([a, b]);
-    expect(first).toBeDefined();
-    expect((first as unknown as FakeBrowser).isConnected()).toBe(true);
-
-    // Exactly two fresh browsers beyond init — one per slot, no leaked
-    // double-launch for the contended slot. (A third gated launch from the
-    // unguarded re-entry would still be parked on its gate and not yet in
-    // `launched`, so additionally assert no 3rd gate was ever requested.)
     const freshBeyondInit = launched.slice(2);
     expect(freshBeyondInit.length).toBe(2);
-    expect(gateResolvers.length).toBe(2);
+    // No erroneous third launch was ever attempted for the contended slot.
+    expect(callCount).toBe(10);
 
     // Pin exact-once: both acquirers are served by the two fresh launches, and
     // each fresh browser maps to a distinct slot (no slot.browser overwrite).
-    const both = await Promise.all([a, b]);
     const servedIds = both.map((br) => (br as unknown as FakeBrowser).__id);
     const freshIds = freshBeyondInit.map((br) => br.__id);
     expect(new Set(servedIds)).toEqual(new Set(freshIds));
@@ -744,7 +766,7 @@ describe("BrowserPool dead-instance detection", () => {
       failAtCalls: [2, 3, 4],
     });
     const { logger, events } = makeLeveledLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
     await pool.init();
     expect(launched).toHaveLength(1);
 
@@ -779,7 +801,7 @@ describe("BrowserPool dead-instance detection", () => {
       failAtCalls: [2, 3, 4, 5],
     });
     const { logger, events } = makeLeveledLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
     await pool.init();
 
     launched[0]!.__crash();
@@ -809,7 +831,7 @@ describe("BrowserPool dead-instance detection", () => {
     // reinit, whose launch (call 2) also fails, ending the pool empty → error.
     const { launchBrowser } = makeFakeLauncher({ failAtCalls: [1, 2, 3] });
     const { logger, events } = makeLeveledLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
     // init's only launch (call 1) throws — init sets `launchBrowser` BEFORE the
     // launch loop, so after catching the throw `this.slots` is empty but the
     // pool can still reinit. (init does not swallow launch errors by design.)
@@ -841,7 +863,7 @@ describe("BrowserPool dead-instance detection", () => {
     // init = call 1 fails (so this.slots stays empty); reinit launches succeed.
     const { launchBrowser, launched } = makeFakeLauncher({ failAtCalls: [1] });
     const { logger } = makeLeveledLogger();
-    const pool = new BrowserPool(poolSize, 100, logger, launchBrowser);
+    const pool = new BrowserPool(poolSize, 100, logger, launchBrowser, 0);
     // init's first launch (call 1) throws, leaving this.slots empty but with
     // `launchBrowser` already set so reinit can run. init does not swallow.
     await expect(pool.init()).rejects.toThrow("simulated launch failure");
@@ -867,7 +889,7 @@ describe("BrowserPool dead-instance detection", () => {
   it("shutdown() does not loop the disconnect handler when closing slot browsers", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
     const { logger, events } = makeFakeLogger();
-    const pool = new BrowserPool(2, 100, logger, launchBrowser);
+    const pool = new BrowserPool(2, 100, logger, launchBrowser, 0);
     await pool.init();
 
     await pool.shutdown();
@@ -880,5 +902,152 @@ describe("BrowserPool dead-instance detection", () => {
     ).toHaveLength(0);
     expect(launched[0]!.__closeCount).toBeGreaterThan(0);
     expect(launched[1]!.__closeCount).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * A launcher that records, for every chromium launch the pool drives, the
+ * wall-clock start time and the number of launches in flight at the moment
+ * this one entered. Used to prove the launch-serialization gate funnels
+ * EVERY launch (init fill, recycle relaunch, lazy relaunchPending) through a
+ * single concurrency-1 gate with a stagger between settled launches.
+ *
+ * `launchDurationMs` makes each fake launch take measurable wall time so an
+ * un-gated burst would overlap (inFlight > 1) — the assertion that
+ * `maxConcurrent === 1` is only meaningful when launches actually overlap
+ * without the gate.
+ */
+function makeRecordingLauncher(opts?: { launchDurationMs?: number }): {
+  launchBrowser: LaunchBrowser;
+  starts: number[];
+  maxConcurrent: number;
+  launched: FakeBrowser[];
+} {
+  const launchDurationMs = opts?.launchDurationMs ?? 20;
+  const starts: number[] = [];
+  const launched: FakeBrowser[] = [];
+  let inFlight = 0;
+  const rec = {
+    launchBrowser: (async (): Promise<Browser> => {
+      starts.push(Date.now());
+      inFlight++;
+      if (inFlight > rec.maxConcurrent) rec.maxConcurrent = inFlight;
+      await new Promise((resolve) => setTimeout(resolve, launchDurationMs));
+      inFlight--;
+      const b = makeFakeBrowser();
+      launched.push(b);
+      return b as unknown as Browser;
+    }) as LaunchBrowser,
+    starts,
+    maxConcurrent: 0,
+    launched,
+  };
+  return rec;
+}
+
+describe("BrowserPool launch serialization gate", () => {
+  it("serializes the initial-fill burst to concurrency 1 and staggers each launch", async () => {
+    // A burst of N near-simultaneous chromium.launch() calls (the initial
+    // pool fill) must NOT overlap — on the Railway staging container a burst
+    // spikes PID demand past the ~1000 ceiling and trips pthread_create
+    // EAGAIN / "Zygote could not fork". The gate funnels every launch through
+    // a concurrency-1 serializer and waits a stagger after each settles.
+    const staggerMs = 30;
+    const rec = makeRecordingLauncher({ launchDurationMs: 20 });
+    const pool = new BrowserPool(
+      6,
+      100,
+      undefined,
+      rec.launchBrowser,
+      staggerMs,
+    );
+    await pool.init();
+
+    // Every one of the 6 initial-fill launches happened.
+    expect(rec.launched).toHaveLength(6);
+
+    // Strict serialization: never two chromium launches in flight at once.
+    expect(rec.maxConcurrent).toBe(1);
+
+    // Consecutive launch starts are spaced at least `staggerMs` apart (the
+    // gate waits AFTER each launch settles before the next may start). Allow a
+    // small scheduler-jitter tolerance below the nominal stagger.
+    const tolerance = 5;
+    for (let i = 1; i < rec.starts.length; i++) {
+      const gap = rec.starts[i]! - rec.starts[i - 1]!;
+      expect(gap).toBeGreaterThanOrEqual(staggerMs - tolerance);
+    }
+
+    await pool.shutdown();
+  });
+
+  it("serializes a burst of simultaneous recycle/relaunch triggers to concurrency 1", async () => {
+    // Recycle bursts (many slots crashing and relaunching near-simultaneously)
+    // are the OTHER PID-spike source the gate must cover. Fill a pool, crash
+    // every browser at once so all disconnect-driven recycles fire together,
+    // and assert their relaunches never overlap.
+    const staggerMs = 20;
+    const rec = makeRecordingLauncher({ launchDurationMs: 20 });
+    const pool = new BrowserPool(
+      5,
+      100,
+      undefined,
+      rec.launchBrowser,
+      staggerMs,
+    );
+    await pool.init();
+    expect(rec.launched).toHaveLength(5);
+
+    // Crash all 5 at once — every recycle's relaunch is triggered in the same
+    // tick, the classic burst the gate must serialize.
+    for (const b of rec.launched.slice(0, 5)) b.__crash();
+
+    // Wait until all 5 relaunches have completed (10 total launches).
+    await waitFor(() => rec.launched.length >= 10, 5_000);
+
+    // No two launches (fill OR relaunch) ever overlapped.
+    expect(rec.maxConcurrent).toBe(1);
+
+    await pool.shutdown();
+  });
+
+  it("honors BROWSER_LAUNCH_STAGGER_MS env var as the default stagger", async () => {
+    // The stagger is env-tunable on staging without a code change. With no
+    // explicit constructor override, the pool reads BROWSER_LAUNCH_STAGGER_MS.
+    const prev = process.env.BROWSER_LAUNCH_STAGGER_MS;
+    process.env.BROWSER_LAUNCH_STAGGER_MS = "25";
+    try {
+      const rec = makeRecordingLauncher({ launchDurationMs: 10 });
+      // No 5th arg → stagger comes from the env var.
+      const pool = new BrowserPool(4, 100, undefined, rec.launchBrowser);
+      await pool.init();
+
+      expect(rec.launched).toHaveLength(4);
+      expect(rec.maxConcurrent).toBe(1);
+      const tolerance = 5;
+      for (let i = 1; i < rec.starts.length; i++) {
+        const gap = rec.starts[i]! - rec.starts[i - 1]!;
+        expect(gap).toBeGreaterThanOrEqual(25 - tolerance);
+      }
+
+      await pool.shutdown();
+    } finally {
+      if (prev === undefined) delete process.env.BROWSER_LAUNCH_STAGGER_MS;
+      else process.env.BROWSER_LAUNCH_STAGGER_MS = prev;
+    }
+  });
+
+  it("still serializes (concurrency 1) when the stagger is set to 0", async () => {
+    // A zero stagger keeps tests fast but MUST still serialize: the gate's
+    // concurrency-1 guarantee is independent of the wait. Proves the gate is
+    // not merely a sleep — it is a real one-at-a-time mutex.
+    const rec = makeRecordingLauncher({ launchDurationMs: 15 });
+    const pool = new BrowserPool(8, 100, undefined, rec.launchBrowser, 0);
+    await pool.init();
+
+    expect(rec.launched).toHaveLength(8);
+    expect(rec.maxConcurrent).toBe(1);
+
+    await pool.shutdown();
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -853,6 +853,31 @@ describe("BrowserPool dead-instance detection", () => {
     await pool.shutdown();
   });
 
+  it("closes browsers already launched when a later init() fill launch throws", async () => {
+    // Multi-slot pool. The fill loop launches calls 1 and 2 successfully, then
+    // call 3 throws (PID-ceiling pthread_create EAGAIN / "Zygote could not
+    // fork" under launch pressure — the exact failure this file exists to
+    // survive). init() must REJECT, but the 2 browsers already launched must
+    // be CLOSED rather than leaked, and the pool's internal state must reset to
+    // empty so a half-initialized pool cannot result. The existing init-failure
+    // tests use a 1-slot pool or first-launch-fails (nothing launched yet),
+    // which is why this partial-fill leak was missed.
+    const { launchBrowser, launched } = makeFakeLauncher({ failAtCalls: [3] });
+    const { logger } = makeLeveledLogger();
+    const pool = new BrowserPool(4, 100, logger, launchBrowser, 0);
+
+    await expect(pool.init()).rejects.toThrow("simulated launch failure");
+
+    // Calls 1 and 2 succeeded before call 3 threw, so two browsers were live.
+    expect(launched).toHaveLength(2);
+    // Both must have been closed during the failed-fill cleanup — not leaked.
+    expect(launched[0]!.__closeCount).toBeGreaterThan(0);
+    expect(launched[1]!.__closeCount).toBeGreaterThan(0);
+    // The pool must be empty after rejection — no half-initialized state.
+    expect(pool.stats().size).toBe(0);
+    expect(pool.stats().available).toBe(0);
+  });
+
   it("does not overshoot poolSize when two concurrent acquires hit an empty pool", async () => {
     // Empty pool (init launches nothing). Two concurrent acquire() calls both
     // see this.slots.length === 0. WITHOUT a reiniting guard, BOTH drive

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1037,6 +1037,56 @@ describe("BrowserPool launch serialization gate", () => {
     }
   });
 
+  it("falls back to the default stagger when the explicit arg is negative (does not silently disable)", async () => {
+    // A negative explicit constructor arg must fall back to the DEFAULT
+    // stagger (150ms) — the same contract the env var already honors — NOT
+    // clamp to 0 and silently disable the stagger. Disabling the stagger
+    // reintroduces the PID-spike the gate exists to prevent. Only 2 launches
+    // so the ~150ms wait stays cheap.
+    const rec = makeRecordingLauncher({ launchDurationMs: 10 });
+    // -50 is negative → must be rejected and fall back to the 150ms default.
+    const pool = new BrowserPool(
+      2,
+      undefined,
+      undefined,
+      rec.launchBrowser,
+      -50,
+    );
+    await pool.init();
+
+    expect(rec.launched).toHaveLength(2);
+    expect(rec.maxConcurrent).toBe(1);
+
+    // The two launches must be spaced by roughly the DEFAULT stagger (150ms),
+    // proving the stagger was NOT disabled. Allow scheduler-jitter tolerance.
+    const gap = rec.starts[1]! - rec.starts[0]!;
+    expect(gap).toBeGreaterThanOrEqual(140);
+
+    await pool.shutdown();
+  });
+
+  it("falls back to the default stagger when the explicit arg is NaN", async () => {
+    // A non-numeric (NaN) explicit constructor arg must also fall back to the
+    // DEFAULT stagger rather than disabling it.
+    const rec = makeRecordingLauncher({ launchDurationMs: 10 });
+    const pool = new BrowserPool(
+      2,
+      undefined,
+      undefined,
+      rec.launchBrowser,
+      NaN,
+    );
+    await pool.init();
+
+    expect(rec.launched).toHaveLength(2);
+    expect(rec.maxConcurrent).toBe(1);
+
+    const gap = rec.starts[1]! - rec.starts[0]!;
+    expect(gap).toBeGreaterThanOrEqual(140);
+
+    await pool.shutdown();
+  });
+
   it("still serializes (concurrency 1) when the stagger is set to 0", async () => {
     // A zero stagger keeps tests fast but MUST still serialize: the gate's
     // concurrency-1 guarantee is independent of the wait. Proves the gate is

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -24,6 +24,25 @@ const RELAUNCH_MAX_ATTEMPTS = 3;
 /** Base backoff between relaunch attempts; doubles each attempt. */
 const RELAUNCH_BACKOFF_BASE_MS = 250;
 
+/**
+ * Default delay the launch-serialization gate waits AFTER each chromium
+ * launch settles before the next launch may start. Tunable on staging via
+ * the `BROWSER_LAUNCH_STAGGER_MS` env var without a code change.
+ *
+ * WHY: the harness drives chromium launches in BURSTS (initial pool fill,
+ * recycle relaunches, lazy relaunchPending recovery, reinit backstop). Each
+ * headless chromium spawns ~50 PIDs (threads count against the container's
+ * ~1000-PID ceiling), so a burst of many simultaneous `chromium.launch()`
+ * calls transiently spikes PID demand far above the eventual steady state and
+ * trips `pthread_create: Resource temporarily unavailable (11)` /
+ * "Zygote could not fork" — every browser fails to launch and a d6 run goes
+ * 0/18. Funneling every launch through a concurrency-1 gate with a stagger
+ * spaces the spawns so the transient spike never exceeds the ceiling, WITHOUT
+ * reducing the eventual pool size. Cold-start pays a one-time warm cost; the
+ * pool warms once and steady-state acquires are instant.
+ */
+const DEFAULT_BROWSER_LAUNCH_STAGGER_MS = 150;
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -92,6 +111,19 @@ export class BrowserPool {
   private readonly logger?: PoolLogger;
   private readonly injectedLaunchBrowser?: LaunchBrowser;
 
+  // Launch-serialization gate. Every chromium launch — no matter which path
+  // triggers it (init fill, acquire-time relaunch, recycle relaunch, reinit
+  // backstop, deferred/pending relaunch) — is funneled through `launchBrowser`,
+  // which chains onto `launchChain` so strictly ONE launch runs at a time and a
+  // `launchStaggerMs` delay elapses after each settles before the next starts.
+  private readonly launchStaggerMs: number;
+  // Tail of the serialized-launch promise chain. Each gated launch awaits the
+  // current tail, runs, staggers, then becomes the new tail — so launches run
+  // one-at-a-time in arrival order. Rejections are swallowed on the CHAIN
+  // (`.catch`) so one failed launch never poisons the queue; the real result
+  // (value or throw) is still surfaced to that launch's own caller.
+  private launchChain: Promise<unknown> = Promise.resolve();
+
   // Tracks which Browser instance maps to which Slot, so release() can find
   // the slot in O(1) even after the slot was removed from `available`.
   private browserToSlot = new Map<Browser, Slot>();
@@ -101,6 +133,7 @@ export class BrowserPool {
     recycleAfter?: number,
     logger?: PoolLogger,
     launchBrowser?: LaunchBrowser,
+    launchStaggerMs?: number,
   ) {
     this.poolSize = size;
     this.logger = logger;
@@ -113,15 +146,29 @@ export class BrowserPool {
       (envRecycle !== undefined && !Number.isNaN(envRecycle)
         ? envRecycle
         : 100);
+
+    // Explicit constructor arg (tests inject a tiny value to stay fast) wins;
+    // otherwise the env var (staging tuning) wins; otherwise the default. A
+    // negative or non-numeric value falls back to the default rather than
+    // disabling the stagger silently.
+    const envStagger = process.env.BROWSER_LAUNCH_STAGGER_MS
+      ? parseInt(process.env.BROWSER_LAUNCH_STAGGER_MS, 10)
+      : undefined;
+    const resolvedStagger =
+      launchStaggerMs ??
+      (envStagger !== undefined && !Number.isNaN(envStagger) && envStagger >= 0
+        ? envStagger
+        : DEFAULT_BROWSER_LAUNCH_STAGGER_MS);
+    this.launchStaggerMs = resolvedStagger >= 0 ? resolvedStagger : 0;
   }
 
   async init(): Promise<void> {
     if (this.injectedLaunchBrowser) {
-      this.launchBrowser = this.injectedLaunchBrowser;
+      this.rawLaunchBrowser = this.injectedLaunchBrowser;
     } else {
       const { chromium } =
         (await import("playwright")) as typeof import("playwright");
-      this.launchBrowser = () =>
+      this.rawLaunchBrowser = () =>
         chromium.launch({
           headless: true,
           args: ["--no-sandbox", "--disable-dev-shm-usage"],
@@ -138,8 +185,50 @@ export class BrowserPool {
     }
   }
 
-  // Assigned during init() after the dynamic import resolves.
-  private launchBrowser!: LaunchBrowser;
+  // The un-gated launcher. Assigned during init() — either the injected fake
+  // (tests) or the real `chromium.launch` wrapper (production). Never called
+  // directly by the pool's lifecycle paths; they all go through
+  // `launchBrowser()`, which serializes via the gate.
+  private rawLaunchBrowser!: LaunchBrowser;
+
+  /**
+   * The single launch seam every pool path routes through (init fill,
+   * acquire-time relaunch, recycle relaunch, reinit backstop, lazy
+   * relaunchPending recovery). It chains onto `launchChain` so that AT MOST
+   * ONE `rawLaunchBrowser()` is in flight at a time across the whole pool, and
+   * a `launchStaggerMs` delay elapses after each launch settles before the
+   * next one begins. This spaces chromium process spawns so a burst never
+   * spikes PID demand past the container ceiling (`pthread_create` EAGAIN /
+   * "Zygote could not fork"), WITHOUT reducing the eventual pool size.
+   *
+   * The caller's `result` resolves the instant `rawLaunchBrowser()` settles —
+   * the stagger does NOT delay the launch's own caller (it must get its
+   * browser as soon as the process is up). The stagger instead gates only the
+   * NEXT launch: the chain tail (`launchChain`) is advanced to a promise that
+   * resolves `launchStaggerMs` AFTER this launch settled, so the following
+   * gated launch cannot begin its `rawLaunchBrowser()` until that window
+   * elapses. The chain swallows failures (`.catch`) so one failed launch does
+   * not poison the queue for subsequent launches; the failing launch's own
+   * caller still receives the rejection via the returned `result` promise. The
+   * stagger applies whether the launch resolved or threw — a failed launch is
+   * just as PID-costly to retry, so the next one must be spaced too.
+   */
+  private launchBrowser = (): Promise<Browser> => {
+    // `gate` is the prior tail: this launch's rawLaunchBrowser() waits for it,
+    // guaranteeing concurrency 1. We capture it before reassigning the tail.
+    const gate = this.launchChain;
+    const result = gate.then(() => this.rawLaunchBrowser());
+    // Advance the tail to "this launch settled (ok or not), THEN staggered".
+    // The next launch chains off THIS, so it cannot start until the stagger
+    // window after this launch settles. `.catch` keeps a thrown launch from
+    // breaking the chain; the throw is still surfaced to `result`'s caller.
+    this.launchChain = result
+      .catch(() => undefined)
+      .then(() =>
+        this.launchStaggerMs > 0 ? delay(this.launchStaggerMs) : undefined,
+      );
+    return result;
+  };
 
   /**
    * Single waiter-first handoff used by every slot-recovery path (reinit,
@@ -214,7 +303,10 @@ export class BrowserPool {
    * acquire timeout / waiter-reject path rather than wedging the pool forever.
    */
   private async reinit(): Promise<void> {
-    if (this.isShutdown || this.launchBrowser === undefined) return;
+    // `rawLaunchBrowser` is the gate's underlying launcher, assigned by
+    // init(). Guard on it (not the always-defined `launchBrowser` arrow) so
+    // reinit is a no-op when init never ran — there is nothing to launch with.
+    if (this.isShutdown || this.rawLaunchBrowser === undefined) return;
     // Set the concurrent-entry guard SYNCHRONOUSLY before the first `await`
     // (before `this.track(...)`) so a second acquire reaching its empty-pool
     // check while this reinit is in flight skips reinit and parks a waiter

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -184,13 +184,34 @@ export class BrowserPool {
         });
     }
 
-    for (let i = 0; i < this.poolSize; i++) {
-      const browser = await this.launchBrowser();
-      const slot: Slot = { browser, contextCount: 0 };
-      this.slots.push(slot);
-      this.available.push(slot);
-      this.browserToSlot.set(browser, slot);
-      this.attachDisconnectHandler(slot, browser);
+    try {
+      for (let i = 0; i < this.poolSize; i++) {
+        const browser = await this.launchBrowser();
+        const slot: Slot = { browser, contextCount: 0 };
+        this.slots.push(slot);
+        this.available.push(slot);
+        this.browserToSlot.set(browser, slot);
+        this.attachDisconnectHandler(slot, browser);
+      }
+    } catch (err) {
+      // A mid-fill launch failure (the PID-ceiling pthread_create EAGAIN /
+      // "Zygote could not fork" this gate exists to survive) must not leak the
+      // browsers already launched on iterations 0..N-1: callers see a rejected
+      // init() and commonly never call shutdown(), so those live chromium
+      // processes would leak permanently and accelerate PID exhaustion. Reset
+      // the pool's internal state BEFORE closing (so a `disconnected` fire from
+      // a close cannot re-enter the recycle path via the slot's disconnect
+      // handler — same ordering shutdown() relies on), then close each launched
+      // browser (closeBrowser logs its own failures) and re-throw to preserve
+      // init()'s reject-on-failure contract.
+      const launched = this.slots;
+      this.slots = [];
+      this.available = [];
+      this.browserToSlot.clear();
+      await Promise.allSettled(
+        launched.map((slot, idx) => this.closeBrowser(slot.browser, idx)),
+      );
+      throw err;
     }
   }
 

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -149,17 +149,26 @@ export class BrowserPool {
 
     // Explicit constructor arg (tests inject a tiny value to stay fast) wins;
     // otherwise the env var (staging tuning) wins; otherwise the default. A
-    // negative or non-numeric value falls back to the default rather than
-    // disabling the stagger silently.
+    // negative or non-numeric value — from EITHER source — falls back to the
+    // default rather than disabling the stagger silently. (Disabling the
+    // stagger reintroduces the launch-burst PID spike the gate exists to
+    // prevent.) Note that an explicit `0` IS valid and intentionally disables
+    // the wait (tests rely on it); only negative/NaN args are rejected.
     const envStagger = process.env.BROWSER_LAUNCH_STAGGER_MS
       ? parseInt(process.env.BROWSER_LAUNCH_STAGGER_MS, 10)
       : undefined;
-    const resolvedStagger =
-      launchStaggerMs ??
-      (envStagger !== undefined && !Number.isNaN(envStagger) && envStagger >= 0
+    const validExplicit =
+      launchStaggerMs !== undefined &&
+      !Number.isNaN(launchStaggerMs) &&
+      launchStaggerMs >= 0
+        ? launchStaggerMs
+        : undefined;
+    const validEnv =
+      envStagger !== undefined && !Number.isNaN(envStagger) && envStagger >= 0
         ? envStagger
-        : DEFAULT_BROWSER_LAUNCH_STAGGER_MS);
-    this.launchStaggerMs = resolvedStagger >= 0 ? resolvedStagger : 0;
+        : undefined;
+    this.launchStaggerMs =
+      validExplicit ?? validEnv ?? DEFAULT_BROWSER_LAUNCH_STAGGER_MS;
   }
 
   async init(): Promise<void> {


### PR DESCRIPTION
## Summary

The staging D6 dashboard goes 0/18 because the harness's single shared `BrowserPool` is contended across overlapping probe suites, and raising the pool size to cover peak demand re-trips the container's **~1000-PID ceiling** on the simultaneous chromium **launch burst** (`pthread_create: Resource temporarily unavailable` / "Zygote could not fork"). Pool sizing alone can't win: 10 starves under cross-probe overlap (acquire timeouts), 16 exceeds the launch-burst thread ceiling. The binding constraint is the *burst*, not the steady-state size.

This PR adds a **launch-serialization gate** to `BrowserPool`: every chromium launch — init fill, recycle relaunch, reinit backstop, lazy `relaunchPending` recovery — is funneled through one **concurrency-1** gate with an env-tunable inter-launch stagger (`BROWSER_LAUNCH_STAGGER_MS`, default **150ms**). This spaces chromium spawns so the transient PID spike never exceeds the ceiling, **without reducing the eventual pool size**. The caller's browser resolves the instant its own launch settles (the stagger only gates the *next* launch); a failed launch is swallowed on the chain so it can't poison the queue, while still surfacing to its own caller.

With the burst removed, the pool can safely be sized to cover peak cross-probe demand (~14) within the sustainable steady-state (~16 ≈ 800 PIDs). The shared pool *is* the global cross-probe cap, so no separate budget mechanism is needed. **NOT** a "reduce concurrency to paper over a race" change.

Full root-cause analysis (incl. the disproven pool=16 attempt and the 1000-PID discovery): the D6 BrowserPool Regression analysis doc, Parts 6-7.

## Commits

1. `serialize browser-pool chromium launches to prevent PID-ceiling EAGAIN` — the gate (concurrency-1 + stagger), wrapping the single launch seam so all paths inherit it.
2. `honor default stagger for negative/NaN launchStaggerMs arg` — CR fix: a negative/NaN explicit arg fell back to **0** (silently disabling the stagger), contradicting its own comment; now falls back to the default like the env var.
3. `close partially-launched browsers when init() fill fails` — CR fix: a mid-fill launch throw (the exact EAGAIN scenario) leaked already-launched chromium; `init()` now closes them and resets state before re-throwing (clears state before closing so the disconnect handler can't re-enter recycle).

## Review

7-agent CR + a 7-agent confirmation round, converged to zero in-subject findings; Procedure 3 bucket-(c) promotion audit returned 0 promotions. Verified the gate's serialization stays well inside the 30s acquire timeout: full-pool relaunch at poolSize 16 × 150ms ≈ ~10s, and a waiter is served on the first successful relaunch (sub-second).

## Test plan

- [x] Red-green unit tests: launch concurrency === 1 + inter-launch spacing honored; negative/NaN stagger falls back to default; `init()` partial-fill closes already-launched browsers.
- [x] Full harness suite green (1675 tests; browser-pool 25).
- [x] typecheck / lint / format / build clean.
- [ ] **Staging validation (post-merge):** deploy to staging, set `BROWSER_POOL_SIZE=14`, watch a real `:40` d6 cron run — confirm acquire-timeouts gone AND no `pthread_create`/EAGAIN/Zygote (the PID-ceiling fix can only be confirmed on the real container). The PID ceiling is a Railway platform limit (~1000, unraisable), so keep `poolSize × stagger` well under the 30s acquire timeout (≤16 × 150ms ≈ 10s, safe).

## Follow-up (separate PR — out of this PR's subject)

CR surfaced a coherent cluster of **pre-existing** `BrowserPool` defects unrelated to launch serialization (untouched by this diff), worth a dedicated **"slot-publication / waiter-handoff hardening"** PR:
- `release()` double-publishes a slot to `available` on a double-release (missing the `!available.includes(slot)` guard that `handOff` has) → potential same-browser double hand-out.
- `handOff`/`release` deliver a browser to a waiter without the `isConnected()` liveness check the available-scan path enforces → a silently-disconnected browser can reach a probe.
- `track()` registers the raw promise in `inFlightRecycles` but removes a derived wrapper, so `shutdown()`'s drain awaits a promise that settles before its cleanup (currently mitigated by per-path `isShutdown` re-checks).
- Plus observability/comment/test nits (inUse gauge divergence, stale `slotIndex` logging, a mis-named recycle-warn test, gate timing-tolerance flake risk).