### PR TITLE
fix(runtime): Properly derive thread names from agents when generating them (fix ENT-732)

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
@@ -1,12 +1,7 @@
 import { Observable } from "rxjs";
 import { describe, it, expect, vi } from "vitest";
-import {
-  AbstractAgent,
-  BaseEvent,
-  EventType,
-  HttpAgent,
-  RunAgentInput,
-} from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import { AbstractAgent, EventType, HttpAgent } from "@ag-ui/client";
 import { A2UIMiddleware } from "@ag-ui/a2ui-middleware";
 import { handleRunAgent } from "../handlers/handle-run";
 import { CopilotRuntime } from "../core/runtime";
@@ -934,6 +929,11 @@ describe("handleRunAgent", () => {
               id: "assistant-1",
               role: "assistant",
               content: '{"title":"**Order refund** status"}',
+            },
+            {
+              id: "tool-1",
+              role: "tool",
+              content: '{"timezone":"UTC","iso":"2026-06-01T00:00:00Z"}',
             },
           ],
         }),

--- a/packages/runtime/src/v2/runtime/__tests__/thread-names.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/thread-names.test.ts
@@ -3,6 +3,7 @@ import type { Message } from "@ag-ui/client";
 
 import {
   ɵnormalizeGeneratedTitle as normalizeGeneratedTitle,
+  ɵselectGeneratedTitleFromMessages as selectGeneratedTitleFromMessages,
   ɵbuildThreadTitlePrompt as buildThreadTitlePrompt,
   ɵhasThreadName as hasThreadName,
 } from "../handlers/intelligence/thread-names";
