### PR TITLE
fix(showcase/shell-dashboard): resolve OPS_BASE_URL at runtime via /api/ops route handler

### DIFF
--- a/showcase/shell-dashboard/next.config.ts
+++ b/showcase/shell-dashboard/next.config.ts
@@ -1,64 +1,27 @@
 import type { NextConfig } from "next";
-import { PHASE_PRODUCTION_BUILD } from "next/constants";
 
 /**
  * Next.js config for the dashboard shell.
  *
  * The Status tab calls the showcase-harness HTTP API at the relative path
- * `/api/ops/*`. There is no /api/ops route handler in this app — the path
- * is a deterministic same-origin proxy that this rewrite forwards to the
- * real showcase-harness service. Going same-origin sidesteps two production
- * blockers:
+ * `/api/ops/*`. That path is served at REQUEST time by the Route Handler at
+ * `src/app/api/ops/[...path]/route.ts`, which reads `OPS_BASE_URL` from the
+ * live process env and proxies to `${OPS_BASE_URL}/api/*`.
+ *
+ * It used to be a `rewrites()` entry, but `next build` freezes `rewrites()`
+ * into the prebuilt Docker image — so the placeholder `OPS_BASE_URL` baked at
+ * build time was frozen too, and every deploy proxied to a dead host
+ * regardless of its runtime env. Moving the proxy into a Route Handler makes
+ * `OPS_BASE_URL` runtime-resolved: the single shared image serves each
+ * environment's own harness URL with no rebuild. As a result this config no
+ * longer reads `OPS_BASE_URL` and `next build` no longer depends on it.
+ *
+ * Going same-origin (vs. a direct cross-origin browser call) sidesteps two
+ * production blockers that remain relevant to the Route Handler too:
  *   1. showcase-harness has no CORS allowlist for cross-origin browser calls.
- *   2. We don't want the ops base URL inlined into the client bundle (it
- *      would also force `NEXT_PUBLIC_*` exposure semantics).
- *
- * `OPS_BASE_URL` is required at START — not at build. `next build`
- * evaluates `rewrites()` so route metadata can be persisted into the
- * artifact, AND `next start` evaluates it again at process boot.
- * Throwing at build time would prevent the runtime-injection deploy
- * pattern (single artifact, env supplied at start). So when invoked
- * under the build phase we accept the absence with a sentinel
- * destination — the rewrite is reconstructed with the real env value
- * at start. At start time, missing OPS_BASE_URL still throws loudly to
- * surface the wiring bug.
- *
- * The config is exported as a function `(phase) => NextConfig` so the
- * build-vs-start distinction is reliable without relying on the
- * `NEXT_PHASE` env (which Next.js does not always export to user code).
+ *   2. The ops base URL stays out of the client bundle (no `NEXT_PUBLIC_*`
+ *      exposure).
  */
-const SENTINEL_OPS_BASE = "http://ops.invalid";
+const nextConfig: NextConfig = {};
 
-export default function nextConfig(phase: string): NextConfig {
-  const isBuildPhase = phase === PHASE_PRODUCTION_BUILD;
-  return {
-    async rewrites() {
-      const opsBase = process.env.OPS_BASE_URL;
-      if (!opsBase) {
-        if (isBuildPhase) {
-          // Build phase: emit a parseable sentinel destination so
-          // `next build` succeeds. `rewrites()` runs again at
-          // `next start` with the real env value (or throws below).
-          return [
-            {
-              source: "/api/ops/:path*",
-              destination: `${SENTINEL_OPS_BASE}/api/:path*`,
-            },
-          ];
-        }
-        throw new Error(
-          "OPS_BASE_URL must be set on this Railway service — see showcase/RAILWAY.md " +
-            "(without it, /api/ops/* requests cannot proxy to showcase-harness)",
-        );
-      }
-      // Strip trailing slashes so we never produce `https://host//api/...`
-      // (some servers reject the double slash). Mirrors the same
-      // normalization in `src/lib/ops-api.ts:resolveBaseUrl` so the
-      // server-side rewrite and client-side fetch agree on the URL shape.
-      const normalized = opsBase.replace(/\/+$/, "");
-      return [
-        { source: "/api/ops/:path*", destination: `${normalized}/api/:path*` },
-      ];
-    },
-  };
-}
+export default nextConfig;

