### PR TITLE
fix(core): dedupe tool results against full history to stop follow-up loops

### DIFF
--- a/packages/core/src/__tests__/core-follow-up.test.ts
+++ b/packages/core/src/__tests__/core-follow-up.test.ts
@@ -243,4 +243,61 @@ describe("CopilotKitCore.runAgent - Follow-up Logic", () => {
     expect(agent.runAgentCalls).toHaveLength(3);
     expect(result.newMessages).toEqual([finalMsg]);
   });
+
+  it("should not re-execute a tool whose result already exists in agent.messages", async () => {
+    // Regression test for #2416 / #3044: when the backend re-emits an
+    // assistant tool-call message whose result is already in the conversation
+    // history, the tool handler must not run again, no duplicate tool-result
+    // message must be inserted, and no follow-up must be triggered. Otherwise
+    // a backend that keeps re-sending the tool call (e.g. after a RunError)
+    // drives an infinite execute → follow-up loop.
+    const handler = vi.fn(async () => "Result");
+    const tool = createTool({
+      name: "dedupeTool",
+      handler,
+      followUp: true,
+    });
+    copilotKitCore.addTool(tool);
+
+    const toolCallId = "tool-call-dedupe-1";
+    const assistantMessage = createAssistantMessage({
+      content: "",
+      toolCalls: [
+        {
+          id: toolCallId,
+          type: "function",
+          function: { name: "dedupeTool", arguments: "{}" },
+        },
+      ],
+    });
+    const toolResultMessage = {
+      id: "tool-result-dedupe-1",
+      role: "tool" as const,
+      toolCallId,
+      content: "Result",
+    };
+
+    // History already contains the assistant tool-call and its result.
+    const agent = new MockAgent({
+      messages: [assistantMessage, toolResultMessage],
+      // Backend re-emits the same assistant tool-call (no result attached).
+      newMessages: [assistantMessage],
+    });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    // Handler must not run again.
+    expect(handler).not.toHaveBeenCalled();
+    // No follow-up run should be triggered (only the initial run).
+    expect(agent.runAgentCalls).toHaveLength(1);
+    // The tool result must still appear exactly once.
+    const toolResults = agent.messages.filter(
+      (m) => m.role === "tool" && m.toolCallId === toolCallId,
+    );
+    expect(toolResults).toHaveLength(1);
+  });
 });

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -393,11 +393,22 @@ export class RunHandler {
     for (const message of newMessages) {
       if (message.role === "assistant") {
         for (const toolCall of message.toolCalls || []) {
-          if (
-            newMessages.findIndex(
+          // Skip tool calls that already have a result. We check both the
+          // current batch (`newMessages`) and the full conversation
+          // (`agent.messages`): when the backend re-emits an assistant
+          // tool-call message whose result is already in history (e.g. after a
+          // RunError retry, history replay, or input-processor reprocessing),
+          // re-executing the handler would duplicate the tool-result message
+          // and trigger another follow-up, producing an infinite loop (#2416,
+          // #3044).
+          const hasResult =
+            newMessages.some(
               (m) => m.role === "tool" && m.toolCallId === toolCall.id,
-            ) === -1
-          ) {
+            ) ||
+            agent.messages.some(
+              (m) => m.role === "tool" && m.toolCallId === toolCall.id,
+            );
+          if (!hasResult) {
             const tool = this.getTool({
               toolName: toolCall.function.name,
               agentId: agent.agentId,


### PR DESCRIPTION
## Summary

Fixes #2416. Also fixes #3044 (same root cause).

`processAgentResult` decides whether to execute a frontend tool by checking if its tool-call already has a result. That check only looked at the **current batch** (`newMessages`):

```ts
newMessages.findIndex((m) => m.role === "tool" && m.toolCallId === toolCall.id) === -1
```

When the backend **re-emits an assistant tool-call message whose result is already in `agent.messages`** — which happens after a `RunError` retry, a history replay, or input-processor reprocessing — the dedupe check misses the existing result. So CopilotKit:

1. re-executes the tool handler,
2. inserts a **duplicate** `tool` result message into history, and
3. triggers another follow-up run.

The next run re-sends the same tool call, and the cycle repeats forever — hammering the backend as fast as it can respond (as shown in #2416's logs, where `result-tooluse_…` appears twice and the run loops indefinitely).

## Change

Check **both** `newMessages` and `agent.messages` for an existing result. An already-answered tool call is skipped entirely: no re-execution, no duplicate tool message, no follow-up.

This complements #4819 (the absolute-depth circuit breaker): #4819 is the safety net against any runaway recursion, while this fixes the most common *source* of the loop.

## Test

- Added a `core-follow-up.test.ts` regression case: history already contains an assistant tool-call and its `tool` result; the backend re-emits the same assistant tool-call. Asserts the handler is **not** called again, no extra follow-up run is triggered, and the tool result still appears exactly once. (Fails before the fix, passes after.)
- `@copilotkit/core` vitest → 40 files / 431 tests pass.
- `tsdown` build → success.