### PR TITLE
fix(angular): disable unlicensed watermark

### DIFF
--- a/.changeset/angular-disable-license-watermark.md
+++ b/.changeset/angular-disable-license-watermark.md
@@ -1,0 +1,11 @@
+---
+"@copilotkitnext/angular": patch
+---
+
+fix(angular): disable the unlicensed watermark
+
+The Angular SDK no longer renders the "CopilotKit Unlicensed" watermark (or logs
+the related "License Required" console warning) when no CopilotCloud license key
+is provided. The watermark implementation is kept in place and can be re-enabled
+by flipping `LICENSE_WATERMARK_ENABLED` back to `true`. The `licenseKey` option
+and its `X-CopilotCloud-Public-Api-Key` header injection are unchanged.

--- a/packages/angular/src/lib/config.ts
+++ b/packages/angular/src/lib/config.ts
@@ -6,6 +6,7 @@ import {
   HumanInTheLoopConfig,
   RenderToolCallConfig,
 } from "./tools";
+import { LICENSE_WATERMARK_ENABLED } from "./license-watermark";
 
 export interface CopilotKitConfig {
   runtimeUrl?: string;
@@ -85,7 +86,11 @@ export function injectCopilotKitConfig(): CopilotKitConfig {
 export function provideCopilotKit(config: CopilotKitConfig): Provider {
   const resolvedLicense = resolveLicense(config);
   const headers = config.headers ?? {};
-  if (!resolvedLicense.valid && resolvedLicense.warning) {
+  if (
+    LICENSE_WATERMARK_ENABLED &&
+    !resolvedLicense.valid &&
+    resolvedLicense.warning
+  ) {
     logLicenseWatermarkWarning(resolvedLicense.warning);
   }
 

--- a/packages/angular/src/lib/copilotkit.spec.ts
+++ b/packages/angular/src/lib/copilotkit.spec.ts
@@ -279,15 +279,13 @@ describe("CopilotKit", () => {
     expect(copilotKit.agents()).toEqual(core.agents);
   });
 
-  it("adds app watermark when license key is missing", () => {
+  it("does not add a watermark when license key is missing (watermark disabled)", () => {
     TestBed.configureTestingModule({
       providers: [provideCopilotKit({ runtimeUrl: "https://runtime.local" })],
     });
 
     TestBed.inject(CopilotKit);
 
-    expect(
-      document.getElementById("copilotkit-license-watermark"),
-    ).toBeTruthy();
+    expect(document.getElementById("copilotkit-license-watermark")).toBeNull();
   });
 });

--- a/packages/angular/src/lib/directives/__tests__/copilotkit-config.directive.spec.ts
+++ b/packages/angular/src/lib/directives/__tests__/copilotkit-config.directive.spec.ts
@@ -37,7 +37,7 @@ describe("CopilotKit config", () => {
     expect(fixture.componentInstance.config.headers).toBe(headers);
   });
 
-  it("does not throw when license key is missing and logs watermark warning", () => {
+  it("does not throw or warn when license key is missing (watermark disabled)", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     expect(() => {
@@ -46,7 +46,7 @@ describe("CopilotKit config", () => {
       });
     }).not.toThrow();
 
-    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("does not inject invalid license key into headers", () => {

--- a/packages/angular/src/lib/license-watermark.ts
+++ b/packages/angular/src/lib/license-watermark.ts
@@ -1,3 +1,7 @@
+// The license watermark is currently disabled. The implementation below is
+// kept intact so it can be re-enabled by flipping this flag back to `true`.
+export const LICENSE_WATERMARK_ENABLED = false;
+
 const WATERMARK_ID = "copilotkit-license-watermark";
 const HEADER_NAME = "X-CopilotCloud-Public-Api-Key";
 const LICENSE_KEY_REGEX = /^ck_pub_[0-9a-f]{32}$/i;
@@ -9,6 +13,10 @@ function hasValidLicenseHeader(headers?: Record<string, string>): boolean {
 }
 
 export function ensureLicenseWatermark(headers?: Record<string, string>): void {
+  if (!LICENSE_WATERMARK_ENABLED) {
+    return;
+  }
+
   if (typeof document === "undefined" || hasValidLicenseHeader(headers)) {
     return;
   }


### PR DESCRIPTION
## What

Disables the "CopilotKit Unlicensed" watermark in the Angular SDK. When no
CopilotCloud license key is provided, the SDK no longer:

- injects the fixed-position `copilotkit-license-watermark` element into the DOM, and
- logs the "License Required" console warning.

## How

The watermark is **not deleted** — it's gated behind a single
`LICENSE_WATERMARK_ENABLED` flag (now `false`) in
`packages/angular/src/lib/license-watermark.ts`. `ensureLicenseWatermark()`
early-returns when disabled, and `provideCopilotKit()` skips the console
warning on the same flag. Re-enabling is a one-line flip back to `true`.

The `licenseKey` option and its `X-CopilotCloud-Public-Api-Key` header
injection are unchanged — supplying a valid key still sets the Cloud header.

## Tests

Updated the two specs that asserted the active-watermark behavior to assert
the now-dormant behavior (no watermark element, no console warning). Full
Angular suite passes (48 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
