### PR TITLE
fix: handle string/list emit_tool_calls in copilotkit_customize_config

### DIFF
--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/dispatch-event-filtering.test.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/dispatch-event-filtering.test.ts
@@ -343,3 +343,115 @@ describe("langGraphDefaultMergeState", () => {
     expect(result.copilotkit.actions[0].name).toBe("SharedTool");
   });
 });
+
+// ---------- emit-tool-calls: string/list filtering ----------
+
+function makeToolEvent(
+  type: EventType,
+  metadata: Record<string, any>,
+  toolCallId = "tc-1",
+  toolCallName?: string,
+) {
+  return {
+    type,
+    toolCallId,
+    ...(toolCallName ? { toolCallName } : {}),
+    ...(type === EventType.TOOL_CALL_START ? { parentMessageId: "msg-1" } : {}),
+    rawEvent: { metadata },
+  };
+}
+
+describe("emit-tool-calls string/list filtering", () => {
+  it("emits only the named tool when emit-tool-calls is a string", () => {
+    const { agent } = createAgent();
+    const meta = { "copilotkit:emit-tool-calls": "draft_email" };
+
+    const matchResult = agent.dispatchEvent(
+      makeToolEvent(EventType.TOOL_CALL_START, meta, "tc-1", "draft_email") as any,
+    );
+    expect(matchResult).toBe(true);
+
+    const noMatchResult = agent.dispatchEvent(
+      makeToolEvent(EventType.TOOL_CALL_START, meta, "tc-2", "list_items") as any,
+    );
+    expect(noMatchResult).toBe(false);
+  });
+
+  it("emits only listed tools when emit-tool-calls is an array", () => {
+    const { agent } = createAgent();
+    const meta = { "copilotkit:emit-tool-calls": ["draft_email", "send_email"] };
+
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_START, meta, "tc-1", "draft_email") as any,
+      ),
+    ).toBe(true);
+
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_START, meta, "tc-2", "send_email") as any,
+      ),
+    ).toBe(true);
+
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_START, meta, "tc-3", "delete_item") as any,
+      ),
+    ).toBe(false);
+  });
+
+  it("resolves name via toolCallNames map for TOOL_CALL_ARGS events", () => {
+    const { agent } = createAgent();
+    const meta = { "copilotkit:emit-tool-calls": ["search"] };
+
+    // First dispatch START to populate the name map
+    agent.dispatchEvent(
+      makeToolEvent(EventType.TOOL_CALL_START, meta, "tc-10", "search") as any,
+    );
+
+    // TOOL_CALL_ARGS has toolCallId but not toolCallName — should resolve via map
+    const argsResult = agent.dispatchEvent({
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: "tc-10",
+      delta: '{"query":"test"}',
+      rawEvent: { metadata: meta },
+    } as any);
+    expect(argsResult).toBe(true);
+
+    // A different id that was never tracked — unknown name defaults to emit
+    const unknownResult = agent.dispatchEvent({
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: "tc-unknown",
+      delta: "{}",
+      rawEvent: { metadata: meta },
+    } as any);
+    expect(unknownResult).toBe(true);
+  });
+
+  it("cleans up toolCallNames on TOOL_CALL_END to prevent memory leak", () => {
+    const { agent } = createAgent();
+    const meta = { "copilotkit:emit-tool-calls": true };
+
+    // START populates the map
+    agent.dispatchEvent(
+      makeToolEvent(EventType.TOOL_CALL_START, meta, "tc-leak", "my_tool") as any,
+    );
+    expect((agent as any).toolCallNames.has("tc-leak")).toBe(true);
+
+    // END should clean it up
+    agent.dispatchEvent(
+      makeToolEvent(EventType.TOOL_CALL_END, meta, "tc-leak") as any,
+    );
+    expect((agent as any).toolCallNames.has("tc-leak")).toBe(false);
+  });
+
+  it("empty list suppresses all tool events", () => {
+    const { agent } = createAgent();
+    const meta = { "copilotkit:emit-tool-calls": [] as string[] };
+
+    const result = agent.dispatchEvent(
+      makeToolEvent(EventType.TOOL_CALL_START, meta, "tc-1", "any_tool") as any,
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
@@ -23,7 +23,7 @@ interface CopilotKitStateEnrichment {
   };
 }
 
-import type { RunAgentInput, CustomEvent } from "@ag-ui/client";
+import type { RunAgentInput, CustomEvent, ToolCallStartEvent } from "@ag-ui/client";
 import { EventType } from "@ag-ui/client";
 
 // Import and re-export from separate file to maintain API compatibility
@@ -36,8 +36,26 @@ import { CustomEventNames } from "./consts";
 export { CustomEventNames };
 
 export class LangGraphAgent extends AGUILangGraphAgent {
+  private toolCallNames: Map<string, string> = new Map();
+
   constructor(config: LangGraphAgentConfig) {
     super(config);
+  }
+
+  private shouldEmitToolCall(
+    emitToolCalls: boolean | string | string[],
+    toolCallName: string | undefined,
+  ): boolean {
+    if (typeof emitToolCalls === "boolean") {
+      return emitToolCalls;
+    }
+    if (!toolCallName) {
+      return true;
+    }
+    if (Array.isArray(emitToolCalls)) {
+      return emitToolCalls.includes(toolCallName);
+    }
+    return emitToolCalls === toolCallName;
   }
 
   dispatchEvent(event: ProcessedEvents) {
@@ -130,12 +148,23 @@ export class LangGraphAgent extends AGUILangGraphAgent {
       event.type === EventType.TOOL_CALL_START ||
       event.type === EventType.TOOL_CALL_ARGS ||
       event.type === EventType.TOOL_CALL_END;
+
+    // Track tool call names for filtering by name
+    if (event.type === EventType.TOOL_CALL_START) {
+      const startEvent = event as unknown as ToolCallStartEvent;
+      if (startEvent.toolCallId && startEvent.toolCallName) {
+        this.toolCallNames.set(startEvent.toolCallId, startEvent.toolCallName);
+      }
+    }
+
     if ("copilotkit:emit-tool-calls" in (rawEvent.metadata || {})) {
-      if (
-        rawEvent.metadata["copilotkit:emit-tool-calls"] === false &&
-        isToolEvent
-      ) {
-        return false;
+      const emitToolCalls = rawEvent.metadata["copilotkit:emit-tool-calls"];
+      if (isToolEvent) {
+        const toolEvent = event as unknown as { toolCallId?: string; toolCallName?: string };
+        const toolCallName = toolEvent.toolCallName ?? (toolEvent.toolCallId ? this.toolCallNames.get(toolEvent.toolCallId) : undefined);
+        if (!this.shouldEmitToolCall(emitToolCalls, toolCallName)) {
+          return false;
+        }
       }
     }
     if ("copilotkit:emit-messages" in (rawEvent.metadata || {})) {

--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
@@ -151,20 +151,29 @@ export class LangGraphAgent extends AGUILangGraphAgent {
 
     // Track tool call names for filtering by name
     if (event.type === EventType.TOOL_CALL_START) {
-      const startEvent = event as unknown as ToolCallStartEvent;
-      if (startEvent.toolCallId && startEvent.toolCallName) {
-        this.toolCallNames.set(startEvent.toolCallId, startEvent.toolCallName);
+      const { toolCallId, toolCallName } = event as unknown as ToolCallStartEvent;
+      if (toolCallId && toolCallName) {
+        this.toolCallNames.set(toolCallId, toolCallName);
       }
     }
 
     if ("copilotkit:emit-tool-calls" in (rawEvent.metadata || {})) {
       const emitToolCalls = rawEvent.metadata["copilotkit:emit-tool-calls"];
       if (isToolEvent) {
-        const toolEvent = event as unknown as { toolCallId?: string; toolCallName?: string };
-        const toolCallName = toolEvent.toolCallName ?? (toolEvent.toolCallId ? this.toolCallNames.get(toolEvent.toolCallId) : undefined);
-        if (!this.shouldEmitToolCall(emitToolCalls, toolCallName)) {
+        const { toolCallId, toolCallName } = event as { toolCallId?: string; toolCallName?: string };
+        const resolvedName = toolCallName ?? (toolCallId ? this.toolCallNames.get(toolCallId) : undefined);
+        if (!this.shouldEmitToolCall(emitToolCalls, resolvedName)) {
           return false;
         }
+      }
+    }
+
+    // Clean up tracked names after filtering to prevent memory leak.
+    // Must happen AFTER the filter check so TOOL_CALL_END can still resolve its name.
+    if (event.type === EventType.TOOL_CALL_END) {
+      const { toolCallId } = event as { toolCallId?: string };
+      if (toolCallId) {
+        this.toolCallNames.delete(toolCallId);
       }
     }
     if ("copilotkit:emit-messages" in (rawEvent.metadata || {})) {

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -68,6 +68,33 @@ class LangGraphAGUIAgent(LangGraphAgent):
     ):
         super().__init__(name=name, graph=graph, description=description, config=config)
         self.constant_schema_keys = self.constant_schema_keys + ["copilotkit"]
+        self._tool_call_names: Dict[str, str] = {}
+
+    def _should_emit_tool_call(
+        self,
+        emit_tool_calls: Union[bool, str, List[str]],
+        event,
+    ) -> bool:
+        """Check if a tool call event should be emitted based on the emit_tool_calls config."""
+        if isinstance(emit_tool_calls, bool):
+            return emit_tool_calls
+
+        # Get the tool call name from the event or the tracked mapping
+        tool_call_name = None
+        if hasattr(event, 'tool_call_name'):
+            tool_call_name = event.tool_call_name
+        elif hasattr(event, 'tool_call_id'):
+            tool_call_name = self._tool_call_names.get(event.tool_call_id)
+
+        if tool_call_name is None:
+            return True
+
+        if isinstance(emit_tool_calls, str):
+            return emit_tool_calls == tool_call_name
+        if isinstance(emit_tool_calls, list):
+            return tool_call_name in emit_tool_calls
+
+        return True
 
     def _dispatch_event(self, event) -> str:
         """Override the dispatch event method to handle custom CopilotKit events and filtering.
@@ -226,6 +253,10 @@ class LangGraphAGUIAgent(LangGraphAgent):
                 EventType.TOOL_CALL_END,
             ]
 
+            # Track tool call names for filtering by name
+            if event.type == EventType.TOOL_CALL_START and hasattr(event, 'tool_call_id') and hasattr(event, 'tool_call_name'):
+                self._tool_call_names[event.tool_call_id] = event.tool_call_name
+
             # Handle both dict and object cases for raw_event
             # See: https://github.com/CopilotKit/CopilotKit/issues/2066
             metadata = (
@@ -235,7 +266,8 @@ class LangGraphAGUIAgent(LangGraphAgent):
             ) or {}
 
             if "copilotkit:emit-tool-calls" in metadata:
-                if metadata["copilotkit:emit-tool-calls"] is False and is_tool_event:
+                emit_tool_calls = metadata["copilotkit:emit-tool-calls"]
+                if is_tool_event and not self._should_emit_tool_call(emit_tool_calls, event):
                     return None  # Don't dispatch this event
 
             if "copilotkit:emit-messages" in metadata:

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -27,6 +27,43 @@ except ImportError:
     from langchain_core.messages import BaseMessage
 
 
+def should_emit_tool_call(
+    tool_call_names: Dict[str, str],
+    emit_tool_calls: Union[bool, str, List[str]],
+    event,
+) -> bool:
+    """Check if a tool call event should be emitted based on the emit_tool_calls config.
+
+    Extracted as a module-level function so it can be tested directly without
+    needing to instantiate LangGraphAGUIAgent (which requires ag_ui_langgraph).
+
+    Args:
+        tool_call_names: Mapping of tool_call_id -> tool_call_name for id-based lookups.
+        emit_tool_calls: The filtering config — True/False, a single tool name, or a list of names.
+        event: The AG-UI event object (has optional tool_call_name/tool_call_id attributes).
+    """
+    if isinstance(emit_tool_calls, bool):
+        return emit_tool_calls
+
+    # Use getattr with None default — hasattr returns True even when the
+    # attribute exists but is None, which would skip the id-lookup fallback.
+    tool_call_name = getattr(event, 'tool_call_name', None)
+    if tool_call_name is None:
+        tool_call_id = getattr(event, 'tool_call_id', None)
+        if tool_call_id is not None:
+            tool_call_name = tool_call_names.get(tool_call_id)
+
+    if tool_call_name is None:
+        return True
+
+    if isinstance(emit_tool_calls, str):
+        return emit_tool_calls == tool_call_name
+    if isinstance(emit_tool_calls, list):
+        return tool_call_name in emit_tool_calls
+
+    return True
+
+
 class CustomEventNames(Enum):
     """Custom event names for CopilotKit"""
 
@@ -75,26 +112,8 @@ class LangGraphAGUIAgent(LangGraphAgent):
         emit_tool_calls: Union[bool, str, List[str]],
         event,
     ) -> bool:
-        """Check if a tool call event should be emitted based on the emit_tool_calls config."""
-        if isinstance(emit_tool_calls, bool):
-            return emit_tool_calls
-
-        # Get the tool call name from the event or the tracked mapping
-        tool_call_name = None
-        if hasattr(event, 'tool_call_name'):
-            tool_call_name = event.tool_call_name
-        elif hasattr(event, 'tool_call_id'):
-            tool_call_name = self._tool_call_names.get(event.tool_call_id)
-
-        if tool_call_name is None:
-            return True
-
-        if isinstance(emit_tool_calls, str):
-            return emit_tool_calls == tool_call_name
-        if isinstance(emit_tool_calls, list):
-            return tool_call_name in emit_tool_calls
-
-        return True
+        """Delegate to the module-level function with instance state."""
+        return should_emit_tool_call(self._tool_call_names, emit_tool_calls, event)
 
     def _dispatch_event(self, event) -> str:
         """Override the dispatch event method to handle custom CopilotKit events and filtering.
@@ -254,8 +273,11 @@ class LangGraphAGUIAgent(LangGraphAgent):
             ]
 
             # Track tool call names for filtering by name
-            if event.type == EventType.TOOL_CALL_START and hasattr(event, 'tool_call_id') and hasattr(event, 'tool_call_name'):
-                self._tool_call_names[event.tool_call_id] = event.tool_call_name
+            if event.type == EventType.TOOL_CALL_START:
+                tc_id = getattr(event, 'tool_call_id', None)
+                tc_name = getattr(event, 'tool_call_name', None)
+                if tc_id and tc_name:
+                    self._tool_call_names[tc_id] = tc_name
 
             # Handle both dict and object cases for raw_event
             # See: https://github.com/CopilotKit/CopilotKit/issues/2066
@@ -269,6 +291,13 @@ class LangGraphAGUIAgent(LangGraphAgent):
                 emit_tool_calls = metadata["copilotkit:emit-tool-calls"]
                 if is_tool_event and not self._should_emit_tool_call(emit_tool_calls, event):
                     return None  # Don't dispatch this event
+
+            # Clean up tracked names after filtering to prevent memory leak.
+            # Must happen AFTER the filter so TOOL_CALL_END can still resolve its name.
+            if event.type == EventType.TOOL_CALL_END:
+                tc_id = getattr(event, 'tool_call_id', None)
+                if tc_id:
+                    self._tool_call_names.pop(tc_id, None)
 
             if "copilotkit:emit-messages" in metadata:
                 if metadata["copilotkit:emit-messages"] is False and is_message_event:

--- a/sdk-python/tests/test_emit_tool_calls.py
+++ b/sdk-python/tests/test_emit_tool_calls.py
@@ -1,0 +1,153 @@
+"""Tests for emit_tool_calls parameter handling in copilotkit_customize_config"""
+
+import sys
+import pytest
+from unittest.mock import MagicMock
+from typing import Union, List
+
+# Mock problematic modules to avoid environment-specific import failures
+# (langgraph.prebuilt.tool_node fails due to version mismatch)
+for mod_name in [
+    "ag_ui_langgraph",
+    "ag_ui_langgraph.middlewares",
+    "ag_ui_langgraph.middlewares.state_streaming",
+    "ag_ui.core",
+    "langchain.agents",
+    "langchain.agents.middleware",
+    "langgraph.prebuilt",
+    "langgraph.prebuilt.tool_node",
+    "langgraph.prebuilt.chat_agent_executor",
+]:
+    sys.modules.setdefault(mod_name, MagicMock())
+
+from copilotkit.langgraph import copilotkit_customize_config
+
+
+class TestCopilotKitCustomizeConfig:
+    """Tests for copilotkit_customize_config emit_tool_calls parameter."""
+
+    def test_emit_tool_calls_boolean_true(self):
+        config = copilotkit_customize_config(None, emit_tool_calls=True)
+        assert config["metadata"]["copilotkit:emit-tool-calls"] is True
+
+    def test_emit_tool_calls_boolean_false(self):
+        config = copilotkit_customize_config(None, emit_tool_calls=False)
+        assert config["metadata"]["copilotkit:emit-tool-calls"] is False
+
+    def test_emit_tool_calls_string(self):
+        config = copilotkit_customize_config(None, emit_tool_calls="my_tool")
+        assert config["metadata"]["copilotkit:emit-tool-calls"] == "my_tool"
+
+    def test_emit_tool_calls_list(self):
+        config = copilotkit_customize_config(
+            None, emit_tool_calls=["tool_a", "tool_b"]
+        )
+        assert config["metadata"]["copilotkit:emit-tool-calls"] == ["tool_a", "tool_b"]
+
+    def test_emit_tool_calls_not_set(self):
+        config = copilotkit_customize_config(None)
+        assert "copilotkit:emit-tool-calls" not in config.get("metadata", {})
+
+    def test_emit_tool_calls_preserves_existing_metadata(self):
+        base_config = {"metadata": {"existing_key": "value"}}
+        config = copilotkit_customize_config(base_config, emit_tool_calls=["tool_a"])
+        assert config["metadata"]["existing_key"] == "value"
+        assert config["metadata"]["copilotkit:emit-tool-calls"] == ["tool_a"]
+
+
+def _should_emit_tool_call(
+    tool_call_names: dict,
+    emit_tool_calls: Union[bool, str, List[str]],
+    event,
+) -> bool:
+    """
+    Standalone version of LangGraphAGUIAgent._should_emit_tool_call for testing.
+    This mirrors the logic in langgraph_agui_agent.py without requiring
+    the full ag_ui_langgraph import chain.
+    """
+    if isinstance(emit_tool_calls, bool):
+        return emit_tool_calls
+
+    tool_call_name = None
+    if hasattr(event, 'tool_call_name'):
+        tool_call_name = event.tool_call_name
+    elif hasattr(event, 'tool_call_id'):
+        tool_call_name = tool_call_names.get(event.tool_call_id)
+
+    if tool_call_name is None:
+        return True
+
+    if isinstance(emit_tool_calls, str):
+        return emit_tool_calls == tool_call_name
+    if isinstance(emit_tool_calls, list):
+        return tool_call_name in emit_tool_calls
+
+    return True
+
+
+def _make_event(tool_call_name=None, tool_call_id=None):
+    event = MagicMock(spec=[])
+    if tool_call_name is not None:
+        event.tool_call_name = tool_call_name
+    if tool_call_id is not None:
+        event.tool_call_id = tool_call_id
+    return event
+
+
+class TestShouldEmitToolCall:
+    """Tests for the _should_emit_tool_call filtering logic."""
+
+    def test_bool_true_emits_all(self):
+        assert _should_emit_tool_call({}, True, _make_event("any_tool")) is True
+
+    def test_bool_false_suppresses_all(self):
+        assert _should_emit_tool_call({}, False, _make_event("any_tool")) is False
+
+    def test_string_match(self):
+        assert _should_emit_tool_call({}, "draft_email", _make_event("draft_email")) is True
+
+    def test_string_no_match(self):
+        assert _should_emit_tool_call({}, "draft_email", _make_event("list_items")) is False
+
+    def test_list_match(self):
+        assert _should_emit_tool_call(
+            {}, ["draft_email", "send_email"], _make_event("draft_email")
+        ) is True
+
+    def test_list_no_match(self):
+        assert _should_emit_tool_call(
+            {}, ["draft_email", "send_email"], _make_event("list_items")
+        ) is False
+
+    def test_list_multiple_matches(self):
+        assert _should_emit_tool_call(
+            {}, ["draft_email", "send_email"], _make_event("send_email")
+        ) is True
+
+    def test_lookup_by_id_match(self):
+        names = {"tc-123": "draft_email"}
+        assert _should_emit_tool_call(
+            names, ["draft_email"], _make_event(tool_call_id="tc-123")
+        ) is True
+
+    def test_lookup_by_id_no_match(self):
+        names = {"tc-123": "list_items"}
+        assert _should_emit_tool_call(
+            names, ["draft_email"], _make_event(tool_call_id="tc-123")
+        ) is False
+
+    def test_unknown_name_defaults_true(self):
+        """When tool name can't be determined, default to emitting."""
+        assert _should_emit_tool_call({}, ["draft_email"], _make_event()) is True
+
+    def test_string_filter_with_id_lookup(self):
+        names = {"tc-456": "search_tool"}
+        assert _should_emit_tool_call(
+            names, "search_tool", _make_event(tool_call_id="tc-456")
+        ) is True
+
+    def test_string_filter_with_id_lookup_no_match(self):
+        names = {"tc-456": "other_tool"}
+        assert _should_emit_tool_call(
+            names, "search_tool", _make_event(tool_call_id="tc-456")
+        ) is False

--- a/sdk-python/tests/test_emit_tool_calls.py
+++ b/sdk-python/tests/test_emit_tool_calls.py
@@ -1,9 +1,11 @@
-"""Tests for emit_tool_calls parameter handling in copilotkit_customize_config"""
+"""Tests for emit_tool_calls parameter handling in copilotkit_customize_config.
+
+Tests the real should_emit_tool_call function imported from langgraph_agui_agent,
+NOT a standalone copy. This ensures test coverage tracks actual production logic.
+"""
 
 import sys
-import pytest
 from unittest.mock import MagicMock
-from typing import Union, List
 
 # Mock problematic modules to avoid environment-specific import failures
 # (langgraph.prebuilt.tool_node fails due to version mismatch)
@@ -21,6 +23,7 @@ for mod_name in [
     sys.modules.setdefault(mod_name, MagicMock())
 
 from copilotkit.langgraph import copilotkit_customize_config
+from copilotkit.langgraph_agui_agent import should_emit_tool_call
 
 
 class TestCopilotKitCustomizeConfig:
@@ -55,99 +58,92 @@ class TestCopilotKitCustomizeConfig:
         assert config["metadata"]["copilotkit:emit-tool-calls"] == ["tool_a"]
 
 
-def _should_emit_tool_call(
-    tool_call_names: dict,
-    emit_tool_calls: Union[bool, str, List[str]],
-    event,
-) -> bool:
-    """
-    Standalone version of LangGraphAGUIAgent._should_emit_tool_call for testing.
-    This mirrors the logic in langgraph_agui_agent.py without requiring
-    the full ag_ui_langgraph import chain.
-    """
-    if isinstance(emit_tool_calls, bool):
-        return emit_tool_calls
-
-    tool_call_name = None
-    if hasattr(event, 'tool_call_name'):
-        tool_call_name = event.tool_call_name
-    elif hasattr(event, 'tool_call_id'):
-        tool_call_name = tool_call_names.get(event.tool_call_id)
-
-    if tool_call_name is None:
-        return True
-
-    if isinstance(emit_tool_calls, str):
-        return emit_tool_calls == tool_call_name
-    if isinstance(emit_tool_calls, list):
-        return tool_call_name in emit_tool_calls
-
-    return True
-
-
-def _make_event(tool_call_name=None, tool_call_id=None):
+def _make_event(tool_call_name=MagicMock, tool_call_id=MagicMock):
+    """Create a mock event. Use MagicMock sentinel to omit attributes entirely."""
     event = MagicMock(spec=[])
-    if tool_call_name is not None:
+    if tool_call_name is not MagicMock:
         event.tool_call_name = tool_call_name
-    if tool_call_id is not None:
+    if tool_call_id is not MagicMock:
         event.tool_call_id = tool_call_id
     return event
 
 
 class TestShouldEmitToolCall:
-    """Tests for the _should_emit_tool_call filtering logic."""
+    """Tests for the real should_emit_tool_call function from langgraph_agui_agent."""
 
     def test_bool_true_emits_all(self):
-        assert _should_emit_tool_call({}, True, _make_event("any_tool")) is True
+        assert should_emit_tool_call({}, True, _make_event("any_tool")) is True
 
     def test_bool_false_suppresses_all(self):
-        assert _should_emit_tool_call({}, False, _make_event("any_tool")) is False
+        assert should_emit_tool_call({}, False, _make_event("any_tool")) is False
 
     def test_string_match(self):
-        assert _should_emit_tool_call({}, "draft_email", _make_event("draft_email")) is True
+        assert should_emit_tool_call({}, "draft_email", _make_event("draft_email")) is True
 
     def test_string_no_match(self):
-        assert _should_emit_tool_call({}, "draft_email", _make_event("list_items")) is False
+        assert should_emit_tool_call({}, "draft_email", _make_event("list_items")) is False
 
     def test_list_match(self):
-        assert _should_emit_tool_call(
+        assert should_emit_tool_call(
             {}, ["draft_email", "send_email"], _make_event("draft_email")
         ) is True
 
     def test_list_no_match(self):
-        assert _should_emit_tool_call(
+        assert should_emit_tool_call(
             {}, ["draft_email", "send_email"], _make_event("list_items")
         ) is False
 
     def test_list_multiple_matches(self):
-        assert _should_emit_tool_call(
+        assert should_emit_tool_call(
             {}, ["draft_email", "send_email"], _make_event("send_email")
         ) is True
 
     def test_lookup_by_id_match(self):
         names = {"tc-123": "draft_email"}
-        assert _should_emit_tool_call(
+        assert should_emit_tool_call(
             names, ["draft_email"], _make_event(tool_call_id="tc-123")
         ) is True
 
     def test_lookup_by_id_no_match(self):
         names = {"tc-123": "list_items"}
-        assert _should_emit_tool_call(
+        assert should_emit_tool_call(
             names, ["draft_email"], _make_event(tool_call_id="tc-123")
         ) is False
 
     def test_unknown_name_defaults_true(self):
         """When tool name can't be determined, default to emitting."""
-        assert _should_emit_tool_call({}, ["draft_email"], _make_event()) is True
+        assert should_emit_tool_call({}, ["draft_email"], _make_event()) is True
 
     def test_string_filter_with_id_lookup(self):
         names = {"tc-456": "search_tool"}
-        assert _should_emit_tool_call(
+        assert should_emit_tool_call(
             names, "search_tool", _make_event(tool_call_id="tc-456")
         ) is True
 
     def test_string_filter_with_id_lookup_no_match(self):
         names = {"tc-456": "other_tool"}
-        assert _should_emit_tool_call(
+        assert should_emit_tool_call(
             names, "search_tool", _make_event(tool_call_id="tc-456")
         ) is False
+
+    def test_none_tool_call_name_falls_through_to_id_lookup(self):
+        """Regression: hasattr returns True for tool_call_name=None.
+        Must fall through to id-lookup instead of emitting unconditionally."""
+        names = {"tc-789": "secret_tool"}
+        # Event has tool_call_name attribute but it's None
+        event = _make_event(tool_call_name=None, tool_call_id="tc-789")
+        assert should_emit_tool_call(names, "secret_tool", event) is True
+        assert should_emit_tool_call(names, "other_tool", event) is False
+
+    def test_none_tool_call_name_no_id_defaults_true(self):
+        """When tool_call_name is None and no tool_call_id, default to emit."""
+        event = _make_event(tool_call_name=None)
+        assert should_emit_tool_call({}, ["draft_email"], event) is True
+
+    def test_empty_list_suppresses_all(self):
+        """Empty list should suppress all named tools."""
+        assert should_emit_tool_call({}, [], _make_event("any_tool")) is False
+
+    def test_empty_list_allows_unknown(self):
+        """Empty list should still allow events with unknown names (no name to check)."""
+        assert should_emit_tool_call({}, [], _make_event()) is True


### PR DESCRIPTION
## Summary

Fixes #5120

- The `emit_tool_calls` parameter of `copilotkit_customize_config` accepts `bool | str | list[str]`, but the AG-UI event dispatching logic only checked for `False`, silently ignoring string/list whitelist values.
- Added `_should_emit_tool_call` (Python) and `shouldEmitToolCall` (TypeScript) methods that properly handle all three types -- matching the existing v1 `RemoteLangGraphEventSource.shouldEmitToolCall` implementation.
- Tool call names are tracked by `tool_call_id` so that `ToolCallArgs` and `ToolCallEnd` events (which don't carry the tool name) can be filtered correctly.

### Files changed
- `sdk-python/copilotkit/langgraph_agui_agent.py` -- Python AG-UI agent filtering
- `packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts` -- TypeScript AG-UI agent filtering
- `sdk-python/tests/test_emit_tool_calls.py` -- 18 unit tests for the filtering logic

## Test plan

- [x] 18 pytest tests covering bool/string/list filtering, ID-based lookup, and unknown-name fallback
- [ ] Manual verification with a LangGraph agent using `emit_tool_calls=["specific_tool"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)