--- a/showcase/shell-dashboard/src/app/api/ops/[...path]/route.test.ts
+++ b/showcase/shell-dashboard/src/app/api/ops/[...path]/route.test.ts
@@ -73,14 +73,19 @@ describe("/api/ops proxy Route Handler", () => {
 
     const calledUrl = String(fetchSpy.mock.calls[0]![0]);
     // Trailing slash on base normalized away; single /api; query preserved.
-    expect(calledUrl).toBe("https://harness.example.com/api/probes/abc?limit=5");
+    expect(calledUrl).toBe(
+      "https://harness.example.com/api/probes/abc?limit=5",
+    );
   });
 
   it("reads OPS_BASE_URL at REQUEST time, not at module load", async () => {
     fetchSpy.mockResolvedValue(new Response("{}", { status: 200 }));
 
     process.env.OPS_BASE_URL = "https://first.example.com";
-    await GET(makeRequest("http://dashboard.local/api/ops/probes"), ctx(["probes"]));
+    await GET(
+      makeRequest("http://dashboard.local/api/ops/probes"),
+      ctx(["probes"]),
+    );
     expect(String(fetchSpy.mock.calls[0]![0])).toBe(
       "https://first.example.com/api/probes",
     );
@@ -88,7 +93,10 @@ describe("/api/ops proxy Route Handler", () => {
     // Change the env between requests — the second call must pick up the
     // new value, proving per-request resolution (no build/module freeze).
     process.env.OPS_BASE_URL = "https://second.example.com";
-    await GET(makeRequest("http://dashboard.local/api/ops/probes"), ctx(["probes"]));
+    await GET(
+      makeRequest("http://dashboard.local/api/ops/probes"),
+      ctx(["probes"]),
+    );
     expect(String(fetchSpy.mock.calls[1]![0])).toBe(
       "https://second.example.com/api/probes",
     );

--- a/showcase/shell-dashboard/src/app/api/ops/[...path]/route.test.ts
+++ b/showcase/shell-dashboard/src/app/api/ops/[...path]/route.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for the runtime /api/ops proxy Route Handler.
+ *
+ * These lock in the behaviors the production overlay depends on:
+ *   - OPS_BASE_URL is read at REQUEST time (per-call), not frozen — the
+ *     whole reason this handler exists instead of a next.config rewrite.
+ *   - The path mapping `/api/ops/<segments>` → `${OPS_BASE_URL}/api/<segments>`
+ *     (single `/api`, never doubled/dropped) plus the original query string.
+ *   - Upstream status + body are relayed through.
+ *   - A missing OPS_BASE_URL yields a clear 503, not a throw/500.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "./route";
+
+const ORIGINAL_OPS_BASE_URL = process.env.OPS_BASE_URL;
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+function makeRequest(url: string, init?: RequestInit): NextRequest {
+  return new NextRequest(new Request(url, init));
+}
+
+function ctx(path: string[]): { params: Promise<{ path: string[] }> } {
+  return { params: Promise.resolve({ path }) };
+}
+
+beforeEach(() => {
+  fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  if (ORIGINAL_OPS_BASE_URL === undefined) {
+    delete process.env.OPS_BASE_URL;
+  } else {
+    process.env.OPS_BASE_URL = ORIGINAL_OPS_BASE_URL;
+  }
+});
+
+describe("/api/ops proxy Route Handler", () => {
+  it("proxies GET /api/ops/probes → ${OPS_BASE_URL}/api/probes", async () => {
+    process.env.OPS_BASE_URL = "https://harness.example.com";
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ probes: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const res = await GET(
+      makeRequest("http://dashboard.local/api/ops/probes"),
+      ctx(["probes"]),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = String(fetchSpy.mock.calls[0]![0]);
+    expect(calledUrl).toBe("https://harness.example.com/api/probes");
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ probes: [] });
+  });
+
+  it("forwards the query string and nested path segments", async () => {
+    process.env.OPS_BASE_URL = "https://harness.example.com/";
+    fetchSpy.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    await GET(
+      makeRequest("http://dashboard.local/api/ops/probes/abc?limit=5"),
+      ctx(["probes", "abc"]),
+    );
+
+    const calledUrl = String(fetchSpy.mock.calls[0]![0]);
+    // Trailing slash on base normalized away; single /api; query preserved.
+    expect(calledUrl).toBe("https://harness.example.com/api/probes/abc?limit=5");
+  });
+
+  it("reads OPS_BASE_URL at REQUEST time, not at module load", async () => {
+    fetchSpy.mockResolvedValue(new Response("{}", { status: 200 }));
+
+    process.env.OPS_BASE_URL = "https://first.example.com";
+    await GET(makeRequest("http://dashboard.local/api/ops/probes"), ctx(["probes"]));
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+      "https://first.example.com/api/probes",
+    );
+
+    // Change the env between requests — the second call must pick up the
+    // new value, proving per-request resolution (no build/module freeze).
+    process.env.OPS_BASE_URL = "https://second.example.com";
+    await GET(makeRequest("http://dashboard.local/api/ops/probes"), ctx(["probes"]));
+    expect(String(fetchSpy.mock.calls[1]![0])).toBe(
+      "https://second.example.com/api/probes",
+    );
+  });
+
+  it("relays the upstream non-2xx status and body through", async () => {
+    process.env.OPS_BASE_URL = "https://harness.example.com";
+    fetchSpy.mockResolvedValue(
+      new Response("boom", { status: 502, statusText: "Bad Gateway" }),
+    );
+
+    const res = await GET(
+      makeRequest("http://dashboard.local/api/ops/probes"),
+      ctx(["probes"]),
+    );
+
+    expect(res.status).toBe(502);
+    await expect(res.text()).resolves.toBe("boom");
+  });
+
+  it("forwards POST method + body to the harness", async () => {
+    process.env.OPS_BASE_URL = "https://harness.example.com";
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ runId: "r1" }), { status: 200 }),
+    );
+
+    await POST(
+      makeRequest("http://dashboard.local/api/ops/probes/smoke/trigger", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ slugs: ["a"] }),
+      }),
+      ctx(["probes", "smoke", "trigger"]),
+    );
+
+    const [calledUrl, calledInit] = fetchSpy.mock.calls[0]!;
+    expect(String(calledUrl)).toBe(
+      "https://harness.example.com/api/probes/smoke/trigger",
+    );
+    expect((calledInit as RequestInit).method).toBe("POST");
+    expect((calledInit as RequestInit).body).toBeDefined();
+  });
+
+  it("returns 503 (not a throw/500) when OPS_BASE_URL is unset", async () => {
+    delete process.env.OPS_BASE_URL;
+
+    const res = await GET(
+      makeRequest("http://dashboard.local/api/ops/probes"),
+      ctx(["probes"]),
+    );
+
+    expect(res.status).toBe(503);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/OPS_BASE_URL/);
+  });
+
+  it("returns 502 when the upstream fetch rejects (harness unreachable)", async () => {
+    process.env.OPS_BASE_URL = "https://harness.example.com";
+    fetchSpy.mockRejectedValue(new Error("ENOTFOUND"));
+
+    const res = await GET(
+      makeRequest("http://dashboard.local/api/ops/probes"),
+      ctx(["probes"]),
+    );
+
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/ENOTFOUND/);
+  });
+});

