### PR TITLE
feat(showcase/harness): fast-fail e2e turns on a sustained error banner

### DIFF
--- a/showcase/harness/src/probes/helpers/conversation-runner.test.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.test.ts
@@ -4,6 +4,7 @@ import {
   fillAndVerifySend,
   readUserMessageCount,
   waitForContentAndSend,
+  AssistantErroredError,
 } from "./conversation-runner.js";
 import type { ConversationTurn, Page } from "./conversation-runner.js";
 
@@ -19,8 +20,13 @@ import type { ConversationTurn, Page } from "./conversation-runner.js";
  * the same value repeats across a quiet window of `assistantSettleMs`.
  *
  * To keep tests deterministic and fast we set `assistantSettleMs` to a
- * small value (50 ms) and use vitest's fake timers where the runner's
- * polling loop would otherwise dominate wall time.
+ * small value (50 ms) so the runner's real-timer polling loop completes
+ * quickly. These tests use REAL timers throughout (no `vi.useFakeTimers`);
+ * scripted `evaluate` count sequences — not clock manipulation — drive the
+ * settle and fast-fail paths deterministically. Multi-turn and multi-poll
+ * tests carry an explicit generous per-test timeout (third `it` arg) so
+ * their cumulative real-sleep cost cannot collide with vitest's 5000 ms
+ * default on a loaded CI runner.
  */
 
 interface PageScript {
@@ -45,6 +51,18 @@ interface PageScript {
   // pulls the next value from the queue; last value repeats forever.
   // Used by skipFill tests to simulate async textarea population.
   inputValues?: string[];
+  // Scripted return values for the error-banner visibility probe (reads
+  // that reference `copilot-error-banner`). Each invocation pulls the
+  // next value; once exhausted the last value repeats forever. A `true`
+  // (or `{ visible: true }`) means the
+  // `[data-testid="copilot-error-banner"]` is visible.
+  // Used by fast-fail tests to simulate the chat error banner appearing
+  // mid-settle without any new assistant message arriving. Each entry may
+  // be a bare boolean (text defaults to "Something went wrong" when
+  // visible) OR an object carrying explicit `text`, so tests can model a
+  // banner whose TEXT changes across polls (a re-armed new/changed error)
+  // — not just its visibility.
+  errorBannerValues?: Array<boolean | { visible: boolean; text?: string }>;
 }
 
 /**
@@ -60,17 +78,44 @@ function wrapEvaluateForUserMessages(
 ): Page["evaluate"] {
   let userCalls = 0;
   return (async <R>(fn: () => R): Promise<R> => {
-    if (fn.toString().includes("copilot-user-message")) {
+    const body = fn.toString();
+    if (body.includes("copilot-user-message")) {
       return userCalls++ as never;
+    }
+    // Error-banner visibility probe: these helpers never simulate a
+    // banner, so return the runner-expected `{ visible: false }` shape
+    // explicitly. Previously this read fell through to `inner(fn)`, which
+    // returns an assistant-count NUMBER — the runner only worked because
+    // `(someNumber).visible` is `undefined` (falsy). Returning the real
+    // shape exercises the genuine "no banner" path instead of relying on
+    // that accident.
+    if (body.includes("copilot-error-banner")) {
+      return { visible: false } as never;
     }
     return inner(fn) as Promise<R>;
   }) as Page["evaluate"];
+}
+
+/**
+ * Mirror the text-shaping `readErrorBanner` applies to a banner's
+ * `textContent` before the SUT sees it. The SUT compares this value across
+ * polls (`textChanged`) to re-arm fast-fail. Keeping this in one place lets
+ * the fake track the production contract exactly: when `readErrorBanner`
+ * returns the FULL text (and truncates only the thrown message), this returns
+ * the full text too.
+ */
+function shapeBannerProbeText(text: string): string {
+  // `readErrorBanner` returns the FULL `textContent` — truncation is applied
+  // downstream only to the thrown message (`BANNER_MESSAGE_MAX_LENGTH`), never
+  // to the value compared across polls. The fake mirrors that contract.
+  return text;
 }
 
 function makePage(script: PageScript = {}): Page {
   const queue = [...(script.evaluateValues ?? [])];
   const userQueue = [...(script.userMessageValues ?? [])];
   const inputQueue = [...(script.inputValues ?? [])];
+  const errorBannerQueue = [...(script.errorBannerValues ?? [])];
   // Auto-succeed counter: first user-message read = 0 (baseline),
   // subsequent reads = 1 (growth detected → verify loop succeeds).
   let autoUserCalls = 0;
@@ -94,6 +139,31 @@ function makePage(script: PageScript = {}): Page {
       // readUserMessageCount function references "copilot-user-message"
       // while readMessageCount references "copilot-assistant-message".
       const fnBody = fn.toString();
+      // Error-banner visibility probe references "copilot-error-banner".
+      // Routed before the message-count branches so it gets its own
+      // scripted queue. Defaults to `false` (no banner) when unscripted
+      // so existing tests are unaffected.
+      if (fnBody.includes("copilot-error-banner")) {
+        const entry =
+          errorBannerQueue.length === 0
+            ? false
+            : errorBannerQueue.length === 1
+              ? errorBannerQueue[0]!
+              : errorBannerQueue.shift()!;
+        const visible = typeof entry === "boolean" ? entry : entry.visible;
+        const text =
+          typeof entry === "boolean" ? "Something went wrong" : entry.text;
+        // Faithfully model the browser-side read contract of
+        // `readErrorBanner`: the probe returns the banner's `textContent` and
+        // the SUT uses that value for the cross-poll `textChanged`
+        // comparison. The fake mirrors whatever shape `readErrorBanner`
+        // yields — see `shapeBannerProbeText` above.
+        const resolved = visible ? (text ?? "Something went wrong") : undefined;
+        return {
+          visible,
+          ...(visible ? { text: shapeBannerProbeText(resolved!) } : {}),
+        } as never;
+      }
       if (fnBody.includes("copilot-user-message")) {
         if (userQueue.length > 0) {
           if (userQueue.length === 1) return userQueue[0]! as never;
@@ -208,7 +278,10 @@ describe("runConversation", () => {
     expect(order).toEqual([1, 2, 3]);
     expect(recorded.fills).toEqual(["first", "second", "third"]);
     expect(recorded.presses).toEqual(["Enter", "Enter", "Enter"]);
-  });
+    // 3 turns × real settle polling ≈ 3.5s locally; explicit generous
+    // per-test timeout keeps it clear of vitest's 5000ms default on a
+    // loaded CI runner.
+  }, 20_000);
 
   it("turn-2 assertion failure: returns failure_turn=2 and error, stops further turns", async () => {
     const recorded = { fills: [] as string[], presses: [] as string[] };
@@ -253,7 +326,9 @@ describe("runConversation", () => {
     expect(turn3Ran).toBe(false);
     // The third input was never typed.
     expect(recorded.fills).toEqual(["first", "second"]);
-  });
+    // Drives 2 turns through real settle polling (~2.1s locally); explicit
+    // timeout keeps it clear of the 5000ms default on a loaded CI runner.
+  }, 20_000);
 
   it("assistant never responds: turn fails with timeout error", async () => {
     const recorded = { fills: [] as string[], presses: [] as string[] };
@@ -280,6 +355,405 @@ describe("runConversation", () => {
     expect(result.turn_durations_ms).toHaveLength(0);
   });
 
+  it("fast-fails when the copilot-error-banner becomes visible and STAYS for 2+ polls mid-settle", async () => {
+    // The turn submits but NO new assistant message ever arrives — the
+    // assistant-message count stays pinned at the baseline (0). Without
+    // the fast-fail path the runner would poll until the full
+    // `responseTimeoutMs` (here 5000ms) expires and throw a generic
+    // timeout. Instead, a FRESH error banner becomes visible mid-settle and
+    // STAYS visible (not present at baseline → differs-from-baseline state).
+    // Under the unified rule, ALL banner detection is debounced behind a
+    // 2-consecutive-poll counter (no more immediate `isNewBanner` path), so
+    // the banner must persist across 2 polls before the runner short-circuits
+    // with a distinguished "chat errored" failure. The scripted queue keeps
+    // the banner visible from poll2 onward (last value repeats), satisfying
+    // the 2-consecutive-poll debounce.
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    const page = makePage({
+      // Assistant count never grows past baseline.
+      evaluateValues: [0],
+      // Banner NOT visible at baseline, then appears at poll2 and STAYS
+      // (last value `true` repeats forever) → 2+ consecutive
+      // differs-from-baseline polls → fast-fail under the unified debounce.
+      errorBannerValues: [false, false, true],
+      recorded,
+    });
+
+    const start = Date.now();
+    const result = await runConversation(
+      page,
+      [{ input: "trigger error", responseTimeoutMs: 5000 }],
+      { assistantSettleMs: 50 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.turns_completed).toBe(0);
+    expect(result.total_turns).toBe(1);
+    expect(result.failure_turn).toBe(1);
+    expect(result.error).toBeDefined();
+    // Distinguished error — NOT the generic "timeout" message. The runner
+    // surfaces the thrown error's MESSAGE, which for a banner fast-fail is
+    // an `AssistantErroredError`. Assert the exact distinguished marker AND
+    // the scripted banner text (not merely the substring "error", which a
+    // generic timeout would also contain). Comparing against a freshly
+    // constructed `AssistantErroredError` message proves the runner threw
+    // that error type with the banner text — the string IS its `.message`.
+    expect(result.error).toBe(
+      new AssistantErroredError("Something went wrong").message,
+    );
+    expect(result.error).toContain("copilot-error-banner visible");
+    expect(result.error).toContain("Something went wrong");
+    expect(result.error!.toLowerCase()).not.toContain("timeout");
+    // Contract guard: the banner fast-fail path throws an
+    // `AssistantErroredError` (an `Error` subclass) carrying this exact
+    // message, so the driver can classify it distinctly from a timeout.
+    const expected = new AssistantErroredError("Something went wrong");
+    expect(expected).toBeInstanceOf(AssistantErroredError);
+    expect(expected).toBeInstanceOf(Error);
+    expect(result.error).toBe(expected.message);
+    // The whole point: bail well before the 5000ms responseTimeout.
+    expect(elapsed).toBeLessThan(2000);
+    // Failed turn's duration is not recorded.
+    expect(result.turn_durations_ms).toHaveLength(0);
+    // Real multi-poll settle loop; explicit timeout for CI headroom.
+  }, 20_000);
+
+  it("does NOT fast-fail on a stale banner whose text is UNCHANGED from baseline", async () => {
+    // A banner that was visible BEFORE the turn was submitted (a stale
+    // banner left over from a prior turn) whose TEXT never changes must
+    // NOT be mistaken for this turn's error. CopilotKit error banners
+    // persist across turns, so an unchanged same-text banner is the
+    // expected steady state — only a NEW or text-CHANGED banner re-arms
+    // the fast-fail. The assistant responds normally (count grows past
+    // baseline and settles) → the turn must SUCCEED despite the
+    // ever-present, same-text banner.
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    const page = makePage({
+      // Assistant count: baseline=0, then grows to 1 and stays → settles.
+      evaluateValues: [0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+      // Banner visible the ENTIRE time with the SAME text, including at
+      // baseline. Same text across polls ⇒ stale ⇒ must NOT fast-fail.
+      errorBannerValues: [{ visible: true, text: "Old error" }],
+      recorded,
+    });
+
+    const result = await runConversation(
+      page,
+      [{ input: "hello", responseTimeoutMs: 5000 }],
+      { assistantSettleMs: 50 },
+    );
+
+    expect(result.turns_completed).toBe(1);
+    expect(result.failure_turn).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    // Real multi-poll settle loop; explicit timeout for CI headroom.
+  }, 20_000);
+
+  it("RE-ARMS fast-fail when a baseline banner's TEXT changes mid-settle (new error)", async () => {
+    // Multi-turn regression: CopilotKit error banners persist across
+    // turns, so a banner can ALREADY be visible at this turn's baseline
+    // (a stale leftover from a prior errored turn). If a NEW error then
+    // occurs this turn, the banner's TEXT changes — but NO new assistant
+    // message arrives, so the count stays pinned at baseline. The old
+    // boolean snapshot (`errorBannerAtBaseline`) disabled the ENTIRE
+    // fast-fail path whenever a banner was present at baseline, so the
+    // 2nd+ errored turn silently paid the full responseTimeout. The fix
+    // snapshots the baseline banner TEXT and re-arms detection when the
+    // visible banner's text DIFFERS from baseline — fast-failing on the
+    // new error even though a stale banner was already up.
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    const page = makePage({
+      // Assistant count never grows past baseline (no new message).
+      evaluateValues: [0],
+      // Banner visible at baseline as "Old error" (stale), then its TEXT
+      // changes to "New error" mid-settle (a fresh error this turn).
+      errorBannerValues: [
+        { visible: true, text: "Old error" },
+        { visible: true, text: "Old error" },
+        { visible: true, text: "New error" },
+      ],
+      recorded,
+    });
+
+    const start = Date.now();
+    const result = await runConversation(
+      page,
+      [{ input: "trigger new error", responseTimeoutMs: 5000 }],
+      { assistantSettleMs: 50 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.turns_completed).toBe(0);
+    expect(result.total_turns).toBe(1);
+    expect(result.failure_turn).toBe(1);
+    expect(result.error).toBeDefined();
+    // Fast-failed on the NEW banner text, not the stale one.
+    expect(result.error).toBe(new AssistantErroredError("New error").message);
+    expect(result.error).toContain("copilot-error-banner visible");
+    expect(result.error).toContain("New error");
+    expect(result.error!.toLowerCase()).not.toContain("timeout");
+    // Bailed well before the 5000ms responseTimeout — the whole point.
+    expect(elapsed).toBeLessThan(2000);
+    expect(result.turn_durations_ms).toHaveLength(0);
+    // Real multi-poll settle loop; explicit timeout for CI headroom.
+  }, 20_000);
+
+  it("does NOT fast-fail when a persisted banner's text FLICKERS for a single poll then reverts (succeeding turn)", async () => {
+    // Finding 2 (streaming false-POSITIVE): a banner that is visible at
+    // baseline (persisted from a prior turn) can have its text transiently
+    // mutate mid-stream — a countdown tick, a momentary empty during a
+    // re-render — while THIS turn is actually SUCCEEDING. An undebounced
+    // `textChanged` check would fire a SPURIOUS `AssistantErroredError` on a
+    // succeeding turn (a false RED, strictly worse than a slow-fail). The fix
+    // debounces ONLY the text-changed path: a changed text must persist
+    // across 2 consecutive polls before it fast-fails. A single-poll flicker
+    // that reverts must NOT fast-fail, so the turn settles normally.
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    const page = makePage({
+      // Assistant count stays AT baseline (0) through the flicker poll so the
+      // flicker is evaluated while `current <= baselineCount` — exercising the
+      // real debounce-reset path, NOT the success-in-flight disarm. THEN it
+      // grows to 1 and freezes so the turn settles AFTER the flicker poll has
+      // been seen. Evaluate draws (a `readMessageCount` per read): #1=boot
+      // baseline (conversation-runner.ts:362), #2=waitForAssistantSettled
+      // initial lastCount, #3=loop poll1, #4=loop poll2 (the flicker poll —
+      // still 0, so debounce path runs), #5=loop poll3 (1), then frozen at 1
+      // → count change resets lastChangeAt, settle fires after settleMs.
+      evaluateValues: [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+      // Banner sequence (1st entry = baseline snapshot, rest = per-poll):
+      //   baseline "Old", poll1 "Old", poll2 "flicker" (transient!),
+      //   poll3+ "Old" (reverted, frozen). The flicker lasts exactly ONE
+      //   poll then reverts — must NOT trip the debounced fast-fail.
+      errorBannerValues: [
+        { visible: true, text: "Old" },
+        { visible: true, text: "Old" },
+        { visible: true, text: "flicker" },
+        { visible: true, text: "Old" },
+      ],
+      recorded,
+    });
+
+    const result = await runConversation(
+      page,
+      [
+        {
+          input: "succeeding turn with banner flicker",
+          responseTimeoutMs: 5000,
+        },
+      ],
+      { assistantSettleMs: 50 },
+    );
+
+    // The flicker reverted, so NO spurious AssistantErroredError — the turn
+    // settled normally and SUCCEEDED.
+    expect(result.turns_completed).toBe(1);
+    expect(result.failure_turn).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    // Real multi-poll settle loop; explicit timeout for CI headroom.
+  }, 20_000);
+
+  it("STILL fast-fails when a baseline banner's changed text is STABLE across 2 consecutive polls (genuine new error, debounced)", async () => {
+    // Finding 2 regression guard: debouncing the text-changed path must NOT
+    // suppress a GENUINE new error. A real new error's banner text changes
+    // and then PERSISTS (it doesn't flicker back). The debounce requires the
+    // changed text to be stable across 2 consecutive polls — a genuine error
+    // satisfies that with one extra ~poll-interval of latency, then
+    // fast-fails. This complements the round-1 re-arm test (which freezes on
+    // the new text) by making the 2-poll-stability requirement explicit.
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    const page = makePage({
+      // Assistant count never grows past baseline (no new message arrives).
+      evaluateValues: [0],
+      // baseline "Old", poll1 "Old", then "New" appears at poll2 and
+      // PERSISTS (poll3 still "New", then frozen on "New"). Stable across
+      // ≥2 consecutive polls ⇒ genuine error ⇒ fast-fail.
+      errorBannerValues: [
+        { visible: true, text: "Old" },
+        { visible: true, text: "Old" },
+        { visible: true, text: "New" },
+        { visible: true, text: "New" },
+      ],
+      recorded,
+    });
+
+    const start = Date.now();
+    const result = await runConversation(
+      page,
+      [{ input: "trigger stable new error", responseTimeoutMs: 5000 }],
+      { assistantSettleMs: 50 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.turns_completed).toBe(0);
+    expect(result.failure_turn).toBe(1);
+    expect(result.error).toBeDefined();
+    expect(result.error).toBe(new AssistantErroredError("New").message);
+    expect(result.error).toContain("copilot-error-banner visible");
+    expect(result.error).toContain("New");
+    expect(result.error!.toLowerCase()).not.toContain("timeout");
+    // Debounce adds ~1 poll of latency at most — still far under the 5000ms
+    // responseTimeout.
+    expect(elapsed).toBeLessThan(2000);
+    expect(result.turn_durations_ms).toHaveLength(0);
+    // Real multi-poll settle loop; explicit timeout for CI headroom.
+  }, 20_000);
+
+  it("does NOT fast-fail when a FRESH banner appears for a SINGLE poll then disappears (succeeding turn)", async () => {
+    // Unified-rule scenario 1 (the common false-RED on the old code): on a
+    // turn with NO banner at baseline, a brand-new error banner can flicker
+    // visible for exactly ONE poll (a transient toast that auto-dismisses,
+    // a single re-render glitch) while the turn is actually SUCCEEDING. The
+    // OLD code fast-failed IMMEDIATELY on any fresh banner (`isNewBanner`,
+    // no debounce) → a spurious AssistantErroredError. The unified rule
+    // debounces ALL banner detection (new AND changed) behind a 2-consecutive
+    // -poll counter, so a single-poll fresh-banner flicker that reverts does
+    // NOT fast-fail and the turn settles normally.
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    const page = makePage({
+      // Assistant count stays AT baseline (0) through the flicker poll so the
+      // fresh-banner flicker is evaluated while `current <= baselineCount` —
+      // exercising the real debounce-reset path, NOT the success-in-flight
+      // disarm. THEN it grows to 1 and freezes → settles AFTER the flicker
+      // poll is reached. Draws (a `readMessageCount` per read): #1=boot
+      // baseline (conversation-runner.ts:362), #2=waitForAssistantSettled
+      // initial lastCount, #3=loop poll1, #4=loop poll2 (the flicker poll —
+      // still 0, so debounce path runs), #5=loop poll3 (1), frozen 1 → count
+      // change resets lastChangeAt, settle fires after settleMs.
+      evaluateValues: [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+      // No banner at baseline. A FRESH banner appears for exactly ONE poll
+      // (poll2) then disappears (poll3+ not visible). Single isolated poll ⇒
+      // must NOT fast-fail under the unified debounce.
+      errorBannerValues: [
+        false,
+        false,
+        { visible: true, text: "transient" },
+        false,
+      ],
+      recorded,
+    });
+
+    const result = await runConversation(
+      page,
+      [
+        {
+          input: "succeeding turn with fresh-banner flicker",
+          responseTimeoutMs: 5000,
+        },
+      ],
+      { assistantSettleMs: 50 },
+    );
+
+    // The fresh banner flickered for one poll then vanished → no spurious
+    // AssistantErroredError; the turn settled and SUCCEEDED.
+    expect(result.turns_completed).toBe(1);
+    expect(result.failure_turn).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    // Real multi-poll settle loop; explicit timeout for CI headroom.
+  }, 20_000);
+
+  it("fast-fails when a CHANGING-text persisted banner stays in a differs-from-baseline state across 2+ polls (countdown/timestamp mutation)", async () => {
+    // Unified-rule scenario 3 (the value-debounce false-NEGATIVE on the old
+    // code): a genuine error whose banner text MUTATES every poll (a retry
+    // countdown "retrying 3 → 2 → 1", a live timestamp, a rotating
+    // request-id) and never repeats the SAME changed value across two polls.
+    // The OLD value-based `pendingChangedText` debounce keyed on the exact
+    // text matching across 2 polls, so a per-poll-mutating error NEVER
+    // matched → never fast-failed → burned the full 30s. The unified rule
+    // keys on "differs from baseline" (a boolean state), not an exact value,
+    // so a banner that stays in the differs-from-baseline state for 2
+    // consecutive polls fast-fails even while its text keeps changing.
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    // Text mutates on EVERY poll and never repeats the prior poll's value
+    // within the (short) timeout window. The OLD value-based debounce keyed
+    // on the SAME changed text repeating across 2 consecutive polls, so a
+    // per-poll-unique sequence NEVER matched → it would have burned the full
+    // timeout (here 800ms ⇒ no generic-timeout flake under the unified rule,
+    // which fast-fails on the 2nd consecutive differs-from-baseline poll).
+    // Enough distinct values to outlast the 800ms / 100ms ≈ 8-poll budget so
+    // the old code can't accidentally hit a frozen-last-value repeat.
+    const mutating = Array.from({ length: 20 }, (_, i) => ({
+      visible: true as const,
+      text: `err-${i + 1}`,
+    }));
+    const page = makePage({
+      // Assistant count never grows past baseline (no real response).
+      evaluateValues: [0],
+      // baseline "err-0"; then text mutates every poll ("err-1", "err-2",
+      // …) — each DIFFERS from baseline, none repeats the prior poll's value.
+      // errorStateNow is true on every poll ⇒ 2 consecutive ⇒ fast-fail
+      // under the unified rule (on the value-debounce old code this never
+      // fired and the turn burned the full timeout).
+      errorBannerValues: [{ visible: true, text: "err-0" }, ...mutating],
+      recorded,
+    });
+
+    const start = Date.now();
+    const result = await runConversation(
+      page,
+      [{ input: "trigger mutating error", responseTimeoutMs: 800 }],
+      { assistantSettleMs: 50 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.turns_completed).toBe(0);
+    expect(result.failure_turn).toBe(1);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("copilot-error-banner visible");
+    expect(result.error!.toLowerCase()).not.toContain("timeout");
+    // Fast-failed on the 2nd consecutive differs-from-baseline poll (~200ms
+    // into the settle), well under the 800ms responseTimeout — the whole
+    // point of the fix. On the old value-debounce code this NEVER matched a
+    // repeated changed value and the turn TIMED OUT, so the error would
+    // contain "timeout" and the assertions above would fail. (The wall-clock
+    // here includes ~600ms of fixed harness boot/selector overhead, so we
+    // assert the not-a-timeout error shape above rather than a tight elapsed
+    // bound; <2000ms still proves we beat the responseTimeout settle path.)
+    expect(elapsed).toBeLessThan(2000);
+    expect(result.turn_durations_ms).toHaveLength(0);
+    // Real multi-poll settle loop (20 mutating banner polls); explicit
+    // timeout for CI headroom.
+  }, 20_000);
+
+  it("does NOT fast-fail when the assistant PRODUCED a response while a banner is also visible/sustained (success-in-flight wins)", async () => {
+    // Unified-rule scenario 6 (the old code let the banner win over a real
+    // response): an error banner can be visible AND sustained while the
+    // assistant ALSO produced a response this turn (count grew past
+    // baseline). A partial/non-fatal warning banner alongside a real answer
+    // must NOT force-fail the turn. The unified rule's condition (b) makes
+    // success-in-flight win: if the message count has grown past baseline,
+    // the turn never fast-fails — the settle path governs, and the turn
+    // SUCCEEDS.
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    const page = makePage({
+      // Assistant count grows past baseline IMMEDIATELY (baseline=0, then 1
+      // and frozen) → a real response is in flight from the first poll on.
+      evaluateValues: [0, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      // A FRESH, SUSTAINED banner is visible every poll (would fast-fail
+      // under the unified debounce if condition (b) didn't gate it on "no
+      // response produced"). Because the count grew, it must be ignored.
+      errorBannerValues: [
+        false,
+        { visible: true, text: "warn" },
+        { visible: true, text: "warn" },
+        { visible: true, text: "warn" },
+      ],
+      recorded,
+    });
+
+    const result = await runConversation(
+      page,
+      [{ input: "response plus banner", responseTimeoutMs: 5000 }],
+      { assistantSettleMs: 50 },
+    );
+
+    // Success-in-flight wins: count grew past baseline, so the sustained
+    // banner is ignored and the turn settles as a SUCCESS.
+    expect(result.turns_completed).toBe(1);
+    expect(result.failure_turn).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    // Real multi-poll settle loop; explicit timeout for CI headroom.
+  }, 20_000);
+
   it("empty turns array: returns zeroes immediately", async () => {
     const page = makePage();
     const result = await runConversation(page, []);
@@ -290,6 +764,62 @@ describe("runConversation", () => {
     expect(result.error).toBeUndefined();
     expect(result.turn_durations_ms).toEqual([]);
   });
+
+  it("RE-ARMS fast-fail when two banners share a 300-char prefix but differ after char 300 (truncation false-negative)", async () => {
+    // Finding 1 (truncation false-negative): a stale baseline banner and a
+    // NEW error banner can share an identical 300-char prefix (e.g. the same
+    // human-readable error copy) and differ only in a trailing suffix (a
+    // request-id, a timestamp, a distinct error code). If banner text is
+    // truncated to 300 chars BEFORE the `textChanged` comparison, the two
+    // distinct errors compare EQUAL → no fast-fail → the turn burns the full
+    // responseTimeout. The fix compares the FULL banner text, so a difference
+    // past char 300 still re-arms the fast-fail.
+    const prefix300 = "ERR " + "A".repeat(300 - 4); // exactly 300 chars
+    expect(prefix300.length).toBe(300);
+    const baselineText = prefix300 + "AAA"; // 303 chars
+    const newErrorText = prefix300 + "BBB"; // 303 chars, same first 300
+    // Sanity: the two differ ONLY after char 300.
+    expect(baselineText.slice(0, 300)).toBe(newErrorText.slice(0, 300));
+    expect(baselineText).not.toBe(newErrorText);
+
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    const page = makePage({
+      // Assistant count never grows past baseline (no new message arrives).
+      evaluateValues: [0],
+      // Banner visible at baseline with `baselineText` (stale), then its text
+      // changes to `newErrorText` mid-settle — differing only past char 300.
+      errorBannerValues: [
+        { visible: true, text: baselineText },
+        { visible: true, text: baselineText },
+        { visible: true, text: newErrorText },
+      ],
+      recorded,
+    });
+
+    const start = Date.now();
+    const result = await runConversation(
+      page,
+      [{ input: "trigger suffix-only error", responseTimeoutMs: 5000 }],
+      { assistantSettleMs: 50 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(result.turns_completed).toBe(0);
+    expect(result.failure_turn).toBe(1);
+    expect(result.error).toBeDefined();
+    // Fast-failed on the NEW error (differs only past char 300) — proves the
+    // comparison used the FULL text, not a 300-char truncation.
+    expect(result.error).toContain("copilot-error-banner visible");
+    expect(result.error!.toLowerCase()).not.toContain("timeout");
+    // The thrown message is truncated for log hygiene, so it carries the
+    // shared prefix; the distinguishing suffix may be elided. What matters is
+    // that we fast-failed at all (timeout would mean the bug reproduced).
+    expect(result.error).toContain(prefix300.slice(0, 50));
+    // Bailed well before the 5000ms responseTimeout — the whole point.
+    expect(elapsed).toBeLessThan(2000);
+    expect(result.turn_durations_ms).toHaveLength(0);
+    // Real multi-poll settle loop; explicit timeout for CI headroom.
+  }, 20_000);
 
   it("falls through the chat-input selectors and uses the first that resolves", async () => {
     // Track which selectors were tried. The first that doesn't throw wins.
@@ -478,6 +1008,14 @@ describe("runConversation", () => {
         if (fn.toString().includes("copilot-user-message")) {
           return userCalls++ as never;
         }
+        // Error-banner visibility probe: return the runner-expected
+        // `{ visible: false }` shape (mirrors `wrapEvaluateForUserMessages`).
+        // Without this branch the read fell through to the assistant-count
+        // path and returned a NUMBER — the no-banner path only "passed" by
+        // the accident that `(number).visible` is `undefined` (falsy).
+        if (fn.toString().includes("copilot-error-banner")) {
+          return { visible: false } as never;
+        }
         assistantCalls++;
         if (assistantCalls === 1) throw new Error("evaluate boom");
         return 1 as never;
@@ -525,6 +1063,12 @@ describe("runConversation", () => {
         // unscoped fallback that this fix was supposed to remove.
         return { length: 999 };
       },
+      // The error-banner probe (readErrorBanner) calls
+      // document.querySelector — returning null exercises the genuine
+      // "no banner" path. Without this the call throws a TypeError that
+      // readErrorBanner silently swallows, so the probe was never really
+      // tested here.
+      querySelector: (): null => null,
     };
 
     let userMsgCalls1 = 0;
@@ -541,14 +1085,23 @@ describe("runConversation", () => {
         // Patch globalThis.document with our fake for the duration
         // of the evaluate call. The selector-fn closes over
         // globalThis at runtime, mirroring the browser-side execution.
+        // Also stub getComputedStyle so the error-banner probe runs its
+        // real code path (returning a visible style) instead of throwing
+        // a swallowed TypeError on the missing global.
         const originalDoc = (globalThis as { document?: unknown }).document;
+        const originalGCS = (globalThis as { getComputedStyle?: unknown })
+          .getComputedStyle;
         (globalThis as { document?: unknown }).document = fakeDocument;
+        (globalThis as { getComputedStyle?: unknown }).getComputedStyle =
+          (() => ({ display: "block", visibility: "visible" })) as unknown;
         try {
           const r = fn();
           evalCount++;
           return r as never;
         } finally {
           (globalThis as { document?: unknown }).document = originalDoc;
+          (globalThis as { getComputedStyle?: unknown }).getComputedStyle =
+            originalGCS;
         }
       },
     };
@@ -589,6 +1142,10 @@ describe("runConversation", () => {
         }
         return { length: 999 };
       },
+      // The error-banner probe (readErrorBanner) calls
+      // document.querySelector — returning null exercises the genuine
+      // "no banner" path instead of a swallowed TypeError.
+      querySelector: (): null => null,
     };
 
     let userMsgCalls2 = 0;
@@ -601,14 +1158,22 @@ describe("runConversation", () => {
         if (fn.toString().includes("copilot-user-message")) {
           return userMsgCalls2++ as never;
         }
+        // Patch document + getComputedStyle so the error-banner probe
+        // runs its real "no banner" path (see the narrowing test above).
         const originalDoc = (globalThis as { document?: unknown }).document;
+        const originalGCS = (globalThis as { getComputedStyle?: unknown })
+          .getComputedStyle;
         (globalThis as { document?: unknown }).document = fakeDocument;
+        (globalThis as { getComputedStyle?: unknown }).getComputedStyle =
+          (() => ({ display: "block", visibility: "visible" })) as unknown;
         try {
           const r = fn();
           evalCount++;
           return r as never;
         } finally {
           (globalThis as { document?: unknown }).document = originalDoc;
+          (globalThis as { getComputedStyle?: unknown }).getComputedStyle =
+            originalGCS;
         }
       },
     };
@@ -1016,7 +1581,9 @@ describe("skipFill turns", () => {
     // Turn 1 Enter (from waitForContentAndSend) + Turn 2 Enter
     // (from fillAndVerifySend).
     expect(recorded.presses).toEqual(["Enter", "Enter"]);
-  });
+    // Drives 2 turns through real settle polling (~1.6s locally); explicit
+    // timeout for CI headroom.
+  }, 20_000);
 
   it("skipFill turn times out when textarea stays empty", async () => {
     const recorded = { fills: [] as string[], presses: [] as string[] };

--- a/showcase/harness/src/probes/helpers/conversation-runner.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.ts
@@ -98,6 +98,54 @@ export const ASSISTANT_MESSAGE_FALLBACK_SELECTOR =
 export const ASSISTANT_MESSAGE_HEADLESS_SELECTOR =
   '[data-message-role="assistant"]';
 
+/**
+ * Stable testid rendered by `@copilotkit/react-core` and
+ * `@copilotkit/react-ui` whenever a chat turn ERRORS (the `ErrorMessage`
+ * chat bubble, the `UsageBanner`, and the toast `BannerErrorDisplay` all
+ * carry it — merged in CopilotKit #5110). When this banner becomes
+ * visible during the assistant-settle wait, the turn has failed and the
+ * runner can fast-fail instead of burning the full response timeout.
+ */
+export const ERROR_BANNER_SELECTOR = '[data-testid="copilot-error-banner"]';
+
+/**
+ * Max characters of banner text to embed in the thrown
+ * `AssistantErroredError` message. This cap is for LOG HYGIENE ONLY — error
+ * banners can carry very long copy (stack-ish detail, repeated retry text)
+ * and we don't want to dump the whole thing into the runner's failure log.
+ *
+ * Critically, this truncation is applied ONLY when shaping the thrown
+ * message — NOT to the value `waitForAssistantSettled` compares across polls
+ * to re-arm fast-fail. Comparing truncated text would make two DIFFERENT
+ * errors that share a 300-char prefix (e.g. identical human copy + differing
+ * request-id/suffix) look equal, suppressing the fast-fail and forcing the
+ * full settle timeout. The comparison therefore uses the FULL banner text;
+ * see `readErrorBanner` (returns untruncated text) and the `textChanged`
+ * check in `waitForAssistantSettled`.
+ */
+const BANNER_MESSAGE_MAX_LENGTH = 300;
+
+/**
+ * Distinguished error thrown by `waitForAssistantSettled` when the chat
+ * error banner becomes visible during the settle wait. Carrying its own
+ * type lets callers tell a fast errored turn apart from a slow settle
+ * timeout. The conversation runner maps any thrown turn error to the
+ * driver's `conversation-error` classification, so an errored turn is
+ * reported as a (fast) `conversation-error` rather than waiting out the
+ * timeout and racing the wall-clock `feature-timeout`.
+ */
+export class AssistantErroredError extends Error {
+  constructor(bannerText?: string) {
+    const detail = bannerText?.trim().slice(0, BANNER_MESSAGE_MAX_LENGTH);
+    super(
+      detail
+        ? `chat errored: copilot-error-banner visible — ${detail}`
+        : "chat errored: copilot-error-banner visible",
+    );
+    this.name = "AssistantErroredError";
+  }
+}
+
 /** Max attempts for the fill+press verify-and-retry loop. */
 const SEND_VERIFY_MAX_ATTEMPTS = 3;
 /** How long to wait after pressing Enter before checking for a user message. */
@@ -752,6 +800,66 @@ async function readMessageCount(page: Page): Promise<number> {
 }
 
 /**
+ * Read whether a chat error banner (`[data-testid="copilot-error-banner"]`)
+ * is currently VISIBLE in the page, and return its FULL text when present.
+ * Visibility (not mere presence) matters: a banner kept in the DOM but
+ * hidden (`display:none` / zero-size / `visibility:hidden`) is not an
+ * active error. Returns `{ visible: false }` on any read error so a
+ * transient DOM hiccup never spuriously fast-fails a turn.
+ *
+ * Returns the UNTRUNCATED `textContent` on purpose: `waitForAssistantSettled`
+ * compares this text across polls to re-arm fast-fail, and truncating here
+ * would make two distinct errors sharing a long common prefix compare equal
+ * (suppressing the fast-fail). The length cap for log hygiene is applied
+ * downstream, only when building the thrown `AssistantErroredError` message
+ * (`BANNER_MESSAGE_MAX_LENGTH`).
+ *
+ * Reached via the same type-erased `globalThis` indirection as
+ * `readMessageCount` because the package tsconfig excludes the `dom` lib.
+ */
+async function readErrorBanner(
+  page: Page,
+): Promise<{ visible: boolean; text?: string }> {
+  try {
+    return await page.evaluate(() => {
+      const win = globalThis as unknown as {
+        document: {
+          querySelector(sel: string): {
+            textContent: string | null;
+            getBoundingClientRect(): { width: number; height: number };
+          } | null;
+        };
+        getComputedStyle(el: unknown): {
+          display: string;
+          visibility: string;
+        };
+      };
+      const el = win.document.querySelector(
+        '[data-testid="copilot-error-banner"]',
+      );
+      if (!el) return { visible: false };
+      const style = win.getComputedStyle(el);
+      if (style.display === "none" || style.visibility === "hidden") {
+        return { visible: false };
+      }
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) {
+        return { visible: false };
+      }
+      return {
+        visible: true,
+        // FULL text — see docstring. Truncation happens only when shaping
+        // the thrown AssistantErroredError message, never on the value
+        // compared across polls to re-arm fast-fail.
+        text: el.textContent ?? "",
+      };
+    });
+  } catch {
+    return { visible: false };
+  }
+}
+
+/**
  * Block until the assistant-message count has grown past `baselineCount`
  * AND remained stable for `settleMs`, OR until `timeoutMs` elapses.
  * Returns the final stable count on success. Throws a `timeout` Error
@@ -761,6 +869,47 @@ async function readMessageCount(page: Page): Promise<number> {
  * timestamp of the most recent count change. If the current poll's
  * count is positive, has surpassed baseline, and `now - lastChangeAt
  * >= settleMs`, the response has settled.
+ *
+ * Fast-fail (ONE unified rule). Each poll also checks the chat error banner
+ * (`[data-testid="copilot-error-banner"]`). We snapshot the banner's
+ * visibility AND text ONCE at the turn's baseline (`bannerVisibleAtBaseline`,
+ * `bannerTextAtBaseline`), then each poll compute a single boolean:
+ *
+ *   errorStateNow = banner.visible &&
+ *                   (!bannerVisibleAtBaseline ||
+ *                    banner.text !== bannerTextAtBaseline)
+ *
+ * i.e. "an error banner is present in a state that DIFFERS from baseline".
+ * This single condition covers BOTH a brand-new banner (none at baseline)
+ * AND a persisted banner whose text changed — and it stays true even if the
+ * banner text keeps mutating each poll (a retry countdown, a live timestamp,
+ * a rotating request-id), because it only requires "differs from baseline",
+ * not a stable exact value across polls.
+ *
+ * We fast-fail (throw `AssistantErroredError`) only when ALL of:
+ *   (a) `errorStateNow` is true on 2 CONSECUTIVE polls. A single consecutive
+ *       counter debounces BOTH the new-banner and changed-banner cases; any
+ *       poll where `errorStateNow` is false resets it to 0. A single isolated
+ *       differs-from-baseline poll (a transient toast flicker, a one-poll
+ *       text glitch on a succeeding turn) therefore does NOT fire.
+ *   (b) the assistant has NOT produced a response this turn — the message
+ *       count has NOT grown past `baselineCount`. Success-in-flight wins: if
+ *       `current > baselineCount`, we never fast-fail (a non-fatal warning
+ *       banner alongside a real answer must not force-fail the turn); the
+ *       settle path governs instead.
+ *
+ * CopilotKit error banners persist across turns, so a stale same-text banner
+ * left over from a prior turn keeps `errorStateNow` false (text == baseline,
+ * banner was visible at baseline) and is intentionally NOT treated as this
+ * turn's error. The full (untruncated) banner text is compared — truncation
+ * applies only to the thrown message (`BANNER_MESSAGE_MAX_LENGTH`) — so two
+ * errors diverging only after the first 300 chars still differ from baseline.
+ *
+ * Inherent (now much smaller) limitation: a differs-from-baseline state that
+ * flickers true for only single ISOLATED polls (never 2 in a row) won't fire,
+ * and a brand-new error whose banner text is byte-identical to a persisted
+ * stale banner cannot be distinguished from it (both keep `errorStateNow`
+ * false). Both fall back to the settle/timeout path. This is intended.
  */
 async function waitForAssistantSettled(opts: {
   page: Page;
@@ -774,18 +923,82 @@ async function waitForAssistantSettled(opts: {
   let lastChangeAt = Date.now();
   let pollCount = 0;
   let lastLoggedCount = lastCount;
+  // Snapshot the error banner's visibility AND text ONCE BEFORE this turn's
+  // response arrives. A pre-existing (stale) banner must not be mistaken for
+  // this turn's error — but because CopilotKit banners persist across turns,
+  // a boolean "was it visible" snapshot alone would disable fast-fail for the
+  // whole turn whenever any banner lingered. Capturing the text lets the
+  // unified `errorStateNow` condition re-arm on a NEW or text-CHANGED banner
+  // even while a stale same-text banner is still on screen.
+  const baselineBanner = await readErrorBanner(page);
+  const bannerVisibleAtBaseline = baselineBanner.visible;
+  const bannerTextAtBaseline = baselineBanner.text;
+  // Single debounce counter shared by BOTH the new-banner and changed-banner
+  // cases: the number of CONSECUTIVE polls on which `errorStateNow` has been
+  // true. Any poll where `errorStateNow` is false resets it to 0. Fast-fail
+  // fires once it reaches 2 — see the unified rule in the docstring above.
+  let consecutiveErrorPolls = 0;
 
   console.debug("[conversation-runner] waitForAssistantSettled — start", {
     baselineCount,
     initialCount: lastCount,
     settleMs,
     timeoutMs,
+    bannerVisibleAtBaseline,
+    bannerTextAtBaseline,
   });
 
   while (Date.now() < deadline) {
     await sleep(POLL_INTERVAL_MS);
+
     const current = await readMessageCount(page);
     pollCount++;
+
+    // Unified fast-fail rule. Compute a single boolean: an error banner is
+    // present in a state that DIFFERS from baseline (a brand-new banner, OR a
+    // persisted banner whose text changed). This stays true even if the text
+    // keeps mutating each poll, since it only requires "differs from
+    // baseline", not a stable exact value.
+    const banner = await readErrorBanner(page);
+    const errorStateNow =
+      banner.visible &&
+      (!bannerVisibleAtBaseline || banner.text !== bannerTextAtBaseline);
+
+    // Condition (b): success-in-flight wins. If the assistant produced a
+    // response this turn (count grew past baseline), NEVER fast-fail — a
+    // non-fatal warning banner alongside a real answer must not force-fail
+    // the turn; the settle path governs. A produced response also disarms
+    // the consecutive-error counter so a banner that appears only after the
+    // response can't retroactively fire.
+    if (current > baselineCount) {
+      consecutiveErrorPolls = 0;
+    } else if (errorStateNow) {
+      // Condition (a): require 2 CONSECUTIVE differs-from-baseline polls
+      // before fast-failing, so a single isolated flicker (a transient toast,
+      // a one-poll text glitch on a succeeding turn) does not raise a spurious
+      // error.
+      consecutiveErrorPolls++;
+      if (consecutiveErrorPolls >= 2) {
+        console.debug(
+          "[conversation-runner] waitForAssistantSettled — error banner differs from baseline across 2 consecutive polls (no response produced), fast-failing",
+          {
+            baselineCount,
+            lastCount,
+            current,
+            pollCount,
+            elapsedMs: Date.now() - (deadline - timeoutMs),
+            bannerText: banner.text,
+            baselineBannerText: bannerTextAtBaseline,
+            bannerVisibleAtBaseline,
+          },
+        );
+        throw new AssistantErroredError(banner.text);
+      }
+    } else {
+      // No differing error state this poll → disarm the debounce.
+      consecutiveErrorPolls = 0;
+    }
+
     if (current !== lastCount) {
       console.debug(
         "[conversation-runner] waitForAssistantSettled — message count changed",


### PR DESCRIPTION
## Summary

`waitForAssistantSettled` now fast-fails (throws `AssistantErroredError`, classified `conversation-error`, in ~2s) instead of burning the full 30s `responseTimeoutMs` when the chat surfaces a genuine error banner.

Each poll snapshots the `copilot-error-banner` testid (shipped in #5110) and computes a single boolean — an error banner is present in a state that **DIFFERS from the turn's baseline** (a brand-new banner, OR a persisted banner whose text changed). The turn fast-fails only when ALL of:

- that differs-from-baseline state is **SUSTAINED across 2 consecutive polls** (a single isolated flicker — a transient toast, a one-poll re-render glitch — is debounced away and does NOT fire), AND
- the assistant produced **NO response this turn** (the message count has not grown past baseline). **Success-in-flight wins**: a non-fatal warning banner alongside a real answer never force-fails the turn; the settle path governs instead.

Because it only acts when the turn would otherwise time out (no response + a sustained error), this is a **strict improvement**: it can only turn a would-be timeout-fail into a fast fail of the **same verdict** — it can never flip a verdict. The full (untruncated) banner text is compared across polls so two errors diverging only after the first 300 chars still differ; truncation applies only to the thrown message.

## Test plan

Red-green unit tests in `conversation-runner.test.ts` (full harness suite green: 1684 passed):

- [x] fresh-banner flicker for a single poll then disappears → does NOT fast-fail (turn succeeds)
- [x] persisted-banner text flicker for a single poll then reverts → does NOT fast-fail (turn succeeds)
- [x] sustained differs-from-baseline across 2 consecutive polls (no response) → fast-fails (~2s, not a timeout)
- [x] dynamic/mutating banner text (countdown/timestamp) sustained across 2 polls → fast-fails (dynamic-text fires)
- [x] stale same-text persisted banner (text == baseline) → no fast-fail (correctly treated as prior turn's error)
- [x] success-in-flight: assistant produced a response while a banner is also visible → does NOT fast-fail (success wins)
- [x] 300-char-prefix: two errors diverging only after the first 300 chars still differ from baseline (full-text compare)
- [x] **mutation check**: temporarily relaxing the debounce to fire on a single poll (`>= 1`) makes both single-poll-flicker tests FAIL, then restored to `>= 2` — proving the two tests genuinely guard the 2-consecutive-poll debounce-reset path (not the success-in-flight disarm)

## Known limitations

Two intentional safe-degrade edges fall back to the normal timeout (correct verdict, just not sped up):

- **count-oscillation**: a response count that briefly grows past baseline and then reverts disarms the debounce, so an error that only sustains after that bounce settles via timeout.
- **synchronous-error-at-baseline**: a brand-new error whose banner text is byte-identical to a persisted stale banner already visible at baseline cannot be distinguished from it, so it settles via timeout.