@@ -80,12 +81,56 @@ describe("normalizeGeneratedTitle", () => {
   });
 
   it("handles JSON with non-string title gracefully", () => {
-    // Falls back to raw text path
-    expect(normalizeGeneratedTitle('{"title":42}')).toBe('{"title":42}');
+    expect(normalizeGeneratedTitle('{"title":42}')).toBeNull();
+  });
+
+  it("rejects JSON without a string title", () => {
+    expect(
+      normalizeGeneratedTitle(
+        '{"timezone":"UTC","iso":"2026-06-01T00:00:00Z"}',
+      ),
+    ).toBeNull();
   });
 
   it("handles malformed JSON gracefully", () => {
-    expect(normalizeGeneratedTitle("{not json}")).toBe("{not json}");
+    expect(normalizeGeneratedTitle("{not json}")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectGeneratedTitleFromMessages
+// ---------------------------------------------------------------------------
+
+describe("selectGeneratedTitleFromMessages", () => {
+  const msg = (role: string, content: unknown): Message =>
+    ({ id: `msg-${role}`, role, content }) as Message;
+
+  it("uses the latest valid assistant title before a tool result", () => {
+    const result = selectGeneratedTitleFromMessages([
+      msg("assistant", '{"title":"Weather request"}'),
+      msg("tool", '{"timezone":"UTC","iso":"2026-06-01T00:00:00Z"}'),
+    ]);
+
+    expect(result).toBe("Weather request");
+  });
+
+  it("ignores malformed assistant JSON and falls back to an earlier valid title", () => {
+    const result = selectGeneratedTitleFromMessages([
+      msg("assistant", '{"title":"Order refund"}'),
+      msg("assistant", '{"timezone":"UTC"}'),
+    ]);
+
+    expect(result).toBe("Order refund");
+  });
+
+  it("returns null when no assistant text response has a valid title", () => {
+    const result = selectGeneratedTitleFromMessages([
+      msg("tool", '{"title":"Tool payload"}'),
+      msg("assistant", { title: "Object payload" }),
+      msg("assistant", '{"title":42}'),
+    ]);
+
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts
@@ -1,12 +1,13 @@
-import { AbstractAgent, Message, RunAgentInput } from "@ag-ui/client";
+import type { Message, RunAgentInput } from "@ag-ui/client";
+import { AbstractAgent } from "@ag-ui/client";
 import { logger } from "@copilotkit/shared";
 import { randomUUID } from "node:crypto";
-import { CopilotIntelligenceRuntimeLike } from "../../core/runtime";
+import type { CopilotIntelligenceRuntimeLike } from "../../core/runtime";
 import {
   cloneAgentForRequest,
   configureAgentForRequest,
 } from "../shared/agent-utils";
-import { ThreadSummary } from "../../intelligence-platform";
+import type { ThreadSummary } from "../../intelligence-platform";
 import { isHandlerResponse } from "../shared/json-response";
 
 const THREAD_NAME_SYSTEM_PROMPT = [
@@ -139,12 +140,7 @@ async function runTitleGenerationAttempt(params: {
     forwardedProps: {},
   });
 
-  const lastMessage = newMessages.at(-1);
-  const titleContent = lastMessage
-    ? stringifyMessageContent(lastMessage.content)
-    : "";
-
-  return normalizeGeneratedTitle(titleContent);
+  return selectGeneratedTitleFromMessages(newMessages);
 }
 
 function buildThreadTitlePrompt(
@@ -203,13 +199,19 @@ function normalizeGeneratedTitle(rawTitle: string): string | null {
     .replace(/\s*```$/, "")
     .trim();
 
+  const jsonLike = isJsonLike(candidate);
+
   try {
     const parsed = JSON.parse(candidate) as { title?: unknown };
     if (typeof parsed.title === "string") {
       candidate = parsed.title;
+    } else if (jsonLike) {
+      return null;
     }
   } catch {
-    // Fall back to using the raw text.
+    if (jsonLike) {
+      return null;
+    }
   }
 
   candidate = candidate
@@ -234,12 +236,38 @@ function normalizeGeneratedTitle(rawTitle: string): string | null {
   return candidate;
 }
 
+function selectGeneratedTitleFromMessages(messages: Message[]): string | null {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.role !== "assistant" || typeof message.content !== "string") {
+      continue;
+    }
+
+    const title = normalizeGeneratedTitle(message.content);
+    if (title) {
+      return title;
+    }
+  }
+
+  return null;
+}
+
+function isJsonLike(candidate: string): boolean {
+  return (
+    (candidate.startsWith("{") && candidate.endsWith("}")) ||
+    (candidate.startsWith("[") && candidate.endsWith("]"))
+  );
+}
+
 function hasThreadName(name: string | null | undefined): boolean {
   return typeof name === "string" && name.trim().length > 0;
 }
 
 /** @internal Exported for testing only. */
 export const ɵnormalizeGeneratedTitle = normalizeGeneratedTitle;
+/** @internal Exported for testing only. */
+export const ɵselectGeneratedTitleFromMessages =
+  selectGeneratedTitleFromMessages;
 /** @internal Exported for testing only. */
 export const ɵbuildThreadTitlePrompt = buildThreadTitlePrompt;
 /** @internal Exported for testing only. */


### PR DESCRIPTION
## Summary
- Select generated thread titles only from assistant text messages returned by the naming run.
- Reject JSON-shaped title output unless it parses to an object with a string title.
- Add Runtime regression coverage for tool-result suffixes and invalid JSON title payloads.

## Validation
- pnpm nx run @copilotkit/runtime:test -- src/v2/runtime/__tests__/thread-names.test.ts src/v2/runtime/__tests__/handle-run.test.ts (passed, 56 tests)
- pnpm nx run @copilotkit/runtime:build (passed)
- Pre-commit package checks passed
- pnpm nx run @copilotkit/runtime:check-types (blocked in dependency task @copilotkit/shared:check-types: missing LicenseContextValue/LicenseMode exports from @copilotkit/license-verifier and telemetry index error)
- NODE_OPTIONS=--max-old-space-size=8192 pnpm nx run @copilotkit/runtime:check-types --excludeTaskDependencies (failed: tsc heap out of memory near 8 GB)