### PR TITLE
Resolve dashboard D6 per-cell via enum keys + correct depth/D6 stats

### DIFF
--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -108,10 +108,7 @@ export default function Page() {
 
   // Compute parity tier counts (validates tier before indexing — fail-loud
   // on unknown tiers rather than producing NaN).
-  const parityStats = useMemo(
-    () => computeParityStats(catalogData.cells),
-    [],
-  );
+  const parityStats = useMemo(() => computeParityStats(catalogData.cells), []);
 
   // Compute docs reachability stats from unique feature IDs
   const docsStats = useMemo(() => {

--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -2,7 +2,7 @@
 // Feature matrix: composable overlay-driven 2-tab layout.
 // Matrix tab: overlay toggles control which visual layers render.
 // Ops tab: probe status grid (unchanged from legacy).
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FeatureGrid } from "@/components/feature-grid";
 import type { CellContext } from "@/components/feature-grid";
 import { StatusTab } from "@/components/status-tab";
@@ -45,6 +45,27 @@ export default function Page() {
 
   const connection = allStatus.status;
 
+  // Wall-clock tick: forces staleness re-evaluation even when no SSE delta
+  // arrives. Without this, a wedged pipeline (no new rows) would never
+  // re-sample time, so a frozen-green cell could never downgrade to stale.
+  // One interval, 60s cadence (well under the staleness window), cleared on
+  // unmount. Bumping `tick` only invalidates the `now` memo below, so the
+  // re-render is cheap — the same recompute that already runs on every SSE
+  // delta.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Single reference time shared by EVERY staleness-deriving call below
+  // (healthStats, depthDistribution, d6Stats, renderCell). Re-sampled when
+  // live-status changes OR the 60s `tick` fires, so chips and stats agree on
+  // which green rows are stale instead of each defaulting to its own
+  // `Date.now()` that may have crossed a window boundary milliseconds later.
+  // Mirrors the single-`now` discipline in cell-matrix.tsx.
+  const now = useMemo(() => Date.now(), [liveStatus, tick]);
+
   // R2-D.1: real probe wiring. `useProbes` polls the ops API every 10s and
   // feeds the schedule grid; `useTriggerProbe` POSTs to /trigger with the
   // operator token. If the token is unset, the trigger callback throws
@@ -85,12 +106,16 @@ export default function Page() {
     for (const cell of catalogData.cells) {
       if (cell.status !== "wired" || cell.feature === null) continue;
       // "wired" status implies supported — no need to check unsupported here
-      const model = buildCellModel(liveStatus, {
-        slug: cell.integration,
-        featureId: cell.feature,
-        isSupported: true,
-        isWired: true,
-      });
+      const model = buildCellModel(
+        liveStatus,
+        {
+          slug: cell.integration,
+          featureId: cell.feature,
+          isSupported: true,
+          isWired: true,
+        },
+        now,
+      );
       switch (model.chipColor) {
         case "green":
           green++;
@@ -107,7 +132,7 @@ export default function Page() {
       }
     }
     return { green, amber, red };
-  }, [liveStatus]);
+  }, [liveStatus, now]);
 
   // Compute parity tier counts
   const parityStats = useMemo(() => {
@@ -163,17 +188,21 @@ export default function Page() {
     for (const cell of catalogData.cells) {
       if (cell.status !== "wired" || cell.feature === null) continue;
       // "wired" status implies supported — no need to check unsupported here
-      const model = buildCellModel(liveStatus, {
-        slug: cell.integration,
-        featureId: cell.feature,
-        isSupported: true,
-        isWired: true,
-      });
+      const model = buildCellModel(
+        liveStatus,
+        {
+          slug: cell.integration,
+          featureId: cell.feature,
+          isSupported: true,
+          isWired: true,
+        },
+        now,
+      );
       const key = `d${model.achievedDepth}` as keyof DepthDistribution;
       dist[key]++;
     }
     return dist;
-  }, [liveStatus]);
+  }, [liveStatus, now]);
 
   // Compute D6 (parity-vs-reference) rollup counts across wired cells.
   const d6Stats = useMemo((): D6Stats => {
@@ -182,7 +211,9 @@ export default function Page() {
     let red = 0;
     for (const cell of catalogData.cells) {
       if (cell.status !== "wired" || cell.feature === null) continue;
-      const state = resolveCell(liveStatus, cell.integration, cell.feature);
+      const state = resolveCell(liveStatus, cell.integration, cell.feature, {
+        now,
+      });
       switch (state.d6.tone) {
         case "green":
           green++;
@@ -196,7 +227,7 @@ export default function Page() {
       }
     }
     return { green, gray, red };
-  }, [liveStatus]);
+  }, [liveStatus, now]);
 
   // renderCell callback wrapping UnifiedCell + buildCellModel.
   // buildCellModel is the single source of truth for cell state — it handles
@@ -207,15 +238,19 @@ export default function Page() {
         ctx.integration.not_supported_features?.includes(ctx.feature.id) ??
         false
       );
-      const model = buildCellModel(ctx.liveStatus, {
-        slug: ctx.integration.slug,
-        featureId: ctx.feature.id,
-        isSupported,
-        isWired: true, // renderCell only called when demo exists
-      });
+      const model = buildCellModel(
+        ctx.liveStatus,
+        {
+          slug: ctx.integration.slug,
+          featureId: ctx.feature.id,
+          isSupported,
+          isWired: true, // renderCell only called when demo exists
+        },
+        now,
+      );
       return <UnifiedCell ctx={ctx} model={model} overlays={overlays} />;
     },
-    [overlays],
+    [overlays, now],
   );
 
   return (

--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -13,18 +13,18 @@ import { useOverlays } from "@/hooks/useOverlays";
 import { OverlayToggleBar } from "@/components/overlay-toggle-bar";
 import { UnifiedCell } from "@/components/unified-cell";
 import { buildCellModel } from "@/lib/cell-model";
+import {
+  computeHealthStats,
+  computeParityStats,
+  computeDepthDistribution,
+  computeD6Stats,
+} from "@/lib/page-stats";
 import { AdaptiveStatsBar } from "@/components/adaptive-stats-bar";
 import { AdaptiveLegend } from "@/components/adaptive-legend";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { BaselineTab } from "@/components/baseline-tab";
 import { DiscoveryAuthBanner } from "@/components/discovery-auth-banner";
-import type { ParityTier } from "@/components/parity-badge";
 import { getDocsStatus } from "@/lib/docs-status";
-import { resolveCell } from "@/lib/live-status";
-import type {
-  DepthDistribution,
-  D6Stats,
-} from "@/components/adaptive-stats-bar";
 import catalog from "@/data/catalog.json";
 import type { CatalogData } from "@/data/catalog-types";
 
@@ -98,61 +98,20 @@ export default function Page() {
   } = useOverlays();
 
   // Compute health stats using buildCellModel — single source of truth for
-  // chip color, so the stats bar matches what's visually displayed in the table.
-  const healthStats = useMemo(() => {
-    let green = 0;
-    let amber = 0;
-    let red = 0;
-    for (const cell of catalogData.cells) {
-      if (cell.status !== "wired" || cell.feature === null) continue;
-      // "wired" status implies supported — no need to check unsupported here
-      const model = buildCellModel(
-        liveStatus,
-        {
-          slug: cell.integration,
-          featureId: cell.feature,
-          isSupported: true,
-          isWired: true,
-        },
-        now,
-      );
-      switch (model.chipColor) {
-        case "green":
-          green++;
-          break;
-        case "amber":
-          amber++;
-          break;
-        case "red":
-          red++;
-          break;
-        case "gray":
-          green++;
-          break; // no data yet, not a failure
-      }
-    }
-    return { green, amber, red };
-  }, [liveStatus, now]);
+  // chip color, so the stats bar matches what's visually displayed in the
+  // table. A gray chip (no data yet) is tracked as `noData`, NOT folded into
+  // green, so the bar agrees with the matrix it summarizes.
+  const healthStats = useMemo(
+    () => computeHealthStats(catalogData.cells, liveStatus, now),
+    [liveStatus, now],
+  );
 
-  // Compute parity tier counts
-  const parityStats = useMemo(() => {
-    const counts: Record<ParityTier, number> = {
-      reference: 0,
-      at_parity: 0,
-      partial: 0,
-      minimal: 0,
-      not_wired: 0,
-    };
-    // Count unique integrations by tier
-    const seen = new Set<string>();
-    for (const cell of catalogData.cells) {
-      if (!seen.has(cell.integration)) {
-        seen.add(cell.integration);
-        counts[cell.parity_tier as ParityTier]++;
-      }
-    }
-    return counts;
-  }, []);
+  // Compute parity tier counts (validates tier before indexing — fail-loud
+  // on unknown tiers rather than producing NaN).
+  const parityStats = useMemo(
+    () => computeParityStats(catalogData.cells),
+    [],
+  );
 
   // Compute docs reachability stats from unique feature IDs
   const docsStats = useMemo(() => {
@@ -175,59 +134,20 @@ export default function Page() {
   }, []);
 
   // Compute depth distribution across all wired cells — re-derives whenever
-  // live-status changes since depth is a function of probe states.
-  const depthDistribution = useMemo((): DepthDistribution => {
-    const dist: DepthDistribution = {
-      d5: 0,
-      d4: 0,
-      d3: 0,
-      d2: 0,
-      d1: 0,
-      d0: 0,
-    };
-    for (const cell of catalogData.cells) {
-      if (cell.status !== "wired" || cell.feature === null) continue;
-      // "wired" status implies supported — no need to check unsupported here
-      const model = buildCellModel(
-        liveStatus,
-        {
-          slug: cell.integration,
-          featureId: cell.feature,
-          isSupported: true,
-          isWired: true,
-        },
-        now,
-      );
-      const key = `d${model.achievedDepth}` as keyof DepthDistribution;
-      dist[key]++;
-    }
-    return dist;
-  }, [liveStatus, now]);
+  // live-status changes since depth is a function of probe states. Uses an
+  // exhaustive achievedDepth→key map so D6-achieved cells land in the `d6`
+  // bucket (the old string cast dropped them).
+  const depthDistribution = useMemo(
+    () => computeDepthDistribution(catalogData.cells, liveStatus, now),
+    [liveStatus, now],
+  );
 
-  // Compute D6 (parity-vs-reference) rollup counts across wired cells.
-  const d6Stats = useMemo((): D6Stats => {
-    let green = 0;
-    let gray = 0;
-    let red = 0;
-    for (const cell of catalogData.cells) {
-      if (cell.status !== "wired" || cell.feature === null) continue;
-      const state = resolveCell(liveStatus, cell.integration, cell.feature, {
-        now,
-      });
-      switch (state.d6.tone) {
-        case "green":
-          green++;
-          break;
-        case "red":
-          red++;
-          break;
-        default:
-          gray++;
-          break;
-      }
-    }
-    return { green, gray, red };
-  }, [liveStatus, now]);
+  // Compute D6 (parity-vs-reference) rollup counts across wired cells —
+  // degraded/stale D6 surfaces distinctly instead of folding into gray.
+  const d6Stats = useMemo(
+    () => computeD6Stats(catalogData.cells, liveStatus, now),
+    [liveStatus, now],
+  );
 
   // renderCell callback wrapping UnifiedCell + buildCellModel.
   // buildCellModel is the single source of truth for cell state — it handles

--- a/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
@@ -125,7 +125,15 @@ describe("computeColumnTallyDetail", () => {
         "d5:my-int/tool-rendering",
         makeRow("d5:my-int/tool-rendering", "d5", "green"),
       ],
-      ["d6:my-int", makeRow("d6:my-int", "d6", "green")],
+      // Per-cell D6 rows (mapped via CATALOG_TO_D5_KEY) green for both cells.
+      [
+        "d6:my-int/agentic-chat",
+        makeRow("d6:my-int/agentic-chat", "d6", "green"),
+      ],
+      [
+        "d6:my-int/tool-rendering",
+        makeRow("d6:my-int/tool-rendering", "d6", "green"),
+      ],
     ]);
 
     const result = computeColumnTallyDetail(
@@ -191,7 +199,10 @@ describe("computeColumnTallyDetail", () => {
         "d5:partial/agentic-chat",
         makeRow("d5:partial/agentic-chat", "d5", "green"),
       ],
-      ["d6:partial", makeRow("d6:partial", "d6", "green")],
+      [
+        "d6:partial/agentic-chat",
+        makeRow("d6:partial/agentic-chat", "d6", "green"),
+      ],
     ]);
 
     const result = computeColumnTallyDetail(
@@ -320,7 +331,10 @@ describe("computeColumnTallyDetail", () => {
         "d5:ns-int/agentic-chat",
         makeRow("d5:ns-int/agentic-chat", "d5", "green"),
       ],
-      ["d6:ns-int", makeRow("d6:ns-int", "d6", "green")],
+      [
+        "d6:ns-int/agentic-chat",
+        makeRow("d6:ns-int/agentic-chat", "d6", "green"),
+      ],
     ]);
 
     const result = computeColumnTallyDetail(
@@ -337,6 +351,52 @@ describe("computeColumnTallyDetail", () => {
       { label: "Feature A", dimension: "e2e", featureId: "agentic-chat" },
     ]);
     expect(result.amber).toEqual([]);
+    expect(result.red).toEqual([]);
+  });
+
+  it("tallies PER-CELL D6 greens in a column with mixed per-cell rows (bug fix)", () => {
+    // The bug: the column tally derived from the integration aggregate
+    // `d6:<slug>`, so the moment ANY cell failed parity the WHOLE column went
+    // red. With per-cell D6 rows, a column with one red and one green cell
+    // tallies one green + one amber/red — NOT all-red.
+    const integration = makeIntegration("lgp", ["agentic-chat", "voice"]);
+    const features = [
+      makeFeature("agentic-chat", "Agentic Chat"),
+      makeFeature("voice", "Voice"),
+    ];
+
+    const liveStatus: LiveStatusMap = new Map([
+      // Both cells contiguous to D5 (green e2e + green d5).
+      ["e2e:lgp/agentic-chat", makeRow("e2e:lgp/agentic-chat", "e2e", "green")],
+      ["e2e:lgp/voice", makeRow("e2e:lgp/voice", "e2e", "green")],
+      ["d5:lgp/agentic-chat", makeRow("d5:lgp/agentic-chat", "d5", "green")],
+      ["d5:lgp/voice", makeRow("d5:lgp/voice", "d5", "green")],
+      // Aggregate is RED (because agentic-chat's parity failed)…
+      ["d6:lgp", makeRow("d6:lgp", "d6", "red")],
+      // …but per-cell: voice passed parity, agentic-chat did not.
+      [
+        "d6:lgp/agentic-chat",
+        makeRow("d6:lgp/agentic-chat", "d6", "red"),
+      ],
+      ["d6:lgp/voice", makeRow("d6:lgp/voice", "d6", "green")],
+    ]);
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "live",
+    );
+
+    expect(result.unknown).toBe(false);
+    // voice: D5 green + per-cell D6 green → green (NOT dragged red by aggregate).
+    expect(result.green).toEqual([
+      { label: "Voice", dimension: "e2e", featureId: "voice" },
+    ]);
+    // agentic-chat: D5 green + per-cell D6 red → amber (D6 above D5).
+    expect(result.amber).toEqual([
+      { label: "Agentic Chat", dimension: "health", featureId: "agentic-chat" },
+    ]);
     expect(result.red).toEqual([]);
   });
 });

--- a/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
@@ -375,10 +375,7 @@ describe("computeColumnTallyDetail", () => {
       // aggregate distractor — NOT consulted by per-cell resolveD6.
       ["d6:lgp", makeRow("d6:lgp", "d6", "red")],
       // …but per-cell: voice passed parity, agentic-chat did not.
-      [
-        "d6:lgp/agentic-chat",
-        makeRow("d6:lgp/agentic-chat", "d6", "red"),
-      ],
+      ["d6:lgp/agentic-chat", makeRow("d6:lgp/agentic-chat", "d6", "red")],
       ["d6:lgp/voice", makeRow("d6:lgp/voice", "d6", "green")],
     ]);
 

