### PR TITLE
fix(showcase/harness): re-architect BrowserPool to pool contexts (durable PID-ceiling fix)

### DIFF
--- a/showcase/harness/src/orchestrator-browser-pool-env.test.ts
+++ b/showcase/harness/src/orchestrator-browser-pool-env.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from "vitest";
+import type { Browser } from "playwright";
+import { BrowserPool } from "./probes/helpers/browser-pool.js";
+import type { LaunchBrowser } from "./probes/helpers/browser-pool.js";
+
+/**
+ * Regression for the NaN env-parsing footgun the orchestrator USED to have when
+ * constructing the BrowserPool (orchestrator.ts ~L292):
+ *
+ *   new BrowserPool({
+ *     browsers: Number(process.env.BROWSER_POOL_BROWSERS ?? ... ?? 3),
+ *     maxContexts: Number(process.env.BROWSER_POOL_MAX_CONTEXTS ?? 24),
+ *     logger,
+ *   })
+ *
+ * `Number("abc")` is `NaN`. Because `NaN` is NOT nullish, the constructor's own
+ * `options.browsers ?? <env/default>` keeps the NaN → `browserCount = NaN` →
+ * `init()`'s `for (i=0; i < NaN; i++)` never iterates → ZERO browsers launch →
+ * every `acquire()` times out with the opaque "BrowserPool acquire timeout"
+ * (this exact shape took down staging).
+ *
+ * The fix: the orchestrator stops pre-parsing and constructs `new BrowserPool({
+ * logger })`, delegating all numeric resolution to the constructor's
+ * parseInt + Number.isNaN + >0 guarded env handling.
+ *
+ * These tests pin both halves of that contract at the BrowserPool boundary by
+ * counting how many times the injected launcher fires during `init()` (which is
+ * exactly `browserCount`). We do NOT touch browser-pool.test.ts (owned
+ * elsewhere) — this file lives orchestrator-side.
+ */
+
+const ENV_KEYS = [
+  "BROWSER_POOL_BROWSERS",
+  "BROWSER_POOL_SIZE",
+  "BROWSER_POOL_MAX_CONTEXTS",
+] as const;
+
+function snapshotEnv(): Record<string, string | undefined> {
+  const snap: Record<string, string | undefined> = {};
+  for (const k of ENV_KEYS) snap[k] = process.env[k];
+  return snap;
+}
+
+function restoreEnv(snap: Record<string, string | undefined>): void {
+  for (const k of ENV_KEYS) {
+    if (snap[k] === undefined) delete process.env[k];
+    else process.env[k] = snap[k];
+  }
+}
+
+/** A launcher that returns a connected no-op Browser and counts its calls. */
+function makeCountingLauncher(): {
+  launch: LaunchBrowser;
+  count: () => number;
+} {
+  let calls = 0;
+  const launch: LaunchBrowser = async () => {
+    calls++;
+    const browser = {
+      isConnected: () => true,
+      on: () => {},
+      async close() {},
+      async newContext() {
+        return { async close() {} };
+      },
+    } as unknown as Browser;
+    return browser;
+  };
+  return { launch, count: () => calls };
+}
+
+describe("orchestrator BrowserPool env construction (NaN footgun regression)", () => {
+  const envSnap = snapshotEnv();
+  afterEach(() => restoreEnv(envSnap));
+
+  it("a non-numeric BROWSER_POOL_BROWSERS yields the default count, never zero", async () => {
+    // Reproduce the staging trigger: a garbage env value.
+    process.env.BROWSER_POOL_BROWSERS = "abc";
+    delete process.env.BROWSER_POOL_SIZE;
+
+    const { launch, count } = makeCountingLauncher();
+    // The FIXED orchestrator construction: only `logger` (here we omit it) plus
+    // the injected launcher. Crucially it does NOT pass a pre-parsed
+    // `browsers: Number(...)` that would smuggle NaN past the constructor guard.
+    const pool = new BrowserPool({ launchBrowser: launch, launchStaggerMs: 0 });
+    await pool.init();
+
+    // Pre-fix (orchestrator passing `browsers: NaN`) this was 0. Post-fix the
+    // constructor's env path rejects the NaN and falls back to the default 3.
+    expect(count()).toBe(3);
+    await pool.shutdown();
+  });
+
+  it("a valid numeric BROWSER_POOL_BROWSERS env is still honored", async () => {
+    process.env.BROWSER_POOL_BROWSERS = "2";
+    delete process.env.BROWSER_POOL_SIZE;
+
+    const { launch, count } = makeCountingLauncher();
+    const pool = new BrowserPool({ launchBrowser: launch, launchStaggerMs: 0 });
+    await pool.init();
+
+    expect(count()).toBe(2);
+    await pool.shutdown();
+  });
+
+  it("an unset env yields the default count", async () => {
+    delete process.env.BROWSER_POOL_BROWSERS;
+    delete process.env.BROWSER_POOL_SIZE;
+
+    const { launch, count } = makeCountingLauncher();
+    const pool = new BrowserPool({ launchBrowser: launch, launchStaggerMs: 0 });
+    await pool.init();
+
+    expect(count()).toBe(3);
+    await pool.shutdown();
+  });
+});

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -950,7 +950,9 @@ export function registerAllProbeDrivers(
 
   if (pool) {
     probeRegistry.register(
-      createE2eSmokeDriver({ launcher: createPooledE2eSmokeLauncher(pool) }),
+      createE2eSmokeDriver({
+        launcher: createPooledE2eSmokeLauncher(pool, logger),
+      }),
     );
     probeRegistry.register(
       createE2eDemosDriver({

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -283,10 +283,19 @@ export async function boot(opts: BootOptions = {}): Promise<{
     });
   }
 
-  const poolSize = process.env.BROWSER_POOL_SIZE
-    ? parseInt(process.env.BROWSER_POOL_SIZE, 10) || 4
-    : 4;
-  const browserPool = new BrowserPool(poolSize, undefined, logger);
+  // Context-pooled BrowserPool: a fixed small set of long-lived browser
+  // PROCESSES (browsers) with a global cap on concurrently-live CONTEXTS
+  // (maxContexts). BROWSER_POOL_BROWSERS is the process count (legacy
+  // BROWSER_POOL_SIZE retained as a fallback, but its meaning shifts from
+  // "concurrent browsers" to "base browser process count"); deploy env should
+  // move to BROWSER_POOL_BROWSERS=3 + BROWSER_POOL_MAX_CONTEXTS=24.
+  const browserPool = new BrowserPool({
+    browsers: Number(
+      process.env.BROWSER_POOL_BROWSERS ?? process.env.BROWSER_POOL_SIZE ?? 3,
+    ),
+    maxContexts: Number(process.env.BROWSER_POOL_MAX_CONTEXTS ?? 24),
+    logger,
+  });
   let browserPoolReady = false;
   try {
     await browserPool.init();

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -302,14 +302,30 @@ export async function boot(opts: BootOptions = {}): Promise<{
     await browserPool.init();
     browserPoolReady = true;
     try {
+      // Only stamp `recovered: true` when a prior degraded (red) state
+      // actually existed — on a cold first boot nothing was recovered, so a
+      // blanket `recovered: true` would misreport a phantom recovery. Probe
+      // for the prior state and emit a neutral healthy signal otherwise.
+      // statusReader failure here must not break the healthy write, so treat
+      // an unreadable prior state as "no prior degraded state".
+      const priorState = await statusReader
+        .getStateByKey("system:browser-pool-degraded")
+        .catch(() => null);
+      const recovered = priorState === "red";
       await writer.write({
         key: "system:browser-pool-degraded",
         state: "green",
-        signal: { recovered: true, recoveredAt: new Date().toISOString() },
+        signal: recovered
+          ? { recovered: true, recoveredAt: new Date().toISOString() }
+          : { healthy: true, healthyAt: new Date().toISOString() },
         observedAt: new Date().toISOString(),
       });
-    } catch {
-      // best-effort -- pool is healthy, status write failure is non-critical
+    } catch (writeErr) {
+      // best-effort -- pool is healthy, status write failure is non-critical.
+      // Warn (matching the failure path) instead of swallowing silently.
+      logger.warn("boot.browser-pool-status-write-failed", {
+        error: writeErr instanceof Error ? writeErr.message : String(writeErr),
+      });
     }
   } catch (err) {
     logger.error("boot.browser-pool-init-failed", { error: String(err) });

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -289,13 +289,14 @@ export async function boot(opts: BootOptions = {}): Promise<{
   // BROWSER_POOL_SIZE retained as a fallback, but its meaning shifts from
   // "concurrent browsers" to "base browser process count"); deploy env should
   // move to BROWSER_POOL_BROWSERS=3 + BROWSER_POOL_MAX_CONTEXTS=24.
-  const browserPool = new BrowserPool({
-    browsers: Number(
-      process.env.BROWSER_POOL_BROWSERS ?? process.env.BROWSER_POOL_SIZE ?? 3,
-    ),
-    maxContexts: Number(process.env.BROWSER_POOL_MAX_CONTEXTS ?? 24),
-    logger,
-  });
+  // Do NOT pre-parse the env here with Number(...): Number("abc") is NaN, and
+  // because NaN is not nullish the constructor's `options.browsers ?? <env/default>`
+  // would keep NaN — yielding browserCount = NaN, so init()'s `for (i=0; i<NaN; ...)`
+  // never iterates and ZERO browsers launch (every acquire then times out). The
+  // BrowserPool constructor already reads BROWSER_POOL_BROWSERS / BROWSER_POOL_SIZE /
+  // BROWSER_POOL_MAX_CONTEXTS from process.env with parseInt + NaN/>0 guards and
+  // sensible defaults, so pass only `logger` and let it own numeric resolution.
+  const browserPool = new BrowserPool({ logger });
   let browserPoolReady = false;
   try {
     await browserPool.init();

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -2,13 +2,18 @@ import { describe, it, expect } from "vitest";
 import {
   e2eChatToolsDriver,
   createE2eSmokeDriver,
-  type E2eBrowser,
-  type E2eBrowserContext,
-  type E2ePage,
-  type E2eSmokeLevelSignal,
-  type E2eSmokePackageSignal,
-  type E2eSmokeSignal,
+  createPooledE2eSmokeLauncher,
 } from "./d4-chat-roundtrip.js";
+import type {
+  E2eBrowser,
+  E2eBrowserContext,
+  E2ePage,
+  E2eSmokeLevelSignal,
+  E2eSmokePackageSignal,
+  E2eSmokeSignal,
+} from "./d4-chat-roundtrip.js";
+import type { BrowserPool } from "../helpers/browser-pool.js";
+import type { Browser } from "playwright";
 import { logger } from "../../logger.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 
@@ -546,6 +551,139 @@ describe("e2eChatToolsDriver package shape: deriveSlug + demosResolver", () => {
     expect(sig.l4).toBe("skipped");
   });
 });
+
+// --- Pooled launcher: context checkout + abort release -------------------
+//
+// Context-pool migration: createPooledE2eSmokeLauncher checks out a pooled
+// CONTEXT per newContext() (pool.acquire) and releases it on close
+// (pool.release). No Browser is held. The leak this guards: on a driver
+// hard-timeout / external abort the invoker's Promise.race abandons the
+// driver while it keeps running with pooled contexts held; without the
+// abort listener those contexts stay inUse across probe ticks, saturating
+// the pool. The abort closure closes each open context (each releasing its
+// pooled context), returning inUse to 0.
+describe("createPooledE2eSmokeLauncher context checkout + abort release", () => {
+  it("checks out a pooled context per newContext() and moves inUse by 1", async () => {
+    const pool = makeFakeContextPool(4);
+    const launcher = createPooledE2eSmokeLauncher(
+      pool as unknown as BrowserPool,
+    );
+    const browser = await launcher();
+    expect(pool.stats().inUse).toBe(0);
+    const ctx = await browser.newContext();
+    expect(pool.stats().inUse).toBe(1);
+    await ctx.close();
+    expect(pool.stats().inUse).toBe(0);
+    expect(pool._releaseLog).toHaveLength(1);
+  });
+
+  it("forwards newContext(opts).extraHTTPHeaders into pool.acquire", async () => {
+    const pool = makeFakeContextPool(4);
+    const launcher = createPooledE2eSmokeLauncher(
+      pool as unknown as BrowserPool,
+    );
+    const browser = await launcher();
+    await browser.newContext({
+      extraHTTPHeaders: {
+        "X-AIMock-Context": "slug-d4",
+        "X-Test-Id": "d4-slug-d4",
+      },
+    });
+    expect(pool._acquireOptions[0]).toEqual({
+      extraHTTPHeaders: {
+        "X-AIMock-Context": "slug-d4",
+        "X-Test-Id": "d4-slug-d4",
+      },
+    });
+  });
+
+  it("closes open contexts on abort (each releasing its pooled context)", async () => {
+    const pool = makeFakeContextPool(4);
+    const launcher = createPooledE2eSmokeLauncher(
+      pool as unknown as BrowserPool,
+    );
+    const ac = new AbortController();
+    const browser = await launcher(ac.signal);
+    const ctx = await browser.newContext();
+    await ctx.newPage();
+    expect(pool.stats().inUse).toBe(1);
+    ac.abort();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(pool._releaseLog).toHaveLength(1);
+    expect(pool.stats().inUse).toBe(0);
+  });
+
+  it("launcher-level close is a no-op (contexts release themselves)", async () => {
+    const pool = makeFakeContextPool(4);
+    const launcher = createPooledE2eSmokeLauncher(
+      pool as unknown as BrowserPool,
+    );
+    const browser = await launcher();
+    const ctx = await browser.newContext();
+    await ctx.close();
+    await browser.close(); // no-op
+    expect(pool._releaseLog).toHaveLength(1);
+  });
+});
+
+// Module-scoped fake context-pool for the createPooledE2eSmokeLauncher tests
+// above — mirrors d6-all-pills.test.ts's helper. Tracks per-CONTEXT
+// acquire/release and the contextOptions each acquire was called with. The
+// release() is idempotent on the inUse counter only in the sense that the
+// real BrowserPool.release is a no-op on a context that's already been
+// released; here each ctxHandle.close() routes to one release call, and the
+// launcher's abort path closes each open context exactly once.
+function makeFakeContextPool(maxContexts: number) {
+  let nextCtxId = 0;
+  let live = 0;
+  const releaseLog: number[] = [];
+  const acquireOptions: Array<
+    { extraHTTPHeaders?: Record<string, string> } | undefined
+  > = [];
+  return {
+    async acquire(options?: { extraHTTPHeaders?: Record<string, string> }) {
+      if (live >= maxContexts) throw new Error("FakePool: at cap");
+      const id = nextCtxId++;
+      live++;
+      acquireOptions.push(options);
+      return {
+        __id: id,
+        async newPage() {
+          return {
+            on: () => {},
+            goto: async () => {},
+            type: async () => {},
+            press: async () => {},
+            waitForSelector: async () => {},
+            textContent: async () => null,
+            evaluate: async () => 0,
+            close: async () => {},
+          } as unknown;
+        },
+        async close() {},
+      } as unknown as Browser;
+    },
+    async release(ctx: unknown) {
+      const c = ctx as { __id: number };
+      releaseLog.push(c.__id);
+      live--;
+    },
+    stats() {
+      return {
+        size: maxContexts,
+        available: maxContexts - live,
+        inUse: live,
+        totalRecycles: 0,
+      };
+    },
+    get _releaseLog() {
+      return releaseLog;
+    },
+    get _acquireOptions() {
+      return acquireOptions;
+    },
+  };
+}
 
 describe("e2eChatToolsDriver module export", () => {
   it("module-level e2eChatToolsDriver has kind === 'e2e_smoke'", () => {

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -64,18 +64,17 @@ function makePage(script: PageScript = {}): E2ePage {
       }
     },
     async textContent(sel) {
-      if (sel === '[data-testid="copilot-assistant-message"]:last-of-type') {
-        return script.assistantText ?? "";
-      }
+      // The driver reads the assistant message via `evaluate()` (see below),
+      // NOT `textContent(:last-of-type)`, so only the `body` read remains.
       if (sel === "body") {
         return script.bodyText ?? "";
       }
       return "";
     },
     async evaluate<R>(fn: () => R): Promise<R> {
-      // The evaluate() call in the driver reads the last assistant
-      // message's textContent via querySelectorAll. In the fake we
-      // return the same assistantText the old textContent path used.
+      // The driver's evaluate() reads the last assistant message's
+      // textContent via querySelectorAll and returns a string. The fake
+      // returns the scripted assistantText as that string.
       return (script.assistantText ?? "") as unknown as R;
     },
     async close() {
@@ -624,29 +623,58 @@ describe("createPooledE2eSmokeLauncher context checkout + abort release", () => 
     await browser.close(); // no-op
     expect(pool._releaseLog).toHaveLength(1);
   });
+
+  // A3 — a normal close() must remove the context from the abort tracking set
+  // so a SUBSEQUENT abort does not re-release it (double release). Before the
+  // fix, close() released but never `openContexts.delete(ctxHandle)`, so abort
+  // closed the already-released context a second time — driving the pool's
+  // inUse negative with a non-idempotent pool. The fix (delete-on-close + an
+  // idempotent pool) keeps the release count accurate at exactly 1 and inUse
+  // at 0.
+  it("does not double-release a normally-closed context on a later abort", async () => {
+    const pool = makeFakeContextPool(4);
+    const launcher = createPooledE2eSmokeLauncher(
+      pool as unknown as BrowserPool,
+    );
+    const ac = new AbortController();
+    const browser = await launcher(ac.signal);
+    const ctx = await browser.newContext();
+    await ctx.newPage();
+    expect(pool.stats().inUse).toBe(1);
+
+    // Normal close first — releases the context exactly once.
+    await ctx.close();
+    expect(pool.stats().inUse).toBe(0);
+    expect(pool._releaseLog).toHaveLength(1);
+
+    // Now abort. The already-closed context must NOT be released again.
+    ac.abort();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(pool._releaseLog).toHaveLength(1); // still exactly one release
+    expect(pool.stats().inUse).toBe(0); // never driven negative
+  });
 });
 
 // Module-scoped fake context-pool for the createPooledE2eSmokeLauncher tests
 // above — mirrors d6-all-pills.test.ts's helper. Tracks per-CONTEXT
-// acquire/release and the contextOptions each acquire was called with. The
-// release() is idempotent on the inUse counter only in the sense that the
-// real BrowserPool.release is a no-op on a context that's already been
-// released; here each ctxHandle.close() routes to one release call, and the
-// launcher's abort path closes each open context exactly once.
+// acquire/release and the contextOptions each acquire was called with.
+// release() is IDEMPOTENT, mirroring the real BrowserPool.release: it tracks a
+// `liveContexts` Set and no-ops on an unknown / already-released context so a
+// double release can never drive the inUse counter negative and silently mask
+// a double-release bug.
 function makeFakeContextPool(maxContexts: number) {
   let nextCtxId = 0;
-  let live = 0;
+  const liveContexts = new Set<object>();
   const releaseLog: number[] = [];
   const acquireOptions: Array<
     { extraHTTPHeaders?: Record<string, string> } | undefined
   > = [];
   return {
     async acquire(options?: { extraHTTPHeaders?: Record<string, string> }) {
-      if (live >= maxContexts) throw new Error("FakePool: at cap");
+      if (liveContexts.size >= maxContexts) throw new Error("FakePool: at cap");
       const id = nextCtxId++;
-      live++;
       acquireOptions.push(options);
-      return {
+      const ctx = {
         __id: id,
         async newPage() {
           return {
@@ -661,18 +689,23 @@ function makeFakeContextPool(maxContexts: number) {
           } as unknown;
         },
         async close() {},
-      } as unknown as Browser;
+      };
+      liveContexts.add(ctx);
+      return ctx as unknown as Browser;
     },
     async release(ctx: unknown) {
-      const c = ctx as { __id: number };
-      releaseLog.push(c.__id);
-      live--;
+      // Unknown / double release — no-op, mirroring BrowserPool.release.
+      if (typeof ctx !== "object" || ctx === null || !liveContexts.has(ctx)) {
+        return;
+      }
+      liveContexts.delete(ctx);
+      releaseLog.push((ctx as { __id: number }).__id);
     },
     stats() {
       return {
         size: maxContexts,
-        available: maxContexts - live,
-        inUse: live,
+        available: maxContexts - liveContexts.size,
+        inUse: liveContexts.size,
         totalRecycles: 0,
       };
     },

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -272,16 +272,17 @@ export function createPooledE2eSmokeLauncher(
   pool: BrowserPool,
 ): E2eBrowserLauncher {
   return async (): Promise<E2eBrowser> => {
-    const browser = await pool.acquire();
+    // CONTEXT-POOLED model: the launcher no longer acquires a Browser. Each
+    // `newContext()` checks out a pooled BrowserContext on a shared long-lived
+    // browser process (`pool.acquire`), and the wrapper's `close()` returns it
+    // (`pool.release`). The pool centralizes the X-AIMock-Strict default header;
+    // per-probe headers (X-AIMock-Context, X-Test-Id) flow through `ctxOpts`.
     return {
       async newContext(ctxOpts?: {
         extraHTTPHeaders?: Record<string, string>;
       }): Promise<E2eBrowserContext> {
-        const ctx = await browser.newContext({
-          extraHTTPHeaders: {
-            "X-AIMock-Strict": "true",
-            ...ctxOpts?.extraHTTPHeaders,
-          },
+        const ctx = await pool.acquire({
+          extraHTTPHeaders: ctxOpts?.extraHTTPHeaders,
         });
         return {
           async newPage(): Promise<E2ePage> {
@@ -296,12 +297,12 @@ export function createPooledE2eSmokeLauncher(
               close: () => page.close(),
             };
           },
-          close: () => ctx.close(),
+          close: () => pool.release(ctx),
         };
       },
-      close: async () => {
-        pool.release(browser);
-      },
+      // Launcher-level close is a no-op: contexts are released individually via
+      // each context-wrapper's close(). There is no Browser held to release.
+      close: async () => {},
     };
   };
 }

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -29,9 +29,12 @@ import type { ProbeContext, ProbeResult } from "../../types/index.js";
  *
  * In-process vs spawn: the orchestrator already runs as a long-lived Node
  * process with `playwright` installed (see Dockerfile). Launching chromium
- * directly via `playwright.chromium.launch()` gives us first-class
- * AbortSignal propagation into `page.close()` / `browser.close()` rather
- * than having to kill a child process.
+ * directly via `playwright.chromium.launch()` keeps the browser in-process
+ * rather than having to kill a child process. Note: the `defaultLauncher`
+ * does NOT wire the AbortSignal — it dedicates a chromium per call and lets
+ * the driver's teardown close it. The POOLED launcher
+ * (`createPooledE2eSmokeLauncher`) is the path that actually re-targets abort
+ * onto open contexts for prompt pool release.
  *
  * Pluggable launcher: the production default imports `playwright` lazily
  * so the driver module loads cleanly in environments without chromium
@@ -291,33 +294,40 @@ export function createPooledE2eSmokeLauncher(
     // pooled context back to the pool, freeing a context slot.
     const openContexts = new Set<{ close(): Promise<void> }>();
 
+    const onAbort = (): void => {
+      if (aborted) return;
+      aborted = true;
+      const ctxCount = openContexts.size;
+      const stats = pool.stats();
+      logger?.warn("probe.e2e-smoke.pool-abort-release", {
+        openContexts: ctxCount,
+        poolAvailable: stats.available,
+        poolInUse: stats.inUse,
+        poolSize: stats.size,
+      });
+      const contextClosePromises = Array.from(openContexts).map((ctx) =>
+        ctx.close().catch(() => {}),
+      );
+      void Promise.allSettled(contextClosePromises).then(() => {
+        logger?.warn("probe.e2e-smoke.pool-abort-released", {
+          closedContexts: ctxCount,
+          poolAvailable: pool.stats().available,
+        });
+      });
+    };
+    // Capture the listener so launcher-level close() can detach it: without
+    // removeEventListener a post-completion abort would fire onAbort after the
+    // run returned (closing nothing, but leaking the listener for the signal's
+    // lifetime).
+    let detachAbort: (() => void) | undefined;
     if (abortSignal) {
-      const onAbort = (): void => {
-        if (aborted) return;
-        aborted = true;
-        const ctxCount = openContexts.size;
-        const stats = pool.stats();
-        logger?.warn("probe.e2e-smoke.pool-abort-release", {
-          openContexts: ctxCount,
-          poolAvailable: stats.available,
-          poolInUse: stats.inUse,
-          poolSize: stats.size,
-        });
-        const contextClosePromises = Array.from(openContexts).map((ctx) =>
-          ctx.close().catch(() => {}),
-        );
-        void Promise.allSettled(contextClosePromises).then(() => {
-          logger?.warn("probe.e2e-smoke.pool-abort-released", {
-            closedContexts: ctxCount,
-            poolAvailable: pool.stats().available,
-          });
-        });
-      };
       if (abortSignal.aborted) {
         aborted = true;
         logger?.warn("probe.e2e-smoke.pool-pre-aborted-release");
       } else {
         abortSignal.addEventListener("abort", onAbort, { once: true });
+        detachAbort = () =>
+          abortSignal.removeEventListener("abort", onAbort);
       }
     }
 
@@ -328,6 +338,14 @@ export function createPooledE2eSmokeLauncher(
         const ctx = await pool.acquire({
           extraHTTPHeaders: ctxOpts?.extraHTTPHeaders,
         });
+        // If the signal was already aborted at launcher construction (the
+        // pre-aborted branch never attached the live abort listener), a context
+        // opened now would never be closed by the abort path. Release it
+        // immediately and refuse so it cannot leak into a torn-down run.
+        if (aborted) {
+          await pool.release(ctx).catch(() => {});
+          throw new Error("e2e-smoke launcher aborted");
+        }
         const ctxHandle = { close: () => pool.release(ctx) };
         openContexts.add(ctxHandle);
         return {
@@ -343,12 +361,19 @@ export function createPooledE2eSmokeLauncher(
               close: () => page.close(),
             };
           },
-          close: () => ctxHandle.close(),
+          close: async () => {
+            openContexts.delete(ctxHandle);
+            await ctxHandle.close();
+          },
         };
       },
-      // Launcher-level close is a no-op: contexts are released individually via
-      // each context-wrapper's close(). There is no Browser held to release.
-      close: async () => {},
+      // Launcher-level close releases nothing itself — contexts are released
+      // individually via each context-wrapper's close() — but it detaches the
+      // abort listener so a post-completion abort can't fire onAbort after the
+      // run returned. There is no Browser held to release.
+      close: async () => {
+        detachAbort?.();
+      },
     };
   };
 }

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -165,7 +165,9 @@ export interface E2eBrowser {
  * dynamically imports `playwright` and calls `chromium.launch()`; tests
  * substitute a fake that returns a scripted E2eBrowser.
  */
-export type E2eBrowserLauncher = () => Promise<E2eBrowser>;
+export type E2eBrowserLauncher = (
+  abortSignal?: AbortSignal,
+) => Promise<E2eBrowser>;
 
 /**
  * Resolver that maps a Railway service slug to its `demos` array, used
@@ -270,13 +272,55 @@ const defaultLauncher: E2eBrowserLauncher = async (): Promise<E2eBrowser> => {
 
 export function createPooledE2eSmokeLauncher(
   pool: BrowserPool,
+  logger?: { warn(event: string, meta?: Record<string, unknown>): void },
 ): E2eBrowserLauncher {
-  return async (): Promise<E2eBrowser> => {
+  return async (abortSignal?: AbortSignal): Promise<E2eBrowser> => {
     // CONTEXT-POOLED model: the launcher no longer acquires a Browser. Each
     // `newContext()` checks out a pooled BrowserContext on a shared long-lived
     // browser process (`pool.acquire`), and the wrapper's `close()` returns it
     // (`pool.release`). The pool centralizes the X-AIMock-Strict default header;
     // per-probe headers (X-AIMock-Context, X-Test-Id) flow through `ctxOpts`.
+    // The abort closure re-targets onto the open contexts: on abort it closes
+    // each (each close() releases its pooled context). Without this listener
+    // those contexts stay in-use across probe ticks when the invoker's
+    // Promise.race abandons the driver on hard-timeout / external abort,
+    // saturating the pool and starving later ticks.
+    let aborted = false;
+
+    // Track open contexts so abort can close them. Each close() releases the
+    // pooled context back to the pool, freeing a context slot.
+    const openContexts = new Set<{ close(): Promise<void> }>();
+
+    if (abortSignal) {
+      const onAbort = (): void => {
+        if (aborted) return;
+        aborted = true;
+        const ctxCount = openContexts.size;
+        const stats = pool.stats();
+        logger?.warn("probe.e2e-smoke.pool-abort-release", {
+          openContexts: ctxCount,
+          poolAvailable: stats.available,
+          poolInUse: stats.inUse,
+          poolSize: stats.size,
+        });
+        const contextClosePromises = Array.from(openContexts).map((ctx) =>
+          ctx.close().catch(() => {}),
+        );
+        void Promise.allSettled(contextClosePromises).then(() => {
+          logger?.warn("probe.e2e-smoke.pool-abort-released", {
+            closedContexts: ctxCount,
+            poolAvailable: pool.stats().available,
+          });
+        });
+      };
+      if (abortSignal.aborted) {
+        aborted = true;
+        logger?.warn("probe.e2e-smoke.pool-pre-aborted-release");
+      } else {
+        abortSignal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
     return {
       async newContext(ctxOpts?: {
         extraHTTPHeaders?: Record<string, string>;
@@ -284,6 +328,8 @@ export function createPooledE2eSmokeLauncher(
         const ctx = await pool.acquire({
           extraHTTPHeaders: ctxOpts?.extraHTTPHeaders,
         });
+        const ctxHandle = { close: () => pool.release(ctx) };
+        openContexts.add(ctxHandle);
         return {
           async newPage(): Promise<E2ePage> {
             const page = await ctx.newPage();
@@ -297,7 +343,7 @@ export function createPooledE2eSmokeLauncher(
               close: () => page.close(),
             };
           },
-          close: () => pool.release(ctx),
+          close: () => ctxHandle.close(),
         };
       },
       // Launcher-level close is a no-op: contexts are released individually via
@@ -436,7 +482,7 @@ export function createE2eSmokeDriver(
 
       try {
         try {
-          browser = await launcher();
+          browser = await launcher(abort.signal);
         } catch (err) {
           // If the driver's hard-timeout fired first and aborted a
           // launcher that observes the signal, surface the timeout path

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -326,8 +326,7 @@ export function createPooledE2eSmokeLauncher(
         logger?.warn("probe.e2e-smoke.pool-pre-aborted-release");
       } else {
         abortSignal.addEventListener("abort", onAbort, { once: true });
-        detachAbort = () =>
-          abortSignal.removeEventListener("abort", onAbort);
+        detachAbort = () => abortSignal.removeEventListener("abort", onAbort);
       }
     }
 

--- a/showcase/harness/src/probes/drivers/d5-single-pill.test.ts
+++ b/showcase/harness/src/probes/drivers/d5-single-pill.test.ts
@@ -1107,7 +1107,11 @@ describe("e2e-deep graceful degradation (FEATURE_CONCURRENCY=1 equivalent)", () 
  */
 function makeDeepFakeContextPool(maxContexts: number) {
   let nextCtxId = 0;
-  let live = 0;
+  // Track the set of currently-live contexts so release fidelity matches
+  // the real BrowserPool: an unknown / double release is a no-op (does
+  // NOT decrement the count). The previous unconditional decrement could
+  // drive `live` negative and silently mask a double-release bug.
+  const liveContexts = new Set<object>();
   const releaseLog: number[] = [];
   const acquireLog: number[] = [];
   const acquireOptions: Array<
@@ -1118,12 +1122,11 @@ function makeDeepFakeContextPool(maxContexts: number) {
     async acquire(options?: {
       extraHTTPHeaders?: Record<string, string>;
     }): Promise<unknown> {
-      if (live >= maxContexts) throw new Error("FakePool: at cap");
+      if (liveContexts.size >= maxContexts) throw new Error("FakePool: at cap");
       const id = nextCtxId++;
-      live++;
       acquireLog.push(id);
       acquireOptions.push(options);
-      return {
+      const ctx = {
         __id: id,
         async newPage() {
           return {
@@ -1140,17 +1143,22 @@ function makeDeepFakeContextPool(maxContexts: number) {
         },
         async close() {},
       };
+      liveContexts.add(ctx);
+      return ctx;
     },
     async release(ctx: unknown): Promise<void> {
-      const c = ctx as { __id: number };
-      releaseLog.push(c.__id);
-      live--;
+      // Unknown / double release — no-op, mirroring BrowserPool.release.
+      if (typeof ctx !== "object" || ctx === null || !liveContexts.has(ctx)) {
+        return;
+      }
+      liveContexts.delete(ctx);
+      releaseLog.push((ctx as { __id: number }).__id);
     },
     stats() {
       return {
         size: maxContexts,
-        available: maxContexts - live,
-        inUse: live,
+        available: maxContexts - liveContexts.size,
+        inUse: liveContexts.size,
         totalRecycles: 0,
       };
     },
@@ -1551,4 +1559,241 @@ describe("e2e-deep deploy-churn grace window", () => {
     expect(sig.passed).toBe(1);
     expect(sig.note).toBeUndefined();
   });
+});
+
+// ---------------------------------------------------------------------
+// Pooled-context budget: feature-timeout must NOT free the semaphore slot
+// until the orphaned (still-in-flight) runFeature's context is actually
+// released. Otherwise a freed slot lets a new feature acquire a context
+// while the orphan still holds one → live contexts exceed
+// FEATURE_CONCURRENCY's budget.
+//
+// We model the pool with a launcher that tracks live/peak contexts and
+// supports a controllably-slow context.close(). Each feature's goto hangs
+// past `featureTimeoutMs` so the per-feature timer fires the synthetic
+// `feature-timeout` verdict while runFeature keeps running and holding its
+// context; context teardown then completes a tick later.
+// ---------------------------------------------------------------------
+/**
+ * Launcher whose contexts simulate pooled checkout: `newContext` increments
+ * a live counter (tracking peak), each context's page `goto` resolves only
+ * after `gotoDelayMs`, and `close()` resolves only after `closeDelayMs`
+ * (the orphan window). Module-scoped so oxlint's consistent-function-scoping
+ * is satisfied.
+ */
+function makeSlowTeardownLauncher(opts: {
+  gotoDelayMs: number;
+  closeDelayMs: number;
+}): {
+  launcher: () => Promise<E2eDeepBrowser>;
+  state: { live: number; peakLive: number; opened: number; closed: number };
+} {
+  const state = { live: 0, peakLive: 0, opened: 0, closed: 0 };
+  const sleep = (ms: number): Promise<void> =>
+    new Promise((r) => setTimeout(r, ms));
+  const browser: E2eDeepBrowser = {
+    async newContext(): Promise<E2eDeepBrowserContext> {
+      state.live++;
+      state.opened++;
+      if (state.live > state.peakLive) state.peakLive = state.live;
+      return {
+        async newPage(): Promise<E2eDeepPage> {
+          // Mirror makePage's growing-count contract so the conversation
+          // settles quickly (no 30s response timeout): baseline 0, then
+          // each press bumps the count so the runner detects growth and
+          // settles. runFeature then reaches its finally and calls the
+          // (deliberately slow) context.close().
+          let messageCount = 0;
+          return {
+            async goto() {
+              // Hang past the per-feature timeout so the synthetic
+              // feature-timeout verdict resolves while this runFeature
+              // (and its held context) is still in flight.
+              await sleep(opts.gotoDelayMs);
+            },
+            async waitForSelector() {},
+            async fill() {},
+            async press() {
+              messageCount++;
+            },
+            async evaluate<R>() {
+              return messageCount as unknown as R;
+            },
+            async click() {},
+            async waitForFunction() {},
+            async close() {},
+          };
+        },
+        async close() {
+          // The orphan window: the context stays live until this resolves.
+          await sleep(opts.closeDelayMs);
+          state.live--;
+          state.closed++;
+        },
+      };
+    },
+    async close() {},
+  };
+  return { launcher: async () => browser, state };
+}
+
+describe("e2e-deep feature-timeout pooled-context budget", () => {
+  beforeEach(() => {
+    __clearD5RegistryForTesting();
+  });
+
+  it("does not exceed FEATURE_CONCURRENCY live contexts when features time out (slot release gated on orphan teardown)", async () => {
+    // 3 features, FEATURE_CONCURRENCY=2. Features 1 & 2 acquire slots and
+    // time out (goto hangs past featureTimeoutMs) but keep holding their
+    // contexts until close() resolves (closeDelayMs later). Feature 3
+    // waits in the semaphore queue. If the slot is freed at timeout
+    // BEFORE the orphan's context is released, feature 3 acquires a 3rd
+    // live context → peakLive === 3 (over budget). Gating slot release on
+    // the in-flight runFeature settling keeps peakLive <= 2.
+    expect(FEATURE_CONCURRENCY).toBe(2);
+
+    const featureTypes = [
+      "agentic-chat",
+      "tool-rendering",
+      "shared-state-read",
+    ] as const;
+    for (const ft of featureTypes) {
+      registerD5Script(
+        makeScript({
+          featureTypes: [ft],
+          fixtureFile: `${ft}.json`,
+          buildTurns: () => [{ input: `test ${ft}` }],
+        }),
+      );
+    }
+
+    const { launcher, state } = makeSlowTeardownLauncher({
+      gotoDelayMs: 60,
+      closeDelayMs: 80,
+    });
+
+    const driver = createE2eDeepDriver({
+      launcher,
+      scriptLoader: async () => {},
+      featureTimeoutMs: 20,
+    });
+    const { writer } = mkWriter();
+
+    const result = await driver.run(mkCtx(writer), {
+      key: "e2e-deep:showcase-test",
+      publicUrl: "https://showcase-test.example.com",
+      name: "showcase-test",
+      features: [...featureTypes],
+      shape: "package",
+    });
+
+    // All three features ran (timed out → red rows), and at no point did
+    // more than FEATURE_CONCURRENCY contexts coexist.
+    expect(state.opened).toBe(3);
+    expect(state.peakLive).toBeLessThanOrEqual(FEATURE_CONCURRENCY);
+    expect(state.live).toBe(0); // all released by the time run() resolves
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.total).toBe(3);
+  }, 20_000);
+});
+
+// ---------------------------------------------------------------------
+// Per-feature retry uses an isolated AbortController per attempt: a retry
+// after a RETRY-ELIGIBLE failure must actually execute the second attempt
+// rather than being silently short-circuited by a poisoned (pre-aborted)
+// signal. We observe attempt execution via context-open count: runFeature
+// returns `abort` WITHOUT opening a context if entered with an aborted
+// signal, so a poisoned retry would open only ONE context. A healthy
+// retry opens TWO.
+// ---------------------------------------------------------------------
+/**
+ * Launcher whose first context FAILS with a retry-eligible `goto-error`
+ * (goto rejects) and whose second context SUCCEEDS. Attempt 1's goto is
+ * padded past RETRY_MIN_DURATION_MS so the retry gate fires. Tracks
+ * contexts opened (one per executed attempt).
+ */
+function makeRetryLauncher(opts: { attempt1DelayMs: number }): {
+  launcher: () => Promise<E2eDeepBrowser>;
+  state: { opened: number };
+} {
+  const state = { opened: 0 };
+  const sleep = (ms: number): Promise<void> =>
+    new Promise((r) => setTimeout(r, ms));
+  const browser: E2eDeepBrowser = {
+    async newContext(): Promise<E2eDeepBrowserContext> {
+      const attempt = ++state.opened;
+      return {
+        async newPage(): Promise<E2eDeepPage> {
+          let messageCount = 0;
+          return {
+            async goto() {
+              if (attempt === 1) {
+                // Burn > RETRY_MIN_DURATION_MS, then fail retry-eligibly.
+                await sleep(opts.attempt1DelayMs);
+                throw new Error("nav blip (retryable)");
+              }
+            },
+            async waitForSelector() {},
+            async fill() {},
+            async press() {
+              messageCount++;
+            },
+            async evaluate<R>() {
+              return messageCount as unknown as R;
+            },
+            async click() {},
+            async waitForFunction() {},
+            async close() {},
+          };
+        },
+        async close() {},
+      };
+    },
+    async close() {},
+  };
+  return { launcher: async () => browser, state };
+}
+
+describe("e2e-deep per-feature retry signal isolation", () => {
+  beforeEach(() => {
+    __clearD5RegistryForTesting();
+  });
+
+  it("executes the second attempt after a retry-eligible failure (fresh, non-aborted signal)", async () => {
+    // Attempt 1 fails with a retry-eligible conversation-error after
+    // >= RETRY_MIN_DURATION_MS (2s); attempt 2 succeeds. The retry must
+    // run with a fresh, un-aborted signal — observed by TWO contexts
+    // being opened (a poisoned/aborted retry would open only one because
+    // runFeature short-circuits to `abort` before newContext()).
+    registerD5Script(
+      makeScript({
+        featureTypes: ["agentic-chat"],
+        fixtureFile: "agentic-chat.json",
+        buildTurns: () => [{ input: "hello" }],
+      }),
+    );
+
+    const { launcher, state } = makeRetryLauncher({ attempt1DelayMs: 2_100 });
+
+    const driver = createE2eDeepDriver({
+      launcher,
+      scriptLoader: async () => {},
+      featureTimeoutMs: 30_000, // well above attempt durations — no timeout
+    });
+    const { writer } = mkWriter();
+
+    const result = await driver.run(mkCtx(writer), {
+      key: "e2e-deep:showcase-test",
+      publicUrl: "https://showcase-test.example.com",
+      name: "showcase-test",
+      features: ["agentic-chat"],
+      shape: "package",
+    });
+
+    // Two attempts executed → two contexts opened; attempt 2 succeeded.
+    expect(state.opened).toBe(2);
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.passed).toBe(1);
+    expect(sig.failed).toEqual([]);
+  }, 15_000);
 });

--- a/showcase/harness/src/probes/drivers/d5-single-pill.test.ts
+++ b/showcase/harness/src/probes/drivers/d5-single-pill.test.ts
@@ -7,17 +7,19 @@ import {
   e2eDeepDriver,
   FEATURE_CONCURRENCY,
   Semaphore,
-  type E2eDeepAggregateSignal,
-  type E2eDeepBrowser,
-  type E2eDeepBrowserContext,
-  type E2eDeepFeatureSignal,
-  type E2eDeepPage,
+} from "./d5-single-pill.js";
+import type {
+  E2eDeepAggregateSignal,
+  E2eDeepBrowser,
+  E2eDeepBrowserContext,
+  E2eDeepFeatureSignal,
+  E2eDeepPage,
 } from "./d5-single-pill.js";
 import {
   __clearD5RegistryForTesting,
   registerD5Script,
-  type D5Script,
 } from "../helpers/d5-registry.js";
+import type { D5Script } from "../helpers/d5-registry.js";
 import { logger } from "../../logger.js";
 import type {
   ProbeContext,
@@ -1089,148 +1091,121 @@ describe("e2e-deep graceful degradation (FEATURE_CONCURRENCY=1 equivalent)", () 
 });
 
 // ---------------------------------------------------------------------
-// Pool starvation fix — verifies that createPooledE2eDeepLauncher
-// releases browsers back to the pool when the abort signal fires,
-// preventing cascading starvation when Promise.race abandons the
-// driver promise on timeout.
+// Context-pool migration: createPooledE2eDeepLauncher now checks out a
+// pooled CONTEXT per newContext() (pool.acquire) and releases it on close
+// (pool.release). maxContexts (reinterpreted POOL_SIZE) is the global cap;
+// each context acquire/release moves inUse by 1. On abort the launcher
+// closes its open contexts (each releasing its context) — NO browser fork.
+// The per-feature X-AIMock-Context / X-Test-Id headers must flow through
+// to pool.acquire so aimock routing still works.
 // ---------------------------------------------------------------------
-describe("createPooledE2eDeepLauncher abort release", () => {
-  /**
-   * Minimal fake pool that tracks acquire/release calls. Uses a simple
-   * array of fake browsers with an available/in-use split. The fake
-   * browsers satisfy the Playwright Browser interface just enough for
-   * the pooled launcher to call newContext() on them.
-   */
-  function makeFakePool(size: number) {
-    interface FakeBrowser {
-      id: number;
-      newContext(): Promise<{
-        newPage(): Promise<{
-          on: (event: string, handler: (...args: unknown[]) => void) => void;
-          waitForSelector: () => Promise<void>;
-          fill: () => Promise<void>;
-          press: () => Promise<void>;
-          evaluate: () => Promise<unknown>;
-          goto: () => Promise<void>;
-          close: () => Promise<void>;
-          click: () => Promise<void>;
-          waitForFunction: () => Promise<void>;
-        }>;
-        close(): Promise<void>;
-      }>;
-      close(): Promise<void>;
-    }
+/**
+ * Fake context-pool tracking per-CONTEXT acquire/release and the
+ * contextOptions each acquire was called with (so header forwarding is
+ * observable). `maxContexts` is the global cap. Module-scoped so oxlint's
+ * consistent-function-scoping is satisfied (captures no parent state).
+ */
+function makeDeepFakeContextPool(maxContexts: number) {
+  let nextCtxId = 0;
+  let live = 0;
+  const releaseLog: number[] = [];
+  const acquireLog: number[] = [];
+  const acquireOptions: Array<
+    { extraHTTPHeaders?: Record<string, string> } | undefined
+  > = [];
 
-    const browsers: FakeBrowser[] = [];
-    for (let i = 0; i < size; i++) {
-      let contextsClosed = 0;
-      browsers.push({
-        id: i,
-        async newContext() {
+  return {
+    async acquire(options?: {
+      extraHTTPHeaders?: Record<string, string>;
+    }): Promise<unknown> {
+      if (live >= maxContexts) throw new Error("FakePool: at cap");
+      const id = nextCtxId++;
+      live++;
+      acquireLog.push(id);
+      acquireOptions.push(options);
+      return {
+        __id: id,
+        async newPage() {
           return {
-            async newPage() {
-              return {
-                on: () => {},
-                waitForSelector: async () => {},
-                fill: async () => {},
-                press: async () => {},
-                evaluate: async () => 0,
-                goto: async () => {},
-                close: async () => {},
-                click: async () => {},
-                waitForFunction: async () => {},
-              };
-            },
-            async close() {
-              contextsClosed++;
-            },
+            on: () => {},
+            waitForSelector: async () => {},
+            fill: async () => {},
+            press: async () => {},
+            evaluate: async () => 0,
+            goto: async () => {},
+            close: async () => {},
+            click: async () => {},
+            waitForFunction: async () => {},
           };
         },
         async close() {},
-      });
-    }
+      };
+    },
+    async release(ctx: unknown): Promise<void> {
+      const c = ctx as { __id: number };
+      releaseLog.push(c.__id);
+      live--;
+    },
+    stats() {
+      return {
+        size: maxContexts,
+        available: maxContexts - live,
+        inUse: live,
+        totalRecycles: 0,
+      };
+    },
+    get _releaseLog() {
+      return releaseLog;
+    },
+    get _acquireLog() {
+      return acquireLog;
+    },
+    get _acquireOptions() {
+      return acquireOptions;
+    },
+  };
+}
 
-    const available = [...browsers];
-    const releaseLog: number[] = [];
-    const acquireLog: number[] = [];
-
-    const pool = {
-      async acquire(): Promise<unknown> {
-        const browser = available.shift();
-        if (!browser) throw new Error("FakePool: no browsers available");
-        acquireLog.push(browser.id);
-        return browser;
-      },
-      release(browser: unknown): void {
-        const fb = browser as FakeBrowser;
-        releaseLog.push(fb.id);
-        available.push(fb);
-      },
-      stats() {
-        return {
-          size,
-          available: available.length,
-          inUse: size - available.length,
-          totalRecycles: 0,
-        };
-      },
-      // Expose internals for assertions.
-      get _available() {
-        return available;
-      },
-      get _releaseLog() {
-        return releaseLog;
-      },
-      get _acquireLog() {
-        return acquireLog;
-      },
-    };
-
-    return pool;
-  }
-
-  it("releases browser back to pool when abort signal fires (prevents starvation)", async () => {
-    const pool = makeFakePool(2);
-    // Cast: the fake pool satisfies BrowserPool structurally for the
-    // subset of methods createPooledE2eDeepLauncher uses.
+describe("createPooledE2eDeepLauncher context checkout + abort release", () => {
+  it("checks out one context per newContext() and moves inUse by 1", async () => {
+    const pool = makeDeepFakeContextPool(4);
     const launcher = createPooledE2eDeepLauncher(
       pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
     );
+    const browser = await launcher();
+    expect(pool.stats().inUse).toBe(0);
 
-    // Acquire both browsers through the launcher.
-    const abortCtrl1 = new AbortController();
-    const abortCtrl2 = new AbortController();
-    const browser1 = await launcher(abortCtrl1.signal);
-    const browser2 = await launcher(abortCtrl2.signal);
+    const ctx = await browser.newContext();
+    expect(pool.stats().inUse).toBe(1);
+    expect(pool.stats().available).toBe(3);
 
-    // Both browsers are now in use — pool should have 0 available.
-    expect(pool.stats().available).toBe(0);
-    expect(pool.stats().inUse).toBe(2);
-
-    // Simulate timeout: abort signal fires for browser1.
-    abortCtrl1.abort();
-
-    // Give the abort handler's async context-close + release a tick.
-    await new Promise((r) => setTimeout(r, 10));
-
-    // Browser1 should be released back to the pool.
-    expect(pool._releaseLog).toContain(0);
-    expect(pool.stats().available).toBe(1);
-
-    // The driver's finally block eventually calls browser.close() —
-    // verify it's a no-op (doesn't double-release).
-    await browser1.close();
-    // Still only 1 release for browser 0.
-    expect(pool._releaseLog.filter((id) => id === 0)).toHaveLength(1);
-
-    // Browser2 is still held — normal close releases it.
-    await browser2.close();
-    expect(pool._releaseLog).toContain(1);
-    expect(pool.stats().available).toBe(2);
+    await ctx.close();
+    expect(pool.stats().inUse).toBe(0);
+    expect(pool._releaseLog).toHaveLength(1);
   });
 
-  it("closes open contexts before releasing on abort", async () => {
-    const pool = makeFakePool(1);
+  it("forwards newContext(opts).extraHTTPHeaders into pool.acquire", async () => {
+    const pool = makeDeepFakeContextPool(2);
+    const launcher = createPooledE2eDeepLauncher(
+      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
+    );
+    const browser = await launcher();
+    await browser.newContext({
+      extraHTTPHeaders: {
+        "X-AIMock-Context": "slug-x",
+        "X-Test-Id": "d5-slug-x",
+      },
+    });
+    expect(pool._acquireOptions[0]).toEqual({
+      extraHTTPHeaders: {
+        "X-AIMock-Context": "slug-x",
+        "X-Test-Id": "d5-slug-x",
+      },
+    });
+  });
+
+  it("closes open contexts on abort (each releasing its pooled context)", async () => {
+    const pool = makeDeepFakeContextPool(2);
     const launcher = createPooledE2eDeepLauncher(
       pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
     );
@@ -1238,103 +1213,27 @@ describe("createPooledE2eDeepLauncher abort release", () => {
     const abortCtrl = new AbortController();
     const browser = await launcher(abortCtrl.signal);
 
-    // Open a context (simulates the driver opening a page).
     const ctx = await browser.newContext();
     const _page = await ctx.newPage();
+    expect(pool.stats().inUse).toBe(1);
 
-    // Abort fires — should close context then release.
     abortCtrl.abort();
     await new Promise((r) => setTimeout(r, 10));
 
-    // Browser released back to pool.
     expect(pool._releaseLog).toHaveLength(1);
-    expect(pool.stats().available).toBe(1);
+    expect(pool.stats().inUse).toBe(0);
   });
 
-  it("handles already-aborted signal (releases immediately)", async () => {
-    const pool = makeFakePool(1);
+  it("launcher-level close is a no-op (contexts release themselves)", async () => {
+    const pool = makeDeepFakeContextPool(2);
     const launcher = createPooledE2eDeepLauncher(
       pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
     );
-
-    // Pre-aborted signal.
-    const abortCtrl = new AbortController();
-    abortCtrl.abort();
-
-    const browser = await launcher(abortCtrl.signal);
-
-    // Should be released immediately (synchronously after acquire).
-    expect(pool._releaseLog).toHaveLength(1);
-    expect(pool.stats().available).toBe(1);
-
-    // Driver's close is a no-op.
-    await browser.close();
-    expect(pool._releaseLog).toHaveLength(1);
-  });
-
-  it("full pool starvation scenario: all slots acquired, timeout releases them for next run", async () => {
-    const POOL_SIZE = 4;
-    const pool = makeFakePool(POOL_SIZE);
-    const launcher = createPooledE2eDeepLauncher(
-      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
-    );
-
-    // Simulate a probe run that acquires all 4 pool slots.
-    const abortCtrls = Array.from(
-      { length: POOL_SIZE },
-      () => new AbortController(),
-    );
-    const browsers = await Promise.all(
-      abortCtrls.map((ac) => launcher(ac.signal)),
-    );
-
-    // Pool is fully exhausted.
-    expect(pool.stats().available).toBe(0);
-    expect(pool.stats().inUse).toBe(POOL_SIZE);
-
-    // Simulate timeout: abort all signals (as the invoker would).
-    for (const ac of abortCtrls) ac.abort();
-    await new Promise((r) => setTimeout(r, 20));
-
-    // All browsers should be released back to the pool.
-    expect(pool.stats().available).toBe(POOL_SIZE);
-    expect(pool._releaseLog).toHaveLength(POOL_SIZE);
-
-    // Next probe run can now acquire all 4 browsers.
-    const nextAbortCtrls = Array.from(
-      { length: POOL_SIZE },
-      () => new AbortController(),
-    );
-    const nextBrowsers = await Promise.all(
-      nextAbortCtrls.map((ac) => launcher(ac.signal)),
-    );
-    expect(pool.stats().available).toBe(0);
-    expect(pool.stats().inUse).toBe(POOL_SIZE);
-
-    // Clean up: normal close for the second run.
-    for (const b of nextBrowsers) await b.close();
-    expect(pool.stats().available).toBe(POOL_SIZE);
-
-    // Driver's finally block for the first run — all no-ops.
-    for (const b of browsers) await b.close();
-    // No extra releases — still POOL_SIZE total from the abort +
-    // POOL_SIZE from the second run's normal close.
-    expect(pool._releaseLog).toHaveLength(POOL_SIZE * 2);
-  });
-
-  it("no-abort path: browser released normally via close()", async () => {
-    const pool = makeFakePool(1);
-    const launcher = createPooledE2eDeepLauncher(
-      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
-    );
-
-    // No abort signal at all (backwards compat with defaultLauncher).
     const browser = await launcher();
-    expect(pool.stats().available).toBe(0);
-
-    await browser.close();
+    const ctx = await browser.newContext();
+    await ctx.close();
+    await browser.close(); // no-op
     expect(pool._releaseLog).toHaveLength(1);
-    expect(pool.stats().available).toBe(1);
   });
 });
 

--- a/showcase/harness/src/probes/drivers/d5-single-pill.test.ts
+++ b/showcase/harness/src/probes/drivers/d5-single-pill.test.ts
@@ -1574,6 +1574,11 @@ describe("e2e-deep deploy-churn grace window", () => {
 // `feature-timeout` verdict while runFeature keeps running and holding its
 // context; context teardown then completes a tick later.
 // ---------------------------------------------------------------------
+/** Module-scoped timer helper (oxlint consistent-function-scoping). */
+function testSleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
 /**
  * Launcher whose contexts simulate pooled checkout: `newContext` increments
  * a live counter (tracking peak), each context's page `goto` resolves only
@@ -1589,8 +1594,6 @@ function makeSlowTeardownLauncher(opts: {
   state: { live: number; peakLive: number; opened: number; closed: number };
 } {
   const state = { live: 0, peakLive: 0, opened: 0, closed: 0 };
-  const sleep = (ms: number): Promise<void> =>
-    new Promise((r) => setTimeout(r, ms));
   const browser: E2eDeepBrowser = {
     async newContext(): Promise<E2eDeepBrowserContext> {
       state.live++;
@@ -1609,7 +1612,7 @@ function makeSlowTeardownLauncher(opts: {
               // Hang past the per-feature timeout so the synthetic
               // feature-timeout verdict resolves while this runFeature
               // (and its held context) is still in flight.
-              await sleep(opts.gotoDelayMs);
+              await testSleep(opts.gotoDelayMs);
             },
             async waitForSelector() {},
             async fill() {},
@@ -1626,7 +1629,7 @@ function makeSlowTeardownLauncher(opts: {
         },
         async close() {
           // The orphan window: the context stays live until this resolves.
-          await sleep(opts.closeDelayMs);
+          await testSleep(opts.closeDelayMs);
           state.live--;
           state.closed++;
         },
@@ -1717,8 +1720,6 @@ function makeRetryLauncher(opts: { attempt1DelayMs: number }): {
   state: { opened: number };
 } {
   const state = { opened: 0 };
-  const sleep = (ms: number): Promise<void> =>
-    new Promise((r) => setTimeout(r, ms));
   const browser: E2eDeepBrowser = {
     async newContext(): Promise<E2eDeepBrowserContext> {
       const attempt = ++state.opened;
@@ -1729,7 +1730,7 @@ function makeRetryLauncher(opts: { attempt1DelayMs: number }): {
             async goto() {
               if (attempt === 1) {
                 // Burn > RETRY_MIN_DURATION_MS, then fail retry-eligibly.
-                await sleep(opts.attempt1DelayMs);
+                await testSleep(opts.attempt1DelayMs);
                 throw new Error("nav blip (retryable)");
               }
             },

--- a/showcase/harness/src/probes/drivers/d5-single-pill.ts
+++ b/showcase/harness/src/probes/drivers/d5-single-pill.ts
@@ -463,31 +463,25 @@ export function createPooledE2eDeepLauncher(
   logger?: { warn(event: string, meta?: Record<string, unknown>): void },
 ): E2eDeepBrowserLauncher {
   return async (abortSignal?: AbortSignal): Promise<E2eDeepBrowser> => {
-    const browser = await pool.acquire();
+    // CONTEXT-POOLED model: each newContext() checks out a pooled
+    // BrowserContext (X-AIMock-Strict centralized in the pool; per-feature
+    // X-AIMock-Context / X-Test-Id flow through `contextOpts`) and the
+    // wrapper's close() releases it. The abort closure re-targets onto the
+    // open contexts: on abort it closes each (each close() releases its
+    // pooled context). There is no Browser held. This still solves the
+    // pool-starvation race — Promise.race in the invoker abandons the driver
+    // promise while it keeps running with pooled contexts held; without this
+    // listener those contexts stay in-use across probe ticks.
+    let aborted = false;
 
-    // Track whether the browser was force-released by an abort so the
-    // driver's normal `browser.close()` in the finally block doesn't
-    // double-release (BrowserPool.release is a no-op for unknown refs
-    // after the browserToSlot entry is removed, but the close() would
-    // fail on an already-closed browser without the guard).
-    let forceReleased = false;
-
-    // Track open browser contexts so abort can close them before
-    // releasing the browser back to the pool. Without this, orphaned
-    // contexts keep the browser busy and the pool slot is effectively
-    // dead until the contexts are GC'd or the browser process crashes.
+    // Track open contexts so abort can close them. Each close() releases the
+    // pooled context back to the pool, freeing a context slot.
     const openContexts = new Set<{ close(): Promise<void> }>();
 
-    // Abort listener: when the invoker's timeout fires, the abort
-    // signal triggers. Force-close all open contexts and release the
-    // browser back to the pool immediately so the next probe run can
-    // acquire it. This prevents pool starvation when Promise.race
-    // abandons the driver promise but the driver keeps running with
-    // the pooled browser held.
     if (abortSignal) {
       const onAbort = (): void => {
-        if (forceReleased) return;
-        forceReleased = true;
+        if (aborted) return;
+        aborted = true;
         const ctxCount = openContexts.size;
         const stats = pool.stats();
         logger?.warn("probe.e2e-deep.pool-abort-release", {
@@ -500,7 +494,6 @@ export function createPooledE2eDeepLauncher(
           ctx.close().catch(() => {}),
         );
         void Promise.allSettled(contextClosePromises).then(() => {
-          pool.release(browser);
           logger?.warn("probe.e2e-deep.pool-abort-released", {
             closedContexts: ctxCount,
             poolAvailable: pool.stats().available,
@@ -508,9 +501,8 @@ export function createPooledE2eDeepLauncher(
         });
       };
       if (abortSignal.aborted) {
-        forceReleased = true;
+        aborted = true;
         logger?.warn("probe.e2e-deep.pool-pre-aborted-release");
-        pool.release(browser);
       } else {
         abortSignal.addEventListener("abort", onAbort, { once: true });
       }
@@ -520,13 +512,10 @@ export function createPooledE2eDeepLauncher(
       async newContext(contextOpts?: {
         extraHTTPHeaders?: Record<string, string>;
       }): Promise<E2eDeepBrowserContext> {
-        const ctx = await browser.newContext({
-          extraHTTPHeaders: {
-            "X-AIMock-Strict": "true",
-            ...contextOpts?.extraHTTPHeaders,
-          },
+        const ctx = await pool.acquire({
+          extraHTTPHeaders: contextOpts?.extraHTTPHeaders,
         });
-        const ctxHandle = { close: () => ctx.close() };
+        const ctxHandle = { close: () => pool.release(ctx) };
         openContexts.add(ctxHandle);
         return {
           async newPage(): Promise<E2eDeepPage> {
@@ -580,14 +569,12 @@ export function createPooledE2eDeepLauncher(
           },
           close: async () => {
             openContexts.delete(ctxHandle);
-            await ctx.close();
+            await pool.release(ctx);
           },
         };
       },
-      close: async () => {
-        if (forceReleased) return;
-        pool.release(browser);
-      },
+      // Launcher-level close is a no-op: each context releases itself.
+      close: async () => {},
     };
   };
 }

--- a/showcase/harness/src/probes/drivers/d5-single-pill.ts
+++ b/showcase/harness/src/probes/drivers/d5-single-pill.ts
@@ -478,33 +478,38 @@ export function createPooledE2eDeepLauncher(
     // pooled context back to the pool, freeing a context slot.
     const openContexts = new Set<{ close(): Promise<void> }>();
 
+    const onAbort = (): void => {
+      if (aborted) return;
+      aborted = true;
+      const ctxCount = openContexts.size;
+      const stats = pool.stats();
+      logger?.warn("probe.e2e-deep.pool-abort-release", {
+        openContexts: ctxCount,
+        poolAvailable: stats.available,
+        poolInUse: stats.inUse,
+        poolSize: stats.size,
+      });
+      const contextClosePromises = Array.from(openContexts).map((ctx) =>
+        ctx.close().catch(() => {}),
+      );
+      void Promise.allSettled(contextClosePromises).then(() => {
+        logger?.warn("probe.e2e-deep.pool-abort-released", {
+          closedContexts: ctxCount,
+          poolAvailable: pool.stats().available,
+        });
+      });
+    };
+    // Capture the listener so launcher-level close() can detach it: without
+    // removeEventListener a post-completion abort would fire onAbort after the
+    // run returned, leaking the listener for the signal's lifetime.
+    let detachAbort: (() => void) | undefined;
     if (abortSignal) {
-      const onAbort = (): void => {
-        if (aborted) return;
-        aborted = true;
-        const ctxCount = openContexts.size;
-        const stats = pool.stats();
-        logger?.warn("probe.e2e-deep.pool-abort-release", {
-          openContexts: ctxCount,
-          poolAvailable: stats.available,
-          poolInUse: stats.inUse,
-          poolSize: stats.size,
-        });
-        const contextClosePromises = Array.from(openContexts).map((ctx) =>
-          ctx.close().catch(() => {}),
-        );
-        void Promise.allSettled(contextClosePromises).then(() => {
-          logger?.warn("probe.e2e-deep.pool-abort-released", {
-            closedContexts: ctxCount,
-            poolAvailable: pool.stats().available,
-          });
-        });
-      };
       if (abortSignal.aborted) {
         aborted = true;
         logger?.warn("probe.e2e-deep.pool-pre-aborted-release");
       } else {
         abortSignal.addEventListener("abort", onAbort, { once: true });
+        detachAbort = () => abortSignal.removeEventListener("abort", onAbort);
       }
     }
 
@@ -515,6 +520,14 @@ export function createPooledE2eDeepLauncher(
         const ctx = await pool.acquire({
           extraHTTPHeaders: contextOpts?.extraHTTPHeaders,
         });
+        // If the signal was already aborted at launcher construction (the
+        // pre-aborted branch never attached the live abort listener), a context
+        // opened now would never be closed by the abort path. Release it
+        // immediately and refuse so it cannot leak into a torn-down run.
+        if (aborted) {
+          await pool.release(ctx).catch(() => {});
+          throw new Error("e2e-deep launcher aborted");
+        }
         const ctxHandle = { close: () => pool.release(ctx) };
         openContexts.add(ctxHandle);
         return {
@@ -573,8 +586,12 @@ export function createPooledE2eDeepLauncher(
           },
         };
       },
-      // Launcher-level close is a no-op: each context releases itself.
-      close: async () => {},
+      // Launcher-level close releases nothing itself (each context releases
+      // itself) but detaches the abort listener so a post-completion abort
+      // can't fire onAbort after the run returned.
+      close: async () => {
+        detachAbort?.();
+      },
     };
   };
 }

--- a/showcase/harness/src/probes/drivers/d5-single-pill.ts
+++ b/showcase/harness/src/probes/drivers/d5-single-pill.ts
@@ -965,6 +965,18 @@ export function createE2eDeepDriver(
 
           await sem.acquire();
           const featureStart = Date.now();
+          // In-flight runFeature promises that may still be holding a
+          // pooled BrowserContext after the Promise.race resolves. On
+          // the feature-timeout path the race resolves a synthetic
+          // result while the real runFeature keeps running until its
+          // abort-driven teardown closes the context (→ pool.release).
+          // We gate sem.release() (outer finally) on these settling so
+          // the freed slot can't be re-acquired while an orphan still
+          // holds a context, which would push live pooled contexts past
+          // the FEATURE_CONCURRENCY-bounded budget.
+          const inFlightRunFeatures: Array<
+            Promise<Awaited<ReturnType<typeof runFeature>>>
+          > = [];
           try {
             if (abort.signal.aborted) {
               await sideEmit(ctx, {
@@ -1064,23 +1076,44 @@ export function createE2eDeepDriver(
               Awaited<ReturnType<typeof runFeature>>
             > => {
               let featureTimer: ReturnType<typeof setTimeout> | undefined;
+              // Per-attempt child controller. It aborts when the parent
+              // (`featureAbort`) fires OR when THIS attempt's timer wins,
+              // so aborting one attempt never poisons the next — the
+              // retry attempt gets a fresh, un-aborted signal. Without
+              // this, a single shared controller aborted by attempt 1
+              // would make attempt 2's runFeature return immediately with
+              // `aborted before start` (a silent no-op retry).
+              const attemptAbort = new AbortController();
+              const onParentAbortChild = (): void => attemptAbort.abort();
+              if (featureAbort.signal.aborted) attemptAbort.abort();
+              else
+                featureAbort.signal.addEventListener(
+                  "abort",
+                  onParentAbortChild,
+                  { once: true },
+                );
+              const runFeaturePromise = runFeature({
+                browser: browserRef,
+                url,
+                pageTimeoutMs,
+                script,
+                buildCtx: {
+                  integrationSlug: slug,
+                  featureType: ft,
+                  baseUrl: backendUrl,
+                },
+                abortSignal: attemptAbort.signal,
+              });
+              inFlightRunFeatures.push(runFeaturePromise);
               try {
                 return await Promise.race([
-                  runFeature({
-                    browser: browserRef,
-                    url,
-                    pageTimeoutMs,
-                    script,
-                    buildCtx: {
-                      integrationSlug: slug,
-                      featureType: ft,
-                      baseUrl: backendUrl,
-                    },
-                    abortSignal: featureAbort.signal,
-                  }),
+                  runFeaturePromise,
                   new Promise<Awaited<ReturnType<typeof runFeature>>>(
                     (resolve) => {
                       featureTimer = setTimeout(() => {
+                        // Abort the parent so the launcher's open-context
+                        // teardown runs; this also aborts the child via
+                        // the listener above.
                         featureAbort.abort();
                         resolve({
                           ok: false,
@@ -1093,6 +1126,10 @@ export function createE2eDeepDriver(
                 ]);
               } finally {
                 if (featureTimer) clearTimeout(featureTimer);
+                featureAbort.signal.removeEventListener(
+                  "abort",
+                  onParentAbortChild,
+                );
               }
             };
 
@@ -1192,6 +1229,14 @@ export function createE2eDeepDriver(
               };
             }
           } finally {
+            // Gate slot release on the real teardown of any in-flight
+            // runFeature. On the timeout path the synthetic verdict has
+            // already been returned to the caller above; here we only
+            // wait for the abandoned runFeature's context teardown (its
+            // own finally → context.close() → pool.release) to settle so
+            // the slot isn't handed to a new feature while an orphan
+            // still holds a pooled context.
+            await Promise.allSettled(inFlightRunFeatures);
             sem.release();
           }
         });

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -618,18 +618,21 @@ describe("e2e-full driver", () => {
 // acquire/release and the contextOptions each acquire was called with.
 function makeFakeContextPool(maxContexts: number) {
   let nextCtxId = 0;
-  let live = 0;
+  // Track the set of currently-live contexts so release fidelity matches
+  // the real BrowserPool: an unknown / double release is a no-op (does
+  // NOT decrement the count). The previous unconditional decrement could
+  // drive `live` negative and silently mask a double-release bug.
+  const liveContexts = new Set<object>();
   const releaseLog: number[] = [];
   const acquireOptions: Array<
     { extraHTTPHeaders?: Record<string, string> } | undefined
   > = [];
   return {
     async acquire(options?: { extraHTTPHeaders?: Record<string, string> }) {
-      if (live >= maxContexts) throw new Error("FakePool: at cap");
+      if (liveContexts.size >= maxContexts) throw new Error("FakePool: at cap");
       const id = nextCtxId++;
-      live++;
       acquireOptions.push(options);
-      return {
+      const ctx = {
         __id: id,
         async newPage() {
           return {
@@ -649,18 +652,23 @@ function makeFakeContextPool(maxContexts: number) {
           } as unknown;
         },
         async close() {},
-      } as unknown as Browser;
+      };
+      liveContexts.add(ctx);
+      return ctx as unknown as Browser;
     },
     async release(ctx: unknown) {
-      const c = ctx as { __id: number };
-      releaseLog.push(c.__id);
-      live--;
+      // Unknown / double release — no-op, mirroring BrowserPool.release.
+      if (typeof ctx !== "object" || ctx === null || !liveContexts.has(ctx)) {
+        return;
+      }
+      liveContexts.delete(ctx);
+      releaseLog.push((ctx as { __id: number }).__id);
     },
     stats() {
       return {
         size: maxContexts,
-        available: maxContexts - live,
-        inUse: live,
+        available: maxContexts - liveContexts.size,
+        inUse: liveContexts.size,
         totalRecycles: 0,
       };
     },
@@ -672,3 +680,219 @@ function makeFakeContextPool(maxContexts: number) {
     },
   };
 }
+
+// ---------------------------------------------------------------------
+// Pooled-context budget (e2e-full): feature-timeout must NOT free the
+// semaphore slot until the orphaned (still-in-flight) runFeature's
+// context is actually released. Otherwise a freed slot lets a new
+// feature acquire a context while the orphan still holds one → live
+// contexts exceed FEATURE_CONCURRENCY_D6's budget. Mirrors the d5 test.
+// ---------------------------------------------------------------------
+/**
+ * Launcher whose contexts simulate pooled checkout: `newContext`
+ * increments a live counter (tracking peak), each context's page `goto`
+ * resolves only after `gotoDelayMs`, and `close()` resolves only after
+ * `closeDelayMs` (the orphan window). Module-scoped for oxlint's
+ * consistent-function-scoping.
+ */
+function makeSlowTeardownLauncherFull(opts: {
+  gotoDelayMs: number;
+  closeDelayMs: number;
+}): {
+  launcher: () => Promise<E2eFullBrowser>;
+  state: { live: number; peakLive: number; opened: number; closed: number };
+} {
+  const state = { live: 0, peakLive: 0, opened: 0, closed: 0 };
+  const sleep = (ms: number): Promise<void> =>
+    new Promise((r) => setTimeout(r, ms));
+  const browser: E2eFullBrowser = {
+    async newContext(): Promise<E2eFullBrowserContext> {
+      state.live++;
+      state.opened++;
+      if (state.live > state.peakLive) state.peakLive = state.live;
+      return {
+        async newPage(): Promise<E2eFullPage> {
+          // Growing-count contract so the conversation settles quickly
+          // (no 30s response timeout): runFeature then reaches its
+          // finally and calls the (deliberately slow) context.close().
+          let messageCount = 0;
+          return {
+            async goto() {
+              await sleep(opts.gotoDelayMs);
+            },
+            async waitForSelector() {},
+            async fill() {},
+            async press() {
+              messageCount++;
+            },
+            async evaluate<R>() {
+              return messageCount as unknown as R;
+            },
+            async click() {},
+            async waitForFunction() {},
+            async close() {},
+          };
+        },
+        async close() {
+          // The orphan window: the context stays live until this resolves.
+          await sleep(opts.closeDelayMs);
+          state.live--;
+          state.closed++;
+        },
+      };
+    },
+    async close() {},
+  };
+  return { launcher: async () => browser, state };
+}
+
+describe("e2e-full feature-timeout pooled-context budget", () => {
+  beforeEach(() => {
+    __clearD5RegistryForTesting();
+  });
+
+  it("does not exceed FEATURE_CONCURRENCY_D6 live contexts when features time out (slot release gated on orphan teardown)", async () => {
+    // FEATURE_CONCURRENCY_D6 features acquire slots and time out (goto
+    // hangs past featureTimeoutMs) but keep holding their contexts until
+    // close() resolves. One extra feature waits in the semaphore queue.
+    // If the slot is freed at timeout BEFORE the orphan's context is
+    // released, the queued feature acquires an over-budget context →
+    // peakLive > FEATURE_CONCURRENCY_D6. Gating slot release on the
+    // in-flight runFeature settling keeps peakLive <= the budget.
+    const conc = FEATURE_CONCURRENCY_D6;
+    const featureTypes = [
+      "agentic-chat",
+      "tool-rendering",
+      "shared-state-read",
+      "shared-state-write",
+      "hitl-text-input",
+    ] as const;
+    expect(featureTypes.length).toBeGreaterThan(conc);
+
+    for (const ft of featureTypes) {
+      registerD5Script(makeScript([ft]));
+    }
+
+    const { launcher, state } = makeSlowTeardownLauncherFull({
+      gotoDelayMs: 60,
+      closeDelayMs: 80,
+    });
+
+    const driver = createE2eFullDriver({
+      launcher,
+      scriptLoader: noopScriptLoader(),
+      featureTimeoutMs: 20,
+    });
+    const sideEmits: ProbeResult<unknown>[] = [];
+    const writer: ProbeResultWriter = {
+      write: async (r) => {
+        sideEmits.push(r);
+      },
+    };
+
+    await driver.run(makeCtx({ writer }), {
+      key: "d6-all-pills-e2e:showcase-test-slug",
+      backendUrl: "https://test.example.com",
+      features: [...featureTypes],
+    });
+
+    expect(state.opened).toBe(featureTypes.length);
+    expect(state.peakLive).toBeLessThanOrEqual(conc);
+    expect(state.live).toBe(0); // all released by the time run() resolves
+  }, 20_000);
+});
+
+// ---------------------------------------------------------------------
+// Per-feature retry uses an isolated AbortController per attempt (e2e-full):
+// a retry after a RETRY-ELIGIBLE failure must actually execute the second
+// attempt rather than being short-circuited by a poisoned (pre-aborted)
+// signal. Observed via context-open count: runFeature returns `abort`
+// WITHOUT opening a context if entered with an aborted signal, so a
+// poisoned retry opens only ONE context; a healthy retry opens TWO.
+// ---------------------------------------------------------------------
+/**
+ * Launcher whose first context FAILS with a retry-eligible `goto-error`
+ * (goto rejects after >RETRY_MIN_DURATION_MS) and whose second SUCCEEDS.
+ * Tracks contexts opened (one per executed attempt).
+ */
+function makeRetryLauncherFull(opts: { attempt1DelayMs: number }): {
+  launcher: () => Promise<E2eFullBrowser>;
+  state: { opened: number };
+} {
+  const state = { opened: 0 };
+  const sleep = (ms: number): Promise<void> =>
+    new Promise((r) => setTimeout(r, ms));
+  const browser: E2eFullBrowser = {
+    async newContext(): Promise<E2eFullBrowserContext> {
+      const attempt = ++state.opened;
+      return {
+        async newPage(): Promise<E2eFullPage> {
+          let messageCount = 0;
+          return {
+            async goto() {
+              if (attempt === 1) {
+                await sleep(opts.attempt1DelayMs);
+                throw new Error("nav blip (retryable)");
+              }
+            },
+            async waitForSelector() {},
+            async fill() {},
+            async press() {
+              messageCount++;
+            },
+            async evaluate<R>() {
+              return messageCount as unknown as R;
+            },
+            async click() {},
+            async waitForFunction() {},
+            async close() {},
+          };
+        },
+        async close() {},
+      };
+    },
+    async close() {},
+  };
+  return { launcher: async () => browser, state };
+}
+
+describe("e2e-full per-feature retry signal isolation", () => {
+  beforeEach(() => {
+    __clearD5RegistryForTesting();
+  });
+
+  it("executes the second attempt after a retry-eligible failure (fresh, non-aborted signal)", async () => {
+    // Attempt 1 fails retry-eligibly (goto-error) after
+    // >= RETRY_MIN_DURATION_MS (2s); attempt 2 succeeds. The retry must
+    // run with a fresh, un-aborted signal — observed by TWO contexts
+    // being opened (a poisoned/aborted retry would open only one).
+    registerD5Script(makeScript(["agentic-chat"]));
+
+    const { launcher, state } = makeRetryLauncherFull({
+      attempt1DelayMs: 2_100,
+    });
+
+    const driver = createE2eFullDriver({
+      launcher,
+      scriptLoader: noopScriptLoader(),
+      featureTimeoutMs: 30_000, // above attempt durations — no timeout
+    });
+    const sideEmits: ProbeResult<unknown>[] = [];
+    const writer: ProbeResultWriter = {
+      write: async (r) => {
+        sideEmits.push(r);
+      },
+    };
+
+    await driver.run(makeCtx({ writer }), {
+      key: "d6-all-pills-e2e:showcase-test-slug",
+      backendUrl: "https://test.example.com",
+      features: ["agentic-chat"],
+    });
+
+    // Two attempts executed → two contexts opened.
+    expect(state.opened).toBe(2);
+    const aggRow = sideEmits.find((r) => r.key === "d6:test-slug");
+    expect(aggRow?.state).toBe("green");
+  }, 15_000);
+});

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -541,102 +541,134 @@ describe("e2e-full driver", () => {
   // ~40 features don't all fail with "Target page, context or
   // browser has been closed".
   // --------------------------------------------------------------------
+  // Context-pool migration: the pooled launcher checks out a pooled
+  // CONTEXT per newContext() (pool.acquire) and releases it on close
+  // (pool.release). No Browser is held, so the dead-browser re-acquire
+  // dance is gone — the pool only opens contexts on live browsers. Each
+  // acquire moves inUse by 1, per-feature headers forward into acquire,
+  // and abort closes open contexts (each releasing its context).
   describe("createPooledE2eFullLauncher", () => {
-    it("releases and re-acquires when acquire() returns a disconnected browser", async () => {
-      const dead = makeFakeBrowserish(false);
-      const fresh = makeFakeBrowserish(true);
-      const acquired: FakeBrowserish[] = [];
-      const released: FakeBrowserish[] = [];
-      let nextIdx = 0;
-      const queue = [dead, fresh];
-      const fakePool = {
-        async acquire() {
-          const b = queue[nextIdx++]!;
-          acquired.push(b);
-          return b as unknown as Browser;
-        },
-        release(b: unknown) {
-          released.push(b as FakeBrowserish);
-        },
-        stats() {
-          return { size: 1, available: 0, inUse: 1, totalRecycles: 0 };
-        },
-      };
-      const warnings: Array<{ event: string; meta?: unknown }> = [];
-      const warnLogger = {
-        warn: (event: string, meta?: Record<string, unknown>) =>
-          warnings.push({ event, meta }),
-      };
+    it("checks out a pooled context per newContext() and moves inUse by 1", async () => {
+      const pool = makeFakeContextPool(4);
       const launcher = createPooledE2eFullLauncher(
-        fakePool as unknown as BrowserPool,
-        warnLogger,
+        pool as unknown as BrowserPool,
       );
       const browser = await launcher();
-      // Must have acquired twice (dead, then fresh) and released the
-      // dead instance back to the pool exactly once.
-      expect(acquired).toHaveLength(2);
-      expect(acquired[0]).toBe(dead);
-      expect(acquired[1]).toBe(fresh);
-      expect(released).toHaveLength(1);
-      expect(released[0]).toBe(dead);
-      // The launcher must return a usable E2eFullBrowser; smoke-test
-      // newContext() to confirm we got back the FRESH instance.
-      await browser.newContext();
-      // Diagnostic warn surfaced so operators can correlate.
-      expect(warnings.map((w) => w.event)).toContain(
-        "probe.e2e-full.pool-acquire-dead",
-      );
+      expect(pool.stats().inUse).toBe(0);
+      const ctx = await browser.newContext();
+      expect(pool.stats().inUse).toBe(1);
+      await ctx.close();
+      expect(pool.stats().inUse).toBe(0);
+      expect(pool._releaseLog).toHaveLength(1);
     });
 
-    it("does not re-acquire when the first acquire returns a healthy browser", async () => {
-      const healthy = makeFakeBrowserish(true);
-      const acquired: FakeBrowserish[] = [];
-      const released: FakeBrowserish[] = [];
-      const fakePool = {
-        async acquire() {
-          acquired.push(healthy);
-          return healthy as unknown as Browser;
-        },
-        release(b: unknown) {
-          released.push(b as FakeBrowserish);
-        },
-        stats() {
-          return { size: 1, available: 0, inUse: 1, totalRecycles: 0 };
-        },
-      };
+    it("forwards newContext(opts).extraHTTPHeaders into pool.acquire", async () => {
+      const pool = makeFakeContextPool(4);
       const launcher = createPooledE2eFullLauncher(
-        fakePool as unknown as BrowserPool,
+        pool as unknown as BrowserPool,
       );
-      await launcher();
-      expect(acquired).toHaveLength(1);
-      expect(released).toHaveLength(0);
+      const browser = await launcher();
+      await browser.newContext({
+        extraHTTPHeaders: {
+          "X-AIMock-Context": "slug-d6",
+          "X-Test-Id": "d6-slug-d6",
+        },
+      });
+      expect(pool._acquireOptions[0]).toEqual({
+        extraHTTPHeaders: {
+          "X-AIMock-Context": "slug-d6",
+          "X-Test-Id": "d6-slug-d6",
+        },
+      });
+    });
+
+    it("closes open contexts on abort (each releasing its pooled context)", async () => {
+      const pool = makeFakeContextPool(4);
+      const launcher = createPooledE2eFullLauncher(
+        pool as unknown as BrowserPool,
+      );
+      const ac = new AbortController();
+      const browser = await launcher(ac.signal);
+      const ctx = await browser.newContext();
+      await ctx.newPage();
+      expect(pool.stats().inUse).toBe(1);
+      ac.abort();
+      await new Promise((r) => setTimeout(r, 10));
+      expect(pool._releaseLog).toHaveLength(1);
+      expect(pool.stats().inUse).toBe(0);
+    });
+
+    it("launcher-level close is a no-op (contexts release themselves)", async () => {
+      const pool = makeFakeContextPool(4);
+      const launcher = createPooledE2eFullLauncher(
+        pool as unknown as BrowserPool,
+      );
+      const browser = await launcher();
+      const ctx = await browser.newContext();
+      await ctx.close();
+      await browser.close(); // no-op
+      expect(pool._releaseLog).toHaveLength(1);
     });
   });
 });
 
-// Module-scoped helpers for the createPooledE2eFullLauncher tests above —
-// lifted out of the describe so oxlint's consistent-function-scoping is
-// satisfied (the factory captures no parent state).
-interface FakeBrowserish {
-  connected: boolean;
-  newContext(): Promise<{
-    close(): Promise<void>;
-    newPage(): Promise<unknown>;
-  }>;
-  isConnected(): boolean;
-}
-
-function makeFakeBrowserish(connected: boolean): FakeBrowserish {
+// Module-scoped fake context-pool for the createPooledE2eFullLauncher tests
+// above — lifted out of the describe so oxlint's consistent-function-scoping
+// is satisfied (the factory captures no parent state). Tracks per-CONTEXT
+// acquire/release and the contextOptions each acquire was called with.
+function makeFakeContextPool(maxContexts: number) {
+  let nextCtxId = 0;
+  let live = 0;
+  const releaseLog: number[] = [];
+  const acquireOptions: Array<
+    { extraHTTPHeaders?: Record<string, string> } | undefined
+  > = [];
   return {
-    connected,
-    isConnected() {
-      return this.connected;
-    },
-    async newContext() {
+    async acquire(options?: { extraHTTPHeaders?: Record<string, string> }) {
+      if (live >= maxContexts) throw new Error("FakePool: at cap");
+      const id = nextCtxId++;
+      live++;
+      acquireOptions.push(options);
       return {
-        close: async () => {},
-        newPage: async () => ({}),
+        __id: id,
+        async newPage() {
+          return {
+            on: () => {},
+            waitForSelector: async () => {},
+            fill: async () => {},
+            press: async () => {},
+            evaluate: async () => 0,
+            goto: async () => {},
+            close: async () => {},
+            click: async () => {},
+            waitForFunction: async () => {},
+            isClosed: () => false,
+            locator: () => ({ count: async () => 0 }),
+            route: async () => {},
+            unroute: async () => {},
+          } as unknown;
+        },
+        async close() {},
+      } as unknown as Browser;
+    },
+    async release(ctx: unknown) {
+      const c = ctx as { __id: number };
+      releaseLog.push(c.__id);
+      live--;
+    },
+    stats() {
+      return {
+        size: maxContexts,
+        available: maxContexts - live,
+        inUse: live,
+        totalRecycles: 0,
       };
+    },
+    get _releaseLog() {
+      return releaseLog;
+    },
+    get _acquireOptions() {
+      return acquireOptions;
     },
   };
 }

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -688,6 +688,11 @@ function makeFakeContextPool(maxContexts: number) {
 // feature acquire a context while the orphan still holds one → live
 // contexts exceed FEATURE_CONCURRENCY_D6's budget. Mirrors the d5 test.
 // ---------------------------------------------------------------------
+/** Module-scoped timer helper (oxlint consistent-function-scoping). */
+function testSleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
 /**
  * Launcher whose contexts simulate pooled checkout: `newContext`
  * increments a live counter (tracking peak), each context's page `goto`
@@ -703,8 +708,6 @@ function makeSlowTeardownLauncherFull(opts: {
   state: { live: number; peakLive: number; opened: number; closed: number };
 } {
   const state = { live: 0, peakLive: 0, opened: 0, closed: 0 };
-  const sleep = (ms: number): Promise<void> =>
-    new Promise((r) => setTimeout(r, ms));
   const browser: E2eFullBrowser = {
     async newContext(): Promise<E2eFullBrowserContext> {
       state.live++;
@@ -718,7 +721,7 @@ function makeSlowTeardownLauncherFull(opts: {
           let messageCount = 0;
           return {
             async goto() {
-              await sleep(opts.gotoDelayMs);
+              await testSleep(opts.gotoDelayMs);
             },
             async waitForSelector() {},
             async fill() {},
@@ -735,7 +738,7 @@ function makeSlowTeardownLauncherFull(opts: {
         },
         async close() {
           // The orphan window: the context stays live until this resolves.
-          await sleep(opts.closeDelayMs);
+          await testSleep(opts.closeDelayMs);
           state.live--;
           state.closed++;
         },
@@ -820,8 +823,6 @@ function makeRetryLauncherFull(opts: { attempt1DelayMs: number }): {
   state: { opened: number };
 } {
   const state = { opened: 0 };
-  const sleep = (ms: number): Promise<void> =>
-    new Promise((r) => setTimeout(r, ms));
   const browser: E2eFullBrowser = {
     async newContext(): Promise<E2eFullBrowserContext> {
       const attempt = ++state.opened;
@@ -831,7 +832,7 @@ function makeRetryLauncherFull(opts: { attempt1DelayMs: number }): {
           return {
             async goto() {
               if (attempt === 1) {
-                await sleep(opts.attempt1DelayMs);
+                await testSleep(opts.attempt1DelayMs);
                 throw new Error("nav blip (retryable)");
               }
             },

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -838,6 +838,18 @@ export function createE2eFullDriver(
 
           await sem.acquire();
           const featureStart = Date.now();
+          // In-flight runFeature promises that may still be holding a
+          // pooled BrowserContext after the Promise.race resolves. On
+          // the feature-timeout path the race resolves a synthetic
+          // result while the real runFeature keeps running until its
+          // abort-driven teardown closes the context (→ pool.release).
+          // We gate sem.release() (outer finally) on these settling so
+          // the freed slot can't be re-acquired while an orphan still
+          // holds a context, which would push live pooled contexts past
+          // the FEATURE_CONCURRENCY-bounded budget.
+          const inFlightRunFeatures: Array<
+            Promise<Awaited<ReturnType<typeof runFeature>>>
+          > = [];
           try {
             if (abort.signal.aborted) {
               await sideEmit(ctx, {
@@ -894,26 +906,47 @@ export function createE2eFullDriver(
               Awaited<ReturnType<typeof runFeature>>
             > => {
               let featureTimer: ReturnType<typeof setTimeout> | undefined;
+              // Per-attempt child controller. It aborts when the parent
+              // (`featureAbort`) fires OR when THIS attempt's timer wins,
+              // so aborting one attempt never poisons the next — the
+              // retry attempt gets a fresh, un-aborted signal. Without
+              // this, a single shared controller aborted by attempt 1
+              // would make attempt 2's runFeature return immediately with
+              // `aborted before start` (a silent no-op retry).
+              const attemptAbort = new AbortController();
+              const onParentAbortChild = (): void => attemptAbort.abort();
+              if (featureAbort.signal.aborted) attemptAbort.abort();
+              else
+                featureAbort.signal.addEventListener(
+                  "abort",
+                  onParentAbortChild,
+                  { once: true },
+                );
+              const runFeaturePromise = runFeature({
+                browser: browserRef,
+                url,
+                slug,
+                featureType: ft,
+                pageTimeoutMs,
+                script,
+                buildCtx: {
+                  integrationSlug: slug,
+                  featureType: ft,
+                  baseUrl: backendUrl,
+                },
+                abortSignal: attemptAbort.signal,
+                logger: ctx.logger,
+              });
+              inFlightRunFeatures.push(runFeaturePromise);
               try {
                 return await Promise.race([
-                  runFeature({
-                    browser: browserRef,
-                    url,
-                    slug,
-                    featureType: ft,
-                    pageTimeoutMs,
-                    script,
-                    buildCtx: {
-                      integrationSlug: slug,
-                      featureType: ft,
-                      baseUrl: backendUrl,
-                    },
-                    abortSignal: featureAbort.signal,
-                    logger: ctx.logger,
-                  }),
+                  runFeaturePromise,
                   new Promise<Awaited<ReturnType<typeof runFeature>>>(
                     (resolve) => {
                       featureTimer = setTimeout(() => {
+                        // Abort the parent so the launcher's open-context
+                        // teardown runs; this also aborts the child via
+                        // the listener above.
                         featureAbort.abort();
                         resolve({
                           ok: false,
@@ -926,6 +959,10 @@ export function createE2eFullDriver(
                 ]);
               } finally {
                 if (featureTimer) clearTimeout(featureTimer);
+                featureAbort.signal.removeEventListener(
+                  "abort",
+                  onParentAbortChild,
+                );
               }
             };
 
@@ -1025,6 +1062,14 @@ export function createE2eFullDriver(
               };
             }
           } finally {
+            // Gate slot release on the real teardown of any in-flight
+            // runFeature. On the timeout path the synthetic verdict has
+            // already been returned to the caller above; here we only
+            // wait for the abandoned runFeature's context teardown (its
+            // own finally → context.close() → pool.release) to settle so
+            // the slot isn't handed to a new feature while an orphan
+            // still holds a pooled context.
+            await Promise.allSettled(inFlightRunFeatures);
             sem.release();
           }
         });

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -345,33 +345,38 @@ export function createPooledE2eFullLauncher(
     let aborted = false;
     const openContexts = new Set<{ close(): Promise<void> }>();
 
+    const onAbort = (): void => {
+      if (aborted) return;
+      aborted = true;
+      const ctxCount = openContexts.size;
+      const stats = pool.stats();
+      logger?.warn("probe.e2e-full.pool-abort-release", {
+        openContexts: ctxCount,
+        poolAvailable: stats.available,
+        poolInUse: stats.inUse,
+        poolSize: stats.size,
+      });
+      const contextClosePromises = Array.from(openContexts).map((ctx) =>
+        ctx.close().catch(() => {}),
+      );
+      void Promise.allSettled(contextClosePromises).then(() => {
+        logger?.warn("probe.e2e-full.pool-abort-released", {
+          closedContexts: ctxCount,
+          poolAvailable: pool.stats().available,
+        });
+      });
+    };
+    // Capture the listener so launcher-level close() can detach it: without
+    // removeEventListener a post-completion abort would fire onAbort after the
+    // run returned, leaking the listener for the signal's lifetime.
+    let detachAbort: (() => void) | undefined;
     if (abortSignal) {
-      const onAbort = (): void => {
-        if (aborted) return;
-        aborted = true;
-        const ctxCount = openContexts.size;
-        const stats = pool.stats();
-        logger?.warn("probe.e2e-full.pool-abort-release", {
-          openContexts: ctxCount,
-          poolAvailable: stats.available,
-          poolInUse: stats.inUse,
-          poolSize: stats.size,
-        });
-        const contextClosePromises = Array.from(openContexts).map((ctx) =>
-          ctx.close().catch(() => {}),
-        );
-        void Promise.allSettled(contextClosePromises).then(() => {
-          logger?.warn("probe.e2e-full.pool-abort-released", {
-            closedContexts: ctxCount,
-            poolAvailable: pool.stats().available,
-          });
-        });
-      };
       if (abortSignal.aborted) {
         aborted = true;
         logger?.warn("probe.e2e-full.pool-pre-aborted-release");
       } else {
         abortSignal.addEventListener("abort", onAbort, { once: true });
+        detachAbort = () => abortSignal.removeEventListener("abort", onAbort);
       }
     }
 
@@ -382,6 +387,14 @@ export function createPooledE2eFullLauncher(
         const ctx = await pool.acquire({
           extraHTTPHeaders: contextOpts?.extraHTTPHeaders,
         });
+        // If the signal was already aborted at launcher construction (the
+        // pre-aborted branch never attached the live abort listener), a context
+        // opened now would never be closed by the abort path. Release it
+        // immediately and refuse so it cannot leak into a torn-down run.
+        if (aborted) {
+          await pool.release(ctx).catch(() => {});
+          throw new Error("e2e-full launcher aborted");
+        }
         const ctxHandle = { close: () => pool.release(ctx) };
         openContexts.add(ctxHandle);
         return {
@@ -440,8 +453,12 @@ export function createPooledE2eFullLauncher(
           },
         };
       },
-      // Launcher-level close is a no-op: each context releases itself.
-      close: async () => {},
+      // Launcher-level close releases nothing itself (each context releases
+      // itself) but detaches the abort listener so a post-completion abort
+      // can't fire onAbort after the run returned.
+      close: async () => {
+        detachAbort?.();
+      },
     };
   };
 }

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -333,35 +333,22 @@ export function createPooledE2eFullLauncher(
   logger?: { warn(event: string, meta?: Record<string, unknown>): void },
 ): E2eFullBrowserLauncher {
   return async (abortSignal?: AbortSignal): Promise<E2eFullBrowser> => {
-    let browser = await pool.acquire();
-
-    // Defensive re-acquire: the pool's acquire() skips zombie slots whose
-    // browser is already disconnected, but a browser can also die in the
-    // narrow window AFTER acquire() returns it but BEFORE we hand it to
-    // `browser.newContext()` — most commonly during the D6 service fan-out's
-    // Chromium-spawn burst, when the kernel returns EAGAIN on fork and a
-    // recently-handed-out chromium dies between this caller and its first
-    // newContext call. Without this guard, the dead browser dooms an entire
-    // service's ~40 features ("Target page, context or browser has been
-    // closed" on every single feature). One re-acquire is enough — release
-    // routes the dead instance back into the pool where its `isConnected`
-    // check + `recycleSlot` recovery take over.
-    if (!browser.isConnected()) {
-      logger?.warn("probe.e2e-full.pool-acquire-dead", {
-        poolAvailable: pool.stats().available,
-        poolInUse: pool.stats().inUse,
-      });
-      pool.release(browser);
-      browser = await pool.acquire();
-    }
-
-    let forceReleased = false;
+    // CONTEXT-POOLED model: each newContext() checks out a pooled
+    // BrowserContext (X-AIMock-Strict centralized in the pool; per-feature
+    // X-AIMock-Context / X-Test-Id flow through `contextOpts`) and the
+    // wrapper's close() releases it. The dead-browser re-acquire dance is
+    // gone: the pool only opens contexts on live browsers (acquire skips
+    // recycling/disconnected browsers and retries on another if newContext
+    // throws), so a dead process can never be handed to a feature. The abort
+    // closure re-targets onto the open contexts: on abort it closes each
+    // (each close() releases its pooled context). There is no Browser held.
+    let aborted = false;
     const openContexts = new Set<{ close(): Promise<void> }>();
 
     if (abortSignal) {
       const onAbort = (): void => {
-        if (forceReleased) return;
-        forceReleased = true;
+        if (aborted) return;
+        aborted = true;
         const ctxCount = openContexts.size;
         const stats = pool.stats();
         logger?.warn("probe.e2e-full.pool-abort-release", {
@@ -374,7 +361,6 @@ export function createPooledE2eFullLauncher(
           ctx.close().catch(() => {}),
         );
         void Promise.allSettled(contextClosePromises).then(() => {
-          pool.release(browser);
           logger?.warn("probe.e2e-full.pool-abort-released", {
             closedContexts: ctxCount,
             poolAvailable: pool.stats().available,
@@ -382,9 +368,8 @@ export function createPooledE2eFullLauncher(
         });
       };
       if (abortSignal.aborted) {
-        forceReleased = true;
+        aborted = true;
         logger?.warn("probe.e2e-full.pool-pre-aborted-release");
-        pool.release(browser);
       } else {
         abortSignal.addEventListener("abort", onAbort, { once: true });
       }
@@ -394,13 +379,10 @@ export function createPooledE2eFullLauncher(
       async newContext(contextOpts?: {
         extraHTTPHeaders?: Record<string, string>;
       }): Promise<E2eFullBrowserContext> {
-        const ctx = await browser.newContext({
-          extraHTTPHeaders: {
-            "X-AIMock-Strict": "true",
-            ...contextOpts?.extraHTTPHeaders,
-          },
+        const ctx = await pool.acquire({
+          extraHTTPHeaders: contextOpts?.extraHTTPHeaders,
         });
-        const ctxHandle = { close: () => ctx.close() };
+        const ctxHandle = { close: () => pool.release(ctx) };
         openContexts.add(ctxHandle);
         return {
           async newPage(): Promise<E2eFullPage> {
@@ -454,14 +436,12 @@ export function createPooledE2eFullLauncher(
           },
           close: async () => {
             openContexts.delete(ctxHandle);
-            await ctx.close();
+            await pool.release(ctx);
           },
         };
       },
-      close: async () => {
-        if (forceReleased) return;
-        pool.release(browser);
-      },
+      // Launcher-level close is a no-op: each context releases itself.
+      close: async () => {},
     };
   };
 }
@@ -724,7 +704,7 @@ export function createE2eFullDriver(
               total: requestedFeatures.length,
               passed: 0,
               failed: [],
-              skipped: [...incapableFeatures.map(String)],
+              skipped: incapableFeatures.map(String),
               incapable:
                 incapableFeatures.length > 0
                   ? incapableFeatures.map(String)

--- a/showcase/harness/src/probes/drivers/e2e-parity.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-parity.test.ts
@@ -5,19 +5,23 @@ import path from "node:path";
 import {
   createDefaultFleetResolver,
   createE2eParityDriver,
+  createPooledE2eParityLauncher,
   e2eParityDriver,
-  type E2eParityAggregateSignal,
-  type E2eParityBrowser,
-  type E2eParityBrowserContext,
-  type E2eParityFeatureSignal,
-  type E2eParityPage,
 } from "./e2e-parity.js";
+import type {
+  E2eParityAggregateSignal,
+  E2eParityBrowser,
+  E2eParityBrowserContext,
+  E2eParityFeatureSignal,
+  E2eParityPage,
+} from "./e2e-parity.js";
+import type { BrowserPool } from "../helpers/browser-pool.js";
+import type { Browser } from "playwright";
 import {
   __clearD5RegistryForTesting,
   registerD5Script,
-  type D5FeatureType,
-  type D5Script,
 } from "../helpers/d5-registry.js";
+import type { D5FeatureType, D5Script } from "../helpers/d5-registry.js";
 import type { ParitySnapshot } from "../helpers/parity-compare.js";
 import type { LoadReferenceResult } from "../helpers/d6-scoping.js";
 import type {
@@ -1512,3 +1516,115 @@ describe("createDefaultFleetResolver", () => {
     await fs.rm(dir, { recursive: true, force: true });
   });
 });
+
+// --- Pooled launcher: context checkout + abort release -------------------
+//
+// Context-pool migration: createPooledE2eParityLauncher checks out a pooled
+// CONTEXT per newContext() (pool.acquire) and releases it on close
+// (pool.release). No Browser is held. The leak this guards: on a driver
+// hard-timeout / external abort the invoker's Promise.race abandons the
+// driver while it keeps running with pooled contexts held; without the
+// abort listener those contexts stay inUse across probe ticks, saturating
+// the pool. The abort closure closes each open context (each releasing its
+// pooled context), returning inUse to 0.
+describe("createPooledE2eParityLauncher context checkout + abort release", () => {
+  it("checks out a pooled context per newContext() and moves inUse by 1", async () => {
+    const pool = makeFakeContextPool(4);
+    const launcher = createPooledE2eParityLauncher(
+      pool as unknown as BrowserPool,
+    );
+    const browser = await launcher();
+    expect(pool.stats().inUse).toBe(0);
+    const ctx = await browser.newContext();
+    expect(pool.stats().inUse).toBe(1);
+    await ctx.close();
+    expect(pool.stats().inUse).toBe(0);
+    expect(pool._releaseLog).toHaveLength(1);
+  });
+
+  it("closes open contexts on abort (each releasing its pooled context)", async () => {
+    const pool = makeFakeContextPool(4);
+    const launcher = createPooledE2eParityLauncher(
+      pool as unknown as BrowserPool,
+    );
+    const ac = new AbortController();
+    const browser = await launcher(ac.signal);
+    const ctx = await browser.newContext();
+    await ctx.newPage();
+    expect(pool.stats().inUse).toBe(1);
+    ac.abort();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(pool._releaseLog).toHaveLength(1);
+    expect(pool.stats().inUse).toBe(0);
+  });
+
+  it("launcher-level close is a no-op (contexts release themselves)", async () => {
+    const pool = makeFakeContextPool(4);
+    const launcher = createPooledE2eParityLauncher(
+      pool as unknown as BrowserPool,
+    );
+    const browser = await launcher();
+    const ctx = await browser.newContext();
+    await ctx.close();
+    await browser.close(); // no-op
+    expect(pool._releaseLog).toHaveLength(1);
+  });
+});
+
+// Module-scoped fake context-pool for the createPooledE2eParityLauncher
+// tests above — mirrors d6-all-pills.test.ts's helper. Tracks per-CONTEXT
+// acquire/release. The real BrowserPool.release is a no-op on an
+// already-released context; here each ctxHandle.close() routes to one
+// release call, and the launcher's abort path closes each open context
+// exactly once.
+function makeFakeContextPool(maxContexts: number) {
+  let nextCtxId = 0;
+  let live = 0;
+  const releaseLog: number[] = [];
+  return {
+    async acquire() {
+      if (live >= maxContexts) throw new Error("FakePool: at cap");
+      const id = nextCtxId++;
+      live++;
+      return {
+        __id: id,
+        async newPage() {
+          return {
+            on: () => {},
+            waitForSelector: async () => {},
+            fill: async () => {},
+            press: async () => {},
+            evaluate: async () => 0,
+            inputValue: async () => "",
+            goto: async () => {},
+            close: async () => {},
+            click: async () => {},
+            waitForFunction: async () => {},
+            isClosed: () => false,
+            locator: () => ({ count: async () => 0 }),
+            route: async () => {},
+            unroute: async () => {},
+            context: () => ({}),
+          } as unknown;
+        },
+        async close() {},
+      } as unknown as Browser;
+    },
+    async release(ctx: unknown) {
+      const c = ctx as { __id: number };
+      releaseLog.push(c.__id);
+      live--;
+    },
+    stats() {
+      return {
+        size: maxContexts,
+        available: maxContexts - live,
+        inUse: live,
+        totalRecycles: 0,
+      };
+    },
+    get _releaseLog() {
+      return releaseLog;
+    },
+  };
+}

--- a/showcase/harness/src/probes/drivers/e2e-parity.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-parity.test.ts
@@ -1573,20 +1573,19 @@ describe("createPooledE2eParityLauncher context checkout + abort release", () =>
 
 // Module-scoped fake context-pool for the createPooledE2eParityLauncher
 // tests above — mirrors d6-all-pills.test.ts's helper. Tracks per-CONTEXT
-// acquire/release. The real BrowserPool.release is a no-op on an
-// already-released context; here each ctxHandle.close() routes to one
-// release call, and the launcher's abort path closes each open context
-// exactly once.
+// acquire/release. release() is IDEMPOTENT, mirroring the real
+// BrowserPool.release: it tracks a `liveContexts` Set and no-ops on an unknown
+// / already-released context so a double release can never drive the inUse
+// counter negative and silently mask a double-release bug.
 function makeFakeContextPool(maxContexts: number) {
   let nextCtxId = 0;
-  let live = 0;
+  const liveContexts = new Set<object>();
   const releaseLog: number[] = [];
   return {
     async acquire() {
-      if (live >= maxContexts) throw new Error("FakePool: at cap");
+      if (liveContexts.size >= maxContexts) throw new Error("FakePool: at cap");
       const id = nextCtxId++;
-      live++;
-      return {
+      const ctx = {
         __id: id,
         async newPage() {
           return {
@@ -1608,18 +1607,23 @@ function makeFakeContextPool(maxContexts: number) {
           } as unknown;
         },
         async close() {},
-      } as unknown as Browser;
+      };
+      liveContexts.add(ctx);
+      return ctx as unknown as Browser;
     },
     async release(ctx: unknown) {
-      const c = ctx as { __id: number };
-      releaseLog.push(c.__id);
-      live--;
+      // Unknown / double release — no-op, mirroring BrowserPool.release.
+      if (typeof ctx !== "object" || ctx === null || !liveContexts.has(ctx)) {
+        return;
+      }
+      liveContexts.delete(ctx);
+      releaseLog.push((ctx as { __id: number }).__id);
     },
     stats() {
       return {
         size: maxContexts,
-        available: maxContexts - live,
-        inUse: live,
+        available: maxContexts - liveContexts.size,
+        inUse: liveContexts.size,
         totalRecycles: 0,
       };
     },

--- a/showcase/harness/src/probes/drivers/e2e-parity.ts
+++ b/showcase/harness/src/probes/drivers/e2e-parity.ts
@@ -374,39 +374,52 @@ export function createPooledE2eParityLauncher(
     // pooled context back to the pool, freeing a context slot.
     const openContexts = new Set<{ close(): Promise<void> }>();
 
+    const onAbort = (): void => {
+      if (aborted) return;
+      aborted = true;
+      const ctxCount = openContexts.size;
+      const stats = pool.stats();
+      logger?.warn("probe.e2e-parity.pool-abort-release", {
+        openContexts: ctxCount,
+        poolAvailable: stats.available,
+        poolInUse: stats.inUse,
+        poolSize: stats.size,
+      });
+      const contextClosePromises = Array.from(openContexts).map((ctx) =>
+        ctx.close().catch(() => {}),
+      );
+      void Promise.allSettled(contextClosePromises).then(() => {
+        logger?.warn("probe.e2e-parity.pool-abort-released", {
+          closedContexts: ctxCount,
+          poolAvailable: pool.stats().available,
+        });
+      });
+    };
+    // Capture the listener so launcher-level close() can detach it: without
+    // removeEventListener a post-completion abort would fire onAbort after the
+    // run returned, leaking the listener for the signal's lifetime.
+    let detachAbort: (() => void) | undefined;
     if (abortSignal) {
-      const onAbort = (): void => {
-        if (aborted) return;
-        aborted = true;
-        const ctxCount = openContexts.size;
-        const stats = pool.stats();
-        logger?.warn("probe.e2e-parity.pool-abort-release", {
-          openContexts: ctxCount,
-          poolAvailable: stats.available,
-          poolInUse: stats.inUse,
-          poolSize: stats.size,
-        });
-        const contextClosePromises = Array.from(openContexts).map((ctx) =>
-          ctx.close().catch(() => {}),
-        );
-        void Promise.allSettled(contextClosePromises).then(() => {
-          logger?.warn("probe.e2e-parity.pool-abort-released", {
-            closedContexts: ctxCount,
-            poolAvailable: pool.stats().available,
-          });
-        });
-      };
       if (abortSignal.aborted) {
         aborted = true;
         logger?.warn("probe.e2e-parity.pool-pre-aborted-release");
       } else {
         abortSignal.addEventListener("abort", onAbort, { once: true });
+        detachAbort = () => abortSignal.removeEventListener("abort", onAbort);
       }
     }
 
     return {
       async newContext(): Promise<E2eParityBrowserContext> {
         const ctx = await pool.acquire();
+        // If the signal was already aborted at launcher construction (the
+        // pre-aborted branch never attached the live abort listener), a context
+        // opened now would never be closed by the abort path. Release it
+        // immediately and refuse so it cannot leak into a torn-down run.
+        if (aborted) {
+          await pool.release(ctx).catch(() => {});
+          throw new Error("e2e-parity launcher aborted");
+        }
         const ctxHandle = { close: () => pool.release(ctx) };
         openContexts.add(ctxHandle);
         return {
@@ -416,10 +429,17 @@ export function createPooledE2eParityLauncher(
             wrapped.asPlaywrightPage = (): PlaywrightPage => page;
             return wrapped;
           },
-          close: () => ctxHandle.close(),
+          close: async () => {
+            openContexts.delete(ctxHandle);
+            await ctxHandle.close();
+          },
         };
       },
-      close: async () => {},
+      // Launcher-level close detaches the abort listener so a post-completion
+      // abort can't fire onAbort after the run returned.
+      close: async () => {
+        detachAbort?.();
+      },
     };
   };
 }

--- a/showcase/harness/src/probes/drivers/e2e-parity.ts
+++ b/showcase/harness/src/probes/drivers/e2e-parity.ts
@@ -2,40 +2,41 @@ import { promises as fs } from "node:fs";
 import { z } from "zod";
 import { truncateUtf8 } from "../../render/filters.js";
 import { showcaseShapeSchema } from "../discovery/railway-services.js";
-import {
-  D5_REGISTRY,
-  type D5BuildContext,
-  type D5FeatureType,
-  type D5Script,
-  isD5FeatureType,
+import { D5_REGISTRY, isD5FeatureType } from "../helpers/d5-registry.js";
+import type {
+  D5BuildContext,
+  D5FeatureType,
+  D5Script,
 } from "../helpers/d5-registry.js";
-import {
-  runConversation,
-  type ConversationResult,
-  type Page as RunnerPage,
+import { runConversation } from "../helpers/conversation-runner.js";
+import type {
+  ConversationResult,
+  Page as RunnerPage,
 } from "../helpers/conversation-runner.js";
-import {
-  attachSseInterceptor as defaultAttachSseInterceptor,
-  type SseCapture,
-  type SseInterceptorHandle,
+import { attachSseInterceptor as defaultAttachSseInterceptor } from "../helpers/sse-interceptor.js";
+import type {
+  SseCapture,
+  SseInterceptorHandle,
 } from "../helpers/sse-interceptor.js";
 import {
   buildSnapshot,
   serializeRelevantDom,
-  type ReferenceCapturePage,
 } from "../helpers/reference-capture.js";
+import type { ReferenceCapturePage } from "../helpers/reference-capture.js";
 import {
   compareParity,
   DEFAULT_PARITY_TOLERANCES,
-  type ParityReport,
-  type ParitySnapshot,
-  type ParityTolerances,
+} from "../helpers/parity-compare.js";
+import type {
+  ParityReport,
+  ParitySnapshot,
+  ParityTolerances,
 } from "../helpers/parity-compare.js";
 import {
   loadReferenceSnapshot,
   selectD6Targets,
-  type LoadReferenceResult,
 } from "../helpers/d6-scoping.js";
+import type { LoadReferenceResult } from "../helpers/d6-scoping.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 import path from "node:path";
@@ -356,12 +357,13 @@ export function createPooledE2eParityLauncher(
   pool: BrowserPool,
 ): E2eParityBrowserLauncher {
   return async (): Promise<E2eParityBrowser> => {
-    const browser = await pool.acquire();
+    // CONTEXT-POOLED model: each newContext() checks out a pooled
+    // BrowserContext (X-AIMock-Strict centralized in the pool) and the
+    // wrapper's close() releases it. No Browser is held; launcher close is a
+    // no-op.
     return {
       async newContext(): Promise<E2eParityBrowserContext> {
-        const ctx = await browser.newContext({
-          extraHTTPHeaders: { "X-AIMock-Strict": "true" },
-        });
+        const ctx = await pool.acquire();
         return {
           async newPage(): Promise<E2eParityPage> {
             const page = await ctx.newPage();
@@ -369,12 +371,10 @@ export function createPooledE2eParityLauncher(
             wrapped.asPlaywrightPage = (): PlaywrightPage => page;
             return wrapped;
           },
-          close: () => ctx.close(),
+          close: () => pool.release(ctx),
         };
       },
-      close: async () => {
-        pool.release(browser);
-      },
+      close: async () => {},
     };
   };
 }

--- a/showcase/harness/src/probes/drivers/e2e-parity.ts
+++ b/showcase/harness/src/probes/drivers/e2e-parity.ts
@@ -210,7 +210,9 @@ export interface E2eParityBrowser {
   close(): Promise<void>;
 }
 
-export type E2eParityBrowserLauncher = () => Promise<E2eParityBrowser>;
+export type E2eParityBrowserLauncher = (
+  abortSignal?: AbortSignal,
+) => Promise<E2eParityBrowser>;
 
 /** SSE interceptor injection. Tests stub; default = the real CDP one. */
 export type E2eParityAttachInterceptor = (
@@ -355,15 +357,58 @@ const defaultLauncher: E2eParityBrowserLauncher =
 
 export function createPooledE2eParityLauncher(
   pool: BrowserPool,
+  logger?: { warn(event: string, meta?: Record<string, unknown>): void },
 ): E2eParityBrowserLauncher {
-  return async (): Promise<E2eParityBrowser> => {
+  return async (abortSignal?: AbortSignal): Promise<E2eParityBrowser> => {
     // CONTEXT-POOLED model: each newContext() checks out a pooled
     // BrowserContext (X-AIMock-Strict centralized in the pool) and the
-    // wrapper's close() releases it. No Browser is held; launcher close is a
-    // no-op.
+    // wrapper's close() releases it. The abort closure re-targets onto the
+    // open contexts: on abort it closes each (each close() releases its
+    // pooled context). There is no Browser held; launcher close is a no-op.
+    // Without this listener those contexts stay in-use across probe ticks
+    // when the invoker's Promise.race abandons the driver on hard-timeout /
+    // external abort, saturating the pool and starving later ticks.
+    let aborted = false;
+
+    // Track open contexts so abort can close them. Each close() releases the
+    // pooled context back to the pool, freeing a context slot.
+    const openContexts = new Set<{ close(): Promise<void> }>();
+
+    if (abortSignal) {
+      const onAbort = (): void => {
+        if (aborted) return;
+        aborted = true;
+        const ctxCount = openContexts.size;
+        const stats = pool.stats();
+        logger?.warn("probe.e2e-parity.pool-abort-release", {
+          openContexts: ctxCount,
+          poolAvailable: stats.available,
+          poolInUse: stats.inUse,
+          poolSize: stats.size,
+        });
+        const contextClosePromises = Array.from(openContexts).map((ctx) =>
+          ctx.close().catch(() => {}),
+        );
+        void Promise.allSettled(contextClosePromises).then(() => {
+          logger?.warn("probe.e2e-parity.pool-abort-released", {
+            closedContexts: ctxCount,
+            poolAvailable: pool.stats().available,
+          });
+        });
+      };
+      if (abortSignal.aborted) {
+        aborted = true;
+        logger?.warn("probe.e2e-parity.pool-pre-aborted-release");
+      } else {
+        abortSignal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
     return {
       async newContext(): Promise<E2eParityBrowserContext> {
         const ctx = await pool.acquire();
+        const ctxHandle = { close: () => pool.release(ctx) };
+        openContexts.add(ctxHandle);
         return {
           async newPage(): Promise<E2eParityPage> {
             const page = await ctx.newPage();
@@ -371,7 +416,7 @@ export function createPooledE2eParityLauncher(
             wrapped.asPlaywrightPage = (): PlaywrightPage => page;
             return wrapped;
           },
-          close: () => pool.release(ctx),
+          close: () => ctxHandle.close(),
         };
       },
       close: async () => {},
@@ -897,7 +942,7 @@ export function createE2eParityDriver(
 
       try {
         try {
-          browser = await launcher();
+          browser = await launcher(abort.signal);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.warn("probe.e2e-parity.launcher-error", {

--- a/showcase/harness/src/probes/drivers/e2e-readiness.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.test.ts
@@ -1382,6 +1382,127 @@ describe("e2e-demos driver", () => {
     expect(failLogs).toHaveLength(1);
     expect(failLogs[0]?.meta?.errName).toBe("Error");
   });
+
+  // --- C13: exhausted per-demo budget must NOT pass timeout:0 -----------
+  //
+  // The per-demo wall-clock budget is `remaining() = max(0, deadline - now)`.
+  // When the budget is already exhausted at the goto/waitForSelector call
+  // site (now MUCH more reachable since pool.acquire() can block ~30s on a
+  // waiter), `remaining()` returns 0. Passing `timeout: 0` to Playwright's
+  // page.goto / page.waitForSelector means WAIT FOREVER — defeating the
+  // per-demo deadline and hanging the whole tick.
+  //
+  // This Playwright-faithful fake reproduces that contract: a `timeout: 0`
+  // (or absent) goto/waitForSelector NEVER resolves; a positive timeout
+  // rejects after that many ms. The driver MUST bail to a timeout result
+  // promptly instead of issuing a forever-wait call.
+  it("bails to a timeout result instead of passing timeout:0 when the per-demo budget is exhausted", async () => {
+    const gotoTimeouts: Array<number | undefined> = [];
+    const selectorTimeouts: Array<number | undefined> = [];
+
+    // Mirrors Playwright's `timeout: 0` === wait-forever semantics. A
+    // zero/absent timeout returns a never-settling promise; a positive
+    // timeout rejects after that delay.
+    function timeoutOrHang(
+      label: string,
+      timeout: number | undefined,
+    ): Promise<never> {
+      if (timeout === undefined || timeout <= 0) {
+        // Wait forever — exactly Playwright's timeout:0 behaviour.
+        return new Promise<never>(() => {});
+      }
+      return new Promise<never>((_resolve, reject) => {
+        setTimeout(
+          () => reject(new Error(`${label} timeout ${timeout}ms exceeded`)),
+          timeout,
+        );
+      });
+    }
+
+    const pwFaithfulPage: E2eDemosPage = {
+      async goto(_url, opts) {
+        gotoTimeouts.push(opts?.timeout);
+        return timeoutOrHang("goto", opts?.timeout);
+      },
+      async waitForSelector(_sel, opts) {
+        selectorTimeouts.push(opts?.timeout);
+        return timeoutOrHang("waitForSelector", opts?.timeout);
+      },
+      async close() {
+        /* no-op */
+      },
+    };
+    const pwFaithfulBrowser: E2eDemosBrowser = {
+      async newContext() {
+        return {
+          async newPage() {
+            return pwFaithfulPage;
+          },
+          async close() {
+            /* no-op */
+          },
+        };
+      },
+      async close() {
+        /* no-op */
+      },
+    };
+
+    const driver = createE2eDemosDriver({
+      launcher: async () => pwFaithfulBrowser,
+      // Generous outer cap so the abort race does NOT mask the bug — the
+      // per-demo deadline (pageTimeoutMs:0) is what must short-circuit.
+      timeoutMs: 60_000,
+      // Zero per-demo budget → deadline is already in the past at the goto
+      // call site → remaining() === 0.
+      pageTimeoutMs: 0,
+    });
+    const { writer, writes } = mkWriter();
+
+    const runP = driver.run(mkCtx(writer), {
+      key: "e2e-demos:budget-exhausted",
+      name: "showcase-budget-exhausted",
+      publicUrl: "https://showcase-budget-exhausted.example.com",
+      demos: ["d1"],
+      shape: "package",
+    });
+
+    // Watchdog: the run MUST resolve promptly. On the buggy code it issues
+    // `timeout: 0` and hangs forever, so this race surfaces the defect
+    // deterministically without a 30s wall-clock wait.
+    const watchdog = new Promise<"HANG">((resolve) => {
+      setTimeout(() => resolve("HANG"), 1_000);
+    });
+    const outcome = await Promise.race([
+      runP.then(() => "RESOLVED" as const),
+      watchdog,
+    ]);
+    expect(outcome).toBe("RESOLVED");
+
+    const result = await runP;
+    // Aggregate red — the single demo could not be verified in its budget.
+    expect(result.state).toBe("red");
+    const sig = result.signal as E2eDemosAggregateSignal;
+    expect(sig.failed).toEqual(["d1"]);
+
+    // The demo's side row must carry a timeout-class failure, NOT a
+    // forever-hang.
+    const sideRow = writes.find((w) => w.key === "e2e:budget-exhausted/d1");
+    expect(sideRow?.state).toBe("red");
+    const rowSig = sideRow?.signal as { errorClass?: string };
+    expect(["selector-timeout", "goto-error", "abort"]).toContain(
+      rowSig?.errorClass,
+    );
+
+    // CRITICAL: no goto/waitForSelector call may have been issued with a
+    // non-positive timeout. A 0 / undefined timeout is the forever-hang bug.
+    for (const t of gotoTimeouts) {
+      expect(typeof t === "number" && t > 0).toBe(true);
+    }
+    for (const t of selectorTimeouts) {
+      expect(typeof t === "number" && t > 0).toBe(true);
+    }
+  });
 });
 
 // --- Integration: shortest-service-first dispatch ------------------------
@@ -1696,18 +1817,22 @@ describe("shortest-service-first dispatch (integration)", () => {
  */
 function makeDemosFakeContextPool(maxContexts: number) {
   let nextCtxId = 0;
-  let live = 0;
   const releaseLog: number[] = [];
   const acquireLog: number[] = [];
   const forks = 0; // a real pool forks only at init; a fake never re-forks here
+  // Track the SET of currently-live contexts (not a bare counter) so the
+  // fake mirrors the real `BrowserPool.release` contract: release of a
+  // context not currently live (unknown / double release) is a no-op and
+  // must NOT decrement the live count. A bare counter would silently go
+  // negative on a double-release, masking launcher double-release bugs.
+  const liveContexts = new Set<unknown>();
 
   return {
     async acquire(): Promise<unknown> {
-      if (live >= maxContexts) throw new Error("FakePool: at cap");
+      if (liveContexts.size >= maxContexts) throw new Error("FakePool: at cap");
       const id = nextCtxId++;
-      live++;
       acquireLog.push(id);
-      return {
+      const ctx = {
         __id: id,
         async newPage() {
           return {
@@ -1718,17 +1843,22 @@ function makeDemosFakeContextPool(maxContexts: number) {
         },
         async close() {},
       };
+      liveContexts.add(ctx);
+      return ctx;
     },
     async release(ctx: unknown): Promise<void> {
+      // Mirror BrowserPool.release: unknown / double release is a no-op.
+      // Only contexts currently checked out decrement the live set + log.
+      if (!liveContexts.has(ctx)) return;
+      liveContexts.delete(ctx);
       const c = ctx as { __id: number };
       releaseLog.push(c.__id);
-      live--;
     },
     stats() {
       return {
         size: maxContexts,
-        available: maxContexts - live,
-        inUse: live,
+        available: maxContexts - liveContexts.size,
+        inUse: liveContexts.size,
         totalRecycles: 0,
       };
     },

--- a/showcase/harness/src/probes/drivers/e2e-readiness.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.test.ts
@@ -650,7 +650,7 @@ describe("e2e-demos driver", () => {
     });
 
     expect(result.state).toBe("red");
-    // Single compound selector tried (not 6 individual ones).
+    // Single compound selector tried (not the individual selectors one-by-one).
     expect(selectorsTried).toHaveLength(1);
     expect(selectorsTried[0]).toContain(
       '[data-testid="copilot-chat-textarea"]',
@@ -1063,13 +1063,13 @@ describe("e2e-demos driver", () => {
     expect(sig?.errorClass).not.toBe("abort");
   });
 
-  // --- C7: selector-loop is abort-responsive ---------------------------
+  // --- C7: the single compound selector wait is abort-responsive -------
 
-  it("aborts mid-selector-loop without walking all 6 selectors", async () => {
-    // Slow waitForSelector + cap fires mid-loop. Without the abort
-    // check between iterations, the worst case is 6*pageTimeoutMs per
-    // demo. Assert the loop bails after a small constant number of
-    // selectors (< 6) once the cap fires.
+  it("aborts during the compound selector wait (single waitForSelector call)", async () => {
+    // The driver issues ONE compound waitForSelector covering all ready
+    // selectors at once (no per-selector loop). A slow compound wait plus a
+    // fired cap must surface as a red result rather than blocking for the
+    // full pageTimeoutMs. Assert exactly the one compound call was made.
     const selectorsTried: string[] = [];
     let resolveFirstSel!: () => void;
     const firstSelGate = new Promise<void>((r) => {
@@ -1133,11 +1133,11 @@ describe("e2e-demos driver", () => {
     const result = await runP;
 
     expect(result.state).toBe("red");
-    // Strict: only the first selector should have been attempted; the
-    // mid-loop abort check must bail before the second iteration runs.
-    expect(selectorsTried.length).toBeLessThan(5);
+    // Compound design: exactly ONE waitForSelector call is made (the single
+    // compound selector), never a per-selector walk.
+    expect(selectorsTried).toHaveLength(1);
     // Side row must reflect either abort or selector-error/timeout, NOT
-    // a wall-clock-bloated six-selector walk.
+    // a wall-clock-bloated multi-selector walk.
     const sideRow = writes.find((w) => w.key === "e2e:abort-mid-loop/d1");
     const sig = sideRow?.signal as { errorClass?: string };
     expect(["abort", "selector-error", "selector-timeout"]).toContain(

--- a/showcase/harness/src/probes/drivers/e2e-readiness.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.test.ts
@@ -7,10 +7,12 @@ import {
   e2eReadinessDriver,
   createE2eDemosDriver,
   createPooledE2eDemosLauncher,
-  type E2eDemosBrowser,
-  type E2eDemosBrowserContext,
-  type E2eDemosPage,
-  type E2eDemosAggregateSignal,
+} from "./e2e-readiness.js";
+import type {
+  E2eDemosBrowser,
+  E2eDemosBrowserContext,
+  E2eDemosPage,
+  E2eDemosAggregateSignal,
 } from "./e2e-readiness.js";
 import { buildProbeInvoker } from "../loader/probe-invoker.js";
 import { createDiscoveryRegistry } from "../discovery/index.js";
@@ -1679,116 +1681,91 @@ describe("shortest-service-first dispatch (integration)", () => {
 });
 
 // ---------------------------------------------------------------------
-// Pool starvation parity with createPooledE2eDeepLauncher (ed0933e5c).
-// e2e-demos shares the same Promise.race-driven outer-timeout pattern
-// as e2e-deep, so it needs the same abort-driven release path or a hung
-// service holds its slot until the orphaned driver promise drains.
+// Context-pool migration: the pooled launcher now checks out a pooled
+// CONTEXT per newContext() (pool.acquire) and releases it on close
+// (pool.release). maxContexts is the global cap (reinterpreted POOL_SIZE).
+// Each context acquire/release moves inUse by 1; on abort the launcher
+// closes its open contexts (each releasing its context) — NO browser fork.
 // ---------------------------------------------------------------------
-describe("createPooledE2eDemosLauncher abort release", () => {
-  /**
-   * Minimal fake pool tracking acquire/release calls. Mirrors the shape
-   * used by createPooledE2eDeepLauncher's tests so the two pooled launchers
-   * exercise an analogous fixture.
-   */
-  function makeFakePool(size: number) {
-    interface FakeBrowser {
-      id: number;
-      newContext(): Promise<{
-        newPage(): Promise<{
-          goto(): Promise<void>;
-          waitForSelector(): Promise<void>;
-          close(): Promise<void>;
-        }>;
-        close(): Promise<void>;
-      }>;
-      close(): Promise<void>;
-    }
+/**
+ * Fake context-pool tracking per-CONTEXT acquire/release. `maxContexts`
+ * is the global cap; acquire() hands out a fresh fake context (its own
+ * newPage + identity) and release(ctx) returns it. Module-scoped so
+ * oxlint's consistent-function-scoping is satisfied (captures no parent
+ * state).
+ */
+function makeDemosFakeContextPool(maxContexts: number) {
+  let nextCtxId = 0;
+  let live = 0;
+  const releaseLog: number[] = [];
+  const acquireLog: number[] = [];
+  const forks = 0; // a real pool forks only at init; a fake never re-forks here
 
-    const browsers: FakeBrowser[] = [];
-    for (let i = 0; i < size; i++) {
-      browsers.push({
-        id: i,
-        async newContext() {
+  return {
+    async acquire(): Promise<unknown> {
+      if (live >= maxContexts) throw new Error("FakePool: at cap");
+      const id = nextCtxId++;
+      live++;
+      acquireLog.push(id);
+      return {
+        __id: id,
+        async newPage() {
           return {
-            async newPage() {
-              return {
-                async goto() {},
-                async waitForSelector() {},
-                async close() {},
-              };
-            },
+            async goto() {},
+            async waitForSelector() {},
             async close() {},
           };
         },
         async close() {},
-      });
-    }
+      };
+    },
+    async release(ctx: unknown): Promise<void> {
+      const c = ctx as { __id: number };
+      releaseLog.push(c.__id);
+      live--;
+    },
+    stats() {
+      return {
+        size: maxContexts,
+        available: maxContexts - live,
+        inUse: live,
+        totalRecycles: 0,
+      };
+    },
+    get _releaseLog() {
+      return releaseLog;
+    },
+    get _acquireLog() {
+      return acquireLog;
+    },
+    get _forks() {
+      return forks;
+    },
+  };
+}
 
-    const available = [...browsers];
-    const releaseLog: number[] = [];
-    const acquireLog: number[] = [];
-
-    return {
-      async acquire(): Promise<unknown> {
-        const browser = available.shift();
-        if (!browser) throw new Error("FakePool: no browsers available");
-        acquireLog.push(browser.id);
-        return browser;
-      },
-      release(browser: unknown): void {
-        const fb = browser as FakeBrowser;
-        releaseLog.push(fb.id);
-        available.push(fb);
-      },
-      stats() {
-        return {
-          size,
-          available: available.length,
-          inUse: size - available.length,
-          totalRecycles: 0,
-        };
-      },
-      get _releaseLog() {
-        return releaseLog;
-      },
-      get _acquireLog() {
-        return acquireLog;
-      },
-    };
-  }
-
-  it("releases the pooled browser when the abort signal fires (prevents starvation)", async () => {
-    const pool = makeFakePool(2);
+describe("createPooledE2eDemosLauncher context checkout + abort release", () => {
+  it("checks out one context per newContext() and moves inUse by 1", async () => {
+    const pool = makeDemosFakeContextPool(4);
     const launcher = createPooledE2eDemosLauncher(
       pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
     );
+    const browser = await launcher();
+    expect(pool.stats().inUse).toBe(0);
 
-    const ac1 = new AbortController();
-    const ac2 = new AbortController();
-    const browser1 = await launcher(ac1.signal);
-    const browser2 = await launcher(ac2.signal);
+    const ctx = await browser.newContext();
+    expect(pool.stats().inUse).toBe(1);
+    expect(pool.stats().available).toBe(3);
 
-    expect(pool.stats().available).toBe(0);
-    expect(pool.stats().inUse).toBe(2);
-
-    ac1.abort();
-    await new Promise((r) => setTimeout(r, 10));
-
-    expect(pool._releaseLog).toContain(0);
-    expect(pool.stats().available).toBe(1);
-
-    // Driver's finally-block close is a no-op after force-release.
-    await browser1.close();
-    expect(pool._releaseLog.filter((id) => id === 0)).toHaveLength(1);
-
-    // Browser2 still held — normal close releases it.
-    await browser2.close();
-    expect(pool._releaseLog).toContain(1);
-    expect(pool.stats().available).toBe(2);
+    await ctx.close();
+    expect(pool.stats().inUse).toBe(0);
+    expect(pool._releaseLog).toHaveLength(1);
+    // No process fork on the hot path.
+    expect(pool._forks).toBe(0);
   });
 
-  it("closes open contexts before releasing on abort", async () => {
-    const pool = makeFakePool(1);
+  it("closes open contexts on abort (each releasing its pooled context)", async () => {
+    const pool = makeDemosFakeContextPool(2);
     const launcher = createPooledE2eDemosLauncher(
       pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
     );
@@ -1797,68 +1774,27 @@ describe("createPooledE2eDemosLauncher abort release", () => {
     const browser = await launcher(ac.signal);
 
     const ctx = await browser.newContext();
-    const _page = await ctx.newPage();
+    await ctx.newPage();
+    expect(pool.stats().inUse).toBe(1);
 
     ac.abort();
     await new Promise((r) => setTimeout(r, 10));
 
+    // The open context was closed → released back to the pool.
     expect(pool._releaseLog).toHaveLength(1);
-    expect(pool.stats().available).toBe(1);
+    expect(pool.stats().inUse).toBe(0);
   });
 
-  it("handles already-aborted signal (releases immediately)", async () => {
-    const pool = makeFakePool(1);
+  it("launcher-level close is a no-op (contexts release themselves)", async () => {
+    const pool = makeDemosFakeContextPool(2);
     const launcher = createPooledE2eDemosLauncher(
       pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
     );
-
-    const ac = new AbortController();
-    ac.abort();
-
-    const browser = await launcher(ac.signal);
-
-    // Released synchronously after acquire (no waiting on abort event).
+    const browser = await launcher();
+    const ctx = await browser.newContext();
+    await ctx.close();
+    await browser.close(); // no-op
+    // Exactly one release — from the context's own close, not the launcher.
     expect(pool._releaseLog).toHaveLength(1);
-    expect(pool.stats().available).toBe(1);
-
-    await browser.close();
-    expect(pool._releaseLog).toHaveLength(1);
-  });
-
-  it("full pool starvation scenario: all slots acquired, abort releases them for the next run", async () => {
-    const POOL_SIZE = 4;
-    const pool = makeFakePool(POOL_SIZE);
-    const launcher = createPooledE2eDemosLauncher(
-      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
-    );
-
-    const acs = Array.from({ length: POOL_SIZE }, () => new AbortController());
-    const browsers = await Promise.all(acs.map((ac) => launcher(ac.signal)));
-
-    expect(pool.stats().available).toBe(0);
-    expect(pool.stats().inUse).toBe(POOL_SIZE);
-
-    for (const ac of acs) ac.abort();
-    await new Promise((r) => setTimeout(r, 20));
-
-    expect(pool.stats().available).toBe(POOL_SIZE);
-    expect(pool._releaseLog).toHaveLength(POOL_SIZE);
-
-    // Next run can acquire all slots immediately.
-    const nextAcs = Array.from(
-      { length: POOL_SIZE },
-      () => new AbortController(),
-    );
-    const nextBrowsers = await Promise.all(
-      nextAcs.map((ac) => launcher(ac.signal)),
-    );
-    expect(pool.stats().available).toBe(0);
-    expect(pool.stats().inUse).toBe(POOL_SIZE);
-
-    for (const b of nextBrowsers) await b.close();
-    for (const b of browsers) await b.close();
-    // POOL_SIZE releases from abort + POOL_SIZE from the second run's
-    // normal close. The first run's normal close is a no-op.
-    expect(pool._releaseLog).toHaveLength(POOL_SIZE * 2);
   });
 });

--- a/showcase/harness/src/probes/drivers/e2e-readiness.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.ts
@@ -867,6 +867,22 @@ async function runDemo(opts: {
   try {
     context = await browser.newContext();
     page = await context.newPage();
+    // Pre-goto budget check: `remaining() === 0` means the per-demo
+    // deadline is already exhausted (e.g. pool.acquire() blocked on a
+    // waiter for the whole budget). Playwright treats `timeout: 0` as
+    // WAIT FOREVER, so issuing the goto with a zero timeout would hang
+    // indefinitely and defeat the deadline. Bail to the same
+    // selector-timeout result the post-wait path emits instead.
+    if (remaining() <= 0) {
+      return {
+        ok: false,
+        errorClass: "selector-timeout",
+        errorDesc: truncateUtf8(
+          `per-demo deadline exceeded after ${pageTimeoutMs}ms`,
+          1200,
+        ),
+      };
+    }
     try {
       await page.goto(url, {
         waitUntil: "domcontentloaded",
@@ -888,6 +904,20 @@ async function runDemo(opts: {
     // when the first didn't match.
     if (abortSignal.aborted) {
       throw new DOMException("aborted", "AbortError");
+    }
+    // Pre-selector budget check: same `timeout: 0` === wait-forever hazard
+    // as the goto above. If the goto consumed the entire budget, bail to a
+    // selector-timeout result rather than issuing a forever-wait selector
+    // call.
+    if (remaining() <= 0) {
+      return {
+        ok: false,
+        errorClass: "selector-timeout",
+        errorDesc: truncateUtf8(
+          `per-demo deadline exceeded after ${pageTimeoutMs}ms`,
+          1200,
+        ),
+      };
     }
     try {
       await page.waitForSelector(READY_SELECTOR_COMPOUND, {

--- a/showcase/harness/src/probes/drivers/e2e-readiness.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.ts
@@ -294,58 +294,55 @@ export function createPooledE2eDemosLauncher(
   logger?: { warn(event: string, meta?: Record<string, unknown>): void },
 ): E2eDemosBrowserLauncher {
   return async (abortSignal?: AbortSignal): Promise<E2eDemosBrowser> => {
-    const browser = await pool.acquire();
-
-    // Track whether the browser was force-released by an abort so the
-    // driver's normal `browser.close()` in the finally block doesn't
-    // double-release the same slot. Mirrors createPooledE2eDeepLauncher's
-    // pattern (see e2e-deep.ts) — pool starvation under outer-timeout was
-    // the documented motivation there and the same race exists here:
-    // Promise.race in the invoker abandons the driver promise but the
-    // driver continues iterating demos with the pooled browser held until
-    // the loop drains. Without this listener the slot stays in-use across
-    // probe ticks and the next tick can't acquire it.
-    let forceReleased = false;
+    // CONTEXT-POOLED model: each newContext() checks out a pooled
+    // BrowserContext (X-AIMock-Strict centralized in the pool) and the
+    // wrapper's close() releases it. The abort closure re-targets onto the
+    // open contexts: on abort it closes each one (each close() releases its
+    // pooled context). There is no Browser held to release. This still solves
+    // the pool-starvation race — Promise.race in the invoker abandons the
+    // driver promise while the driver continues iterating demos with pooled
+    // contexts held; without this listener those contexts stay in-use across
+    // probe ticks and the cap stays saturated.
+    let aborted = false;
     const openContexts = new Set<{ close(): Promise<void> }>();
 
+    const closeAllOpenContexts = (): void => {
+      if (aborted) return;
+      aborted = true;
+      const ctxCount = openContexts.size;
+      const stats = pool.stats();
+      logger?.warn("probe.e2e-demos.pool-abort-release", {
+        openContexts: ctxCount,
+        poolAvailable: stats.available,
+        poolInUse: stats.inUse,
+        poolSize: stats.size,
+      });
+      const contextClosePromises = Array.from(openContexts).map((ctx) =>
+        ctx.close().catch(() => {}),
+      );
+      void Promise.allSettled(contextClosePromises).then(() => {
+        logger?.warn("probe.e2e-demos.pool-abort-released", {
+          closedContexts: ctxCount,
+          poolAvailable: pool.stats().available,
+        });
+      });
+    };
+
     if (abortSignal) {
-      const onAbort = (): void => {
-        if (forceReleased) return;
-        forceReleased = true;
-        const ctxCount = openContexts.size;
-        const stats = pool.stats();
-        logger?.warn("probe.e2e-demos.pool-abort-release", {
-          openContexts: ctxCount,
-          poolAvailable: stats.available,
-          poolInUse: stats.inUse,
-          poolSize: stats.size,
-        });
-        const contextClosePromises = Array.from(openContexts).map((ctx) =>
-          ctx.close().catch(() => {}),
-        );
-        void Promise.allSettled(contextClosePromises).then(() => {
-          pool.release(browser);
-          logger?.warn("probe.e2e-demos.pool-abort-released", {
-            closedContexts: ctxCount,
-            poolAvailable: pool.stats().available,
-          });
-        });
-      };
       if (abortSignal.aborted) {
-        forceReleased = true;
+        aborted = true;
         logger?.warn("probe.e2e-demos.pool-pre-aborted-release");
-        pool.release(browser);
       } else {
-        abortSignal.addEventListener("abort", onAbort, { once: true });
+        abortSignal.addEventListener("abort", closeAllOpenContexts, {
+          once: true,
+        });
       }
     }
 
     return {
       async newContext(): Promise<E2eDemosBrowserContext> {
-        const ctx = await browser.newContext({
-          extraHTTPHeaders: { "X-AIMock-Strict": "true" },
-        });
-        const ctxHandle = { close: () => ctx.close() };
+        const ctx = await pool.acquire();
+        const ctxHandle = { close: () => pool.release(ctx) };
         openContexts.add(ctxHandle);
         return {
           async newPage(): Promise<E2eDemosPage> {
@@ -358,14 +355,12 @@ export function createPooledE2eDemosLauncher(
           },
           close: async () => {
             openContexts.delete(ctxHandle);
-            await ctx.close();
+            await pool.release(ctx);
           },
         };
       },
-      close: async () => {
-        if (forceReleased) return;
-        pool.release(browser);
-      },
+      // Launcher-level close is a no-op: each context releases itself.
+      close: async () => {},
     };
   };
 }

--- a/showcase/harness/src/probes/drivers/e2e-readiness.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.ts
@@ -207,30 +207,37 @@ const DEFAULT_PAGE_TIMEOUT_MS = 30 * 1000;
 const TIMEOUT_ENV_VAR = "E2E_DEMOS_TIMEOUT_MS";
 
 /**
- * Structural-ready selectors tried in order. First match wins; a demo is
- * considered green if any one resolves within the page timeout. Kept as a
- * const array so the production config and the unit tests agree on the
- * exact ordering — a refactor that re-orders the list surfaces as a test
- * diff.
+ * Structural-ready selectors. A demo is considered green if ANY one of these
+ * resolves within the page timeout — they are combined into a single compound
+ * CSS selector (`READY_SELECTOR_COMPOUND`) and matched simultaneously by one
+ * `waitForSelector` call, so there is no per-selector ordering at match time.
+ * Kept as a const array so the production config and the unit tests agree on
+ * the exact set — a refactor that adds/removes an entry surfaces as a test
+ * diff. The list-order rationale below is for human readability only.
  *
- * Ordering rationale (kept in lockstep with `conversation-runner.ts`'s
+ * Selector rationale (kept in lockstep with `conversation-runner.ts`'s
  * CHAT_INPUT_SELECTORS — this driver only checks visibility so the
- * div-wrapper testid wouldn't actually break it, but matching ordering
+ * div-wrapper testid wouldn't actually break it, but matching the set
  * keeps a single mental model for both probes):
  *   1. CopilotKit V2 canonical textarea testid — the actual `<textarea>`
  *      inside the V2 chat input. Strictest, fillable signal.
  *   2. Scoped descendant — any `<textarea>` nested under the V2 wrapper
  *      `[data-testid="copilot-chat-input"]`, for V2 UIs whose textarea
  *      doesn't carry its own testid.
- *   3. Bare `textarea` — covers V1 CopilotKit and generic chat UIs whose
+ *   3. V2 chat-toggle testid — the launcher button for popup/sidebar UIs
+ *      whose composer mounts only after the panel opens.
+ *   4. Bare `textarea` — covers V1 CopilotKit and generic chat UIs whose
  *      composer is a plain `<textarea>` without a testid.
- *   4. Default placeholder — input-element composers whose UI uses
+ *   5. Default placeholder — input-element composers whose UI uses
  *      `<input placeholder="Type a message">` instead of a textarea.
- *   5-6. Generic chat-affordance fallbacks. Custom-composer demos (e.g.
- *      `headless-simple`, `headless-complete`) build their own UI on top
- *      of `useAgent`, so they lack both the testid and the default
- *      placeholder but still render a text input / ARIA textbox. A match
- *      on any of these is enough structural evidence that the demo
+ *   6-7. Generic chat-affordance fallbacks (`input[type="text"]`,
+ *      `[role="textbox"]`). Custom-composer demos (e.g. `headless-simple`,
+ *      `headless-complete`) build their own UI on top of `useAgent`, so they
+ *      lack both the testid and the default placeholder but still render a
+ *      text input / ARIA textbox.
+ *   8. Auth sign-in card — `/demos/auth` renders a sign-in surface BEFORE the
+ *      chat input mounts; the testid signals "demo route booted" pre-auth.
+ *      A match on any of these is enough structural evidence that the demo
  *      route booted.
  */
 const READY_SELECTORS = [
@@ -328,6 +335,10 @@ export function createPooledE2eDemosLauncher(
       });
     };
 
+    // Capture the listener so launcher-level close() can detach it: without
+    // removeEventListener a post-completion abort would fire the handler after
+    // the run returned, leaking the listener for the signal's lifetime.
+    let detachAbort: (() => void) | undefined;
     if (abortSignal) {
       if (abortSignal.aborted) {
         aborted = true;
@@ -336,12 +347,22 @@ export function createPooledE2eDemosLauncher(
         abortSignal.addEventListener("abort", closeAllOpenContexts, {
           once: true,
         });
+        detachAbort = () =>
+          abortSignal.removeEventListener("abort", closeAllOpenContexts);
       }
     }
 
     return {
       async newContext(): Promise<E2eDemosBrowserContext> {
         const ctx = await pool.acquire();
+        // If the signal was already aborted at launcher construction (the
+        // pre-aborted branch never attached the live abort listener), a context
+        // opened now would never be closed by the abort path. Release it
+        // immediately and refuse so it cannot leak into a torn-down run.
+        if (aborted) {
+          await pool.release(ctx).catch(() => {});
+          throw new Error("e2e-demos launcher aborted");
+        }
         const ctxHandle = { close: () => pool.release(ctx) };
         openContexts.add(ctxHandle);
         return {
@@ -359,8 +380,12 @@ export function createPooledE2eDemosLauncher(
           },
         };
       },
-      // Launcher-level close is a no-op: each context releases itself.
-      close: async () => {},
+      // Launcher-level close releases nothing itself (each context releases
+      // itself) but detaches the abort listener so a post-completion abort
+      // can't fire the handler after the run returned.
+      close: async () => {
+        detachAbort?.();
+      },
     };
   };
 }

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1,48 +1,48 @@
 import { describe, it, expect } from "vitest";
-import type { Browser } from "playwright";
+import type { Browser, BrowserContext } from "playwright";
 import { BrowserPool } from "./browser-pool.js";
 import type { LaunchBrowser } from "./browser-pool.js";
 
 /**
- * Minimal `Browser` stand-in that exposes the surface BrowserPool actually
- * uses (`isConnected`, `on`, `close`, `newContext`) plus test-only hooks
- * for simulating chromium lifecycle events:
+ * Minimal `BrowserContext` stand-in. Tracks close + the extraHTTPHeaders the
+ * pool opened it with so tests can assert header centralization + forwarding.
+ */
+interface FakeContext {
+  readonly __id: number;
+  readonly __headers?: Record<string, string>;
+  close(): Promise<void>;
+  readonly __closeCount: number;
+}
+
+/**
+ * Minimal `Browser` stand-in that exposes the surface BrowserPool uses
+ * (`isConnected`, `on`, `close`, `newContext`) plus test hooks:
  *
- *   - `__crash()`           — fires the `disconnected` event AND flips
- *                             `isConnected` false. Mirrors a real chromium
- *                             that died and notified Playwright cleanly.
- *   - `__silentlyDisconnect()` — flips `isConnected` false but does NOT
- *                             fire `disconnected`. Mirrors a process that
- *                             died without Playwright noticing in time
- *                             (e.g. WebSocket hung), so the pool's only
- *                             defense is the on-acquire health check.
+ *   - `__crash()` — fires `disconnected` AND flips `isConnected` false.
+ *   - `__silentlyDisconnect()` — flips `isConnected` false WITHOUT firing.
  */
 interface FakeBrowser {
   readonly __id: number;
   isConnected(): boolean;
   on(event: string, handler: (...args: unknown[]) => void): void;
   close(): Promise<void>;
-  newContext(): Promise<{ close(): Promise<void> }>;
+  newContext(opts?: {
+    extraHTTPHeaders?: Record<string, string>;
+  }): Promise<FakeContext>;
   __crash(): void;
   __silentlyDisconnect(): void;
-  /**
-   * Re-fire the `disconnected` event WITHOUT touching `isConnected`. Models a
-   * delayed/duplicate disconnect delivery for an already-dead browser — e.g.
-   * Playwright drains a late `disconnected` for an OLD browser instance after
-   * the slot has already been parked and is being relaunched. `__crash` can
-   * only fire once (it no-ops when already disconnected), so this is the hook
-   * for the "late disconnect races concurrent relaunch" race.
-   */
-  __fireDisconnectLate(): void;
   readonly __closeCount: number;
+  readonly __contexts: FakeContext[];
 }
 
 let nextBrowserId = 0;
+let nextContextId = 0;
 
-function makeFakeBrowser(): FakeBrowser {
+function makeFakeBrowser(opts?: { newContextThrows?: boolean }): FakeBrowser {
   const id = nextBrowserId++;
   let connected = true;
   let closeCount = 0;
+  const contexts: FakeContext[] = [];
   const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
   const fire = (event: string): void => {
     for (const h of handlers.get(event) ?? []) h();
@@ -51,6 +51,9 @@ function makeFakeBrowser(): FakeBrowser {
     __id: id,
     get __closeCount() {
       return closeCount;
+    },
+    get __contexts() {
+      return contexts;
     },
     isConnected: () => connected,
     on(event, handler) {
@@ -64,8 +67,24 @@ function makeFakeBrowser(): FakeBrowser {
       connected = false;
       if (wasConnected) fire("disconnected");
     },
-    async newContext() {
-      return { close: async () => {} };
+    async newContext(ctxOpts) {
+      if (opts?.newContextThrows) {
+        throw new Error("simulated newContext failure");
+      }
+      const ctxId = nextContextId++;
+      let ctxCloseCount = 0;
+      const ctx: FakeContext = {
+        __id: ctxId,
+        __headers: ctxOpts?.extraHTTPHeaders,
+        get __closeCount() {
+          return ctxCloseCount;
+        },
+        async close() {
+          ctxCloseCount++;
+        },
+      };
+      contexts.push(ctx);
+      return ctx;
     },
     __crash() {
       if (connected) {
@@ -76,9 +95,6 @@ function makeFakeBrowser(): FakeBrowser {
     __silentlyDisconnect() {
       connected = false;
     },
-    __fireDisconnectLate() {
-      fire("disconnected");
-    },
   };
 }
 
@@ -88,56 +104,31 @@ interface FakeLauncher {
 }
 
 function makeFakeLauncher(opts?: {
-  failAt?: number;
   failAtCalls?: number[];
+  newContextThrowsForCalls?: number[];
 }): FakeLauncher {
   const launched: FakeBrowser[] = [];
   let callCount = 0;
   const launchBrowser = async (): Promise<Browser> => {
     callCount++;
-    if (
-      (opts?.failAt !== undefined && callCount === opts.failAt) ||
-      opts?.failAtCalls?.includes(callCount)
-    ) {
+    if (opts?.failAtCalls?.includes(callCount)) {
       throw new Error("simulated launch failure");
     }
-    const b = makeFakeBrowser();
+    const b = makeFakeBrowser({
+      newContextThrows: opts?.newContextThrowsForCalls?.includes(callCount),
+    });
     launched.push(b);
     return b as unknown as Browser;
   };
   return { launchBrowser, launched };
 }
 
-interface CapturedLog {
+interface LeveledLog {
+  level: "info" | "warn" | "error";
   event: string;
   meta?: Record<string, unknown>;
 }
 
-function makeFakeLogger(): {
-  logger: { info: (msg: string, meta?: Record<string, unknown>) => void };
-  events: CapturedLog[];
-} {
-  const events: CapturedLog[] = [];
-  return {
-    logger: {
-      info(msg, meta) {
-        events.push({ event: msg, meta });
-      },
-    },
-    events,
-  };
-}
-
-interface LeveledLog extends CapturedLog {
-  level: "info" | "warn" | "error";
-}
-
-/**
- * Fake logger that captures the SEVERITY each event was emitted at. Unlike
- * `makeFakeLogger` (info-only), this exposes `warn`/`error` so routing-by-
- * severity is observable: a capacity-loss event logged via `logger.error(...)`
- * must show up with `level: "error"`, never `level: "info"`.
- */
 function makeLeveledLogger(): {
   logger: {
     info: (msg: string, meta?: Record<string, unknown>) => void;
@@ -149,1338 +140,396 @@ function makeLeveledLogger(): {
   const events: LeveledLog[] = [];
   return {
     logger: {
-      info(msg, meta) {
-        events.push({ level: "info", event: msg, meta });
-      },
-      warn(msg, meta) {
-        events.push({ level: "warn", event: msg, meta });
-      },
-      error(msg, meta) {
-        events.push({ level: "error", event: msg, meta });
-      },
+      info: (event, meta) => events.push({ level: "info", event, meta }),
+      warn: (event, meta) => events.push({ level: "warn", event, meta }),
+      error: (event, meta) => events.push({ level: "error", event, meta }),
     },
     events,
   };
 }
 
-/**
- * Flush pending microtasks `times` times so post-recycle state settles
- * enough to observe without tearing the pool down. It does NOT advance real
- * `setTimeout` backoff timers — tests that depend on backoff elapsing use
- * `waitFor` instead.
- */
-async function drainMicrotasks(times = 5): Promise<void> {
-  for (let i = 0; i < times; i++) {
-    await Promise.resolve();
-  }
+async function drainMicrotasks(times = 10): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
 }
 
-/**
- * Poll `predicate` until it returns true or `timeoutMs` elapses. The pool's
- * recycle/relaunch paths use real `setTimeout` backoff, so state transitions
- * (slot eviction, relaunchPending parking, deferred recovery) settle over
- * wall-clock time rather than microtasks. Rejects on timeout so a test that
- * relies on a precondition fails loudly instead of asserting on stale state.
- */
 async function waitFor(
   predicate: () => boolean,
   timeoutMs = 3_000,
 ): Promise<void> {
   const start = Date.now();
   while (!predicate()) {
-    if (Date.now() - start > timeoutMs) {
-      throw new Error("waitFor timed out");
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
 }
 
-describe("BrowserPool dead-instance detection", () => {
-  it("registers a disconnected listener on each browser at init and recycles when one fires", async () => {
+const ctxId = (c: BrowserContext): number => (c as unknown as FakeContext).__id;
+
+describe("BrowserPool — context pooling over fixed browser set", () => {
+  // CASE 1 — THE load-bearing assertion: no process fork on the hot path.
+  it("does NOT fork a browser process across many acquire/release cycles (launched stays == N)", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
-    const { logger, events } = makeFakeLogger();
-    const pool = new BrowserPool(2, 100, logger, launchBrowser, 0);
-    await pool.init();
-    expect(launched).toHaveLength(2);
-
-    // Crash slot 0's browser. The disconnected listener should fire and
-    // kick recycle, which launches a fresh browser (the 3rd one).
-    launched[0]!.__crash();
-    await drainMicrotasks();
-
-    const disconnected = events.find(
-      (e) => e.event === "browser-pool.disconnected",
-    );
-    expect(disconnected).toBeDefined();
-    expect(disconnected?.meta).toEqual({ slotIndex: 0 });
-
-    await pool.shutdown();
-    // After shutdown awaits the in-flight recycle, the fresh launch must
-    // have completed.
-    expect(launched.length).toBeGreaterThanOrEqual(3);
-  });
-
-  it("acquire() skips a silently-disconnected slot and returns the next live one", async () => {
-    const { launchBrowser, launched } = makeFakeLauncher();
-    const { logger, events } = makeFakeLogger();
-    const pool = new BrowserPool(2, 100, logger, launchBrowser, 0);
-    await pool.init();
-
-    const slot0Browser = launched[0]!;
-    const slot1Browser = launched[1]!;
-
-    // Silent disconnect: `isConnected` flips false without firing the
-    // event. acquire() must still skip it.
-    slot0Browser.__silentlyDisconnect();
-
-    const acquired = await pool.acquire();
-    expect(acquired).toBe(slot1Browser as unknown as Browser);
-
-    expect(
-      events.some((e) => e.event === "browser-pool.skipped-dead-slot"),
-    ).toBe(true);
-
-    await pool.shutdown();
-  });
-
-  it("acquire() recycles every zombie slot and falls through to the waiter path when no live slots remain", async () => {
-    const { launchBrowser, launched } = makeFakeLauncher();
-    const pool = new BrowserPool(2, 100, undefined, launchBrowser, 0);
-    await pool.init();
-
-    launched[0]!.__silentlyDisconnect();
-    launched[1]!.__silentlyDisconnect();
-
-    // Both available slots are zombies. acquire() should kick recycle on
-    // each and return a Promise that resolves once a recycled browser
-    // becomes available.
-    const acquirePromise = pool.acquire();
-
-    await drainMicrotasks(20);
-
-    const acquired = await acquirePromise;
-    // The fresh launch is browser #2 or #3 — either is fine.
-    const fresh = launched.slice(2);
-    expect(fresh).toContain(acquired as unknown as FakeBrowser);
-
-    await pool.shutdown();
-  });
-
-  it("disconnected event during in-use slot triggers a recycle that delivers a fresh browser to the next acquire", async () => {
-    const { launchBrowser, launched } = makeFakeLauncher();
-    const pool = new BrowserPool(1, 100, undefined, launchBrowser, 0);
-    await pool.init();
-
-    const browser = await pool.acquire();
-    expect(browser).toBe(launched[0] as unknown as Browser);
-
-    // Simulate chromium dying while the probe still holds the browser.
-    launched[0]!.__crash();
-    await drainMicrotasks(20);
-
-    const next = await pool.acquire();
-    expect(next).not.toBe(browser);
-    expect(next).toBe(launched[launched.length - 1] as unknown as Browser);
-
-    await pool.shutdown();
-  });
-
-  it("does not double-recycle when both the disconnect event and the on-acquire zombie check fire for the same slot", async () => {
-    const { launchBrowser, launched } = makeFakeLauncher();
-    const pool = new BrowserPool(1, 100, undefined, launchBrowser, 0);
-    await pool.init();
-
-    // Crash fires disconnect AND flips isConnected false.
-    launched[0]!.__crash();
-    // Acquire while the recycle is still in flight — sees nothing in
-    // available, falls through to waiter path. The disconnect-driven
-    // recycle delivers the fresh browser to the waiter.
-    const acquired = await pool.acquire();
-
-    // Exactly one fresh browser was launched (the recycle replacement).
-    expect(launched.length).toBe(2);
-    expect(acquired).toBe(launched[1] as unknown as Browser);
-
-    await pool.shutdown();
-  });
-
-  it("release() of a slot whose browser disconnected after acquire still recycles instead of returning a dead browser to available", async () => {
-    const { launchBrowser, launched } = makeFakeLauncher();
-    const { logger, events } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    await pool.init();
-
-    const browser = await pool.acquire();
-    // Silent disconnect: no event fires. The pool only learns the slot
-    // is dead at the next isConnected check — which the patched
-    // release() now performs before re-queuing.
-    (browser as unknown as FakeBrowser).__silentlyDisconnect();
-    pool.release(browser);
-
-    await drainMicrotasks(20);
-
-    expect(
-      events.some((e) => e.event === "browser-pool.release-dead-slot"),
-    ).toBe(true);
-    // A fresh browser was launched; the dead one was not re-queued.
-    expect(launched.length).toBe(2);
-
-    const next = await pool.acquire();
-    expect(next).toBe(launched[1] as unknown as Browser);
-    expect((next as unknown as FakeBrowser).isConnected()).toBe(true);
-
-    await pool.shutdown();
-  });
-
-  it("does not double-publish a slot to available when the same live browser is released twice", async () => {
-    // Bug #1 guard. release(browser) looks the slot up via browserToSlot; a
-    // still-live slot (not recycled) survives a SECOND release(sameBrowser),
-    // and the no-waiter branch used to `this.available.push(slot)`
-    // UNCONDITIONALLY — so the slot appeared twice in `available` and the next
-    // two acquires handed the SAME browser to two probes. handOff already
-    // guards this with `!this.available.includes(slot)`; release must too.
-    // Single-slot pool so the only slot's publication count is directly
-    // observable: a double-push duplicates the SOLE slot in `available`.
-    const { launchBrowser, launched } = makeFakeLauncher();
-    const pool = new BrowserPool(1, 100, undefined, launchBrowser, 0);
-    await pool.init();
-
-    const browser = await pool.acquire();
-    expect(browser).toBe(launched[0] as unknown as Browser);
-
-    // Double-release the SAME live browser. The second release must be a
-    // no-op for `available` (the slot is already queued) — not a second push.
-    pool.release(browser);
-    pool.release(browser);
-
-    // The single slot must appear in `available` exactly once after the
-    // double-release — never twice.
-    expect(pool.stats().available).toBe(1);
-
-    // First acquire draws the (single) slot, emptying `available`. With the
-    // double-push the duplicate would remain, so a SECOND immediate acquire
-    // would wrongly hand out the SAME browser to a concurrent probe; with the
-    // guard `available` is empty and the second acquire parks as a waiter.
-    const first = await pool.acquire();
-    expect(first).toBe(launched[0] as unknown as Browser);
-
-    await expect(pool.acquire(50)).rejects.toThrow(
-      "BrowserPool acquire timeout",
-    );
-
-    await pool.shutdown();
-  });
-
-  it("does not hand the SAME live browser to two waiters when it is released twice while waiters are queued", async () => {
-    // Bug guard (idempotent release on the WAITER path). release(browser)
-    // routes a live return through handOff(slot, slot.browser). handOff's
-    // waiter branch is `const w = this.waiters.shift(); if (w) w.resolve(b)`
-    // with NO idempotency guard. A SECOND release(sameLiveBrowser) still finds
-    // the slot in browserToSlot (a live slot is never deleted), passes the
-    // contextCount/isConnected checks, calls handOff again, shifts a SECOND
-    // waiter and resolves it with the SAME browser — two probes driving one
-    // chromium. The existing `!available.includes(slot)` guard only covers the
-    // NO-waiter branch; the waiter branch was unguarded. Checked-out tracking
-    // makes the second release a no-op on BOTH paths.
-    //
-    // Single-slot pool so the only live browser's publication is directly
-    // observable. Acquire it (checking it out), queue TWO waiters, then
-    // double-release the SAME browser. Only ONE waiter may be served with it;
-    // the second release is a no-op so the second waiter stays pending until
-    // its own timeout.
-    const { launchBrowser, launched } = makeFakeLauncher();
-    const pool = new BrowserPool(1, 100, undefined, launchBrowser, 0);
-    await pool.init();
-
-    const browser = await pool.acquire();
-    expect(browser).toBe(launched[0] as unknown as Browser);
-
-    // Queue two waiters (no available slots — the only browser is held).
-    const waiterA = pool.acquire(5_000);
-    const waiterB = pool.acquire(150);
-    await drainMicrotasks();
-
-    // Double-release the SAME live browser. The first release serves waiterA;
-    // the second MUST be a no-op (the slot is no longer checked out), so it
-    // must NOT shift and resolve waiterB with the same browser.
-    pool.release(browser);
-    pool.release(browser);
-
-    const settled = await Promise.allSettled([waiterA, waiterB]);
-    // waiterA was served with the live browser.
-    expect(settled[0]!.status).toBe("fulfilled");
-    expect((settled[0] as PromiseFulfilledResult<Browser>).value).toBe(
-      launched[0] as unknown as Browser,
-    );
-    // waiterB must NOT have been resolved with the same browser — it stays
-    // pending and times out. With the bug it would resolve with launched[0].
-    expect(settled[1]!.status).toBe("rejected");
-    expect((settled[1] as PromiseRejectedResult).reason).toMatchObject({
-      message: "BrowserPool acquire timeout",
+    const pool = new BrowserPool({
+      browsers: 3,
+      maxContexts: 24,
+      recycleAfter: 300,
+      launchBrowser,
+      launchStaggerMs: 0,
     });
+    await pool.init();
+    expect(launched.length).toBe(3);
 
-    // Exactly one browser was ever launched — no fresh one, and the single one
-    // was handed to exactly one waiter.
-    expect(launched).toHaveLength(1);
+    // Acquire/release many contexts across many cycles. The OLD pool forked
+    // on the 100th release (recycleAfter); the new pool never forks here.
+    for (let i = 0; i < 250; i++) {
+      const ctx = await pool.acquire();
+      await pool.release(ctx);
+    }
 
+    expect(launched.length).toBe(3); // init only — zero forks on the hot path
     await pool.shutdown();
   });
 
-  it("reports stats().inUse from actually-checked-out slots, decrementing on release", async () => {
-    // inUse must reflect slots currently handed to a caller, derived from the
-    // checked-out set, not the `liveSlots.length - available` subtraction.
-    const { launchBrowser } = makeFakeLauncher();
-    const pool = new BrowserPool(2, 100, undefined, launchBrowser, 0);
+  // CASE 2 — release(ctx) closes the context, no relaunch.
+  it("release(ctx) closes the context and does not relaunch", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 10,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    const ctx = await pool.acquire();
+    const fake = ctx as unknown as FakeContext;
+    expect(fake.__closeCount).toBe(0);
+    await pool.release(ctx);
+    expect(fake.__closeCount).toBe(1);
+    expect(launched.length).toBe(2);
+    await pool.shutdown();
+  });
+
+  // CASE 3 — maxContexts cap + FIFO waiter; launched never grows.
+  it("enforces maxContexts and serves a pending FIFO waiter on release without forking", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
     await pool.init();
 
-    expect(pool.stats().inUse).toBe(0);
-    expect(pool.stats().available).toBe(2);
-
-    const a = await pool.acquire();
-    expect(pool.stats().inUse).toBe(1);
-    expect(pool.stats().available).toBe(1);
-
-    const b = await pool.acquire();
+    const c1 = await pool.acquire();
+    const c2 = await pool.acquire();
     expect(pool.stats().inUse).toBe(2);
     expect(pool.stats().available).toBe(0);
 
-    pool.release(a);
-    expect(pool.stats().inUse).toBe(1);
-    expect(pool.stats().available).toBe(1);
+    // Third acquire pends past the cap.
+    let c3: BrowserContext | undefined;
+    const pending = pool.acquire().then((c) => (c3 = c));
+    await drainMicrotasks();
+    expect(c3).toBeUndefined();
 
-    // Idempotent: a second release of the same browser must not drive inUse
-    // negative or otherwise corrupt the count.
-    pool.release(a);
-    expect(pool.stats().inUse).toBe(1);
-    expect(pool.stats().available).toBe(1);
+    // Release frees one — the waiter is served.
+    await pool.release(c1);
+    await pending;
+    expect(c3).toBeDefined();
+    expect(pool.stats().inUse).toBe(2);
+    expect(launched.length).toBe(1); // never grew
 
-    pool.release(b);
-    expect(pool.stats().inUse).toBe(0);
-    expect(pool.stats().available).toBe(2);
-
+    await pool.release(c2);
+    await pool.release(c3!);
     await pool.shutdown();
   });
 
-  it("recovers after a transient relaunch failure instead of permanently shrinking the pool to 0", async () => {
-    // Single-slot pool. The browser crashes; the recycle's relaunch fails
-    // ONCE (the 2nd launch call), then a subsequent launch succeeds. The
-    // pool must NOT permanently evict the slot — it must keep capacity and
-    // self-heal so a later acquire() still returns a live browser.
-    const { launchBrowser, launched } = makeFakeLauncher({ failAtCalls: [2] });
-    const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    await pool.init();
-    expect(launched).toHaveLength(1);
-
-    // Crash the only browser. The disconnect-driven recycle relaunches, but
-    // launch #2 throws (the simulated transient failure).
-    launched[0]!.__crash();
-    await drainMicrotasks(30);
-
-    // BUG: the old code spliced the slot out of `this.slots` on launch
-    // failure, leaving size 0 forever. The pool must instead retain or
-    // re-create the slot so capacity recovers.
-    const acquired = await pool.acquire(5_000);
-    expect(acquired).toBeDefined();
-    expect((acquired as unknown as FakeBrowser).isConnected()).toBe(true);
-
-    // Pool reports non-zero size again — it healed rather than draining.
-    expect(pool.stats().size).toBeGreaterThan(0);
-
-    await pool.shutdown();
-  });
-
-  it("does not hand a queued waiter a browser that is already disconnected at handoff time", async () => {
-    // Bug #2 guard. The acquire() available-scan recycles a zombie before
-    // handing it out, but the WAITER-served path (handOff) used to
-    // `waiter.resolve(browser)` with NO liveness check. So a browser that
-    // silently disconnected in the window between launch and handoff could be
-    // delivered to a waiting probe. handOff (and release's waiter branch) must
-    // check `browser.isConnected()` before resolving; if dead, recycle the
-    // slot and leave the waiter queued so a LIVE browser serves it.
-    //
-    // Single-slot pool. Crash the only browser to drive a recycle. The
-    // recycle's first relaunch (call 2) returns a browser that is BORN DEAD
-    // (silently disconnected the instant it is launched), so at handOff time
-    // it reports isConnected() === false. A waiter is queued before the
-    // handoff. The waiter must NOT be resolved with the dead browser; instead
-    // the slot recycles again and call 3 (a live browser) serves the waiter.
-    const launched: FakeBrowser[] = [];
-    let callCount = 0;
-    let releaseRelaunch: (() => void) | undefined;
-    const relaunchGate = new Promise<void>((resolve) => {
-      releaseRelaunch = resolve;
-    });
-    const launchBrowser: LaunchBrowser = async () => {
-      callCount++;
-      const b = makeFakeBrowser();
-      launched.push(b);
-      if (callCount === 2) {
-        // The recycle replacement is born dead: it launches, then silently
-        // disconnects before the pool hands it to the waiter. Gate it so we
-        // can queue a waiter before the handoff runs.
-        await relaunchGate;
-        b.__silentlyDisconnect();
-      }
-      return b as unknown as Browser;
-    };
-    const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    await pool.init();
-    expect(launched).toHaveLength(1);
-
-    // Crash the only browser; the disconnect-driven recycle starts and its
-    // relaunch (call 2) blocks on the gate.
-    launched[0]!.__crash();
-    await waitFor(() => callCount >= 2, 3_000);
-
-    // Queue a waiter while the (born-dead) relaunch is gated. acquire sees no
-    // available slot and parks this waiter.
-    const acquirePromise = pool.acquire(5_000);
-    await drainMicrotasks(10);
-
-    // Release the gated relaunch. The fresh browser is born dead, so handOff
-    // must NOT resolve the waiter with it — it parks the slot relaunchPending
-    // (the slot is busy in the recycle path) and leaves the waiter QUEUED.
-    releaseRelaunch!();
-    await drainMicrotasks(20);
-
-    // The recycle path is busy at handoff time, so recovery is lazy: a
-    // subsequent acquire() drives relaunchPendingSlots, relaunches (call 3 —
-    // live), and serves the still-queued ORIGINAL waiter via handOff (FIFO).
-    // This second acquire's own waiter then times out (single slot already
-    // re-held), but the original `acquirePromise` resolves with the LIVE
-    // browser. (Driving recovery on the next probe tick is the pool's
-    // intended lazy-recovery contract.)
-    const second = pool.acquire(50);
-
-    const acquired = await acquirePromise;
-    expect((acquired as unknown as FakeBrowser).isConnected()).toBe(true);
-    // The waiter was served a LIVE browser, never the born-dead call-2 one.
-    expect((acquired as unknown as FakeBrowser).__id).not.toBe(
-      launched[1]!.__id,
-    );
-
-    await expect(second).rejects.toThrow("BrowserPool acquire timeout");
-
-    await pool.shutdown();
-  });
-
-  it("recovers a fully-parked pool (all slots relaunchPending, size 0) via the lazy relaunchPendingSlots path on the next acquire", async () => {
-    // 2-slot pool. Both browsers crash and EVERY immediate relaunch attempt
-    // fails for both slots. Each slot makes RELAUNCH_MAX_ATTEMPTS (=3) launch
-    // calls during recycle, so for 2 slots that is launch calls 3..8 (init
-    // used calls 1 and 2). Failing 3..8 exhausts every immediate retry and
-    // parks BOTH slots as `relaunchPending` — they are NOT evicted from
-    // `this.slots` (capacity is preserved), so `stats().size` reads 0 during
-    // the outage while the slots stay parked. Recovery is therefore via the
-    // lazy `relaunchPendingSlots()` path on the next acquire (launch call 9
-    // succeeds), NOT the `reinit()` backstop (which only fires when
-    // `this.slots` is truly empty). This test asserts that actual mechanism.
-    const { launchBrowser, launched } = makeFakeLauncher({
-      failAtCalls: [3, 4, 5, 6, 7, 8],
-    });
-    const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(2, 100, logger, launchBrowser, 0);
-    await pool.init();
-    expect(launched).toHaveLength(2);
-
-    launched[0]!.__crash();
-    launched[1]!.__crash();
-    // The recycle uses real setTimeout backoff between attempts, so give it
-    // a wall-clock window to exhaust all retries and park both slots.
-    await waitFor(() => pool.stats().size === 0, 5_000);
-
-    // Precondition: every slot is parked, so live capacity (`size`) reads 0
-    // during the outage. The slots themselves are retained — recovery comes
-    // through the relaunchPending path, not a from-scratch reinit.
-    expect(pool.stats().size).toBe(0);
-
-    // The next acquire() recovers the parked slots via relaunchPendingSlots
-    // (launch call 9 succeeds) and hands back a live browser instead of
-    // hanging until timeout. `size` returns to non-zero once recovered.
-    const acquired = await pool.acquire(5_000);
-    expect(acquired).toBeDefined();
-    expect((acquired as unknown as FakeBrowser).isConnected()).toBe(true);
-    expect(pool.stats().size).toBeGreaterThan(0);
-
-    await pool.shutdown();
-  });
-
-  it("recovers a parked slot on the next acquire() after every immediate relaunch failed", async () => {
-    // Single-slot pool. The browser crashes and EVERY immediate relaunch
-    // attempt fails (launch calls 2..4 — RELAUNCH_MAX_ATTEMPTS=3), so the slot
-    // is parked relaunchPending. There is no background timer to recover it;
-    // recovery is lazy. A LATER launch (call 5) succeeds, and the NEXT
-    // acquire() must drive `relaunchPendingSlots()` to relaunch the slot and
-    // hand back a fresh, connected browser. This replaces the old
-    // deferred-timer test that asserted a waiter was served WITHOUT a second
-    // acquire() — that behavior intentionally no longer holds.
-    const { launchBrowser, launched } = makeFakeLauncher({
-      failAtCalls: [2, 3, 4],
-    });
-    const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    await pool.init();
-    expect(launched).toHaveLength(1);
-
-    // Hand out the only browser, then crash it while held. The disconnect
-    // recycle relaunches but calls 2..4 all fail, parking the slot.
-    const held = await pool.acquire();
-    expect(held).toBe(launched[0] as unknown as Browser);
-    (held as unknown as FakeBrowser).__crash();
-
-    // Wait until the recycle has fully exhausted its immediate retries and
-    // parked the slot — live capacity reads 0 and nothing is recovering it.
-    await waitFor(() => pool.stats().size === 0, 3_000);
-
-    // The next acquire() drives the lazy recovery: relaunchPendingSlots
-    // re-attempts the launch (call 5 succeeds) and the parked/waiting caller
-    // gets a fresh connected browser.
-    const recovered = await pool.acquire(5_000);
-    expect(recovered).toBeDefined();
-    expect((recovered as unknown as FakeBrowser).isConnected()).toBe(true);
-    expect((recovered as unknown as FakeBrowser).__id).toBe(
-      launched[launched.length - 1]!.__id,
-    );
-
-    await pool.shutdown();
-  });
-
-  it("does not double-publish a relaunchPending slot when recovery is driven concurrently", async () => {
-    // Drive a single slot into relaunchPending (all immediate retries fail),
-    // then trigger TWO concurrent acquire()-driven relaunches racing for the
-    // same slot. With a re-entry guard the slot is launched exactly once and
-    // its fresh browser is handed to exactly one acquirer — never published to
-    // `available` twice nor handed to two probes (guards bug #2).
-    const { launchBrowser, launched } = makeFakeLauncher({
-      failAtCalls: [2, 3, 4],
-    });
-    const { logger } = makeFakeLogger();
-    // Stagger 0 keeps the test fast; the launch-serialization gate's
-    // concurrency-1 guarantee (the property under test here, that the slot is
-    // launched exactly once) holds independent of the stagger length.
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    await pool.init();
-
-    const held = await pool.acquire();
-    (held as unknown as FakeBrowser).__crash();
-    // Let the immediate recycle retries (calls 2..4) exhaust and PARK the slot
-    // as relaunchPending before we drive concurrent recovery. We wait on
-    // `size === 0` (slot parked, recycle fully done) rather than
-    // `available === 0` — `available` is already 0 the instant the only
-    // browser was handed out, so it would let the race start while the recycle
-    // is still in flight and the slot is not yet pending. No `.catch` swallow
-    // here — if the precondition never settles, the test must fail loudly
-    // rather than proceed on stale state.
-    await waitFor(() => pool.stats().size === 0, 3_000);
-
-    // Two acquirers race for the single recovering slot, each driving
-    // relaunchPendingSlots. With the launch-serialization gate, exactly one of
-    // them claims the slot (relaunchingSlots) and drives the single gated
-    // launch; the other skips (slot busy) and parks as a waiter. The freshly
-    // launched browser is handed off to one of the two — the WINNER — and the
-    // LOSER is left parked. The loser uses a SHORT timeout so this test stays
-    // fast: a parked waiter is only rejected by `shutdown()`, and the gate's
-    // extra `await` can let the loser register its waiter AFTER `shutdown()`
-    // has already drained the waiter set, in which case only its own timeout
-    // frees it. We assert the WINNER got exactly the one fresh launch; the
-    // loser's fate (short-timeout reject) is not the property under test.
-    const a = pool.acquire(150);
-    const b = pool.acquire(150);
-
-    const settled = await Promise.allSettled([a, b]);
-    const fulfilled = settled.filter(
-      (s): s is PromiseFulfilledResult<Browser> => s.status === "fulfilled",
-    );
-    // Exactly one acquirer was served (the single slot can serve only one
-    // before being re-held); the other parked and timed out.
-    expect(fulfilled).toHaveLength(1);
-    const first = fulfilled[0]!.value;
-    expect((first as unknown as FakeBrowser).isConnected()).toBe(true);
-
-    // Exactly one fresh browser (the successful relaunch, call 5) was
-    // created beyond init — no leaked second launch from a re-entrant relaunch.
-    const freshBeyondInit = launched.slice(1);
-    expect(freshBeyondInit.length).toBe(1);
-
-    // Exact-once: the browser handed to the winning acquirer must BE that
-    // single fresh launch. Asserting only `length === 1` can pass even if the
-    // winner were served some other instance; pinning the id proves the slot
-    // was launched once and that launch is exactly what got served.
-    expect((first as unknown as FakeBrowser).__id).toBe(
-      freshBeyondInit[0]!.__id,
-    );
-
-    // The single slot must never appear twice in `available`.
-    expect(pool.stats().available).toBeLessThanOrEqual(1);
-    expect(pool.stats().size).toBe(1);
-
-    await pool.shutdown();
-  });
-
-  it("recovers a parked slot via a later acquire() even when an intervening acquire()'s relaunch also failed", async () => {
-    // Lazy-recovery guard. A single-slot pool. The browser crashes via a
-    // `disconnected` event while NO acquire is waiting. The recycle exhausts
-    // all immediate retries (calls 2..4 fail) and parks the slot
-    // relaunchPending. There is no background timer — recovery is purely
-    // acquire()-driven.
-    //
-    // A first acquire()'s leading relaunchPendingSlots() attempt (call 5) ALSO
-    // fails, so that acquire parks a waiter and eventually times out (no timer
-    // re-arms recovery). A LATER acquire() then drives relaunchPendingSlots
-    // again (call 6 succeeds) and gets the fresh connected browser. This proves
-    // the on-demand recovery is robust to a failed intervening relaunch — the
-    // harness probes continuously, so a subsequent probe tick recovers.
-    const { launchBrowser, launched } = makeFakeLauncher({
-      failAtCalls: [2, 3, 4, 5],
-    });
-    const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    await pool.init();
-    expect(launched).toHaveLength(1);
-
-    // Crash the idle browser. The recycle exhausts immediate retries and parks
-    // the slot relaunchPending (no waiter queued, no timer to recover it).
-    launched[0]!.__crash();
-    // Wait until the recycle has fully exhausted its immediate retries and
-    // parked the slot — i.e. live capacity reads 0.
-    await waitFor(() => pool.stats().size === 0, 3_000);
-
-    // First acquire(): its leading relaunchPendingSlots attempt is call 5,
-    // which fails, so it parks a waiter that hits its (short) timeout — no
-    // timer re-arms recovery, which is the intended lazy behavior.
-    await expect(pool.acquire(50)).rejects.toThrow(
-      "BrowserPool acquire timeout",
-    );
-
-    // A LATER acquire() drives relaunchPendingSlots again; call 6 succeeds and
-    // the parked slot is recovered with a fresh connected browser.
-    const recovered = await pool.acquire(5_000);
-    expect(recovered).toBeDefined();
-    expect((recovered as unknown as FakeBrowser).isConnected()).toBe(true);
-    expect((recovered as unknown as FakeBrowser).__id).toBe(
-      launched[launched.length - 1]!.__id,
-    );
-
-    await pool.shutdown();
-  });
-
-  it("launches exactly one fresh browser when a late disconnect for an OLD browser races relaunchPendingSlots relaunching the same slot", async () => {
-    // Bug #2 guard. A slot parked relaunchPending still holds its OLD (dead)
-    // browser as slot.browser and is still in this.slots. relaunchPendingSlots
-    // begins relaunching it (slot enters relaunchingSlots, NOT recyclingSlots).
-    // While that relaunch is in flight, a LATE `disconnected` fire for the OLD
-    // browser passes the disconnect handler's guards (slot.browser === old,
-    // slots.includes(slot)) and reaches recycleSlot. The OLD guard only
-    // consulted recyclingSlots, so recycleSlot would proceed and launch a
-    // SECOND fresh browser — leaking one process / double-swapping slot.browser.
-    // isSlotBusy (which also checks relaunchingSlots) must make recycleSlot a
-    // no-op so exactly ONE fresh browser is launched and not double-published.
-    //
-    // Deterministic race: gate the relaunchPendingSlots launch so the slot is
-    // mid-relaunch (in relaunchingSlots) when we re-fire the old disconnect.
-    const launched: FakeBrowser[] = [];
-    let callCount = 0;
-    let releaseRelaunch: (() => void) | undefined;
-    const relaunchGate = new Promise<void>((resolve) => {
-      releaseRelaunch = resolve;
-    });
-    // init = call 1; recycle's 3 immediate retries = calls 2..4 (all fail) to
-    // park the slot; the relaunchPendingSlots relaunch = call 5, which we gate.
-    const failCalls = new Set([2, 3, 4]);
-    const launchBrowser: LaunchBrowser = async () => {
-      callCount++;
-      if (failCalls.has(callCount)) {
-        throw new Error("simulated launch failure");
-      }
-      if (callCount === 5) {
-        await relaunchGate;
-      }
-      const b = makeFakeBrowser();
-      launched.push(b);
-      return b as unknown as Browser;
-    };
-    const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    await pool.init();
-    expect(launched).toHaveLength(1);
-    const oldBrowser = launched[0]!;
-
-    // Crash the only browser. The disconnect-driven recycle relaunches, but
-    // calls 2..4 all fail, parking the slot relaunchPending. slot.browser is
-    // still oldBrowser (no successful swap), and the slot remains in
-    // this.slots — so a future disconnect for oldBrowser is still routed here.
-    oldBrowser.__crash();
-    await waitFor(() => pool.stats().size === 0, 3_000);
-
-    // Drive relaunchPendingSlots via an acquire(): it picks the pending slot,
-    // adds it to relaunchingSlots, and awaits the gated launch (call 5).
-    const acquirePromise = pool.acquire(5_000);
-    await drainMicrotasks(10);
-
-    // Now fire a LATE disconnect for the OLD browser while the relaunch is
-    // gated and the slot sits in relaunchingSlots (but NOT recyclingSlots).
-    // `__crash` already fired once and no-ops now, so re-fire the event
-    // directly to model the delayed delivery. Without the cross-set guard this
-    // re-enters recycleSlot and launches a second browser; with isSlotBusy it
-    // is a no-op (slot.browser is still oldBrowser, so handler guards pass).
-    oldBrowser.__fireDisconnectLate();
-    await drainMicrotasks(10);
-
-    // Release the gated relaunch; the single fresh browser is delivered.
-    releaseRelaunch!();
-    const acquired = await acquirePromise;
-    expect(acquired).toBeDefined();
-    expect((acquired as unknown as FakeBrowser).isConnected()).toBe(true);
-
-    // Let any erroneously-spawned second recycle settle so a leak would show.
-    await drainMicrotasks(20);
-
-    // Exactly ONE fresh browser beyond init — the late disconnect did not
-    // launch a second. No leaked process, no double-publish.
-    const freshBeyondInit = launched.slice(1);
-    expect(freshBeyondInit.length).toBe(1);
-    expect((acquired as unknown as FakeBrowser).__id).toBe(
-      freshBeyondInit[0]!.__id,
-    );
-    expect(pool.stats().available).toBeLessThanOrEqual(1);
-    expect(pool.stats().size).toBe(1);
-
-    await pool.shutdown();
-  });
-
-  it("launches exactly one fresh browser per slot when two pending slots are recovered by two concurrent relaunchPendingSlots invocations", async () => {
-    // Bug #1 guard (multi-slot reachable double-launch). relaunchPendingSlots
-    // snapshots `pending` ONCE then loops. With >=2 pending slots and two
-    // concurrent acquire()-driven invocations:
-    //   - invocation 1 snapshots [A, B], processes A (adds A to
-    //     relaunchingSlots, awaits A's gated launch);
-    //   - invocation 2 starts during that await, snapshots [B] (A is now
-    //     busy), claims B and relaunches it;
-    //   - invocation 1's A launch resolves; its loop advances to B and — with
-    //     NO in-loop re-check — re-adds B and launches a SECOND browser for B,
-    //     overwriting slot.browser (leaking the first) and double-publishing.
-    // The in-loop `if (this.isSlotBusy(slot) || !slot.relaunchPending)
-    // continue;` makes invocation 1 skip B, so EXACTLY ONE fresh browser is
-    // launched per slot.
-    //
-    // Deterministic race, ADAPTED for the launch-serialization gate. The gate
-    // funnels EVERY launch through a concurrency-1 serializer, so two recovery
-    // launches can never be in flight (running rawLaunchBrowser) at the same
-    // instant. We therefore gate ONLY the FIRST recovery launch (call 9, slot
-    // A driven by invocation 1). While that launch is gated/held, invocation 2
-    // runs, snapshots pending as [slot B] (slot A is busy in relaunchingSlots),
-    // and CLAIMS slot B (adds it to relaunchingSlots) before its own launch
-    // (call 10) queues behind call 9 in the gate chain. Releasing call 9 lets
-    // invocation 1's loop advance to slot B — where the in-loop guard
-    // `if (this.isSlotBusy(slot) || !slot.relaunchPending) continue;` MUST skip
-    // it (B is busy / no longer pending), so EXACTLY ONE fresh browser is
-    // launched per slot. Stagger 0 keeps the chain advancing fast.
-    const launched: FakeBrowser[] = [];
-    let callCount = 0;
-    let releaseCall9: (() => void) | undefined;
-    const call9Gate = new Promise<void>((resolve) => {
-      releaseCall9 = resolve;
-    });
-    // init = calls 1,2; the two slots' immediate recycle retries
-    // (RELAUNCH_MAX_ATTEMPTS=3 each) = calls 3..8, all fail to park both slots.
-    // Recovery relaunches are calls 9 (gated) and 10.
-    const failCalls = new Set([3, 4, 5, 6, 7, 8]);
-    const launchBrowser: LaunchBrowser = async () => {
-      callCount++;
-      if (failCalls.has(callCount)) {
-        throw new Error("simulated launch failure");
-      }
-      if (callCount === 9) {
-        await call9Gate;
-      }
-      const b = makeFakeBrowser();
-      launched.push(b);
-      return b as unknown as Browser;
-    };
-    const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(2, 100, logger, launchBrowser, 0);
-    await pool.init();
-    expect(launched).toHaveLength(2);
-
-    // Park BOTH slots as relaunchPending: crash both, let all immediate
-    // retries (calls 3..8) exhaust. Live capacity drops to 0 while both slots
-    // stay in this.slots.
-    launched[0]!.__crash();
-    launched[1]!.__crash();
-    await waitFor(() => pool.stats().size === 0, 5_000);
-    expect(pool.stats().size).toBe(0);
-
-    // Drive two concurrent relaunchPendingSlots invocations via two acquire()s.
-    // Invocation 1 (a) snapshots [slotA, slotB], claims slotA, and its slotA
-    // launch (call 9) blocks on the gate. Invocation 2 (b) then runs: it
-    // snapshots [slotB] (slotA busy), claims slotB, and its slotB launch (call
-    // 10) is queued in the serialization chain BEHIND the gated call 9.
-    const a = pool.acquire(5_000);
-    const b = pool.acquire(5_000);
-
-    // Wait until call 9 is actually in flight (gated) — i.e. invocation 1 has
-    // claimed slotA and reached its launch. By this point invocation 2 has had
-    // the chance to claim slotB. Drain microtasks so invocation 2's synchronous
-    // claim-then-queue has run before we release call 9.
-    await waitFor(() => callCount >= 9, 3_000);
-    await drainMicrotasks(30);
-
-    // Release call 9. Invocation 1's slotA launch resolves; its loop advances
-    // to slotB. WITHOUT the in-loop guard it would launch a SECOND browser for
-    // slotB (a 3rd launch, call 11). WITH the guard it skips slotB (busy / no
-    // longer pending). Call 10 (invocation 2's slotB launch) then runs.
-    releaseCall9!();
-
-    // Both acquirers must be served — one per slot — and exactly two fresh
-    // browsers launched beyond init (no leaked third launch for the contended
-    // slot).
-    const both = await Promise.all([a, b]);
-    both.forEach((br) =>
-      expect((br as unknown as FakeBrowser).isConnected()).toBe(true),
-    );
-
-    await drainMicrotasks(30);
-
-    const freshBeyondInit = launched.slice(2);
-    expect(freshBeyondInit.length).toBe(2);
-    // No erroneous third launch was ever attempted for the contended slot.
-    expect(callCount).toBe(10);
-
-    // Pin exact-once: both acquirers are served by the two fresh launches, and
-    // each fresh browser maps to a distinct slot (no slot.browser overwrite).
-    const servedIds = both.map((br) => (br as unknown as FakeBrowser).__id);
-    const freshIds = freshBeyondInit.map((br) => br.__id);
-    expect(new Set(servedIds)).toEqual(new Set(freshIds));
-
-    // Two live slots recovered, never double-published into available.
-    expect(pool.stats().size).toBe(2);
-    expect(pool.stats().available).toBeLessThanOrEqual(2);
-
-    await pool.shutdown();
-    await Promise.allSettled([a, b]);
-  });
-
-  it("routes capacity-loss events to error and per-attempt failures to warn", async () => {
-    // Single-slot pool. The browser crashes and EVERY immediate relaunch
-    // attempt fails (calls 2..4 — RELAUNCH_MAX_ATTEMPTS=3), so each per-attempt
-    // close/relaunch failure must log at warn while the terminal capacity-loss
-    // event (`recycle-relaunch-failed`) must log at error.
-    const { launchBrowser, launched } = makeFakeLauncher({
-      failAtCalls: [2, 3, 4],
-    });
-    const { logger, events } = makeLeveledLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    await pool.init();
-    expect(launched).toHaveLength(1);
-
-    launched[0]!.__crash();
-    await waitFor(() => pool.stats().size === 0, 3_000);
-
-    // Terminal capacity-loss after all retries → error.
-    const recycleFailed = events.find(
-      (e) => e.event === "browser-pool.recycle-relaunch-failed",
-    );
-    expect(recycleFailed).toBeDefined();
-    expect(recycleFailed?.level).toBe("error");
-
-    // The capacity-loss event must NOT also have been emitted at info.
-    expect(
-      events.some(
-        (e) =>
-          e.event === "browser-pool.recycle-relaunch-failed" &&
-          e.level === "info",
-      ),
-    ).toBe(false);
-
-    await pool.shutdown();
-  });
-
-  it("routes per-attempt relaunch-failed (lazy recovery) to warn", async () => {
-    // Single-slot pool. Crash + all immediate retries fail (calls 2..4) parks
-    // the slot. A first acquire's lazy relaunchPendingSlots attempt (call 5)
-    // ALSO fails → `relaunch-failed` must log at warn (per-attempt, not a
-    // terminal capacity loss).
-    const { launchBrowser, launched } = makeFakeLauncher({
-      failAtCalls: [2, 3, 4, 5],
-    });
-    const { logger, events } = makeLeveledLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    await pool.init();
-
-    launched[0]!.__crash();
-    await waitFor(() => pool.stats().size === 0, 3_000);
-
-    // First acquire drives a relaunchPendingSlots attempt (call 5) which fails.
-    await expect(pool.acquire(50)).rejects.toThrow(
-      "BrowserPool acquire timeout",
-    );
-
-    const relaunchFailed = events.find(
-      (e) => e.event === "browser-pool.relaunch-failed",
-    );
-    expect(relaunchFailed).toBeDefined();
-    expect(relaunchFailed?.level).toBe("warn");
-
-    await pool.shutdown();
-  });
-
-  it("emits an error when reinit ends with an empty pool (every relaunch failed)", async () => {
-    // 1-slot pool. After init (call 1), every subsequent launch fails. The
-    // backstop reinit() can only run when this.slots is truly empty, so we
-    // construct a never-launched pool: init throws nothing (call 1 succeeds),
-    // but to reach the empty-pool reinit path we use a 1-slot pool whose ONLY
-    // slot was never created because init's launch failed. Use failAt=1 so
-    // init launches nothing, leaving this.slots empty; the next acquire drives
-    // reinit, whose launch (call 2) also fails, ending the pool empty → error.
-    const { launchBrowser } = makeFakeLauncher({ failAtCalls: [1, 2, 3] });
-    const { logger, events } = makeLeveledLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    // init's only launch (call 1) throws — init sets `launchBrowser` BEFORE the
-    // launch loop, so after catching the throw `this.slots` is empty but the
-    // pool can still reinit. (init does not swallow launch errors by design.)
-    await expect(pool.init()).rejects.toThrow("simulated launch failure");
-    expect(pool.stats().size).toBe(0);
-
-    // acquire drives the empty-pool reinit backstop; its launch (call 2) fails,
-    // so reinitInner's loop ends with this.slots.length === 0 → error emit.
-    await expect(pool.acquire(50)).rejects.toThrow(
-      "BrowserPool acquire timeout",
-    );
-
-    const reinitEmpty = events.find(
-      (e) => e.event === "browser-pool.reinit-empty",
-    );
-    expect(reinitEmpty).toBeDefined();
-    expect(reinitEmpty?.level).toBe("error");
-
-    await pool.shutdown();
-  });
-
-  it("closes browsers already launched when a later init() fill launch throws", async () => {
-    // Multi-slot pool. The fill loop launches calls 1 and 2 successfully, then
-    // call 3 throws (PID-ceiling pthread_create EAGAIN / "Zygote could not
-    // fork" under launch pressure — the exact failure this file exists to
-    // survive). init() must REJECT, but the 2 browsers already launched must
-    // be CLOSED rather than leaked, and the pool's internal state must reset to
-    // empty so a half-initialized pool cannot result. The existing init-failure
-    // tests use a 1-slot pool or first-launch-fails (nothing launched yet),
-    // which is why this partial-fill leak was missed.
-    const { launchBrowser, launched } = makeFakeLauncher({ failAtCalls: [3] });
-    const { logger } = makeLeveledLogger();
-    const pool = new BrowserPool(4, 100, logger, launchBrowser, 0);
-
-    await expect(pool.init()).rejects.toThrow("simulated launch failure");
-
-    // Calls 1 and 2 succeeded before call 3 threw, so two browsers were live.
-    expect(launched).toHaveLength(2);
-    // Both must have been closed during the failed-fill cleanup — not leaked.
-    expect(launched[0]!.__closeCount).toBeGreaterThan(0);
-    expect(launched[1]!.__closeCount).toBeGreaterThan(0);
-    // The pool must be empty after rejection — no half-initialized state.
-    expect(pool.stats().size).toBe(0);
-    expect(pool.stats().available).toBe(0);
-  });
-
-  it("does not overshoot poolSize when two concurrent acquires hit an empty pool", async () => {
-    // Empty pool (init launches nothing). Two concurrent acquire() calls both
-    // see this.slots.length === 0. WITHOUT a reiniting guard, BOTH drive
-    // reinit() and each launches up to poolSize browsers — overshoot. WITH the
-    // guard, the second acquire skips reinit and falls through to the waiter
-    // queue, so at most poolSize browsers are launched.
-    const poolSize = 2;
-    // init = call 1 fails (so this.slots stays empty); reinit launches succeed.
-    const { launchBrowser, launched } = makeFakeLauncher({ failAtCalls: [1] });
-    const { logger } = makeLeveledLogger();
-    const pool = new BrowserPool(poolSize, 100, logger, launchBrowser, 0);
-    // init's first launch (call 1) throws, leaving this.slots empty but with
-    // `launchBrowser` already set so reinit can run. init does not swallow.
-    await expect(pool.init()).rejects.toThrow("simulated launch failure");
-    expect(pool.stats().size).toBe(0);
-
-    const a = pool.acquire(5_000);
-    const b = pool.acquire(5_000);
-
-    const first = await Promise.race([a, b]);
-    expect(first).toBeDefined();
-    expect((first as unknown as FakeBrowser).isConnected()).toBe(true);
-
-    await drainMicrotasks(30);
-
-    // The guard ensures only ONE reinit ran: at most poolSize browsers exist.
-    expect(launched.length).toBeLessThanOrEqual(poolSize);
-    expect(pool.stats().size).toBeLessThanOrEqual(poolSize);
-
-    await pool.shutdown();
-    await Promise.allSettled([a, b]);
-  });
-
-  it("tracks the SAME wrapper object it removes, so awaiting the tracked promise waits for its cleanup", async () => {
-    // Bug #3 guard. track(promise) added the RAW inner promise to
-    // inFlightRecycles, while the wrapper it returned (and the inner methods
-    // await) was `promise.catch(...).finally(() => delete(promise))`. shutdown
-    // drains `Array.from(inFlightRecycles)` — i.e. the RAW promise, which
-    // settles one or more microtasks BEFORE the wrapper's `.finally` cleanup
-    // runs. So a consumer that awaits the EXACT object in the set (as shutdown
-    // does) is NOT guaranteed the cleanup has run when that await resolves —
-    // the drain under-waits. recycleSlot does this correctly (adds and removes
-    // the same recyclePromise object). The fix makes track add/return the SAME
-    // wrapper, so the object shutdown awaits is the very wrapper whose
-    // `.finally` removes it — when it settles, the cleanup has run.
-    //
-    // Behavioral RED that does NOT depend on microtask luck: grab the exact
-    // object stored in inFlightRecycles (what shutdown awaits), await THAT
-    // object, then SYNCHRONOUSLY assert the set is empty. With the fix the set
-    // element IS the wrapper, so its `.finally` ran by the time the await
-    // resolves → set empty. With the bug the set element is the RAW promise,
-    // which resolves BEFORE the wrapper's `.finally` → set still has 1 entry at
-    // that synchronous checkpoint. The private set is read reflectively
-    // (white-box) per the bug's nature: raw-vs-wrapper is otherwise
-    // unobservable because the inner recovery methods swallow their own errors.
-    const launched: FakeBrowser[] = [];
-    let callCount = 0;
-    let releaseReinit: (() => void) | undefined;
-    const reinitGate = new Promise<void>((resolve) => {
-      releaseReinit = resolve;
-    });
-    const launchBrowser: LaunchBrowser = async () => {
-      callCount++;
-      // init's launch (call 1) fails so this.slots stays empty → the next
-      // acquire drives the reinit() backstop, whose launch (call 2) we gate.
-      if (callCount === 1) {
-        throw new Error("simulated launch failure");
-      }
-      if (callCount === 2) {
-        await reinitGate;
-      }
-      const b = makeFakeBrowser();
-      launched.push(b);
-      return b as unknown as Browser;
-    };
-    const { logger } = makeFakeLogger();
-    const pool = new BrowserPool(1, 100, logger, launchBrowser, 0);
-    // init's only launch (call 1) throws → this.slots empty, but rawLaunchBrowser
-    // is set so the empty-pool reinit backstop can run.
-    await expect(pool.init()).rejects.toThrow("simulated launch failure");
-
-    // Drive the reinit backstop via an acquire; its launch (call 2) blocks on
-    // the gate, so a tracked recovery promise is in flight. A short timeout so
-    // the waiter (acquire re-queues after reinit returns) rejects promptly
-    // instead of hanging the test.
-    const acquirePromise = pool.acquire(100);
-    await waitFor(() => callCount >= 2, 3_000);
-
-    const inFlight = (pool as unknown as { inFlightRecycles: Set<unknown> })
-      .inFlightRecycles;
-    expect(inFlight.size).toBe(1);
-
-    // The exact object shutdown would await — the single tracked entry.
-    const tracked = Array.from(inFlight)[0] as Promise<unknown>;
-
-    // Release the gated launch so the tracked recovery settles.
-    releaseReinit!();
-
-    // Await the EXACT tracked object, then synchronously check the set. With
-    // the fix this object is the wrapper whose `.finally` removed it → empty.
-    // With the bug it is the raw promise, which settles before cleanup → not
-    // yet empty.
-    await tracked;
-    expect(inFlight.size).toBe(0);
-
-    await pool.shutdown();
-    await Promise.allSettled([acquirePromise]);
-  });
-
-  it("shutdown() does not loop the disconnect handler when closing slot browsers", async () => {
+  // CASE 4 — least-loaded assignment across N browsers.
+  it("assigns contexts to the least-loaded live browser", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
-    const { logger, events } = makeFakeLogger();
-    const pool = new BrowserPool(2, 100, logger, launchBrowser, 0);
+    const pool = new BrowserPool({
+      browsers: 3,
+      maxContexts: 30,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
     await pool.init();
 
-    await pool.shutdown();
+    // First 3 acquires should each land on a distinct browser (all start at 0).
+    const c1 = await pool.acquire();
+    const c2 = await pool.acquire();
+    const c3 = await pool.acquire();
+    const owners = launched.map((b) => b.__contexts.length);
+    expect(owners).toEqual([1, 1, 1]);
 
-    // shutdown closes both browsers, which fires disconnected on the fakes.
-    // The handler must early-return on isShutdown so no relaunches happen.
+    // 4th acquire goes to a browser tied at the minimum (1 each → first).
+    await pool.acquire();
+    const after = launched.map((b) => b.__contexts.length).sort();
+    expect(after).toEqual([1, 1, 2]);
+
+    void c1;
+    void c2;
+    void c3;
+    await pool.shutdown();
+  });
+
+  // CASE 5 — browser crash: its contexts removed, ONE relaunch, subsequent
+  // acquire served by a live browser, blast radius = only its contexts.
+  it("recovers from a browser crash with exactly one relaunch and bounded blast radius", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const { logger } = makeLeveledLogger();
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 10,
+      logger,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
     expect(launched.length).toBe(2);
-    expect(
-      events.filter((e) => e.event === "browser-pool.recycle"),
-    ).toHaveLength(0);
-    expect(launched[0]!.__closeCount).toBeGreaterThan(0);
-    expect(launched[1]!.__closeCount).toBeGreaterThan(0);
-  });
-});
 
-/**
- * A launcher that records, for every chromium launch the pool drives, the
- * wall-clock start time and the number of launches in flight at the moment
- * this one entered. Used to prove the launch-serialization gate funnels
- * EVERY launch (init fill, recycle relaunch, lazy relaunchPending) through a
- * single concurrency-1 gate with a stagger between settled launches.
- *
- * `launchDurationMs` makes each fake launch take measurable wall time so an
- * un-gated burst would overlap (inFlight > 1) — the assertion that
- * `maxConcurrent === 1` is only meaningful when launches actually overlap
- * without the gate.
- */
-function makeRecordingLauncher(opts?: { launchDurationMs?: number }): {
-  launchBrowser: LaunchBrowser;
-  starts: number[];
-  maxConcurrent: number;
-  launched: FakeBrowser[];
-} {
-  const launchDurationMs = opts?.launchDurationMs ?? 20;
-  const starts: number[] = [];
-  const launched: FakeBrowser[] = [];
-  let inFlight = 0;
-  const rec = {
-    launchBrowser: (async (): Promise<Browser> => {
-      starts.push(Date.now());
-      inFlight++;
-      if (inFlight > rec.maxConcurrent) rec.maxConcurrent = inFlight;
-      await new Promise((resolve) => setTimeout(resolve, launchDurationMs));
-      inFlight--;
-      const b = makeFakeBrowser();
-      launched.push(b);
-      return b as unknown as Browser;
-    }) as LaunchBrowser,
-    starts,
-    maxConcurrent: 0,
-    launched,
-  };
-  return rec;
-}
+    // Acquire one context on each browser.
+    const c1 = await pool.acquire();
+    const c2 = await pool.acquire();
+    expect(pool.stats().inUse).toBe(2);
 
-describe("BrowserPool waiter-served release-leak (CR finding)", () => {
-  it("recovers the slot when the served waiter releases the browser in its own awaited continuation", async () => {
-    // CR finding (7-agent confirmation round): release() was made idempotent
-    // via the `checkedOut` Set. In handOff's waiter branch the slot's
-    // `checkedOut.add(slot)` is DEFERRED via queueMicrotask (microtask M),
-    // while `waiter.resolve(browser)` runs synchronously right after. The
-    // worry: the served waiter's await-continuation (call it C) calls
-    // `release(browser)` BEFORE M runs, so release hits `!checkedOut.has(slot)`
-    // → no-ops → the slot is ORPHANED (never returned to `available`,
-    // contextCount never advances) = permanent capacity leak.
-    //
-    // Counter-claim: M is queued BEFORE resolve(), and resolve() schedules C,
-    // so by microtask FIFO M runs before C — making the leak unreachable. This
-    // test settles that timing claim empirically.
-    //
-    // Scenario: single-slot pool. A holder owns the only browser; a waiter is
-    // parked. The holder releases, which serves the waiter via handOff. In the
-    // WAITER'S OWN awaited continuation we immediately (synchronously, in that
-    // continuation's frame) release the served browser back to the pool. If the
-    // leak is real, that release no-ops and the slot is lost; if FIFO holds, the
-    // slot is recovered and lands back in `available`.
-    const { launchBrowser, launched } = makeFakeLauncher();
-    const pool = new BrowserPool(1, 100, undefined, launchBrowser, 0);
-    await pool.init();
+    // Crash the browser that owns c1 (browser 0).
+    launched[0]!.__crash();
+    await waitFor(() => launched.length === 3); // exactly one relaunch
 
-    // Holder takes the only browser; slot is now checked out, none available.
-    const holderBrowser = await pool.acquire();
-    expect(holderBrowser).toBe(launched[0] as unknown as Browser);
-    expect(pool.stats().available).toBe(0);
+    expect(launched.length).toBe(3);
+    // The crashed browser's context was dropped from accounting; c2 survives.
     expect(pool.stats().inUse).toBe(1);
 
-    // Park a waiter. Its continuation models a real probe: await the acquire,
-    // then synchronously release the browser it was served — exactly the frame
-    // the finding targets (C running before microtask M).
-    let waiterReleased = false;
-    const waiterFlow = (async () => {
-      const servedBrowser = await pool.acquire(5_000);
-      // Synchronous release inside the waiter's own continuation frame.
-      pool.release(servedBrowser);
-      waiterReleased = true;
-      return servedBrowser;
-    })();
+    // A subsequent acquire is served by a live browser (no throw).
+    const c3 = await pool.acquire();
+    expect(c3).toBeDefined();
 
-    // Let the waiter park before the holder releases.
+    await pool.release(c2);
+    await pool.release(c3);
+    void c1;
+    await pool.shutdown();
+  });
+
+  // CASE 6 — hygiene recycle fires exactly once and ONLY when idle.
+  it("hygiene-recycles a browser once it has served recycleAfter contexts AND is idle", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 10,
+      recycleAfter: 3,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(1);
+
+    // Serve 2 contexts (below threshold) → no relaunch.
+    for (let i = 0; i < 2; i++) {
+      const c = await pool.acquire();
+      await pool.release(c);
+    }
+    await drainMicrotasks();
+    expect(launched.length).toBe(1);
+
+    // The 3rd release crosses recycleAfter=3 while idle → exactly one recycle.
+    const c = await pool.acquire();
+    await pool.release(c);
+    await waitFor(() => launched.length === 2);
+    expect(launched.length).toBe(2);
+
+    await pool.shutdown();
+  });
+
+  it("does NOT hygiene-recycle while the browser still has live contexts", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 10,
+      recycleAfter: 2,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Hold one context open while crossing the threshold via others.
+    const held = await pool.acquire();
+    const a = await pool.acquire();
+    await pool.release(a);
+    const b = await pool.acquire();
+    await pool.release(b);
+    await drainMicrotasks();
+    // servedContexts >= 2 but a live context is held → no recycle yet.
+    expect(launched.length).toBe(1);
+
+    await pool.release(held);
+    await pool.shutdown();
+  });
+
+  // CASE 7 — never hands out a context on a recycling/disconnected browser.
+  it("never opens a context on a disconnected browser", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 10,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Silently disconnect browser 0 (no event) — acquire must skip it.
+    launched[0]!.__silentlyDisconnect();
+    const c1 = await pool.acquire();
+    // Context must have been opened on the live browser (index 1).
+    expect(launched[1]!.__contexts.map((x) => x.__id)).toContain(ctxId(c1));
+    expect(launched[0]!.__contexts.length).toBe(0);
+
+    await pool.release(c1);
+    await pool.shutdown();
+  });
+
+  // CASE 8 — shutdown rejects waiters, awaits in-flight recycle, closes all,
+  // no relaunch loop.
+  it("shutdown rejects queued waiters and closes all browsers", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 1,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    const c1 = await pool.acquire();
+    // Pend a waiter past the cap.
+    let rejected: Error | undefined;
+    const pending = pool.acquire().catch((e: Error) => (rejected = e));
     await drainMicrotasks();
 
-    // Holder releases — handOff serves the parked waiter with the live browser,
-    // deferring `checkedOut.add(slot)` to microtask M and resolving the waiter
-    // synchronously. The waiter's continuation C then releases the browser.
-    pool.release(holderBrowser);
+    await pool.shutdown();
+    await pending;
+    expect(rejected).toBeInstanceOf(Error);
+    expect(launched[0]!.__closeCount).toBeGreaterThanOrEqual(1);
+    void c1;
+  });
 
-    // Drain everything so M and C have both run.
-    const servedBrowser = await waiterFlow;
-    await drainMicrotasks(20);
+  // CASE 9 — stats() semantics.
+  it("reports stats with maxContexts size and live-context-derived counters", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 5,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
 
-    expect(waiterReleased).toBe(true);
-    expect(servedBrowser).toBe(launched[0] as unknown as Browser);
+    expect(pool.stats()).toEqual({
+      size: 5,
+      available: 5,
+      inUse: 0,
+      totalRecycles: 0,
+    });
 
-    // THE ASSERTION THAT SETTLES IT: the slot must have been RECOVERED by the
-    // waiter's release. If the leak is real, available stays 0 and inUse stays
-    // pinned at 1 (orphaned slot) — capacity permanently lost.
-    expect(pool.stats().available).toBe(1);
+    const c1 = await pool.acquire();
+    const c2 = await pool.acquire();
+    expect(pool.stats()).toEqual({
+      size: 5,
+      available: 3,
+      inUse: 2,
+      totalRecycles: 0,
+    });
+
+    await pool.release(c1);
+    expect(pool.stats()).toEqual({
+      size: 5,
+      available: 4,
+      inUse: 1,
+      totalRecycles: 0,
+    });
+
+    await pool.release(c2);
+    await pool.shutdown();
+  });
+
+  // Header centralization: X-AIMock-Strict default + caller header merge.
+  it("centralizes X-AIMock-Strict and merges caller-supplied headers", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 5,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    const ctx = await pool.acquire({
+      extraHTTPHeaders: {
+        "X-AIMock-Context": "slug-a",
+        "X-Test-Id": "d4-slug-a",
+      },
+    });
+    const headers = (ctx as unknown as FakeContext).__headers;
+    expect(headers).toEqual({
+      "X-AIMock-Strict": "true",
+      "X-AIMock-Context": "slug-a",
+      "X-Test-Id": "d4-slug-a",
+    });
+
+    await pool.release(ctx);
+    await pool.shutdown();
+  });
+
+  // Double / unknown release is a no-op.
+  it("double release is a no-op", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 5,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    const ctx = await pool.acquire();
+    await pool.release(ctx);
     expect(pool.stats().inUse).toBe(0);
-
-    // And the recovered slot must be re-acquirable (back in rotation), proving
-    // it is genuinely usable capacity, not a phantom available count.
-    const reacquired = await pool.acquire(1_000);
-    expect(reacquired).toBe(launched[0] as unknown as Browser);
-    expect(pool.stats().inUse).toBe(1);
-
-    // No fresh browser was ever launched — the single one cycled correctly.
-    expect(launched).toHaveLength(1);
-
+    // Second release must not drive inUse negative.
+    await pool.release(ctx);
+    expect(pool.stats().inUse).toBe(0);
     await pool.shutdown();
   });
-});
 
-describe("BrowserPool launch serialization gate", () => {
-  it("serializes the initial-fill burst to concurrency 1 and staggers each launch", async () => {
-    // A burst of N near-simultaneous chromium.launch() calls (the initial
-    // pool fill) must NOT overlap — on the Railway staging container a burst
-    // spikes PID demand past the ~1000 ceiling and trips pthread_create
-    // EAGAIN / "Zygote could not fork". The gate funnels every launch through
-    // a concurrency-1 serializer and waits a stagger after each settles.
-    const staggerMs = 30;
-    const rec = makeRecordingLauncher({ launchDurationMs: 20 });
-    const pool = new BrowserPool(
-      6,
-      100,
-      undefined,
-      rec.launchBrowser,
-      staggerMs,
-    );
+  // acquire after shutdown throws.
+  it("acquire after shutdown throws", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 5,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
     await pool.init();
-
-    // Every one of the 6 initial-fill launches happened.
-    expect(rec.launched).toHaveLength(6);
-
-    // Strict serialization: never two chromium launches in flight at once.
-    expect(rec.maxConcurrent).toBe(1);
-
-    // Consecutive launch starts are spaced at least `staggerMs` apart (the
-    // gate waits AFTER each launch settles before the next may start). Allow a
-    // small scheduler-jitter tolerance below the nominal stagger.
-    const tolerance = 5;
-    for (let i = 1; i < rec.starts.length; i++) {
-      const gap = rec.starts[i]! - rec.starts[i - 1]!;
-      expect(gap).toBeGreaterThanOrEqual(staggerMs - tolerance);
-    }
-
     await pool.shutdown();
+    await expect(pool.acquire()).rejects.toThrow(/shut down/);
   });
 
-  it("serializes a burst of simultaneous recycle/relaunch triggers to concurrency 1", async () => {
-    // Recycle bursts (many slots crashing and relaunching near-simultaneously)
-    // are the OTHER PID-spike source the gate must cover. Fill a pool, crash
-    // every browser at once so all disconnect-driven recycles fire together,
-    // and assert their relaunches never overlap.
-    const staggerMs = 20;
-    const rec = makeRecordingLauncher({ launchDurationMs: 20 });
-    const pool = new BrowserPool(
-      5,
-      100,
-      undefined,
-      rec.launchBrowser,
-      staggerMs,
-    );
-    await pool.init();
-    expect(rec.launched).toHaveLength(5);
-
-    // Crash all 5 at once — every recycle's relaunch is triggered in the same
-    // tick, the classic burst the gate must serialize.
-    for (const b of rec.launched.slice(0, 5)) b.__crash();
-
-    // Wait until all 5 relaunches have completed (10 total launches).
-    await waitFor(() => rec.launched.length >= 10, 5_000);
-
-    // No two launches (fill OR relaunch) ever overlapped.
-    expect(rec.maxConcurrent).toBe(1);
-
-    await pool.shutdown();
-  });
-
-  it("honors BROWSER_LAUNCH_STAGGER_MS env var as the default stagger", async () => {
-    // The stagger is env-tunable on staging without a code change. With no
-    // explicit constructor override, the pool reads BROWSER_LAUNCH_STAGGER_MS.
-    const prev = process.env.BROWSER_LAUNCH_STAGGER_MS;
-    process.env.BROWSER_LAUNCH_STAGGER_MS = "25";
+  // env fallback: BROWSER_POOL_SIZE seeds browser count when BROWSERS unset.
+  it("falls back to BROWSER_POOL_SIZE for browser count when BROWSER_POOL_BROWSERS is unset", async () => {
+    const prevBrowsers = process.env.BROWSER_POOL_BROWSERS;
+    const prevSize = process.env.BROWSER_POOL_SIZE;
+    delete process.env.BROWSER_POOL_BROWSERS;
+    process.env.BROWSER_POOL_SIZE = "2";
     try {
-      const rec = makeRecordingLauncher({ launchDurationMs: 10 });
-      // No 5th arg → stagger comes from the env var.
-      const pool = new BrowserPool(4, 100, undefined, rec.launchBrowser);
+      const { launchBrowser, launched } = makeFakeLauncher();
+      const pool = new BrowserPool({ launchBrowser, launchStaggerMs: 0 });
       await pool.init();
-
-      expect(rec.launched).toHaveLength(4);
-      expect(rec.maxConcurrent).toBe(1);
-      const tolerance = 5;
-      for (let i = 1; i < rec.starts.length; i++) {
-        const gap = rec.starts[i]! - rec.starts[i - 1]!;
-        expect(gap).toBeGreaterThanOrEqual(25 - tolerance);
-      }
-
+      expect(launched.length).toBe(2);
       await pool.shutdown();
     } finally {
-      if (prev === undefined) delete process.env.BROWSER_LAUNCH_STAGGER_MS;
-      else process.env.BROWSER_LAUNCH_STAGGER_MS = prev;
+      if (prevBrowsers === undefined) delete process.env.BROWSER_POOL_BROWSERS;
+      else process.env.BROWSER_POOL_BROWSERS = prevBrowsers;
+      if (prevSize === undefined) delete process.env.BROWSER_POOL_SIZE;
+      else process.env.BROWSER_POOL_SIZE = prevSize;
     }
-  });
-
-  it("falls back to the default stagger when the explicit arg is negative (does not silently disable)", async () => {
-    // A negative explicit constructor arg must fall back to the DEFAULT
-    // stagger (150ms) — the same contract the env var already honors — NOT
-    // clamp to 0 and silently disable the stagger. Disabling the stagger
-    // reintroduces the PID-spike the gate exists to prevent. Only 2 launches
-    // so the ~150ms wait stays cheap.
-    const rec = makeRecordingLauncher({ launchDurationMs: 10 });
-    // -50 is negative → must be rejected and fall back to the 150ms default.
-    const pool = new BrowserPool(
-      2,
-      undefined,
-      undefined,
-      rec.launchBrowser,
-      -50,
-    );
-    await pool.init();
-
-    expect(rec.launched).toHaveLength(2);
-    expect(rec.maxConcurrent).toBe(1);
-
-    // The two launches must be spaced by roughly the DEFAULT stagger (150ms),
-    // proving the stagger was NOT disabled. Allow scheduler-jitter tolerance.
-    const gap = rec.starts[1]! - rec.starts[0]!;
-    expect(gap).toBeGreaterThanOrEqual(140);
-
-    await pool.shutdown();
-  });
-
-  it("falls back to the default stagger when the explicit arg is NaN", async () => {
-    // A non-numeric (NaN) explicit constructor arg must also fall back to the
-    // DEFAULT stagger rather than disabling it.
-    const rec = makeRecordingLauncher({ launchDurationMs: 10 });
-    const pool = new BrowserPool(
-      2,
-      undefined,
-      undefined,
-      rec.launchBrowser,
-      NaN,
-    );
-    await pool.init();
-
-    expect(rec.launched).toHaveLength(2);
-    expect(rec.maxConcurrent).toBe(1);
-
-    const gap = rec.starts[1]! - rec.starts[0]!;
-    expect(gap).toBeGreaterThanOrEqual(140);
-
-    await pool.shutdown();
-  });
-
-  it("still serializes (concurrency 1) when the stagger is set to 0", async () => {
-    // A zero stagger keeps tests fast but MUST still serialize: the gate's
-    // concurrency-1 guarantee is independent of the wait. Proves the gate is
-    // not merely a sleep — it is a real one-at-a-time mutex.
-    const rec = makeRecordingLauncher({ launchDurationMs: 15 });
-    const pool = new BrowserPool(8, 100, undefined, rec.launchBrowser, 0);
-    await pool.init();
-
-    expect(rec.launched).toHaveLength(8);
-    expect(rec.maxConcurrent).toBe(1);
-
-    await pool.shutdown();
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -12,6 +12,11 @@ interface FakeContext {
   readonly __headers?: Record<string, string>;
   close(): Promise<void>;
   readonly __closeCount: number;
+  /** When set, close() parks until __releaseClose() is called — lets a test
+   *  hold a release()'s `await context.close()` open while a concurrent
+   *  acquire interleaves (drives the release/recycle straddle race). */
+  __deferClose(): void;
+  __releaseClose(): void;
 }
 
 /**
@@ -33,17 +38,28 @@ interface FakeBrowser {
   __silentlyDisconnect(): void;
   readonly __closeCount: number;
   readonly __contexts: FakeContext[];
+  /** Release ALL pending deferred newContext() calls (see `deferNewContext`). */
+  __releaseNewContexts(): void;
+  /** Number of newContext() calls currently parked awaiting release. */
+  readonly __pendingNewContexts: number;
 }
 
 let nextBrowserId = 0;
 let nextContextId = 0;
 
-function makeFakeBrowser(opts?: { newContextThrows?: boolean }): FakeBrowser {
+function makeFakeBrowser(opts?: {
+  newContextThrows?: boolean;
+  /** When true, newContext() does NOT resolve until __releaseNewContexts() is
+   *  called. Lets a test park an in-flight context-open across an await so a
+   *  concurrent acquire/release/timeout can interleave deterministically. */
+  deferNewContext?: boolean;
+}): FakeBrowser {
   const id = nextBrowserId++;
   let connected = true;
   let closeCount = 0;
   const contexts: FakeContext[] = [];
   const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+  const pendingReleases: Array<() => void> = [];
   const fire = (event: string): void => {
     for (const h of handlers.get(event) ?? []) h();
   };
@@ -54,6 +70,13 @@ function makeFakeBrowser(opts?: { newContextThrows?: boolean }): FakeBrowser {
     },
     get __contexts() {
       return contexts;
+    },
+    get __pendingNewContexts() {
+      return pendingReleases.length;
+    },
+    __releaseNewContexts() {
+      const toRelease = pendingReleases.splice(0, pendingReleases.length);
+      for (const r of toRelease) r();
     },
     isConnected: () => connected,
     on(event, handler) {
@@ -71,15 +94,33 @@ function makeFakeBrowser(opts?: { newContextThrows?: boolean }): FakeBrowser {
       if (opts?.newContextThrows) {
         throw new Error("simulated newContext failure");
       }
+      if (opts?.deferNewContext) {
+        await new Promise<void>((resolve) => pendingReleases.push(resolve));
+      }
       const ctxId = nextContextId++;
       let ctxCloseCount = 0;
+      let deferClose = false;
+      let pendingClose: (() => void) | undefined;
       const ctx: FakeContext = {
         __id: ctxId,
         __headers: ctxOpts?.extraHTTPHeaders,
         get __closeCount() {
           return ctxCloseCount;
         },
+        __deferClose() {
+          deferClose = true;
+        },
+        __releaseClose() {
+          const r = pendingClose;
+          pendingClose = undefined;
+          r?.();
+        },
         async close() {
+          if (deferClose) {
+            await new Promise<void>((resolve) => {
+              pendingClose = resolve;
+            });
+          }
           ctxCloseCount++;
         },
       };
@@ -106,6 +147,9 @@ interface FakeLauncher {
 function makeFakeLauncher(opts?: {
   failAtCalls?: number[];
   newContextThrowsForCalls?: number[];
+  /** 1-based launch-call indices whose browser should DEFER every
+   *  newContext() until __releaseNewContexts() is called. */
+  deferNewContextForCalls?: number[];
 }): FakeLauncher {
   const launched: FakeBrowser[] = [];
   let callCount = 0;
@@ -116,6 +160,7 @@ function makeFakeLauncher(opts?: {
     }
     const b = makeFakeBrowser({
       newContextThrows: opts?.newContextThrowsForCalls?.includes(callCount),
+      deferNewContext: opts?.deferNewContextForCalls?.includes(callCount),
     });
     launched.push(b);
     return b as unknown as Browser;
@@ -531,5 +576,209 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       if (prevSize === undefined) delete process.env.BROWSER_POOL_SIZE;
       else process.env.BROWSER_POOL_SIZE = prevSize;
     }
+  });
+
+  // ── CONCURRENT-PATH RACE REGRESSIONS ──────────────────────────────────────
+  // The cases above are all SEQUENTIAL (await each acquire before the next),
+  // which is exactly why the check-then-await-then-mutate races never showed.
+  // These drive concurrent / interleaved paths.
+
+  // RACE A — N concurrent acquire() never exceed maxContexts. With a SYNC
+  // reservation the cap holds even when every acquire passes its check during
+  // one another's newContext() await. Use a deferred-newContext browser so all
+  // acquires sit in newContext() simultaneously, then assert no overshoot.
+  it("N concurrent acquire() never exceed maxContexts (no cap overshoot)", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher({
+      // The single init browser defers newContext so all acquires park in the
+      // await together — the window the old code overshot in.
+      deferNewContextForCalls: [1],
+    });
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Fire 5 concurrent acquires at a cap of 2.
+    const acquires = Array.from({ length: 5 }, () => pool.acquire());
+    await drainMicrotasks();
+
+    // With a synchronous reservation, AT MOST maxContexts newContext() calls
+    // are ever in flight. The old code let all 5 pass the check and call
+    // newContext() → overshoot.
+    expect(launched[0]!.__pendingNewContexts).toBeLessThanOrEqual(2);
+
+    // Release the parked opens; the 2 reserved ones resolve, the rest pend.
+    launched[0]!.__releaseNewContexts();
+    await drainMicrotasks();
+
+    expect(pool.stats().inUse).toBe(2);
+    expect(pool.stats().available).toBe(0);
+    expect(pool.stats().inUse).toBeLessThanOrEqual(2);
+
+    // Total contexts ever opened on the browser must never exceed the cap
+    // while 3 acquires are still pending as waiters.
+    expect(launched[0]!.__contexts.length).toBeLessThanOrEqual(2);
+
+    await pool.shutdown();
+    // The 3 still-pending acquires reject on shutdown; swallow them.
+    await Promise.allSettled(acquires);
+  });
+
+  // RACE B — the newContext-failure retry path must respect the cap. The retry
+  // branch in acquire() previously called openContextOn() with no cap re-check;
+  // under the reservation model the retry reuses the held reservation and never
+  // overshoots.
+  it("the newContext-failure retry path respects maxContexts", async () => {
+    // Two browsers: browser 1 (launch call 1) throws on newContext so the first
+    // acquire fails-and-retries onto browser 2 (launch call 2). Concurrent
+    // acquires must still not exceed the cap across the retry.
+    const { launchBrowser, launched } = makeFakeLauncher({
+      newContextThrowsForCalls: [1],
+    });
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 1,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Two concurrent acquires at a cap of 1. The first may hit browser 1
+    // (throws) and retry onto browser 2; the second must NOT also open on
+    // browser 2 past the cap.
+    const [r1, r2] = await Promise.allSettled([
+      pool.acquire(undefined, 200),
+      pool.acquire(undefined, 200),
+    ]);
+    await drainMicrotasks();
+
+    // Exactly one context should be live (cap=1); the other pends/times out.
+    expect(pool.stats().inUse).toBeLessThanOrEqual(1);
+    const totalLive = launched.reduce((n, b) => n + b.__contexts.length, 0);
+    expect(totalLive).toBeLessThanOrEqual(1);
+
+    // Clean up whichever acquire succeeded.
+    for (const r of [r1, r2]) {
+      if (r.status === "fulfilled") await pool.release(r.value);
+    }
+    await pool.shutdown();
+  });
+
+  // RACE C — a waiter that times out WHILE serveNextWaiter is opening its
+  // context must NOT leak the freshly-opened context. The orphan must be closed
+  // and the count rolled back.
+  it("does not leak a context when a waiter times out mid-serveNextWaiter", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher({
+      deferNewContextForCalls: [1],
+    });
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 1,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Fill the cap with one context (parked open → release it).
+    const c1p = pool.acquire();
+    await drainMicrotasks();
+    launched[0]!.__releaseNewContexts();
+    const c1 = await c1p;
+    expect(pool.stats().inUse).toBe(1);
+
+    // Enqueue a waiter with a SHORT timeout — it pends past the cap.
+    let waiterRejected: Error | undefined;
+    const waiterP = pool
+      .acquire(undefined, 20)
+      .catch((e: Error) => (waiterRejected = e));
+    await drainMicrotasks();
+
+    // Release c1 → serveNextWaiter() picks the waiter, calls newContext()
+    // (parked, deferred). While that open is in flight, let the waiter's
+    // 20ms timeout fire.
+    await pool.release(c1);
+    await drainMicrotasks();
+    await new Promise((r) => setTimeout(r, 40)); // waiter times out now
+    expect(waiterRejected).toBeInstanceOf(Error);
+
+    // Now let the parked newContext() for the dead waiter resolve.
+    launched[0]!.__releaseNewContexts();
+    await drainMicrotasks();
+
+    // The orphan context must have been CLOSED and the count rolled back to 0.
+    // Old code: resolve() no-ops on the settled waiter → context leaks, count
+    // stuck at 1.
+    expect(pool.stats().inUse).toBe(0);
+    expect(pool.stats().available).toBe(1);
+    // Every context ever opened on the browser must be closed.
+    const openButNotClosed = launched[0]!.__contexts.filter(
+      (c) => c.__closeCount === 0,
+    );
+    expect(openButNotClosed.length).toBe(0);
+
+    await pool.shutdown();
+  });
+
+  // RACE D — release/recycle interleave must NOT recycle a browser that still
+  // has (or concurrently gains) a live context. With the fix, release() does
+  // its bookkeeping (delete + decrement) and evaluates the idle-recycle
+  // decision off purely SYNCHRONOUS state, with no await straddling the
+  // decrement and the size check, and only THEN awaits context.close(). A
+  // concurrent acquire that lands while a parked close is in flight therefore
+  // cannot be abandoned by a spurious recycle: the recycle decision was already
+  // taken against the true live-set, and a busy browser is never recycled.
+  //
+  // This is a forward regression GUARD for the close/accounting reorder. (It
+  // holds on the pre-fix code too, because the pre-fix order kept the released
+  // context IN the live set across its close-await — conservative, never
+  // reading a false-idle. The reorder makes the no-await-gap invariant explicit
+  // and machine-checkable so a future edit that re-introduces an await between
+  // the decrement and the size check is caught here.)
+  it("release evaluates the idle-recycle decision on synchronous state and never recycles a busy browser (close/accounting reorder)", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 5,
+      recycleAfter: 1, // eligible after the very first served context
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(1);
+
+    // Hold one context open for the entire test so the browser is NEVER idle —
+    // a recycle would be spurious and would abandon `held`.
+    const held = await pool.acquire();
+    // Serve + release a second context so servedContexts crosses recycleAfter=1.
+    const c1 = await pool.acquire();
+    expect(pool.stats().inUse).toBe(2);
+
+    // Park c1's close so release(c1) straddles its `await context.close()`.
+    (c1 as unknown as FakeContext).__deferClose();
+    const release1 = pool.release(c1);
+    await drainMicrotasks();
+
+    // While that close is parked, acquire + release ANOTHER context. The
+    // browser is busy throughout (held is live) so no release may recycle it.
+    const c2 = await pool.acquire();
+    await pool.release(c2);
+    await drainMicrotasks();
+
+    // Let c1's parked close finish.
+    (c1 as unknown as FakeContext).__releaseClose();
+    await release1;
+    await drainMicrotasks();
+
+    // `held` is still live; its browser must NOT have been recycled.
+    expect(pool.stats().totalRecycles).toBe(0);
+    expect(launched.length).toBe(1);
+    expect(launched[0]!.isConnected()).toBe(true);
+    expect(pool.stats().inUse).toBe(1); // only `held` remains
+
+    await pool.release(held);
+    await pool.shutdown();
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -385,6 +385,53 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     await pool.shutdown();
   });
 
+  // A1 — release/serve/recycle race. A release that crosses the recycleAfter
+  // boundary WHILE a waiter is queued must NOT hygiene-recycle the freed entry:
+  // serveNextWaiter() reserves + asynchronously opens a context on that same
+  // entry, and a recycle fired on the now-stale synchronous snapshot would tear
+  // the browser out from under the just-served waiter. The hygiene recycle must
+  // defer to a later genuinely-idle release.
+  it("does NOT hygiene-recycle on a boundary-crossing release while a waiter is queued (serve wins)", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 1,
+      recycleAfter: 1, // the very first served context makes the entry eligible
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(1);
+
+    // Fill the cap with one context → servedContexts becomes 1 (>= recycleAfter).
+    const c1 = await pool.acquire();
+    expect(pool.stats().inUse).toBe(1);
+
+    // Queue a waiter past the cap.
+    let c2: BrowserContext | undefined;
+    const pending = pool.acquire().then((c) => (c2 = c));
+    await drainMicrotasks();
+    expect(c2).toBeUndefined();
+
+    // Release c1: it crosses recycleAfter=1 while idle (shouldRecycle would be
+    // true) BUT a waiter is queued, so the waiter must be served onto the SAME
+    // browser and NO recycle may fire.
+    await pool.release(c1);
+    await pending;
+
+    expect(c2).toBeDefined();
+    // No recycle, no relaunch — the waiter is served on the original browser.
+    expect(pool.stats().totalRecycles).toBe(0);
+    expect(launched.length).toBe(1);
+    expect(launched[0]!.isConnected()).toBe(true);
+    // The served context lives on the original browser.
+    expect(launched[0]!.__contexts.map((x) => x.__id)).toContain(ctxId(c2!));
+    expect(pool.stats().inUse).toBe(1);
+
+    await pool.release(c2!);
+    await pool.shutdown();
+  });
+
   it("does NOT hygiene-recycle while the browser still has live contexts", async () => {
     const { launchBrowser, launched } = makeFakeLauncher();
     const pool = new BrowserPool({
@@ -664,6 +711,50 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     for (const r of [r1, r2]) {
       if (r.status === "fulfilled") await pool.release(r.value);
     }
+    await pool.shutdown();
+  });
+
+  // A2 — acquire() retry path: a SECOND consecutive newContext failure (a
+  // second browser dying in the same EAGAIN burst) must enqueue the caller as
+  // a waiter and let recovery fulfill it gracefully, NOT reject hard. The first
+  // attempt throws → recycle + re-reserve + retry onto the other browser; the
+  // retry ALSO throws → the fix recycles the retry browser and pends a waiter
+  // that resolves once the recycle relaunch lands.
+  it("enqueues the caller (no hard reject) when the acquire retry's newContext also fails", async () => {
+    // Both initial browsers (launch calls 1 + 2) throw on newContext. Their
+    // recycle relaunches (calls 3 + 4) succeed and drain the queued waiter.
+    const { launchBrowser, launched } = makeFakeLauncher({
+      newContextThrowsForCalls: [1, 2],
+    });
+    const { logger, events } = makeLeveledLogger();
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 2,
+      logger,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(2);
+
+    // Single acquire: first attempt throws → retry onto the other browser →
+    // retry ALSO throws. The fix must enqueue rather than reject. Give a
+    // generous timeout so the recovery relaunch resolves it.
+    const ctx = await pool.acquire(undefined, 2_000);
+    expect(ctx).toBeDefined();
+
+    // Both original browsers were recycled (their newContext threw); the
+    // relaunched ones served the waiter — no hard rejection reached the caller.
+    expect(pool.stats().totalRecycles).toBeGreaterThanOrEqual(2);
+    expect(launched.length).toBe(4); // 2 init + 2 relaunch
+    // The retry-failure path logged its dedicated warn (proves we hit it).
+    expect(
+      events.some(
+        (e) => e.event === "browser-pool.acquire-retry-newcontext-failed",
+      ),
+    ).toBe(true);
+
+    await pool.release(ctx);
     await pool.shutdown();
   });
 

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -872,4 +872,282 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     await pool.release(held);
     await pool.shutdown();
   });
+
+  // ── RECYCLE-VS-IN-FLIGHT-OPEN INVARIANT MATRIX ────────────────────────────
+  // One structural invariant closes a whole class of recycle-vs-concurrent-
+  // operation races: a context being opened in `openContextOn` has taken a cap
+  // reservation BEFORE its `await newContext()` but is added to
+  // `entry.liveContexts` only AFTER the await resolves. During that window
+  // `liveContexts.size` undercounts, so any recycle/idle decision made off
+  // `liveContexts.size` alone is blind to the in-flight open. The fix adds a
+  // per-entry `pendingOpens` counter and a single `isEntryIdle` predicate that
+  // every recycle/idle decision consults, an orphan guard in `openContextOn`
+  // for the entry-recycled-mid-await case, and a `recyclePending` flag so a
+  // deferred hygiene recycle still fires at the next idle release under
+  // sustained waiter pressure. The cases below are parametrized over the two
+  // faces of the gap (in-flight open invisible to recycle; deferred recycle
+  // starved) and the belt-and-suspenders orphan path.
+
+  // MATRIX (a) — a hygiene recycle does NOT fire while an `openContextOn` is in
+  // flight on that entry. recycleAfter=1 makes the entry eligible after one
+  // served context; a SECOND open is parked in newContext() (pendingOpens=1,
+  // not yet in liveContexts) when the boundary-crossing release lands. The
+  // pre-fix `liveContexts.size === 0` idle check reads the entry as idle and
+  // hygiene-recycles it OUT FROM UNDER the in-flight open (RED). The fix's
+  // `isEntryRecyclable` (pendingOpens === 0) defers it.
+  it("MATRIX(a): does NOT hygiene-recycle while an openContextOn is in flight on that entry", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher({
+      deferNewContextForCalls: [1],
+    });
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      recycleAfter: 1, // first served context makes the entry eligible
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(1);
+
+    // Open c1 (parked) → release the park so c1 becomes live; servedContexts=1.
+    const c1p = pool.acquire();
+    await drainMicrotasks();
+    launched[0]!.__releaseNewContexts();
+    const c1 = await c1p;
+    expect(pool.stats().inUse).toBe(1);
+
+    // Start a SECOND acquire — it parks in newContext() (deferred), so its open
+    // is IN FLIGHT (pendingOpens=1) but it is NOT yet in liveContexts.
+    let c2: BrowserContext | undefined;
+    const c2p = pool.acquire().then((c) => (c2 = c));
+    await drainMicrotasks();
+    expect(c2).toBeUndefined();
+    expect(launched[0]!.__pendingNewContexts).toBe(1);
+
+    // Release c1: servedContexts(1) >= recycleAfter(1) and (pre-fix) liveContexts
+    // is now empty, so the pre-fix code hygiene-recycles immediately — tearing
+    // the browser down under the in-flight c2 open.
+    await pool.release(c1);
+    await drainMicrotasks();
+
+    // INVARIANT: no recycle fired while the open was in flight.
+    expect(pool.stats().totalRecycles).toBe(0);
+    expect(launched.length).toBe(1);
+    expect(launched[0]!.isConnected()).toBe(true);
+
+    // Let the in-flight open resolve; c2 lands live on the SAME original browser.
+    launched[0]!.__releaseNewContexts();
+    await c2p;
+    expect(c2).toBeDefined();
+    expect(launched[0]!.__contexts.map((x) => x.__id)).toContain(ctxId(c2!));
+    expect(pool.stats().inUse).toBe(1);
+
+    await pool.release(c2!);
+    await pool.shutdown();
+  });
+
+  // MATRIX (b) — an `openContextOn` whose entry is recycled MID-AWAIT closes the
+  // freshly-opened orphan + rolls back the count (no cap leak, no dead context
+  // handed out). A held context keeps the entry from being idle; the open is
+  // parked; we CRASH the browser mid-open (recovery recycle reassigns
+  // entry.browser). When the parked newContext() resolves, the orphan guard
+  // (entry.browser !== browserBefore / !isConnected) closes it, rolls back the
+  // reservation, and surfaces a failure so acquire's retry path enqueues. The
+  // pre-fix code adds the orphan to liveContexts on a dead/replaced browser,
+  // leaking a cap slot and handing out a dead context (RED).
+  it("MATRIX(b): closes the orphan + rolls back the count when an open's entry is recycled mid-await", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher({
+      // Browser 1 (init) defers newContext; its relaunch (call 2) does not, so
+      // the enqueued caller is eventually served on the fresh browser.
+      deferNewContextForCalls: [1],
+    });
+    const { logger, events } = makeLeveledLogger();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      recycleAfter: 1000, // hygiene out of the picture; this is the crash path
+      logger,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(1);
+
+    // Start an acquire — parks in newContext() on browser 0 (pendingOpens=1).
+    let acquired: BrowserContext | undefined;
+    const acquireP = pool
+      .acquire(undefined, 2_000)
+      .then((c) => (acquired = c))
+      .catch(() => {});
+    await drainMicrotasks();
+    expect(launched[0]!.__pendingNewContexts).toBe(1);
+    expect(pool.stats().inUse).toBe(1); // reservation taken for the in-flight open
+
+    // CRASH browser 0 while its open is in flight → recovery recycle reassigns
+    // entry.browser to a fresh process (launch call 2) and drains waiters.
+    launched[0]!.__crash();
+    await waitFor(() => launched.length === 2);
+
+    // Now resolve the parked open on the ORIGINAL (now-dead/replaced) browser.
+    // The orphan guard must close it, roll back the reservation, and surface a
+    // failure (acquire then enqueues + the relaunch serves the caller).
+    launched[0]!.__releaseNewContexts();
+    await drainMicrotasks();
+
+    // The caller is eventually served once a fresh (non-deferred) browser is
+    // available. Drain any parked opens on the relaunched browsers so the
+    // enqueued caller resolves, then await it.
+    await waitFor(() => {
+      for (const b of launched.slice(1)) {
+        if (b.__pendingNewContexts > 0) b.__releaseNewContexts();
+      }
+      return acquired !== undefined;
+    });
+    await acquireP;
+
+    // The orphan guard logged its dedicated warn (proves we hit it).
+    expect(
+      events.some((e) => e.event === "browser-pool.open-orphaned-by-recycle"),
+    ).toBe(true);
+
+    // NO cap leak: the orphaned open's reservation was rolled back. The only
+    // live context is the one served on a fresh browser.
+    expect(acquired).toBeDefined();
+    expect(pool.stats().inUse).toBe(1);
+    // The orphan context on the ORIGINAL (dead) browser was closed, never
+    // handed out — no open-but-not-closed context lingers on it.
+    const origOrphans = launched[0]!.__contexts.filter(
+      (c) => c.__closeCount === 0,
+    );
+    expect(origOrphans.length).toBe(0);
+    // The handed-out context is NOT the orphan from the dead original browser.
+    expect(launched[0]!.__contexts.map((x) => x.__id)).not.toContain(
+      ctxId(acquired!),
+    );
+    // It lives on a live (recycled/fresh) browser that is connected.
+    const owner = launched.find((b) =>
+      b.__contexts.some((c) => c.__id === ctxId(acquired!)),
+    );
+    expect(owner).toBeDefined();
+    expect(owner!.__id).not.toBe(launched[0]!.__id);
+    expect(owner!.isConnected()).toBe(true);
+
+    await pool.release(acquired!);
+    await pool.shutdown();
+  });
+
+  // MATRIX (c) — a hygiene recycle that becomes eligible on a release while a
+  // concurrent open is in flight (pendingOpens=1) must NOT fire during the open,
+  // and the eligibility must NOT be lost: it fires at the next safe idle
+  // release (recyclePending honored). This is the GAP-2 face — the eligible
+  // recycle is deferred while the entry is busy with an in-flight open, and the
+  // fix carries the intent forward rather than dropping it.
+  //
+  // The pre-fix idle check is `liveContexts.size === 0` and is blind to the
+  // in-flight open, so on the boundary-crossing release (which has NO queued
+  // waiter → the pre-fix `!hadWaiter` gate is satisfied) it FIRES the hygiene
+  // recycle DURING the concurrent open — tearing the browser down under it
+  // (RED). The fix's `isEntryRecyclable` (pendingOpens===0) defers it and
+  // `recyclePending` makes it fire at the next idle release instead.
+  it("MATRIX(c): an eligible hygiene recycle defers past an in-flight open and fires at the next idle release", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher({
+      deferNewContextForCalls: [1], // browser0 defers every newContext
+    });
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 3,
+      recycleAfter: 1, // eligible after the first served context
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(1);
+
+    // Open c0 (parked) → release park → c0 live; served0=1 (>= recycleAfter).
+    const c0p = pool.acquire();
+    await drainMicrotasks();
+    launched[0]!.__releaseNewContexts();
+    const c0 = await c0p;
+    expect(pool.stats().inUse).toBe(1);
+
+    // Start a CONCURRENT acquire c1 — it reserves a slot and parks in
+    // newContext() (deferred). pendingOpens=1, NOT yet in liveContexts. NO
+    // waiter is queued (cap=3 has room), so the boundary-crossing release below
+    // has hadWaiter=false.
+    let c1: BrowserContext | undefined;
+    const c1p = pool.acquire().then((c) => (c1 = c));
+    await drainMicrotasks();
+    expect(c1).toBeUndefined();
+    expect(launched[0]!.__pendingNewContexts).toBe(1);
+
+    // Release c0: servedContexts(1) >= recycleAfter(1); the pre-fix idle check
+    // (liveContexts.size===0, blind to pendingOpens) is satisfied and there is
+    // NO waiter, so the pre-fix code FIRES the hygiene recycle here — DURING
+    // c1's in-flight open.
+    await pool.release(c0);
+    await drainMicrotasks();
+
+    // INVARIANT: no recycle fired while c1's open is in flight.
+    expect(launched[0]!.__pendingNewContexts).toBe(1); // c1 still opening
+    expect(pool.stats().totalRecycles).toBe(0);
+    expect(launched[0]!.isConnected()).toBe(true);
+
+    // Let c1's open complete → c1 live on the original browser, served0=2.
+    launched[0]!.__releaseNewContexts();
+    await c1p;
+    expect(c1).toBeDefined();
+    expect(launched[0]!.__contexts.map((x) => x.__id)).toContain(ctxId(c1!));
+    // The recycle was deferred, not dropped.
+    expect(pool.stats().totalRecycles).toBe(0);
+
+    // Release c1 with no waiter queued → entry genuinely idle + recycle pending
+    // → the deferred hygiene recycle fires at this safe idle point.
+    await pool.release(c1!);
+    await waitFor(() => launched.length === 2);
+    expect(pool.stats().totalRecycles).toBe(1);
+    expect(launched.length).toBe(2);
+
+    await pool.shutdown();
+  });
+
+  // MATRIX (d) — the prior serve-vs-recycle guard still holds: a
+  // boundary-crossing release WHILE a waiter is queued must serve the waiter
+  // onto the SAME browser and NOT recycle it out from under the just-served
+  // waiter. (Mirrors A1; re-asserted here so the recyclePending mechanics added
+  // for (c) did not regress the deferral.)
+  it("MATRIX(d): does NOT recycle out from under a just-served waiter (serve-vs-recycle guard preserved)", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 1,
+      recycleAfter: 1,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(1);
+
+    const c1 = await pool.acquire();
+    expect(pool.stats().inUse).toBe(1);
+
+    let c2: BrowserContext | undefined;
+    const c2p = pool.acquire().then((c) => (c2 = c));
+    await drainMicrotasks();
+    expect(c2).toBeUndefined();
+
+    // The boundary-crossing release serves the waiter, does NOT recycle.
+    await pool.release(c1);
+    await c2p;
+
+    expect(c2).toBeDefined();
+    expect(pool.stats().totalRecycles).toBe(0);
+    expect(launched.length).toBe(1);
+    expect(launched[0]!.isConnected()).toBe(true);
+    // The served context lives on the original (un-recycled) browser.
+    expect(launched[0]!.__contexts.map((x) => x.__id)).toContain(ctxId(c2!));
+    expect(pool.stats().inUse).toBe(1);
+
+    await pool.release(c2!);
+    await pool.shutdown();
+  });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -1,45 +1,23 @@
-import type { Browser } from "playwright";
-
-interface Slot {
-  browser: Browser;
-  contextCount: number;
-  /**
-   * True when this slot's last relaunch attempt failed and the slot is
-   * currently holding a dead browser. A pending slot is kept in
-   * `this.slots` (so capacity is not permanently lost) but is NOT placed
-   * in `available` — `acquire()` lazily re-launches it on demand.
-   */
-  relaunchPending?: boolean;
-}
-
-/**
- * Number of immediate relaunch attempts (with backoff between them) a
- * recycle makes before giving up and leaving the slot in the
- * `relaunchPending` state for a later lazy retry. A single transient
- * chromium launch failure (OOM spike, fd exhaustion) must not
- * permanently shrink the pool, so we retry rather than evict.
- */
-const RELAUNCH_MAX_ATTEMPTS = 3;
-
-/** Base backoff between relaunch attempts; doubles each attempt. */
-const RELAUNCH_BACKOFF_BASE_MS = 250;
+import type { Browser, BrowserContext } from "playwright";
 
 /**
  * Default delay the launch-serialization gate waits AFTER each chromium
  * launch settles before the next launch may start. Tunable on staging via
  * the `BROWSER_LAUNCH_STAGGER_MS` env var without a code change.
  *
- * WHY: the harness drives chromium launches in BURSTS (initial pool fill,
- * recycle relaunches, lazy relaunchPending recovery, reinit backstop). Each
- * headless chromium spawns ~50 PIDs (threads count against the container's
- * ~1000-PID ceiling), so a burst of many simultaneous `chromium.launch()`
- * calls transiently spikes PID demand far above the eventual steady state and
- * trips `pthread_create: Resource temporarily unavailable (11)` /
- * "Zygote could not fork" — every browser fails to launch and a d6 run goes
- * 0/18. Funneling every launch through a concurrency-1 gate with a stagger
- * spaces the spawns so the transient spike never exceeds the ceiling, WITHOUT
- * reducing the eventual pool size. Cold-start pays a one-time warm cost; the
- * pool warms once and steady-state acquires are instant.
+ * WHY: the harness drives chromium launches in BURSTS — but ONLY at startup
+ * (init fills the fixed browser set) and on the RARE recovery/hygiene paths
+ * (crash recovery, served-context recycle). Each headless chromium spawns
+ * ~50 PIDs (threads count against the container's ~1000-PID ceiling), so a
+ * burst of many simultaneous `chromium.launch()` calls transiently spikes
+ * PID demand far above the eventual steady state and trips
+ * `pthread_create: Resource temporarily unavailable (11)` / "Zygote could
+ * not fork" — every browser fails to launch and a d6 run goes 0/18.
+ * Funneling every launch through a concurrency-1 gate with a stagger spaces
+ * the spawns so the transient spike never exceeds the ceiling. Cold-start
+ * pays a one-time warm cost; the fixed browser set warms once and
+ * steady-state acquires (which only open CONTEXTS, never fork a process)
+ * are instant.
  */
 const DEFAULT_BROWSER_LAUNCH_STAGGER_MS = 150;
 
@@ -47,9 +25,19 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Options forwarded to `browser.newContext`. The pool centralizes the
+ *  `X-AIMock-Strict` default header here; callers add their per-probe
+ *  headers (X-AIMock-Context, X-Test-Id) via `extraHTTPHeaders`. */
+export interface ContextOptions {
+  extraHTTPHeaders?: Record<string, string>;
+}
+
 interface Waiter {
-  resolve: (browser: Browser) => void;
+  resolve: (context: BrowserContext) => void;
   reject: (err: Error) => void;
+  /** Context options stored so a freshly-created context for this waiter
+   *  carries the headers the original acquire() requested. */
+  options?: ContextOptions;
 }
 
 export interface BrowserPoolStats {
@@ -82,97 +70,125 @@ interface PoolLogger {
  */
 export type LaunchBrowser = () => Promise<Browser>;
 
+/**
+ * One long-lived browser PROCESS in the fixed set. Contexts are pooled over
+ * this — the hot path (`acquire`/`release`) opens and closes CONTEXTS on an
+ * already-running browser and never forks a process. A browser is only
+ * relaunched on the RARE recovery (crash) or hygiene (served-context
+ * threshold) paths.
+ */
+interface BrowserEntry {
+  browser: Browser;
+  /** Contexts currently checked out from this browser (handed to callers,
+   *  not yet released). */
+  liveContexts: Set<BrowserContext>;
+  /** Cumulative count of contexts served by this browser since its last
+   *  (re)launch. Drives the served-context hygiene recycle. */
+  servedContexts: number;
+  /** True while this entry is being torn down + relaunched. acquire() skips
+   *  a recycling entry so a context is never opened on a dying browser. */
+  recycling: boolean;
+}
+
+export interface BrowserPoolOptions {
+  /** Number of long-lived browser processes in the fixed set. Default 3
+   *  (env BROWSER_POOL_BROWSERS, legacy fallback BROWSER_POOL_SIZE). */
+  browsers?: number;
+  /** Global cap on concurrently-live contexts across all browsers. Default
+   *  24 (env BROWSER_POOL_MAX_CONTEXTS). acquire() past this pends a waiter. */
+  maxContexts?: number;
+  /** Per-browser served-context hygiene threshold: once a browser has served
+   *  >= recycleAfter contexts AND has no live contexts, it is recycled (its
+   *  process is replaced) to bound memory/handle drift. Default 300 (env
+   *  BROWSER_POOL_RECYCLE_AFTER). This is RARE — not the hot path. */
+  recycleAfter?: number;
+  logger?: PoolLogger;
+  /** Injected launcher (tests). Defaults to the real chromium launcher. */
+  launchBrowser?: LaunchBrowser;
+  /** Stagger between serialized launches (ms). Tests pass 0. */
+  launchStaggerMs?: number;
+}
+
+/**
+ * Pools `BrowserContext`s over a FIXED, small set of long-lived browser
+ * PROCESSES. The checkout unit is a `BrowserContext`: `acquire()` opens a
+ * context on the least-loaded live browser and `release()` closes it — NO
+ * process fork on the hot path. Browser processes are launched only at
+ * `init()` (the fixed set), on crash recovery, and on the served-context
+ * hygiene recycle. This is the durable PID-ceiling fix: a steady-state run
+ * forks N processes total, not one-per-recycle.
+ */
 export class BrowserPool {
-  private readonly poolSize: number;
+  private readonly browserCount: number;
+  private readonly maxContexts: number;
   private readonly recycleAfter: number;
-  private slots: Slot[] = [];
-  private available: Slot[] = [];
+  private browsers: BrowserEntry[] = [];
+  private liveContextCount = 0;
+  private contextToBrowser = new Map<BrowserContext, BrowserEntry>();
   private waiters: Waiter[] = [];
   private totalRecycles = 0;
   private inFlightRecycles = new Set<Promise<void>>();
-  private recyclingSlots = new Set<Slot>();
-  // Re-entry guard for the relaunchPending recovery path. A slot is marked
-  // here while its lazy relaunch is in flight so two concurrent invocations
-  // (an acquire()-driven relaunch racing a late `disconnected` fire that
-  // re-enters recycleSlot for the same slot) cannot both launch a browser for
-  // the same slot — which would leak one process and/or publish the slot to
-  // `available` twice.
-  private relaunchingSlots = new Set<Slot>();
-  // Re-entry guard for the empty-pool reinit backstop, mirroring the
-  // relaunchingSlots/recyclingSlots idiom. Two concurrent acquire() calls
-  // against a truly-empty pool (this.slots.length === 0) would each drive
-  // reinit() and each launch up to poolSize browsers — overshooting capacity.
-  // Setting this synchronously before reinit's first await makes the second
-  // acquire skip reinit and fall through to the waiter queue, where the first
-  // reinit's handOff serves it. Cleared in a finally so a thrown reinit can't
-  // wedge the guard set forever.
-  private reiniting = false;
   private isShutdown = false;
   private readonly logger?: PoolLogger;
   private readonly injectedLaunchBrowser?: LaunchBrowser;
 
-  // Launch-serialization gate. Every chromium launch — no matter which path
-  // triggers it (init fill, acquire-time relaunch, recycle relaunch, reinit
-  // backstop, deferred/pending relaunch) — is funneled through `launchBrowser`,
-  // which chains onto `launchChain` so strictly ONE launch runs at a time and a
-  // `launchStaggerMs` delay elapses after each settles before the next starts.
+  // Launch-serialization gate. Every chromium launch — init fill, crash
+  // recovery, hygiene recycle — is funneled through `launchBrowser`, which
+  // chains onto `launchChain` so strictly ONE launch runs at a time and a
+  // `launchStaggerMs` delay elapses after each settles before the next
+  // starts.
   private readonly launchStaggerMs: number;
-  // Tail of the serialized-launch promise chain. Each gated launch awaits the
-  // current tail, runs, staggers, then becomes the new tail — so launches run
-  // one-at-a-time in arrival order. Rejections are swallowed on the CHAIN
-  // (`.catch`) so one failed launch never poisons the queue; the real result
-  // (value or throw) is still surfaced to that launch's own caller.
   private launchChain: Promise<unknown> = Promise.resolve();
 
-  // Tracks which Browser instance maps to which Slot, so release() can find
-  // the slot in O(1) even after the slot was removed from `available`.
-  private browserToSlot = new Map<Browser, Slot>();
+  constructor(options: BrowserPoolOptions = {}) {
+    this.logger = options.logger;
+    this.injectedLaunchBrowser = options.launchBrowser;
 
-  // Slots whose browser is currently handed out to a caller (acquire's
-  // available-scan return, or a handOff that resolved a waiter). A slot enters
-  // this set exactly when its browser is delivered to a holder and leaves it
-  // exactly when that holder releases it (or the slot is recycled). It is the
-  // idempotency anchor for release(): a release() whose slot is NOT in this set
-  // is a double/foreign return and must be a no-op, so the same live browser
-  // can never be handed to two waiters via handOff's unguarded waiter branch.
-  // It also backs `stats().inUse` directly (the count of checked-out slots),
-  // which is more precise than the prior `liveSlots - available` subtraction.
-  private checkedOut = new Set<Slot>();
+    const envBrowsers = process.env.BROWSER_POOL_BROWSERS
+      ? parseInt(process.env.BROWSER_POOL_BROWSERS, 10)
+      : process.env.BROWSER_POOL_SIZE
+        ? parseInt(process.env.BROWSER_POOL_SIZE, 10)
+        : undefined;
+    this.browserCount =
+      options.browsers ??
+      (envBrowsers !== undefined &&
+      !Number.isNaN(envBrowsers) &&
+      envBrowsers > 0
+        ? envBrowsers
+        : 3);
 
-  constructor(
-    size = 4,
-    recycleAfter?: number,
-    logger?: PoolLogger,
-    launchBrowser?: LaunchBrowser,
-    launchStaggerMs?: number,
-  ) {
-    this.poolSize = size;
-    this.logger = logger;
-    this.injectedLaunchBrowser = launchBrowser;
+    const envMax = process.env.BROWSER_POOL_MAX_CONTEXTS
+      ? parseInt(process.env.BROWSER_POOL_MAX_CONTEXTS, 10)
+      : undefined;
+    this.maxContexts =
+      options.maxContexts ??
+      (envMax !== undefined && !Number.isNaN(envMax) && envMax > 0
+        ? envMax
+        : 24);
+
     const envRecycle = process.env.BROWSER_POOL_RECYCLE_AFTER
       ? parseInt(process.env.BROWSER_POOL_RECYCLE_AFTER, 10)
       : undefined;
     this.recycleAfter =
-      recycleAfter ??
-      (envRecycle !== undefined && !Number.isNaN(envRecycle)
+      options.recycleAfter ??
+      (envRecycle !== undefined && !Number.isNaN(envRecycle) && envRecycle > 0
         ? envRecycle
-        : 100);
+        : 300);
 
     // Explicit constructor arg (tests inject a tiny value to stay fast) wins;
     // otherwise the env var (staging tuning) wins; otherwise the default. A
     // negative or non-numeric value — from EITHER source — falls back to the
-    // default rather than disabling the stagger silently. (Disabling the
-    // stagger reintroduces the launch-burst PID spike the gate exists to
-    // prevent.) Note that an explicit `0` IS valid and intentionally disables
-    // the wait (tests rely on it); only negative/NaN args are rejected.
+    // default rather than disabling the stagger silently. An explicit `0` IS
+    // valid and intentionally disables the wait (tests rely on it); only
+    // negative/NaN args are rejected.
     const envStagger = process.env.BROWSER_LAUNCH_STAGGER_MS
       ? parseInt(process.env.BROWSER_LAUNCH_STAGGER_MS, 10)
       : undefined;
     const validExplicit =
-      launchStaggerMs !== undefined &&
-      !Number.isNaN(launchStaggerMs) &&
-      launchStaggerMs >= 0
-        ? launchStaggerMs
+      options.launchStaggerMs !== undefined &&
+      !Number.isNaN(options.launchStaggerMs) &&
+      options.launchStaggerMs >= 0
+        ? options.launchStaggerMs
         : undefined;
     const validEnv =
       envStagger !== undefined && !Number.isNaN(envStagger) && envStagger >= 0
@@ -196,31 +212,30 @@ export class BrowserPool {
     }
 
     try {
-      for (let i = 0; i < this.poolSize; i++) {
+      for (let i = 0; i < this.browserCount; i++) {
         const browser = await this.launchBrowser();
-        const slot: Slot = { browser, contextCount: 0 };
-        this.slots.push(slot);
-        this.available.push(slot);
-        this.browserToSlot.set(browser, slot);
-        this.attachDisconnectHandler(slot, browser);
+        const entry: BrowserEntry = {
+          browser,
+          liveContexts: new Set(),
+          servedContexts: 0,
+          recycling: false,
+        };
+        this.browsers.push(entry);
+        this.attachDisconnectHandler(entry, browser);
       }
     } catch (err) {
       // A mid-fill launch failure (the PID-ceiling pthread_create EAGAIN /
       // "Zygote could not fork" this gate exists to survive) must not leak the
-      // browsers already launched on iterations 0..N-1: callers see a rejected
-      // init() and commonly never call shutdown(), so those live chromium
-      // processes would leak permanently and accelerate PID exhaustion. Reset
-      // the pool's internal state BEFORE closing (so a `disconnected` fire from
-      // a close cannot re-enter the recycle path via the slot's disconnect
-      // handler — same ordering shutdown() relies on), then close each launched
-      // browser (closeBrowser logs its own failures) and re-throw to preserve
-      // init()'s reject-on-failure contract.
-      const launched = this.slots;
-      this.slots = [];
-      this.available = [];
-      this.browserToSlot.clear();
+      // browsers already launched: callers see a rejected init() and commonly
+      // never call shutdown(), so those live chromium processes would leak
+      // permanently. Reset state BEFORE closing (so a `disconnected` fire from
+      // a close cannot re-enter recovery), then close each launched browser and
+      // re-throw to preserve init()'s reject-on-failure contract.
+      const launched = this.browsers;
+      this.browsers = [];
+      this.contextToBrowser.clear();
       await Promise.allSettled(
-        launched.map((slot, idx) => this.closeBrowser(slot.browser, idx)),
+        launched.map((entry, idx) => this.closeBrowser(entry.browser, idx)),
       );
       throw err;
     }
@@ -233,36 +248,24 @@ export class BrowserPool {
   private rawLaunchBrowser!: LaunchBrowser;
 
   /**
-   * The single launch seam every pool path routes through (init fill,
-   * acquire-time relaunch, recycle relaunch, reinit backstop, lazy
-   * relaunchPending recovery). It chains onto `launchChain` so that AT MOST
-   * ONE `rawLaunchBrowser()` is in flight at a time across the whole pool, and
-   * a `launchStaggerMs` delay elapses after each launch settles before the
-   * next one begins. This spaces chromium process spawns so a burst never
-   * spikes PID demand past the container ceiling (`pthread_create` EAGAIN /
-   * "Zygote could not fork"), WITHOUT reducing the eventual pool size.
+   * The single launch seam every pool path routes through (init fill, crash
+   * recovery, hygiene recycle). It chains onto `launchChain` so AT MOST ONE
+   * `rawLaunchBrowser()` is in flight at a time across the whole pool, and a
+   * `launchStaggerMs` delay elapses after each launch settles before the next
+   * begins. This spaces chromium process spawns so a burst never spikes PID
+   * demand past the container ceiling.
    *
    * The caller's `result` resolves the instant `rawLaunchBrowser()` settles —
-   * the stagger does NOT delay the launch's own caller (it must get its
-   * browser as soon as the process is up). The stagger instead gates only the
-   * NEXT launch: the chain tail (`launchChain`) is advanced to a promise that
-   * resolves `launchStaggerMs` AFTER this launch settled, so the following
-   * gated launch cannot begin its `rawLaunchBrowser()` until that window
-   * elapses. The chain swallows failures (`.catch`) so one failed launch does
-   * not poison the queue for subsequent launches; the failing launch's own
-   * caller still receives the rejection via the returned `result` promise. The
-   * stagger applies whether the launch resolved or threw — a failed launch is
-   * just as PID-costly to retry, so the next one must be spaced too.
+   * the stagger does NOT delay the launch's own caller. It instead gates only
+   * the NEXT launch. The chain swallows failures (`.catch`) so one failed
+   * launch does not poison the queue; the failing launch's own caller still
+   * receives the rejection via the returned `result`. The stagger applies
+   * whether the launch resolved or threw — a failed launch is just as
+   * PID-costly to retry.
    */
   private launchBrowser = (): Promise<Browser> => {
-    // `gate` is the prior tail: this launch's rawLaunchBrowser() waits for it,
-    // guaranteeing concurrency 1. We capture it before reassigning the tail.
     const gate = this.launchChain;
     const result = gate.then(() => this.rawLaunchBrowser());
-    // Advance the tail to "this launch settled (ok or not), THEN staggered".
-    // The next launch chains off THIS, so it cannot start until the stagger
-    // window after this launch settles. `.catch` keeps a thrown launch from
-    // breaking the chain; the throw is still surfaced to `result`'s caller.
     this.launchChain = result
       .catch(() => undefined)
       .then(() =>
@@ -272,450 +275,212 @@ export class BrowserPool {
   };
 
   /**
-   * Single waiter-first handoff used by every slot-recovery path (reinit,
-   * recycle success, relaunchPendingSlots) AND by release(). A freshly
-   * launched (or just-released) browser must go to a queued waiter if one
-   * exists — otherwise the waiter is stranded until its acquire timeout while
-   * a live browser sits idle in `available`. Only when there is no waiter
-   * does the slot land in `available` (guarded by `includes` so a slot is
-   * never published twice).
-   *
-   * Liveness gate: the acquire() available-scan recycles a zombie
-   * (`!isConnected()`) before handing it out, but the waiter-served path
-   * historically did not — so a browser that silently disconnected in the
-   * window between launch/release and this handoff could be delivered to a
-   * waiting probe. Before resolving a waiter (or publishing to `available`),
-   * check `isConnected()`. If the browser is dead, do NOT hand it out: leave
-   * the waiter QUEUED (so a live browser serves it) and route the slot back
-   * into recovery —
-   *   - if the slot is idle (release()'s path), `recycleSlot` re-launches it
-   *     immediately and its eventual handOff serves the still-queued waiter;
-   *   - if the slot is already owned by a recovery path (recycle IIFE /
-   *     relaunchPendingSlots, where `isSlotBusy` is true and `recycleSlot`
-   *     would no-op), park it `relaunchPending` so the next acquire's
-   *     `relaunchPendingSlots` re-launches and serves the queued waiter.
-   * Either way the waiter is never dropped and a dead browser is never
-   * handed out.
-   */
-  private handOff(slot: Slot, browser: Browser): void {
-    if (!browser.isConnected()) {
-      // warn, not info: this is a capacity-affecting event — it strands a
-      // queued waiter (kept queued, served later by a live browser) and routes
-      // the slot back into recovery. It must reach the warn/Sentry alert
-      // pipeline, consistent with reinit-empty / recycle-relaunch-failed.
-      this.logger?.warn?.("browser-pool.handoff-dead-browser", {
-        slotIndex: this.slots.indexOf(slot),
-      });
-      // Keep the waiter queued — do NOT shift it. Route the slot back into
-      // recovery so a live browser serves the waiter on a later tick.
-      if (this.isSlotBusy(slot)) {
-        slot.relaunchPending = true;
-      } else {
-        this.recycleSlot(slot);
-      }
-      return;
-    }
-    const waiter = this.waiters.shift();
-    if (waiter) {
-      // The waiter is now the slot's holder, so its eventual release() is the
-      // one (and only) release that may return this slot. Mark it checked out —
-      // but DEFER the mark to a microtask. release() calls handOff synchronously
-      // (the live-slot return path), so a re-add HERE would make the slot
-      // checked-out again WITHIN the same synchronous frame as a double
-      // `release(sameBrowser)`: the original holder's second release would then
-      // pass the `checkedOut.has(slot)` guard and steal THIS waiter's
-      // release-right, shifting and resolving a second waiter with the same
-      // browser. Deferring the re-add to a microtask keeps the slot un-checked
-      // through the rest of the current synchronous frame (so the second
-      // release is a no-op) while still marking it long before the waiter — a
-      // distinct task scheduled by `resolve()` — could ever release it. (A
-      // recycle/shutdown that supersedes this handoff between now and the
-      // microtask clears `checkedOut` for the slot, so the deferred add cannot
-      // resurrect a stale checkout: it only re-checks the slot is still the
-      // live holder's by re-confirming the browser still maps to it.)
-      // LOAD-BEARING ordering (covered by the "waiter-served release does not
-      // leak the slot" control-mutant test): the checkedOut.add MUST be
-      // enqueued via queueMicrotask BEFORE waiter.resolve so it runs before the
-      // waiter's resolve continuation (microtask FIFO). Do NOT refactor to
-      // setTimeout or extra .then hops — any reordering re-opens the
-      // double-serve race the mutant test guards against.
-      const waitingBrowser = browser;
-      queueMicrotask(() => {
-        if (this.browserToSlot.get(waitingBrowser) === slot) {
-          this.checkedOut.add(slot);
-        }
-      });
-      waiter.resolve(browser);
-    } else if (!this.available.includes(slot)) {
-      this.available.push(slot);
-    }
-  }
-
-  /**
    * Close a browser, routing any failure through the structured logger with
-   * the originating slot index instead of silently swallowing it. A close
+   * the originating browser index instead of silently swallowing it. A close
    * failure is non-fatal (the process may have already crashed) but must be
    * visible to the harness log/Sentry pipeline.
    */
   private async closeBrowser(
     browser: Browser,
-    slotIndex: number,
+    browserIndex: number,
   ): Promise<void> {
     try {
       await browser.close();
     } catch (err) {
       this.logger?.warn?.("browser-pool.close-failed", {
-        slotIndex,
+        browserIndex,
         error: err instanceof Error ? err.message : String(err),
       });
     }
   }
 
   /**
-   * Track an in-flight recovery launch (reinit / relaunchPendingSlots) so
-   * `shutdown()` can drain it. Without this, a launch that resolves AFTER
-   * shutdown has awaited `inFlightRecycles` leaks a browser the pool never
-   * closes.
+   * Pick the live browser with the fewest live contexts. Skips entries that
+   * are recycling or whose browser has disconnected — acquire() must never
+   * open a context on a dying browser. Returns undefined when no live browser
+   * is available (caller enqueues a waiter; crash recovery fulfills it).
    */
-  private track(promise: Promise<void>): Promise<void> {
-    // Build the wrapper FIRST, then track and return the SAME wrapper object.
-    // Tracking the raw `promise` while returning a distinct wrapper would let
-    // `shutdown()`'s `Array.from(inFlightRecycles)` drain await the RAW promise
-    // — which settles BEFORE the wrapper's `.catch`/`.finally` post-settle work
-    // runs — so the drain would under-wait and shutdown could proceed before
-    // this recovery's cleanup completed. Adding/removing the SAME object means
-    // shutdown awaits the wrapper (including its cleanup).
-    //
-    // Note recycleSlot does NOT follow this same-object pattern: it adds the
-    // RAW IIFE `recyclePromise` to `inFlightRecycles` and its `.catch`/`.finally`
-    // is a SEPARATE chain. That is fine there because shutdown awaits the IIFE,
-    // whose body performs the real recovery work — only the inert post-shutdown
-    // set-cleanup in the detached `.finally` is under-waited, which is harmless.
-    // Here, by contrast, the wrapper's `.catch`/`.finally` is the only thing
-    // tracked, so it must be the SAME object that is added and removed.
-    // The `.catch` absorbs any throw with a logged event so it can never
-    // surface as an unhandled rejection (the inner methods swallow their own
-    // launch errors today, but a future throw must stay contained — a recovery
-    // launch failing is non-fatal to the pool).
-    const wrapped: Promise<void> = promise
-      .catch((err: unknown) => {
-        this.logger?.error?.("browser-pool.recovery-failed", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      })
-      .finally(() => {
-        this.inFlightRecycles.delete(wrapped);
-      });
-    this.inFlightRecycles.add(wrapped);
-    return wrapped;
-  }
-
-  /**
-   * Backstop re-initialization for the truly-empty pool. Called from
-   * `acquire()` only when `this.slots` is empty — i.e. nothing was ever
-   * launched (init never ran / launched nothing). This is NOT the all-slots-
-   * crashed recovery path: failed recycles keep their slots in `this.slots`
-   * (parked `relaunchPending`) and are recovered by `relaunchPendingSlots()`,
-   * so they never reach this backstop. Re-launches up to `poolSize` browsers,
-   * tolerating partial failure — even one fresh slot lets a waiting probe
-   * proceed. A total failure here surfaces to the caller via the normal
-   * acquire timeout / waiter-reject path rather than wedging the pool forever.
-   */
-  private async reinit(): Promise<void> {
-    // `rawLaunchBrowser` is the gate's underlying launcher, assigned by
-    // init(). Guard on it (not the always-defined `launchBrowser` arrow) so
-    // reinit is a no-op when init never ran — there is nothing to launch with.
-    if (this.isShutdown || this.rawLaunchBrowser === undefined) return;
-    // Set the concurrent-entry guard SYNCHRONOUSLY before the first `await`
-    // (before `this.track(...)`) so a second acquire reaching its empty-pool
-    // check while this reinit is in flight skips reinit and parks a waiter
-    // instead of launching its own duplicate set of browsers. Cleared in the
-    // `finally` so a thrown reinit can't leave the guard latched forever.
-    this.reiniting = true;
-    try {
-      // Track the whole reinit so a shutdown racing this launch loop drains it
-      // before closing slots, rather than leaking a browser that resolves after
-      // shutdown already awaited the in-flight set.
-      await this.track(this.reinitInner());
-    } finally {
-      this.reiniting = false;
-    }
-  }
-
-  private async reinitInner(): Promise<void> {
-    this.logger?.info("browser-pool.reinit", { poolSize: this.poolSize });
-    for (
-      let i = 0;
-      i < this.poolSize && this.slots.length < this.poolSize;
-      i++
-    ) {
-      try {
-        const browser = await this.launchBrowser();
-        if (this.isShutdown) {
-          // This browser was never added to `this.slots`, so there is no real
-          // originating slot index. Pass -1 rather than a fabricated index
-          // (`this.slots.length`) that would masquerade as a live slot.
-          await this.closeBrowser(browser, -1);
-          return;
-        }
-        const slot: Slot = { browser, contextCount: 0 };
-        this.slots.push(slot);
-        this.browserToSlot.set(browser, slot);
-        this.attachDisconnectHandler(slot, browser);
-        this.handOff(slot, browser);
-      } catch (err) {
-        // Best effort — keep trying the remaining slots. If none succeed
-        // the pool stays empty and the next acquire retries reinit. Per-attempt
-        // failure is a warn: a single slot failing to relaunch is recoverable
-        // (other slots may succeed, or a later acquire retries).
-        this.logger?.warn?.("browser-pool.reinit-failed", {
-          error: err instanceof Error ? err.message : String(err),
-        });
+  private pickLeastLoaded(): BrowserEntry | undefined {
+    let best: BrowserEntry | undefined;
+    for (const entry of this.browsers) {
+      if (entry.recycling) continue;
+      if (!entry.browser.isConnected()) continue;
+      if (
+        best === undefined ||
+        entry.liveContexts.size < best.liveContexts.size
+      ) {
+        best = entry;
       }
     }
-
-    // The genuine empty-pool capacity-loss signal: reinit ran but every launch
-    // failed, so the pool ends with zero slots. Unlike the per-attempt warn
-    // above, this is the terminal "pool ended empty" outage and must reach the
-    // error/Sentry pipeline. Per-attempt reinit-failed stays warn (recoverable);
-    // this distinct end-of-loop emit fires once when the backstop drained empty.
-    if (this.slots.length === 0) {
-      this.logger?.error?.("browser-pool.reinit-empty", {
-        poolSize: this.poolSize,
-      });
-    }
+    return best;
   }
 
   /**
-   * A slot is "busy" while either recovery path owns it: `recycleSlot` (which
-   * tracks via `recyclingSlots`) or `relaunchPendingSlotsInner` (which tracks
-   * via `relaunchingSlots`). The two sets guard disjoint entry points, so each
-   * entry point must consult BOTH — otherwise a late `disconnected` fire for a
-   * pending slot's OLD browser would re-enter `recycleSlot` while
-   * `relaunchPendingSlots` is concurrently relaunching the same slot, and both
-   * would launch a fresh browser (the second swap overwrites `slot.browser`,
-   * leaking the first process and/or double-publishing the slot).
+   * Open a context on the given live browser, centralizing the
+   * `X-AIMock-Strict` default header, and track it. Increments the served and
+   * live counters. The caller is responsible for having confirmed capacity
+   * and a live browser.
    */
-  private isSlotBusy(slot: Slot): boolean {
-    return this.recyclingSlots.has(slot) || this.relaunchingSlots.has(slot);
+  private async openContextOn(
+    entry: BrowserEntry,
+    options?: ContextOptions,
+  ): Promise<BrowserContext> {
+    const context = await entry.browser.newContext({
+      extraHTTPHeaders: {
+        "X-AIMock-Strict": "true",
+        ...options?.extraHTTPHeaders,
+      },
+    });
+    entry.liveContexts.add(context);
+    entry.servedContexts++;
+    this.liveContextCount++;
+    this.contextToBrowser.set(context, entry);
+    return context;
   }
 
-  /**
-   * Re-attempt the launch for every slot parked as `relaunchPending`. Each
-   * such slot was retained (not evicted) after a failed recycle so capacity
-   * is preserved; here we lazily replace its dead browser with a fresh one.
-   * A still-failing launch leaves the slot pending for the next acquire.
-   *
-   * Two concerns this method must own (a late `disconnected` fire for a
-   * pending slot's OLD browser can re-enter `recycleSlot` while an
-   * acquire()-driven call is relaunching the same slot):
-   *   - Re-entry: `relaunchingSlots` marks a slot before its `await` so a
-   *     racing invocation skips it — otherwise both launch a browser, the
-   *     second overwrites `slot.browser` (leaking the first) and/or the slot
-   *     is handed to two acquirers.
-   *   - Handoff: a fresh browser is delivered to a queued waiter first
-   *     (`handOff`) so the relaunch actually serves the waiter parked by the
-   *     acquire that drove it, instead of only pushing to `available`.
-   */
-  private async relaunchPendingSlots(): Promise<void> {
-    if (this.isShutdown) return;
-    await this.track(this.relaunchPendingSlotsInner());
-  }
-
-  private async relaunchPendingSlotsInner(): Promise<void> {
-    const pending = this.slots.filter(
-      (s) => s.relaunchPending && !this.isSlotBusy(s),
-    );
-    for (const slot of pending) {
-      if (this.isShutdown) return;
-      // Re-validate against the once-captured `pending` snapshot before
-      // claiming the slot. A concurrent invocation (a second acquire()-driven
-      // relaunch, or a late `disconnected` re-entering recycleSlot) may have
-      // claimed this slot (isSlotBusy) or already recovered it
-      // (relaunchPending cleared) during a prior iteration's `await`. Without
-      // this check-then-set — with NO `await` between the check and the
-      // `add` — both invocations would launch a fresh browser for the same
-      // slot, the second overwriting `slot.browser` (leaking the first
-      // process) and double-publishing via handOff. Mirrors recycleSlot's
-      // `if (this.isSlotBusy(slot)) return;` guard.
-      if (this.isSlotBusy(slot) || !slot.relaunchPending) continue;
-      // Mark before the await so a concurrent invocation skips this slot.
-      this.relaunchingSlots.add(slot);
-      try {
-        const fresh = await this.launchBrowser();
-        if (this.isShutdown) {
-          await this.closeBrowser(fresh, this.slots.indexOf(slot));
-          return;
-        }
-        this.browserToSlot.delete(slot.browser);
-        slot.browser = fresh;
-        slot.contextCount = 0;
-        slot.relaunchPending = false;
-        this.browserToSlot.set(fresh, slot);
-        this.attachDisconnectHandler(slot, fresh);
-        this.handOff(slot, fresh);
-        this.logger?.info("browser-pool.relaunch-recovered", {
-          slotIndex: this.slots.indexOf(slot),
-        });
-      } catch (err) {
-        // Still failing — leave it pending for the next acquire to retry. This
-        // is a per-attempt failure (the slot stays parked and recoverable), so
-        // warn rather than error.
-        this.logger?.warn?.("browser-pool.relaunch-failed", {
-          slotIndex: this.slots.indexOf(slot),
-          error: err instanceof Error ? err.message : String(err),
-        });
-      } finally {
-        this.relaunchingSlots.delete(slot);
-      }
-    }
-  }
-
-  async acquire(timeoutMs = 30_000): Promise<Browser> {
+  async acquire(
+    options?: ContextOptions,
+    timeoutMs = 30_000,
+  ): Promise<BrowserContext> {
     if (this.isShutdown) {
       throw new Error("BrowserPool is shut down");
     }
 
-    // Backstop: only when `this.slots` is truly empty — nothing was ever
-    // launched (init() never ran or launched nothing) — does the pool have no
-    // slot to recover, so reinit from scratch. NOTE: a burst of crashes whose
-    // relaunches all fail does NOT empty `this.slots`; those slots are kept
-    // and parked as `relaunchPending`, and are recovered below via
-    // `relaunchPendingSlots()`, not here. (`stats().size` may read 0 in that
-    // state, but `size` does not gate this backstop — `this.slots.length`
-    // does.)
-    if (this.slots.length === 0 && !this.reiniting) {
-      await this.reinit();
-    } else if (this.slots.length > 0) {
-      // Lazily relaunch any slot whose last relaunch failed. This is the
-      // recovery path for a transient launch failure: the slot was kept
-      // (capacity preserved) but parked as `relaunchPending`; the next
-      // acquire re-attempts the launch before falling through to the
-      // normal available-slot scan.
-      await this.relaunchPendingSlots();
+    // At-cap → pend a FIFO waiter carrying this acquire's options. release()
+    // (or a recovery handoff) creates a fresh context for it when capacity
+    // frees up, keeping the cap saturated.
+    if (this.liveContextCount >= this.maxContexts) {
+      return this.enqueueWaiter(options, timeoutMs);
     }
-    // The remaining case — `slots.length === 0 && this.reiniting` — is the
-    // concurrent-acquire skip: another acquire's reinit is already launching
-    // up to poolSize browsers, so this call does NOT launch its own duplicate
-    // set. It falls through to the waiter-queue path below; the in-flight
-    // reinit's `handOff` serves this waiter as soon as a fresh browser lands.
 
-    // Skip zombie slots whose browser has disconnected but whose disconnect
-    // handler hasn't yet completed the recycle. Without this loop, a single
-    // dead chromium process locks every probe that draws its slot until
-    // either the harness restarts or `recycleAfter` release-cycles trigger the
-    // contextCount-based recycle. Each zombie is kicked into recycle so the
-    // pool self-heals across ticks.
-    while (this.available.length > 0) {
-      const slot = this.available.shift()!;
-      if (slot.browser.isConnected()) {
-        // This slot is now handed to the caller — mark it checked out so its
-        // matching release() is the single return that may re-publish it, and
-        // a duplicate release() is a no-op.
-        this.checkedOut.add(slot);
-        this.logger?.info("browser-pool.acquire", {
-          available: this.available.length,
-          inUse: this.checkedOut.size,
-        });
-        return slot.browser;
-      }
-      this.logger?.info("browser-pool.skipped-dead-slot", {
-        slotIndex: this.slots.indexOf(slot),
+    const entry = this.pickLeastLoaded();
+    if (!entry) {
+      // No live browser right now (all recycling / disconnected). Enqueue a
+      // waiter — crash recovery's relaunch fulfills it on the next tick.
+      return this.enqueueWaiter(options, timeoutMs);
+    }
+
+    try {
+      const context = await this.openContextOn(entry, options);
+      this.logger?.info("browser-pool.acquire", {
+        available: this.maxContexts - this.liveContextCount,
+        inUse: this.liveContextCount,
       });
-      this.recycleSlot(slot);
+      return context;
+    } catch (err) {
+      // The browser died between pickLeastLoaded and newContext. Kick its
+      // recycle and retry ONCE on another live browser.
+      this.logger?.warn?.("browser-pool.acquire-newcontext-failed", {
+        browserIndex: this.browsers.indexOf(entry),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      this.recycleBrowser(entry);
+      const retry = this.pickLeastLoaded();
+      if (retry) {
+        const context = await this.openContextOn(retry, options);
+        return context;
+      }
+      // No other live browser — pend a waiter; recovery fulfills it.
+      return this.enqueueWaiter(options, timeoutMs);
     }
+  }
 
-    return new Promise<Browser>((resolve, reject) => {
-      const waiter: Waiter = { resolve, reject };
+  /**
+   * Enqueue a FIFO waiter for a context with a bounded timeout. The waiter
+   * carries its `options` so the context eventually created for it (by
+   * release() or a recovery handoff) gets the requested headers.
+   */
+  private enqueueWaiter(
+    options: ContextOptions | undefined,
+    timeoutMs: number,
+  ): Promise<BrowserContext> {
+    return new Promise<BrowserContext>((resolve, reject) => {
+      const waiter: Waiter = { resolve, reject, options };
       const timer = setTimeout(() => {
         const idx = this.waiters.indexOf(waiter);
         if (idx !== -1) this.waiters.splice(idx, 1);
         reject(new Error("BrowserPool acquire timeout"));
       }, timeoutMs);
-
-      // Wrap resolve/reject so the timeout is always cleared.
       const origResolve = waiter.resolve;
       const origReject = waiter.reject;
-      waiter.resolve = (browser: Browser) => {
+      waiter.resolve = (context) => {
         clearTimeout(timer);
-        origResolve(browser);
+        origResolve(context);
       };
-      waiter.reject = (err: Error) => {
+      waiter.reject = (err) => {
         clearTimeout(timer);
         origReject(err);
       };
-
       this.waiters.push(waiter);
-
-      // No timer re-arms recovery here. A parked waiter is served by the next
-      // acquire()/release()-driven relaunch: the harness probes continuously,
-      // so a fresh probe tick drives `relaunchPendingSlots()` (via acquire) or
-      // `handOff` (via release) and serves this waiter. In the degenerate idle
-      // case the waiter hits its bounded `timeoutMs` and the caller retries on
-      // the next tick — the no-eviction + lazy-recovery design already prevents
-      // the pool from draining permanently to 0.
     });
   }
 
-  release(browser: Browser): void {
-    if (this.isShutdown) return;
-
-    const slot = this.browserToSlot.get(browser);
-
-    // Browser was already recycled or doesn't belong to this pool.
-    if (!slot) return;
-
-    // Idempotency guard covering BOTH return paths. A live slot is never
-    // removed from `browserToSlot`, so a SECOND release(sameLiveBrowser) still
-    // resolves the slot here and — without this check — would re-enter handOff,
-    // shift a SECOND waiter, and resolve it with the SAME browser (two probes
-    // driving one chromium). The `!available.includes(slot)` guard inside
-    // handOff only covers the no-waiter branch; this guard closes the waiter
-    // branch too. A release whose slot is not currently checked out is a
-    // double release (or a foreign/stale reference) and must be a no-op. The
-    // matching `add` happens when the slot is handed out (acquire's scan or
-    // handOff's waiter branch); clearing it here makes the first release the
-    // only one that proceeds.
-    if (!this.checkedOut.has(slot)) return;
-    this.checkedOut.delete(slot);
-
-    slot.contextCount++;
-
-    if (slot.contextCount >= this.recycleAfter) {
-      this.recycleSlot(slot);
-      return;
-    }
-
-    // Defensive: a release-time isConnected check catches the race where
-    // the disconnect event hasn't fired yet (Playwright's events are
-    // asynchronous) but the underlying process is already dead. Without
-    // this, a dead browser would re-enter `available` and the next
-    // acquire would hand it out before the disconnect handler runs.
-    if (!slot.browser.isConnected()) {
-      this.logger?.info("browser-pool.release-dead-slot", {
-        slotIndex: this.slots.indexOf(slot),
+  /**
+   * Serve the next FIFO waiter by creating a fresh context on the
+   * least-loaded live browser with the waiter's stored options. Keeps the cap
+   * saturated. If no live browser is available the waiter stays queued (a
+   * recovery relaunch serves it later). A newContext failure kicks the
+   * browser's recycle and re-queues the waiter at the FRONT so ordering is
+   * preserved.
+   */
+  private async serveNextWaiter(): Promise<void> {
+    if (this.waiters.length === 0) return;
+    const entry = this.pickLeastLoaded();
+    if (!entry) return; // No live browser — waiter served by a later relaunch.
+    const waiter = this.waiters.shift()!;
+    try {
+      const context = await this.openContextOn(entry, waiter.options);
+      waiter.resolve(context);
+    } catch (err) {
+      this.logger?.warn?.("browser-pool.serve-waiter-failed", {
+        browserIndex: this.browsers.indexOf(entry),
+        error: err instanceof Error ? err.message : String(err),
       });
-      this.recycleSlot(slot);
+      // Re-queue at the front so FIFO order is preserved, then recycle the
+      // dead browser. Its relaunch handoff re-attempts the queued waiters.
+      this.waiters.unshift(waiter);
+      this.recycleBrowser(entry);
+    }
+  }
+
+  async release(context: BrowserContext): Promise<void> {
+    if (this.isShutdown) {
+      // Best-effort close; nothing to track post-shutdown.
+      await context.close().catch(() => {});
       return;
     }
 
-    // Route the live-slot return through the shared waiter-first handoff so
-    // there is ONE waiter-served path with ONE set of invariants: the
-    // `!available.includes(slot)` guard (a double release() of a still-live
-    // slot looks the slot up successfully BOTH times — the slot was never
-    // recycled, so it stays in browserToSlot — and an unconditional push would
-    // publish it to `available` twice, handing the SAME browser to two probes)
-    // AND the `isConnected()` liveness gate (the release-time check above is
-    // synchronous, but handOff re-checks before resolving so a dead browser is
-    // never delivered to a waiter on this path either). The slot is idle here
-    // (not in any recovery set), so a dead-browser handoff recycles it
-    // immediately rather than parking it pending.
-    this.handOff(slot, slot.browser);
-    const s = this.stats();
+    const entry = this.contextToBrowser.get(context);
+    // Unknown / double release — no-op.
+    if (!entry) return;
+
+    await context.close().catch(() => {});
+    this.contextToBrowser.delete(context);
+    entry.liveContexts.delete(context);
+    this.liveContextCount--;
+
     this.logger?.info("browser-pool.release", {
-      available: s.available,
-      inUse: s.inUse,
+      available: this.maxContexts - this.liveContextCount,
+      inUse: this.liveContextCount,
     });
+
+    // Keep the cap saturated: if a waiter is queued, hand it a fresh context
+    // on the least-loaded live browser now that capacity freed up.
+    if (this.waiters.length > 0) {
+      void this.serveNextWaiter();
+    }
+
+    // Hygiene recycle: once a browser has served enough contexts AND is idle
+    // (no live contexts), replace its process to bound memory/handle drift.
+    // This is the RARE path — it fires at most once per `recycleAfter`
+    // contexts per browser and never on a busy browser.
+    if (
+      entry.servedContexts >= this.recycleAfter &&
+      entry.liveContexts.size === 0 &&
+      !entry.recycling
+    ) {
+      this.recycleBrowser(entry);
+    }
   }
 
   async shutdown(): Promise<void> {
@@ -732,203 +497,146 @@ export class BrowserPool {
       await Promise.allSettled(Array.from(this.inFlightRecycles));
     }
 
-    // Close every browser we know about. Route through closeBrowser so a
-    // close failure is logged with its slot index rather than silently
-    // swallowed.
-    const closers = this.slots.map((slot, idx) =>
-      this.closeBrowser(slot.browser, idx),
+    // Close every live context, then every browser. Route through closeBrowser
+    // so a close failure is logged with its browser index.
+    const contextClosers = Array.from(this.contextToBrowser.keys()).map((c) =>
+      c.close().catch(() => {}),
+    );
+    await Promise.allSettled(contextClosers);
+
+    const closers = this.browsers.map((entry, idx) =>
+      this.closeBrowser(entry.browser, idx),
     );
     await Promise.allSettled(closers);
 
-    this.slots = [];
-    this.available = [];
-    this.browserToSlot.clear();
-    this.checkedOut.clear();
+    this.browsers = [];
+    this.contextToBrowser.clear();
+    this.liveContextCount = 0;
   }
 
   stats(): BrowserPoolStats {
-    // `size` counts only live (non-pending) capacity. A slot parked as
-    // `relaunchPending` holds a dead browser and is being recovered lazily,
-    // so it is not usable capacity and must not inflate `size`. (`inUse` is NOT
-    // filtered by `relaunchPending` — it derives from `this.checkedOut.size`
-    // below, the set of slots actually handed to a caller.) When
-    // every slot is pending, `size` reads 0 — that surfaces the outage to
-    // callers, but it is NOT what gates recovery. The parked slots remain in
-    // `this.slots`, so `acquire()` recovers them via `relaunchPendingSlots()`
-    // (the `this.slots.length === 0` reinit backstop is a separate
-    // never-launched case), not via this size reading.
-    const liveSlots = this.slots.filter((s) => !s.relaunchPending);
-    const availableCount = this.available.length;
     return {
-      size: liveSlots.length,
-      available: availableCount,
-      // Derive `inUse` from the explicit checked-out set — the slots actually
-      // handed to a caller right now — rather than the `liveSlots - available`
-      // subtraction, which was inconsistently filtered (e.g. a slot mid-recycle
-      // is neither live-counted the same way nor in `available`, skewing the
-      // difference). `checkedOut` is maintained at every checkout/return/recycle
-      // site, so its size is the precise in-use gauge.
-      inUse: this.checkedOut.size,
+      // `size` is the context capacity, not the process count — driver tests
+      // assert acquire/release moves the counters by 1 per context.
+      size: this.maxContexts,
+      available: this.maxContexts - this.liveContextCount,
+      inUse: this.liveContextCount,
       totalRecycles: this.totalRecycles,
     };
   }
 
   /**
    * Register a `disconnected` listener on a browser so a chromium process
-   * that crashes mid-life proactively recycles its slot instead of waiting
-   * for the next release-driven check. Three guards keep stale fires
-   * harmless:
+   * that crashes mid-life proactively recycles its entry. Three guards keep
+   * stale fires harmless:
    *
    *   1. Pool shutdown: handler may fire as we close everything; ignore.
-   *   2. Slot reassignment: `slot.browser` may already point to a fresh
+   *   2. Entry reassignment: `entry.browser` may already point to a fresh
    *      browser if recycle completed before the old browser's disconnect
-   *      event drained — the late fire is for the OLD instance, not the
-   *      slot's current one.
-   *   3. Slot eviction: launch failure during recycle removes the slot
-   *      from `this.slots`; a disconnect for a no-longer-tracked slot is
-   *      a no-op.
+   *      event drained — the late fire is for the OLD instance.
+   *   3. Entry eviction: launch failure during recycle removes the entry from
+   *      `this.browsers`; a disconnect for a no-longer-tracked entry is a
+   *      no-op.
    */
-  private attachDisconnectHandler(slot: Slot, browser: Browser): void {
+  private attachDisconnectHandler(entry: BrowserEntry, browser: Browser): void {
     browser.on("disconnected", () => {
       if (this.isShutdown) return;
-      if (slot.browser !== browser) return;
-      if (!this.slots.includes(slot)) return;
+      if (entry.browser !== browser) return;
+      if (!this.browsers.includes(entry)) return;
       this.logger?.info("browser-pool.disconnected", {
-        slotIndex: this.slots.indexOf(slot),
+        browserIndex: this.browsers.indexOf(entry),
       });
-      this.recycleSlot(slot);
+      this.recycleBrowser(entry);
     });
   }
 
-  private recycleSlot(slot: Slot): void {
-    // Gate entry on shutdown so a late recycle cannot register a fresh promise
-    // in `inFlightRecycles` AFTER shutdown() snapshotted that set via
-    // `Array.from`, which would let its fresh browser escape the drain. The
-    // disconnect handler already checks isShutdown, but recycleSlot has other
-    // entry points (acquire()'s zombie scan, release()'s dead-slot check), so
-    // harden the function itself. Matches the isShutdown gating reinit() and
-    // relaunchPendingSlots() already do at their entry points.
+  /**
+   * RARE path — crash recovery + served-context hygiene. Replaces the entry's
+   * browser PROCESS with a fresh one. A recycle guard makes a second call for
+   * the same entry a no-op. The entry's live contexts (if any — e.g. a crash
+   * while contexts were held) are abandoned: their holders' next op rejects,
+   * so their probe fails (bounded blast radius — only this browser's
+   * contexts). On launch failure the entry is evicted; if that empties the
+   * browser set while waiters are queued, every waiter is rejected.
+   */
+  private recycleBrowser(entry: BrowserEntry): void {
     if (this.isShutdown) return;
-    // Re-entry guard: a second call for the same slot is a no-op. This must
-    // honor BOTH recovery sets (via isSlotBusy), not just recyclingSlots — a
-    // slot parked relaunchPending still holds its OLD dead browser in
-    // `slot.browser` and is still in `this.slots`, so a late `disconnected`
-    // fire for that old browser passes the handler's guards and reaches here
-    // while `relaunchPendingSlots` may already be relaunching the same slot.
-    // Without consulting relaunchingSlots, both would launch a fresh browser
-    // and the second swap would overwrite `slot.browser`, leaking one process
-    // and/or double-publishing the slot.
-    if (this.isSlotBusy(slot)) return;
-    this.recyclingSlots.add(slot);
-
-    // A recycled slot's OLD browser is no longer a usable checkout: whether it
-    // was in-use (disconnect-during-hold) or idle (acquire's zombie scan), the
-    // slot is being torn down and relaunched. Clear it so the set never leaks a
-    // stale entry across recycle (a fresh browser starts NOT checked out until
-    // re-acquired or handed to a waiter via the relaunch's handOff). release()
-    // paths that route here (contextCount/dead-slot) already cleared it; this
-    // covers the other entry points (disconnect handler, acquire zombie scan).
-    this.checkedOut.delete(slot);
-
+    if (entry.recycling) return;
+    entry.recycling = true;
     this.totalRecycles++;
-    const slotIdx = this.slots.indexOf(slot);
+
+    const browserIdx = this.browsers.indexOf(entry);
     this.logger?.info("browser-pool.recycle", {
-      slotIndex: slotIdx,
-      contextCount: slot.contextCount,
+      browserIndex: browserIdx,
+      servedContexts: entry.servedContexts,
       recycleAfter: this.recycleAfter,
       totalRecycles: this.totalRecycles,
     });
 
-    // Remove the old browser from the lookup map immediately so a
-    // double-release of the stale reference is a no-op.
-    this.browserToSlot.delete(slot.browser);
-
-    // Remove from available in case it's still there (shouldn't be in
-    // the normal path, but defensive).
-    const availIdx = this.available.indexOf(slot);
-    if (availIdx !== -1) {
-      this.available.splice(availIdx, 1);
+    // Drop the abandoned live contexts from the global lookup + count so a
+    // later release() of a stale reference is a no-op and the cap accounting
+    // stays accurate.
+    for (const ctx of entry.liveContexts) {
+      this.contextToBrowser.delete(ctx);
+      this.liveContextCount--;
     }
+    entry.liveContexts.clear();
 
-    const oldBrowser = slot.browser;
+    const oldBrowser = entry.browser;
 
     const recyclePromise = (async () => {
-      await this.closeBrowser(oldBrowser, slotIdx);
+      await this.closeBrowser(oldBrowser, browserIdx);
 
       if (this.isShutdown) return;
 
-      // Retry the relaunch a bounded number of times with backoff. A single
-      // transient launch failure (OOM spike, fd exhaustion) must NOT
-      // permanently shrink the pool — the old code spliced the slot out on
-      // the first failure, so one bad launch monotonically drained the pool
-      // to empty and it never self-healed.
-      let lastErr: unknown;
-      for (let attempt = 1; attempt <= RELAUNCH_MAX_ATTEMPTS; attempt++) {
-        if (this.isShutdown) return;
-        try {
-          const fresh = await this.launchBrowser();
-
-          if (this.isShutdown) {
-            // Shutdown was initiated while we were launching. Close the
-            // fresh browser and don't hand it to anyone.
-            await this.closeBrowser(fresh, this.slots.indexOf(slot));
-            return;
-          }
-
-          slot.browser = fresh;
-          slot.contextCount = 0;
-          slot.relaunchPending = false;
-          this.browserToSlot.set(fresh, slot);
-          this.attachDisconnectHandler(slot, fresh);
-
-          this.handOff(slot, fresh);
+      try {
+        const fresh = await this.launchBrowser();
+        if (this.isShutdown) {
+          await this.closeBrowser(fresh, this.browsers.indexOf(entry));
           return;
-        } catch (err) {
-          lastErr = err;
-          if (attempt < RELAUNCH_MAX_ATTEMPTS) {
-            await delay(RELAUNCH_BACKOFF_BASE_MS * 2 ** (attempt - 1));
+        }
+        entry.browser = fresh;
+        entry.servedContexts = 0;
+        entry.liveContexts.clear();
+        entry.recycling = false;
+        this.attachDisconnectHandler(entry, fresh);
+        // Drain queued waiters onto the freshly-launched browser.
+        while (
+          this.waiters.length > 0 &&
+          this.liveContextCount < this.maxContexts &&
+          entry.browser.isConnected()
+        ) {
+          await this.serveNextWaiter();
+        }
+      } catch (err) {
+        // Launch failed — evict the entry so it does not masquerade as live
+        // capacity. If the browser set is now empty and waiters are queued,
+        // reject them all (no process can serve them).
+        this.logger?.error?.("browser-pool.recycle-relaunch-failed", {
+          browserIndex: this.browsers.indexOf(entry),
+          error: err instanceof Error ? err.message : String(err),
+        });
+        const idx = this.browsers.indexOf(entry);
+        if (idx !== -1) this.browsers.splice(idx, 1);
+        if (this.browsers.length === 0 && this.waiters.length > 0) {
+          for (const waiter of this.waiters) {
+            waiter.reject(new Error("BrowserPool has no live browsers"));
           }
+          this.waiters = [];
         }
       }
-
-      // All immediate retries failed. Do NOT evict the slot — keep it in
-      // `this.slots` so capacity is preserved and park it as
-      // `relaunchPending`. The next `acquire()` lazily re-attempts the
-      // launch (see relaunchPendingSlots), and the empty-pool backstop in
-      // acquire() re-initializes if every slot ends up pending/lost.
-      slot.relaunchPending = true;
-      // Capacity loss after exhausting ALL immediate retries — the slot is now
-      // parked dead and only a later lazy acquire can recover it. This is a
-      // genuine capacity-loss signal that must reach error/Sentry, not info.
-      this.logger?.error?.("browser-pool.recycle-relaunch-failed", {
-        slotIndex: this.slots.indexOf(slot),
-        attempts: RELAUNCH_MAX_ATTEMPTS,
-        poolSize: this.slots.length,
-        error: lastErr instanceof Error ? lastErr.message : String(lastErr),
-      });
-
-      // Leave the slot parked as `relaunchPending` — no timer kick. The next
-      // `acquire()` re-attempts the launch via `relaunchPendingSlots()` and a
-      // release-driven recycle recovers via `handOff`, so a queued waiter is
-      // served by the next probe tick (or, in the degenerate idle case, the
-      // caller retries after the waiter's bounded acquire timeout).
     })();
 
     this.inFlightRecycles.add(recyclePromise);
-    // Absorb any throw with a logged `.catch` before the `.finally`, mirroring
-    // track(). The IIFE swallows its own launch errors today, but a future
-    // synchronous throw (e.g. handOff/attachDisconnectHandler/browserToSlot.set)
-    // must stay contained — a recycle failing is non-fatal to the pool and must
-    // never surface as an unhandled rejection.
     recyclePromise
       .catch((err: unknown) => {
         this.logger?.error?.("browser-pool.recycle-failed", {
-          slotIndex: this.slots.indexOf(slot),
+          browserIndex: this.browsers.indexOf(entry),
           error: err instanceof Error ? err.message : String(err),
         });
       })
       .finally(() => {
-        this.recyclingSlots.delete(slot);
+        entry.recycling = false;
         this.inFlightRecycles.delete(recyclePromise);
       });
   }

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -38,6 +38,12 @@ interface Waiter {
   /** Context options stored so a freshly-created context for this waiter
    *  carries the headers the original acquire() requested. */
   options?: ContextOptions;
+  /** Set true the instant this waiter settles via EITHER the timeout-reject
+   *  wrapper OR the resolve wrapper. `serveNextWaiter` consults it AFTER its
+   *  `await openContextOn` so a context opened for a waiter that timed out
+   *  mid-open is closed + rolled back instead of orphaned (a leak that
+   *  permanently bleeds capacity). */
+  settled: boolean;
 }
 
 export interface BrowserPoolStats {
@@ -316,24 +322,67 @@ export class BrowserPool {
   }
 
   /**
-   * Open a context on the given live browser, centralizing the
-   * `X-AIMock-Strict` default header, and track it. Increments the served and
-   * live counters. The caller is responsible for having confirmed capacity
-   * and a live browser.
+   * Synchronously RESERVE one slot against the cap, with NO await between the
+   * check and the increment. This is the synchronization primitive that makes
+   * the cap hold under concurrency: because JS is single-threaded, an
+   * increment that is synchronous with its bound check cannot be interleaved by
+   * another `acquire`, so concurrent acquires can never collectively pass the
+   * check and overshoot `maxContexts` the way a check-then-`await`-then-mutate
+   * sequence could. Returns `true` if a slot was reserved (`liveContextCount`
+   * now reflects it as in-use), `false` if at cap. Every successful reservation
+   * MUST be matched by exactly one of: a context tracked via
+   * `trackOpenedContext` (the reservation becomes a live context), or a
+   * rollback via `releaseReservation` (the open failed / was orphaned).
+   */
+  private reserveSlot(): boolean {
+    if (this.liveContextCount >= this.maxContexts) return false;
+    this.liveContextCount++;
+    return true;
+  }
+
+  /**
+   * Roll back a reservation (or a live-context decrement), clamped at 0 so a
+   * future double-decrement / double-release can never drive the count
+   * negative and desync `stats()`.
+   */
+  private releaseReservation(): void {
+    if (this.liveContextCount > 0) this.liveContextCount--;
+  }
+
+  /**
+   * Open a context on the given live browser against a reservation the caller
+   * ALREADY took via `reserveSlot()`. Centralizes the `X-AIMock-Strict` default
+   * header. On success the reservation is converted into a tracked live context
+   * (the reservation already counted it in `liveContextCount`, so no second
+   * increment). On `newContext()` failure the reservation is rolled back and
+   * the error re-thrown — the caller decides whether to retry (it must
+   * re-reserve) or give up.
+   *
+   * PRECONDITION: the caller holds a reservation. This method never checks the
+   * cap itself; the cap is enforced synchronously at `reserveSlot()`.
    */
   private async openContextOn(
     entry: BrowserEntry,
     options?: ContextOptions,
   ): Promise<BrowserContext> {
-    const context = await entry.browser.newContext({
-      extraHTTPHeaders: {
-        "X-AIMock-Strict": "true",
-        ...options?.extraHTTPHeaders,
-      },
-    });
+    let context: BrowserContext;
+    try {
+      context = await entry.browser.newContext({
+        extraHTTPHeaders: {
+          "X-AIMock-Strict": "true",
+          ...options?.extraHTTPHeaders,
+        },
+      });
+    } catch (err) {
+      // The open failed — give the reserved slot back so it does not bleed
+      // capacity permanently.
+      this.releaseReservation();
+      throw err;
+    }
+    // Convert the held reservation into a tracked live context. The reservation
+    // already incremented liveContextCount, so do NOT increment again here.
     entry.liveContexts.add(context);
     entry.servedContexts++;
-    this.liveContextCount++;
     this.contextToBrowser.set(context, entry);
     return context;
   }
@@ -349,14 +398,22 @@ export class BrowserPool {
     // At-cap → pend a FIFO waiter carrying this acquire's options. release()
     // (or a recovery handoff) creates a fresh context for it when capacity
     // frees up, keeping the cap saturated.
-    if (this.liveContextCount >= this.maxContexts) {
+    //
+    // SYNCHRONOUS RESERVATION: take the slot before any await. If reserveSlot()
+    // returns false we are at cap and pend a waiter (the waiter re-reserves
+    // when served). Because the check-and-increment in reserveSlot() has no
+    // await between them, concurrent acquires cannot collectively overshoot the
+    // cap during one another's newContext() awaits.
+    if (!this.reserveSlot()) {
       return this.enqueueWaiter(options, timeoutMs);
     }
 
     const entry = this.pickLeastLoaded();
     if (!entry) {
-      // No live browser right now (all recycling / disconnected). Enqueue a
-      // waiter — crash recovery's relaunch fulfills it on the next tick.
+      // No live browser right now (all recycling / disconnected). Give the
+      // reservation back and enqueue a waiter — crash recovery's relaunch
+      // re-reserves and fulfills it on the next tick.
+      this.releaseReservation();
       return this.enqueueWaiter(options, timeoutMs);
     }
 
@@ -368,19 +425,27 @@ export class BrowserPool {
       });
       return context;
     } catch (err) {
-      // The browser died between pickLeastLoaded and newContext. Kick its
-      // recycle and retry ONCE on another live browser.
+      // The browser died between pickLeastLoaded and newContext. openContextOn
+      // already rolled the reservation back on failure, so RE-RESERVE before
+      // the retry — this keeps the retry path cap-correct instead of opening a
+      // context with no reservation behind it.
       this.logger?.warn?.("browser-pool.acquire-newcontext-failed", {
         browserIndex: this.browsers.indexOf(entry),
         error: err instanceof Error ? err.message : String(err),
       });
       this.recycleBrowser(entry);
+      if (!this.reserveSlot()) {
+        // Another concurrent acquire took the freed slot first — pend a waiter.
+        return this.enqueueWaiter(options, timeoutMs);
+      }
       const retry = this.pickLeastLoaded();
       if (retry) {
         const context = await this.openContextOn(retry, options);
         return context;
       }
-      // No other live browser — pend a waiter; recovery fulfills it.
+      // No other live browser — give the re-reservation back and pend a
+      // waiter; recovery fulfills it.
+      this.releaseReservation();
       return this.enqueueWaiter(options, timeoutMs);
     }
   }
@@ -395,20 +460,26 @@ export class BrowserPool {
     timeoutMs: number,
   ): Promise<BrowserContext> {
     return new Promise<BrowserContext>((resolve, reject) => {
-      const waiter: Waiter = { resolve, reject, options };
+      const waiter: Waiter = { resolve, reject, options, settled: false };
       const timer = setTimeout(() => {
         const idx = this.waiters.indexOf(waiter);
         if (idx !== -1) this.waiters.splice(idx, 1);
+        // Mark settled BEFORE rejecting so a serveNextWaiter() that already
+        // shift()ed this waiter and is mid-`await openContextOn` observes the
+        // dead state and closes/rolls back the context instead of orphaning it.
+        waiter.settled = true;
         reject(new Error("BrowserPool acquire timeout"));
       }, timeoutMs);
       const origResolve = waiter.resolve;
       const origReject = waiter.reject;
       waiter.resolve = (context) => {
         clearTimeout(timer);
+        waiter.settled = true;
         origResolve(context);
       };
       waiter.reject = (err) => {
         clearTimeout(timer);
+        waiter.settled = true;
         origReject(err);
       };
       this.waiters.push(waiter);
@@ -427,20 +498,61 @@ export class BrowserPool {
     if (this.waiters.length === 0) return;
     const entry = this.pickLeastLoaded();
     if (!entry) return; // No live browser — waiter served by a later relaunch.
+
+    // SYNCHRONOUS RESERVATION before shifting + opening. A waiter only exists
+    // because acquire() rolled back its reservation when it pended, so the slot
+    // must be re-reserved here. If we cannot reserve we are at cap (a concurrent
+    // release + recycle-drain both tried to serve) — leave the waiter queued for
+    // the next freed slot rather than overshoot.
+    if (!this.reserveSlot()) return;
+
     const waiter = this.waiters.shift()!;
+
+    // The waiter may have settled (timed out) between being enqueued and being
+    // shifted here — if so it is already off the queue handled by the timeout
+    // splice OR was the head; either way do NOT open a context for a dead
+    // waiter. Roll the reservation back and serve the next one instead.
+    if (waiter.settled) {
+      this.releaseReservation();
+      if (this.waiters.length > 0) void this.serveNextWaiter();
+      return;
+    }
+
+    let context: BrowserContext;
     try {
-      const context = await this.openContextOn(entry, waiter.options);
-      waiter.resolve(context);
+      context = await this.openContextOn(entry, waiter.options);
     } catch (err) {
       this.logger?.warn?.("browser-pool.serve-waiter-failed", {
         browserIndex: this.browsers.indexOf(entry),
         error: err instanceof Error ? err.message : String(err),
       });
-      // Re-queue at the front so FIFO order is preserved, then recycle the
-      // dead browser. Its relaunch handoff re-attempts the queued waiters.
+      // openContextOn already rolled the reservation back on failure. Re-queue
+      // at the front so FIFO order is preserved, then recycle the dead browser.
+      // Its relaunch handoff re-attempts the queued waiters (which re-reserve).
       this.waiters.unshift(waiter);
       this.recycleBrowser(entry);
+      return;
     }
+
+    // DEAD-WAITER ORPHAN GUARD: the waiter may have timed out WHILE the
+    // newContext() above was in flight. Its resolve() would now no-op, so the
+    // freshly-opened context would be counted in liveContextCount yet never
+    // released — a permanent capacity bleed. Detect the settled waiter, CLOSE
+    // the orphan context, roll back its accounting, and serve the next waiter
+    // with the freed slot instead.
+    if (waiter.settled) {
+      this.contextToBrowser.delete(context);
+      entry.liveContexts.delete(context);
+      this.releaseReservation();
+      void context.close().catch(() => {});
+      this.logger?.warn?.("browser-pool.serve-waiter-orphan-closed", {
+        browserIndex: this.browsers.indexOf(entry),
+      });
+      if (this.waiters.length > 0) void this.serveNextWaiter();
+      return;
+    }
+
+    waiter.resolve(context);
   }
 
   async release(context: BrowserContext): Promise<void> {
@@ -454,15 +566,33 @@ export class BrowserPool {
     // Unknown / double release — no-op.
     if (!entry) return;
 
-    await context.close().catch(() => {});
+    // SYNCHRONOUS ACCOUNTING FIRST, then close(). The unfixed code awaited
+    // `context.close()` BEFORE this bookkeeping + the idle-recycle decision, so
+    // a concurrent acquire/openContextOn could interleave during the close
+    // await and the recycle decision could be evaluated against stale state.
+    // Doing the bookkeeping AND evaluating the idle-recycle decision off purely
+    // SYNCHRONOUS state — with no await between the decrement and the size
+    // check — removes that window: a new context cannot sneak in between the
+    // decrement and the decision.
     this.contextToBrowser.delete(context);
     entry.liveContexts.delete(context);
-    this.liveContextCount--;
+    this.releaseReservation();
 
     this.logger?.info("browser-pool.release", {
       available: this.maxContexts - this.liveContextCount,
       inUse: this.liveContextCount,
     });
+
+    // Hygiene-recycle decision, captured SYNCHRONOUSLY against current state
+    // (no await gap above could have mutated liveContexts since the decrement).
+    const shouldRecycle =
+      entry.servedContexts >= this.recycleAfter &&
+      entry.liveContexts.size === 0 &&
+      !entry.recycling;
+
+    // Close the released context AFTER the accounting/decision so the close
+    // await cannot straddle them. Best-effort; failure is non-fatal.
+    await context.close().catch(() => {});
 
     // Keep the cap saturated: if a waiter is queued, hand it a fresh context
     // on the least-loaded live browser now that capacity freed up.
@@ -474,11 +604,7 @@ export class BrowserPool {
     // (no live contexts), replace its process to bound memory/handle drift.
     // This is the RARE path — it fires at most once per `recycleAfter`
     // contexts per browser and never on a busy browser.
-    if (
-      entry.servedContexts >= this.recycleAfter &&
-      entry.liveContexts.size === 0 &&
-      !entry.recycling
-    ) {
+    if (shouldRecycle) {
       this.recycleBrowser(entry);
     }
   }
@@ -575,10 +701,11 @@ export class BrowserPool {
 
     // Drop the abandoned live contexts from the global lookup + count so a
     // later release() of a stale reference is a no-op and the cap accounting
-    // stays accurate.
+    // stays accurate. Clamp each decrement (releaseReservation) so the count
+    // can never go negative if a context was concurrently released.
     for (const ctx of entry.liveContexts) {
       this.contextToBrowser.delete(ctx);
-      this.liveContextCount--;
+      this.releaseReservation();
     }
     entry.liveContexts.clear();
 
@@ -636,7 +763,12 @@ export class BrowserPool {
         });
       })
       .finally(() => {
-        entry.recycling = false;
+        // Do NOT reset `entry.recycling` here. Each path already leaves it
+        // correct: the success path cleared it (and reattached the entry as a
+        // live, non-recycling browser); the eviction path spliced the entry out
+        // of `this.browsers` entirely, so flipping `recycling` back to false
+        // would wrongly resurrect a dead entry as eligible. Only drop the
+        // in-flight tracking handle here.
         this.inFlightRecycles.delete(recyclePromise);
       });
   }

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -94,6 +94,25 @@ interface BrowserEntry {
   /** True while this entry is being torn down + relaunched. acquire() skips
    *  a recycling entry so a context is never opened on a dying browser. */
   recycling: boolean;
+  /** Count of `openContextOn` calls currently IN FLIGHT on this entry —
+   *  incremented BEFORE the `await browser.newContext()` and decremented in
+   *  BOTH the success and failure paths. This closes the window where a
+   *  context has taken a cap reservation but is not yet in `liveContexts`:
+   *  during that await `liveContexts.size` undercounts, so any recycle/idle
+   *  decision made off `liveContexts.size` alone is blind to the in-flight
+   *  open. Every idle/recycle predicate MUST consult `pendingOpens` (via
+   *  `isEntryIdle`) so a hygiene recycle never tears the browser down under an
+   *  in-flight open. */
+  pendingOpens: number;
+  /** Set true when a `release()` computed `shouldRecycle` true but DEFERRED
+   *  the hygiene recycle because a waiter was just served onto the freed slot
+   *  (the `!hadWaiter` guard). Under sustained saturation a waiter is queued at
+   *  nearly every release, so that guard would otherwise STARVE the hygiene
+   *  recycle forever. This flag carries the pending intent forward: the next
+   *  release that finds the entry genuinely idle (no live contexts, no pending
+   *  opens) fires the deferred recycle and clears the flag — closing the
+   *  starvation without recycling out from under a just-served waiter. */
+  recyclePending: boolean;
 }
 
 export interface BrowserPoolOptions {
@@ -225,6 +244,8 @@ export class BrowserPool {
           liveContexts: new Set(),
           servedContexts: 0,
           recycling: false,
+          pendingOpens: 0,
+          recyclePending: false,
         };
         this.browsers.push(entry);
         this.attachDisconnectHandler(entry, browser);
@@ -350,6 +371,30 @@ export class BrowserPool {
   }
 
   /**
+   * SINGLE idle predicate every recycle/teardown decision consults. An entry
+   * is idle ONLY when it has neither a live (checked-out) context NOR an open
+   * in flight. The `pendingOpens` term is the structural fix: a context that
+   * has taken a reservation but is still awaiting `newContext()` is not yet in
+   * `liveContexts`, so `liveContexts.size === 0` alone would read a busy entry
+   * as idle and let a hygiene recycle tear the browser down mid-open. Consult
+   * THIS, never `liveContexts.size === 0` directly, for any idle decision.
+   */
+  private isEntryIdle(entry: BrowserEntry): boolean {
+    return entry.liveContexts.size === 0 && entry.pendingOpens === 0;
+  }
+
+  /**
+   * True when a NON-crash (hygiene) recycle may safely fire for this entry: it
+   * must be genuinely idle (`isEntryIdle`) AND not already recycling. The crash
+   * path does NOT use this — a disconnected/dead browser is recycled regardless
+   * of in-flight opens (those opens will fail against the dead browser and roll
+   * themselves back).
+   */
+  private isEntryRecyclable(entry: BrowserEntry): boolean {
+    return !entry.recycling && this.isEntryIdle(entry);
+  }
+
+  /**
    * Open a context on the given live browser against a reservation the caller
    * ALREADY took via `reserveSlot()`. Centralizes the `X-AIMock-Strict` default
    * header. On success the reservation is converted into a tracked live context
@@ -365,9 +410,18 @@ export class BrowserPool {
     entry: BrowserEntry,
     options?: ContextOptions,
   ): Promise<BrowserContext> {
+    // Capture the browser instance BEFORE the await. If the entry is recycled
+    // mid-open, `entry.browser` is reassigned to a fresh process — the context
+    // we get back belongs to a browser that is being / has been torn down, so
+    // it must not be handed out or counted. Mark the in-flight open so any
+    // concurrent recycle/idle decision (`isEntryIdle`) sees it and does NOT
+    // treat the entry as idle during this await window.
+    const browserBefore = entry.browser;
+    entry.pendingOpens++;
+
     let context: BrowserContext;
     try {
-      context = await entry.browser.newContext({
+      context = await browserBefore.newContext({
         extraHTTPHeaders: {
           "X-AIMock-Strict": "true",
           ...options?.extraHTTPHeaders,
@@ -375,12 +429,37 @@ export class BrowserPool {
       });
     } catch (err) {
       // The open failed — give the reserved slot back so it does not bleed
-      // capacity permanently.
+      // capacity permanently, and clear the in-flight marker.
+      entry.pendingOpens--;
       this.releaseReservation();
       throw err;
     }
+
+    // BELT-AND-SUSPENDERS for the recycle-vs-open race: the entry may have been
+    // recycled (crash recovery or a hygiene recycle that fired before this
+    // counter was consulted) WHILE the newContext() above was in flight. If so
+    // the freshly-opened context is an orphan on a torn-down browser — closing
+    // or otherwise counting it would corrupt the cap and could hand a dead
+    // context to a holder. Detect that state, close the orphan, roll back the
+    // reservation + the in-flight marker, and surface as a failure so the
+    // caller's retry/enqueue path handles it.
+    if (
+      entry.recycling ||
+      entry.browser !== browserBefore ||
+      !browserBefore.isConnected()
+    ) {
+      entry.pendingOpens--;
+      this.releaseReservation();
+      void context.close().catch(() => {});
+      this.logger?.warn?.("browser-pool.open-orphaned-by-recycle", {
+        browserIndex: this.browsers.indexOf(entry),
+      });
+      throw new Error("browser-pool: context open orphaned by recycle");
+    }
+
     // Convert the held reservation into a tracked live context. The reservation
     // already incremented liveContextCount, so do NOT increment again here.
+    entry.pendingOpens--;
     entry.liveContexts.add(context);
     entry.servedContexts++;
     this.contextToBrowser.set(context, entry);
@@ -619,10 +698,12 @@ export class BrowserPool {
 
     // Hygiene-recycle decision, captured SYNCHRONOUSLY against current state
     // (no await gap above could have mutated liveContexts since the decrement).
+    // `isEntryRecyclable` consults BOTH liveContexts AND pendingOpens, so an
+    // in-flight open keeps the entry off the recycle path even though it isn't
+    // yet in liveContexts.
     const shouldRecycle =
       entry.servedContexts >= this.recycleAfter &&
-      entry.liveContexts.size === 0 &&
-      !entry.recycling;
+      this.isEntryRecyclable(entry);
 
     // Close the released context AFTER the accounting/decision so the close
     // await cannot straddle them. Best-effort; failure is non-fatal.
@@ -646,15 +727,37 @@ export class BrowserPool {
     }
 
     // Hygiene recycle: once a browser has served enough contexts AND is idle
-    // (no live contexts), replace its process to bound memory/handle drift.
-    // This is the RARE path — it fires at most once per `recycleAfter`
-    // contexts per browser and never on a busy browser. Gate on `!hadWaiter`:
-    // when a waiter was just served onto this freed slot, defer the hygiene
-    // recycle to a later genuinely-idle release rather than recycle the
-    // browser out from under the just-served waiter. The hygiene recycle is
-    // the rare path, so deferring it is harmless.
-    if (shouldRecycle && !hadWaiter) {
-      this.recycleBrowser(entry);
+    // (no live contexts, no in-flight opens), replace its process to bound
+    // memory/handle drift. This is the RARE path — it fires at most once per
+    // `recycleAfter` contexts per browser and never on a busy browser.
+    //
+    // The `!hadWaiter` guard (a prior fix) defers the recycle when a waiter was
+    // just served onto this freed slot, so the browser is not torn down under
+    // the just-served waiter. But under SUSTAINED saturation a waiter is queued
+    // at nearly every release, so on its own that guard STARVES the hygiene
+    // recycle — the documented memory/handle-drift bound is never met exactly
+    // when it matters. We close that without reintroducing the serve-vs-recycle
+    // race by carrying the deferred intent on `entry.recyclePending`:
+    //
+    //   - if shouldRecycle this round but a waiter was served, set the flag and
+    //     defer (do not recycle now);
+    //   - on EVERY release, if the entry is now genuinely recyclable (idle, no
+    //     pending opens, not already recycling) AND either shouldRecycle this
+    //     round OR a recycle is pending, fire it and clear the flag.
+    //
+    // Serving a waiter is asynchronous (`serveNextWaiter` reserves + opens on
+    // the next tick), so right after a serve the entry is NOT idle — either a
+    // live context exists or `pendingOpens > 0` — and `isEntryRecyclable`
+    // returns false, naturally deferring to the next genuinely-idle release.
+    if (shouldRecycle && hadWaiter) {
+      entry.recyclePending = true;
+    }
+    if (
+      this.isEntryRecyclable(entry) &&
+      (shouldRecycle || entry.recyclePending)
+    ) {
+      entry.recyclePending = false;
+      this.recycleBrowser(entry, "hygiene");
     }
   }
 
@@ -733,10 +836,31 @@ export class BrowserPool {
    * so their probe fails (bounded blast radius — only this browser's
    * contexts). On launch failure the entry is evicted; if that empties the
    * browser set while waiters are queued, every waiter is rejected.
+   *
+   * `reason` distinguishes a genuine crash/disconnect (the browser is already
+   * dead) from a hygiene recycle (the browser is healthy, we are replacing it
+   * proactively to bound drift). A HYGIENE recycle must NEVER tear down an
+   * entry with an in-flight open (`pendingOpens > 0`): the freshly-opening
+   * context would land on a browser we are about to close, becoming a dead
+   * context counted against the cap. `release()` already gates the hygiene call
+   * on `isEntryRecyclable` (pendingOpens === 0), but we re-check here as
+   * defense-in-depth and bail. The CRASH path proceeds regardless — the browser
+   * is dead anyway, and the in-flight open's own newContext()/orphan-guard
+   * rolls itself back.
    */
-  private recycleBrowser(entry: BrowserEntry): void {
+  private recycleBrowser(
+    entry: BrowserEntry,
+    reason: "crash" | "hygiene" = "crash",
+  ): void {
     if (this.isShutdown) return;
     if (entry.recycling) return;
+    // Hygiene recycle never proceeds against an in-flight open — defer it (the
+    // pending intent is carried on `recyclePending`, which the next idle
+    // release will honor). The crash path is exempt: the browser is dead.
+    if (reason === "hygiene" && entry.pendingOpens > 0) {
+      entry.recyclePending = true;
+      return;
+    }
     entry.recycling = true;
     this.totalRecycles++;
 
@@ -775,6 +899,9 @@ export class BrowserPool {
         entry.servedContexts = 0;
         entry.liveContexts.clear();
         entry.recycling = false;
+        // The deferred-recycle intent was satisfied by THIS recycle — clear it
+        // so the fresh browser does not inherit a stale "recycle me" flag.
+        entry.recyclePending = false;
         this.attachDisconnectHandler(entry, fresh);
         // Drain queued waiters onto the freshly-launched browser. Guard
         // forward progress: serveNextWaiter() can return WITHOUT consuming a

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -440,8 +440,27 @@ export class BrowserPool {
       }
       const retry = this.pickLeastLoaded();
       if (retry) {
-        const context = await this.openContextOn(retry, options);
-        return context;
+        try {
+          const context = await this.openContextOn(retry, options);
+          return context;
+        } catch (retryErr) {
+          // A SECOND browser died in the same EAGAIN burst — the exact
+          // scenario this module exists to survive. openContextOn already
+          // rolled the re-reservation back on this throw, so accounting is
+          // safe; mirror the first-attempt recovery: recycle `retry` and pend
+          // a waiter so the caller is gracefully enqueued (served when a
+          // context frees / a recovery relaunch lands) instead of receiving a
+          // hard rejection. Do NOT re-reserve here — the rollback already
+          // happened, and enqueueWaiter pends without a reservation (the
+          // waiter re-reserves when served).
+          this.logger?.warn?.("browser-pool.acquire-retry-newcontext-failed", {
+            browserIndex: this.browsers.indexOf(retry),
+            error:
+              retryErr instanceof Error ? retryErr.message : String(retryErr),
+          });
+          this.recycleBrowser(retry);
+          return this.enqueueWaiter(options, timeoutMs);
+        }
       }
       // No other live browser — give the re-reservation back and pend a
       // waiter; recovery fulfills it.
@@ -494,6 +513,21 @@ export class BrowserPool {
    * browser's recycle and re-queues the waiter at the FRONT so ordering is
    * preserved.
    */
+  /**
+   * Fire-and-forget recursive re-serve. The recursive `serveNextWaiter()`
+   * calls inside `serveNextWaiter` itself are not awaited (they re-enter to
+   * drain the next waiter after a dead-waiter skip / orphan close), so a future
+   * throw would surface as an unhandled promise rejection. Route any failure to
+   * the structured logger instead.
+   */
+  private scheduleServeNextWaiter(): void {
+    this.serveNextWaiter().catch((err: unknown) => {
+      this.logger?.error?.("browser-pool.serve-waiter-unhandled", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
   private async serveNextWaiter(): Promise<void> {
     if (this.waiters.length === 0) return;
     const entry = this.pickLeastLoaded();
@@ -514,7 +548,7 @@ export class BrowserPool {
     // waiter. Roll the reservation back and serve the next one instead.
     if (waiter.settled) {
       this.releaseReservation();
-      if (this.waiters.length > 0) void this.serveNextWaiter();
+      if (this.waiters.length > 0) this.scheduleServeNextWaiter();
       return;
     }
 
@@ -548,7 +582,7 @@ export class BrowserPool {
       this.logger?.warn?.("browser-pool.serve-waiter-orphan-closed", {
         browserIndex: this.browsers.indexOf(entry),
       });
-      if (this.waiters.length > 0) void this.serveNextWaiter();
+      if (this.waiters.length > 0) this.scheduleServeNextWaiter();
       return;
     }
 
@@ -595,16 +629,31 @@ export class BrowserPool {
     await context.close().catch(() => {});
 
     // Keep the cap saturated: if a waiter is queued, hand it a fresh context
-    // on the least-loaded live browser now that capacity freed up.
-    if (this.waiters.length > 0) {
-      void this.serveNextWaiter();
+    // on the least-loaded live browser now that capacity freed up. Capture
+    // whether a waiter was queued BEFORE serving it: serveNextWaiter() may
+    // reserve + asynchronously open a context on THIS just-freed entry, which
+    // would race the hygiene recycle below (the recycle snapshot was taken
+    // synchronously above and is now stale — recycling would tear the browser
+    // out from under the just-served waiter, intermittently failing/stalling a
+    // probe under load).
+    const hadWaiter = this.waiters.length > 0;
+    if (hadWaiter) {
+      this.serveNextWaiter().catch((err: unknown) => {
+        this.logger?.error?.("browser-pool.serve-waiter-unhandled", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
     }
 
     // Hygiene recycle: once a browser has served enough contexts AND is idle
     // (no live contexts), replace its process to bound memory/handle drift.
     // This is the RARE path — it fires at most once per `recycleAfter`
-    // contexts per browser and never on a busy browser.
-    if (shouldRecycle) {
+    // contexts per browser and never on a busy browser. Gate on `!hadWaiter`:
+    // when a waiter was just served onto this freed slot, defer the hygiene
+    // recycle to a later genuinely-idle release rather than recycle the
+    // browser out from under the just-served waiter. The hygiene recycle is
+    // the rare path, so deferring it is harmless.
+    if (shouldRecycle && !hadWaiter) {
       this.recycleBrowser(entry);
     }
   }
@@ -727,13 +776,21 @@ export class BrowserPool {
         entry.liveContexts.clear();
         entry.recycling = false;
         this.attachDisconnectHandler(entry, fresh);
-        // Drain queued waiters onto the freshly-launched browser.
+        // Drain queued waiters onto the freshly-launched browser. Guard
+        // forward progress: serveNextWaiter() can return WITHOUT consuming a
+        // waiter (pickLeastLoaded() momentarily undefined / reserveSlot()
+        // false) while isConnected() still reports true — without the guard the
+        // loop would busy-spin, yielding only to microtasks. Break the instant
+        // a serve made no progress (waiter count unchanged); a later release or
+        // recovery handoff drains the remaining waiters.
         while (
           this.waiters.length > 0 &&
           this.liveContextCount < this.maxContexts &&
           entry.browser.isConnected()
         ) {
+          const before = this.waiters.length;
           await this.serveNextWaiter();
+          if (this.waiters.length >= before) break;
         }
       } catch (err) {
         // Launch failed — evict the entry so it does not masquerade as live


### PR DESCRIPTION
## Summary

Re-architects the showcase-harness `BrowserPool` from pooling browser **processes** to pooling browser **contexts** over a fixed, small set of long-lived browsers. This is the durable fix for the Railway PID-ceiling `EAGAIN` failures and resolves the long-standing tension between d6 concurrency and acquire-timeout starvation.

### What changed

- **Process pooling -> context pooling.** Instead of launching/tearing down one browser process per concurrent probe (which scaled PID/thread usage with concurrency and tripped Railway's PID ceiling), the pool now keeps a fixed number of long-lived browsers (default 3) and hands out *browser contexts* on top of them. Context creation is cheap and does not consume new PIDs the way a fresh browser launch does.
- **Synchronous-reservation cap model.** Acquire reserves a context slot synchronously against `maxContexts` before any async launch/open work, so the cap is never overshot by concurrent acquirers racing through an `await`. Over-cap acquirers queue as waiters and are served in order on release.
- **Recycle/idle invariant via `pendingOpens`.** The recycle path and in-flight context-open path are reconciled through a single idle invariant that accounts for `pendingOpens` (contexts reserved but not yet materialized), closing the recycle-vs-in-flight-open race so a browser is never recycled out from under a context that is mid-open.
- **Driver launcher migration.** The pooled launchers (d4 chat-roundtrip, d5 single-pill, d6 all-pills, e2e-parity, e2e-readiness) were migrated from process checkout to context checkout, including abort-path context release so an aborted/timed-out probe releases its pooled context (and detaches its abort listener) instead of leaking it.

### Why it fixes both failure modes

- **PID exhaustion:** capping live browsers at a small fixed number (3 long-lived browsers) decouples PID/thread footprint from concurrency, so high d6 concurrency no longer walks the process table into Railway's PID ceiling.
- **d6 acquire-timeout starvation:** `maxContexts` is now decoupled from the browser/PID count, so the pool can serve many concurrent contexts (default 24) off those 3 browsers without starving acquirers on a too-small process pool.

### Deploy requirement (env meaning shifted)

The env knob meaning changed from `BROWSER_POOL_SIZE` (number of pooled processes) to a two-axis model. The staging env must be set to:

- `BROWSER_POOL_BROWSERS=3`
- `BROWSER_POOL_MAX_CONTEXTS=24`

`BROWSER_POOL_SIZE` no longer carries its previous meaning; deploys must use the two new vars.

## Deferred follow-ups (bucket b/c)

Surfaced during CR and intentionally deferred (non-blocking for this PR):

- JSDoc placement fixes on the pool API.
- Added test coverage for the init-mid-fill path, the launch-gate path, and the recycle-failure path.
- `pickLeastLoaded` load metric incorporating `pendingOpens`.
- Orchestrator observability for the unpooled-fallback path.
- e2e-parity interceptor-leak-on-throw (parity harness only; not prod-wired).
- d6 deploy-churn + NSF accounting.

## Test plan

- [x] `oxfmt --check .` clean (one whitespace reformat applied + committed)
- [x] `oxlint` — 0 errors / 0 warnings
- [x] `tsc -p tsconfig.build.json --noEmit` — clean
- [x] `vitest run` — 100 files / 1702 tests passing
- [x] `tsc -p tsconfig.build.json` build — clean, dist emitted
- [ ] Set staging env `BROWSER_POOL_BROWSERS=3` + `BROWSER_POOL_MAX_CONTEXTS=24` before deploy