### PR TITLE
Env-gate LOCAL_SERVICES_JSON injection in harness service discovery

### DIFF
--- a/showcase/harness/src/probes/discovery/railway-services.test.ts
+++ b/showcase/harness/src/probes/discovery/railway-services.test.ts
@@ -1793,3 +1793,195 @@ describe("railwayServicesSource", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// LOCAL_SERVICES_JSON injection seam
+// ---------------------------------------------------------------------------
+//
+// The local D6 gate (and any non-Railway driver) feeds the IDENTICAL
+// RailwayServiceInfo[] shape into the probe path without querying Railway.
+// The critical correctness contract: the injected `demos` array MUST survive
+// onto the resolved RailwayServiceInfo, because the d6-all-pills driver derives
+// its feature matrix via `demosToFeatureTypes(input.demos ?? [])`. An empty
+// `demos` short-circuits the driver to a zero-cell false-green, so this seam
+// is worthless unless `demos` is plumbed end-to-end.
+
+// A fetch that fails loudly: the local-injection path must NOT touch Railway
+// at all, so any fetch call here is a contract violation.
+const NO_FETCH: typeof fetch = async () => {
+  throw new Error(
+    "LOCAL_SERVICES_JSON path must not query Railway (fetch called)",
+  );
+};
+
+describe("railwayServicesSource — LOCAL_SERVICES_JSON injection", () => {
+  it("returns the injected services WITH demos populated, without querying Railway", async () => {
+    const localServices = [
+      {
+        name: "showcase-langgraph-python",
+        publicUrl: "http://langgraph-python:10000",
+        demos: ["agentic_chat", "human_in_the_loop"],
+      },
+    ];
+    const env = {
+      ...BASE_ENV,
+      LOCAL_SERVICES_JSON: JSON.stringify(localServices),
+    };
+    const out = await railwayServicesSource.enumerate(
+      makeCtx(NO_FETCH, env),
+      {},
+    );
+
+    expect(out).toHaveLength(1);
+    const svc = out[0]!;
+    expect(svc.name).toBe("showcase-langgraph-python");
+    expect(svc.publicUrl).toBe("http://langgraph-python:10000");
+    // The load-bearing assertion: demos survive onto the resolved record so
+    // the d6-all-pills driver's `demosToFeatureTypes(input.demos)` produces a
+    // real feature matrix instead of a zero-cell false-green.
+    expect(svc.demos).toEqual(["agentic_chat", "human_in_the_loop"]);
+    // shape is recomputed from the name via classifyShape (single source of
+    // truth) rather than trusted from the injected record.
+    expect(svc.shape).toBe("package");
+  });
+
+  it("does NOT engage the injection seam when LOCAL_SERVICES_JSON is unset (Railway path unchanged)", async () => {
+    // No LOCAL_SERVICES_JSON in env → the Railway discovery path runs exactly
+    // as today. We assert byte-identical behaviour by driving the normal
+    // scripted-fetch happy path and confirming the seam never short-circuits.
+    const { fetchImpl, calls } = makeFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse([
+          {
+            id: "svc-1",
+            name: "showcase-langgraph-python",
+            image: "ghcr.io/org/langgraph-python:latest",
+            domain: "langgraph-python.up.railway.app",
+          },
+        ]),
+      },
+      { status: 200, body: { data: { variables: {} } } },
+    ]);
+    // BASE_ENV has no LOCAL_SERVICES_JSON → Railway path.
+    const out = await railwayServicesSource.enumerate(
+      makeCtx(fetchImpl, BASE_ENV),
+      {},
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]!.name).toBe("showcase-langgraph-python");
+    expect(out[0]!.publicUrl).toBe("https://langgraph-python.up.railway.app");
+    // The Railway path made its GraphQL round-trips — proof the seam was a
+    // no-op and discovery behaviour is unchanged when the env var is absent.
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it("treats empty-string LOCAL_SERVICES_JSON as unset (no-op, Railway path runs)", async () => {
+    const { fetchImpl, calls } = makeFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse([
+          {
+            id: "svc-1",
+            name: "showcase-langgraph-python",
+            image: "ghcr.io/org/langgraph-python:latest",
+            domain: "langgraph-python.up.railway.app",
+          },
+        ]),
+      },
+      { status: 200, body: { data: { variables: {} } } },
+    ]);
+    const env = { ...BASE_ENV, LOCAL_SERVICES_JSON: "" };
+    const out = await railwayServicesSource.enumerate(
+      makeCtx(fetchImpl, env),
+      {},
+    );
+    expect(out).toHaveLength(1);
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it("applies namePrefix + nameExcludes filters to injected services", async () => {
+    const localServices = [
+      {
+        name: "showcase-langgraph-python",
+        publicUrl: "http://langgraph-python:10000",
+        demos: ["agentic_chat"],
+      },
+      {
+        name: "showcase-crewai-python",
+        publicUrl: "http://crewai-python:10000",
+        demos: ["agentic_chat"],
+      },
+      {
+        name: "smoke-runner",
+        publicUrl: "http://smoke-runner:10000",
+        demos: [],
+      },
+    ];
+    const env = {
+      ...BASE_ENV,
+      LOCAL_SERVICES_JSON: JSON.stringify(localServices),
+    };
+    const out = await railwayServicesSource.enumerate(makeCtx(NO_FETCH, env), {
+      namePrefix: "showcase-",
+      nameExcludes: ["showcase-crewai-python"],
+    });
+    // smoke-runner dropped by namePrefix; crewai dropped by nameExcludes.
+    expect(out.map((s) => s.name)).toEqual(["showcase-langgraph-python"]);
+  });
+
+  it("throws DiscoverySourceSchemaError when LOCAL_SERVICES_JSON is not valid JSON", async () => {
+    const env = { ...BASE_ENV, LOCAL_SERVICES_JSON: "{not json" };
+    await expect(
+      railwayServicesSource.enumerate(makeCtx(NO_FETCH, env), {}),
+    ).rejects.toBeInstanceOf(DiscoverySourceSchemaError);
+  });
+
+  it("throws DiscoverySourceSchemaError when LOCAL_SERVICES_JSON has the wrong shape", async () => {
+    // Missing required `publicUrl`.
+    const env = {
+      ...BASE_ENV,
+      LOCAL_SERVICES_JSON: JSON.stringify([{ name: "showcase-x" }]),
+    };
+    await expect(
+      railwayServicesSource.enumerate(makeCtx(NO_FETCH, env), {}),
+    ).rejects.toBeInstanceOf(DiscoverySourceSchemaError);
+  });
+
+  it("defaults demos to [] when an injected record omits it", async () => {
+    const localServices = [
+      {
+        name: "showcase-langgraph-python",
+        publicUrl: "http://langgraph-python:10000",
+      },
+    ];
+    const env = {
+      ...BASE_ENV,
+      LOCAL_SERVICES_JSON: JSON.stringify(localServices),
+    };
+    const out = await railwayServicesSource.enumerate(
+      makeCtx(NO_FETCH, env),
+      {},
+    );
+    expect(out[0]!.demos).toEqual([]);
+  });
+
+  it("does not require Railway credentials on the injection path", async () => {
+    // No RAILWAY_* creds at all — the injection path must not throw
+    // DiscoverySourceAuthError because it never consults Railway.
+    const localServices = [
+      {
+        name: "showcase-langgraph-python",
+        publicUrl: "http://langgraph-python:10000",
+        demos: ["agentic_chat"],
+      },
+    ];
+    const env = { LOCAL_SERVICES_JSON: JSON.stringify(localServices) };
+    const out = await railwayServicesSource.enumerate(
+      makeCtx(NO_FETCH, env),
+      {},
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]!.demos).toEqual(["agentic_chat"]);
+  });
+});