--- a/showcase/shell-dashboard/src/app/api/ops/[...path]/route.ts
+++ b/showcase/shell-dashboard/src/app/api/ops/[...path]/route.ts
@@ -168,27 +168,42 @@ async function proxy(
 
 type RouteContext = { params: Promise<{ path: string[] }> };
 
-export async function GET(req: NextRequest, ctx: RouteContext): Promise<Response> {
+export async function GET(
+  req: NextRequest,
+  ctx: RouteContext,
+): Promise<Response> {
   const { path } = await ctx.params;
   return proxy(req, path);
 }
 
-export async function POST(req: NextRequest, ctx: RouteContext): Promise<Response> {
+export async function POST(
+  req: NextRequest,
+  ctx: RouteContext,
+): Promise<Response> {
   const { path } = await ctx.params;
   return proxy(req, path);
 }
 
-export async function PUT(req: NextRequest, ctx: RouteContext): Promise<Response> {
+export async function PUT(
+  req: NextRequest,
+  ctx: RouteContext,
+): Promise<Response> {
   const { path } = await ctx.params;
   return proxy(req, path);
 }
 
-export async function PATCH(req: NextRequest, ctx: RouteContext): Promise<Response> {
+export async function PATCH(
+  req: NextRequest,
+  ctx: RouteContext,
+): Promise<Response> {
   const { path } = await ctx.params;
   return proxy(req, path);
 }
 
-export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<Response> {
+export async function DELETE(
+  req: NextRequest,
+  ctx: RouteContext,
+): Promise<Response> {
   const { path } = await ctx.params;
   return proxy(req, path);
 }

--- a/showcase/shell-dashboard/src/app/api/ops/[...path]/route.ts
+++ b/showcase/shell-dashboard/src/app/api/ops/[...path]/route.ts
@@ -1,0 +1,194 @@
+/**
+ * Runtime proxy for the showcase-harness ops HTTP API.
+ *
+ * The Status tab fetches `/api/ops/*` as a same-origin path (see
+ * `src/lib/ops-api.ts`). This Route Handler forwards those requests, at
+ * REQUEST time, to the harness at `${OPS_BASE_URL}/api/*`.
+ *
+ * Why a Route Handler and not a `next.config.ts` rewrite:
+ *   `rewrites()` is evaluated by `next build` and frozen into the prebuilt
+ *   Docker image. The shared CI build bakes a placeholder (`http://ops.invalid`)
+ *   to satisfy the build, so every deploy of the single `:latest` image
+ *   proxied to a dead host regardless of its runtime `OPS_BASE_URL`. By
+ *   reading `process.env.OPS_BASE_URL` inside the handler — forced dynamic so
+ *   Next.js never statically caches it — each Railway environment resolves its
+ *   own harness URL from the same image, with no rebuild.
+ *
+ * Same-origin (vs. a direct cross-origin browser call) is still required
+ * because the harness has no CORS allowlist, and it keeps the harness URL
+ * out of the client bundle.
+ *
+ * Path mapping: the client calls `/api/ops/probes`, which arrives here as
+ * `path = ["probes"]` and is proxied to `${OPS_BASE_URL}/api/probes`. The
+ * harness serves its endpoints under `/api/*`, so the proxied prefix is a
+ * single `/api` — never doubled, never dropped.
+ */
+import type { NextRequest } from "next/server";
+
+// Read OPS_BASE_URL per request from the live process env. force-dynamic +
+// revalidate 0 guarantee this handler is never statically optimized or
+// cached, so the value is resolved at runtime on every request rather than
+// frozen at build time.
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+// The handler proxies arbitrary harness routes (incl. POST trigger) and must
+// run on the Node.js runtime so it can read the full process env.
+export const runtime = "nodejs";
+
+/**
+ * Resolve the harness base URL from the runtime env. Returns `null` (rather
+ * than throwing, as the old build-time guard did) so the handler can answer
+ * with a clear 503 instead of crashing the request — the wiring bug is then
+ * visible in the response, not a build failure.
+ */
+function resolveOpsBaseUrl(): string | null {
+  // Read the non-public `OPS_BASE_URL` only. The `NEXT_PUBLIC_*`-prefixed
+  // alternate is intentionally NOT consulted here: it is banned in shell
+  // source by the `copilotkit/no-public-env-shell-read` oxlint rule (a
+  // `NEXT_PUBLIC_*` read is the build-freeze footgun this whole change
+  // exists to remove). `OPS_BASE_URL` is the canonical runtime var per
+  // showcase/RAILWAY.md and runtime-config.ts.
+  const raw = process.env.OPS_BASE_URL;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  // Strip trailing slashes so we never produce `https://host//api/...`
+  // (some servers reject the double slash). Mirrors the normalization in
+  // `src/lib/ops-api.ts:resolveBaseUrl`.
+  return trimmed.replace(/\/+$/, "");
+}
+
+/**
+ * Build the upstream harness URL for an incoming `/api/ops/*` request.
+ * `pathSegments` is the `[...path]` capture (e.g. `["probes", "<id>"]`),
+ * which maps to `${base}/api/<segments>` plus the original query string.
+ */
+function buildUpstreamUrl(
+  base: string,
+  pathSegments: string[],
+  search: string,
+): string {
+  const encoded = pathSegments
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  return `${base}/api/${encoded}${search}`;
+}
+
+// Hop-by-hop and host-specific headers must NOT be forwarded to the upstream
+// (host would point fetch at the wrong origin; connection/length are managed
+// by the fetch/runtime layer). Everything else (content-type, accept,
+// authorization, etc.) is forwarded so the trigger token and JSON negotiation
+// reach the harness intact.
+const STRIPPED_REQUEST_HEADERS = new Set([
+  "host",
+  "connection",
+  "content-length",
+  "transfer-encoding",
+  "accept-encoding",
+]);
+
+// Strip the upstream's content-encoding/length when relaying back — `fetch`
+// has already decoded the body, so re-advertising the original encoding would
+// corrupt the client-visible response.
+const STRIPPED_RESPONSE_HEADERS = new Set([
+  "content-encoding",
+  "content-length",
+  "transfer-encoding",
+  "connection",
+]);
+
+async function proxy(
+  req: NextRequest,
+  pathSegments: string[],
+): Promise<Response> {
+  const base = resolveOpsBaseUrl();
+  if (!base) {
+    return Response.json(
+      {
+        error:
+          "OPS_BASE_URL is not set on this deploy — the ops proxy cannot reach " +
+          "showcase-harness. Set OPS_BASE_URL on the Railway service (see " +
+          "showcase/RAILWAY.md).",
+      },
+      { status: 503 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const upstreamUrl = buildUpstreamUrl(base, pathSegments, url.search);
+
+  const headers = new Headers();
+  req.headers.forEach((value, key) => {
+    if (!STRIPPED_REQUEST_HEADERS.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  });
+
+  // GET/HEAD requests must not carry a body. For other methods, stream the
+  // incoming body through to the harness (covers the POST trigger payload).
+  const method = req.method.toUpperCase();
+  const hasBody = method !== "GET" && method !== "HEAD";
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method,
+      headers,
+      body: hasBody ? await req.arrayBuffer() : undefined,
+      // Never let Next.js or the platform cache the proxied response — the
+      // Status tab polls live data and must see current harness state.
+      cache: "no-store",
+      redirect: "manual",
+    });
+  } catch (err) {
+    // Upstream unreachable (DNS/connection failure). Surface a 502 with the
+    // target so the failure is attributable instead of a generic 500.
+    const message = err instanceof Error ? err.message : String(err);
+    return Response.json(
+      { error: `ops proxy failed to reach ${upstreamUrl}: ${message}` },
+      { status: 502 },
+    );
+  }
+
+  // Relay the upstream status + body, copying through headers except the
+  // encoding/length ones that fetch has already resolved.
+  const responseHeaders = new Headers();
+  upstreamResponse.headers.forEach((value, key) => {
+    if (!STRIPPED_RESPONSE_HEADERS.has(key.toLowerCase())) {
+      responseHeaders.set(key, value);
+    }
+  });
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: responseHeaders,
+  });
+}
+
+type RouteContext = { params: Promise<{ path: string[] }> };
+
+export async function GET(req: NextRequest, ctx: RouteContext): Promise<Response> {
+  const { path } = await ctx.params;
+  return proxy(req, path);
+}
+
+export async function POST(req: NextRequest, ctx: RouteContext): Promise<Response> {
+  const { path } = await ctx.params;
+  return proxy(req, path);
+}
+
+export async function PUT(req: NextRequest, ctx: RouteContext): Promise<Response> {
+  const { path } = await ctx.params;
+  return proxy(req, path);
+}
+
+export async function PATCH(req: NextRequest, ctx: RouteContext): Promise<Response> {
+  const { path } = await ctx.params;
+  return proxy(req, path);
+}
+
+export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<Response> {
+  const { path } = await ctx.params;
+  return proxy(req, path);
+}

--- a/showcase/shell-dashboard/src/lib/ops-api.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.ts
@@ -14,11 +14,12 @@
  *      populated at request time by the root layout's inline <script>) —
  *      opt-in escape hatch for direct cross-origin calls; production does
  *      NOT set this because showcase-harness has no CORS allowlist.
- *   3. `/api/ops` — same-origin path served by the Next.js rewrite in
- *      `next.config.ts`. This is the production contract, not a guess: the
- *      rewrite forwards `/api/ops/:path*` to `${OPS_BASE_URL}/api/:path*`
- *      on the server side, so the browser only ever sees same-origin calls
- *      and `OPS_BASE_URL` stays out of the client bundle.
+ *   3. `/api/ops` — same-origin path served by the Route Handler in
+ *      `src/app/api/ops/[...path]/route.ts`. This is the production
+ *      contract, not a guess: the handler forwards `/api/ops/<path>` to
+ *      `${OPS_BASE_URL}/api/<path>` on the server side (reading
+ *      `OPS_BASE_URL` at request time), so the browser only ever sees
+ *      same-origin calls and `OPS_BASE_URL` stays out of the client bundle.
  *
  * The trigger token is supplied by the caller (typically read from
  * `process.env.NEXT_PUBLIC_OPS_TRIGGER_TOKEN` at the React layer).
@@ -143,7 +144,7 @@ const FALLBACK_BASE_URL = "/api/ops";
  *     direct cross-origin calls (e.g. local dev hitting a remote
  *     harness). Production deploys leave this empty so the call stays
  *     same-origin via the next.config.ts rewrite.
- *  3. `/api/ops` — same-origin path served by the Next.js rewrite.
+ *  3. `/api/ops` — same-origin path served by the Route Handler.
  *
  * Whitespace-only and empty values are treated as missing — the same
  * defensive trim as the prior `process.env.NEXT_PUBLIC_OPS_BASE_URL?.trim()`

--- a/showcase/shell-dashboard/src/lib/runtime-config.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.ts
@@ -20,7 +20,8 @@ export interface RuntimeConfig {
   pocketbaseUrl: string;
   /** Showcase shell host — used to build Demo / Code / docs-shell links. */
   shellUrl: string;
-  /** Ops API base URL — server-side rewrite target for /api/ops/*. */
+  /** Ops API base URL — request-time proxy target for /api/ops/* (served
+   * by the Route Handler at src/app/api/ops/[...path]/route.ts). */
   opsBaseUrl: string;
 }
 
@@ -63,11 +64,11 @@ export function getRuntimeConfig(
   );
   const opsBaseUrl = readUrl(
     "OPS_BASE_URL",
-    // shell-dashboard's next.config.ts validates OPS_BASE_URL at
-    // start time, so reaching the fallback here means something
-    // is wrong with the launch sequence. Use a sentinel that
-    // produces visible breakage rather than silently routing to
-    // a guessed host.
+    // The /api/ops proxy Route Handler reads OPS_BASE_URL directly at
+    // request time and returns a 503 when it is unset, so reaching this
+    // fallback only matters for any server component that surfaces the
+    // configured value. Use a sentinel that produces visible breakage
+    // rather than silently routing to a guessed host.
     isProd ? "http://ops.invalid" : "http://localhost:9020",
     isProd,
   );

--- a/showcase/shell-dashboard/tests/runtime-env-switch.spike.test.ts
+++ b/showcase/shell-dashboard/tests/runtime-env-switch.spike.test.ts
@@ -12,10 +12,11 @@ import { setTimeout as wait } from "node:timers/promises";
 // into the bundle), this test fails because the first boot's URL
 // values leak into the second boot's HTML.
 //
-// One nuance vs the original spike: shell-dashboard's next.config.ts
-// `rewrites()` reads OPS_BASE_URL and Next.js evaluates rewrites at
-// build time (not only at start). So we DO pass an OPS_BASE_URL at
-// build — but the value is a sentinel placeholder that no boot uses.
+// The /api/ops/* proxy is served by the Route Handler at
+// `src/app/api/ops/[...path]/route.ts`, which reads OPS_BASE_URL from
+// process.env at REQUEST time — so the build does NOT need OPS_BASE_URL
+// at all. We still pass a sentinel placeholder at build to prove the
+// build tolerates (and ignores) it; no boot ever uses that value.
 // The properties under test (the inlined __SHOWCASE_CONFIG__ script
 // emitted by `src/app/layout.tsx`) are read from process.env at
 // request time by `getRuntimeConfig()` and therefore reflect the
@@ -29,17 +30,19 @@ const PORT_B = 3802;
 // resolution.
 const SHELL_DASHBOARD_DIR = import.meta.dirname + "/..";
 
-// Sentinel used ONLY to satisfy next.config.ts rewrites() during
-// `next build`. Per-boot env vars below override this for the
-// __SHOWCASE_CONFIG__ injection that the test actually asserts on.
+// Sentinel passed at `next build` time purely to prove the build
+// tolerates and ignores it (the proxy now resolves OPS_BASE_URL at
+// request time in the Route Handler, not at build). Per-boot env vars
+// below drive the __SHOWCASE_CONFIG__ injection the test asserts on.
 const BUILD_TIME_OPS_PLACEHOLDER = "http://build-placeholder.invalid";
 
 describe("Option B: one artifact, two env values, no rebuild", () => {
   beforeAll(() => {
-    // Build ONCE. Pass a placeholder OPS_BASE_URL only so
-    // next.config.ts:rewrites() can construct its proxy entry.
-    // No POCKETBASE_URL / SHELL_URL — those are read at request
-    // time by getRuntimeConfig() and must not be required at build.
+    // Build ONCE. The placeholder OPS_BASE_URL is passed only to prove
+    // the build ignores it — the /api/ops proxy resolves OPS_BASE_URL at
+    // request time in the Route Handler. No POCKETBASE_URL / SHELL_URL —
+    // those are read at request time by getRuntimeConfig() and must not
+    // be required at build.
     //
     // Use `npm run build` (not `npx next build` directly) so the
     // `prebuild` script runs and the generated data fixtures


### PR DESCRIPTION
## Root cause: build-time freeze of OPS_BASE_URL

The shell-dashboard ships as a **prebuilt** Docker image (`ghcr.io/copilotkit/showcase-shell-dashboard:latest`). The Feature Matrix health overlay calls `/api/ops/probes`, which was served by a `next.config.ts` `rewrites()` entry proxying `/api/ops/:path*` → `${process.env.OPS_BASE_URL}/api/:path*`.

Next.js evaluates `rewrites()` at **`next build`** and freezes the result into the image. To satisfy a throw-if-unset guard, the build was fed the placeholder `OPS_BASE_URL=http://ops.invalid`, which got **frozen into the artifact**. So at runtime:

- every `/api/ops/*` call → `ENOTFOUND ops.invalid` → **500**
- the overlay got no probe data → **downgraded every Feature Matrix cell to amber** (zero green), even though staging PocketBase data was green
- the correct Railway runtime env `OPS_BASE_URL=https://harness-staging-2ee4.up.railway.app` was **ignored** because the value was frozen at build

Same freeze bakes the **production** harness URL into the single shared `:latest` image, so even a correct rebuild would point staging's proxy at the prod harness.

## Fix: runtime-resolved Route Handler

- New `src/app/api/ops/[...path]/route.ts` proxies at **request time**: reads `process.env.OPS_BASE_URL` per request (`export const dynamic = "force-dynamic"`, `revalidate = 0`, `runtime = "nodejs"` — never statically cached), forwards method + query string + headers + body, and relays the upstream status + body. GET/POST/PUT/PATCH/DELETE supported.
- Path mapping: `/api/ops/probes` → `${OPS_BASE_URL}/api/probes` (single `/api`, trailing slashes normalized; never doubled/dropped). Matches the post-rearch harness, which serves `/api/probes`.
- Missing `OPS_BASE_URL` at runtime → clear **503** (not a build throw). Unreachable upstream → **502** with the target URL.
- Removed the `/api/ops/*` rewrite **and** the build-time throw-if-unset guard from `next.config.ts`. The build no longer depends on `OPS_BASE_URL`.
- The Route Handler reads only the non-public `OPS_BASE_URL` (the `NEXT_PUBLIC_*` alternate is banned in shell source by the `copilotkit/no-public-env-shell-read` oxlint rule — a public read is the exact build-freeze footgun this change removes).
- Updated stale comments in `ops-api.ts`, `runtime-config.ts`, and the env-switch spike test that referenced the old rewrite.

### Resolves both traps with one image
Each environment now resolves its **own** runtime `OPS_BASE_URL` from the same shared artifact — staging proxies to the staging harness, prod to the prod harness, no rebuild required.

## Validation
- **Build without `OPS_BASE_URL`** → succeeds. `/api/ops/[...path]` reported as `ƒ (Dynamic) server-rendered on demand` (not statically optimized).
- **Live runtime proxy**: started the production server (built with no `OPS_BASE_URL`) with `OPS_BASE_URL=https://harness-staging-2ee4.up.railway.app`; `GET /api/ops/probes` returned the live staging-harness probes JSON (200, `cache-control: no-cache`), proving runtime resolution + correct path mapping.
- New `route.test.ts`: 7 tests (request-time env resolution, path/query mapping, status/body relay, POST body forwarding, 503-when-unset, 502-on-upstream-failure). Red-green verified.
- Full package unit suite: **686 passed, 1 skipped**. Typecheck clean. oxlint clean on changed files.

## Deploy note
**Requires the dashboard image to rebuild + redeploy.** Each Railway environment must have `OPS_BASE_URL` set (staging: `https://harness-staging-2ee4.up.railway.app`). The shared CI build no longer needs to bake any harness URL.

## Test plan
- [ ] CI green
- [ ] Rebuild + redeploy `showcase-shell-dashboard` image
- [ ] Confirm staging Feature Matrix overlay shows green cells (probe data flowing via `/api/ops/probes`)