### PR TITLE
Single-service showcase promote dropdown + unattended promote

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -22,10 +22,42 @@ on:
   workflow_dispatch:
     inputs:
       service:
-        description: "SSOT key, dispatch_name, or 'all'"
+        description: "Service to promote (dispatch_name or SSOT key). 'all' = whole fleet. Leave the placeholder to abort."
         required: true
-        default: "all"
-        type: string
+        type: choice
+        # >>> BEGIN GENERATED service options (showcase/scripts/sync-promote-service-options.ts) — DO NOT EDIT
+        default: __select_a_service__
+        options:
+          - __select_a_service__
+          - all
+          - ag2
+          - agno
+          - built-in-agent
+          - claude-sdk-python
+          - claude-sdk-typescript
+          - crewai-crews
+          - google-adk
+          - langgraph-fastapi
+          - langgraph-python
+          - langgraph-typescript
+          - langroid
+          - llamaindex
+          - mastra
+          - ms-agent-dotnet
+          - ms-agent-harness-dotnet
+          - ms-agent-python
+          - pocketbase
+          - pydantic-ai
+          - shell
+          - shell-dashboard
+          - shell-docs
+          - shell-dojo
+          - showcase-aimock
+          - showcase-harness
+          - spring-ai
+          - strands
+          - webhooks
+        # <<< END GENERATED service options
       digest:
         description: "Optional digest override (default: snapshot from staging)"
         required: false
@@ -66,20 +98,52 @@ jobs:
         id: resolve
         env:
           INPUT: ${{ inputs.service }}
+          DIGEST: ${{ inputs.digest }}
         run: |
           set -euo pipefail
           GENERATED="showcase/scripts/railway-envs.generated.json"
+          if [ "$INPUT" = "__select_a_service__" ]; then
+            echo "::error::No service selected. Re-run and pick a service (or 'all') from the dropdown."
+            exit 1
+          fi
           if [ "$INPUT" = "all" ]; then
