### PR TITLE
docs: simplify cookbook navigation

### DIFF
--- a/showcase/shell-docs/src/app/cookbook/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/cookbook/[...slug]/page.tsx
@@ -41,6 +41,11 @@ export default async function CookbookSlugPage({
   const slugPath = `cookbook/${slug.join("/")}`;
   const navTree = buildNavTree(path.join(CONTENT_DIR, "cookbook"), "cookbook");
   return (
-    <DocsPageView slugPath={slugPath} slugHrefPrefix="" navTree={navTree} />
+    <DocsPageView
+      slugPath={slugPath}
+      slugHrefPrefix=""
+      navTree={navTree}
+      sidebarBannerSlot={null}
+    />
   );
 }

--- a/showcase/shell-docs/src/app/cookbook/page.tsx
+++ b/showcase/shell-docs/src/app/cookbook/page.tsx
@@ -1,13 +1,6 @@
-// /cookbook — the cookbook landing page.
-//
-// Mirrors how /reference works today: a dedicated route with a sidebar
-// scoped to its own meta.json tree, so opening the cookbook shows only
-// the recipes — not the full Documentation tree.
-
-import path from "path";
 import type { Metadata } from "next";
-import { DocsPageView } from "@/components/docs-page-view";
-import { CONTENT_DIR, buildNavTree, loadDoc } from "@/lib/docs-render";
+import { redirect } from "next/navigation";
+import { loadDoc } from "@/lib/docs-render";
 import { buildDocMetadata } from "@/lib/seo-metadata";
 
 export const dynamic = "force-dynamic";
@@ -23,9 +16,5 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default function CookbookLandingPage() {
-  // Scope the sidebar to the cookbook subtree only.
-  const navTree = buildNavTree(path.join(CONTENT_DIR, "cookbook"), "cookbook");
-  return (
-    <DocsPageView slugPath="cookbook" slugHrefPrefix="" navTree={navTree} />
-  );
+  redirect("/cookbook/daytona");
 }

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -105,6 +105,8 @@ export interface DocsPageViewProps {
   navTree?: NavNode[];
   /** Banner slot rendered above the main content column. */
   bannerSlot?: React.ReactNode;
+  /** Banner slot rendered at the top of the sidebar. */
+  sidebarBannerSlot?: React.ReactNode;
   /** When set, hide the main MDX body (used by pivot-only pages). */
   hideBody?: boolean;
   /**
@@ -142,6 +144,7 @@ export async function DocsPageView({
   frameworkOverride,
   navTree,
   bannerSlot,
+  sidebarBannerSlot,
   hideBody = false,
   ContentWrapper,
 }: DocsPageViewProps) {
@@ -199,7 +202,16 @@ export async function DocsPageView({
   const fumadocsToc = tocHeadingsToFumadocs(tocHeadings);
 
   return (
-    <ShellDocsLayout tree={pageTree} banner={<SidebarFrameworkSelector />}>
+    <ShellDocsLayout
+      tree={pageTree}
+      banner={
+        sidebarBannerSlot === undefined ? (
+          <SidebarFrameworkSelector />
+        ) : (
+          sidebarBannerSlot
+        )
+      }
+    >
       <DocsPage
         toc={fumadocsToc}
         breadcrumb={{ enabled: false }}

--- a/showcase/shell-docs/src/content/docs/cookbook/meta.json
+++ b/showcase/shell-docs/src/content/docs/cookbook/meta.json
@@ -2,7 +2,6 @@
   "title": "Cookbook",
   "root": true,
   "pages": [
-    "---Recipes---",
     "daytona"
   ]
 }

--- a/showcase/shell-docs/src/content/docs/cookbook/meta.json
+++ b/showcase/shell-docs/src/content/docs/cookbook/meta.json
@@ -2,7 +2,6 @@
   "title": "Cookbook",
   "root": true,
   "pages": [
-    "index",
     "---Recipes---",
     "daytona"
   ]


### PR DESCRIPTION
## Problem

The cookbook sidebar reused the docs framework picker and showed extra grouping chrome even though Daytona is the only cookbook page.

## Why

The cookbook routes render through the shared docs page view, which always injected the framework selector into the sidebar and included the cookbook overview/section header from `meta.json`.

## Fix

- Let cookbook pages explicitly suppress the shared sidebar selector.
- Redirect `/cookbook` to `/cookbook/daytona`.
- Keep the cookbook sidebar to the single Daytona page link.

Validation:
- `npm run lint` in `showcase/shell-docs` passes with existing warnings.
- `npm run build` in `showcase/shell-docs` passes with existing Next/Turbopack warnings.
- Repo pre-commit package checks passed on both commits.
- `npm run typecheck` currently fails on existing `SignupLink` test prop errors unrelated to this change.