### PR TITLE
feat(react-core): add showIntelligenceIndicator prop to opt out of auto-mounted pill

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -387,7 +387,7 @@ export function CopilotChatMessageView({
 }: CopilotChatMessageViewProps) {
   const renderCustomMessage = useRenderCustomMessages();
   const { renderActivityMessage } = useRenderActivityMessage();
-  const { copilotkit } = useCopilotKit();
+  const { copilotkit, showIntelligenceIndicator = true } = useCopilotKit();
   const config = useCopilotChatConfiguration();
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
 
@@ -613,7 +613,15 @@ export function CopilotChatMessageView({
     // assistant messages avoids the per-slot `useAgent` subscription
     // and four effects on user/reasoning/activity slots that would just
     // return null at the role gate anyway.
-    if (copilotkit.intelligence !== undefined && message.role === "assistant") {
+    //
+    // Suppressed entirely when `showIntelligenceIndicator` is `false`
+    // (set via the `CopilotKitProvider` prop) so apps with their own
+    // custom intelligence status UI can opt out.
+    if (
+      showIntelligenceIndicator &&
+      copilotkit.intelligence !== undefined &&
+      message.role === "assistant"
+    ) {
       elements.push(
         <IntelligenceIndicator
           key={`${message.id}-intelligence`}

--- a/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
@@ -151,18 +151,22 @@ const RunAgentHarness: React.FC<{ withIntelligence: boolean }> = ({
 
 interface RenderOptions {
   withIntelligence?: boolean;
+  showIntelligenceIndicator?: boolean;
 }
 
 const renderForIndicator = (
   agent: MockStepwiseAgent,
   options: RenderOptions = {},
 ): void => {
-  const { withIntelligence = true } = options;
+  const { withIntelligence = true, showIntelligenceIndicator } = options;
 
   // No `renderCustomMessages` prop is passed — the indicator
   // auto-mounts when intelligence is configured.
   render(
-    <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+    <CopilotKitProvider
+      agents__unsafe_dev_only={{ default: agent }}
+      showIntelligenceIndicator={showIntelligenceIndicator}
+    >
       <CopilotChatConfigurationProvider agentId="default" threadId="t">
         <RunAgentHarness withIntelligence={withIntelligence} />
         <div style={{ height: 400 }}>
@@ -363,6 +367,21 @@ describe('IntelligenceIndicator — "Using CopilotKit Intelligence" (auto-mounte
     emitAssistantMessageWithToolCalls(agent, "m1", [{ id: "tc1", arg: "{}" }]);
 
     // Without the gate, the pill would be visible by now.
+    await new Promise((r) => setTimeout(r, 80));
+    expectNoPillAnywhere();
+  });
+
+  it("showIntelligenceIndicator=false: does not render even when intelligence is configured", async () => {
+    const agent = makeAgent();
+    renderForIndicator(agent, { showIntelligenceIndicator: false });
+    await screen.findByTestId("trigger-run");
+
+    await triggerRun(agent);
+    startRun(agent);
+    emitAssistantMessageWithToolCalls(agent, "m1", [{ id: "tc1", arg: "{}" }]);
+
+    // Intelligence is configured (withIntelligence defaults to true), so
+    // without the opt-out the pill would be visible by now.
     await new Promise((r) => setTimeout(r, 80));
     expectNoPillAnywhere();
   });

--- a/packages/react-core/src/v2/context.ts
+++ b/packages/react-core/src/v2/context.ts
@@ -17,6 +17,14 @@ export interface CopilotKitContextValue {
    * are captured even before child components mount.
    */
   executingToolCallIds: ReadonlySet<string>;
+  /**
+   * Whether the built-in `IntelligenceIndicator` pill auto-mounts on
+   * assistant messages when the runtime is in intelligence mode.
+   * Mirrors the `showIntelligenceIndicator` prop on `CopilotKitProvider`.
+   * When omitted (e.g. providers that don't surface the option), consumers
+   * treat it as `true` for backward compatibility.
+   */
+  showIntelligenceIndicator?: boolean;
 }
 
 export const EMPTY_SET: ReadonlySet<string> = new Set();

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -4,7 +4,6 @@ import type { AbstractAgent } from "@ag-ui/client";
 import type { FrontendTool } from "@copilotkit/core";
 import type React from "react";
 import {
-  type ReactNode,
   useMemo,
   useEffect,
   useLayoutEffect,
@@ -12,23 +11,18 @@ import {
   useRef,
   useState,
 } from "react";
+import type { ReactNode } from "react";
 // Context extracted to ../context.ts for cross-platform reuse (React Native)
-import {
-  CopilotKitContext,
-  type CopilotKitContextValue,
-  LicenseContext,
-} from "../context";
+import { CopilotKitContext, LicenseContext } from "../context";
+import type { CopilotKitContextValue } from "../context";
 export type { CopilotKitContextValue } from "../context";
 export { CopilotKitContext, useLicenseContext } from "../context";
 import { z } from "zod";
 import { CopilotKitInspector } from "../components/CopilotKitInspector";
 import type { Anchor } from "@copilotkit/web-inspector";
 import { LicenseWarningBanner } from "../components/license-warning-banner";
-import {
-  createLicenseContextValue,
-  type LicenseContextValue,
-  type DebugConfig,
-} from "@copilotkit/shared";
+import { createLicenseContextValue } from "@copilotkit/shared";
+import type { LicenseContextValue, DebugConfig } from "@copilotkit/shared";
 import type { CopilotKitCoreErrorCode } from "@copilotkit/core";
 import {
   MCPAppsActivityContentSchema,
@@ -153,6 +147,19 @@ export interface CopilotKitProviderProps {
   };
   showDevConsole?: boolean | "auto";
   /**
+   * Whether the built-in `IntelligenceIndicator` pill ("Using CopilotKit
+   * Intelligence") auto-mounts on assistant messages when the runtime is in
+   * intelligence mode (e.g. for OAuth-gated MCP HTTP servers that require
+   * user verification).
+   *
+   * Set to `false` to suppress the auto-mounted indicator — useful for apps
+   * that render their own custom agent/intelligence status UI and don't want
+   * the default pill to appear alongside it.
+   *
+   * @default true
+   */
+  showIntelligenceIndicator?: boolean;
+  /**
    * Error handler called when CopilotKit encounters an error.
    * Fires for all error types (runtime connection failures, agent errors, tool errors).
    */
@@ -261,6 +268,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   humanInTheLoop,
   openGenerativeUI,
   showDevConsole = false,
+  showIntelligenceIndicator = true,
   useSingleEndpoint,
   onError,
   a2ui,
@@ -749,8 +757,8 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   }, [copilotkit, sandboxFunctionsDescriptors, openGenUIActive]);
 
   const contextValue = useMemo<CopilotKitContextValue>(
-    () => ({ copilotkit, executingToolCallIds }),
-    [copilotkit, executingToolCallIds],
+    () => ({ copilotkit, executingToolCallIds, showIntelligenceIndicator }),
+    [copilotkit, executingToolCallIds, showIntelligenceIndicator],
   );
 
   // License context — driven by server-reported status via /info endpoint


### PR DESCRIPTION
## Summary

Fixes #5126.

The built-in `IntelligenceIndicator` pill ("Using CopilotKit Intelligence") auto-mounts on assistant messages whenever the runtime is in intelligence mode, with no way to turn it off. Apps that render their own intelligence/agent status UI end up showing the default pill alongside their custom one.

This adds a `showIntelligenceIndicator` prop on `CopilotKitProvider` so consumers can opt out.

## Changes

- **`CopilotKitProvider`** — new `showIntelligenceIndicator?: boolean` prop (default `true`), threaded through context.
- **`context.ts`** — added optional `showIntelligenceIndicator` to `CopilotKitContextValue` (optional so RN provider and existing mocks stay compatible; consumers treat `undefined` as `true`).
- **`CopilotChatMessageView`** — auto-mount gate now also checks `showIntelligenceIndicator`; reads default `true`.
- **Test** — added an e2e case asserting the pill does not render when `showIntelligenceIndicator={false}`, even with intelligence configured.

## Backward compatibility

Default is `true`, so existing behavior is unchanged. Only an explicit `false` suppresses the pill.

## Testing

- `nx run @copilotkit/react-core:test` — 1172/1172 pass (incl. the new case)
- `nx run @copilotkit/react-core:build` — passes