-            CSV=$(jq -r '.services[] | select(.probe.prod == true) | .name' "$GENERATED" | sort -u | tr '\n' ',' | sed 's/,$//')
-          else
-            RESOLVED=$(jq -r --arg s "$INPUT" '
-              .services[] | select(.name == $s or .dispatchName == $s) | .name
-            ' "$GENERATED" | head -n1)
-            if [ -z "$RESOLVED" ]; then
-              echo "::error::Unknown service '$INPUT' (not an SSOT key or dispatch_name)"
+            # A single digest identifies at most one service's image, so a
+            # fleet-wide promote pinned to one digest is always wrong. The
+            # per-service promote loop would slip past bin/railway's own
+            # --digest guard (each call passes a positional service), so reject
+            # the combination loud and early here.
+            if [ -n "${DIGEST:-}" ]; then
+              echo "::error::--digest cannot be combined with 'all' (a single digest is meaningless across multiple services); pick one service."
               exit 1
             fi
-            CSV="$RESOLVED"
+            CSV=$(jq -r '.services[] | select(.probe.prod == true) | .name' "$GENERATED" | sort -u | tr '\n' ',' | sed 's/,$//')
+          else
+            # Capture the FULL match set (no `head` — that would silently mask
+            # an ambiguous match, and piping jq into head under pipefail can
+            # SIGPIPE jq and abort with no ::error:: annotation). Then count
+            # and branch fail-loud.
+            # Independently enforce prod-eligibility here: the dropdown
+            # advertises a prod-eligible set, but a stale/edited dropdown could
+            # offer a probe.prod:false service. Filtering on probe.prod == true
+            # ensures the single-service path never promotes a non-eligible
+            # service to prod, matching the `all` branch's gate.
+            MATCHES=$(jq -r --arg s "$INPUT" '
+              .services[]
+              | select(.name == $s or .dispatchName == $s)
+              | select(.probe.prod == true)
+              | .name
+            ' "$GENERATED")
+            # `grep -c` on empty input exits 1 under set -e; guard with || true.
+            COUNT=$(printf '%s' "$MATCHES" | grep -c . || true)
+            if [ "$COUNT" -eq 0 ]; then
+              echo "::error::Unknown or not prod-eligible service '$INPUT' (not an SSOT key/dispatch_name, or probe.prod is not true)"
+              exit 1
+            elif [ "$COUNT" -gt 1 ]; then
+              LIST=$(printf '%s' "$MATCHES" | tr '\n' ',' | sed 's/,$//')
+              echo "::error::Ambiguous service '$INPUT' matches multiple SSOT entries: $LIST"
+              exit 1
+            fi
+            CSV="$MATCHES"
           fi
           echo "services_csv=$CSV" >> "$GITHUB_OUTPUT"
 
@@ -153,7 +217,7 @@ jobs:
           # green but we keep the script-level guard as defense in depth.
           IFS=',' read -ra SVCS <<< "$SERVICES_CSV"
           for svc in "${SVCS[@]}"; do
-            args=(promote "$svc")
+            args=(promote "$svc" --yes --non-interactive)
             if [ -n "${DIGEST:-}" ]; then
               args+=(--digest "$DIGEST")
             fi
@@ -197,18 +261,36 @@ jobs:
     permissions:
       contents: read
       actions: read
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
     steps:
       - name: Compute state
         id: state
         env:
+          RESOLVE: ${{ needs.resolve-targets.result }}
           PRE: ${{ needs.verify-staging-precondition.result }}
           PROMOTE: ${{ needs.promote.result }}
           PROD: ${{ needs.verify-prod.result }}
           CSV: ${{ needs.resolve-targets.outputs.services_csv }}
+          INPUT: ${{ inputs.service }}
         run: |
           set -euo pipefail
-          if [ "$PRE" = "success" ] && [ "$PROMOTE" = "success" ] && [ "$PROD" = "success" ]; then
+          if [ "$INPUT" = "__select_a_service__" ]; then
+            # Deliberate no-op abort: a human clicked Run without picking a
+            # service. resolve-targets exits 1 and the downstream jobs skip.
+            # This is NOT a failed promote — emit a neutral state so no red
+            # alert pages #oss-alerts.
+            STATE="aborted"; ICON=":heavy_minus_sign:"
+          elif [ "$PRE" = "success" ] && [ "$PROMOTE" = "success" ] && [ "$PROD" = "success" ]; then
             STATE="success"; ICON=":white_check_mark:"
+          elif [ "$RESOLVE" = "cancelled" ] || [ "$PRE" = "cancelled" ] || [ "$PROMOTE" = "cancelled" ] || [ "$PROD" = "cancelled" ]; then
+            # A human cancelled the run (e.g. via the Actions UI). This is a
+            # deliberate stop, not a failed promote — emit a neutral state so
+            # no red alert pages #oss-alerts. Cancelling DURING resolve-targets
+            # leaves the three downstream jobs `skipped` (not `cancelled`), so
+            # we must consult RESOLVE here too or the cancel would fall through
+            # to `failure` and fire a false red page.
+            STATE="cancelled"; ICON=":heavy_minus_sign:"
           else
             STATE="failure"; ICON=":x:"
           fi
@@ -218,7 +300,7 @@ jobs:
             echo "csv=$CSV"
           } >> "$GITHUB_OUTPUT"
       - name: Post to #oss-alerts
-        if: steps.state.outputs.state == 'failure'
+        if: steps.state.outputs.state == 'failure' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK != ''
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
@@ -226,9 +308,10 @@ jobs:
           payload: |
             {
               "text": ${{ toJSON(format(
-                '{0} *Showcase Promote Failed*\nServices: `{1}`\npre-staging={2} promote={3} verify-prod={4}\n<{5}/{6}/actions/runs/{7}|View run>',
+                '{0} *Showcase Promote Failed*\nServices: `{1}`\nresolve-targets={2} pre-staging={3} promote={4} verify-prod={5}\n<{6}/{7}/actions/runs/{8}|View run>',
                 steps.state.outputs.icon,
                 steps.state.outputs.csv,
+                needs.resolve-targets.result,
                 needs.verify-staging-precondition.result,
                 needs.promote.result,
                 needs.verify-prod.result,
@@ -237,3 +320,9 @@ jobs:
                 github.run_id
               )) }}
             }
+      - name: Log (no Slack — webhook unset)
+        if: steps.state.outputs.state == 'failure' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK == ''
+        env:
+          CSV: ${{ steps.state.outputs.csv }}
+        run: |
+          echo "::warning::Showcase promote failed for '$CSV' but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -206,8 +206,9 @@ jobs:
         # unique FAIL lines) lives in `showcase/scripts/fail-baseline.json`;
         # see that file for the full ratchet semantics and adjustment
         # procedure. Weekly backlog visibility is provided by
-        # `.github/workflows/showcase_drift-report.yml`. Drift-to-zero work
-        # is tracked in GitHub issue #4047.
+        # `.github/workflows/showcase_drift-report.yml`. Driving the drift to
+        # zero (and flipping this advisory ratchet to fully enforcing) is
+        # future work.
         run: |
           set -euo pipefail
 
@@ -363,6 +364,36 @@ jobs:
       - name: Validate manifests & generate registry
         working-directory: showcase/scripts
         run: pnpm exec tsx generate-registry.ts
+
+      # ADVISORY ONLY — never fail the build. The promote dropdown is
+      # self-healed by the lefthook pre-commit hook; this step only warns if a
+      # commit somehow lands with a drifted showcase_promote.yml `service`
+      # dropdown (e.g. hook skipped). The trailing `|| true` keeps a non-zero
+      # `--check` exit from reddening validate.
+      - name: Advisory — promote dropdown drift check
+        working-directory: showcase/scripts
+        run: |
+          # ADVISORY ONLY: capture the exit code without letting a non-zero
+          # `--check` redden the build. `|| true` alone would discard rc and
+          # collapse every failure mode into the misleading "stale, re-run"
+          # warning. sync-promote-service-options.ts exits:
+          #   1 => drift (dropdown out of date; re-running the generator fixes it)
+          #   2 => read error
+          #   3 => missing/duplicate/malformed marker block (corruption)
+          # Only rc=1 is actually self-heals-by-rerun; rc>=2 needs a human, and
+          # the suggested re-run would itself fail — so report it distinctly.
+          set +e
+          pnpm exec tsx sync-promote-service-options.ts --check
+          rc=$?
+          set -e
+          if [ "$rc" -eq 1 ]; then
+            echo "::warning::showcase_promote.yml service dropdown is stale. Run: npx tsx showcase/scripts/sync-promote-service-options.ts and commit the result."
+          elif [ "$rc" -ge 2 ]; then
+            echo "::warning::sync-promote-service-options.ts failed (exit $rc) — marker block missing/duplicated or read error; investigate before trusting the dropdown."
+          fi
+          # Always succeed: this step must never fail the build (the lefthook
+          # pre-commit hook self-heals; CI only warns).
+          exit 0
 
       - name: Bundle demo content
         working-directory: showcase/scripts

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,8 +21,7 @@ pre-commit:
       # drift from the set of promotable services. Plain regenerate + git add
       # (no stash) — keep this hook worktree-safe; lefthook's shared
       # refs/stash is not safe across concurrent worktree commits.
-      glob:
-        "{showcase/scripts/railway-envs.ts,showcase/scripts/sync-promote-service-options.ts,.github/workflows/showcase_promote.yml}"
+      glob: "{showcase/scripts/railway-envs.ts,showcase/scripts/sync-promote-service-options.ts,.github/workflows/showcase_promote.yml}"
       run: |
         set -euo pipefail
         pnpm exec tsx showcase/scripts/sync-promote-service-options.ts \

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,6 +14,19 @@ pre-commit:
     check-binaries:
       tags: binaries
       run: bash scripts/hooks/check-binaries.sh
+    sync-promote-dropdown:
+      tags: promote-dropdown
+      # Regenerate the showcase_promote.yml `service` dropdown from the
+      # railway-envs.ts SSOT and re-stage it so the option list can never
+      # drift from the set of promotable services. Plain regenerate + git add
+      # (no stash) — keep this hook worktree-safe; lefthook's shared
+      # refs/stash is not safe across concurrent worktree commits.
+      glob:
+        "{showcase/scripts/railway-envs.ts,showcase/scripts/sync-promote-service-options.ts,.github/workflows/showcase_promote.yml}"
+      run: |
+        set -euo pipefail
+        pnpm exec tsx showcase/scripts/sync-promote-service-options.ts \
+          && git add .github/workflows/showcase_promote.yml
     sync-lockfile:
       tags: lockfile
       glob: "{packages,examples,showcase/scripts}/**/package.json"

--- a/showcase/scripts/__tests__/sync-promote-service-options.test.ts
+++ b/showcase/scripts/__tests__/sync-promote-service-options.test.ts
@@ -1,0 +1,625 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import { SERVICES } from "../railway-envs";
+// Importing the module MUST NOT trigger main() (the robust import.meta.url
+// guard ensures the file only runs main when invoked directly, never on
+// import). If this import wrote the workflow, the suite would have side
+// effects on the real file — see the dedicated guard test below.
+import { computeOptionTokens, SENTINEL } from "../sync-promote-service-options";
+
+const SCRIPT = resolve(__dirname, "..", "sync-promote-service-options.ts");
+
+// The exact diagnostic fragments the generator emits for each marker-error
+// case. Tests assert against these specific strings (not a generic /marker/i)
+// so a regression that swaps one diagnostic for another is caught.
+const DIAG_NOT_FOUND = "generated marker block not found";
+const DIAG_DUPLICATE = "duplicate generated markers";
+const DIAG_OUT_OF_ORDER = "malformed marker block";
+
+// A minimal but representative workflow fixture: the real showcase_promote.yml
+// has many more jobs, but for the generator's purposes all that matters is
+// the `service:` input block carrying the generated marker region. We keep
+// unrelated content around the markers to prove it is preserved verbatim.
+const BEGIN =
+  "# >>> BEGIN GENERATED service options (showcase/scripts/sync-promote-service-options.ts) — DO NOT EDIT";
+const END = "# <<< END GENERATED service options";
+
+function fixture(generatedBody: string): string {
+  return [
+    'name: "Showcase: Promote (staging → prod)"',
+    "",
+    "on:",
+    "  workflow_dispatch:",
+    "    inputs:",
+    "      service:",
+    '        description: "Service to promote"',
+    "        required: true",
+    "        type: choice",
+    `        ${BEGIN}`,
+    generatedBody,
+    `        ${END}`,
+    "      digest:",
+    '        description: "Optional digest override"',
+    "        required: false",
+    "        type: string",
+    "",
+    "jobs:",
+    "  resolve-targets:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - run: echo hi",
+    "",
+  ].join("\n");
+}
+
+// A synthetic services map shaped like SERVICES (Record<string, ServiceEntry
+// & { dispatchName?: string }>). Only the fields computeOptionTokens reads
+// (`probe.prod` and `dispatchName`) carry meaningful values here; the rest are
+// filler to satisfy the type. Keys are deliberately ordered so that sorting by
+// SSOT KEY would produce a DIFFERENT order than sorting by the RENDERED token,
+// proving the sort is by rendered token.
+const SYNTHETIC: typeof SERVICES = {
+  // SSOT key "zeta" but renders as "alpha" via dispatchName → must sort FIRST.
+  zeta: {
+    serviceId: "s-zeta",
+    prodInstanceId: "p-zeta",
+    stagingInstanceId: "st-zeta",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "alpha",
+    domains: { staging: "zeta.staging", prod: "zeta.prod" },
+    probe: { staging: true, prod: true, driver: "harness" },
+  },
+  // SSOT key "beta", no dispatchName → token falls back to the bare key
+  // "beta", which sorts AFTER the rendered token "alpha" (from key "zeta").
+  beta: {
+    serviceId: "s-beta",
+    prodInstanceId: "p-beta",
+    stagingInstanceId: "st-beta",
+    ciBuilt: true,
+    gateValidated: true,
+    // no dispatchName → token falls back to the SSOT key "beta".
+    domains: { staging: "beta.staging", prod: "beta.prod" },
+    probe: { staging: true, prod: true, driver: "harness" },
+  },
+  // prod:false → MUST be excluded from the dropdown entirely.
+  excluded: {
+    serviceId: "s-excl",
+    prodInstanceId: "p-excl",
+    stagingInstanceId: "st-excl",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "aaa-would-sort-first",
+    domains: { staging: "excl.staging", prod: "excl.prod" },
+    probe: { staging: true, prod: false, driver: "harness" },
+  },
+};
+
+describe("computeOptionTokens (unit)", () => {
+  it("excludes probe.prod:false, sorts by rendered token, prefers dispatchName", () => {
+    const tokens = computeOptionTokens(SYNTHETIC);
+
+    // (a) The prod:false entry is excluded even though its dispatchName
+    // ("aaa-would-sort-first") would otherwise sort to the very front.
+    expect(tokens).not.toContain("aaa-would-sort-first");
+    expect(tokens).not.toContain("excluded");
+
+    // (c) dispatchName wins over the SSOT key: "zeta" surfaces as "alpha",
+    // and its bare key never appears.
+    expect(tokens).toContain("alpha");
+    expect(tokens).not.toContain("zeta");
+    // "beta" has no dispatchName → its key is used verbatim.
+    expect(tokens).toContain("beta");
+
+    // (b) Ordering: SENTINEL, then "all", then promotable tokens sorted
+    // alphabetically by the RENDERED token. Sorting by SSOT key would have
+    // put "beta" before "alpha" (because key "beta" < key "zeta"); the
+    // rendered-token sort puts "alpha" first.
+    expect(tokens).toEqual([SENTINEL, "all", "alpha", "beta"]);
+  });
+
+  it("throws (fail loud) on a YAML-unsafe rendered token, naming token + SSOT key", () => {
+    // A future SSOT entry whose dispatchName carries a YAML-special char (here
+    // a colon + space) would, if interpolated raw, emit a malformed workflow
+    // the pre-commit hook silently `git add`s. The generator must fail loud.
+    const badMap: typeof SERVICES = {
+      gamma: {
+        serviceId: "s-gamma",
+        prodInstanceId: "p-gamma",
+        stagingInstanceId: "st-gamma",
+        ciBuilt: true,
+        gateValidated: true,
+        dispatchName: "bad: token", // colon + space → NOT YAML-safe
+        domains: { staging: "g.staging", prod: "g.prod" },
+        probe: { staging: true, prod: true, driver: "harness" },
+      },
+    };
+    expect(() => computeOptionTokens(badMap)).toThrow(/not YAML-safe/);
+    // The diagnostic names the offending token and its SSOT key.
+    expect(() => computeOptionTokens(badMap)).toThrow(/bad: token/);
+    expect(() => computeOptionTokens(badMap)).toThrow(/gamma/);
+  });
+
+  it("throws (fail loud) on a duplicate assembled token, naming the offender", () => {
+    // Two distinct SSOT keys whose RENDERED tokens collide: key "dup-a" has
+    // dispatchName "dup", and key "dup" has no dispatchName → both render as
+    // "dup". assertDispatchNamesUnique would NOT catch this (it only compares
+    // dispatchName-vs-dispatchName), so the generator must guard the
+    // assembled list itself or it would emit a duplicate `- dup` option that
+    // the pre-commit hook silently `git add`s. The exact-match resolve guard
+    // catches it because token "dup" matches BOTH services (key "dup" by
+    // name, key "dup-a" by dispatchName) → resolves to 2, not 1.
+    const dupMap: typeof SERVICES = {
+      "dup-a": {
+        serviceId: "s-dupa",
+        prodInstanceId: "p-dupa",
+        stagingInstanceId: "st-dupa",
+        ciBuilt: true,
+        gateValidated: true,
+        dispatchName: "dup",
+        domains: { staging: "dupa.staging", prod: "dupa.prod" },
+        probe: { staging: true, prod: true, driver: "harness" },
+      },
+      dup: {
+        serviceId: "s-dup",
+        prodInstanceId: "p-dup",
+        stagingInstanceId: "st-dup",
+        ciBuilt: true,
+        gateValidated: true,
+        // no dispatchName → renders as the bare key "dup", colliding with
+        // the dispatchName above.
+        domains: { staging: "dup.staging", prod: "dup.prod" },
+        probe: { staging: true, prod: true, driver: "harness" },
+      },
+    };
+    expect(() => computeOptionTokens(dupMap)).toThrow(/resolves to 2 services/);
+    expect(() => computeOptionTokens(dupMap)).toThrow(/"dup"/);
+  });
+
+  it("throws (fail loud) on a CROSS-collision the dedupe guard misses: distinct rendered tokens that resolve ambiguously", () => {
+    // The bug the exact-match resolve guard exists to catch, which the OLD
+    // rendered-token dedupe guard MISSED:
+    //   - Service A ("svc-a") has dispatchName "foo" → renders token "foo".
+    //   - Service B ("foo")  has dispatchName "bar" → renders token "bar".
+    // The two RENDERED tokens ("foo" and "bar") are DISTINCT, so a dedupe
+    // guard sees no duplicate and passes. But under the workflow resolve
+    // predicate (s.name === T || s.dispatchName === T), token "foo" matches
+    // BOTH A (by dispatchName "foo") AND B (by name "foo") → ambiguous and
+    // un-promotable. The generator must fail loud, naming the ambiguous
+    // token and both colliding service keys.
+    const crossMap: typeof SERVICES = {
+      "svc-a": {
+        serviceId: "s-a",
+        prodInstanceId: "p-a",
+        stagingInstanceId: "st-a",
+        ciBuilt: true,
+        gateValidated: true,
+        dispatchName: "foo", // renders token "foo"
+        domains: { staging: "a.staging", prod: "a.prod" },
+        probe: { staging: true, prod: true, driver: "harness" },
+      },
+      foo: {
+        serviceId: "s-foo",
+        prodInstanceId: "p-foo",
+        stagingInstanceId: "st-foo",
+        ciBuilt: true,
+        gateValidated: true,
+        dispatchName: "bar", // renders token "bar" (DISTINCT from "foo")
+        domains: { staging: "foo.staging", prod: "foo.prod" },
+        probe: { staging: true, prod: true, driver: "harness" },
+      },
+    };
+    // Token "foo" resolves to 2 services (svc-a by dispatchName, foo by name).
+    expect(() => computeOptionTokens(crossMap)).toThrow(
+      /resolves to 2 services/,
+    );
+    // Diagnostic names the ambiguous token and BOTH colliding service keys.
+    expect(() => computeOptionTokens(crossMap)).toThrow(/"foo"/);
+    expect(() => computeOptionTokens(crossMap)).toThrow(/svc-a/);
+  });
+
+  it("does NOT throw when a prod:false service shares a token with a prod-eligible service (resolve step also filters probe.prod)", () => {
+    // The generator's uniqueness guard mirrors the workflow resolve step's
+    // predicate EXACTLY — including its `probe.prod === true` filter. So a
+    // non-prod service sharing a name/dispatchName token with a prod-eligible
+    // service is NOT a collision: the resolve step would filter the non-prod
+    // candidate out and resolve the token unambiguously to the single
+    // prod-eligible service.
+    //   - Service X ("svc-x", probe.prod:true) has dispatchName "shared" →
+    //     renders + emits token "shared".
+    //   - Service Y ("shared", probe.prod:false) has name "shared" → would
+    //     match token "shared" by name, but is filtered out by the prod guard.
+    // Under an all-services match filter, token "shared" would resolve to 2
+    // services (X by dispatchName, Y by name) and THROW (false positive). With
+    // the probe.prod restriction it resolves to exactly 1 (X) and must pass.
+    const prodFilteredMap: typeof SERVICES = {
+      "svc-x": {
+        serviceId: "s-x",
+        prodInstanceId: "p-x",
+        stagingInstanceId: "st-x",
+        ciBuilt: true,
+        gateValidated: true,
+        dispatchName: "shared", // renders + emits token "shared"
+        domains: { staging: "x.staging", prod: "x.prod" },
+        probe: { staging: true, prod: true, driver: "harness" },
+      },
+      shared: {
+        serviceId: "s-shared",
+        prodInstanceId: "p-shared",
+        stagingInstanceId: "st-shared",
+        ciBuilt: true,
+        gateValidated: true,
+        // name "shared" collides with X's emitted token, but probe.prod:false
+        // means the resolve step (and now the guard) filters it out.
+        domains: { staging: "shared.staging", prod: "shared.prod" },
+        probe: { staging: true, prod: false, driver: "harness" },
+      },
+    };
+    // The guard must NOT throw: X resolves uniquely once Y is excluded.
+    expect(() => computeOptionTokens(prodFilteredMap)).not.toThrow();
+    // X's token IS emitted; the prod:false service Y never appears.
+    const tokens = computeOptionTokens(prodFilteredMap);
+    expect(tokens).toContain("shared");
+    expect(tokens).toEqual([SENTINEL, "all", "shared"]);
+  });
+
+  it("throws (fail loud) when a real-service token collides with a reserved literal", () => {
+    // A service whose rendered token is exactly "all" (the explicit
+    // whole-fleet literal). If allowed through it would emit a SECOND `- all`
+    // option and masquerade as the reserved value the resolve step
+    // special-cases. The generator must fail loud, naming the offender.
+    const reservedCollisionMap: typeof SERVICES = {
+      delta: {
+        serviceId: "s-delta",
+        prodInstanceId: "p-delta",
+        stagingInstanceId: "st-delta",
+        ciBuilt: true,
+        gateValidated: true,
+        dispatchName: "all", // collides with the reserved "all" literal
+        domains: { staging: "d.staging", prod: "d.prod" },
+        probe: { staging: true, prod: true, driver: "harness" },
+      },
+    };
+    expect(() => computeOptionTokens(reservedCollisionMap)).toThrow(
+      /reserved literal/,
+    );
+    expect(() => computeOptionTokens(reservedCollisionMap)).toThrow(/"all"/);
+  });
+});
+
+describe("sync-promote-service-options", () => {
+  let workDir: string;
+  let wfPath: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "sync-promote-"));
+    wfPath = join(workDir, "showcase_promote.yml");
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("rewrites a drifted options block to the exact expected ordered list", () => {
+    // Seed with deliberately wrong/stale content inside the markers.
+    writeFileSync(
+      wfPath,
+      fixture(
+        [
+          "        default: all",
+          "        options:",
+          "          - all",
+          "          - bogus-stale-entry",
+        ].join("\n"),
+      ),
+    );
+    execFileSync("npx", ["tsx", SCRIPT, `--workflow=${wfPath}`], {
+      stdio: "pipe",
+    });
+    const after = readFileSync(wfPath, "utf8");
+    const doc = parseYaml(after);
+    const input = doc.on.workflow_dispatch.inputs.service;
+    // The rendered dropdown is the FULL, ordered token list: SENTINEL, then
+    // "all", then every probe.prod service rendered as (dispatchName ?? name)
+    // and sorted ALPHABETICALLY BY RENDERED TOKEN (not by SSOT key). Deep-equal
+    // against the generator's own output so the test tracks the SSOT and the
+    // token-sort order exactly.
+    expect(input.options).toEqual(computeOptionTokens(SERVICES));
+    expect(input.options[0]).toBe("__select_a_service__");
+    expect(input.options[1]).toBe("all");
+    expect(input.default).toBe("__select_a_service__");
+    expect(input.options).toContain("ag2");
+    expect(input.options).toContain("pocketbase"); // no dispatchName → name fallback
+    expect(input.options).not.toContain("bogus-stale-entry");
+    // dispatchName tokens, not SSOT keys, for services that define one.
+    expect(input.options).not.toContain("showcase-ag2");
+  });
+
+  it("is idempotent: a second run is byte-identical and --check exits 0", () => {
+    writeFileSync(wfPath, fixture("        default: all\n        options:"));
+    execFileSync("npx", ["tsx", SCRIPT, `--workflow=${wfPath}`], {
+      stdio: "pipe",
+    });
+    const first = readFileSync(wfPath, "utf8");
+    execFileSync("npx", ["tsx", SCRIPT, `--workflow=${wfPath}`], {
+      stdio: "pipe",
+    });
+    const second = readFileSync(wfPath, "utf8");
+    expect(second).toBe(first);
+    const check = spawnSync(
+      "npx",
+      ["tsx", SCRIPT, "--check", `--workflow=${wfPath}`],
+      { encoding: "utf8" },
+    );
+    expect(check.status).toBe(0);
+  });
+
+  it("--check exits 1 on drift with the re-run diagnostic", () => {
+    writeFileSync(
+      wfPath,
+      fixture(
+        ["        default: all", "        options:", "          - all"].join(
+          "\n",
+        ),
+      ),
+    );
+    const result = spawnSync(
+      "npx",
+      ["tsx", SCRIPT, "--check", `--workflow=${wfPath}`],
+      { encoding: "utf8" },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/sync-promote-service-options/);
+    expect(result.stderr).toMatch(/re-run/i);
+  });
+
+  it("places the sentinel as option[0] and sets default to the sentinel", () => {
+    writeFileSync(wfPath, fixture("        options:"));
+    execFileSync("npx", ["tsx", SCRIPT, `--workflow=${wfPath}`], {
+      stdio: "pipe",
+    });
+    const doc = parseYaml(readFileSync(wfPath, "utf8"));
+    const input = doc.on.workflow_dispatch.inputs.service;
+    expect(input.options[0]).toBe("__select_a_service__");
+    expect(input.default).toBe("__select_a_service__");
+  });
+
+  it("fails loud (non-zero) when markers are missing — no silent rewrite", () => {
+    const noMarkers = [
+      "on:",
+      "  workflow_dispatch:",
+      "    inputs:",
+      "      service:",
+      '        description: "Service to promote"',
+      "        type: choice",
+      "",
+    ].join("\n");
+    writeFileSync(wfPath, noMarkers);
+    const result = spawnSync("npx", ["tsx", SCRIPT, `--workflow=${wfPath}`], {
+      encoding: "utf8",
+    });
+    // Render error → exit 3, with the SPECIFIC "not found" diagnostic.
+    expect(result.status).toBe(3);
+    expect(result.stderr).toContain(DIAG_NOT_FOUND);
+    expect(result.stderr).not.toContain(DIAG_DUPLICATE);
+    expect(result.stderr).not.toContain(DIAG_OUT_OF_ORDER);
+    // The file must be untouched (no silent rewrite of the wrong region).
+    expect(readFileSync(wfPath, "utf8")).toBe(noMarkers);
+  });
+
+  it("fails loud when markers are duplicated", () => {
+    const dup = [
+      "      service:",
+      "        type: choice",
+      `        ${BEGIN}`,
+      "        options:",
+      `        ${END}`,
+      "      other:",
+      "        type: choice",
+      `        ${BEGIN}`,
+      "        options:",
+      `        ${END}`,
+      "",
+    ].join("\n");
+    writeFileSync(wfPath, dup);
+    const result = spawnSync("npx", ["tsx", SCRIPT, `--workflow=${wfPath}`], {
+      encoding: "utf8",
+    });
+    // Render error → exit 3, with the SPECIFIC "duplicate" diagnostic.
+    expect(result.status).toBe(3);
+    expect(result.stderr).toContain(DIAG_DUPLICATE);
+    expect(result.stderr).not.toContain(DIAG_NOT_FOUND);
+    expect(result.stderr).not.toContain(DIAG_OUT_OF_ORDER);
+    expect(readFileSync(wfPath, "utf8")).toBe(dup);
+  });
+
+  it("fails loud when markers are out of order (END before BEGIN)", () => {
+    // Exactly one BEGIN and one END, but END appears FIRST. This must be
+    // distinguished from "not found" and "duplicate" with its own diagnostic.
+    const outOfOrder = [
+      "      service:",
+      "        type: choice",
+      `        ${END}`,
+      "        options:",
+      `        ${BEGIN}`,
+      "",
+    ].join("\n");
+    writeFileSync(wfPath, outOfOrder);
+    const result = spawnSync("npx", ["tsx", SCRIPT, `--workflow=${wfPath}`], {
+      encoding: "utf8",
+    });
+    // Render error → nonzero exit 3, with the SPECIFIC "malformed" diagnostic.
+    expect(result.status).toBe(3);
+    expect(result.stderr).toContain(DIAG_OUT_OF_ORDER);
+    expect(result.stderr).not.toContain(DIAG_NOT_FOUND);
+    expect(result.stderr).not.toContain(DIAG_DUPLICATE);
+    // The file must be left untouched.
+    expect(readFileSync(wfPath, "utf8")).toBe(outOfOrder);
+  });
+
+  it("exits 2 on a read error (nonexistent --workflow path)", () => {
+    const missingPath = join(workDir, "does-not-exist.yml");
+    const result = spawnSync(
+      "npx",
+      ["tsx", SCRIPT, `--workflow=${missingPath}`],
+      { encoding: "utf8" },
+    );
+    // ALL read failures, including a missing file, exit 2 (not 3).
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("failed to read");
+  });
+
+  it("rejects an unknown flag (fail loud, exit 2) instead of silently writing", () => {
+    // Seed a valid workflow so the ONLY reason to fail is the bad arg — a
+    // typo like `--chek` must NOT silently fall through to a destructive
+    // write of the real workflow.
+    writeFileSync(wfPath, fixture("        options:"));
+    const before = readFileSync(wfPath, "utf8");
+    const result = spawnSync(
+      "npx",
+      ["tsx", SCRIPT, "--chek", `--workflow=${wfPath}`],
+      { encoding: "utf8" },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("Unknown argument: --chek");
+    // The file is untouched — no silent write happened.
+    expect(readFileSync(wfPath, "utf8")).toBe(before);
+  });
+
+  it("rejects an empty --workflow= value (fail loud, exit 2)", () => {
+    const result = spawnSync("npx", ["tsx", SCRIPT, "--workflow="], {
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("--workflow= requires a path value");
+  });
+
+  it("rejects a bare --workflow with no value (fail loud, exit 2)", () => {
+    const result = spawnSync("npx", ["tsx", SCRIPT, "--workflow", wfPath], {
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("--workflow requires a value");
+  });
+
+  it("rejects a duplicate --workflow= (fail loud, exit 2)", () => {
+    const other = join(workDir, "other.yml");
+    const result = spawnSync(
+      "npx",
+      ["tsx", SCRIPT, `--workflow=${wfPath}`, `--workflow=${other}`],
+      { encoding: "utf8" },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("--workflow may only be supplied once");
+  });
+
+  it("preserves content outside the markers and keeps valid YAML", () => {
+    writeFileSync(wfPath, fixture("        options:"));
+    execFileSync("npx", ["tsx", SCRIPT, `--workflow=${wfPath}`], {
+      stdio: "pipe",
+    });
+    const after = readFileSync(wfPath, "utf8");
+    // Surrounding structure is intact.
+    expect(after).toContain('name: "Showcase: Promote (staging → prod)"');
+    expect(after).toContain("      digest:");
+    expect(after).toContain("  resolve-targets:");
+    // Still parses, and the digest input is untouched.
+    const doc = parseYaml(after);
+    expect(doc.on.workflow_dispatch.inputs.digest.type).toBe("string");
+    expect(doc.on.workflow_dispatch.inputs.service.type).toBe("choice");
+  });
+
+  it("importing the module does NOT trigger main() (import.meta.url guard)", () => {
+    // Spawn a tsx process whose entrypoint is an ESM eval that dynamically
+    // IMPORTS the module — so process.argv[1] is the eval shim, NOT the module
+    // path. The `import.meta.url` guard must therefore see argv[1] !== its own
+    // URL and skip main(). If the guard were broken, main() would run on
+    // import, read the DEFAULT workflow path, and print "wrote ..."/"already
+    // up to date." We assert no such generator output appears, and that the
+    // import itself completes (the sentinel prints AFTER the await).
+    const importer = join(workDir, "importer.mjs");
+    // Point at the .ts source via a file:// URL so tsx transpiles it on import.
+    const scriptUrl = `file://${SCRIPT}`;
+    writeFileSync(
+      importer,
+      [
+        `await import(${JSON.stringify(scriptUrl)});`,
+        `process.stdout.write("IMPORT_OK\\n");`,
+      ].join("\n"),
+    );
+    const result = spawnSync("npx", ["tsx", importer], {
+      encoding: "utf8",
+      cwd: workDir,
+    });
+    // The import completed cleanly...
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("IMPORT_OK");
+    // ...and main() never ran: none of its stdout/stderr signatures appear.
+    expect(result.stdout).not.toMatch(/^wrote /m);
+    expect(result.stdout).not.toContain("already up to date");
+    expect(result.stdout).not.toContain("up to date.");
+    expect(result.stderr).not.toContain("failed to read");
+  });
+
+  it("every generated token round-trips to exactly ONE SSOT service (resolve-step contract)", () => {
+    const tokens = computeOptionTokens(SERVICES);
+    // The literals the resolve step special-cases; they must never collide
+    // with a real service token.
+    const reserved = new Set([SENTINEL, "all"]);
+
+    for (const token of tokens) {
+      if (reserved.has(token)) continue;
+
+      // The SAME predicate the workflow's resolve step uses to map a chosen
+      // dropdown token back to an SSOT service, applied EXACTLY:
+      //   (.name === token || .dispatchName === token) && .probe.prod === true
+      // The resolve step is `select(.name == $s or .dispatchName == $s) |
+      // select(.probe.prod == true)`, so the `probe.prod === true` filter is a
+      // load-bearing term of the predicate, NOT a redundant one we can omit.
+      // Including it here keeps this round-trip check identical to both the
+      // resolve step and the generator's own uniqueness guard: a future
+      // non-prod service sharing a name/dispatchName token with a prod-eligible
+      // service would resolve unambiguously to the single prod-eligible service
+      // (the non-prod candidate is filtered out), so it must NOT be counted as
+      // an ambiguous match here either.
+      const matches = Object.entries(SERVICES).filter(
+        ([name, entry]) =>
+          entry.probe.prod === true &&
+          (name === token || entry.dispatchName === token),
+      );
+      // Exactly ONE service resolves from each generated token — no ambiguity,
+      // no orphans. This pins the generator↔resolve contract.
+      expect(
+        matches.length,
+        `token "${token}" should resolve to exactly one service, got ${matches.length}`,
+      ).toBe(1);
+    }
+
+    // No real-service token may masquerade as a reserved literal. The loop
+    // above `continue`s on reserved tokens, so it can never observe this —
+    // assert it DIRECTLY against the SSOT instead: iterate every real
+    // service, render its token exactly as computeOptionTokens does
+    // (dispatchName ?? key), and require none equals "all" or SENTINEL.
+    for (const [name, entry] of Object.entries(SERVICES)) {
+      const rendered = entry.dispatchName ?? name;
+      expect(
+        rendered,
+        `SSOT service "${name}" renders token "${rendered}", which collides with reserved literal SENTINEL`,
+      ).not.toBe(SENTINEL);
+      expect(
+        rendered,
+        `SSOT service "${name}" renders token "${rendered}", which collides with reserved literal "all"`,
+      ).not.toBe("all");
+    }
+
+    // Sanity: the reserved literals appear exactly once each, in order.
+    expect(tokens[0]).toBe(SENTINEL);
+    expect(tokens[1]).toBe("all");
+    expect(tokens.filter((t) => t === SENTINEL)).toHaveLength(1);
+    expect(tokens.filter((t) => t === "all")).toHaveLength(1);
+  });
+});

--- a/showcase/scripts/sync-promote-service-options.ts
+++ b/showcase/scripts/sync-promote-service-options.ts
@@ -1,0 +1,415 @@
+#!/usr/bin/env npx tsx
+/**
+ * sync-promote-service-options.ts — Self-maintaining dropdown generator for
+ * the `service` workflow_dispatch input of
+ * `.github/workflows/showcase_promote.yml`.
+ *
+ * The promote workflow's `service` input used to be a freeform `type: string`
+ * defaulting to "all", which made it trivially easy to accidentally kick off
+ * a whole-fleet prod promote. This generator turns it into a `type: choice`
+ * dropdown whose option list is derived directly from the SSOT
+ * (`railway-envs.ts` → `SERVICES`), so the dropdown can never drift from the
+ * set of promotable services.
+ *
+ * Option ordering (deliberate):
+ *   1. SENTINEL ("__select_a_service__") — FIRST. The anti-footgun default is
+ *      enforced by the emitted `default: <SENTINEL>` key (see
+ *      `renderGeneratedBody`), NOT by list position: GitHub honors an explicit
+ *      `default:` when present and only falls back to `options[0]` when it is
+ *      absent. Listing the sentinel first is secondary/cosmetic — it keeps the
+ *      default visually at the top of the menu. Selecting the sentinel aborts
+ *      the run (the workflow's resolve step rejects it), so nothing happens
+ *      unless a human picks a real target.
+ *   2. "all" — the explicit whole-fleet promote.
+ *   3. Each `probe.prod === true` service, rendered as its `dispatchName`
+ *      when set, else its `.name`, sorted alphabetically by the RENDERED
+ *      token so the dropdown reads in alphabetical order to a human.
+ *
+ * The generated block is spliced between two markers inside the workflow
+ * file. Everything outside the markers is preserved verbatim. If the markers
+ * are missing, duplicated, or malformed the generator FAILS LOUD (non-zero
+ * exit) rather than silently rewriting the wrong region.
+ *
+ * Flags:
+ *   --check              Validate without writing. See exit codes below.
+ *   --workflow=<path>    Override the target workflow path (used by tests).
+ *                        Defaults to the tracked showcase_promote.yml.
+ *
+ * Any unrecognized argument, a bare `--workflow` (no `=value`), an empty
+ * `--workflow=` value, or a duplicate `--workflow=` fails loud (exit 2).
+ *
+ * Exit codes:
+ *   1  Drift — under --check ONLY, the file would change (re-run to
+ *      regenerate). Exit 1 (drift) is the only code unique to --check; a
+ *      --check run can still exit 2 or 3 via the shared read/render paths.
+ *   2  I/O or usage error — the workflow file could not be read OR (in write
+ *      mode) could not be written, OR the CLI args were invalid (unknown
+ *      flag, bare/empty/duplicate --workflow). Covers ALL read failures
+ *      (including a missing file), write failures (EACCES/ENOSPC/etc.), and
+ *      argument-parse failures. Applies to BOTH the default write mode and
+ *      --check (--check only reads). Failing loud on a bad arg prevents a
+ *      typo like `--chek` from silently performing a destructive write.
+ *   3  Marker/render error — the generated marker block is missing,
+ *      duplicated, or malformed (out of order), or a rendered option token
+ *      is not YAML-safe, so the region cannot be spliced safely. The file is
+ *      left untouched. Applies to BOTH the default write mode and --check.
+ *
+ * Idempotent: writes only when the rendered content differs from disk. A
+ * lefthook pre-commit hook runs this (regenerate + `git add` the workflow)
+ * on commits that touch the SSOT or the generator, so the dropdown tracks
+ * the SSOT. (The hook is scoped to those paths and is bypassed by
+ * `LEFTHOOK=0`, so it is a convenience, not an ironclad guarantee.)
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SERVICES } from "./railway-envs";
+
+/** Selecting this option aborts the promote run (rejected by resolve step). */
+export const SENTINEL = "__select_a_service__";
+
+/**
+ * Tokens are interpolated RAW into the YAML `options:` list (`- ${token}`).
+ * A token carrying a YAML-special character (`:`, space, `#`, `*`, `&`,
+ * quotes, etc.) would silently emit a malformed workflow that the pre-commit
+ * hook then `git add`s. Today every SSOT key/dispatchName is `[a-z0-9-]`, but
+ * a future entry could break that, so we fail loud instead. The class below
+ * is a conservative ALLOWLIST — ASCII alphanumerics plus `.`, `_`, and `-`.
+ * Every character it permits is YAML-plain-scalar-safe, but the allowlist is
+ * deliberately narrower than the full set of YAML-safe characters: it is a
+ * whitelist of what we accept, not a proof of general YAML safety.
+ */
+const SAFE_TOKEN = /^[A-Za-z0-9._-]+$/;
+
+export const BEGIN_MARKER =
+  "# >>> BEGIN GENERATED service options (showcase/scripts/sync-promote-service-options.ts) — DO NOT EDIT";
+export const END_MARKER = "# <<< END GENERATED service options";
+
+const DEFAULT_WORKFLOW_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  ".github",
+  "workflows",
+  "showcase_promote.yml",
+);
+
+/**
+ * The ordered option-token list rendered into the dropdown:
+ *   [SENTINEL, "all", ...probe.prod services rendered as
+ *    (dispatchName ?? name) and sorted alphabetically by the RENDERED token]
+ *
+ * Sorting by the rendered token (rather than by SSOT key) means the menu
+ * reads in alphabetical order to a human — the SSOT key is invisible to the
+ * person picking a target, so ordering by it produces a scrambled-looking
+ * list.
+ */
+export function computeOptionTokens(
+  services: typeof SERVICES = SERVICES,
+): string[] {
+  const promotable = Object.entries(services)
+    .filter(([, entry]) => entry.probe.prod === true)
+    .map(([name, entry]) => {
+      const token = entry.dispatchName ?? name;
+      // Fail loud (routes through the exit-3 render path) rather than emit a
+      // YAML-breaking option the pre-commit hook would silently `git add`.
+      if (!SAFE_TOKEN.test(token)) {
+        throw new Error(
+          `sync-promote-service-options: option token "${token}" (SSOT key ` +
+            `"${name}") is not YAML-safe. Tokens must match ` +
+            `${SAFE_TOKEN} — fix the service's dispatchName or key.`,
+        );
+      }
+      return token;
+    })
+    // Deterministic byte/codepoint comparison rather than `localeCompare`:
+    // the lefthook hook runs on dev machines with varied LANG/LC_*, while
+    // CI's `--check` runs on a Depot runner, so locale-dependent collation
+    // could flag the dropdown as stale or ping-pong the file. A pinned
+    // codepoint sort (mirroring the repo's `LC_ALL=C` usage for `sort`) is
+    // stable across every machine.
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+  // Enforce the EXACT invariant the workflow's resolve step relies on. The
+  // resolve step maps a chosen dropdown token T back to a service via the
+  // predicate `s.name === T || s.dispatchName === T` and FAILS if more than
+  // one service matches (ambiguous → un-promotable). So every token we emit
+  // MUST resolve to exactly one service under that same predicate, and must
+  // not collide with a reserved literal ("all"/SENTINEL) the resolve step
+  // special-cases.
+  //
+  // This single structural check SUBSUMES the older piecemeal guards:
+  //   - reserved-literal collision (T === "all" || T === SENTINEL), and
+  //   - rendered-token dedupe (two services rendering the SAME token T match
+  //     each other under the predicate → matches.length > 1).
+  // Crucially it ALSO catches the case those guards MISSED: one service's
+  // rendered token T equaling a DIFFERENT service's `name`/`dispatchName`
+  // (e.g. A renders "foo" via dispatchName while B has name "foo" but a
+  // different dispatchName, so B renders a distinct token "bar"). The dedupe
+  // guard saw two distinct rendered tokens and passed, yet token "foo"
+  // resolves to BOTH A and B and is un-promotable. assertDispatchNamesUnique
+  // only dedupes dispatchName-vs-dispatchName and cannot see this either.
+  const reserved = new Set([SENTINEL, "all"]);
+  const allEntries = Object.entries(services);
+  for (const token of promotable) {
+    if (reserved.has(token)) {
+      throw new Error(
+        `sync-promote-service-options: option token ${JSON.stringify(token)} ` +
+          `collides with a reserved literal ("all" or ${JSON.stringify(SENTINEL)}). ` +
+          `A real service must not render as a reserved dropdown value — fix ` +
+          `the offending dispatchName or SSOT key.`,
+      );
+    }
+    // The resolve-step predicate, applied EXACTLY as the workflow does:
+    // `(name === token || dispatchName === token) && probe.prod === true`.
+    // The `probe.prod === true` restriction is load-bearing — the workflow's
+    // resolve step is `select(.name == $s or .dispatchName == $s) |
+    // select(.probe.prod == true)`, so the match set is restricted to
+    // prod-eligible services. Omitting it here would make the guard STRICTER
+    // than resolve: a future non-prod service sharing a name/dispatchName token
+    // with a prod-eligible service would be counted as a collision and throw
+    // (false positive, hard-blocking regeneration), even though the workflow
+    // would resolve that token unambiguously to the single prod-eligible
+    // service. With the restriction the guard is logically equivalent to
+    // resolve (the same predicate, modulo TS short-circuit AND vs jq's two
+    // chained `select`s in the opposite order).
+    const matches = allEntries.filter(
+      ([name, entry]) =>
+        entry.probe.prod === true &&
+        (name === token || entry.dispatchName === token),
+    );
+    if (matches.length !== 1) {
+      const keys = matches.map(([name]) => name);
+      throw new Error(
+        `sync-promote-service-options: option token ${JSON.stringify(token)} ` +
+          `resolves to ${matches.length} services ${JSON.stringify(keys)} ` +
+          `under the workflow resolve predicate ` +
+          `(s.name === token || s.dispatchName === token), but must resolve ` +
+          `to EXACTLY ONE. ${
+            matches.length > 1
+              ? `An ambiguous token is un-promotable (the resolve step fails ` +
+                `on >1 match). Fix the colliding dispatchName(s) or SSOT key(s).`
+              : `A token resolving to zero services should be impossible by ` +
+                `construction — this indicates an SSOT/generator inconsistency.`
+          }`,
+      );
+    }
+  }
+  return [SENTINEL, "all", ...promotable];
+}
+
+/**
+ * Render the generated body that sits BETWEEN the markers. The body carries
+ * the `default:` and `options:` keys at the SAME indentation as the BEGIN/END
+ * markers (`indent`), with list items indented one level (two spaces) deeper.
+ *
+ * The indentation is derived from the detected marker line rather than
+ * hardcoded so the body can never disagree with the marker lines that
+ * `renderWorkflow` re-emits: if the markers ever move to a different indent,
+ * the generated body follows them and the YAML stays valid.
+ */
+export function renderGeneratedBody(tokens: string[], indent: string): string {
+  const lines: string[] = [];
+  lines.push(`${indent}default: ${SENTINEL}`);
+  lines.push(`${indent}options:`);
+  for (const token of tokens) {
+    lines.push(`${indent}  - ${token}`);
+  }
+  return lines.join("\n");
+}
+
+interface MarkerSpan {
+  /** Index of the line containing BEGIN_MARKER. */
+  beginLine: number;
+  /** Index of the line containing END_MARKER. */
+  endLine: number;
+  /** The leading whitespace of the BEGIN marker line (preserved on splice). */
+  indent: string;
+}
+
+/**
+ * Locate the single marker pair. THROWS if zero or more than one BEGIN/END
+ * marker exists, or if they are out of order — never silently rewrite.
+ */
+function findMarkerSpan(lines: string[]): MarkerSpan {
+  const begins: number[] = [];
+  const ends: number[] = [];
+  // Match the TRIMMED line for equality with the marker, not `includes`:
+  // an incidental mention of the marker text in a comment or value
+  // elsewhere in the file would otherwise be miscounted as a duplicate
+  // marker and block all regeneration. Only a true marker line — whose
+  // sole content (modulo indentation) is the marker — counts.
+  lines.forEach((line, i) => {
+    const trimmed = line.trim();
+    if (trimmed === BEGIN_MARKER) begins.push(i);
+    if (trimmed === END_MARKER) ends.push(i);
+  });
+  if (begins.length === 0 || ends.length === 0) {
+    throw new Error(
+      `sync-promote-service-options: generated marker block not found ` +
+        `(expected exactly one BEGIN and one END marker). ` +
+        `BEGIN found ${begins.length}, END found ${ends.length}.`,
+    );
+  }
+  if (begins.length > 1 || ends.length > 1) {
+    throw new Error(
+      `sync-promote-service-options: duplicate generated markers ` +
+        `(found ${begins.length} BEGIN and ${ends.length} END markers; ` +
+        `expected exactly one of each). Refusing to rewrite.`,
+    );
+  }
+  const beginLine = begins[0];
+  const endLine = ends[0];
+  if (endLine <= beginLine) {
+    throw new Error(
+      `sync-promote-service-options: malformed marker block ` +
+        `(END marker at line ${endLine + 1} is not after BEGIN marker at ` +
+        `line ${beginLine + 1}). Refusing to rewrite.`,
+    );
+  }
+  const indentMatch = lines[beginLine].match(/^(\s*)/);
+  const indent = indentMatch ? indentMatch[1] : "";
+  return { beginLine, endLine, indent };
+}
+
+/**
+ * Produce the full file content with the generated body spliced between the
+ * markers. The marker lines themselves are preserved (re-emitted with their
+ * original indentation), and the body is rendered at that same detected
+ * indent so the keys/items always align with the markers. Content before
+ * BEGIN and after END is untouched.
+ */
+export function renderWorkflow(current: string, tokens: string[]): string {
+  // Normalize on \n for splicing; the workflow is LF-committed.
+  const lines = current.split("\n");
+  const { beginLine, endLine, indent } = findMarkerSpan(lines);
+  const body = renderGeneratedBody(tokens, indent);
+  const before = lines.slice(0, beginLine);
+  const after = lines.slice(endLine + 1);
+  const spliced = [
+    ...before,
+    `${indent}${BEGIN_MARKER}`,
+    body,
+    `${indent}${END_MARKER}`,
+    ...after,
+  ];
+  return spliced.join("\n");
+}
+
+interface ParsedArgs {
+  check: boolean;
+  workflowPath: string;
+}
+
+/**
+ * Parse CLI args, accepting EXACTLY `--check` and one `--workflow=<path>`.
+ *
+ * Fail loud (THROW) on any unrecognized arg, a bare `--workflow` with no
+ * value, an empty `--workflow=` value, or a duplicate `--workflow=`. This
+ * mirrors the sibling `verify-deploy.ts` (`Unknown argument: <a>`): a typo
+ * like `--chek` must NOT silently fall through to a destructive write, and a
+ * mishandled `--workflow` must NOT silently target the wrong file. Thrown
+ * errors are caught in main() and surface as the usage/I-O exit code (2).
+ */
+export function parseArgs(args: string[]): ParsedArgs {
+  let check = false;
+  let workflowPath: string | undefined;
+  for (const a of args) {
+    if (a === "--check") {
+      check = true;
+    } else if (a.startsWith("--workflow=")) {
+      const v = a.slice("--workflow=".length);
+      if (v === "") {
+        throw new Error("--workflow= requires a path value");
+      }
+      if (workflowPath !== undefined) {
+        throw new Error("--workflow may only be supplied once");
+      }
+      workflowPath = resolve(v);
+    } else if (a === "--workflow") {
+      // Bare `--workflow` with no `=<value>`: this tool only accepts the
+      // equals form, so reject rather than silently swallow the next arg.
+      throw new Error("--workflow requires a value (use --workflow=<path>)");
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return { check, workflowPath: workflowPath ?? DEFAULT_WORKFLOW_PATH };
+}
+
+function main(): void {
+  let check: boolean;
+  let workflowPath: string;
+  try {
+    ({ check, workflowPath } = parseArgs(process.argv.slice(2)));
+  } catch (err) {
+    // Usage error → exit 2 (same code as an I/O error; both are "couldn't
+    // even get to the render step"). Fail loud, no silent fallthrough to a
+    // destructive write.
+    process.stderr.write(
+      `sync-promote-service-options: ${(err as Error).message}\n`,
+    );
+    process.exit(2);
+  }
+
+  let current: string;
+  try {
+    current = readFileSync(workflowPath, "utf8");
+  } catch (err) {
+    process.stderr.write(
+      `sync-promote-service-options: failed to read ${workflowPath}: ${
+        (err as Error).message
+      }\n`,
+    );
+    process.exit(2);
+  }
+
+  // computeOptionTokens throws on a YAML-unsafe token; renderWorkflow throws
+  // (fail loud) on missing/duplicate/malformed markers. Both are render-class
+  // failures → exit 3. renderWorkflow also renders the body at the detected
+  // marker indent.
+  let next: string;
+  try {
+    const tokens = computeOptionTokens();
+    next = renderWorkflow(current, tokens);
+  } catch (err) {
+    process.stderr.write(`${(err as Error).message}\n`);
+    process.exit(3);
+  }
+
+  if (check) {
+    if (current !== next) {
+      process.stderr.write(
+        `showcase_promote.yml service dropdown is stale. Re-run:\n` +
+          `  npx tsx showcase/scripts/sync-promote-service-options.ts\n`,
+      );
+      process.exit(1);
+    }
+    process.stdout.write(
+      "showcase_promote.yml service dropdown is up to date.\n",
+    );
+    return;
+  }
+
+  if (current !== next) {
+    try {
+      writeFileSync(workflowPath, next);
+    } catch (err) {
+      // A write failure (EACCES/ENOSPC/etc.) is an I/O error, same class as a
+      // read failure → exit 2, consistent with the documented contract and the
+      // fail-loud philosophy (no raw stack trace).
+      process.stderr.write(
+        `sync-promote-service-options: failed to write ${workflowPath}: ${
+          (err as Error).message
+        }\n`,
+      );
+      process.exit(2);
+    }
+    process.stdout.write(`wrote ${workflowPath}\n`);
+  } else {
+    process.stdout.write(`${workflowPath} already up to date.\n`);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();


### PR DESCRIPTION
## Summary

Makes the showcase **single-service** staging→prod promote actually usable, and removes the accidental-whole-fleet footgun.

- **Self-maintaining dropdown.** The `service` input of `showcase_promote.yml` becomes a `type: choice` dropdown generated from the SSOT (`railway-envs.ts`) by a new `showcase/scripts/sync-promote-service-options.ts`. A lefthook pre-commit hook regenerates + restages it (fail-loud: a failed regen blocks the commit), and an advisory CI drift check warns on drift. The generator is fail-loud end-to-end: every emitted token must resolve to exactly one service under the *same* predicate the resolve step uses (`name|dispatchName` match **and** `probe.prod`), tokens must be YAML-safe, args are strict (a typo'd flag can't trigger a destructive write), and markers are validated before any rewrite.
- **Anti-footgun default.** The dropdown's first/default option is a rejected sentinel (`__select_a_service__`), so a blind "Run workflow" aborts instead of promoting. `resolve-targets` also fails loud on an ambiguous match (no silent `head -n1`), re-filters `probe.prod` independently, and rejects `--digest` combined with `all`.
- **Promote runs unattended.** The promote job was missing `--yes --non-interactive`, so it would die 100% of the time in CI's non-TTY env (this was masked because every run died earlier at the staging precondition). The manual dispatch + explicit service selection *is* the human authorization, so the job now runs unattended.
- **Notify hardening.** Empty-webhook guard + fallback warning (the broken Slack step that crashed with "Missing input"), neutral state for a sentinel abort and for any cancellation, and `resolve-targets.result` surfaced in the failure alert for triage.

Origin: operators kept accidentally running the default `all` promote, which the fleet-wide staging-green precondition then failed on whenever any one service (e.g. `showcase-ag2`) was red. Single-service promote (`-f service=shell-docs`) was the intended path but the promote job itself was non-functional.

## Review

This went through a full multi-round CR loop (7 reviewer agents/round, converged to zero demonstrable findings + a bucket-(c) promotion audit returning zero promotions). Test suite: 1709 vitest tests pass; tsc clean; actionlint clean (modulo the pre-existing `depot-ubuntu-24.04-4` runner-label warning).

## Follow-ups (not blocking, intentionally deferred)
- Add `*.yml text eol=lf` to `.gitattributes` (renderWorkflow assumes LF; only `*.sh` is currently pinned).
- Add `.github/workflows/showcase_promote.yml` to `showcase_validate.yml`'s `paths:` so a hand-edit to the committed dropdown triggers the advisory drift check.
- Notify alerting-precision: distinguish resolve-targets *input-validation* rejections from infra failures (currently both page).
- Pre-existing (out of scope): the `lint-fix` lefthook hook swallows `ruff`/`oxfmt` failures; `emit-railway-envs-json.ts` uses a looser `isMain` guard.

## Test plan
- [ ] CI green on this PR.
- [ ] After merge (staging auto-deploys), run `gh workflow run showcase_promote.yml -f service=shell-docs` and confirm a docs-only promote (unaffected by other services' staging health).