### PR TITLE
fix(showcase): correct turnIndex drift in agno/spring-ai/langgraph-fastapi d6 fixtures

### DIFF
--- a/showcase/aimock/d6/agno/agentic-chat.json
+++ b/showcase/aimock/d6/agno/agentic-chat.json
@@ -7,9 +7,9 @@
   },
   "fixtures": [
     {
+      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
-        "turnIndex": 0,
         "context": "agno"
       },
       "response": {
@@ -17,9 +17,9 @@
       }
     },
     {
+      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
-        "turnIndex": 0,
         "context": "agno"
       },
       "response": {
@@ -27,9 +27,9 @@
       }
     },
     {
+      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
-        "turnIndex": 0,
         "context": "agno"
       },
       "response": {

--- a/showcase/aimock/d6/langgraph-fastapi/agentic-chat.json
+++ b/showcase/aimock/d6/langgraph-fastapi/agentic-chat.json
@@ -7,9 +7,9 @@
   },
   "fixtures": [
     {
+      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
-        "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -17,9 +17,9 @@
       }
     },
     {
+      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
-        "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -27,9 +27,9 @@
       }
     },
     {
+      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
-        "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
       "response": {

--- a/showcase/aimock/d6/spring-ai/agentic-chat.json
+++ b/showcase/aimock/d6/spring-ai/agentic-chat.json
@@ -7,9 +7,9 @@
   },
   "fixtures": [
     {
+      "_comment": "agentic-chat turn 1 — goldfish name. No turnIndex gate: the probe sends 3 sequential turns in one thread; turnIndex would restrict this to the first turn only, causing turns 2-3 to fall through to proxy.",
       "match": {
         "userMessage": "good name for a goldfish",
-        "turnIndex": 0,
         "context": "spring-ai"
       },
       "response": {
@@ -17,9 +17,9 @@
       }
     },
     {
+      "_comment": "agentic-chat turn 2 — tank name. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "name for its tank",
-        "turnIndex": 0,
         "context": "spring-ai"
       },
       "response": {
@@ -27,9 +27,9 @@
       }
     },
     {
+      "_comment": "agentic-chat turn 3 — recall. No turnIndex gate (multi-turn conversation).",
       "match": {
         "userMessage": "what we named the goldfish",
-        "turnIndex": 0,
         "context": "spring-ai"
       },
       "response": {


### PR DESCRIPTION
## Summary

The aimock matcher gates a fixture's `turnIndex` against the request's assistant-message count: a fixture only fires when `assistantCount === turnIndex`. So `turnIndex` must equal the number of assistant turns already in the conversation when that fixture should match — turn 1 is `turnIndex: 0`, turn 2 is `turnIndex: 1`, etc. A multi-turn conversation fixture that wants to match on *every* turn must **omit** `turnIndex` entirely and disambiguate purely by `userMessage`, which is exactly what the canonical clean pattern (langgraph-python and the other 15 frameworks) does.

The `agno`, `spring-ai`, and `langgraph-fastapi` `agentic-chat` fixtures had baked `turnIndex: 0` onto **all three** goldfish conversation turns. Turn 2+ carries one or more assistant messages, so `assistantCount !== 0` and the turn-2/turn-3 fixtures could never match. aimock returned no-match, the request fell through to the proxy, and the d6 cell failed — surfacing as the 503 → proxy → 502 cascade on staging.

This PR drops `turnIndex: 0` from the multi-turn goldfish turns in all three files, mirroring the langgraph-python canonical pattern, and adds clarifying `_comment` keys on each turn.

## Findings

- The 503/502 cascade had been diagnosed on two integrations (agno, spring-ai). Auditing the full d6 fixture set turned up a **third** affected integration, **langgraph-fastapi**, carrying the identical `turnIndex: 0`-on-all-turns defect.
- **Single-turn** fixtures correctly keep `turnIndex: 0` (a single-turn match where `assistantCount === 0` is correct) — those are unchanged.
- The other **15 frameworks** were already clean (no `turnIndex` on multi-turn conversation turns).
- Local before/after evidence: turn-2 went 503 → 200 for all three frameworks after the fix; turn-1 was unregressed.

## Test plan

- [x] All three JSON files parse (valid JSON).
- [x] `validate-fixture-tool-surface.ts` — green (no drift).
- [x] `validate-parity.ts` — exit 0.
- [x] `validate-pins.ts` ratchet — FAIL count and hash unchanged vs `fail-baseline.json` (63, matching hash); none of the FAIL lines touch these fixtures.
- [x] `vitest run` (build-pipeline tests) — 1670 passed.
- [ ] The real signal is a clean staging d6 run on these cells (agno / spring-ai / langgraph-fastapi agentic-chat), verified post-merge.