### PR TITLE
fix(showcase/harness): harden BrowserPool slot publication

### DIFF
--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -332,6 +332,135 @@ describe("BrowserPool dead-instance detection", () => {
     await pool.shutdown();
   });
 
+  it("does not double-publish a slot to available when the same live browser is released twice", async () => {
+    // Bug #1 guard. release(browser) looks the slot up via browserToSlot; a
+    // still-live slot (not recycled) survives a SECOND release(sameBrowser),
+    // and the no-waiter branch used to `this.available.push(slot)`
+    // UNCONDITIONALLY — so the slot appeared twice in `available` and the next
+    // two acquires handed the SAME browser to two probes. handOff already
+    // guards this with `!this.available.includes(slot)`; release must too.
+    // Single-slot pool so the only slot's publication count is directly
+    // observable: a double-push duplicates the SOLE slot in `available`.
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool(1, 100, undefined, launchBrowser, 0);
+    await pool.init();
+
+    const browser = await pool.acquire();
+    expect(browser).toBe(launched[0] as unknown as Browser);
+
+    // Double-release the SAME live browser. The second release must be a
+    // no-op for `available` (the slot is already queued) — not a second push.
+    pool.release(browser);
+    pool.release(browser);
+
+    // The single slot must appear in `available` exactly once after the
+    // double-release — never twice.
+    expect(pool.stats().available).toBe(1);
+
+    // First acquire draws the (single) slot, emptying `available`. With the
+    // double-push the duplicate would remain, so a SECOND immediate acquire
+    // would wrongly hand out the SAME browser to a concurrent probe; with the
+    // guard `available` is empty and the second acquire parks as a waiter.
+    const first = await pool.acquire();
+    expect(first).toBe(launched[0] as unknown as Browser);
+
+    await expect(pool.acquire(50)).rejects.toThrow(
+      "BrowserPool acquire timeout",
+    );
+
+    await pool.shutdown();
+  });
+
+  it("does not hand the SAME live browser to two waiters when it is released twice while waiters are queued", async () => {
+    // Bug guard (idempotent release on the WAITER path). release(browser)
+    // routes a live return through handOff(slot, slot.browser). handOff's
+    // waiter branch is `const w = this.waiters.shift(); if (w) w.resolve(b)`
+    // with NO idempotency guard. A SECOND release(sameLiveBrowser) still finds
+    // the slot in browserToSlot (a live slot is never deleted), passes the
+    // contextCount/isConnected checks, calls handOff again, shifts a SECOND
+    // waiter and resolves it with the SAME browser — two probes driving one
+    // chromium. The existing `!available.includes(slot)` guard only covers the
+    // NO-waiter branch; the waiter branch was unguarded. Checked-out tracking
+    // makes the second release a no-op on BOTH paths.
+    //
+    // Single-slot pool so the only live browser's publication is directly
+    // observable. Acquire it (checking it out), queue TWO waiters, then
+    // double-release the SAME browser. Only ONE waiter may be served with it;
+    // the second release is a no-op so the second waiter stays pending until
+    // its own timeout.
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool(1, 100, undefined, launchBrowser, 0);
+    await pool.init();
+
+    const browser = await pool.acquire();
+    expect(browser).toBe(launched[0] as unknown as Browser);
+
+    // Queue two waiters (no available slots — the only browser is held).
+    const waiterA = pool.acquire(5_000);
+    const waiterB = pool.acquire(150);
+    await drainMicrotasks();
+
+    // Double-release the SAME live browser. The first release serves waiterA;
+    // the second MUST be a no-op (the slot is no longer checked out), so it
+    // must NOT shift and resolve waiterB with the same browser.
+    pool.release(browser);
+    pool.release(browser);
+
+    const settled = await Promise.allSettled([waiterA, waiterB]);
+    // waiterA was served with the live browser.
+    expect(settled[0]!.status).toBe("fulfilled");
+    expect((settled[0] as PromiseFulfilledResult<Browser>).value).toBe(
+      launched[0] as unknown as Browser,
+    );
+    // waiterB must NOT have been resolved with the same browser — it stays
+    // pending and times out. With the bug it would resolve with launched[0].
+    expect(settled[1]!.status).toBe("rejected");
+    expect((settled[1] as PromiseRejectedResult).reason).toMatchObject({
+      message: "BrowserPool acquire timeout",
+    });
+
+    // Exactly one browser was ever launched — no fresh one, and the single one
+    // was handed to exactly one waiter.
+    expect(launched).toHaveLength(1);
+
+    await pool.shutdown();
+  });
+
+  it("reports stats().inUse from actually-checked-out slots, decrementing on release", async () => {
+    // inUse must reflect slots currently handed to a caller, derived from the
+    // checked-out set, not the `liveSlots.length - available` subtraction.
+    const { launchBrowser } = makeFakeLauncher();
+    const pool = new BrowserPool(2, 100, undefined, launchBrowser, 0);
+    await pool.init();
+
+    expect(pool.stats().inUse).toBe(0);
+    expect(pool.stats().available).toBe(2);
+
+    const a = await pool.acquire();
+    expect(pool.stats().inUse).toBe(1);
+    expect(pool.stats().available).toBe(1);
+
+    const b = await pool.acquire();
+    expect(pool.stats().inUse).toBe(2);
+    expect(pool.stats().available).toBe(0);
+
+    pool.release(a);
+    expect(pool.stats().inUse).toBe(1);
+    expect(pool.stats().available).toBe(1);
+
+    // Idempotent: a second release of the same browser must not drive inUse
+    // negative or otherwise corrupt the count.
+    pool.release(a);
+    expect(pool.stats().inUse).toBe(1);
+    expect(pool.stats().available).toBe(1);
+
+    pool.release(b);
+    expect(pool.stats().inUse).toBe(0);
+    expect(pool.stats().available).toBe(2);
+
+    await pool.shutdown();
+  });
+
   it("recovers after a transient relaunch failure instead of permanently shrinking the pool to 0", async () => {
     // Single-slot pool. The browser crashes; the recycle's relaunch fails
     // ONCE (the 2nd launch call), then a subsequent launch succeeds. The
@@ -357,6 +486,82 @@ describe("BrowserPool dead-instance detection", () => {
 
     // Pool reports non-zero size again — it healed rather than draining.
     expect(pool.stats().size).toBeGreaterThan(0);
+
+    await pool.shutdown();
+  });
+
+  it("does not hand a queued waiter a browser that is already disconnected at handoff time", async () => {
+    // Bug #2 guard. The acquire() available-scan recycles a zombie before
+    // handing it out, but the WAITER-served path (handOff) used to
+    // `waiter.resolve(browser)` with NO liveness check. So a browser that
+    // silently disconnected in the window between launch and handoff could be
+    // delivered to a waiting probe. handOff (and release's waiter branch) must
+    // check `browser.isConnected()` before resolving; if dead, recycle the
+    // slot and leave the waiter queued so a LIVE browser serves it.
+    //
+    // Single-slot pool. Crash the only browser to drive a recycle. The
+    // recycle's first relaunch (call 2) returns a browser that is BORN DEAD
+    // (silently disconnected the instant it is launched), so at handOff time
+    // it reports isConnected() === false. A waiter is queued before the
+    // handoff. The waiter must NOT be resolved with the dead browser; instead
+    // the slot recycles again and call 3 (a live browser) serves the waiter.
+    const launched: FakeBrowser[] = [];
+    let callCount = 0;
+    let releaseRelaunch: (() => void) | undefined;
+    const relaunchGate = new Promise<void>((resolve) => {
+      releaseRelaunch = resolve;
+    });
+    const launchBrowser: LaunchBrowser = async () => {
+      callCount++;
+      const b = makeFakeBrowser();
+      launched.push(b);
+      if (callCount === 2) {
+        // The recycle replacement is born dead: it launches, then silently
+        // disconnects before the pool hands it to the waiter. Gate it so we
+        // can queue a waiter before the handoff runs.
+        await relaunchGate;
+        b.__silentlyDisconnect();
+      }
+      return b as unknown as Browser;
+    };
+    const { logger } = makeFakeLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
+    await pool.init();
+    expect(launched).toHaveLength(1);
+
+    // Crash the only browser; the disconnect-driven recycle starts and its
+    // relaunch (call 2) blocks on the gate.
+    launched[0]!.__crash();
+    await waitFor(() => callCount >= 2, 3_000);
+
+    // Queue a waiter while the (born-dead) relaunch is gated. acquire sees no
+    // available slot and parks this waiter.
+    const acquirePromise = pool.acquire(5_000);
+    await drainMicrotasks(10);
+
+    // Release the gated relaunch. The fresh browser is born dead, so handOff
+    // must NOT resolve the waiter with it — it parks the slot relaunchPending
+    // (the slot is busy in the recycle path) and leaves the waiter QUEUED.
+    releaseRelaunch!();
+    await drainMicrotasks(20);
+
+    // The recycle path is busy at handoff time, so recovery is lazy: a
+    // subsequent acquire() drives relaunchPendingSlots, relaunches (call 3 —
+    // live), and serves the still-queued ORIGINAL waiter via handOff (FIFO).
+    // This second acquire's own waiter then times out (single slot already
+    // re-held), but the original `acquirePromise` resolves with the LIVE
+    // browser. (Driving recovery on the next probe tick is the pool's
+    // intended lazy-recovery contract.)
+    const second = pool.acquire(50);
+
+    const acquired = await acquirePromise;
+    expect((acquired as unknown as FakeBrowser).isConnected()).toBe(true);
+    // The waiter was served a LIVE browser, never the born-dead call-2 one.
+    expect((acquired as unknown as FakeBrowser).__id).not.toBe(
+      launched[1]!.__id,
+    );
+
+    await expect(second).rejects.toThrow("BrowserPool acquire timeout");
 
     await pool.shutdown();
   });
@@ -911,6 +1116,82 @@ describe("BrowserPool dead-instance detection", () => {
     await Promise.allSettled([a, b]);
   });
 
+  it("tracks the SAME wrapper object it removes, so awaiting the tracked promise waits for its cleanup", async () => {
+    // Bug #3 guard. track(promise) added the RAW inner promise to
+    // inFlightRecycles, while the wrapper it returned (and the inner methods
+    // await) was `promise.catch(...).finally(() => delete(promise))`. shutdown
+    // drains `Array.from(inFlightRecycles)` — i.e. the RAW promise, which
+    // settles one or more microtasks BEFORE the wrapper's `.finally` cleanup
+    // runs. So a consumer that awaits the EXACT object in the set (as shutdown
+    // does) is NOT guaranteed the cleanup has run when that await resolves —
+    // the drain under-waits. recycleSlot does this correctly (adds and removes
+    // the same recyclePromise object). The fix makes track add/return the SAME
+    // wrapper, so the object shutdown awaits is the very wrapper whose
+    // `.finally` removes it — when it settles, the cleanup has run.
+    //
+    // Behavioral RED that does NOT depend on microtask luck: grab the exact
+    // object stored in inFlightRecycles (what shutdown awaits), await THAT
+    // object, then SYNCHRONOUSLY assert the set is empty. With the fix the set
+    // element IS the wrapper, so its `.finally` ran by the time the await
+    // resolves → set empty. With the bug the set element is the RAW promise,
+    // which resolves BEFORE the wrapper's `.finally` → set still has 1 entry at
+    // that synchronous checkpoint. The private set is read reflectively
+    // (white-box) per the bug's nature: raw-vs-wrapper is otherwise
+    // unobservable because the inner recovery methods swallow their own errors.
+    const launched: FakeBrowser[] = [];
+    let callCount = 0;
+    let releaseReinit: (() => void) | undefined;
+    const reinitGate = new Promise<void>((resolve) => {
+      releaseReinit = resolve;
+    });
+    const launchBrowser: LaunchBrowser = async () => {
+      callCount++;
+      // init's launch (call 1) fails so this.slots stays empty → the next
+      // acquire drives the reinit() backstop, whose launch (call 2) we gate.
+      if (callCount === 1) {
+        throw new Error("simulated launch failure");
+      }
+      if (callCount === 2) {
+        await reinitGate;
+      }
+      const b = makeFakeBrowser();
+      launched.push(b);
+      return b as unknown as Browser;
+    };
+    const { logger } = makeFakeLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
+    // init's only launch (call 1) throws → this.slots empty, but rawLaunchBrowser
+    // is set so the empty-pool reinit backstop can run.
+    await expect(pool.init()).rejects.toThrow("simulated launch failure");
+
+    // Drive the reinit backstop via an acquire; its launch (call 2) blocks on
+    // the gate, so a tracked recovery promise is in flight. A short timeout so
+    // the waiter (acquire re-queues after reinit returns) rejects promptly
+    // instead of hanging the test.
+    const acquirePromise = pool.acquire(100);
+    await waitFor(() => callCount >= 2, 3_000);
+
+    const inFlight = (pool as unknown as { inFlightRecycles: Set<unknown> })
+      .inFlightRecycles;
+    expect(inFlight.size).toBe(1);
+
+    // The exact object shutdown would await — the single tracked entry.
+    const tracked = Array.from(inFlight)[0] as Promise<unknown>;
+
+    // Release the gated launch so the tracked recovery settles.
+    releaseReinit!();
+
+    // Await the EXACT tracked object, then synchronously check the set. With
+    // the fix this object is the wrapper whose `.finally` removed it → empty.
+    // With the bug it is the raw promise, which settles before cleanup → not
+    // yet empty.
+    await tracked;
+    expect(inFlight.size).toBe(0);
+
+    await pool.shutdown();
+    await Promise.allSettled([acquirePromise]);
+  });
+
   it("shutdown() does not loop the disconnect handler when closing slot browsers", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
     const { logger, events } = makeFakeLogger();
@@ -969,6 +1250,83 @@ function makeRecordingLauncher(opts?: { launchDurationMs?: number }): {
   };
   return rec;
 }
+
+describe("BrowserPool waiter-served release-leak (CR finding)", () => {
+  it("recovers the slot when the served waiter releases the browser in its own awaited continuation", async () => {
+    // CR finding (7-agent confirmation round): release() was made idempotent
+    // via the `checkedOut` Set. In handOff's waiter branch the slot's
+    // `checkedOut.add(slot)` is DEFERRED via queueMicrotask (microtask M),
+    // while `waiter.resolve(browser)` runs synchronously right after. The
+    // worry: the served waiter's await-continuation (call it C) calls
+    // `release(browser)` BEFORE M runs, so release hits `!checkedOut.has(slot)`
+    // → no-ops → the slot is ORPHANED (never returned to `available`,
+    // contextCount never advances) = permanent capacity leak.
+    //
+    // Counter-claim: M is queued BEFORE resolve(), and resolve() schedules C,
+    // so by microtask FIFO M runs before C — making the leak unreachable. This
+    // test settles that timing claim empirically.
+    //
+    // Scenario: single-slot pool. A holder owns the only browser; a waiter is
+    // parked. The holder releases, which serves the waiter via handOff. In the
+    // WAITER'S OWN awaited continuation we immediately (synchronously, in that
+    // continuation's frame) release the served browser back to the pool. If the
+    // leak is real, that release no-ops and the slot is lost; if FIFO holds, the
+    // slot is recovered and lands back in `available`.
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool(1, 100, undefined, launchBrowser, 0);
+    await pool.init();
+
+    // Holder takes the only browser; slot is now checked out, none available.
+    const holderBrowser = await pool.acquire();
+    expect(holderBrowser).toBe(launched[0] as unknown as Browser);
+    expect(pool.stats().available).toBe(0);
+    expect(pool.stats().inUse).toBe(1);
+
+    // Park a waiter. Its continuation models a real probe: await the acquire,
+    // then synchronously release the browser it was served — exactly the frame
+    // the finding targets (C running before microtask M).
+    let waiterReleased = false;
+    const waiterFlow = (async () => {
+      const servedBrowser = await pool.acquire(5_000);
+      // Synchronous release inside the waiter's own continuation frame.
+      pool.release(servedBrowser);
+      waiterReleased = true;
+      return servedBrowser;
+    })();
+
+    // Let the waiter park before the holder releases.
+    await drainMicrotasks();
+
+    // Holder releases — handOff serves the parked waiter with the live browser,
+    // deferring `checkedOut.add(slot)` to microtask M and resolving the waiter
+    // synchronously. The waiter's continuation C then releases the browser.
+    pool.release(holderBrowser);
+
+    // Drain everything so M and C have both run.
+    const servedBrowser = await waiterFlow;
+    await drainMicrotasks(20);
+
+    expect(waiterReleased).toBe(true);
+    expect(servedBrowser).toBe(launched[0] as unknown as Browser);
+
+    // THE ASSERTION THAT SETTLES IT: the slot must have been RECOVERED by the
+    // waiter's release. If the leak is real, available stays 0 and inUse stays
+    // pinned at 1 (orphaned slot) — capacity permanently lost.
+    expect(pool.stats().available).toBe(1);
+    expect(pool.stats().inUse).toBe(0);
+
+    // And the recovered slot must be re-acquirable (back in rotation), proving
+    // it is genuinely usable capacity, not a phantom available count.
+    const reacquired = await pool.acquire(1_000);
+    expect(reacquired).toBe(launched[0] as unknown as Browser);
+    expect(pool.stats().inUse).toBe(1);
+
+    // No fresh browser was ever launched — the single one cycled correctly.
+    expect(launched).toHaveLength(1);
+
+    await pool.shutdown();
+  });
+});
 
 describe("BrowserPool launch serialization gate", () => {
   it("serializes the initial-fill burst to concurrency 1 and staggers each launch", async () => {

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -128,6 +128,17 @@ export class BrowserPool {
   // the slot in O(1) even after the slot was removed from `available`.
   private browserToSlot = new Map<Browser, Slot>();
 
+  // Slots whose browser is currently handed out to a caller (acquire's
+  // available-scan return, or a handOff that resolved a waiter). A slot enters
+  // this set exactly when its browser is delivered to a holder and leaves it
+  // exactly when that holder releases it (or the slot is recycled). It is the
+  // idempotency anchor for release(): a release() whose slot is NOT in this set
+  // is a double/foreign return and must be a no-op, so the same live browser
+  // can never be handed to two waiters via handOff's unguarded waiter branch.
+  // It also backs `stats().inUse` directly (the count of checked-out slots),
+  // which is more precise than the prior `liveSlots - available` subtraction.
+  private checkedOut = new Set<Slot>();
+
   constructor(
     size = 4,
     recycleAfter?: number,
@@ -262,15 +273,78 @@ export class BrowserPool {
 
   /**
    * Single waiter-first handoff used by every slot-recovery path (reinit,
-   * recycle success, relaunchPendingSlots). A freshly launched browser must
-   * go to a queued waiter if one exists — otherwise the waiter is stranded
-   * until its acquire timeout while a live browser sits idle in `available`.
-   * Only when there is no waiter does the slot land in `available` (guarded
-   * by `includes` so a slot is never published twice).
+   * recycle success, relaunchPendingSlots) AND by release(). A freshly
+   * launched (or just-released) browser must go to a queued waiter if one
+   * exists — otherwise the waiter is stranded until its acquire timeout while
+   * a live browser sits idle in `available`. Only when there is no waiter
+   * does the slot land in `available` (guarded by `includes` so a slot is
+   * never published twice).
+   *
+   * Liveness gate: the acquire() available-scan recycles a zombie
+   * (`!isConnected()`) before handing it out, but the waiter-served path
+   * historically did not — so a browser that silently disconnected in the
+   * window between launch/release and this handoff could be delivered to a
+   * waiting probe. Before resolving a waiter (or publishing to `available`),
+   * check `isConnected()`. If the browser is dead, do NOT hand it out: leave
+   * the waiter QUEUED (so a live browser serves it) and route the slot back
+   * into recovery —
+   *   - if the slot is idle (release()'s path), `recycleSlot` re-launches it
+   *     immediately and its eventual handOff serves the still-queued waiter;
+   *   - if the slot is already owned by a recovery path (recycle IIFE /
+   *     relaunchPendingSlots, where `isSlotBusy` is true and `recycleSlot`
+   *     would no-op), park it `relaunchPending` so the next acquire's
+   *     `relaunchPendingSlots` re-launches and serves the queued waiter.
+   * Either way the waiter is never dropped and a dead browser is never
+   * handed out.
    */
   private handOff(slot: Slot, browser: Browser): void {
+    if (!browser.isConnected()) {
+      // warn, not info: this is a capacity-affecting event — it strands a
+      // queued waiter (kept queued, served later by a live browser) and routes
+      // the slot back into recovery. It must reach the warn/Sentry alert
+      // pipeline, consistent with reinit-empty / recycle-relaunch-failed.
+      this.logger?.warn?.("browser-pool.handoff-dead-browser", {
+        slotIndex: this.slots.indexOf(slot),
+      });
+      // Keep the waiter queued — do NOT shift it. Route the slot back into
+      // recovery so a live browser serves the waiter on a later tick.
+      if (this.isSlotBusy(slot)) {
+        slot.relaunchPending = true;
+      } else {
+        this.recycleSlot(slot);
+      }
+      return;
+    }
     const waiter = this.waiters.shift();
     if (waiter) {
+      // The waiter is now the slot's holder, so its eventual release() is the
+      // one (and only) release that may return this slot. Mark it checked out —
+      // but DEFER the mark to a microtask. release() calls handOff synchronously
+      // (the live-slot return path), so a re-add HERE would make the slot
+      // checked-out again WITHIN the same synchronous frame as a double
+      // `release(sameBrowser)`: the original holder's second release would then
+      // pass the `checkedOut.has(slot)` guard and steal THIS waiter's
+      // release-right, shifting and resolving a second waiter with the same
+      // browser. Deferring the re-add to a microtask keeps the slot un-checked
+      // through the rest of the current synchronous frame (so the second
+      // release is a no-op) while still marking it long before the waiter — a
+      // distinct task scheduled by `resolve()` — could ever release it. (A
+      // recycle/shutdown that supersedes this handoff between now and the
+      // microtask clears `checkedOut` for the slot, so the deferred add cannot
+      // resurrect a stale checkout: it only re-checks the slot is still the
+      // live holder's by re-confirming the browser still maps to it.)
+      // LOAD-BEARING ordering (covered by the "waiter-served release does not
+      // leak the slot" control-mutant test): the checkedOut.add MUST be
+      // enqueued via queueMicrotask BEFORE waiter.resolve so it runs before the
+      // waiter's resolve continuation (microtask FIFO). Do NOT refactor to
+      // setTimeout or extra .then hops — any reordering re-opens the
+      // double-serve race the mutant test guards against.
+      const waitingBrowser = browser;
+      queueMicrotask(() => {
+        if (this.browserToSlot.get(waitingBrowser) === slot) {
+          this.checkedOut.add(slot);
+        }
+      });
       waiter.resolve(browser);
     } else if (!this.available.includes(slot)) {
       this.available.push(slot);
@@ -304,21 +378,36 @@ export class BrowserPool {
    * closes.
    */
   private track(promise: Promise<void>): Promise<void> {
-    this.inFlightRecycles.add(promise);
-    // Chain the cleanup onto what we return (and await), and absorb any throw
-    // with a logged `.catch` so it can never surface as an unhandled
-    // rejection. The inner methods swallow their own launch errors today, but
-    // a future throw inside reinitInner/relaunchPendingSlotsInner must stay
-    // contained — a recovery launch failing is non-fatal to the pool.
-    return promise
+    // Build the wrapper FIRST, then track and return the SAME wrapper object.
+    // Tracking the raw `promise` while returning a distinct wrapper would let
+    // `shutdown()`'s `Array.from(inFlightRecycles)` drain await the RAW promise
+    // — which settles BEFORE the wrapper's `.catch`/`.finally` post-settle work
+    // runs — so the drain would under-wait and shutdown could proceed before
+    // this recovery's cleanup completed. Adding/removing the SAME object means
+    // shutdown awaits the wrapper (including its cleanup).
+    //
+    // Note recycleSlot does NOT follow this same-object pattern: it adds the
+    // RAW IIFE `recyclePromise` to `inFlightRecycles` and its `.catch`/`.finally`
+    // is a SEPARATE chain. That is fine there because shutdown awaits the IIFE,
+    // whose body performs the real recovery work — only the inert post-shutdown
+    // set-cleanup in the detached `.finally` is under-waited, which is harmless.
+    // Here, by contrast, the wrapper's `.catch`/`.finally` is the only thing
+    // tracked, so it must be the SAME object that is added and removed.
+    // The `.catch` absorbs any throw with a logged event so it can never
+    // surface as an unhandled rejection (the inner methods swallow their own
+    // launch errors today, but a future throw must stay contained — a recovery
+    // launch failing is non-fatal to the pool).
+    const wrapped: Promise<void> = promise
       .catch((err: unknown) => {
         this.logger?.error?.("browser-pool.recovery-failed", {
           error: err instanceof Error ? err.message : String(err),
         });
       })
       .finally(() => {
-        this.inFlightRecycles.delete(promise);
+        this.inFlightRecycles.delete(wrapped);
       });
+    this.inFlightRecycles.add(wrapped);
+    return wrapped;
   }
 
   /**
@@ -514,15 +603,19 @@ export class BrowserPool {
     // Skip zombie slots whose browser has disconnected but whose disconnect
     // handler hasn't yet completed the recycle. Without this loop, a single
     // dead chromium process locks every probe that draws its slot until
-    // either the harness restarts or 100 release-cycles trigger the
+    // either the harness restarts or `recycleAfter` release-cycles trigger the
     // contextCount-based recycle. Each zombie is kicked into recycle so the
     // pool self-heals across ticks.
     while (this.available.length > 0) {
       const slot = this.available.shift()!;
       if (slot.browser.isConnected()) {
+        // This slot is now handed to the caller — mark it checked out so its
+        // matching release() is the single return that may re-publish it, and
+        // a duplicate release() is a no-op.
+        this.checkedOut.add(slot);
         this.logger?.info("browser-pool.acquire", {
           available: this.available.length,
-          inUse: this.slots.length - this.available.length,
+          inUse: this.checkedOut.size,
         });
         return slot.browser;
       }
@@ -572,6 +665,20 @@ export class BrowserPool {
     // Browser was already recycled or doesn't belong to this pool.
     if (!slot) return;
 
+    // Idempotency guard covering BOTH return paths. A live slot is never
+    // removed from `browserToSlot`, so a SECOND release(sameLiveBrowser) still
+    // resolves the slot here and — without this check — would re-enter handOff,
+    // shift a SECOND waiter, and resolve it with the SAME browser (two probes
+    // driving one chromium). The `!available.includes(slot)` guard inside
+    // handOff only covers the no-waiter branch; this guard closes the waiter
+    // branch too. A release whose slot is not currently checked out is a
+    // double release (or a foreign/stale reference) and must be a no-op. The
+    // matching `add` happens when the slot is handed out (acquire's scan or
+    // handOff's waiter branch); clearing it here makes the first release the
+    // only one that proceeds.
+    if (!this.checkedOut.has(slot)) return;
+    this.checkedOut.delete(slot);
+
     slot.contextCount++;
 
     if (slot.contextCount >= this.recycleAfter) {
@@ -592,12 +699,18 @@ export class BrowserPool {
       return;
     }
 
-    const waiter = this.waiters.shift();
-    if (waiter) {
-      waiter.resolve(slot.browser);
-    } else {
-      this.available.push(slot);
-    }
+    // Route the live-slot return through the shared waiter-first handoff so
+    // there is ONE waiter-served path with ONE set of invariants: the
+    // `!available.includes(slot)` guard (a double release() of a still-live
+    // slot looks the slot up successfully BOTH times — the slot was never
+    // recycled, so it stays in browserToSlot — and an unconditional push would
+    // publish it to `available` twice, handing the SAME browser to two probes)
+    // AND the `isConnected()` liveness gate (the release-time check above is
+    // synchronous, but handOff re-checks before resolving so a dead browser is
+    // never delivered to a waiter on this path either). The slot is idle here
+    // (not in any recovery set), so a dead-browser handoff recycles it
+    // immediately rather than parking it pending.
+    this.handOff(slot, slot.browser);
     const s = this.stats();
     this.logger?.info("browser-pool.release", {
       available: s.available,
@@ -630,12 +743,15 @@ export class BrowserPool {
     this.slots = [];
     this.available = [];
     this.browserToSlot.clear();
+    this.checkedOut.clear();
   }
 
   stats(): BrowserPoolStats {
     // `size` counts only live (non-pending) capacity. A slot parked as
     // `relaunchPending` holds a dead browser and is being recovered lazily,
-    // so it is not usable capacity and must not inflate `size`/`inUse`. When
+    // so it is not usable capacity and must not inflate `size`. (`inUse` is NOT
+    // filtered by `relaunchPending` — it derives from `this.checkedOut.size`
+    // below, the set of slots actually handed to a caller.) When
     // every slot is pending, `size` reads 0 — that surfaces the outage to
     // callers, but it is NOT what gates recovery. The parked slots remain in
     // `this.slots`, so `acquire()` recovers them via `relaunchPendingSlots()`
@@ -646,9 +762,13 @@ export class BrowserPool {
     return {
       size: liveSlots.length,
       available: availableCount,
-      // Clamp to 0 so a future invariant break (availableCount exceeding
-      // liveSlots.length) can never surface as a negative gauge.
-      inUse: Math.max(0, liveSlots.length - availableCount),
+      // Derive `inUse` from the explicit checked-out set — the slots actually
+      // handed to a caller right now — rather than the `liveSlots - available`
+      // subtraction, which was inconsistently filtered (e.g. a slot mid-recycle
+      // is neither live-counted the same way nor in `available`, skewing the
+      // difference). `checkedOut` is maintained at every checkout/return/recycle
+      // site, so its size is the precise in-use gauge.
+      inUse: this.checkedOut.size,
       totalRecycles: this.totalRecycles,
     };
   }
@@ -700,6 +820,15 @@ export class BrowserPool {
     // and/or double-publishing the slot.
     if (this.isSlotBusy(slot)) return;
     this.recyclingSlots.add(slot);
+
+    // A recycled slot's OLD browser is no longer a usable checkout: whether it
+    // was in-use (disconnect-during-hold) or idle (acquire's zombie scan), the
+    // slot is being torn down and relaunched. Clear it so the set never leaks a
+    // stale entry across recycle (a fresh browser starts NOT checked out until
+    // re-acquired or handed to a waiter via the relaunch's handOff). release()
+    // paths that route here (contextCount/dead-slot) already cleared it; this
+    // covers the other entry points (disconnect handler, acquire zombie scan).
+    this.checkedOut.delete(slot);
 
     this.totalRecycles++;
     const slotIdx = this.slots.indexOf(slot);


### PR DESCRIPTION
## Summary
Three fixes hardening BrowserPool slot publication:

1. **Idempotent `release()` via checked-out tracking** — prevents a double-`release()` from double-serving one browser to two waiters. The waiter-path `checkedOut` add is deferred one microtask to defeat a same-frame double-release; this ordering is FIFO-proven safe and covered by a control-mutant test.
2. **`handOff` liveness gate** — never hand a disconnected browser to a waiter; recycle (idle slot) or park `relaunchPending` (busy slot) instead, keeping the waiter queued for a live browser.
3. **`track()` registers the same wrapper it removes** — so `shutdown()`'s drain awaits the recovery's cleanup rather than under-waiting the raw promise.

These harden pre-existing latent bugs. The launch-gate (#5137) already fixed the d6 infra issue, so this is robustness hardening.

## Test plan
- [x] red-green: double-release-idempotency (double `release()` is a no-op)
- [x] red-green: dead-browser-liveness-gate (disconnected browser never handed to a waiter)
- [x] red-green: track-wrapper-drain (shutdown awaits recovery cleanup)
- [x] red-green: waiter-served-release-no-leak control-mutant (deferred microtask add ordering)
- [x] full harness suite green (99 files, 1681 tests)
- [x] `tsc --noEmit` clean, build clean, oxfmt + oxlint clean