### PR TITLE
fix(showcase/shell-dashboard): keep client ops fetch same-origin via /api/ops

### DIFF
--- a/showcase/shell-dashboard/src/app/layout.tsx
+++ b/showcase/shell-dashboard/src/app/layout.tsx
@@ -47,6 +47,14 @@ export default function RootLayout({
   // inside getRuntimeConfig opts this segment out of the static
   // cache so the inline <script> below always reflects the current
   // Railway env vars.
+  //
+  // NOTE: `runtimeConfig.opsBaseUrl` is the CLIENT direct override
+  // (`NEXT_PUBLIC_OPS_DIRECT_BASE_URL`, default ""), NOT the server proxy
+  // target `OPS_BASE_URL`. The harness URL must never be serialized into
+  // `window.__SHOWCASE_CONFIG__` — doing so makes the browser fetch the
+  // harness cross-origin (CORS-blocked). With opsBaseUrl empty the client
+  // uses the same-origin `/api/ops` proxy, which reads `OPS_BASE_URL`
+  // server-side in the Route Handler.
   const runtimeConfig = getRuntimeConfig();
   const injection = `window.__SHOWCASE_CONFIG__=${serializeRuntimeConfig(runtimeConfig)};`;
 

--- a/showcase/shell-dashboard/src/lib/ops-api.test.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.test.ts
@@ -115,6 +115,45 @@ describe("fetchProbes", () => {
     expect(String(url)).toBe("https://ops.example.com/probes");
   });
 
+  it("uses same-origin /api/ops when opsBaseUrl is empty (no client-direct override)", async () => {
+    // Regression for the staging no-data bug: when the injected client
+    // config carries an EMPTY opsBaseUrl (the production default — the
+    // server proxy target OPS_BASE_URL is NOT leaked into the client),
+    // the client must fall through to the same-origin /api/ops proxy
+    // rather than fetching the harness cross-origin.
+    (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
+      {
+        pocketbaseUrl: "",
+        shellUrl: "",
+        opsBaseUrl: "",
+      };
+    fetchSpy.mockResolvedValue(jsonResponse(emptyProbesResponse()));
+    await fetchProbes();
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toBe("/api/ops/probes");
+    // And explicitly NOT the cross-origin harness path.
+    expect(String(url)).not.toMatch(/^https?:\/\//);
+  });
+
+  it("does NOT fetch the harness directly when only the server proxy target is configured", async () => {
+    // The injected client config never carries the harness URL as a
+    // fetch base in production. Simulate the post-fix injection: the
+    // server proxy target lives only in process.env.OPS_BASE_URL (read
+    // by the Route Handler), and the client config's opsBaseUrl stays
+    // empty. The client must hit /api/ops, never the harness origin.
+    (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
+      {
+        pocketbaseUrl: "",
+        shellUrl: "",
+        opsBaseUrl: "",
+      };
+    fetchSpy.mockResolvedValue(jsonResponse(emptyProbesResponse()));
+    await fetchProbes();
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toBe("/api/ops/probes");
+    expect(String(url)).not.toContain("harness-staging");
+  });
+
   it("strips trailing slashes from baseUrl", async () => {
     fetchSpy.mockResolvedValue(jsonResponse(emptyProbesResponse()));
     await fetchProbes({ baseUrl: "http://ops.test/" });

--- a/showcase/shell-dashboard/src/lib/ops-api.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.ts
@@ -12,8 +12,13 @@
  *   1. explicit `baseUrl` param (overrides everything; used in tests + SSR)
  *   2. `runtimeConfig.opsBaseUrl` (read from `window.__SHOWCASE_CONFIG__`,
  *      populated at request time by the root layout's inline <script>) —
- *      opt-in escape hatch for direct cross-origin calls; production does
- *      NOT set this because showcase-harness has no CORS allowlist.
+ *      opt-in escape hatch for direct cross-origin calls, sourced from the
+ *      client-intended `NEXT_PUBLIC_OPS_DIRECT_BASE_URL` env var. This is
+ *      DISTINCT from the server proxy target `OPS_BASE_URL` (read only by
+ *      the Route Handler). It defaults to "" — including in production —
+ *      so the client falls through to step 3; the harness URL is never
+ *      injected into the client bundle (showcase-harness has no CORS
+ *      allowlist, so a direct cross-origin call would be blocked).
  *   3. `/api/ops` — same-origin path served by the Route Handler in
  *      `src/app/api/ops/[...path]/route.ts`. This is the production
  *      contract, not a guess: the handler forwards `/api/ops/<path>` to
@@ -140,11 +145,13 @@ const FALLBACK_BASE_URL = "/api/ops";
 /**
  * Resolve the API base URL with this precedence:
  *  1. explicit `baseUrl` param — used in tests + SSR.
- *  2. `runtimeConfig.opsBaseUrl` — set by the env when a deploy wants
+ *  2. `runtimeConfig.opsBaseUrl` — the client DIRECT override, sourced
+ *     from `NEXT_PUBLIC_OPS_DIRECT_BASE_URL`, for deploys that want
  *     direct cross-origin calls (e.g. local dev hitting a remote
- *     harness). Production deploys leave this empty so the call stays
- *     same-origin via the next.config.ts rewrite.
- *  3. `/api/ops` — same-origin path served by the Route Handler.
+ *     harness). Production leaves this empty (it is NOT the server proxy
+ *     target `OPS_BASE_URL`) so the call stays same-origin via step 3.
+ *  3. `/api/ops` — same-origin path served by the Route Handler, which
+ *     forwards to `${OPS_BASE_URL}/api/<path>` server-side.
  *
  * Whitespace-only and empty values are treated as missing — the same
  * defensive trim as the prior `process.env.NEXT_PUBLIC_OPS_BASE_URL?.trim()`

--- a/showcase/shell-dashboard/src/lib/runtime-config.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.test.ts
@@ -44,7 +44,8 @@ describe("server getRuntimeConfig (shell-dashboard)", () => {
     process.env.OPS_BASE_URL = "https://harness-staging-2ee4.up.railway.app";
     // Client direct override — explicit opt-in, sourced from the
     // NEXT_PUBLIC_OPS_DIRECT_BASE_URL var.
-    process.env.NEXT_PUBLIC_OPS_DIRECT_BASE_URL = "https://ops-direct.example.com";
+    process.env.NEXT_PUBLIC_OPS_DIRECT_BASE_URL =
+      "https://ops-direct.example.com";
     expect(getRuntimeConfig()).toEqual({
       pocketbaseUrl: "https://pocketbase-staging-eec0.up.railway.app",
       shellUrl: "https://showcase.staging.copilotkit.ai",

--- a/showcase/shell-dashboard/src/lib/runtime-config.test.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.test.ts
@@ -19,9 +19,11 @@ describe("server getRuntimeConfig (shell-dashboard)", () => {
       "POCKETBASE_URL",
       "SHELL_URL",
       "OPS_BASE_URL",
+      "OPS_DIRECT_BASE_URL",
       "NEXT_PUBLIC_POCKETBASE_URL",
       "NEXT_PUBLIC_SHELL_URL",
       "NEXT_PUBLIC_OPS_BASE_URL",
+      "NEXT_PUBLIC_OPS_DIRECT_BASE_URL",
       "NODE_ENV",
     ]) {
       delete (process.env as Record<string, string | undefined>)[k];
@@ -37,19 +39,37 @@ describe("server getRuntimeConfig (shell-dashboard)", () => {
     process.env.POCKETBASE_URL =
       "https://pocketbase-staging-eec0.up.railway.app";
     process.env.SHELL_URL = "https://showcase.staging.copilotkit.ai";
+    // Server proxy target (read only by the Route Handler) — must NOT
+    // become the client-injected opsBaseUrl.
     process.env.OPS_BASE_URL = "https://harness-staging-2ee4.up.railway.app";
+    // Client direct override — explicit opt-in, sourced from the
+    // NEXT_PUBLIC_OPS_DIRECT_BASE_URL var.
+    process.env.NEXT_PUBLIC_OPS_DIRECT_BASE_URL = "https://ops-direct.example.com";
     expect(getRuntimeConfig()).toEqual({
       pocketbaseUrl: "https://pocketbase-staging-eec0.up.railway.app",
       shellUrl: "https://showcase.staging.copilotkit.ai",
-      opsBaseUrl: "https://harness-staging-2ee4.up.railway.app",
+      opsBaseUrl: "https://ops-direct.example.com",
     });
+  });
+
+  it("opsBaseUrl defaults to empty in prod even when OPS_BASE_URL (server proxy target) is set", () => {
+    // Regression for the staging no-data bug: the server proxy target
+    // OPS_BASE_URL must NOT leak into the client config as a fetch base.
+    // With no client-direct override, opsBaseUrl is empty so the client
+    // falls through to the same-origin /api/ops proxy.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.POCKETBASE_URL = "https://pb.example.com";
+    process.env.SHELL_URL = "https://shell.example.com";
+    process.env.OPS_BASE_URL = "https://harness-staging-2ee4.up.railway.app";
+    const cfg = getRuntimeConfig();
+    expect(cfg.opsBaseUrl).toBe("");
   });
 
   it("strips trailing slashes", () => {
     (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.POCKETBASE_URL = "https://pb.example.com/";
     process.env.SHELL_URL = "https://shell.example.com//";
-    process.env.OPS_BASE_URL = "https://ops.example.com///";
+    process.env.NEXT_PUBLIC_OPS_DIRECT_BASE_URL = "https://ops.example.com///";
     const cfg = getRuntimeConfig();
     expect(cfg.pocketbaseUrl).toBe("https://pb.example.com");
     expect(cfg.shellUrl).toBe("https://shell.example.com");
@@ -61,10 +81,12 @@ describe("server getRuntimeConfig (shell-dashboard)", () => {
     const cfg = getRuntimeConfig();
     expect(cfg.pocketbaseUrl).toBe("http://127.0.0.1:8090");
     expect(cfg.shellUrl).toBe("http://localhost:3000");
-    expect(cfg.opsBaseUrl).toBe("http://localhost:9020");
+    // No client-direct override set → empty so dev also uses /api/ops
+    // unless the developer opts in via NEXT_PUBLIC_OPS_DIRECT_BASE_URL.
+    expect(cfg.opsBaseUrl).toBe("");
   });
 
-  it("falls back to sentinels and console.errors in production", () => {
+  it("falls back to sentinels and console.errors in production (opsBaseUrl exempt)", () => {
     (process.env as Record<string, string>).NODE_ENV = "production";
     const errs: string[] = [];
     const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
@@ -74,10 +96,13 @@ describe("server getRuntimeConfig (shell-dashboard)", () => {
     spy.mockRestore();
     expect(cfg.pocketbaseUrl).toBe("http://pocketbase.invalid");
     expect(cfg.shellUrl).toBe("about:blank#shell-url-missing");
-    expect(cfg.opsBaseUrl).toBe("http://ops.invalid");
+    // opsBaseUrl is an opt-in client override, not a required URL: it
+    // defaults to empty (→ same-origin /api/ops) and does NOT emit a
+    // FATAL-CONFIG sentinel/error.
+    expect(cfg.opsBaseUrl).toBe("");
     expect(errs.some((m) => m.includes("POCKETBASE_URL"))).toBe(true);
     expect(errs.some((m) => m.includes("SHELL_URL"))).toBe(true);
-    expect(errs.some((m) => m.includes("OPS_BASE_URL"))).toBe(true);
+    expect(errs.some((m) => m.includes("OPS_BASE_URL"))).toBe(false);
   });
 
   it("reads live process.env on each call (no module-load freeze)", () => {
@@ -90,34 +115,47 @@ describe("server getRuntimeConfig (shell-dashboard)", () => {
     expect(getRuntimeConfig().pocketbaseUrl).toBe("https://second.example.com");
   });
 
-  it("accepts NEXT_PUBLIC_* fallbacks when bare names are unset", () => {
+  it("sources opsBaseUrl from NEXT_PUBLIC_OPS_DIRECT_BASE_URL, NOT the bare OPS_BASE_URL", () => {
+    // The client-direct override is ONLY the NEXT_PUBLIC_-prefixed name.
+    // The bare OPS_BASE_URL (server proxy target) must never leak into
+    // the client config — that is exactly the bug being fixed.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.POCKETBASE_URL = "https://pb.example.com";
+    process.env.SHELL_URL = "https://shell.example.com";
+    process.env.OPS_BASE_URL = "https://server-proxy-target.example.com";
+    const cfg = getRuntimeConfig();
+    expect(cfg.opsBaseUrl).toBe("");
+
+    process.env.NEXT_PUBLIC_OPS_DIRECT_BASE_URL =
+      "https://client-direct.example.com";
+    const cfg2 = getRuntimeConfig();
+    expect(cfg2.opsBaseUrl).toBe("https://client-direct.example.com");
+  });
+
+  it("accepts NEXT_PUBLIC_* fallbacks when bare names are unset (pb/shell)", () => {
     // Deploy-config contract: shell-dashboard reads bare names first,
     // but tolerates NEXT_PUBLIC_-prefixed variants so a Railway
     // service that follows the shell-docs naming convention still
     // wires through. See the readUrl fallback chain in
-    // runtime-config.ts.
+    // runtime-config.ts. (opsBaseUrl is intentionally exempt — it is
+    // sourced from the NEXT_PUBLIC_OPS_DIRECT_BASE_URL client override.)
     (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.NEXT_PUBLIC_POCKETBASE_URL = "https://alt-pb.example.com";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://alt-shell.example.com";
-    process.env.NEXT_PUBLIC_OPS_BASE_URL = "https://alt-ops.example.com";
     const cfg = getRuntimeConfig();
     expect(cfg.pocketbaseUrl).toBe("https://alt-pb.example.com");
     expect(cfg.shellUrl).toBe("https://alt-shell.example.com");
-    expect(cfg.opsBaseUrl).toBe("https://alt-ops.example.com");
   });
 
-  it("bare names take precedence over NEXT_PUBLIC_ variants when both set", () => {
+  it("bare names take precedence over NEXT_PUBLIC_ variants when both set (pb/shell)", () => {
     (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.POCKETBASE_URL = "https://primary-pb.example.com";
     process.env.SHELL_URL = "https://primary-shell.example.com";
-    process.env.OPS_BASE_URL = "https://primary-ops.example.com";
     process.env.NEXT_PUBLIC_POCKETBASE_URL = "https://alt-pb.example.com";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://alt-shell.example.com";
-    process.env.NEXT_PUBLIC_OPS_BASE_URL = "https://alt-ops.example.com";
     const cfg = getRuntimeConfig();
     expect(cfg.pocketbaseUrl).toBe("https://primary-pb.example.com");
     expect(cfg.shellUrl).toBe("https://primary-shell.example.com");
-    expect(cfg.opsBaseUrl).toBe("https://primary-ops.example.com");
   });
 
   it("getRuntimeConfigForMiddleware skips noStore() (Edge runtime path)", async () => {

--- a/showcase/shell-dashboard/src/lib/runtime-config.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.ts
@@ -81,9 +81,7 @@ export function getRuntimeConfig(
   // proxy unless a developer explicitly opts in. No sentinel and no
   // FATAL-CONFIG: an unset override is the normal production case, not a
   // misconfiguration.
-  const opsBaseUrl = (
-    process.env.NEXT_PUBLIC_OPS_DIRECT_BASE_URL ?? ""
-  )
+  const opsBaseUrl = (process.env.NEXT_PUBLIC_OPS_DIRECT_BASE_URL ?? "")
     .trim()
     .replace(/\/+$/, "");
 

--- a/showcase/shell-dashboard/src/lib/runtime-config.ts
+++ b/showcase/shell-dashboard/src/lib/runtime-config.ts
@@ -20,8 +20,19 @@ export interface RuntimeConfig {
   pocketbaseUrl: string;
   /** Showcase shell host — used to build Demo / Code / docs-shell links. */
   shellUrl: string;
-  /** Ops API base URL — request-time proxy target for /api/ops/* (served
-   * by the Route Handler at src/app/api/ops/[...path]/route.ts). */
+  /**
+   * Client DIRECT ops base URL — an opt-in escape hatch for direct
+   * cross-origin calls (e.g. local dev hitting a remote harness),
+   * sourced from `NEXT_PUBLIC_OPS_DIRECT_BASE_URL`. Defaults to "" so
+   * `ops-api.ts:resolveBaseUrl()` falls through to the same-origin
+   * `/api/ops` proxy.
+   *
+   * This is DISTINCT from the server proxy target `OPS_BASE_URL`, which
+   * is read directly (server-only) by the Route Handler at
+   * `src/app/api/ops/[...path]/route.ts` and is intentionally NEVER
+   * injected into the client config — leaking it makes the browser fetch
+   * the harness cross-origin (CORS-blocked, wrong path).
+   */
   opsBaseUrl: string;
 }
 
@@ -62,16 +73,19 @@ export function getRuntimeConfig(
     isProd ? PROD_INVALID_SHELL_URL : "http://localhost:3000",
     isProd,
   );
-  const opsBaseUrl = readUrl(
-    "OPS_BASE_URL",
-    // The /api/ops proxy Route Handler reads OPS_BASE_URL directly at
-    // request time and returns a 503 when it is unset, so reaching this
-    // fallback only matters for any server component that surfaces the
-    // configured value. Use a sentinel that produces visible breakage
-    // rather than silently routing to a guessed host.
-    isProd ? "http://ops.invalid" : "http://localhost:9020",
-    isProd,
-  );
+  // Client DIRECT ops override — opt-in escape hatch for direct
+  // cross-origin calls. Sourced ONLY from the NEXT_PUBLIC_-prefixed
+  // client-intended name (NOT the bare server proxy target OPS_BASE_URL,
+  // which the Route Handler reads server-side). Defaults to "" in every
+  // environment so the client falls through to the same-origin /api/ops
+  // proxy unless a developer explicitly opts in. No sentinel and no
+  // FATAL-CONFIG: an unset override is the normal production case, not a
+  // misconfiguration.
+  const opsBaseUrl = (
+    process.env.NEXT_PUBLIC_OPS_DIRECT_BASE_URL ?? ""
+  )
+    .trim()
+    .replace(/\/+$/, "");
 
   return { pocketbaseUrl, shellUrl, opsBaseUrl };
 }

--- a/showcase/shell-dashboard/tests/runtime-env-switch.spike.test.ts
+++ b/showcase/shell-dashboard/tests/runtime-env-switch.spike.test.ts
@@ -107,11 +107,18 @@ describe("Option B: one artifact, two env values, no rebuild", () => {
     const cfg = await bootAndProbe(PORT_A, {
       POCKETBASE_URL: "https://pb-env-a.example.com",
       SHELL_URL: "https://shell-env-a.example.com",
+      // Server proxy target (read by the Route Handler) — must NOT leak
+      // into the injected client config.
       OPS_BASE_URL: "https://ops-env-a.example.com",
+      // Client-direct override (opt-in) — THIS is what flows into the
+      // injected __SHOWCASE_CONFIG__.opsBaseUrl.
+      NEXT_PUBLIC_OPS_DIRECT_BASE_URL: "https://ops-direct-env-a.example.com",
     });
     expect(cfg.pocketbaseUrl).toBe("https://pb-env-a.example.com");
     expect(cfg.shellUrl).toBe("https://shell-env-a.example.com");
-    expect(cfg.opsBaseUrl).toBe("https://ops-env-a.example.com");
+    // opsBaseUrl reflects the client-direct override, NOT the server
+    // proxy target OPS_BASE_URL.
+    expect(cfg.opsBaseUrl).toBe("https://ops-direct-env-a.example.com");
   }, 60_000);
 
   it("serves env-B URLs on the second boot of THE SAME ARTIFACT", async () => {
@@ -119,10 +126,25 @@ describe("Option B: one artifact, two env values, no rebuild", () => {
       POCKETBASE_URL: "https://pb-env-b.example.com",
       SHELL_URL: "https://shell-env-b.example.com",
       OPS_BASE_URL: "https://ops-env-b.example.com",
+      NEXT_PUBLIC_OPS_DIRECT_BASE_URL: "https://ops-direct-env-b.example.com",
     });
     expect(cfg.pocketbaseUrl).toBe("https://pb-env-b.example.com");
     expect(cfg.shellUrl).toBe("https://shell-env-b.example.com");
-    expect(cfg.opsBaseUrl).toBe("https://ops-env-b.example.com");
+    expect(cfg.opsBaseUrl).toBe("https://ops-direct-env-b.example.com");
+  }, 60_000);
+
+  it("does NOT leak the server proxy target OPS_BASE_URL into the client config", async () => {
+    // Regression for the staging no-data bug: a deploy that sets ONLY
+    // OPS_BASE_URL (server proxy target) and no client-direct override
+    // must inject an EMPTY opsBaseUrl so the client falls through to the
+    // same-origin /api/ops proxy instead of fetching the harness
+    // cross-origin (CORS-blocked + wrong path).
+    const cfg = await bootAndProbe(PORT_A, {
+      POCKETBASE_URL: "https://pb-leak.example.com",
+      SHELL_URL: "https://shell-leak.example.com",
+      OPS_BASE_URL: "https://harness-should-not-leak.example.com",
+    });
+    expect(cfg.opsBaseUrl).toBe("");
   }, 60_000);
 
   afterAll(() => {


### PR DESCRIPTION
## Summary

Follow-on to #5148. The staging D6 dashboard rendered **no data** (empty Ops tab, no green cells in the matrix overlay) even though the backend was healthy. Browser-console ground truth showed the **client** doing a direct cross-origin fetch to `https://harness-staging-2ee4.up.railway.app/probes` — CORS-blocked (harness has no `Access-Control-Allow-Origin`) and the wrong path (`/probes` vs `/api/probes`).

### Root cause
`getRuntimeConfig()` sourced the client `RuntimeConfig.opsBaseUrl` from the **server proxy target** `OPS_BASE_URL` (the harness URL on staging) and `layout.tsx` serialized it into `window.__SHOWCASE_CONFIG__`. So `ops-api.ts:resolveBaseUrl()` used the harness URL as the fetch base and bypassed the same-origin `/api/ops` Route Handler that #5148 added. The Route Handler reads `process.env.OPS_BASE_URL` itself, so the server proxy worked — but the client never called it.

### Fix
Decouple the two env surfaces:
- **Server proxy target** `OPS_BASE_URL` — server-only, read by the `/api/ops/[...path]` Route Handler; **never** injected into the client.
- **Client direct override** `NEXT_PUBLIC_OPS_DIRECT_BASE_URL` — opt-in escape hatch for direct cross-origin dev calls; **defaults to `""`** so the client falls through to the same-origin `/api/ops` proxy.

With the override empty (the normal production/staging case), the browser fetches `/api/ops/probes` (same-origin) → Route Handler → `${OPS_BASE_URL}/api/probes`. No CORS, correct path.

## Test plan
- [x] Red→green regression tests: `opsBaseUrl` defaults to `""` even when `OPS_BASE_URL` is set; sourced only from `NEXT_PUBLIC_OPS_DIRECT_BASE_URL`; empty override → client uses `/api/ops/probes`, never the harness directly; server proxy target does NOT leak into the client config.
- [x] `tsc --noEmit` clean; `vitest run` 48 files / 693 passing; `next build` green (incl. `/api/ops/[...path]` dynamic route).
- [ ] Post-merge: dashboard image rebuilds → staging redeploy → verify cells render green and Ops tab populates.