--- a/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
@@ -256,7 +256,8 @@ describe("computeColumnTallyDetail", () => {
         "e2e:h-int/agentic-chat",
         makeRow("e2e:h-int/agentic-chat", "e2e", "green"),
       ],
-      // chat green → D4 green (tools absent, worst-state skips it)
+      // tools row absent → not folded into the worst-state comparison; chat
+      // green alone yields D4 green.
       ["chat:h-int", makeRow("chat:h-int", "chat", "green")],
       // d5 red → ladder broken at D5 → chipColor red, dimension health
       ["d5:h-int/agentic-chat", makeRow("d5:h-int/agentic-chat", "d5", "red")],
@@ -371,7 +372,7 @@ describe("computeColumnTallyDetail", () => {
       ["e2e:lgp/voice", makeRow("e2e:lgp/voice", "e2e", "green")],
       ["d5:lgp/agentic-chat", makeRow("d5:lgp/agentic-chat", "d5", "green")],
       ["d5:lgp/voice", makeRow("d5:lgp/voice", "d5", "green")],
-      // Aggregate is RED (because agentic-chat's parity failed)…
+      // aggregate distractor — NOT consulted by per-cell resolveD6.
       ["d6:lgp", makeRow("d6:lgp", "d6", "red")],
       // …but per-cell: voice passed parity, agentic-chat did not.
       [

--- a/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
@@ -344,8 +344,8 @@ describe("(2) D6 / D5 enum fan-out rollup → chip color", () => {
 
   interface FanCase {
     name: string;
-    d5: State | "missing-one" | "absent";
-    d6: State | "missing-one" | "absent";
+    d5: State | "missing-one" | "absent" | "red-late";
+    d6: State | "missing-one" | "absent" | "red-late";
     expectChip: ChipColor;
   }
 
@@ -361,11 +361,19 @@ describe("(2) D6 / D5 enum fan-out rollup → chip color", () => {
     { name: "D5 all-missing + D6 absent", d5: "absent", d6: "absent", expectChip: "gray" },
     // D5 partial (1 sub-key missing) + D6 absent → D5 null (strict) → gray
     { name: "D5 partial + D6 absent", d5: "missing-one", d6: "absent", expectChip: "gray" },
-    // D5 any-fail (one red sub-key) → red (broken ladder dominates D6)
-    { name: "D5 any-fail", d5: "red", d6: "green", expectChip: "red" },
+    // D5 any-fail (one red sub-key, RED FIRST) → red (broken ladder dominates D6)
+    { name: "D5 any-fail (red first)", d5: "red", d6: "green", expectChip: "red" },
+    // D5 any-fail with the red sub-key NOT first (greens, then a red) →
+    // still red. Proves the worst-state fold is order-independent: a red
+    // encountered AFTER greens must not be lost. Mirrors the
+    // mid-list-red worst-state style in cell-model.test.ts / live-status.test.ts.
+    { name: "D5 any-fail (red NOT first)", d5: "red-late", d6: "green", expectChip: "red" },
   ];
 
-  function buildFanRows(kind: State | "missing-one" | "absent", dim: "d5" | "d6"): StatusRow[] {
+  function buildFanRows(
+    kind: State | "missing-one" | "absent" | "red-late",
+    dim: "d5" | "d6",
+  ): StatusRow[] {
     const keys = CATALOG_TO_D5_KEY[BC] ?? [];
     if (kind === "absent") return [];
     if (kind === "missing-one") {
@@ -378,6 +386,14 @@ describe("(2) D6 / D5 enum fan-out rollup → chip color", () => {
       // One red sub-key, rest green → worst-state red.
       return keys.map((k, i) =>
         row(keyFor(dim, SLUG, k), dim, i === 0 ? "red" : "green"),
+      );
+    }
+    if (kind === "red-late") {
+      // Greens first, then a red in a LATER slot (last key) → worst-state
+      // must still resolve red regardless of fold order.
+      const lastIdx = keys.length - 1;
+      return keys.map((k, i) =>
+        row(keyFor(dim, SLUG, k), dim, i === lastIdx ? "red" : "green"),
       );
     }
     return keys.map((k) => row(keyFor(dim, SLUG, k), dim, kind));
@@ -469,9 +485,8 @@ describe("(3) per-cell D6 vs aggregate precedence (c64aebc42)", () => {
 
   it("aggregate-only (no per-cell row) → D6 no-data → chip gray for enum-mapped feature", () => {
     // Only the aggregate exists; the per-cell enum row is absent. Because
-    // resolveD6 reads per-cell keys, D6 resolves to no-data (status null),
-    // and D5 green + D6 missing → amber per the ladder... but here D5 is also
-    // unemitted → D5 null + D6 missing → gray.
+    // resolveD6 reads per-cell keys, D6 resolves to no-data (status null).
+    // Here D5 is also unemitted → D5 null + D6 no-data → gray.
     const live = mapOf([
       ...gateGreen(FEATURE),
       row(keyFor("d6", SLUG), "d6", "green"), // aggregate ONLY

--- a/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
@@ -249,12 +249,18 @@ describe("(1) per-depth badge rendering — API/RT/CV/D6", () => {
     // CV (d5) — single enum key (agentic-chat→agentic-chat)
     {
       badge: "CV",
-      rows: [...gateGreen(FEATURE), row(keyFor("d5", SLUG, FEATURE), "d5", "green")],
+      rows: [
+        ...gateGreen(FEATURE),
+        row(keyFor("d5", SLUG, FEATURE), "d5", "green"),
+      ],
       expectStatus: "green",
     },
     {
       badge: "CV",
-      rows: [...gateGreen(FEATURE), row(keyFor("d5", SLUG, FEATURE), "d5", "red")],
+      rows: [
+        ...gateGreen(FEATURE),
+        row(keyFor("d5", SLUG, FEATURE), "d5", "red"),
+      ],
       expectStatus: "red",
     },
     // D6 — single enum key
@@ -288,9 +294,8 @@ describe("(1) per-depth badge rendering — API/RT/CV/D6", () => {
       );
       expect(labels.length).toBe(1);
       // The glyph sibling carries the tone class.
-      const glyphSpan = labels[0].parentElement?.querySelector(
-        "span.tabular-nums",
-      );
+      const glyphSpan =
+        labels[0].parentElement?.querySelector("span.tabular-nums");
       expect(glyphSpan).not.toBeNull();
       const expected = BADGE_RENDER[c.expectStatus ?? "null"];
       expect(glyphSpan?.textContent).toBe(expected.glyph);
@@ -352,22 +357,57 @@ describe("(2) D6 / D5 enum fan-out rollup → chip color", () => {
   // Derived from spec §5 chipColor decision table. Gate is green throughout.
   const fanCases: FanCase[] = [
     // D5 all-green + D6 all-green → green
-    { name: "D5 all-pass + D6 all-pass", d5: "green", d6: "green", expectChip: "green" },
+    {
+      name: "D5 all-pass + D6 all-pass",
+      d5: "green",
+      d6: "green",
+      expectChip: "green",
+    },
     // D5 all-green + D6 any-fail → amber (D5 green, D6 red)
-    { name: "D5 all-pass + D6 all-fail", d5: "green", d6: "red", expectChip: "amber" },
+    {
+      name: "D5 all-pass + D6 all-fail",
+      d5: "green",
+      d6: "red",
+      expectChip: "amber",
+    },
     // D5 all-green + D6 absent (unemitted) → amber (D5 green, D6 missing)
-    { name: "D5 all-pass + D6 absent", d5: "green", d6: "absent", expectChip: "amber" },
+    {
+      name: "D5 all-pass + D6 absent",
+      d5: "green",
+      d6: "absent",
+      expectChip: "amber",
+    },
     // D5 all-missing (none emitted) + D6 absent → D5 null → gray
-    { name: "D5 all-missing + D6 absent", d5: "absent", d6: "absent", expectChip: "gray" },
+    {
+      name: "D5 all-missing + D6 absent",
+      d5: "absent",
+      d6: "absent",
+      expectChip: "gray",
+    },
     // D5 partial (1 sub-key missing) + D6 absent → D5 null (strict) → gray
-    { name: "D5 partial + D6 absent", d5: "missing-one", d6: "absent", expectChip: "gray" },
+    {
+      name: "D5 partial + D6 absent",
+      d5: "missing-one",
+      d6: "absent",
+      expectChip: "gray",
+    },
     // D5 any-fail (one red sub-key, RED FIRST) → red (broken ladder dominates D6)
-    { name: "D5 any-fail (red first)", d5: "red", d6: "green", expectChip: "red" },
+    {
+      name: "D5 any-fail (red first)",
+      d5: "red",
+      d6: "green",
+      expectChip: "red",
+    },
     // D5 any-fail with the red sub-key NOT first (greens, then a red) →
     // still red. Proves the worst-state fold is order-independent: a red
     // encountered AFTER greens must not be lost. Mirrors the
     // mid-list-red worst-state style in cell-model.test.ts / live-status.test.ts.
-    { name: "D5 any-fail (red NOT first)", d5: "red-late", d6: "green", expectChip: "red" },
+    {
+      name: "D5 any-fail (red NOT first)",
+      d5: "red-late",
+      d6: "green",
+      expectChip: "red",
+    },
   ];
 
   function buildFanRows(
@@ -545,7 +585,9 @@ describe("(4) depth chip rendering D0..D6 × wired/unwired", () => {
 
   it("regression always forces danger-red regardless of color", () => {
     for (const color of colors) {
-      expect(chipColorToClass(color, true)).toBe("bg-[var(--danger)] text-white");
+      expect(chipColorToClass(color, true)).toBe(
+        "bg-[var(--danger)] text-white",
+      );
     }
   });
 
@@ -679,9 +721,7 @@ describe("(6) edges + rollup precedence", () => {
     // `tabular-nums`, so a container-wide selector would catch the chip.
     const healthLayer = queryByTestId("health-layer");
     expect(healthLayer).not.toBeNull();
-    expect(
-      healthLayer?.querySelectorAll("span.tabular-nums").length,
-    ).toBe(0);
+    expect(healthLayer?.querySelectorAll("span.tabular-nums").length).toBe(0);
     expect(queryByTestId("depth-chip")?.className).toContain(CHIP_CLASS.gray);
   });
 
@@ -745,11 +785,7 @@ describe("(6) edges + rollup precedence", () => {
     const integration = {
       slug: SLUG,
       name: "Agno",
-      demos: [
-        { id: "agentic-chat" },
-        { id: "voice" },
-        { id: "subagents" },
-      ],
+      demos: [{ id: "agentic-chat" }, { id: "voice" }, { id: "subagents" }],
     } as unknown as Integration;
     const features = [
       makeFeature("agentic-chat"), // green

--- a/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
@@ -1,0 +1,800 @@
+/**
+ * Dashboard cell color / badge / chip / rollup MATRIX.
+ *
+ * Table-driven verification of input (PocketBase `status` rows) → VISUAL
+ * OUTPUT (the colors/badges/chips/rollups an operator actually sees on the
+ * Coverage matrix). Distinct from `cell-model.test.ts` (which asserts the
+ * `CellModel` intermediate values): this suite asserts the RENDERED
+ * representation — TestBadge tone class + glyph, DepthChip CSS class, the
+ * `resolveCell` rollup tone, and the column-tally bucketing — so a regression
+ * in the model→pixel mapping (e.g. a badge tone class drift, or a chip color
+ * class swap) is caught even when the model values are unchanged.
+ *
+ * EXPECTED values are derived from the AUTHORITATIVE spec
+ * "🧮 Showcase Dashboard — Visualization & Rollup Logic"
+ * (notion 3733aa38185281d09385ebb7237e89d9, §4–§7), with one explicit,
+ * documented divergence: this worktree's HEAD is the per-cell D6 fix
+ * (commit c64aebc42), which the spec itself flags as the open question in §3
+ * ("the dashboard's resolveD6 was NOT updated to read those per-cell rows" on
+ * origin/main). We assert the FIXED per-cell behavior; see the
+ * "code-vs-doc divergence" describe block for the explicit delta.
+ *
+ * Covered:
+ *   (1) per-depth single-key pass→green/fail→red/missing→(no badge) for
+ *       API(d3)/RT(d4)/CV(d5)/D6, asserted as RENDERED badge tone+glyph.
+ *   (2) D6 enum fan-out rollup — beautiful-chat 5-key all-pass/any-fail/
+ *       all-missing/partial → documented chip color; the 1:1 + rename
+ *       mappings (headless-complete, chat-customization-css, gen-ui-tool-based).
+ *   (3) per-cell-vs-aggregate precedence (c64aebc42 fix): resolveD6 reads the
+ *       per-cell enum row, the aggregate-only column resolves gray for an
+ *       enum-mapped feature.
+ *   (4) depth chip D0..D6 × wired/unwired CSS class.
+ *   (5) overlay gating: health overlay → badges, depth overlay → chip.
+ *   (6) edges: unknown/empty/conflicting/no-mapping.
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { UnifiedCell } from "../unified-cell";
+import type { UnifiedCellProps } from "../unified-cell";
+import { DepthChip, chipColorToClass } from "../depth-chip";
+import { computeColumnTally } from "../feature-grid";
+import type { CellContext } from "../feature-grid";
+import type { Integration, Feature, Demo } from "@/lib/registry";
+import { buildCellModel } from "@/lib/cell-model";
+import type { CellModel, ChipColor, TestStatus } from "@/lib/cell-model";
+import { resolveCell, keyFor, CATALOG_TO_D5_KEY } from "@/lib/live-status";
+import type {
+  LiveStatusMap,
+  StatusRow,
+  State,
+  BadgeTone,
+} from "@/lib/live-status";
+import { TONE_CLASS } from "../badges";
+import type { Overlay } from "@/lib/overlay-types";
+
+// ---------------------------------------------------------------------------
+// Reusable fixture builders (test-hygiene: typed, no `as any`, top-level)
+// ---------------------------------------------------------------------------
+
+const FRESH = new Date().toISOString();
+
+function row(
+  key: string,
+  dimension: string,
+  state: State,
+  overrides: Partial<StatusRow> = {},
+): StatusRow {
+  return {
+    id: `id-${key}`,
+    key,
+    dimension,
+    state,
+    signal: {},
+    observed_at: FRESH,
+    transitioned_at: FRESH,
+    fail_count: state === "red" ? 1 : 0,
+    first_failure_at: state === "red" ? FRESH : null,
+    ...overrides,
+  };
+}
+
+function mapOf(rows: StatusRow[]): LiveStatusMap {
+  const m: LiveStatusMap = new Map();
+  for (const r of rows) m.set(r.key, r);
+  return m;
+}
+
+const SLUG = "agno";
+
+/**
+ * Build the live-status rows that hold the D1–D4 gate green for `featureId`,
+ * so D5/D6 are the only variables under test. (Gate = e2e green + chat green;
+ * see resolveD3/resolveD4.)
+ */
+function gateGreen(featureId: string): StatusRow[] {
+  return [
+    row(keyFor("e2e", SLUG, featureId), "e2e", "green"),
+    row(keyFor("chat", SLUG), "chat", "green"),
+  ];
+}
+
+/** Emit one row per mapped D5 sub-key for `featureId`, all the same state. */
+function d5Family(featureId: string, state: State): StatusRow[] {
+  const keys = CATALOG_TO_D5_KEY[featureId] ?? [];
+  return keys.map((k) => row(keyFor("d5", SLUG, k), "d5", state));
+}
+
+/** Emit one row per mapped D6 sub-key for `featureId`, all the same state. */
+function d6Family(featureId: string, state: State): StatusRow[] {
+  const keys = CATALOG_TO_D5_KEY[featureId] ?? [];
+  return keys.map((k) => row(keyFor("d6", SLUG, k), "d6", state));
+}
+
+function wiredModel(
+  live: LiveStatusMap,
+  featureId: string,
+  now: number = Date.now(),
+): CellModel {
+  return buildCellModel(
+    live,
+    { slug: SLUG, featureId, isSupported: true, isWired: true },
+    now,
+  );
+}
+
+// --- Minimal CellContext / props builders for component render --------------
+
+function makeIntegration(): Integration {
+  return {
+    slug: SLUG,
+    name: "Agno",
+    demos: [],
+  } as unknown as Integration;
+}
+
+function makeFeature(featureId: string): Feature {
+  return {
+    id: featureId,
+    name: featureId,
+    category: "chat-ui",
+    kind: "demo",
+  } as unknown as Feature;
+}
+
+function makeDemo(featureId: string): Demo {
+  return { id: featureId } as unknown as Demo;
+}
+
+function makeCtx(live: LiveStatusMap, featureId: string): CellContext {
+  return {
+    integration: makeIntegration(),
+    feature: makeFeature(featureId),
+    demo: makeDemo(featureId),
+    hostedUrl: "https://example.test/demo",
+    shellUrl: "https://example.test",
+    liveStatus: live,
+    connection: "live",
+  };
+}
+
+function renderCell(
+  live: LiveStatusMap,
+  featureId: string,
+  overlays: Overlay[],
+): ReturnType<typeof render> {
+  const model = wiredModel(live, featureId);
+  const props: UnifiedCellProps = {
+    ctx: makeCtx(live, featureId),
+    model,
+    overlays: new Set(overlays),
+  };
+  return render(<UnifiedCell {...props} />);
+}
+
+// ---------------------------------------------------------------------------
+// Reference tables — the single source of expected mappings.
+// ---------------------------------------------------------------------------
+
+/**
+ * status → rendered TestBadge tone + glyph (unified-cell.tsx:44-60).
+ * `null` status → glyph "?" → Badge returns null (no badge rendered).
+ * `undefined` row for `tone` means "no element expected".
+ */
+const BADGE_RENDER: Record<
+  Exclude<TestStatus, null> | "null",
+  { tone: BadgeTone; glyph: string }
+> = {
+  green: { tone: "green", glyph: "✓" },
+  red: { tone: "red", glyph: "✗" },
+  amber: { tone: "amber", glyph: "~" },
+  null: { tone: "gray", glyph: "?" },
+};
+
+/** chipColor → CSS class (depth-chip.tsx chipColorToClass, no regression). */
+const CHIP_CLASS: Record<ChipColor, string> = {
+  green: "bg-emerald-600 text-white",
+  amber: "bg-[var(--amber)] text-white",
+  red: "bg-[var(--danger)] text-white",
+  gray: "bg-[var(--text-muted)]/20 text-[var(--text-muted)]",
+};
+
+// ===========================================================================
+// (1) Per-depth single-key: pass→green / fail→red / missing→(no badge),
+//     asserted as the RENDERED badge tone class + glyph.
+// ===========================================================================
+
+describe("(1) per-depth badge rendering — API/RT/CV/D6", () => {
+  // agentic-chat is 1:1 mapped (CATALOG_TO_D5_KEY["agentic-chat"] =
+  // ["agentic-chat"]) so each depth is a single key, isolating one badge.
+  const FEATURE = "agentic-chat";
+
+  interface DepthCase {
+    badge: "API" | "RT" | "CV" | "D6";
+    /** rows that set THIS depth's state; gate rows added automatically. */
+    rows: StatusRow[];
+    expectStatus: TestStatus;
+  }
+
+  // Each case sets the named depth's underlying row(s); for the chip to even
+  // reach a given depth the lower rungs must be green, so we layer rows.
+  const cases: DepthCase[] = [
+    // API (d3) — single e2e key
+    {
+      badge: "API",
+      rows: [row(keyFor("e2e", SLUG, FEATURE), "e2e", "green")],
+      expectStatus: "green",
+    },
+    {
+      badge: "API",
+      rows: [row(keyFor("e2e", SLUG, FEATURE), "e2e", "red")],
+      expectStatus: "red",
+    },
+    // RT (d4) — chat/tools; green requires gate green first
+    {
+      badge: "RT",
+      rows: [
+        row(keyFor("e2e", SLUG, FEATURE), "e2e", "green"),
+        row(keyFor("chat", SLUG), "chat", "green"),
+      ],
+      expectStatus: "green",
+    },
+    {
+      badge: "RT",
+      rows: [
+        row(keyFor("e2e", SLUG, FEATURE), "e2e", "green"),
+        row(keyFor("chat", SLUG), "chat", "red"),
+      ],
+      expectStatus: "red",
+    },
+    // CV (d5) — single enum key (agentic-chat→agentic-chat)
+    {
+      badge: "CV",
+      rows: [...gateGreen(FEATURE), row(keyFor("d5", SLUG, FEATURE), "d5", "green")],
+      expectStatus: "green",
+    },
+    {
+      badge: "CV",
+      rows: [...gateGreen(FEATURE), row(keyFor("d5", SLUG, FEATURE), "d5", "red")],
+      expectStatus: "red",
+    },
+    // D6 — single enum key
+    {
+      badge: "D6",
+      rows: [
+        ...gateGreen(FEATURE),
+        row(keyFor("d5", SLUG, FEATURE), "d5", "green"),
+        row(keyFor("d6", SLUG, FEATURE), "d6", "green"),
+      ],
+      expectStatus: "green",
+    },
+    {
+      badge: "D6",
+      rows: [
+        ...gateGreen(FEATURE),
+        row(keyFor("d5", SLUG, FEATURE), "d5", "green"),
+        row(keyFor("d6", SLUG, FEATURE), "d6", "red"),
+      ],
+      expectStatus: "red",
+    },
+  ];
+
+  for (const c of cases) {
+    it(`${c.badge} ${c.expectStatus} → tone ${BADGE_RENDER[c.expectStatus ?? "null"].tone}, glyph ${BADGE_RENDER[c.expectStatus ?? "null"].glyph}`, () => {
+      const live = mapOf(c.rows);
+      const { container } = renderCell(live, FEATURE, ["health"]);
+      // Find the badge by its leading label text (API/RT/CV/D6).
+      const labels = Array.from(container.querySelectorAll("span")).filter(
+        (s) => s.textContent === c.badge,
+      );
+      expect(labels.length).toBe(1);
+      // The glyph sibling carries the tone class.
+      const glyphSpan = labels[0].parentElement?.querySelector(
+        "span.tabular-nums",
+      );
+      expect(glyphSpan).not.toBeNull();
+      const expected = BADGE_RENDER[c.expectStatus ?? "null"];
+      expect(glyphSpan?.textContent).toBe(expected.glyph);
+      expect(glyphSpan?.className).toContain(TONE_CLASS[expected.tone]);
+    });
+  }
+
+  it("missing depth → no badge rendered (RT absent when chat/tools missing)", () => {
+    // Only e2e present → d4 (RT) does not exist → no RT badge.
+    const live = mapOf([row(keyFor("e2e", SLUG, FEATURE), "e2e", "green")]);
+    const { container } = renderCell(live, FEATURE, ["health"]);
+    const rtLabels = Array.from(container.querySelectorAll("span")).filter(
+      (s) => s.textContent === "RT",
+    );
+    expect(rtLabels.length).toBe(0);
+  });
+
+  it("no-data depth (mapped, unemitted) → no badge (glyph '?' → Badge null)", () => {
+    // Gate green, D5 mapped but unemitted → d5.status null → CV glyph "?"
+    // → Badge returns null. The CV badge must NOT render.
+    const live = mapOf(gateGreen(FEATURE));
+    const model = wiredModel(live, FEATURE);
+    expect(model.d5?.exists).toBe(true);
+    expect(model.d5?.status).toBeNull();
+    const { container } = renderCell(live, FEATURE, ["health"]);
+    const cvLabels = Array.from(container.querySelectorAll("span")).filter(
+      (s) => s.textContent === "CV",
+    );
+    expect(cvLabels.length).toBe(0);
+  });
+});
+
+// ===========================================================================
+// (2) D6 enum fan-out rollup — beautiful-chat (5 keys) + rename mappings.
+//     Assert the documented chip color (spec §5 chipColor table) per the
+//     fan-out family state, AND the actual rendered chip CSS class.
+// ===========================================================================
+
+describe("(2) D6 / D5 enum fan-out rollup → chip color", () => {
+  const BC = "beautiful-chat"; // 5 sub-keys
+
+  it("beautiful-chat maps to exactly 5 D5/D6 sub-keys (fan-out)", () => {
+    expect(CATALOG_TO_D5_KEY[BC]).toEqual([
+      "beautiful-chat-toggle-theme",
+      "beautiful-chat-pie-chart",
+      "beautiful-chat-bar-chart",
+      "beautiful-chat-search-flights",
+      "beautiful-chat-schedule-meeting",
+    ]);
+  });
+
+  interface FanCase {
+    name: string;
+    d5: State | "missing-one" | "absent";
+    d6: State | "missing-one" | "absent";
+    expectChip: ChipColor;
+  }
+
+  // Derived from spec §5 chipColor decision table. Gate is green throughout.
+  const fanCases: FanCase[] = [
+    // D5 all-green + D6 all-green → green
+    { name: "D5 all-pass + D6 all-pass", d5: "green", d6: "green", expectChip: "green" },
+    // D5 all-green + D6 any-fail → amber (D5 green, D6 red)
+    { name: "D5 all-pass + D6 all-fail", d5: "green", d6: "red", expectChip: "amber" },
+    // D5 all-green + D6 absent (unemitted) → amber (D5 green, D6 missing)
+    { name: "D5 all-pass + D6 absent", d5: "green", d6: "absent", expectChip: "amber" },
+    // D5 all-missing (none emitted) + D6 absent → D5 null → gray
+    { name: "D5 all-missing + D6 absent", d5: "absent", d6: "absent", expectChip: "gray" },
+    // D5 partial (1 sub-key missing) + D6 absent → D5 null (strict) → gray
+    { name: "D5 partial + D6 absent", d5: "missing-one", d6: "absent", expectChip: "gray" },
+    // D5 any-fail (one red sub-key) → red (broken ladder dominates D6)
+    { name: "D5 any-fail", d5: "red", d6: "green", expectChip: "red" },
+  ];
+
+  function buildFanRows(kind: State | "missing-one" | "absent", dim: "d5" | "d6"): StatusRow[] {
+    const keys = CATALOG_TO_D5_KEY[BC] ?? [];
+    if (kind === "absent") return [];
+    if (kind === "missing-one") {
+      // Emit all-but-one green (drop the bar-chart sub-key).
+      return keys
+        .filter((k) => k !== "beautiful-chat-bar-chart")
+        .map((k) => row(keyFor(dim, SLUG, k), dim, "green"));
+    }
+    if (kind === "red") {
+      // One red sub-key, rest green → worst-state red.
+      return keys.map((k, i) =>
+        row(keyFor(dim, SLUG, k), dim, i === 0 ? "red" : "green"),
+      );
+    }
+    return keys.map((k) => row(keyFor(dim, SLUG, k), dim, kind));
+  }
+
+  for (const c of fanCases) {
+    it(`${c.name} → chip ${c.expectChip}`, () => {
+      const live = mapOf([
+        ...gateGreen(BC),
+        ...buildFanRows(c.d5, "d5"),
+        ...buildFanRows(c.d6, "d6"),
+      ]);
+      const model = wiredModel(live, BC);
+      expect(model.chipColor).toBe(c.expectChip);
+
+      // Rendered chip CSS class must match the chip color.
+      const { getByTestId } = renderCell(live, BC, ["depth"]);
+      const chip = getByTestId("depth-chip");
+      expect(chip.className).toContain(CHIP_CLASS[c.expectChip]);
+    });
+  }
+
+  // 1:1 + rename mappings — each resolves through a SINGLE renamed enum key.
+  interface RenameCase {
+    featureId: string;
+    enumKey: string;
+  }
+  const renameCases: RenameCase[] = [
+    { featureId: "headless-complete", enumKey: "gen-ui-headless-complete" },
+    { featureId: "chat-customization-css", enumKey: "chat-css" },
+    { featureId: "gen-ui-tool-based", enumKey: "gen-ui-custom" },
+    { featureId: "agentic-chat", enumKey: "agentic-chat" }, // 1:1 verbatim
+  ];
+
+  for (const rc of renameCases) {
+    it(`${rc.featureId} maps to enum key '${rc.enumKey}' and greens when that key passes`, () => {
+      expect(CATALOG_TO_D5_KEY[rc.featureId]).toEqual([rc.enumKey]);
+      // Drive D5+D6 via the RENAMED enum key — proves the fan-out reads the
+      // enum key, not the raw catalog featureId.
+      const live = mapOf([
+        ...gateGreen(rc.featureId),
+        row(keyFor("d5", SLUG, rc.enumKey), "d5", "green"),
+        row(keyFor("d6", SLUG, rc.enumKey), "d6", "green"),
+      ]);
+      const model = wiredModel(live, rc.featureId);
+      expect(model.d5?.status).toBe("green");
+      expect(model.d6?.status).toBe("green");
+      expect(model.chipColor).toBe("green");
+
+      // Negative control: a row keyed by the RAW featureId (when it differs
+      // from the enum key) must NOT be consulted.
+      if (rc.enumKey !== rc.featureId) {
+        const rawOnly = mapOf([
+          ...gateGreen(rc.featureId),
+          row(keyFor("d5", SLUG, rc.featureId), "d5", "green"),
+          row(keyFor("d6", SLUG, rc.featureId), "d6", "green"),
+        ]);
+        const rawModel = wiredModel(rawOnly, rc.featureId);
+        // Enum key absent → D5 no-data → gray, NOT green.
+        expect(rawModel.d5?.status).toBeNull();
+        expect(rawModel.chipColor).toBe("gray");
+      }
+    });
+  }
+});
+
+// ===========================================================================
+// (3) Per-cell vs aggregate precedence (c64aebc42 fix).
+//     resolveD6 reads the per-cell enum row; the aggregate `d6:<slug>` is
+//     NOT consulted. An aggregate-only column → gray for an enum-mapped
+//     feature.
+// ===========================================================================
+
+describe("(3) per-cell D6 vs aggregate precedence (c64aebc42)", () => {
+  const FEATURE = "agentic-chat";
+
+  it("green per-cell row wins over a RED aggregate → chip green", () => {
+    const live = mapOf([
+      ...gateGreen(FEATURE),
+      row(keyFor("d5", SLUG, FEATURE), "d5", "green"),
+      row(keyFor("d6", SLUG), "d6", "red"), // aggregate red (other cell failed)
+      row(keyFor("d6", SLUG, FEATURE), "d6", "green"), // this cell's per-cell row
+    ]);
+    const model = wiredModel(live, FEATURE);
+    expect(model.d6?.status).toBe("green");
+    expect(model.d6?.row?.key).toBe("d6:agno/agentic-chat");
+    expect(model.chipColor).toBe("green");
+  });
+
+  it("aggregate-only (no per-cell row) → D6 no-data → chip gray for enum-mapped feature", () => {
+    // Only the aggregate exists; the per-cell enum row is absent. Because
+    // resolveD6 reads per-cell keys, D6 resolves to no-data (status null),
+    // and D5 green + D6 missing → amber per the ladder... but here D5 is also
+    // unemitted → D5 null + D6 missing → gray.
+    const live = mapOf([
+      ...gateGreen(FEATURE),
+      row(keyFor("d6", SLUG), "d6", "green"), // aggregate ONLY
+    ]);
+    const model = wiredModel(live, FEATURE);
+    // Aggregate must not be read as the per-cell value.
+    expect(model.d6?.status).toBeNull();
+    expect(model.d6?.row).toBeNull();
+    // D5 unemitted (null) + D6 no-data → gray.
+    expect(model.chipColor).toBe("gray");
+  });
+
+  it("two features on the same slug resolve INDEPENDENT per-cell D6 rows", () => {
+    const live = mapOf([
+      ...gateGreen("agentic-chat"),
+      row(keyFor("e2e", SLUG, "voice"), "e2e", "green"),
+      row(keyFor("chat", SLUG), "chat", "green"),
+      row(keyFor("d5", SLUG, "agentic-chat"), "d5", "green"),
+      row(keyFor("d5", SLUG, "voice"), "d5", "green"),
+      row(keyFor("d6", SLUG), "d6", "red"), // aggregate ignored
+      row(keyFor("d6", SLUG, "agentic-chat"), "d6", "green"),
+      row(keyFor("d6", SLUG, "voice"), "d6", "red"),
+    ]);
+    const a = wiredModel(live, "agentic-chat");
+    const b = wiredModel(live, "voice");
+    expect(a.chipColor).toBe("green");
+    expect(b.chipColor).toBe("amber"); // D5 green + D6 red → amber
+    expect(a.d6?.row?.key).toBe("d6:agno/agentic-chat");
+    expect(b.d6?.row?.key).toBe("d6:agno/voice");
+  });
+
+  it("resolveCell D6 badge tone also reads per-cell, not aggregate", () => {
+    const live = mapOf([
+      ...gateGreen(FEATURE),
+      row(keyFor("d6", SLUG), "d6", "red"), // aggregate red
+      row(keyFor("d6", SLUG, FEATURE), "d6", "green"), // per-cell green
+    ]);
+    const cell = resolveCell(live, SLUG, FEATURE);
+    expect(cell.d6.tone).toBe("green");
+    expect(cell.d6.row?.key).toBe("d6:agno/agentic-chat");
+  });
+});
+
+// ===========================================================================
+// (4) Depth chip D0..D6 × wired/unwired CSS class.
+// ===========================================================================
+
+describe("(4) depth chip rendering D0..D6 × wired/unwired", () => {
+  // chipColorToClass mapping is the pure contract; assert each color.
+  const colors: ChipColor[] = ["green", "amber", "red", "gray"];
+  for (const color of colors) {
+    it(`chipColorToClass('${color}') → ${CHIP_CLASS[color]}`, () => {
+      expect(chipColorToClass(color)).toBe(CHIP_CLASS[color]);
+    });
+  }
+
+  it("regression always forces danger-red regardless of color", () => {
+    for (const color of colors) {
+      expect(chipColorToClass(color, true)).toBe("bg-[var(--danger)] text-white");
+    }
+  });
+
+  // Wired chip renders D{depth} text + data-depth + the chipColor class.
+  const depths: Array<0 | 1 | 2 | 3 | 4 | 5 | 6> = [0, 1, 2, 3, 4, 5, 6];
+  for (const depth of depths) {
+    it(`wired chip depth ${depth} renders "D${depth}" with data-depth`, () => {
+      const { getByTestId } = render(
+        <DepthChip chipColor="green" depth={depth} status="wired" />,
+      );
+      const chip = getByTestId("depth-chip");
+      expect(chip.textContent).toBe(`D${depth}`);
+      expect(chip.getAttribute("data-depth")).toBe(String(depth));
+      expect(chip.className).toContain(CHIP_CLASS.green);
+    });
+  }
+
+  it("unwired (not-wired) cell → gray chip at depth 0", () => {
+    const model = buildCellModel(mapOf([]), {
+      slug: SLUG,
+      featureId: "agentic-chat",
+      isSupported: true,
+      isWired: false,
+    });
+    expect(model.chipColor).toBe("gray");
+    expect(model.achievedDepth).toBe(0);
+    const { getByTestId } = render(
+      <DepthChip
+        chipColor={model.chipColor}
+        depth={model.achievedDepth}
+        status="wired"
+      />,
+    );
+    expect(getByTestId("depth-chip").className).toContain(CHIP_CLASS.gray);
+  });
+
+  it("unshipped chip renders '--' dashed (not a depth)", () => {
+    const { getByTestId } = render(
+      <DepthChip chipColor="gray" depth={0} status="unshipped" />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.textContent).toBe("--");
+    expect(chip.getAttribute("data-status")).toBe("unshipped");
+  });
+
+  it("unsupported chip renders the ban glyph + slate fill", () => {
+    const { getByTestId } = render(
+      <DepthChip chipColor="gray" depth={0} status="unsupported" />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.getAttribute("data-status")).toBe("unsupported");
+    expect(chip.className).toContain("bg-slate-500/10");
+  });
+});
+
+// ===========================================================================
+// (5) Overlay gating — health overlay → badges, depth overlay → chip.
+// ===========================================================================
+
+describe("(5) overlay gating: which layers render", () => {
+  const FEATURE = "agentic-chat";
+  function liveAllGreen(): LiveStatusMap {
+    return mapOf([
+      ...gateGreen(FEATURE),
+      row(keyFor("d5", SLUG, FEATURE), "d5", "green"),
+      row(keyFor("d6", SLUG, FEATURE), "d6", "green"),
+    ]);
+  }
+
+  it("health overlay only → HealthLayer (badges) present, no DepthLayer", () => {
+    const { queryByTestId } = renderCell(liveAllGreen(), FEATURE, ["health"]);
+    expect(queryByTestId("health-layer")).not.toBeNull();
+    expect(queryByTestId("depth-layer")).toBeNull();
+  });
+
+  it("depth overlay only → DepthLayer (chip) present, no HealthLayer", () => {
+    const { queryByTestId } = renderCell(liveAllGreen(), FEATURE, ["depth"]);
+    expect(queryByTestId("depth-layer")).not.toBeNull();
+    expect(queryByTestId("health-layer")).toBeNull();
+  });
+
+  it("both overlays → both layers render", () => {
+    const { queryByTestId } = renderCell(liveAllGreen(), FEATURE, [
+      "depth",
+      "health",
+    ]);
+    expect(queryByTestId("depth-layer")).not.toBeNull();
+    expect(queryByTestId("health-layer")).not.toBeNull();
+  });
+
+  it("no overlays → empty cell (no layers)", () => {
+    const { queryByTestId } = renderCell(liveAllGreen(), FEATURE, []);
+    expect(queryByTestId("unified-cell-empty")).not.toBeNull();
+    expect(queryByTestId("health-layer")).toBeNull();
+    expect(queryByTestId("depth-layer")).toBeNull();
+  });
+
+  it("unsupported cell short-circuits to ban-icon regardless of overlays", () => {
+    const props: UnifiedCellProps = {
+      ctx: makeCtx(mapOf([]), FEATURE),
+      model: buildCellModel(mapOf([]), {
+        slug: SLUG,
+        featureId: FEATURE,
+        isSupported: false,
+        isWired: false,
+      }),
+      overlays: new Set<Overlay>(["depth", "health"]),
+    };
+    const { queryByTestId } = render(<UnifiedCell {...props} />);
+    expect(queryByTestId("unified-cell-unsupported")).not.toBeNull();
+    expect(queryByTestId("health-layer")).toBeNull();
+    expect(queryByTestId("depth-layer")).toBeNull();
+  });
+});
+
+// ===========================================================================
+// (6) Edges: empty / conflicting / no-mapping / rollup precedence.
+// ===========================================================================
+
+describe("(6) edges + rollup precedence", () => {
+  const FEATURE = "agentic-chat";
+
+  it("empty live map → gray chip, no badges, achieved 0", () => {
+    const live = mapOf([]);
+    const model = wiredModel(live, FEATURE);
+    expect(model.chipColor).toBe("gray");
+    expect(model.achievedDepth).toBe(0);
+    const { queryByTestId } = renderCell(live, FEATURE, ["health", "depth"]);
+    // No badges (all levels no-data/missing → all glyph "?" → Badge null).
+    // Scope to the HealthLayer — the DepthChip span ALSO carries
+    // `tabular-nums`, so a container-wide selector would catch the chip.
+    const healthLayer = queryByTestId("health-layer");
+    expect(healthLayer).not.toBeNull();
+    expect(
+      healthLayer?.querySelectorAll("span.tabular-nums").length,
+    ).toBe(0);
+    expect(queryByTestId("depth-chip")?.className).toContain(CHIP_CLASS.gray);
+  });
+
+  it("no-mapping feature (no CATALOG_TO_D5_KEY) → D5/D6 not-exist → gray at D4 ceiling", () => {
+    const FEATURE_UNMAPPED = "no-such-d5-feature";
+    expect(CATALOG_TO_D5_KEY[FEATURE_UNMAPPED]).toBeUndefined();
+    const live = mapOf(gateGreen(FEATURE_UNMAPPED));
+    const model = wiredModel(live, FEATURE_UNMAPPED);
+    expect(model.d5?.exists).toBe(false);
+    expect(model.d6?.exists).toBe(false);
+    expect(model.ceilingDepth).toBe(4);
+    expect(model.chipColor).toBe("gray");
+  });
+
+  it("conflicting D4: green chat + red tools → worst-state red → red chip", () => {
+    const live = mapOf([
+      row(keyFor("e2e", SLUG, FEATURE), "e2e", "green"),
+      row(keyFor("chat", SLUG), "chat", "green"),
+      row(keyFor("tools", SLUG), "tools", "red"),
+    ]);
+    const model = wiredModel(live, FEATURE);
+    expect(model.d4?.status).toBe("red");
+    expect(model.chipColor).toBe("red");
+  });
+
+  it("resolveCell rollup precedence: red > amber(degraded) > green", () => {
+    // red wins
+    const redLive = mapOf([
+      row(keyFor("health", SLUG), "health", "green"),
+      row(keyFor("e2e", SLUG, FEATURE), "e2e", "red"),
+    ]);
+    expect(resolveCell(redLive, SLUG, FEATURE).rollup).toBe("red");
+
+    // degraded → amber when no red
+    const amberLive = mapOf([
+      row(keyFor("health", SLUG), "health", "degraded"),
+      row(keyFor("e2e", SLUG, FEATURE), "e2e", "green"),
+    ]);
+    expect(resolveCell(amberLive, SLUG, FEATURE).rollup).toBe("amber");
+
+    // all green → green
+    const greenLive = mapOf([
+      row(keyFor("health", SLUG), "health", "green"),
+      row(keyFor("e2e", SLUG, FEATURE), "e2e", "green"),
+    ]);
+    expect(resolveCell(greenLive, SLUG, FEATURE).rollup).toBe("green");
+  });
+
+  it("connection error → rollup forced to error tone (stale-green suppressed)", () => {
+    const live = mapOf([
+      row(keyFor("health", SLUG), "health", "green"),
+      row(keyFor("e2e", SLUG, FEATURE), "e2e", "green"),
+    ]);
+    const cell = resolveCell(live, SLUG, FEATURE, { connection: "error" });
+    // Would-be green becomes error when the stream is down.
+    expect(cell.rollup).toBe("error");
+  });
+
+  it("column tally buckets by chipColor; gray excluded", () => {
+    // Build three features: green, red, gray (no-data) and assert counts.
+    const integration = {
+      slug: SLUG,
+      name: "Agno",
+      demos: [
+        { id: "agentic-chat" },
+        { id: "voice" },
+        { id: "subagents" },
+      ],
+    } as unknown as Integration;
+    const features = [
+      makeFeature("agentic-chat"), // green
+      makeFeature("voice"), // red
+      makeFeature("subagents"), // gray (no data)
+    ];
+    const live = mapOf([
+      // agentic-chat full green
+      row(keyFor("e2e", SLUG, "agentic-chat"), "e2e", "green"),
+      row(keyFor("chat", SLUG), "chat", "green"),
+      row(keyFor("d5", SLUG, "agentic-chat"), "d5", "green"),
+      row(keyFor("d6", SLUG, "agentic-chat"), "d6", "green"),
+      // voice red e2e → red chip
+      row(keyFor("e2e", SLUG, "voice"), "e2e", "red"),
+      // subagents → no rows → gray (excluded)
+    ]);
+    const tally = computeColumnTally(integration, features, live, "live");
+    expect(tally).toEqual({ green: 1, amber: 0, red: 1, unknown: false });
+  });
+
+  it("column tally returns unknown=true when connection is error", () => {
+    const integration = {
+      slug: SLUG,
+      name: "Agno",
+      demos: [{ id: "agentic-chat" }],
+    } as unknown as Integration;
+    const tally = computeColumnTally(
+      integration,
+      [makeFeature("agentic-chat")],
+      mapOf([]),
+      "error",
+    );
+    expect(tally).toEqual({ green: 0, amber: 0, red: 0, unknown: true });
+  });
+});
+
+// ===========================================================================
+// CODE-VS-DOC DIVERGENCE (reported as a finding, asserted as code behavior).
+// ===========================================================================
+
+describe("code-vs-doc divergence — D6 per-cell (spec §3 open question)", () => {
+  // The Notion spec (§3, §4 resolveD6) documents origin/main, where resolveD6
+  // reads ONLY the integration aggregate `d6:<slug>`. THIS worktree (HEAD
+  // c64aebc42) resolves D6 PER-CELL via CATALOG_TO_D5_KEY — the spec's own
+  // "open question" resolved. These assertions lock the FIXED behavior and
+  // document the delta so the next reader knows the doc trails the code.
+  const FEATURE = "agentic-chat";
+
+  it("FIXED behavior: aggregate is NOT the per-cell D6 source (contradicts spec §4 origin/main text)", () => {
+    const live = mapOf([
+      ...gateGreen(FEATURE),
+      row(keyFor("d5", SLUG, FEATURE), "d5", "green"),
+      row(keyFor("d6", SLUG), "d6", "red"), // aggregate red
+      row(keyFor("d6", SLUG, FEATURE), "d6", "green"), // per-cell green
+    ]);
+    const model = wiredModel(live, FEATURE);
+    // Spec §4 (origin/main) would predict the aggregate red → cell amber/red.
+    // FIXED code: per-cell green → chip green.
+    expect(model.d6?.row?.key).toBe(keyFor("d6", SLUG, FEATURE));
+    expect(model.d6?.row?.key).not.toBe(keyFor("d6", SLUG));
+    expect(model.chipColor).toBe("green");
+  });
+});

--- a/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
@@ -374,7 +374,7 @@ describe("deriveDepth", () => {
     expect(result.achieved).toBe(4);
   });
 
-  it("returns D6 when D0-D5 green plus D6 green (aggregate key)", () => {
+  it("returns D6 when D0-D5 green plus D6 green (per-cell key)", () => {
     const c = cell("lgp", "agentic-chat");
     const live = mapOf([
       row("health:lgp", "health", "green"),
@@ -382,7 +382,7 @@ describe("deriveDepth", () => {
       row("e2e:lgp/agentic-chat", "e2e", "green"),
       row("chat:lgp", "chat", "green"),
       row("d5:lgp/agentic-chat", "d5", "green"),
-      row("d6:lgp", "d6", "green"),
+      row("d6:lgp/agentic-chat", "d6", "green"),
     ]);
     const result = deriveDepth(c, live);
     expect(result.achieved).toBe(6);
@@ -429,7 +429,7 @@ describe("deriveDepth", () => {
         row("e2e:lgp/agentic-chat", "e2e", "green", FRESH_AT),
         row("chat:lgp", "chat", "green", FRESH_AT),
         row("d5:lgp/agentic-chat", "d5", "green", FRESH_AT),
-        row("d6:lgp", "d6", "green", STALE_AT),
+        row("d6:lgp/agentic-chat", "d6", "green", STALE_AT),
       ]);
       const result = deriveDepth(c, live, NOW);
       // Stale green D6 must not advance past D5.
@@ -444,7 +444,7 @@ describe("deriveDepth", () => {
         row("e2e:lgp/agentic-chat", "e2e", "green", FRESH_AT),
         row("chat:lgp", "chat", "green", FRESH_AT),
         row("d5:lgp/agentic-chat", "d5", "green", FRESH_AT),
-        row("d6:lgp", "d6", "green", FRESH_AT),
+        row("d6:lgp/agentic-chat", "d6", "green", FRESH_AT),
       ]);
       const result = deriveDepth(c, live, NOW);
       expect(result.achieved).toBe(6);
@@ -592,7 +592,7 @@ describe("deriveDepth", () => {
         row("e2e:lgp/agentic-chat", "e2e", "green"),
         row("chat:lgp", "chat", "green"),
         row("d5:lgp/agentic-chat", "d5", "green"),
-        row("d6:lgp", "d6", "green"),
+        row("d6:lgp/agentic-chat", "d6", "green"),
       ]);
       const result = deriveDepth(c, live);
       expect(result.achieved).toBe(6);

--- a/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
@@ -701,6 +701,20 @@ describe("deriveDepth", () => {
       expect(result.isRegression).toBe(false);
     });
 
+    it("stub with no live data → maxPossible=0, NOT a regression (stub = not-yet-wired)", () => {
+      // A `stub` cell is "not yet wired", not "regressed". Treating it like
+      // `unshipped` (maxPossible=0) means a stub with no probe data does not
+      // light up the regression indicator. Pre-fix, computeMaxPossible gave a
+      // stub the same 4/6 ceiling as a wired cell, so achieved=0 < maxPossible
+      // falsely flagged isRegression.
+      const c = cell("lgp", "agentic-chat", "stub");
+      const live = mapOf([]);
+      const result = deriveDepth(c, live);
+      expect(result.achieved).toBe(0);
+      expect(result.maxPossible).toBe(0);
+      expect(result.isRegression).toBe(false);
+    });
+
     it("null feature → maxPossible=2 (integration-scoped only)", () => {
       const c: CatalogCell = {
         id: "lgp/null",

--- a/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
@@ -405,6 +405,26 @@ describe("UnifiedCell", () => {
       expect(getByTestId("unified-cell-empty")).toBeInTheDocument();
       expect(queryByTestId("unified-cell")).not.toBeInTheDocument();
     });
+
+    // ── d6 is a content-bearing overlay (surfaces depth + health) ─────
+    // Regression guard: a {d6}-only set must NOT render a blank cell even
+    // though only adaptive-stats-bar reads overlays.has("d6"). Per-cell the
+    // d6 pill surfaces the depth chip + health badges (incl. the D6 badge).
+    it("renders depth + health content (not blank) for a {d6}-only overlay set", () => {
+      const ctx = makeCtx();
+      const model = makeModel({ d6: makeLevel(true, "green") });
+      const { getByTestId, queryByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("d6")} />,
+      );
+
+      // Cell is NOT the blank-empty placeholder.
+      expect(queryByTestId("unified-cell-empty")).not.toBeInTheDocument();
+      expect(getByTestId("unified-cell")).toBeInTheDocument();
+      // Depth + health content surfaces, including the D6 badge.
+      expect(getByTestId("depth-layer")).toBeInTheDocument();
+      expect(getByTestId("health-layer")).toBeInTheDocument();
+      expect(getByTestId("mock-badge-D6")).toBeInTheDocument();
+    });
   });
 
   // ── Additional coverage ───────────────────────────────────────────

--- a/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
@@ -12,6 +12,7 @@ import type { Overlay } from "@/lib/overlay-types";
 
 /** Depth distribution: count of cells at each depth level. */
 export interface DepthDistribution {
+  d6: number;
   d5: number;
   d4: number;
   d3: number;
@@ -23,6 +24,8 @@ export interface DepthDistribution {
 /** D6 (parity-vs-reference) rollup counts. */
 export interface D6Stats {
   green: number;
+  /** Degraded / stale-green D6 cells — surfaced distinctly, not hidden as gray. */
+  degraded: number;
   gray: number;
   red: number;
 }
@@ -31,7 +34,7 @@ export interface AdaptiveStatsBarProps {
   overlays: Set<Overlay>;
   catalog: CatalogData;
   /** Health stats (computed externally) */
-  healthStats?: { green: number; amber: number; red: number };
+  healthStats?: { green: number; amber: number; red: number; noData: number };
   /** Parity tier counts (computed externally) */
   parityStats?: Record<ParityTier, number>;
   /** Docs stats (computed externally) */
@@ -164,13 +167,14 @@ function DepthSection({
   );
 }
 
-/** Compact depth distribution: D5..D1 counts in a single row. */
+/** Compact depth distribution: D6..D1 counts in a single row. */
 function DepthDistributionSection({
   distribution,
 }: {
   distribution: DepthDistribution;
 }) {
   const levels: { key: keyof DepthDistribution; label: string }[] = [
+    { key: "d6", label: "D6" },
     { key: "d5", label: "D5" },
     { key: "d4", label: "D4" },
     { key: "d3", label: "D3" },
@@ -197,7 +201,7 @@ function DepthDistributionSection({
 function HealthSection({
   stats,
 }: {
-  stats: { green: number; amber: number; red: number };
+  stats: { green: number; amber: number; red: number; noData: number };
 }) {
   return (
     <div className="flex items-center gap-3">
@@ -223,6 +227,14 @@ function HealthSection({
           value={stats.red}
           label="red"
           colorClass="text-[var(--danger)]"
+        />
+      </span>
+      <span className="flex items-center gap-1">
+        <Dot color="var(--text-muted)" />
+        <MiniStat
+          value={stats.noData}
+          label="no data"
+          colorClass="text-[var(--text-muted)]"
         />
       </span>
     </div>
@@ -261,6 +273,14 @@ function D6Section({ stats }: { stats: D6Stats }) {
           value={stats.green}
           label="green"
           colorClass="text-[var(--ok)]"
+        />
+      </span>
+      <span className="flex items-center gap-1">
+        <Dot color="var(--amber)" />
+        <MiniStat
+          value={stats.degraded}
+          label="degraded"
+          colorClass="text-[var(--amber)]"
         />
       </span>
       <span className="flex items-center gap-1">

--- a/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
@@ -10,14 +10,21 @@ import type { ParityTier } from "./parity-badge";
 import type { CatalogData } from "../data/catalog-types";
 import type { Overlay } from "@/lib/overlay-types";
 
-/** Depth distribution: count of cells at each depth level. */
+/**
+ * Depth distribution: count of cells at each achieved depth.
+ *
+ * Keys mirror the only values `buildCellModel().achievedDepth` can produce
+ * (`0 | 3 | 4 | 5 | 6`). There is no d1/d2 bucket — the contiguous-ladder
+ * algorithm in cell-model.ts never yields achievedDepth 1 or 2, so those
+ * buckets would be permanently 0. `d0` is wired-but-unverified (no passing
+ * rung yet); the rendered row includes it so the distribution sums to the
+ * wired-cell count.
+ */
 export interface DepthDistribution {
   d6: number;
   d5: number;
   d4: number;
   d3: number;
-  d2: number;
-  d1: number;
   d0: number;
 }
 
@@ -167,7 +174,14 @@ function DepthSection({
   );
 }
 
-/** Compact depth distribution: D6..D1 counts in a single row. */
+/**
+ * Compact depth distribution: D6, D5, D4, D3, D0 counts in a single row.
+ *
+ * Only depths `buildCellModel().achievedDepth` can produce are shown. D0 (wired
+ * but no passing rung yet) is rendered so wired-unverified cells stay visible
+ * and the row sums to the "Wired" count; the never-reachable D1/D2 rows are
+ * omitted instead of rendering permanent zeros.
+ */
 function DepthDistributionSection({
   distribution,
 }: {
@@ -178,8 +192,7 @@ function DepthDistributionSection({
     { key: "d5", label: "D5" },
     { key: "d4", label: "D4" },
     { key: "d3", label: "D3" },
-    { key: "d2", label: "D2" },
-    { key: "d1", label: "D1" },
+    { key: "d0", label: "D0" },
   ];
 
   return (
@@ -343,7 +356,11 @@ export function AdaptiveStatsBar({
   depthDistribution,
   d6Stats,
 }: AdaptiveStatsBarProps) {
-  const sections: React.ReactNode[] = [];
+  // Typed as ReactElement (not ReactNode) so each section's stable `key` is
+  // readable below — the wrapper reuses it for correct reconciliation when
+  // overlays toggle, instead of an array index that shifts as sections appear
+  // and disappear.
+  const sections: React.ReactElement[] = [];
 
   // Base — always present
   sections.push(
@@ -382,7 +399,7 @@ export function AdaptiveStatsBar({
       className="px-8 py-3 flex items-center gap-4 border-b border-[var(--border)] bg-[var(--bg-muted)]"
     >
       {sections.map((section, i) => (
-        <div key={i} className="flex items-center gap-4">
+        <div key={section.key} className="flex items-center gap-4">
           {i > 0 && <Divider />}
           {section}
         </div>

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -257,21 +257,24 @@ function arePropsEqual(
 
   if (p.liveStatus === n.liveStatus) return true;
 
-  // Map identity changed — verify only the rows this cell reads. Mirrors
-  // the lookups in resolveCell + LevelStrip-adjacent helpers; D5 AND D6 are
-  // resolved per-cell through CATALOG_TO_D5_KEY, so we walk the same
-  // indirection here to avoid false-negative skips. Keep this list in sync
-  // with resolveCell + resolveD5Row + resolveD6Row in lib/live-status.ts.
+  // Map identity changed — verify only the rows this cell reads. The sole
+  // consumer of liveStatus in this cell is DepthLayer → deriveDepth(), so we
+  // watch exactly the keys deriveDepth reads: health:<slug> (D1),
+  // agent:<slug> (D2), e2e:<slug>/<featureId> (D3), chat:<slug> + tools:<slug>
+  // (D4), and the d5:/d6:<slug>/<featureType> per-cell rows (D5/D6). Keep this
+  // list in sync with deriveDepth in components/depth-utils.ts.
   const slug = p.integration.slug;
   const featureId = p.feature.id;
   const directKeys = [
     keyFor("health", slug),
+    keyFor("agent", slug),
     keyFor("e2e", slug, featureId),
-    keyFor("smoke", slug),
+    keyFor("chat", slug),
+    keyFor("tools", slug),
   ];
   // D5 + D6 per-cell sub-keys (both map catalog featureId → featureType via
   // CATALOG_TO_D5_KEY). An unmapped feature has no per-cell rows, so nothing
-  // is added — the resolver returns no-data for it either way.
+  // is added — deriveDepth returns no D5/D6 advancement for it either way.
   const featureKeys = CATALOG_TO_D5_KEY[featureId];
   if (featureKeys && featureKeys.length > 0) {
     for (const ft of featureKeys) {

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -19,7 +19,7 @@ import { LinkPreview } from "@/components/link-preview";
 import { DepthChip } from "@/components/depth-chip";
 import { deriveDepth } from "@/components/depth-utils";
 import type { CatalogCell } from "@/components/depth-utils";
-import { keyFor } from "@/lib/live-status";
+import { keyFor, CATALOG_TO_D5_KEY } from "@/lib/live-status";
 
 import type { Overlay } from "@/lib/overlay-types";
 export type { Overlay };
@@ -258,19 +258,27 @@ function arePropsEqual(
   if (p.liveStatus === n.liveStatus) return true;
 
   // Map identity changed — verify only the rows this cell reads. Mirrors
-  // the lookups in resolveCell + LevelStrip-adjacent helpers; D5 is
-  // resolved through CATALOG_TO_D5_KEY, so we walk the same indirection
-  // here to avoid false-negative skips. Keep this list in sync with
-  // resolveCell + resolveD5Row in lib/live-status.ts.
+  // the lookups in resolveCell + LevelStrip-adjacent helpers; D5 AND D6 are
+  // resolved per-cell through CATALOG_TO_D5_KEY, so we walk the same
+  // indirection here to avoid false-negative skips. Keep this list in sync
+  // with resolveCell + resolveD5Row + resolveD6Row in lib/live-status.ts.
   const slug = p.integration.slug;
   const featureId = p.feature.id;
   const directKeys = [
     keyFor("health", slug),
     keyFor("e2e", slug, featureId),
     keyFor("smoke", slug),
-    keyFor("d5", slug, featureId),
-    keyFor("d6", slug),
   ];
+  // D5 + D6 per-cell sub-keys (both map catalog featureId → featureType via
+  // CATALOG_TO_D5_KEY). An unmapped feature has no per-cell rows, so nothing
+  // is added — the resolver returns no-data for it either way.
+  const featureKeys = CATALOG_TO_D5_KEY[featureId];
+  if (featureKeys && featureKeys.length > 0) {
+    for (const ft of featureKeys) {
+      directKeys.push(keyFor("d5", slug, ft));
+      directKeys.push(keyFor("d6", slug, ft));
+    }
+  }
   for (const k of directKeys) {
     if (prev.ctx.liveStatus.get(k) !== next.ctx.liveStatus.get(k)) return false;
   }

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -11,7 +11,7 @@
  *   D3 = e2e:<slug>/<featureId> green (per-cell)
  *   D4 = chat:<slug> OR tools:<slug> green (integration-scoped)
  *   D5 = d5:<slug>/<d5FeatureType> green (per-cell, mapped via CATALOG_TO_D5_KEY)
- *   D6 = d6:<slug> green (integration-scoped aggregate)
+ *   D6 = d6:<slug>/<d5FeatureType> green (per-cell, mapped via CATALOG_TO_D5_KEY)
  *
  * Achieved depth = highest D where ALL lower depths are also green.
  * Short-circuits: if any level is not green, stop there.
@@ -134,6 +134,32 @@ function isD5Green(
 }
 
 /**
+ * Check whether all D6 PB rows for a given (slug, catalogFeatureId) are green
+ * AND fresh. D6 is PER-CELL, not an integration aggregate: the `e2e-parity`
+ * driver emits `d6:<slug>/<featureType>` rows over the same featureType
+ * keyspace as D5 (both fan out over `demosToFeatureTypes`), so D6 resolves
+ * through the SAME `CATALOG_TO_D5_KEY` bridge. Returns false if the feature has
+ * no mapping or any mapped row is missing/non-green/stale — `every(...)`
+ * mirrors `isD5Green` and `cell-model.ts` `resolveD6` so all consumers agree.
+ * The integration-level `d6:<slug>` aggregate is NOT read here (it is red
+ * whenever any cell fails and would deny D6 to genuinely-green cells).
+ */
+function isD6Green(
+  live: LiveStatusMap,
+  slug: string,
+  featureId: string,
+  now: number,
+): boolean {
+  const d6Keys = CATALOG_TO_D5_KEY[featureId];
+  if (!d6Keys || d6Keys.length === 0) {
+    return false;
+  }
+  return d6Keys.every((d6Key) =>
+    isGreenAndFresh(live, keyFor("d6", slug, d6Key), now),
+  );
+}
+
+/**
  * Compute the maximum possible depth for a cell based on probe EXISTENCE.
  * This checks whether the structural prerequisites for each depth level
  * exist (key mappings, feature ID), NOT whether probes are currently green.
@@ -141,8 +167,9 @@ function isD5Green(
  * - D0: always possible for wired/stub cells
  * - D1-D4: always possible if the cell has a feature ID
  * - D5: possible only if CATALOG_TO_D5_KEY[featureId] exists and has entries
- * - D6: possible when a D5 mapping exists (D6 uses an integration-scoped
- *   aggregate key, so no additional per-feature mapping is needed)
+ * - D6: possible when a D5 mapping exists — D6 is per-cell and resolves
+ *   through the SAME CATALOG_TO_D5_KEY bridge, so the D5 mapping check
+ *   doubles as the D6 reachability check
  */
 function computeMaxPossible(cell: CatalogCell): AchievedDepth {
   // Unsupported/unshipped: max possible is 0.
@@ -285,8 +312,11 @@ export function deriveDepth(
   }
   achieved = 5;
 
-  // D6: d6:<slug> green (integration-scoped aggregate)
-  if (isGreenAndFresh(live, keyFor("d6", cell.integration), now)) {
+  // D6: d6:<slug>/<featureType> green (per-cell, mapped via CATALOG_TO_D5_KEY).
+  // PER-CELL, not the integration aggregate: the e2e-parity driver emits one
+  // row per featureType; the aggregate `d6:<slug>` is red whenever any cell
+  // fails and would deny D6 to a genuinely-green cell. Mirrors isD5Green.
+  if (isD6Green(live, cell.integration, cell.feature, now)) {
     achieved = 6;
   }
 

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -143,6 +143,10 @@ function isD5Green(
  * mirrors `isD5Green` and `cell-model.ts` `resolveD6` so all consumers agree.
  * The integration-level `d6:<slug>` aggregate is NOT read here (it is red
  * whenever any cell fails and would deny D6 to genuinely-green cells).
+ *
+ * The ladder walk in `deriveDepth` invokes this ONLY after D5 is green (the
+ * walk is contiguous), so D6 can never be credited over a broken D5 — a green
+ * D6 row on a red-D5 cell is short-circuited before reaching this check.
  */
 function isD6Green(
   live: LiveStatusMap,
@@ -164,7 +168,9 @@ function isD6Green(
  * This checks whether the structural prerequisites for each depth level
  * exist (key mappings, feature ID), NOT whether probes are currently green.
  *
- * - D0: always possible for wired/stub cells
+ * - unshipped/unsupported/stub: max possible is 0 (no probes attached — a
+ *   `stub` is "not yet wired", not a regressed cell)
+ * - D0: always possible for wired cells
  * - D1-D4: always possible if the cell has a feature ID
  * - D5: possible only if CATALOG_TO_D5_KEY[featureId] exists and has entries
  * - D6: possible when a D5 mapping exists — D6 is per-cell and resolves
@@ -172,8 +178,15 @@ function isD6Green(
  *   doubles as the D6 reachability check
  */
 function computeMaxPossible(cell: CatalogCell): AchievedDepth {
-  // Unsupported/unshipped: max possible is 0.
-  if (cell.status === "unsupported" || cell.status === "unshipped") {
+  // Unsupported/unshipped/stub: max possible is 0. A `stub` cell is "not yet
+  // wired" — like `unshipped`, it has no probes attached, so capping its
+  // ceiling at 0 keeps achieved===maxPossible and prevents a false-positive
+  // regression flag for a cell that simply hasn't been built yet.
+  if (
+    cell.status === "unsupported" ||
+    cell.status === "unshipped" ||
+    cell.status === "stub"
+  ) {
     return 0;
   }
 

--- a/showcase/shell-dashboard/src/components/overlay-toggle-bar.tsx
+++ b/showcase/shell-dashboard/src/components/overlay-toggle-bar.tsx
@@ -6,33 +6,12 @@
  * individual visual overlays; presets apply curated combinations.
  */
 
-import type { Overlay } from "@/lib/overlay-types";
-export type { Overlay };
-
-export interface OverlayPreset {
-  id: string;
-  label: string;
-  overlays: readonly Overlay[];
-}
-
-export const ALL_OVERLAYS: readonly Overlay[] = [
-  "links",
-  "depth",
-  "health",
-  "parity",
-  "docs",
-  "d6",
-];
-
-export const PRESETS: readonly OverlayPreset[] = [
-  { id: "catalog", label: "Catalog", overlays: ["links", "health", "docs"] },
-  { id: "assessment", label: "Assessment", overlays: ["depth", "health"] },
-  {
-    id: "parity-review",
-    label: "Parity Review",
-    overlays: ["depth", "parity"],
-  },
-];
+// Single source of truth for overlay/preset definitions lives in
+// @/lib/overlay-types. Re-export here for backwards-compatible imports.
+import type { Overlay, OverlayPreset } from "@/lib/overlay-types";
+import { ALL_OVERLAYS, PRESETS } from "@/lib/overlay-types";
+export type { Overlay, OverlayPreset };
+export { ALL_OVERLAYS, PRESETS };
 
 const OVERLAY_LABELS: Record<Overlay, string> = {
   links: "Links",

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -313,16 +313,16 @@ function arePropsEqual(
   // Add D5 + D6 sub-keys from CATALOG_TO_D5_KEY. D6 is per-cell (not the
   // integration aggregate), resolved through the SAME featureType bridge as
   // D5 — see resolveD6Row/resolveD6. Keep in sync with resolveCell +
-  // buildCellModel.
+  // buildCellModel. An unmapped feature contributes no D5/D6 keys: the
+  // resolvers (resolveD5/resolveD6) return exists:false and never read a
+  // direct `d5:/d6:<slug>/<featureId>` key, so there is no direct-key
+  // fallback to watch here.
   const featureKeys = CATALOG_TO_D5_KEY[featureId];
   if (featureKeys && featureKeys.length > 0) {
     for (const ft of featureKeys) {
       directKeys.push(keyFor("d5", slug, ft));
       directKeys.push(keyFor("d6", slug, ft));
     }
-  } else {
-    directKeys.push(keyFor("d5", slug, featureId));
-    directKeys.push(keyFor("d6", slug, featureId));
   }
 
   for (const k of directKeys) {

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -310,17 +310,20 @@ function arePropsEqual(
     keyFor("tools", slug),
   ];
 
-  // Add D5 sub-keys from CATALOG_TO_D5_KEY
-  const d5Keys = CATALOG_TO_D5_KEY[featureId];
-  if (d5Keys && d5Keys.length > 0) {
-    for (const d5Key of d5Keys) {
-      directKeys.push(keyFor("d5", slug, d5Key));
+  // Add D5 + D6 sub-keys from CATALOG_TO_D5_KEY. D6 is per-cell (not the
+  // integration aggregate), resolved through the SAME featureType bridge as
+  // D5 — see resolveD6Row/resolveD6. Keep in sync with resolveCell +
+  // buildCellModel.
+  const featureKeys = CATALOG_TO_D5_KEY[featureId];
+  if (featureKeys && featureKeys.length > 0) {
+    for (const ft of featureKeys) {
+      directKeys.push(keyFor("d5", slug, ft));
+      directKeys.push(keyFor("d6", slug, ft));
     }
   } else {
     directKeys.push(keyFor("d5", slug, featureId));
+    directKeys.push(keyFor("d6", slug, featureId));
   }
-
-  directKeys.push(keyFor("d6", slug));
 
   for (const k of directKeys) {
     if (prev.ctx.liveStatus.get(k) !== next.ctx.liveStatus.get(k)) return false;

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -211,9 +211,17 @@ function UnifiedCellInner({ ctx, model, overlays }: UnifiedCellProps) {
   const isDocsOnly = ctx.feature.kind === "docs-only";
   const isTesting = ctx.feature.kind === "testing";
   const hasLinks = overlays.has("links");
-  const hasDepth = overlays.has("depth");
   const hasHealth = overlays.has("health");
   const hasDocs = overlays.has("docs");
+
+  // The d6 pill is primarily a stats-bar overlay (only AdaptiveStatsBar reads
+  // overlays.has("d6")). Per-cell it has no section of its own, so a
+  // {d6}-only set would otherwise produce a blank matrix (hasContent false).
+  // Treat d6 as content-bearing for the cell by surfacing the depth chip +
+  // health badges (the health row already renders the per-cell D6 badge), so
+  // an active d6 pill always shows meaningful per-cell content.
+  const hasD6 = overlays.has("d6");
+  const hasDepth = overlays.has("depth") || hasD6;
 
   // docs-only features: only links and docs layers, no depth or health.
   if (isDocsOnly) {
@@ -232,8 +240,11 @@ function UnifiedCellInner({ ctx, model, overlays }: UnifiedCellProps) {
     );
   }
 
+  // d6 surfaces the health row too, so its per-cell D6 badge is visible.
+  const showHealth = hasHealth || hasD6;
+
   // Check if any layer will produce content
-  const hasContent = hasLinks || hasDepth || hasHealth || hasDocs;
+  const hasContent = hasLinks || hasDepth || showHealth || hasDocs;
 
   if (!hasContent) {
     return <div data-testid="unified-cell-empty" />;
@@ -246,7 +257,7 @@ function UnifiedCellInner({ ctx, model, overlays }: UnifiedCellProps) {
     >
       {hasLinks && <LinksLayer ctx={ctx} />}
       {hasDepth && <DepthLayer ctx={ctx} model={model} />}
-      {hasHealth && !ctx.demo.command && <HealthLayer model={model} />}
+      {showHealth && !ctx.demo.command && <HealthLayer model={model} />}
       {hasDocs && <DocsLayer ctx={ctx} />}
     </div>
   );

--- a/showcase/shell-dashboard/src/hooks/__tests__/useOverlays.test.ts
+++ b/showcase/shell-dashboard/src/hooks/__tests__/useOverlays.test.ts
@@ -13,14 +13,19 @@ beforeEach(() => {
   hashValue = "";
   storageMap.clear();
 
-  // Stub location.hash as a getter/setter so the hook can both read and write.
-  vi.stubGlobal("location", {
-    ...window.location,
-    get hash() {
-      return hashValue;
-    },
-    set hash(v: string) {
-      hashValue = v.startsWith("#") ? v : `#${v}`;
+  // Stub window.location.hash explicitly (the hook reads window.location.hash).
+  // jsdom makes window === globalThis, but defining on window keeps the
+  // read-path genuinely exercised and robust to that assumption changing.
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      ...window.location,
+      get hash() {
+        return hashValue;
+      },
+      set hash(v: string) {
+        hashValue = v.startsWith("#") ? v : `#${v}`;
+      },
     },
   });
 
@@ -346,6 +351,63 @@ describe("useOverlays", () => {
     });
 
     expect(result.current.activeTab).toBe("matrix");
+  });
+
+  // Extra: setTab persists overlays to localStorage (symmetry with toggle)
+  it("setTab persists overlays to localStorage", async () => {
+    const useOverlays = await importHook();
+    const { result } = renderHook(() => useOverlays());
+
+    // Default set is links + health + depth. Switching tabs should persist
+    // the current overlay set just like toggle/updateOverlays do.
+    storageMap.delete("dashboard:overlays");
+
+    act(() => {
+      result.current.setTab("ops");
+    });
+
+    const stored = storageMap.get("dashboard:overlays");
+    expect(stored).toBeDefined();
+    const parsed: Overlay[] = JSON.parse(stored!);
+    expect(parsed).toContain("links");
+    expect(parsed).toContain("health");
+    expect(parsed).toContain("depth");
+  });
+
+  // Extra: #baseline hash resolves to the baseline tab
+  it("hash #baseline sets tab to baseline", async () => {
+    hashValue = "#baseline";
+    const useOverlays = await importHook();
+    const { result } = renderHook(() => useOverlays());
+
+    expect(result.current.activeTab).toBe("baseline");
+  });
+
+  // Extra: selectProbe leaves tab + hash consistent (ops probe drilldown)
+  it("selectProbe leaves tab and hash consistent", async () => {
+    const useOverlays = await importHook();
+    const { result } = renderHook(() => useOverlays());
+
+    act(() => {
+      result.current.setTab("ops");
+    });
+    expect(result.current.activeTab).toBe("ops");
+
+    act(() => {
+      result.current.selectProbe("probe-123");
+    });
+
+    expect(result.current.activeTab).toBe("ops");
+    expect(result.current.selectedProbeId).toBe("probe-123");
+    expect(hashValue).toBe("#ops:probe=probe-123");
+
+    // Clearing the probe returns to a plain #ops hash, still on ops tab.
+    act(() => {
+      result.current.selectProbe(null);
+    });
+    expect(result.current.activeTab).toBe("ops");
+    expect(result.current.selectedProbeId).toBeNull();
+    expect(hashValue).toBe("#ops");
   });
 
   // Extra: localStorage fallback when no hash present

--- a/showcase/shell-dashboard/src/hooks/__tests__/useOverlays.test.ts
+++ b/showcase/shell-dashboard/src/hooks/__tests__/useOverlays.test.ts
@@ -71,13 +71,14 @@ async function importHook() {
 
 describe("useOverlays", () => {
   // 1. Default state
-  it("defaults to links + health when no hash and no localStorage", async () => {
+  it("defaults to links + health + depth when no hash and no localStorage", async () => {
     const useOverlays = await importHook();
     const { result } = renderHook(() => useOverlays());
 
     expect(result.current.overlays.has("links")).toBe(true);
     expect(result.current.overlays.has("health")).toBe(true);
-    expect(result.current.overlays.size).toBe(2);
+    expect(result.current.overlays.has("depth")).toBe(true);
+    expect(result.current.overlays.size).toBe(3);
     expect(result.current.activeTab).toBe("matrix");
   });
 
@@ -86,28 +87,31 @@ describe("useOverlays", () => {
     const useOverlays = await importHook();
     const { result } = renderHook(() => useOverlays());
 
+    // "parity" is not in the default set (links + health + depth)
     act(() => {
-      result.current.toggle("depth");
+      result.current.toggle("parity");
     });
 
-    expect(result.current.overlays.has("depth")).toBe(true);
+    expect(result.current.overlays.has("parity")).toBe(true);
     expect(result.current.overlays.has("links")).toBe(true);
     expect(result.current.overlays.has("health")).toBe(true);
-    expect(result.current.overlays.size).toBe(3);
+    expect(result.current.overlays.has("depth")).toBe(true);
+    expect(result.current.overlays.size).toBe(4);
   });
 
   it("toggle removes an overlay when present", async () => {
     const useOverlays = await importHook();
     const { result } = renderHook(() => useOverlays());
 
-    // Remove "links" — "health" remains
+    // Remove "links" — "health" + "depth" remain
     act(() => {
       result.current.toggle("links");
     });
 
     expect(result.current.overlays.has("links")).toBe(false);
     expect(result.current.overlays.has("health")).toBe(true);
-    expect(result.current.overlays.size).toBe(1);
+    expect(result.current.overlays.has("depth")).toBe(true);
+    expect(result.current.overlays.size).toBe(2);
   });
 
   // 3. Minimum-one rule
@@ -115,9 +119,13 @@ describe("useOverlays", () => {
     const useOverlays = await importHook();
     const { result } = renderHook(() => useOverlays());
 
-    // Start with links + health, remove links so only health remains
+    // Start with links + health + depth; remove links and depth so only
+    // health remains
     act(() => {
       result.current.toggle("links");
+    });
+    act(() => {
+      result.current.toggle("depth");
     });
     expect(result.current.overlays.size).toBe(1);
     expect(result.current.overlays.has("health")).toBe(true);
@@ -162,7 +170,7 @@ describe("useOverlays", () => {
     const useOverlays = await importHook();
     const { result } = renderHook(() => useOverlays());
 
-    // Default is links + health — not an exact preset match
+    // Default is links + health + depth — not an exact preset match
     expect(result.current.activePreset).toBeNull();
   });
 
@@ -171,10 +179,8 @@ describe("useOverlays", () => {
     const useOverlays = await importHook();
     const { result } = renderHook(() => useOverlays());
 
-    act(() => {
-      result.current.toggle("depth");
-    });
-
+    // "depth" is in the default set, so showFilters is true out of the box
+    expect(result.current.overlays.has("depth")).toBe(true);
     expect(result.current.showFilters).toBe(true);
   });
 
@@ -194,7 +200,11 @@ describe("useOverlays", () => {
     const useOverlays = await importHook();
     const { result } = renderHook(() => useOverlays());
 
-    // Default is links + health. Add docs.
+    // Default is links + health + depth. Remove depth, add docs so the set
+    // is links + health + docs (no filter-trigger overlays).
+    act(() => {
+      result.current.toggle("depth");
+    });
     act(() => {
       result.current.toggle("docs");
     });
@@ -202,6 +212,7 @@ describe("useOverlays", () => {
     expect(result.current.overlays.has("links")).toBe(true);
     expect(result.current.overlays.has("health")).toBe(true);
     expect(result.current.overlays.has("docs")).toBe(true);
+    expect(result.current.overlays.has("depth")).toBe(false);
     expect(result.current.showFilters).toBe(false);
   });
 
@@ -274,15 +285,17 @@ describe("useOverlays", () => {
     const useOverlays = await importHook();
     const { result } = renderHook(() => useOverlays());
 
+    // Add "parity" on top of the default (links + health + depth)
     act(() => {
-      result.current.toggle("depth");
+      result.current.toggle("parity");
     });
 
-    // Hash should contain all three overlays in canonical order
+    // Hash should contain all four overlays in canonical order
     expect(hashValue).toContain("matrix:");
     expect(hashValue).toContain("links");
     expect(hashValue).toContain("depth");
     expect(hashValue).toContain("health");
+    expect(hashValue).toContain("parity");
   });
 
   // 16. localStorage persists overlay state
@@ -309,7 +322,7 @@ describe("useOverlays", () => {
 
     expect(result.current.has("links")).toBe(true);
     expect(result.current.has("health")).toBe(true);
-    expect(result.current.has("depth")).toBe(false);
+    expect(result.current.has("depth")).toBe(true);
     expect(result.current.has("parity")).toBe(false);
     expect(result.current.has("docs")).toBe(false);
   });

--- a/showcase/shell-dashboard/src/hooks/useOverlays.ts
+++ b/showcase/shell-dashboard/src/hooks/useOverlays.ts
@@ -249,6 +249,9 @@ export function useOverlays(): UseOverlaysReturn {
       setActiveTabRaw(tab);
       setSelectedProbeIdRaw(null);
       writeHash(tab, overlays, null, true);
+      // Persist the current overlay set for symmetry with toggle/updateOverlays
+      // so the user's overlay selection survives across tab switches + reloads.
+      saveToStorage(overlays);
     },
     [overlays],
   );

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1238,4 +1238,127 @@ describe("buildCellModel", () => {
       expect(model.d4?.status).toBe("red");
     });
   });
+
+  // ── Effective-row invariant: .row.state must AGREE with .status ─────
+  // The returned `.row` must be the EFFECTIVE (stale-downgraded) row, so
+  // `stateToTestStatus(.row.state) === .status`. This mirrors the invariant
+  // in live-status.ts `buildBadge`, whose returned `.row` is the effective
+  // row (`{ ...row, state: "degraded" }`). Previously resolveD4/D5/D6 returned
+  // the RAW status row while `.status` was derived from the stale-downgraded
+  // effective state, so a stale-green fold reported `.row.state === "green"`
+  // but `.status === "amber"` — an internal contradiction.
+  describe("effective-row invariant (.row.state agrees with .status)", () => {
+    const NOW = Date.parse("2026-05-30T12:00:00Z");
+
+    function rowAtAge(
+      key: string,
+      dimension: string,
+      ageMs: number,
+      state: State = "green",
+    ) {
+      const observedAt = new Date(NOW - ageMs).toISOString();
+      return row(key, dimension, state, {
+        observed_at: observedAt,
+        transitioned_at: observedAt,
+      });
+    }
+
+    const E2E_STALE = E2E_STALE_AFTER_MS + 60 * 60 * 1000;
+    const D4_STALE = D4_STALE_AFTER_MS + 60 * 1000;
+    const FRESH = 60 * 1000;
+
+    it("D4: stale-green folds to amber and .row.state matches .status", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", D4_STALE, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d4?.status).toBe("amber");
+      // The effective row must reflect the downgrade, not the raw green state.
+      expect(model.d4?.row?.state).toBe("degraded");
+    });
+
+    it("D5: stale-green folds to amber and .row.state matches .status", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", E2E_STALE, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d5?.status).toBe("amber");
+      expect(model.d5?.row?.state).toBe("degraded");
+    });
+
+    it("D6: stale-green folds to amber and .row.state matches .status", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", FRESH, "green"),
+        rowAtAge(keyFor("d6", "agno", "agentic-chat"), "d6", E2E_STALE, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d6?.status).toBe("amber");
+      expect(model.d6?.row?.state).toBe("degraded");
+    });
+
+    it("D5: fresh-green keeps the raw row (no spurious downgrade)", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", FRESH, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d5?.status).toBe("green");
+      // Fresh green is not downgraded: .row.state stays green.
+      expect(model.d5?.row?.state).toBe("green");
+    });
+  });
+
+  // ── CHARACTERIZATION: buildCellModel does NOT read health:/agent: rows ──
+  // resolveD3 credits D3 from the `e2e:<slug>/<feature>` row ALONE. The
+  // implicit "D1/D2 gate" (a failing liveness probe drags e2e down) is a
+  // PRODUCER-SIDE invariant: the e2e driver is expected not to emit green
+  // when health/agent are red. buildCellModel itself never consults the
+  // health:/agent: rows, so a fresh-green e2e row credits D3 even when a
+  // health/agent row is red or absent. This test PINS that documented
+  // current behavior; it does NOT assert a new requirement.
+  describe("D1/D2 gate is a producer invariant (characterization)", () => {
+    it("credits D3 from a fresh-green e2e row even when health: is RED", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "no-d5-feature"), "e2e", "green"),
+        // A red liveness/agent row is present but buildCellModel ignores it.
+        row(keyFor("health", "agno"), "health", "red"),
+        row(keyFor("agent", "agno"), "agent", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "no-d5-feature"));
+      // D3 is credited from e2e alone — health/agent rows are not consulted.
+      expect(model.d3!.status).toBe("green");
+      expect(model.achievedDepth).toBe(3);
+    });
+
+    it("credits D3 from a fresh-green e2e row even when health:/agent: are ABSENT", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "no-d5-feature"), "e2e", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "no-d5-feature"));
+      expect(model.d3!.status).toBe("green");
+      expect(model.achievedDepth).toBe(3);
+    });
+  });
 });

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -742,7 +742,10 @@ describe("buildCellModel", () => {
         row(keyFor("d6", "agno", "agentic-chat"), "d6", "red"),
         row(keyFor("d6", "agno", "voice"), "d6", "green"),
       ]);
-      const modelChat = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      const modelChat = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+      );
       const modelVoice = buildCellModel(live, wiredInput("agno", "voice"));
       expect(modelChat.d6!.status).toBe("red");
       expect(modelVoice.d6!.status).toBe("green");
@@ -767,7 +770,11 @@ describe("buildCellModel", () => {
         row(keyFor("d5", "agno", "beautiful-chat-toggle-theme"), "d5", "green"),
         row(keyFor("d5", "agno", "beautiful-chat-pie-chart"), "d5", "green"),
         row(keyFor("d5", "agno", "beautiful-chat-bar-chart"), "d5", "green"),
-        row(keyFor("d5", "agno", "beautiful-chat-search-flights"), "d5", "green"),
+        row(
+          keyFor("d5", "agno", "beautiful-chat-search-flights"),
+          "d5",
+          "green",
+        ),
         row(
           keyFor("d5", "agno", "beautiful-chat-schedule-meeting"),
           "d5",
@@ -776,7 +783,11 @@ describe("buildCellModel", () => {
         // D6: only 4 of 5 per-cell rows present (bar-chart omitted).
         row(keyFor("d6", "agno", "beautiful-chat-toggle-theme"), "d6", "green"),
         row(keyFor("d6", "agno", "beautiful-chat-pie-chart"), "d6", "green"),
-        row(keyFor("d6", "agno", "beautiful-chat-search-flights"), "d6", "green"),
+        row(
+          keyFor("d6", "agno", "beautiful-chat-search-flights"),
+          "d6",
+          "green",
+        ),
         row(
           keyFor("d6", "agno", "beautiful-chat-schedule-meeting"),
           "d6",
@@ -801,7 +812,11 @@ describe("buildCellModel", () => {
         row(keyFor("d5", "agno", "beautiful-chat-toggle-theme"), "d5", "green"),
         row(keyFor("d5", "agno", "beautiful-chat-pie-chart"), "d5", "green"),
         row(keyFor("d5", "agno", "beautiful-chat-bar-chart"), "d5", "green"),
-        row(keyFor("d5", "agno", "beautiful-chat-search-flights"), "d5", "green"),
+        row(
+          keyFor("d5", "agno", "beautiful-chat-search-flights"),
+          "d5",
+          "green",
+        ),
         row(
           keyFor("d5", "agno", "beautiful-chat-schedule-meeting"),
           "d5",
@@ -810,7 +825,11 @@ describe("buildCellModel", () => {
         // D6: one present sub-row is red, bar-chart missing.
         row(keyFor("d6", "agno", "beautiful-chat-toggle-theme"), "d6", "green"),
         row(keyFor("d6", "agno", "beautiful-chat-pie-chart"), "d6", "red"),
-        row(keyFor("d6", "agno", "beautiful-chat-search-flights"), "d6", "green"),
+        row(
+          keyFor("d6", "agno", "beautiful-chat-search-flights"),
+          "d6",
+          "green",
+        ),
         row(
           keyFor("d6", "agno", "beautiful-chat-schedule-meeting"),
           "d6",
@@ -1286,7 +1305,12 @@ describe("buildCellModel", () => {
       const live = mapOf([
         rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
         rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
-        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", E2E_STALE, "green"),
+        rowAtAge(
+          keyFor("d5", "agno", "agentic-chat"),
+          "d5",
+          E2E_STALE,
+          "green",
+        ),
       ]);
       const model = buildCellModel(
         live,
@@ -1302,7 +1326,12 @@ describe("buildCellModel", () => {
         rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
         rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
         rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", FRESH, "green"),
-        rowAtAge(keyFor("d6", "agno", "agentic-chat"), "d6", E2E_STALE, "green"),
+        rowAtAge(
+          keyFor("d6", "agno", "agentic-chat"),
+          "d6",
+          E2E_STALE,
+          "green",
+        ),
       ]);
       const model = buildCellModel(
         live,

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -189,15 +189,16 @@ describe("buildCellModel", () => {
       expect(model.d5!.exists).toBe(true);
       expect(model.d5!.status).toBe("red");
       expect(model.achievedDepth).toBe(4);
-      expect(model.ceilingDepth).toBe(5);
-      // D6-ceiling: D5 not green, D6 absent → red
+      // agentic-chat is D6-mapped, so D6 EXISTS (mapped, unemitted) → ceiling 6.
+      expect(model.ceilingDepth).toBe(6);
+      // D6-ceiling: D5 not green → broken ladder → red
       expect(model.chipColor).toBe("red");
     });
   });
 
   // ── All three pass → D5 green ───────────────────────────────────────
   describe("D3+D4+D5 pass, no D6", () => {
-    it("returns amber chip (D6-ceiling: D5 green but D6 absent)", () => {
+    it("returns amber chip (D6-ceiling: D5 green but D6 unemitted)", () => {
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
@@ -205,7 +206,8 @@ describe("buildCellModel", () => {
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.achievedDepth).toBe(5);
-      expect(model.ceilingDepth).toBe(5);
+      // agentic-chat is D6-mapped, so D6 EXISTS (mapped, unemitted) → ceiling 6.
+      expect(model.ceilingDepth).toBe(6);
       // D6-ceiling: D5 green but D6 not green → amber
       expect(model.chipColor).toBe("amber");
     });
@@ -222,7 +224,8 @@ describe("buildCellModel", () => {
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d3!.status).toBe("red");
       expect(model.achievedDepth).toBe(0);
-      expect(model.ceilingDepth).toBe(5);
+      // agentic-chat is D6-mapped, so D6 EXISTS (mapped, unemitted) → ceiling 6.
+      expect(model.ceilingDepth).toBe(6);
       // tests exist (ceiling > 0) but none pass → red
       expect(model.chipColor).toBe("red");
     });
@@ -315,8 +318,10 @@ describe("buildCellModel", () => {
       expect(model.d5!.status).toBe("red");
       // D5 is red → achievedDepth stops at D4
       expect(model.achievedDepth).toBe(4);
-      expect(model.ceilingDepth).toBe(5);
-      // D6-ceiling: D5 not green, D6 absent → red
+      // beautiful-chat is D6-mapped (same featureType bridge as D5), so D6
+      // EXISTS (mapped, unemitted → status null) → ceiling is 6.
+      expect(model.ceilingDepth).toBe(6);
+      // D6-ceiling: D5 not green → broken ladder → red
       expect(model.chipColor).toBe("red");
     });
 
@@ -487,7 +492,8 @@ describe("buildCellModel", () => {
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.achievedDepth).toBe(3);
-      expect(model.ceilingDepth).toBe(5);
+      // agentic-chat is D6-mapped, so D6 EXISTS (mapped, unemitted) → ceiling 6.
+      expect(model.ceilingDepth).toBe(6);
       // D6-ceiling: D4 red → gate failure → red
       expect(model.chipColor).toBe("red");
     });
@@ -508,7 +514,7 @@ describe("buildCellModel", () => {
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
         row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
-        row(keyFor("d6", "agno"), "d6", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d6!.exists).toBe(true);
@@ -521,7 +527,7 @@ describe("buildCellModel", () => {
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
         row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
-        row(keyFor("d6", "agno"), "d6", "red"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "red"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d5!.status).toBe("green");
@@ -530,7 +536,7 @@ describe("buildCellModel", () => {
       expect(model.chipColor).toBe("amber");
     });
 
-    it("D5 green + D6 missing → amber", () => {
+    it("D5 green + D6 unemitted → amber", () => {
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
@@ -538,8 +544,10 @@ describe("buildCellModel", () => {
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d5!.status).toBe("green");
-      expect(model.d6!.exists).toBe(false);
-      // D5 green but D6 absent → amber
+      // agentic-chat is D6-mapped → D6 EXISTS but has no emitted data.
+      expect(model.d6!.exists).toBe(true);
+      expect(model.d6!.status).toBeNull();
+      // D5 green but D6 not green (no-data) → amber
       expect(model.chipColor).toBe("amber");
     });
 
@@ -548,7 +556,7 @@ describe("buildCellModel", () => {
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red"),
         row(keyFor("chat", "agno"), "chat", "green"),
         row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
-        row(keyFor("d6", "agno"), "d6", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d3!.status).toBe("red");
@@ -574,7 +582,7 @@ describe("buildCellModel", () => {
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
         row(keyFor("d5", "agno", "agentic-chat"), "d5", "red"),
-        row(keyFor("d6", "agno"), "d6", "red"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "red"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d5!.status).toBe("red");
@@ -585,13 +593,13 @@ describe("buildCellModel", () => {
 
     it("D5 red + D6 green → red (contiguous-ladder gate)", () => {
       // A red D5 below a green D6 must NOT paint green: the verification
-      // ladder is broken at D5, so D6's aggregate pass is not trustworthy
+      // ladder is broken at D5, so D6's per-cell pass is not trustworthy
       // evidence of this cell's health. Red wins.
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
         row(keyFor("d5", "agno", "agentic-chat"), "d5", "red"),
-        row(keyFor("d6", "agno"), "d6", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d5!.status).toBe("red");
@@ -605,7 +613,7 @@ describe("buildCellModel", () => {
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
-        row(keyFor("d6", "agno"), "d6", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d5!.exists).toBe(true);
@@ -618,7 +626,7 @@ describe("buildCellModel", () => {
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
-        row(keyFor("d6", "agno"), "d6", "red"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "red"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d5!.status).toBeNull();
@@ -626,34 +634,43 @@ describe("buildCellModel", () => {
       expect(model.chipColor).toBe("red");
     });
 
-    it("D5 null + D6 missing → gray (no data)", () => {
+    it("D5 null + D6 unemitted → gray (no data)", () => {
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d5!.status).toBeNull();
-      expect(model.d6!.exists).toBe(false);
+      // agentic-chat is D6-mapped → D6 EXISTS but has no emitted data.
+      expect(model.d6!.exists).toBe(true);
+      expect(model.d6!.status).toBeNull();
       expect(model.chipColor).toBe("gray");
     });
 
-    it("D6 uses aggregate key not per-cell", () => {
-      // D6 is keyed by slug only (d6:<slug>), not per-feature.
-      // Two different features on the same slug should see the same D6 row.
+    it("D6 uses per-cell keys, not the integration aggregate", () => {
+      // D6 is keyed per-feature (d6:<slug>/<featureType>), NOT by slug only.
+      // Two different features on the same slug resolve INDEPENDENT D6 rows;
+      // the aggregate `d6:<slug>` (here red) is not consulted.
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
-        row(keyFor("e2e", "agno", "beautiful-chat"), "e2e", "green"),
-        row(keyFor("d6", "agno"), "d6", "green"),
+        row(keyFor("e2e", "agno", "voice"), "e2e", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        row(keyFor("d5", "agno", "voice"), "d5", "green"),
+        // Aggregate is red but must NOT be read…
+        row(keyFor("d6", "agno"), "d6", "red"),
+        // …per-cell rows differ between the two features.
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
+        row(keyFor("d6", "agno", "voice"), "d6", "red"),
       ]);
       const modelA = buildCellModel(live, wiredInput("agno", "agentic-chat"));
-      const modelB = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
-      // Both cells resolve the same D6 row
-      expect(modelA.d6!.exists).toBe(true);
+      const modelB = buildCellModel(live, wiredInput("agno", "voice"));
+      // Each cell resolves its OWN per-cell row.
       expect(modelA.d6!.status).toBe("green");
-      expect(modelB.d6!.exists).toBe(true);
-      expect(modelB.d6!.status).toBe("green");
-      // Same underlying row object
-      expect(modelA.d6!.row).toBe(modelB.d6!.row);
+      expect(modelB.d6!.status).toBe("red");
+      // Distinct underlying rows (not a shared aggregate).
+      expect(modelA.d6!.row?.key).toBe("d6:agno/agentic-chat");
+      expect(modelB.d6!.row?.key).toBe("d6:agno/voice");
+      expect(modelA.d6!.row).not.toBe(modelB.d6!.row);
     });
 
     it("ceilingDepth is 6 when D6 data exists", () => {
@@ -661,11 +678,162 @@ describe("buildCellModel", () => {
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
         row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
-        row(keyFor("d6", "agno"), "d6", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.ceilingDepth).toBe(6);
       expect(model.achievedDepth).toBe(6);
+    });
+  });
+
+  // ── D6 PER-CELL resolution (bug fix: was reading the integration
+  //    aggregate `d6:<slug>`, painting genuinely-green cells red) ───────
+  describe("D6 per-cell resolution (bug fix)", () => {
+    it("resolves GREEN from the per-cell row even when the aggregate d6:<slug> is RED", () => {
+      // The whole bug: aggregate `d6:agno` is RED (some OTHER cell failed),
+      // but THIS cell's per-cell row `d6:agno/agentic-chat` is GREEN. The
+      // cell must read its own per-cell row → green, NOT the red aggregate.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        // Aggregate is red (a different cell in the column failed)…
+        row(keyFor("d6", "agno"), "d6", "red"),
+        // …but this cell's per-cell parity row passed.
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d6!.exists).toBe(true);
+      expect(model.d6!.status).toBe("green");
+      // Resolved row is the PER-CELL row, not the aggregate.
+      expect(model.d6!.row?.key).toBe("d6:agno/agentic-chat");
+      // D5 green + D6 green → green chip.
+      expect(model.chipColor).toBe("green");
+    });
+
+    it("resolves RED from the per-cell row even when the aggregate d6:<slug> is GREEN", () => {
+      // Inverse: aggregate happens to be green but THIS cell's per-cell row
+      // is red. The cell must surface its own red, not the green aggregate.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        row(keyFor("d6", "agno"), "d6", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d6!.status).toBe("red");
+      expect(model.d6!.row?.key).toBe("d6:agno/agentic-chat");
+      // D5 green + per-cell D6 red → amber (D6 is above D5 in the ladder).
+      expect(model.chipColor).toBe("amber");
+    });
+
+    it("two features on the same slug resolve DIFFERENT per-cell D6 rows", () => {
+      // The aggregate model made every cell in a column identical. Per-cell
+      // rows let a green cell sit next to a red cell in the same integration.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("e2e", "agno", "voice"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        row(keyFor("d5", "agno", "voice"), "d5", "green"),
+        // aggregate red, but per-cell rows differ:
+        row(keyFor("d6", "agno"), "d6", "red"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "red"),
+        row(keyFor("d6", "agno", "voice"), "d6", "green"),
+      ]);
+      const modelChat = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      const modelVoice = buildCellModel(live, wiredInput("agno", "voice"));
+      expect(modelChat.d6!.status).toBe("red");
+      expect(modelVoice.d6!.status).toBe("green");
+      // Distinct underlying rows — not the shared aggregate.
+      expect(modelChat.d6!.row?.key).toBe("d6:agno/agentic-chat");
+      expect(modelVoice.d6!.row?.key).toBe("d6:agno/voice");
+      expect(modelChat.d6!.row).not.toBe(modelVoice.d6!.row);
+      // Voice is fully green at D6; chat caps at amber on its red D6.
+      expect(modelVoice.chipColor).toBe("green");
+      expect(modelChat.chipColor).toBe("amber");
+    });
+
+    it("does NOT credit D6 green when one mapped per-cell sub-row is MISSING (strict, mirrors resolveD5)", () => {
+      // beautiful-chat maps to 5 D6 sub-keys (same featureTypes as D5). Emit
+      // only 4 per-cell D6 rows (bar-chart missing). A missing mapped sub-row
+      // means the family is unverified → D6 status null (no-data), NOT green.
+      // Mirrors resolveD5's strict missing-sub-row handling.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "beautiful-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        // All 5 D5 sub-rows green so the cell reaches D5.
+        row(keyFor("d5", "agno", "beautiful-chat-toggle-theme"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-pie-chart"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-bar-chart"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-search-flights"), "d5", "green"),
+        row(
+          keyFor("d5", "agno", "beautiful-chat-schedule-meeting"),
+          "d5",
+          "green",
+        ),
+        // D6: only 4 of 5 per-cell rows present (bar-chart omitted).
+        row(keyFor("d6", "agno", "beautiful-chat-toggle-theme"), "d6", "green"),
+        row(keyFor("d6", "agno", "beautiful-chat-pie-chart"), "d6", "green"),
+        row(keyFor("d6", "agno", "beautiful-chat-search-flights"), "d6", "green"),
+        row(
+          keyFor("d6", "agno", "beautiful-chat-schedule-meeting"),
+          "d6",
+          "green",
+        ),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
+      expect(model.d6!.exists).toBe(true);
+      // Missing sub-row → no-data, NOT green and NOT red.
+      expect(model.d6!.status).toBeNull();
+      // D5 green but D6 unverified (no-data) → amber (ladder intact to D5).
+      expect(model.chipColor).toBe("amber");
+      expect(model.achievedDepth).toBe(5);
+    });
+
+    it("still reports D6 red when a present per-cell sub-row is red even if another is missing", () => {
+      // A present red D6 sub-row signals a real parity failure regardless of a
+      // missing sibling — red dominates no-data (mirrors resolveD5).
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "beautiful-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-toggle-theme"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-pie-chart"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-bar-chart"), "d5", "green"),
+        row(keyFor("d5", "agno", "beautiful-chat-search-flights"), "d5", "green"),
+        row(
+          keyFor("d5", "agno", "beautiful-chat-schedule-meeting"),
+          "d5",
+          "green",
+        ),
+        // D6: one present sub-row is red, bar-chart missing.
+        row(keyFor("d6", "agno", "beautiful-chat-toggle-theme"), "d6", "green"),
+        row(keyFor("d6", "agno", "beautiful-chat-pie-chart"), "d6", "red"),
+        row(keyFor("d6", "agno", "beautiful-chat-search-flights"), "d6", "green"),
+        row(
+          keyFor("d6", "agno", "beautiful-chat-schedule-meeting"),
+          "d6",
+          "green",
+        ),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
+      expect(model.d6!.status).toBe("red");
+      // D5 green + per-cell D6 red → amber.
+      expect(model.chipColor).toBe("amber");
+    });
+
+    it("unmapped feature has no D6 test (exists:false)", () => {
+      // A featureId absent from CATALOG_TO_D5_KEY has no per-cell D6 row,
+      // so D6 does not exist for it — mirrors resolveD5's unmapped handling.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "no-d5-feature"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        // A stray aggregate row must NOT be picked up for the unmapped cell.
+        row(keyFor("d6", "agno"), "d6", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "no-d5-feature"));
+      expect(model.d6!.exists).toBe(false);
     });
   });
 
@@ -725,23 +893,25 @@ describe("buildCellModel", () => {
     //    no-data, not a slide-back. ──
     it("is FALSE when the next rung (D5) is mapped but has no emitted data", () => {
       // D3 green + D4 green, D5 mapped but NO d5 rows emitted →
-      // achieved=4, ceiling=5, d5.exists=true but d5.status===null.
-      // No data above achieved → NOT a regression.
+      // achieved=4, d5.exists=true but d5.status===null. (ceiling is 6 since
+      // agentic-chat is also D6-mapped.) The next rung above achieved (D5)
+      // has no emitted data → NOT a regression.
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.achievedDepth).toBe(4);
-      expect(model.ceilingDepth).toBe(5);
+      expect(model.ceilingDepth).toBe(6);
       expect(model.d5?.exists).toBe(true);
       expect(model.d5?.status).toBeNull();
       expect(model.isRegression).toBe(false);
     });
 
     it("is TRUE when the next rung (D5) is below ceiling AND emitted red data", () => {
-      // D3 green + D4 green + D5 red → achieved=4, ceiling=5, and d5 has
-      // emitted (status==='red'). A real slide-back → regression.
+      // D3 green + D4 green + D5 red → achieved=4, and d5 has emitted
+      // (status==='red'). (ceiling is 6 since agentic-chat is also D6-mapped.)
+      // A real slide-back at the next rung → regression.
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),
@@ -749,7 +919,7 @@ describe("buildCellModel", () => {
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.achievedDepth).toBe(4);
-      expect(model.ceilingDepth).toBe(5);
+      expect(model.ceilingDepth).toBe(6);
       expect(model.d5?.status).toBe("red");
       expect(model.isRegression).toBe(true);
     });
@@ -880,7 +1050,7 @@ describe("buildCellModel", () => {
         rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
         rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
         rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", FRESH, "green"),
-        rowAtAge(keyFor("d6", "agno"), "d6", STALE, "green"),
+        rowAtAge(keyFor("d6", "agno", "agentic-chat"), "d6", STALE, "green"),
       ]);
       const model = buildCellModel(
         live,
@@ -900,7 +1070,7 @@ describe("buildCellModel", () => {
         rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
         rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
         rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", FRESH, "green"),
-        rowAtAge(keyFor("d6", "agno"), "d6", FRESH, "green"),
+        rowAtAge(keyFor("d6", "agno", "agentic-chat"), "d6", FRESH, "green"),
       ]);
       const model = buildCellModel(
         live,

--- a/showcase/shell-dashboard/src/lib/__tests__/page-stats.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/page-stats.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  computeHealthStats,
+  computeParityStats,
+  computeDepthDistribution,
+  computeD6Stats,
+} from "../page-stats";
+import type { LiveStatusMap, StatusRow, State } from "../live-status";
+import { keyFor } from "../live-status";
+import type { CatalogCell } from "../../data/catalog-types";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const FRESH = new Date().toISOString();
+
+function row(
+  key: string,
+  dimension: string,
+  state: State,
+  overrides: Partial<StatusRow> = {},
+): StatusRow {
+  return {
+    id: `id-${key}`,
+    key,
+    dimension,
+    state,
+    signal: {},
+    observed_at: FRESH,
+    transitioned_at: FRESH,
+    fail_count: state === "red" ? 1 : 0,
+    first_failure_at: state === "red" ? FRESH : null,
+    ...overrides,
+  };
+}
+
+function mapOf(rows: StatusRow[]): LiveStatusMap {
+  const m: LiveStatusMap = new Map();
+  for (const r of rows) m.set(r.key, r);
+  return m;
+}
+
+function wiredCell(overrides: Partial<CatalogCell> = {}): CatalogCell {
+  return {
+    id: `${overrides.integration ?? "agno"}/${overrides.feature ?? "agentic-chat"}`,
+    manifestation: "integrated",
+    integration: "agno",
+    integration_name: "Agno",
+    feature: "agentic-chat",
+    feature_name: "Agentic Chat",
+    status: "wired",
+    parity_tier: "at_parity",
+    max_depth: 4,
+    category: null,
+    category_name: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Build the full set of green rows that drive `(slug, feature)` to
+ * achievedDepth === 6: e2e (D3) + chat/tools (D4) + d5 + d6 sub-rows, all
+ * green-and-fresh. `agentic-chat` maps to the single d5/d6 key `agentic-chat`.
+ */
+function fullDepth6Rows(slug: string, feature: string): StatusRow[] {
+  return [
+    row(keyFor("e2e", slug, feature), "e2e", "green"),
+    row(keyFor("chat", slug), "chat", "green"),
+    row(keyFor("tools", slug), "tools", "green"),
+    row(keyFor("d5", slug, feature), "d5", "green"),
+    row(keyFor("d6", slug, feature), "d6", "green"),
+  ];
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Finding #1 — D6 cells must NOT be dropped from the depth distribution.
+// ---------------------------------------------------------------------------
+
+describe("computeDepthDistribution — D6 (Finding #1)", () => {
+  it("counts a D6-achieved cell in the d6 bucket (not dropped to NaN)", () => {
+    const cell = wiredCell({ integration: "agno", feature: "agentic-chat" });
+    const live = mapOf(fullDepth6Rows("agno", "agentic-chat"));
+    const now = Date.parse(FRESH);
+
+    const dist = computeDepthDistribution([cell], live, now);
+
+    // The cell reaches achievedDepth 6 → must land in d6, not vanish.
+    expect(dist.d6).toBe(1);
+    expect(dist.d5).toBe(0);
+    expect(dist.d4).toBe(0);
+    expect(dist.d3).toBe(0);
+    expect(dist.d0).toBe(0);
+    // No bucket may be NaN (the old `as keyof` cast produced dist["d6"]++ = NaN).
+    for (const v of Object.values(dist)) expect(Number.isNaN(v)).toBe(false);
+  });
+
+  it("buckets cells across multiple depths simultaneously", () => {
+    const d6Cell = wiredCell({ integration: "agno", feature: "agentic-chat" });
+    // A wired cell with no live rows → achievedDepth 0 → d0 bucket.
+    const d0Cell = wiredCell({
+      integration: "mastra",
+      feature: "agentic-chat",
+    });
+    const live = mapOf(fullDepth6Rows("agno", "agentic-chat"));
+    const now = Date.parse(FRESH);
+
+    const dist = computeDepthDistribution([d6Cell, d0Cell], live, now);
+
+    expect(dist.d6).toBe(1);
+    expect(dist.d0).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding #2 — d6Stats must surface amber (degraded) distinctly, not as gray.
+// ---------------------------------------------------------------------------
+
+describe("computeD6Stats — degraded (Finding #2)", () => {
+  it("counts a stale-green D6 cell as degraded, not gray", () => {
+    const cell = wiredCell({ integration: "agno", feature: "agentic-chat" });
+    // D6 row is green but observed long ago → resolveCell downgrades to amber.
+    const stale = new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString();
+    const live = mapOf([
+      row(keyFor("d6", "agno", "agentic-chat"), "d6", "green", {
+        observed_at: stale,
+      }),
+    ]);
+    const now = Date.now();
+
+    const stats = computeD6Stats([cell], live, now);
+
+    expect(stats.degraded).toBe(1);
+    expect(stats.gray).toBe(0);
+    expect(stats.green).toBe(0);
+    expect(stats.red).toBe(0);
+  });
+
+  it("still counts green / red / gray (no row) correctly", () => {
+    const greenCell = wiredCell({ integration: "agno", feature: "agentic-chat" });
+    const redCell = wiredCell({ integration: "mastra", feature: "agentic-chat" });
+    const grayCell = wiredCell({ integration: "agno", feature: "tool-rendering" });
+    const live = mapOf([
+      row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
+      row(keyFor("d6", "mastra", "agentic-chat"), "d6", "red"),
+      // grayCell: no d6 row for tool-rendering → gray.
+    ]);
+    const now = Date.now();
+
+    const stats = computeD6Stats([greenCell, redCell, grayCell], live, now);
+
+    expect(stats.green).toBe(1);
+    expect(stats.red).toBe(1);
+    expect(stats.gray).toBe(1);
+    expect(stats.degraded).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding #3 — healthStats must NOT fold gray (no-data) into green.
+// ---------------------------------------------------------------------------
+
+describe("computeHealthStats — gray is no-data, not green (Finding #3)", () => {
+  it("counts a no-data wired cell as noData, not green", () => {
+    const cell = wiredCell({ integration: "agno", feature: "agentic-chat" });
+    // No live rows → buildCellModel chipColor gray.
+    const live = mapOf([]);
+    const now = Date.now();
+
+    const stats = computeHealthStats([cell], live, now);
+
+    expect(stats.noData).toBe(1);
+    expect(stats.green).toBe(0);
+    expect(stats.amber).toBe(0);
+    expect(stats.red).toBe(0);
+  });
+
+  it("counts a genuinely green cell as green", () => {
+    const cell = wiredCell({ integration: "agno", feature: "agentic-chat" });
+    const live = mapOf(fullDepth6Rows("agno", "agentic-chat"));
+    const now = Date.parse(FRESH);
+
+    const stats = computeHealthStats([cell], live, now);
+
+    expect(stats.green).toBe(1);
+    expect(stats.noData).toBe(0);
+  });
+
+  it("ignores non-wired cells", () => {
+    const stub = wiredCell({ status: "stub" });
+    const unshipped = wiredCell({ status: "unshipped" });
+    const stats = computeHealthStats([stub, unshipped], mapOf([]), Date.now());
+    expect(stats).toEqual({ green: 0, amber: 0, red: 0, noData: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding #5 — parity_tier must be validated before indexing (no NaN).
+// ---------------------------------------------------------------------------
+
+describe("computeParityStats — unknown tier (Finding #5)", () => {
+  it("counts known tiers per unique integration", () => {
+    const cells = [
+      wiredCell({ integration: "a", parity_tier: "reference" }),
+      wiredCell({ integration: "a", parity_tier: "reference" }), // dup int → ignored
+      wiredCell({ integration: "b", parity_tier: "partial" }),
+      wiredCell({ integration: "c", parity_tier: "not_wired" }),
+    ];
+    const counts = computeParityStats(cells);
+    expect(counts.reference).toBe(1);
+    expect(counts.partial).toBe(1);
+    expect(counts.not_wired).toBe(1);
+    expect(counts.at_parity).toBe(0);
+    expect(counts.minimal).toBe(0);
+  });
+
+  it("skips an unknown tier instead of producing NaN, and fails loud", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cells = [
+      wiredCell({ integration: "good", parity_tier: "minimal" }),
+      // Forward-incompatible / corrupt catalog row with an unknown tier.
+      wiredCell({
+        integration: "bad",
+        parity_tier: "totally_unknown" as CatalogCell["parity_tier"],
+      }),
+    ];
+
+    const counts = computeParityStats(cells);
+
+    expect(counts.minimal).toBe(1);
+    // No NaN anywhere — the unknown tier is skipped, not indexed.
+    for (const v of Object.values(counts)) expect(Number.isNaN(v)).toBe(false);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(errSpy.mock.calls[0][0]).toContain("unknown parity_tier");
+  });
+});

--- a/showcase/shell-dashboard/src/lib/__tests__/page-stats.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/page-stats.test.ts
@@ -114,6 +114,36 @@ describe("computeDepthDistribution — D6 (Finding #1)", () => {
     expect(dist.d6).toBe(1);
     expect(dist.d0).toBe(1);
   });
+
+  it("lands a wired-but-unverified cell in d0 and sums to the wired total", () => {
+    // Three wired cells: one reaches D6, two have no live data → D0.
+    const d6Cell = wiredCell({ integration: "agno", feature: "agentic-chat" });
+    const d0CellA = wiredCell({ integration: "mastra", feature: "agentic-chat" });
+    const d0CellB = wiredCell({ integration: "crewai", feature: "agentic-chat" });
+    // A non-wired cell must NOT be counted toward the wired total.
+    const stub = wiredCell({ integration: "x", feature: "agentic-chat", status: "stub" });
+    const cells = [d6Cell, d0CellA, d0CellB, stub];
+    const live = mapOf(fullDepth6Rows("agno", "agentic-chat"));
+    const now = Date.parse(FRESH);
+
+    const dist = computeDepthDistribution(cells, live, now);
+
+    // The two no-data wired cells land in d0 (visible, not vanished).
+    expect(dist.d0).toBe(2);
+    expect(dist.d6).toBe(1);
+
+    // The distribution exposes EXACTLY the reachable buckets — no dead d1/d2
+    // keys that buildCellModel().achievedDepth (0|3|4|5|6) can never populate.
+    expect(Object.keys(dist).sort()).toEqual(["d0", "d3", "d4", "d5", "d6"]);
+
+    // Every bucket sums to the count of wired cells (3), not including the stub.
+    const wiredCount = cells.filter(
+      (c) => c.status === "wired" && c.feature !== null,
+    ).length;
+    const total = Object.values(dist).reduce((a, b) => a + b, 0);
+    expect(total).toBe(wiredCount);
+    expect(total).toBe(3);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/showcase/shell-dashboard/src/lib/__tests__/page-stats.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/page-stats.test.ts
@@ -118,10 +118,20 @@ describe("computeDepthDistribution — D6 (Finding #1)", () => {
   it("lands a wired-but-unverified cell in d0 and sums to the wired total", () => {
     // Three wired cells: one reaches D6, two have no live data → D0.
     const d6Cell = wiredCell({ integration: "agno", feature: "agentic-chat" });
-    const d0CellA = wiredCell({ integration: "mastra", feature: "agentic-chat" });
-    const d0CellB = wiredCell({ integration: "crewai", feature: "agentic-chat" });
+    const d0CellA = wiredCell({
+      integration: "mastra",
+      feature: "agentic-chat",
+    });
+    const d0CellB = wiredCell({
+      integration: "crewai",
+      feature: "agentic-chat",
+    });
     // A non-wired cell must NOT be counted toward the wired total.
-    const stub = wiredCell({ integration: "x", feature: "agentic-chat", status: "stub" });
+    const stub = wiredCell({
+      integration: "x",
+      feature: "agentic-chat",
+      status: "stub",
+    });
     const cells = [d6Cell, d0CellA, d0CellB, stub];
     const live = mapOf(fullDepth6Rows("agno", "agentic-chat"));
     const now = Date.parse(FRESH);
@@ -171,9 +181,18 @@ describe("computeD6Stats — degraded (Finding #2)", () => {
   });
 
   it("still counts green / red / gray (no row) correctly", () => {
-    const greenCell = wiredCell({ integration: "agno", feature: "agentic-chat" });
-    const redCell = wiredCell({ integration: "mastra", feature: "agentic-chat" });
-    const grayCell = wiredCell({ integration: "agno", feature: "tool-rendering" });
+    const greenCell = wiredCell({
+      integration: "agno",
+      feature: "agentic-chat",
+    });
+    const redCell = wiredCell({
+      integration: "mastra",
+      feature: "agentic-chat",
+    });
+    const grayCell = wiredCell({
+      integration: "agno",
+      feature: "tool-rendering",
+    });
     const live = mapOf([
       row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
       row(keyFor("d6", "mastra", "agentic-chat"), "d6", "red"),

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -103,7 +103,10 @@ function resolveD4(live: LiveStatusMap, slug: string, now: number): TestLevel {
   }
 
   // Fold to the worst effective state across present rows, applying the
-  // per-row stale-green→degraded downgrade before comparing.
+  // per-row stale-green→degraded downgrade before comparing. The winner row
+  // is stored in its EFFECTIVE (downgraded) form so `.row.state` agrees with
+  // `.status` — mirroring `buildBadge` in live-status.ts, whose returned
+  // `.row` is the effective row.
   let winner: StatusRow | null = null;
   let worstState: State | null = null;
   for (const candidate of [chatRow, toolsRow]) {
@@ -116,15 +119,24 @@ function resolveD4(live: LiveStatusMap, slug: string, now: number): TestLevel {
       worstState === null ||
       STATE_RANK[effectiveState] > STATE_RANK[worstState]
     ) {
-      winner = candidate;
+      winner =
+        effectiveState === candidate.state
+          ? candidate
+          : { ...candidate, state: effectiveState };
       worstState = effectiveState;
     }
   }
 
+  if (!winner || worstState === null) {
+    // Both rows present-checked above, so this is unreachable in practice;
+    // guard anyway instead of asserting (mirrors resolveD5/resolveD6).
+    return { exists: true, status: null, row: null };
+  }
+
   return {
     exists: true,
-    status: stateToTestStatus(worstState!),
-    row: winner!,
+    status: stateToTestStatus(worstState),
+    row: winner,
   };
 }
 
@@ -190,7 +202,10 @@ function resolveD5(
       worstState === null ||
       STATE_RANK[effectiveState] > STATE_RANK[worstState]
     ) {
-      worstRow = row;
+      // Store the EFFECTIVE (downgraded) row so `.row.state` agrees with
+      // `.status` — mirrors `buildBadge` in live-status.ts.
+      worstRow =
+        effectiveState === row.state ? row : { ...row, state: effectiveState };
       worstState = effectiveState;
     }
   }
@@ -225,6 +240,11 @@ function resolveD5(
  * the frozen-green row is no longer trustworthy evidence of health. Only
  * green is downgraded — a stale red/degraded row already signals a problem
  * and is left as-is.
+ *
+ * PRODUCER-INVARIANT ASSUMPTION: the implicit D1/D2 gate is enforced
+ * upstream, not here — this resolver credits D3 from the `e2e:<slug>/<feature>`
+ * row ALONE and never consults the `health:<slug>`/`agent:<slug>` rows. The
+ * e2e driver is expected not to emit green when liveness is red.
  */
 function resolveD3(
   live: LiveStatusMap,
@@ -310,7 +330,10 @@ function resolveD6(
       worstState === null ||
       STATE_RANK[effectiveState] > STATE_RANK[worstState]
     ) {
-      worstRow = row;
+      // Store the EFFECTIVE (downgraded) row so `.row.state` agrees with
+      // `.status` — mirrors `buildBadge` in live-status.ts.
+      worstRow =
+        effectiveState === row.state ? row : { ...row, state: effectiveState };
       worstState = effectiveState;
     }
   }

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -247,29 +247,93 @@ function resolveD3(
 }
 
 /**
- * Resolve the D6 (parity-vs-reference) test level for `slug`.
+ * Resolve the D6 (parity-vs-reference) test level for `(slug, featureId)`.
  *
- * D6 is an aggregate integration-level signal (`d6:<slug>`), NOT per-cell.
- * The e2e-full driver emits a single row per integration that covers
- * the entire parity comparison against the reference implementation.
+ * D6 is PER-CELL, not an integration aggregate. The `e2e-parity` driver
+ * emits one `d6:<slug>/<featureType>` row per featureType (mirroring D5's
+ * keyspace — both fan out over `demosToFeatureTypes`), PLUS a single
+ * integration-level aggregate `d6:<slug>` row. The aggregate is red whenever
+ * ANY cell fails, so resolving cells against it would paint genuinely-green
+ * cells red. This resolver therefore reads the PER-CELL row, mapped through
+ * `CATALOG_TO_D5_KEY` (the same catalog-featureId → featureType bridge D5
+ * uses); the aggregate `d6:<slug>` row no longer drives per-cell rendering.
  *
- * Staleness applies the same downgrade as `resolveD3`: a green D6 row whose
- * `observed_at` is older than `E2E_STALE_AFTER_MS` is downgraded to `amber`
- * (degraded), so a frozen-green row from a stalled driver no longer credits
- * D6 forever. Only green is downgraded; stale red/degraded is left as-is.
+ * Mirrors `resolveD5` exactly:
+ *
+ * Staleness applies the same downgrade as `resolveD3`, but PER SUB-ROW and
+ * BEFORE the worst-state fold: a green D6 sub-row whose `observed_at` is older
+ * than `E2E_STALE_AFTER_MS` is treated as `degraded` while folding, so a
+ * fresh-green sub-row can never win the all-green tie and mask a stale-green
+ * sibling. Only green is downgraded; a stale red/degraded sub-row already
+ * signals a problem.
+ *
+ * STRICT on missing sub-rows: a multi-key family is credited green ONLY when
+ * EVERY mapped sub-row is present and green-and-fresh — a missing mapped
+ * sub-row forces the family out of green and resolves to `status: null`
+ * (no-data/unverified). A present RED sub-row still yields red (red dominates
+ * no-data). This matches `depth-utils.ts` `isD6Green`, which uses
+ * `d6Keys.every(...)`, and the identical handling in `resolveD5`.
  */
-function resolveD6(live: LiveStatusMap, slug: string, now: number): TestLevel {
-  const row = live.get(keyFor("d6", slug)) ?? null;
-  if (!row) {
+function resolveD6(
+  live: LiveStatusMap,
+  slug: string,
+  featureId: string,
+  now: number,
+): TestLevel {
+  const d6Keys = CATALOG_TO_D5_KEY[featureId];
+
+  // No mapping → test doesn't exist for this feature.
+  if (!d6Keys || d6Keys.length === 0) {
     return { exists: false, status: null, row: null };
   }
-  if (row.state === "green" && isStale(row, now, E2E_STALE_AFTER_MS)) {
-    return { exists: true, status: "amber", row };
+
+  let worstRow: StatusRow | null = null;
+  let worstState: State | null = null;
+  let anyMissing = false;
+  for (const d6Key of d6Keys) {
+    const row = live.get(keyFor("d6", slug, d6Key)) ?? null;
+    if (!row) {
+      // STRICT: a missing mapped sub-row means the family is unverified —
+      // it can no longer be credited green. Mirrors `isD6Green`'s
+      // `every(...)` in depth-utils.ts so both consumers agree.
+      anyMissing = true;
+      continue;
+    }
+    // Per-row staleness downgrade applied BEFORE the fold: a green sub-row
+    // that is stale folds in as `degraded` so it can never win the all-green
+    // tie and mask a fresh-green sibling.
+    const effectiveState: State =
+      row.state === "green" && isStale(row, now, E2E_STALE_AFTER_MS)
+        ? "degraded"
+        : row.state;
+    if (
+      worstState === null ||
+      STATE_RANK[effectiveState] > STATE_RANK[worstState]
+    ) {
+      worstRow = row;
+      worstState = effectiveState;
+    }
   }
+
+  if (!worstRow || worstState === null) {
+    // Keys are mapped but no rows emitted yet — test exists but has no
+    // data. Treat as exists=true so ceilingDepth reflects it.
+    return { exists: true, status: null, row: null };
+  }
+
+  // STRICT missing-sub-row handling: when a mapped sub-row is absent the
+  // family is unverified. A present RED sub-row still signals a real failure
+  // (red dominates no-data), but a present green/degraded fold must NOT be
+  // credited — collapse it to no-data (status: null) so the chip renders
+  // gray/amber per the ladder, not a false-green.
+  if (anyMissing && worstState !== "red") {
+    return { exists: true, status: null, row: null };
+  }
+
   return {
     exists: true,
-    status: stateToTestStatus(row.state),
-    row,
+    status: stateToTestStatus(worstState),
+    row: worstRow,
   };
 }
 
@@ -329,7 +393,7 @@ export function buildCellModel(
   const d3 = resolveD3(live, slug, featureId, now);
   const d4 = resolveD4(live, slug, now);
   const d5 = resolveD5(live, slug, featureId, now);
-  const d6 = resolveD6(live, slug, now);
+  const d6 = resolveD6(live, slug, featureId, now);
 
   // ceilingDepth: highest CONTIGUOUS depth where a test EXISTS.
   // D4 only counts if D3 exists; D5 only counts if D4 counts; D6 only

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -55,17 +55,21 @@ describe("keyFor", () => {
     // the dashboard MUST match the producer shape.
     expect(keyFor("d5", "agno", "agentic-chat")).toBe("d5:agno/agentic-chat");
   });
-  it("d6 uses integration-scoped key (no featureId)", () => {
-    // Driver `e2e-full` emits one row per integration (`d6:<slug>`),
-    // not per cell — the dashboard looks up d6 without featureId.
-    expect(keyFor("d6", "agno")).toBe("d6:agno");
-  });
-  it("d6 keyFor still supports featureId for generic helper coverage", () => {
-    // keyFor is a generic helper — it CAN produce per-feature d6 keys,
-    // but production D6 lookups use integration-scoped keys only.
+  it("d6 uses the per-cell key shape production reads", () => {
+    // Driver `e2e-parity` emits one `d6:<slug>/<featureType>` row per cell
+    // (the same featureType keyspace D5 uses, mapped via CATALOG_TO_D5_KEY),
+    // and the dashboard resolves D6 PER-CELL against that key — see
+    // resolveD6Row. This is the shape per-cell rendering actually looks up.
     expect(keyFor("d6", "agno", "tool-rendering")).toBe(
       "d6:agno/tool-rendering",
     );
+  });
+  it("d6 aggregate key shape still exists but is NOT what per-cell rendering reads", () => {
+    // keyFor CAN still produce the bare `d6:<slug>` aggregate key, and the
+    // `e2e-parity` driver still emits a single aggregate row that is red
+    // whenever ANY cell fails. But resolveD6Row never reads it — per-cell
+    // badges resolve the mapped `d6:<slug>/<featureType>` row instead.
+    expect(keyFor("d6", "agno")).toBe("d6:agno");
   });
   it("throws when slug contains ':' (lookup-map collision guard)", () => {
     expect(() => keyFor("smoke", "bad:slug")).toThrow(/must not contain/);
@@ -398,9 +402,15 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
   // red > degraded > green — so a single amber pill turns the badge
   // amber instead of staying green behind a co-iterated green sibling.
   it("d5 multi-key fan-out: red beats green when red comes after green", () => {
+    // All 5 mapped sub-rows present so the worst-state fold — not STRICT
+    // missing handling — is what credits red. (A red still dominates a
+    // missing sub-row, but emitting the full family pins the fold ordering.)
     const live = mapOf([
       row("d5:agno/beautiful-chat-toggle-theme", "d5", "green"),
       row("d5:agno/beautiful-chat-pie-chart", "d5", "red"),
+      row("d5:agno/beautiful-chat-bar-chart", "d5", "green"),
+      row("d5:agno/beautiful-chat-search-flights", "d5", "green"),
+      row("d5:agno/beautiful-chat-schedule-meeting", "d5", "green"),
     ]);
     const c = resolveCell(live, "agno", "beautiful-chat");
     expect(c.d5.tone).toBe("red");
@@ -408,9 +418,15 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
   });
 
   it("d5 multi-key fan-out: red beats green when red comes BEFORE green", () => {
+    // All 5 mapped sub-rows present so the worst-state fold — not STRICT
+    // missing handling — is what credits red, with red listed FIRST to pin
+    // order-independence of the fold.
     const live = mapOf([
       row("d5:agno/beautiful-chat-toggle-theme", "d5", "red"),
       row("d5:agno/beautiful-chat-pie-chart", "d5", "green"),
+      row("d5:agno/beautiful-chat-bar-chart", "d5", "green"),
+      row("d5:agno/beautiful-chat-search-flights", "d5", "green"),
+      row("d5:agno/beautiful-chat-schedule-meeting", "d5", "green"),
     ]);
     const c = resolveCell(live, "agno", "beautiful-chat");
     expect(c.d5.tone).toBe("red");

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -321,11 +321,15 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
   });
 
   it("resolves d5 / d6 per-feature rows when present", () => {
-    // D5 uses per-feature keys (d5:<slug>/<featureId>),
-    // D6 uses integration-scoped aggregate keys (d6:<slug>).
+    // D5 AND D6 use per-feature keys (`<dim>:<slug>/<featureType>`), both
+    // mapped from catalog featureId via CATALOG_TO_D5_KEY. The aggregate
+    // `d6:<slug>` here (green) must NOT be read — the per-cell row wins.
     const live = mapOf([
       row("d5:agno/agentic-chat", "d5", "green"),
-      row("d6:agno", "d6", "red"),
+      // aggregate green distractor — not consulted:
+      row("d6:agno", "d6", "green"),
+      // per-cell red is what the badge surfaces:
+      row("d6:agno/agentic-chat", "d6", "red"),
     ]);
     const c = resolveCell(live, "agno", "agentic-chat");
     expect(c.d5.tone).toBe("green");
@@ -333,7 +337,7 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
     expect(c.d5.row?.key).toBe("d5:agno/agentic-chat");
     expect(c.d6.tone).toBe("red");
     expect(c.d6.label).toBe("✗");
-    expect(c.d6.row?.key).toBe("d6:agno");
+    expect(c.d6.row?.key).toBe("d6:agno/agentic-chat");
   });
 
   it("falls through to gray '?' when d5 / d6 rows are absent", () => {
@@ -355,13 +359,13 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
     // Note: with LS1 in force, health-only does NOT roll up to green
     // (e2e is also required); rollup is "gray" and the red d5/d6 rows
     // must not promote it to red.
-    // D6 uses integration-scoped aggregate keys (d6:<slug>), not per-feature.
-    // `agentic-chat` is a real CATALOG_TO_D5_KEY entry (single-key family);
-    // its d5 row resolves through resolveD5Row's mapped path.
+    // D5 AND D6 use per-feature keys (`<dim>:<slug>/<featureType>`), mapped
+    // via CATALOG_TO_D5_KEY. `agentic-chat` is a real single-key family;
+    // both its d5/d6 rows resolve through the mapped per-cell path.
     const live = mapOf([
       row("health:agno", "health", "green"),
       row("d5:agno/agentic-chat", "d5", "red"),
-      row("d6:agno", "d6", "red"),
+      row("d6:agno/agentic-chat", "d6", "red"),
     ]);
     const c = resolveCell(live, "agno", "agentic-chat");
     expect(c.rollup).toBe("gray");
@@ -647,12 +651,13 @@ describe("resolveCell — staleness downgrade (unification A)", () => {
   });
 
   it("stale-green d6 badge downgrades to amber (6h window)", () => {
+    // D6 is per-cell (d6:<slug>/<featureType>), so use a mapped feature.
     const live = mapOf([
-      row("d6:agno", "d6", "green", {
+      row("d6:agno/agentic-chat", "d6", "green", {
         observed_at: freshAt(E2E_STALE_AFTER_MS + 60 * 60 * 1000),
       }),
     ]);
-    const c = resolveCell(live, "agno", "ac", { now: NOW });
+    const c = resolveCell(live, "agno", "agentic-chat", { now: NOW });
     expect(c.d6.tone).toBe("amber");
   });
 

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
+  CATALOG_TO_D5_KEY,
   keyFor,
   mergeRowsToMap,
   resolveCell,
@@ -81,6 +82,21 @@ describe("keyFor", () => {
     expect(() => keyFor("e2e", "agno", "bad:id")).toThrow(/must not contain/);
     expect(() => keyFor("e2e", "agno", "bad/id")).toThrow(/must not contain/);
   });
+  it("every CATALOG_TO_D5_KEY mapping value is delimiter-free (keyFor feeds these as featureId)", () => {
+    // resolveD5Row/resolveD6Row pass each mapping value into keyFor as the
+    // featureId segment. keyFor's guard protects slug + the caller-supplied
+    // featureId, but NOT the mapping values themselves — a ':' or '/' smuggled
+    // into a mapping value would produce an ambiguous/colliding key. Assert the
+    // table is clean so the guard's coverage is complete.
+    for (const [feature, d5Keys] of Object.entries(CATALOG_TO_D5_KEY)) {
+      for (const d5Key of d5Keys) {
+        expect(
+          d5Key.includes(":") || d5Key.includes("/"),
+          `CATALOG_TO_D5_KEY["${feature}"] value "${d5Key}" must not contain ':' or '/'`,
+        ).toBe(false);
+      }
+    }
+  });
 });
 
 describe("upsertByKey", () => {
@@ -138,6 +154,19 @@ describe("mergeRowsToMap", () => {
       [row("e2e:a/b", "e2e", "red")],
     );
     expect(map.size).toBe(2);
+    expect(warn).not.toHaveBeenCalled();
+  });
+  it("does NOT warn on identical-content rows with different references (no false collision)", () => {
+    // The same producer row re-allocated across two groups (different object
+    // reference, identical key/state/observed_at/transitioned_at) is NOT a
+    // genuine invariant violation. Pre-fix the reference-based `prior !== r`
+    // check fired a noisy false warning here.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const a = row("dup:k", "smoke", "green");
+    const aClone = row("dup:k", "smoke", "green"); // distinct object, same content
+    expect(a).not.toBe(aClone);
+    const map = mergeRowsToMap([a], [aClone]);
+    expect(map.get("dup:k")?.state).toBe("green");
     expect(warn).not.toHaveBeenCalled();
   });
   it("warns on collision but still applies last-wins (disjoint-key invariant guard)", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -192,23 +192,12 @@ export const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
 };
 
 /**
- * Resolve the rolled-up D5 row for `(slug, featureId)`.
- *
- * Precedence across the multi-key set (red > degraded > green) — the
- * cell's badge tone reflects the worst-state row in the family. A
- * naive "first non-null wins" or "only red wins" implementation
- * silently masks degraded sub-rows behind green ones; for a cell like
- * `beautiful-chat` which fans out to 5 per-pill keys, that means an
- * amber sub-row would render the cell green and operators would never
- * see the partial regression.
- *
- * Missing rows are treated as not-yet-emitted and are NOT a signal of
- * health — but they also can't be "worst" because we can't compare
- * them to anything. The caller (`resolveCell`) renders gray when no
- * row is returned, which surfaces "no data yet" distinctly from
- * green.
+ * Worst-state precedence ranking shared by `resolveD5Row` AND `resolveD6Row`
+ * (red > degraded > green): a higher rank dominates the worst-state fold across
+ * a multi-key family. Not D5-specific — both per-feature resolvers fold over
+ * it, so the name reflects that scope.
  */
-const D5_STATE_RANK: Readonly<Record<State, number>> = {
+const WORST_STATE_RANK: Readonly<Record<State, number>> = {
   red: 3,
   degraded: 2,
   green: 1,
@@ -227,6 +216,23 @@ function effectiveState(row: StatusRow, now: number, maxAgeMs: number): State {
     : row.state;
 }
 
+/**
+ * Resolve the rolled-up D5 row for `(slug, featureId)`.
+ *
+ * Precedence across the multi-key set (red > degraded > green) — the
+ * cell's badge tone reflects the worst-state row in the family. A
+ * naive "first non-null wins" or "only red wins" implementation
+ * silently masks degraded sub-rows behind green ones; for a cell like
+ * `beautiful-chat` which fans out to 5 per-pill keys, that means an
+ * amber sub-row would render the cell green and operators would never
+ * see the partial regression.
+ *
+ * Missing rows are treated as not-yet-emitted and are NOT a signal of
+ * health — but they also can't be "worst" because we can't compare
+ * them to anything. The caller (`resolveCell`) renders gray when no
+ * row is returned, which surfaces "no data yet" distinctly from
+ * green.
+ */
 function resolveD5Row(
   live: LiveStatusMap,
   slug: string,
@@ -266,7 +272,10 @@ function resolveD5Row(
       continue;
     }
     const eff = effectiveState(row, now, E2E_STALE_AFTER_MS);
-    if (worstState === null || D5_STATE_RANK[eff] > D5_STATE_RANK[worstState]) {
+    if (
+      worstState === null ||
+      WORST_STATE_RANK[eff] > WORST_STATE_RANK[worstState]
+    ) {
       worst = row;
       worstState = eff;
     }
@@ -319,7 +328,10 @@ function resolveD6Row(
       continue;
     }
     const eff = effectiveState(row, now, E2E_STALE_AFTER_MS);
-    if (worstState === null || D5_STATE_RANK[eff] > D5_STATE_RANK[worstState]) {
+    if (
+      worstState === null ||
+      WORST_STATE_RANK[eff] > WORST_STATE_RANK[worstState]
+    ) {
       worst = row;
       worstState = eff;
     }
@@ -690,13 +702,21 @@ export function upsertByKey<T extends { key: string }>(
  * Surface it via `console.warn` so dev mode catches the regression
  * without changing return semantics (last-wins is still fine for
  * eventual consistency).
+ *
+ * The warning fires only on GENUINE divergence — two rows with the same key
+ * but a different observable state (compared via `rowsAreNoop`, the same
+ * key/state/observed_at/transitioned_at shallow check the reducer uses).
+ * Identical-content-but-different-reference rows (e.g. the same producer row
+ * re-allocated across two groups) are NOT a real invariant violation and used
+ * to fire a noisy false warning under the old reference-based `prior !== r`
+ * check.
  */
 export function mergeRowsToMap(...rowGroups: StatusRow[][]): LiveStatusMap {
   const map: LiveStatusMap = new Map();
   for (const rows of rowGroups) {
     for (const r of rows) {
       const prior = map.get(r.key);
-      if (prior !== undefined && prior !== r) {
+      if (prior !== undefined && !rowsAreNoop(prior, r)) {
         // eslint-disable-next-line no-console
         console.warn(
           `mergeRowsToMap: disjoint-key invariant violated for key="${r.key}" ` +

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -3,13 +3,15 @@
  * showcase-harness design spec).
  *
  * PB row keys: `<dimension>:<slug>` for integration-level dimensions
- * (e.g. `health`, `agent`, `chat`, `tools`, `d6`), or
- * `<dimension>:<slug>/<featureId>` for per-feature dimensions
- * (e.g. `smoke`, `e2e`, `d5`). The `d5:` per-feature rows
- * are emitted by the `e2e-deep` driver, and `d6:` integration-scoped
- * rows are emitted by the `e2e-full` driver (D5/D6 spec) — D5
- * featureId here is the D5 featureType (e.g. `agentic-chat`) so the
- * existing per-cell lookup pattern stays uniform.
+ * (e.g. `health`, `agent`, `chat`, `tools`), or
+ * `<dimension>:<slug>/<featureType>` for per-feature dimensions
+ * (e.g. `smoke`, `e2e`, `d5`, `d6`). The `d5:` per-feature rows are
+ * emitted by the `e2e-deep` driver, and `d6:` per-feature rows by the
+ * `e2e-parity` driver (D5/D6 spec) — both fan out over the same
+ * `D5FeatureType` keyspace (e.g. `agentic-chat`) so the per-cell lookup
+ * pattern stays uniform. The e2e-parity driver ALSO writes an
+ * integration-level `d6:<slug>` aggregate, but the dashboard resolves D6
+ * per-cell (the aggregate is red whenever any cell fails).
  */
 
 import { formatTs } from "./format-ts";
@@ -68,11 +70,14 @@ export interface CellState {
    */
   d5: BadgeRender;
   /**
-   * D6 (parity-vs-reference) integration-scoped badge. Sourced from
-   * `d6:<slug>` rows emitted by the `e2e-full` driver. D6 runs the full
-   * feature matrix for each integration — a missing row resolves to a
-   * gray `?` badge. Does NOT contribute to the rollup for the same
-   * reason as D5.
+   * D6 (parity-vs-reference) PER-CELL badge. Sourced from
+   * `d6:<slug>/<featureType>` rows emitted by the `e2e-parity` driver and
+   * mapped from catalog featureId via CATALOG_TO_D5_KEY (the same bridge as
+   * D5). The driver also writes an integration-level `d6:<slug>` aggregate,
+   * but the dashboard resolves cells per-cell — the aggregate is red whenever
+   * ANY cell fails and would mis-paint green cells red. A missing row resolves
+   * to a gray `?` badge. Does NOT contribute to the rollup for the same reason
+   * as D5.
    */
   d6: BadgeRender;
   /** Rollup tone for the cell, by precedence red > degraded > green > error > unknown. */
@@ -269,6 +274,56 @@ function resolveD5Row(
   // A missing mapped sub-row makes the family unverified: collapse a
   // present green/degraded fold to no-data (null). A present red still
   // dominates (returns the red row).
+  if (anyMissing && worstState !== "red") {
+    return null;
+  }
+  return worst;
+}
+
+/**
+ * Resolve the rolled-up D6 (parity-vs-reference) row for `(slug, featureId)`.
+ *
+ * D6 is PER-CELL, not an integration aggregate. The `e2e-parity` driver emits
+ * one `d6:<slug>/<featureType>` row per featureType (the same featureType
+ * keyspace D5 uses — both fan out over `demosToFeatureTypes`) PLUS a single
+ * aggregate `d6:<slug>` row that is red whenever ANY cell fails. Resolving a
+ * cell's badge against that aggregate painted genuinely-green cells red, so we
+ * resolve the PER-CELL row, mapped through `CATALOG_TO_D5_KEY` (the same
+ * catalog-featureId → featureType bridge D5 uses). The aggregate `d6:<slug>`
+ * row no longer drives per-cell rendering.
+ *
+ * Identical semantics to `resolveD5Row`: worst-state across the mapped family
+ * (red > degraded > green), per-sub-row stale-green→degraded fold (E2E 6h
+ * window) applied BEFORE the fold, and STRICT on missing sub-rows — a missing
+ * mapped sub-row collapses a present green/degraded fold to `null` (no-data →
+ * gray badge) UNLESS a present sub-row is red (red dominates no-data). An
+ * unmapped feature returns `null` (no D6 test exists for it).
+ */
+function resolveD6Row(
+  live: LiveStatusMap,
+  slug: string,
+  featureId: string,
+  now: number = Date.now(),
+): StatusRow | null {
+  const d6Keys = CATALOG_TO_D5_KEY[featureId];
+  if (!d6Keys || d6Keys.length === 0) {
+    return null;
+  }
+  let worst: StatusRow | null = null;
+  let worstState: State | null = null;
+  let anyMissing = false;
+  for (const d6Key of d6Keys) {
+    const row = live.get(keyFor("d6", slug, d6Key)) ?? null;
+    if (!row) {
+      anyMissing = true;
+      continue;
+    }
+    const eff = effectiveState(row, now, E2E_STALE_AFTER_MS);
+    if (worstState === null || D5_STATE_RANK[eff] > D5_STATE_RANK[worstState]) {
+      worst = row;
+      worstState = eff;
+    }
+  }
   if (anyMissing && worstState !== "red") {
     return null;
   }
@@ -496,17 +551,18 @@ export function resolveCell(
   // the same D2 badge. Informational — does NOT contribute to the
   // rollup (same model as smoke).
   const agentRow = live.get(keyFor("agent", slug)) ?? null;
-  // D5 per-feature rows (`d5:<slug>/<featureType>`) emitted by the
-  // e2e-deep driver. D6 uses aggregate keys (`d6:<slug>`) emitted by the
-  // e2e-full driver — one row per integration, not per cell, because
-  // D6 probes test the integration as a whole.
-  // Informational — they do NOT contribute to the rollup
-  // (alert engine routes them independently, same model as smoke). A
-  // missing row resolves to a gray "?" badge, which is the expected
-  // resting state for D6 cells outside their weekly-rotation slot.
+  // D5 + D6 per-feature rows, both keyed `<dim>:<slug>/<featureType>` and
+  // mapped from catalog featureId via CATALOG_TO_D5_KEY. D5 rows come from
+  // the e2e-deep driver; D6 rows from the e2e-parity driver, which emits one
+  // `d6:<slug>/<featureType>` row per featureType (PLUS an integration-level
+  // `d6:<slug>` aggregate the dashboard no longer reads per-cell — it is red
+  // whenever ANY cell fails and would paint green cells red).
+  // Informational — neither contributes to the rollup (alert engine routes
+  // them independently, same model as smoke). A missing row resolves to a
+  // gray "?" badge, the expected resting state for cells outside their
+  // weekly-rotation slot.
   const d5Row = resolveD5Row(live, slug, featureId, now);
-  // D6 probe writes aggregate keys d6:<slug>, not per-cell d6:<slug>/<featureId>.
-  const d6Row = live.get(keyFor("d6", slug)) ?? null;
+  const d6Row = resolveD6Row(live, slug, featureId, now);
 
   // Rollup contributors: health + e2e (Decision #7: smokeRow dropped).
   // Each contributor's stale-green is downgraded to degraded BEFORE tone

--- a/showcase/shell-dashboard/src/lib/overlay-types.ts
+++ b/showcase/shell-dashboard/src/lib/overlay-types.ts
@@ -13,6 +13,7 @@ export const ALL_OVERLAYS: readonly Overlay[] = [
 export const DEFAULT_OVERLAYS: readonly Overlay[] = [
   "links",
   "health",
+  "depth",
 ] as const;
 
 export interface OverlayPreset {

--- a/showcase/shell-dashboard/src/lib/page-stats.ts
+++ b/showcase/shell-dashboard/src/lib/page-stats.ts
@@ -1,0 +1,231 @@
+/**
+ * page-stats — pure aggregate-stat computations for the AdaptiveStatsBar.
+ *
+ * Extracted from `app/page.tsx` so the aggregate functions are unit-testable
+ * in isolation (mirrors the `computeColumnTally` pattern in feature-grid.tsx).
+ * Every function here derives from the SAME `buildCellModel` / `resolveCell`
+ * single source of truth that `renderCell` uses, so the stats bar agrees with
+ * the matrix it summarizes.
+ */
+
+import { buildCellModel } from "@/lib/cell-model";
+import { resolveCell } from "@/lib/live-status";
+import type { LiveStatusMap } from "@/lib/live-status";
+import type { CatalogCell } from "@/data/catalog-types";
+import type { ParityTier } from "@/components/parity-badge";
+import type {
+  DepthDistribution,
+  D6Stats,
+} from "@/components/adaptive-stats-bar";
+
+/** Health rollup counts derived from `buildCellModel().chipColor`. */
+export interface HealthStats {
+  green: number;
+  amber: number;
+  red: number;
+  /**
+   * Cells with no actionable signal yet (`chipColor === "gray"`). Tracked
+   * separately so a gray chip in the matrix is NOT folded into green in the
+   * stats bar — the stats bar must mirror what the matrix shows.
+   */
+  noData: number;
+}
+
+/** All ParityTier values, used to validate `cell.parity_tier` before indexing. */
+const PARITY_TIERS: ReadonlySet<ParityTier> = new Set<ParityTier>([
+  "reference",
+  "at_parity",
+  "partial",
+  "minimal",
+  "not_wired",
+]);
+
+/**
+ * Exhaustive achievedDepth → DepthDistribution key map. The compiler enforces
+ * completeness: `buildCellModel().achievedDepth` is typed `0 | 3 | 4 | 5 | 6`,
+ * so every reachable depth (including D6) MUST have an entry or this fails to
+ * type-check. Replaces the unchecked `` `d${depth}` as keyof `` cast that
+ * silently produced a `"d6"` key the type lacked, dropping D6 cells.
+ */
+const DEPTH_TO_KEY: Record<0 | 3 | 4 | 5 | 6, keyof DepthDistribution> = {
+  0: "d0",
+  3: "d3",
+  4: "d4",
+  5: "d5",
+  6: "d6",
+};
+
+/**
+ * Health stats across all wired cells, derived from `buildCellModel().chipColor`.
+ *
+ * `isSupported: true` is correct by construction: `generate-registry.ts`
+ * resolves a feature listed in `not_supported_features` to catalog status
+ * `"unsupported"` BEFORE the `"wired"` branch, so a `status === "wired"` cell
+ * can never also be unsupported. The matrix's `renderCell` derives support from
+ * `not_supported_features`, but for wired cells that always yields supported —
+ * the two agree, so passing `true` here keeps the stats bar consistent with the
+ * matrix. See `determineCellStatus` in scripts/generate-registry.ts.
+ *
+ * A gray chip (no data yet) is counted as `noData`, NOT green: the matrix shows
+ * gray, so folding it into green would make the stats bar disagree with the
+ * matrix it summarizes.
+ */
+export function computeHealthStats(
+  cells: readonly CatalogCell[],
+  liveStatus: LiveStatusMap,
+  now: number,
+): HealthStats {
+  let green = 0;
+  let amber = 0;
+  let red = 0;
+  let noData = 0;
+  for (const cell of cells) {
+    if (cell.status !== "wired" || cell.feature === null) continue;
+    const model = buildCellModel(
+      liveStatus,
+      {
+        slug: cell.integration,
+        featureId: cell.feature,
+        isSupported: true,
+        isWired: true,
+      },
+      now,
+    );
+    switch (model.chipColor) {
+      case "green":
+        green++;
+        break;
+      case "amber":
+        amber++;
+        break;
+      case "red":
+        red++;
+        break;
+      case "gray":
+        noData++;
+        break;
+    }
+  }
+  return { green, amber, red, noData };
+}
+
+/**
+ * Parity-tier counts across unique integrations.
+ *
+ * `cell.parity_tier` is validated against the known `ParityTier` set before
+ * indexing — an unknown tier (corrupt/forward-incompatible catalog data) is
+ * skipped rather than producing `counts[undefined]++ === NaN`. Logged loudly so
+ * the bad data surfaces instead of silently corrupting the bar.
+ */
+export function computeParityStats(
+  cells: readonly CatalogCell[],
+): Record<ParityTier, number> {
+  const counts: Record<ParityTier, number> = {
+    reference: 0,
+    at_parity: 0,
+    partial: 0,
+    minimal: 0,
+    not_wired: 0,
+  };
+  const seen = new Set<string>();
+  for (const cell of cells) {
+    if (seen.has(cell.integration)) continue;
+    seen.add(cell.integration);
+    const tier = cell.parity_tier;
+    if (!PARITY_TIERS.has(tier as ParityTier)) {
+      // Fail-loud on unknown tier — skip the count rather than indexing with
+      // an undefined key (which yields NaN and poisons every downstream sum).
+      console.error(
+        `computeParityStats: unknown parity_tier ${JSON.stringify(
+          tier,
+        )} for integration ${JSON.stringify(cell.integration)} — skipping`,
+      );
+      continue;
+    }
+    counts[tier as ParityTier]++;
+  }
+  return counts;
+}
+
+/**
+ * Depth distribution across all wired cells, keyed by achieved depth.
+ *
+ * Uses the exhaustive `DEPTH_TO_KEY` map instead of a string cast so D6-achieved
+ * cells land in the `d6` bucket (the previous `` `d${depth}` as keyof `` cast
+ * produced a `"d6"` key the type lacked → `dist["d6"]++ === NaN`, dropping every
+ * D6 cell). `isSupported: true` is correct by construction — see
+ * `computeHealthStats`.
+ */
+export function computeDepthDistribution(
+  cells: readonly CatalogCell[],
+  liveStatus: LiveStatusMap,
+  now: number,
+): DepthDistribution {
+  const dist: DepthDistribution = {
+    d6: 0,
+    d5: 0,
+    d4: 0,
+    d3: 0,
+    d2: 0,
+    d1: 0,
+    d0: 0,
+  };
+  for (const cell of cells) {
+    if (cell.status !== "wired" || cell.feature === null) continue;
+    const model = buildCellModel(
+      liveStatus,
+      {
+        slug: cell.integration,
+        featureId: cell.feature,
+        isSupported: true,
+        isWired: true,
+      },
+      now,
+    );
+    const key = DEPTH_TO_KEY[model.achievedDepth];
+    dist[key]++;
+  }
+  return dist;
+}
+
+/**
+ * D6 (parity-vs-reference) rollup counts across wired cells.
+ *
+ * The D6 badge tone (`resolveCell().d6.tone`) is one of green / red / amber
+ * (degraded or stale-green) / gray (no row). Amber is counted as `degraded` and
+ * surfaced distinctly — folding it into gray (the previous `default` branch)
+ * hid stale/degraded D6 as "no data". This matches how the matrix and staleness
+ * machinery treat a degraded D6 badge.
+ */
+export function computeD6Stats(
+  cells: readonly CatalogCell[],
+  liveStatus: LiveStatusMap,
+  now: number,
+): D6Stats {
+  let green = 0;
+  let degraded = 0;
+  let gray = 0;
+  let red = 0;
+  for (const cell of cells) {
+    if (cell.status !== "wired" || cell.feature === null) continue;
+    const state = resolveCell(liveStatus, cell.integration, cell.feature, {
+      now,
+    });
+    switch (state.d6.tone) {
+      case "green":
+        green++;
+        break;
+      case "red":
+        red++;
+        break;
+      case "amber":
+        degraded++;
+        break;
+      default:
+        // gray (no row) — distinct from degraded.
+        gray++;
+        break;
+    }
+  }
+  return { green, degraded, gray, red };
+}

--- a/showcase/shell-dashboard/src/lib/page-stats.ts
+++ b/showcase/shell-dashboard/src/lib/page-stats.ts
@@ -69,6 +69,14 @@ const DEPTH_TO_KEY: Record<0 | 3 | 4 | 5 | 6, keyof DepthDistribution> = {
  * A gray chip (no data yet) is counted as `noData`, NOT green: the matrix shows
  * gray, so folding it into green would make the stats bar disagree with the
  * matrix it summarizes.
+ *
+ * NO DEDUP (unlike `computeParityStats`/docsStats): `catalogData.cells` is
+ * one row per grid cell — an `(integration, feature)` pair is unique across the
+ * catalog (verified: 0 duplicate pairs). Health is a PER-CELL signal, so every
+ * wired cell is counted exactly once. `computeParityStats` dedups by
+ * `integration` because parity is per-integration (many cells share one slug),
+ * and docsStats dedups by `feature` because docs are per-feature; neither
+ * applies to a genuinely per-cell rollup.
  */
 export function computeHealthStats(
   cells: readonly CatalogCell[],
@@ -166,8 +174,6 @@ export function computeDepthDistribution(
     d5: 0,
     d4: 0,
     d3: 0,
-    d2: 0,
-    d1: 0,
     d0: 0,
   };
   for (const cell of cells) {


### PR DESCRIPTION
## Summary
- **Fix per-cell D6 resolution**: the dashboard's `resolveD6` now reads per-cell ENUM keys (`d6:<slug>/<featureType>` via `CATALOG_TO_D5_KEY` fan-out) instead of the integration aggregate — D6 cells render real per-cell green/red instead of all-gray.
- **Depth + D6 surfaced by default**: `DEFAULT_OVERLAYS = [links, health, depth]` (the per-cell D6 badge rides on the Health layer; the depth chip folds D6).
- **Correct the aggregate stats bar** (`page-stats.ts` extraction): D6 cells were dropped from the depth distribution (`dist["d6"]++` → `NaN`, masked by an `as` cast); gray/no-data cells were counted as green; `d6Stats` swallowed amber into gray. Now renders the reachable buckets **D0/D3/D4/D5/D6** (dropped permanently-zero D1/D2), tracks `noData` and `degraded` distinctly, and validates `parity_tier` fail-loud.
- **Test coverage**: new table-driven cell color/rollup matrix (`dashboard-color-matrix.test.tsx`) + `page-stats.test.ts` + order-independence/comment hardening.
- **CR fixes**: effective (stale-downgraded) `.row` from cell-model resolvers, `WORST_STATE_RANK` rename, composed-cell memo keys, overlay-types re-export dedup, `setTab` persistence + `window.location` test stub, `page.tsx` shared-`now` threading + 60s staleness re-render.

## Verification
- **776 tests pass / 1 skip**, `tsc --noEmit` clean, Next.js production build OK.
- **Local visual proof**: seeded enum D6 rows (30✓/8✗/0 gray) into a local PocketBase, rebuilt this branch, screenshotted bare `#matrix` — per-cell D6 green/red renders, and the depth distribution shows `D6:30 D5:8 D4:0 D3:0 D0:588`.
- **7-agent code review converged** over 3 confirmation cycles.

## Notes
- The **#5152 `d6-all-pills` driver must stay on enum keys** (matches this dashboard's `resolveD6` + the `d5-mapping-drift` test). Do not revert it to raw catalog keys.
- **Follow-up (separate PR)**: stats-bar single-source-of-truth hardening (`computeD6Stats`→`buildCellModel`; reconcile `resolveD6Row`/`resolveD5Row` to the effective row; thread `connection` into stats for SSE-offline; docs-only stats exclusion); delete deprecated `composed-cell.tsx` + `deriveDepth`; `useOverlays` mount-hash deep-link clobber; Notion visualization-doc sync to per-cell `resolveD6`.

## Test plan
- [ ] CI green
- [ ] After staging deploy, dashboard renders per-cell D6 green/red (not all-gray) for LangGraph-Python