--- a/showcase/harness/src/probes/discovery/railway-services.ts
+++ b/showcase/harness/src/probes/discovery/railway-services.ts
@@ -448,6 +448,98 @@ function deriveSlugFromServiceName(name: string): string {
   return name.startsWith("showcase-") ? name.slice("showcase-".length) : name;
 }
 
+/**
+ * Static local-injection schema for `LOCAL_SERVICES_JSON`. The local D6 gate
+ * (and any non-Railway driver) feeds the IDENTICAL `RailwayServiceInfo[]`
+ * shape to the probe path without querying Railway — only the URLs differ
+ * (local container hostnames vs Railway public domains). Required fields:
+ * `name` (e.g. `showcase-langgraph-python`) and `publicUrl` (the live URL the
+ * specs navigate against, e.g. `http://langgraph-python:10000`). Every other
+ * `RailwayServiceInfo` field defaults so an operator only has to supply the
+ * two that actually vary by environment.
+ *
+ * `shape` is recomputed from `name` via `classifyShape` (single source of
+ * truth) so an injected record can never disagree with the classifier the
+ * Railway path uses.
+ *
+ * `demos` is load-bearing: the d6-all-pills driver derives its feature matrix
+ * via `demosToFeatureTypes(input.demos ?? [])`, so an injected record with an
+ * empty/missing `demos` array short-circuits the driver to a zero-cell
+ * false-green. Callers that want a real Playwright run MUST supply the demo
+ * IDs for the integration here.
+ */
+const LocalServiceSchema = z
+  .object({
+    name: z.string().min(1),
+    publicUrl: z.string().url(),
+    imageRef: z.string().optional(),
+    env: z.record(z.string()).optional(),
+    deployedDigest: z.string().optional(),
+    demos: z.array(z.string()).optional(),
+    notSupportedFeatures: z.array(z.string()).optional(),
+    deployedAt: z.string().optional(),
+  })
+  .passthrough();
+
+const LocalServicesSchema = z.array(LocalServiceSchema);
+
+/**
+ * Build the full `RailwayServiceInfo[]` from `LOCAL_SERVICES_JSON`, applying
+ * the SAME `namePrefix` / `nameExcludes` filter the Railway path applies so a
+ * probe's discovery filter behaves identically against injected records.
+ * Throws `DiscoverySourceSchemaError` (same taxonomy as a Railway shape
+ * failure) when the JSON is malformed, so the invoker surfaces a single keyed
+ * synthetic error rather than a silent empty roster.
+ */
+function buildLocalServices(
+  ctx: DiscoveryContext,
+  raw: string,
+  filter: z.infer<typeof ConfigSchema>,
+): RailwayServiceInfo[] {
+  let parsedUnknown: unknown;
+  try {
+    parsedUnknown = JSON.parse(raw);
+  } catch (err) {
+    throw new DiscoverySourceSchemaError(
+      "railway-services",
+      `LOCAL_SERVICES_JSON was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      undefined,
+      err,
+    );
+  }
+  const parsed = LocalServicesSchema.safeParse(parsedUnknown);
+  if (!parsed.success) {
+    throw new DiscoverySourceSchemaError(
+      "railway-services",
+      `LOCAL_SERVICES_JSON did not match expected shape: ${parsed.error.message}`,
+      undefined,
+      parsed.error,
+    );
+  }
+  const excludeSet = new Set(filter.nameExcludes ?? []);
+  const out: RailwayServiceInfo[] = [];
+  for (const svc of parsed.data) {
+    if (filter.namePrefix && !svc.name.startsWith(filter.namePrefix)) continue;
+    if (excludeSet.has(svc.name)) continue;
+    out.push({
+      name: svc.name,
+      imageRef: svc.imageRef ?? "",
+      publicUrl: svc.publicUrl,
+      env: svc.env ?? {},
+      shape: classifyShape(svc.name, { logger: ctx.logger }),
+      deployedDigest: svc.deployedDigest ?? "",
+      demos: svc.demos ?? [],
+      notSupportedFeatures: svc.notSupportedFeatures ?? [],
+      deployedAt: svc.deployedAt ?? "",
+    });
+  }
+  ctx.logger.info("discovery.railway-services.local-injection", {
+    count: out.length,
+    names: out.map((s) => s.name),
+  });
+  return out;
+}
+
 export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
   name: "railway-services",
   configSchema: ConfigSchema,
@@ -456,6 +548,20 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
     // see ConfigSchema docstring above for why this is flat, not a
     // `{filter: {...}}` wrapper.
     const filter = ConfigSchema.parse(rawConfig ?? {});
+
+    // Local-injection seam: when `LOCAL_SERVICES_JSON` is set, feed the
+    // IDENTICAL RailwayServiceInfo[] shape from a static list instead of
+    // querying Railway. This lets the local D6 gate exercise the EXACT probe
+    // code path the cron/staging entrypoint uses — only the service URLs
+    // differ (local container hostnames vs Railway public domains). Nothing
+    // downstream (invoker, driver, rollup) can tell the records came from a
+    // static list. Railway creds are NOT consulted on this path. An empty
+    // string is treated as unset so an exported-but-empty env var falls back
+    // to the Railway path rather than failing as malformed JSON.
+    const localServicesJson = ctx.env.LOCAL_SERVICES_JSON;
+    if (localServicesJson) {
+      return buildLocalServices(ctx, localServicesJson, filter);
+    }
 
     // Load registry-derived demos map once per enumerate(). The map is
     // the source of truth for the invoker's `e2e_demos` shortest-first


### PR DESCRIPTION
## Summary

Adds a permanent, env-gated injection seam to the showcase harness service discovery (`showcase/harness/src/probes/discovery/railway-services.ts`). When `LOCAL_SERVICES_JSON` is set, the harness (especially the d6-all-pills-e2e driver) runs against **LOCAL** backend services instead of performing Railway discovery — enabling apples-to-apples LOCAL D6 verification without Railway credentials.

- **Zero behavior change when unset/empty.** An unset or empty `LOCAL_SERVICES_JSON` takes the byte-identical Railway discovery path — the seam is fully transparent in the default configuration.
- **`demos` plumbed end-to-end (load-bearing).** The injected service records carry `demos` all the way through. This matters: empty `demos` would short-circuit the D6 driver into a false 15ms zero-cell "green," masking real failures. Plumbing `demos` end-to-end is what makes the LOCAL path a faithful stand-in for Railway discovery.
- **Enables apples-to-apples LOCAL D6 verification** — run the full pill suite against local services with the same code path shape as staging.

## Notes

- 8 new tests covering the `LOCAL_SERVICES_JSON injection` path (66 tests total in `railway-services.test.ts`, all passing).
- Env-gated: no Railway credentials required when services are injected.
- The injection seam executes the real discovery code (not mocked).

## Test plan

- [ ] `tsc --noEmit` (typecheck) exits 0
- [ ] `railway-services.test.ts` passes (66 tests, incl. all 8 `LOCAL_SERVICES_JSON injection` tests)
- [ ] Injection seam executes against the real code path (verified via `discovery.railway-services.local-injection` log emission, not a mock)
- [ ] Unset/empty `LOCAL_SERVICES_JSON` produces a byte-identical Railway discovery path (zero behavior change)
- [ ] `demos` plumbed end-to-end through injected service records (guards against false zero-cell D6 green)