### PR TITLE
fix(showcase): bake LANGGRAPH_HTTP configurable_headers into langgraph.json

### DIFF
--- a/showcase/integrations/langgraph-fastapi/langgraph.json
+++ b/showcase/integrations/langgraph-fastapi/langgraph.json
@@ -1,5 +1,10 @@
 {
   "dependencies": ["."],
+  "http": {
+    "configurable_headers": {
+      "include": ["x-*"]
+    }
+  },
   "graphs": {
     "sample_agent": "./src/agents/src/agent.py:graph",
     "beautiful_chat": "./src/agents/src/beautiful_chat.py:graph",

--- a/showcase/integrations/langgraph-python/langgraph.json
+++ b/showcase/integrations/langgraph-python/langgraph.json
@@ -1,6 +1,11 @@
 {
   "dependencies": ["."],
   "env": ".env",
+  "http": {
+    "configurable_headers": {
+      "include": ["x-*"]
+    }
+  },
   "graphs": {
     "sample_agent": "./src/agents/main.py:graph",
     "tool_rendering": "./src/agents/tool_rendering_agent.py:graph",


### PR DESCRIPTION
## Summary

Moves the D6 header-conveyance config from an env-only `LANGGRAPH_HTTP` var to on-disk `langgraph.json`, so it rides image promotion instead of drifting per-environment.

`langgraph.json` for `langgraph-python` and `langgraph-fastapi` now declares:

```json
"http": { "configurable_headers": { "include": ["x-*"] } }
```

## Why

- **Required + uniform conveyance config belongs on-disk.** The env-only `LANGGRAPH_HTTP` was missing on prod `langgraph-python` / `langgraph-fastapi`, so header conveyance would 404 there. Baking it into `langgraph.json` means the config travels with the image through promotion and cannot drift out of sync between environments.
- **The env-only approach was latently unreliable even where set.** `langgraph dev` actively pops the `LANGGRAPH_HTTP` env var when `langgraph.json` lacks an `http` key, so relying on the env var alone was fragile by design.

## Validation

- Schema key (`http.configurable_headers.include`) confirmed against pinned `langgraph-cli` 0.4.21 / `langgraph-api` 0.7.101.
- `langgraph.json` is in each image's Docker build context (COPYed into both images).
- Conveyance verified locally with the `LANGGRAPH_HTTP` env var **unset**: both services forwarded `x-aimock-context`; negative control without the key conveyed nothing.
- `langgraph-typescript` is unaffected — it does pure-code conveyance and needs no `langgraph.json` change.
- Pre-commit hooks (full nx publint/attw suite) ran and passed at commit time.

## Test plan

- [x] Local conveyance proof (env var unset, plus negative control)
- [ ] Real signal: a clean staging d6 run post-merge