### PR TITLE
fix(core): add circuit breaker to prevent infinite follow-up loops

### DIFF
--- a/packages/core/src/__tests__/core-full.test.ts
+++ b/packages/core/src/__tests__/core-full.test.ts
@@ -241,6 +241,49 @@ describe("CopilotKitCore.runAgent - Full Test Suite", () => {
       }
     });
 
+    it("TEST 9b: should stop recursive follow-ups at the depth limit instead of looping forever", async () => {
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      // A tool that always requests a follow-up. The agent always returns a
+      // fresh tool call for it, so without a circuit breaker processAgentResult
+      // would recurse into runAgent indefinitely.
+      const tool = createTool({
+        name: "loopingTool",
+        handler: vi.fn(async () => "Result"),
+        followUp: true,
+      });
+      copilotKitCore.addTool(tool);
+
+      const agent = new MockAgent({
+        newMessages: [createToolCallMessage("loopingTool")],
+      });
+      copilotKitCore.addAgent__unsafe_dev_only({
+        id: "test",
+        agent: agent as any,
+      });
+
+      // Every run keeps emitting a brand-new tool call so needsFollowUp stays true.
+      agent.runAgentCallback = () => {
+        agent.setNewMessages([createToolCallMessage("loopingTool")]);
+      };
+
+      const result = await copilotKitCore.runAgent({ agent: agent as any });
+
+      // It must terminate rather than hang, capped by the absolute depth limit (100).
+      expect(agent.runAgentCalls.length).toBeGreaterThan(1);
+      expect(agent.runAgentCalls.length).toBeLessThanOrEqual(100);
+      expect(result).toBeDefined();
+
+      // A warning must be emitted when the breaker trips, for debuggability.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Follow-up depth limit"),
+      );
+
+      warnSpy.mockRestore();
+    });
+
     it("TEST 10: should handle concurrent tool calls", async () => {
       const delays = [50, 30, 70];
       const tools = delays.map((delay, i) =>

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -69,6 +69,20 @@ interface ExecuteToolHandlerResult {
 }
 
 /**
+ * Absolute safety cap on the depth of recursive follow-up runs triggered by
+ * `processAgentResult`. Without this, any scenario that keeps
+ * `needsFollowUp = true` (e.g. the LLM repeatedly calling the same tool, a
+ * backend that errors after receiving tool results, or input processors that
+ * reprocess tool messages) would loop indefinitely, silently consuming API
+ * quota and potentially DOS'ing the backend.
+ *
+ * The cap is deliberately high so that legitimate multi-step agent workflows
+ * (search → fill form → confirm → update → send email, etc.) are never
+ * affected; it only trips on runaway recursion.
+ */
+const MAX_FOLLOW_UP_DEPTH = 100;
+
+/**
  * Handles agent execution, tool calling, and agent connectivity for CopilotKitCore.
  * Manages the complete lifecycle of agent runs including tool execution and follow-ups.
  */
@@ -438,12 +452,28 @@ export class RunHandler {
     }
 
     if (needsFollowUp && !this._runAbortController?.signal.aborted) {
-      // Yield to the framework scheduler before the follow-up run so that any
-      // deferred state updates (e.g. React useEffect in useAgentContext) can
-      // complete and write fresh values into the context store before runAgent
-      // reads it. The base implementation is a no-op; React overrides this.
-      await this._internal.waitForPendingFrameworkUpdates();
-      return await this.runAgent({ agent });
+      // Circuit breaker: bail out instead of recursing once the follow-up
+      // chain exceeds an absolute safety cap. `_runDepth` reflects the current
+      // depth of nested runAgent calls (it is incremented in runAgent and
+      // decremented in its finally block), so a runaway loop — repeated
+      // identical tool calls, a backend that keeps erroring after tool
+      // results, reprocessed tool messages, etc. — eventually trips this
+      // guard rather than looping forever and exhausting API quota.
+      if (this._runDepth >= MAX_FOLLOW_UP_DEPTH) {
+        logger.warn(
+          `[CopilotKit] Follow-up depth limit (${MAX_FOLLOW_UP_DEPTH}) reached for agent "${agentId}". ` +
+            `Stopping recursive follow-up runs to prevent an infinite loop. ` +
+            `This usually indicates a tool that keeps requesting a follow-up (e.g. the LLM repeatedly ` +
+            `calling the same tool). Consider setting "followUp: false" on the offending tool.`,
+        );
+      } else {
+        // Yield to the framework scheduler before the follow-up run so that any
+        // deferred state updates (e.g. React useEffect in useAgentContext) can
+        // complete and write fresh values into the context store before runAgent
+        // reads it. The base implementation is a no-op; React overrides this.
+        await this._internal.waitForPendingFrameworkUpdates();
+        return await this.runAgent({ agent });
+      }
     }
 
     void this._internal.suggestionEngine.reloadSuggestions(agentId);


### PR DESCRIPTION
## Summary

Fixes #4819.

`processAgentResult` recurses into `runAgent` whenever `needsFollowUp` is true, with **no depth limit, no circuit breaker, no duplicate detection**. Any scenario that keeps `needsFollowUp = true` loops forever:

- The LLM repeatedly calling the same tool
- The backend returning a `RunError` after receiving tool results (#2416)
- Input processors reprocessing tool messages (#3044)

This silently consumes API quota and can DOS the backend. The only existing workaround — setting `followUp: false` on a tool — is too blunt and breaks legitimate multi-step workflows.

## Change

- Add an absolute safety cap `MAX_FOLLOW_UP_DEPTH = 100`, reusing the existing `_runDepth` counter (incremented in `runAgent`, decremented in its `finally`).
- In `processAgentResult`, when the depth cap is reached: stop recursing, emit a `logger.warn` (for debuggability), and return the current result normally (already-inserted tool messages are preserved).
- The cap is deliberately high so legitimate multi-step workflows (search → fill form → confirm → update → send email) are never affected; it only trips on runaway recursion.

This protects against **all** infinite-loop scenarios in the issue, not just specific triggers, without requiring users to set `followUp: false`.

## Test

- Added `core-full.test.ts` TEST 9b: an agent that always returns a fresh tool call (so `needsFollowUp` stays true). Asserts the run terminates, `runAgent` is capped at ≤100 calls, and a warning is emitted.
- `nx run @copilotkit/core:test` → 40 files / 431 tests pass.
- `nx run @copilotkit/core:build` → success.