### PR TITLE
fix(showcase): bump @ag-ui/langgraph to 0.0.36 in langgraph integrations

### DIFF
--- a/showcase/integrations/langgraph-fastapi/package-lock.json
+++ b/showcase/integrations/langgraph-fastapi/package-lock.json
@@ -86,6 +86,11 @@
         "rxjs": "7.8.1"
       }
     },
+    "node_modules/@ag-ui/a2ui-toolkit": {
+      "version": "0.0.1-alpha.3",
+      "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-toolkit/-/a2ui-toolkit-0.0.1-alpha.3.tgz",
+      "integrity": "sha512-9U4DtwJ6rHO4vn4ixYVnRJGrO7u07phT/AjgsHymLf4cvPw57PNZACc4y6eTtayG0IcySNqRGW/wE+qjlXzgzw=="
+    },
     "node_modules/@ag-ui/client": {
       "version": "0.0.53",
       "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
@@ -121,10 +126,11 @@
       }
     },
     "node_modules/@ag-ui/langgraph": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.34.tgz",
-      "integrity": "sha512-3BV3/X9iRXL3EOFq1DxAZffbh2V6bJ2G8aoNJP6wHx40jbPdJT7aDvZb4DmzlFmXVWJ2kzfD4AnvxLAx9ooPLQ==",
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.36.tgz",
+      "integrity": "sha512-0m8WRj3kYGCI8SPk30oo7PHVnbhAZBIxBuwSdBjl8VQu1OWAnQrzUqUvEI+X6JTXk1Y9sviF8TIPCq3qsmD1cA==",
       "dependencies": {
+        "@ag-ui/a2ui-toolkit": "0.0.1-alpha.3",
         "@langchain/core": "^1.1.40",
         "@langchain/langgraph-sdk": "^1.8.8",
         "langchain": ">=1.2.0",

--- a/showcase/integrations/langgraph-fastapi/package.json
+++ b/showcase/integrations/langgraph-fastapi/package.json
@@ -50,12 +50,14 @@
     "typescript": "^5.7.0"
   },
   "overrides": {
+    "@ag-ui/langgraph": "0.0.36",
     "@copilotkit/web-inspector": {
       "@copilotkit/core": "1.59.2"
     }
   },
   "pnpm": {
     "overrides": {
+      "@ag-ui/langgraph": "0.0.36",
       "@copilotkit/web-inspector>@copilotkit/core": "1.59.2"
     }
   }

--- a/showcase/integrations/langgraph-python/package-lock.json
+++ b/showcase/integrations/langgraph-python/package-lock.json
@@ -85,6 +85,11 @@
         "rxjs": "7.8.1"
       }
     },
+    "node_modules/@ag-ui/a2ui-toolkit": {
+      "version": "0.0.1-alpha.3",
+      "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-toolkit/-/a2ui-toolkit-0.0.1-alpha.3.tgz",
+      "integrity": "sha512-9U4DtwJ6rHO4vn4ixYVnRJGrO7u07phT/AjgsHymLf4cvPw57PNZACc4y6eTtayG0IcySNqRGW/wE+qjlXzgzw=="
+    },
     "node_modules/@ag-ui/client": {
       "version": "0.0.53",
       "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
@@ -120,10 +125,11 @@
       }
     },
     "node_modules/@ag-ui/langgraph": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.34.tgz",
-      "integrity": "sha512-3BV3/X9iRXL3EOFq1DxAZffbh2V6bJ2G8aoNJP6wHx40jbPdJT7aDvZb4DmzlFmXVWJ2kzfD4AnvxLAx9ooPLQ==",
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.36.tgz",
+      "integrity": "sha512-0m8WRj3kYGCI8SPk30oo7PHVnbhAZBIxBuwSdBjl8VQu1OWAnQrzUqUvEI+X6JTXk1Y9sviF8TIPCq3qsmD1cA==",
       "dependencies": {
+        "@ag-ui/a2ui-toolkit": "0.0.1-alpha.3",
         "@langchain/core": "^1.1.40",
         "@langchain/langgraph-sdk": "^1.8.8",
         "langchain": ">=1.2.0",

--- a/showcase/integrations/langgraph-python/package.json
+++ b/showcase/integrations/langgraph-python/package.json
@@ -49,12 +49,14 @@
     "typescript": "^5.7.0"
   },
   "overrides": {
+    "@ag-ui/langgraph": "0.0.36",
     "@copilotkit/web-inspector": {
       "@copilotkit/core": "latest"
     }
   },
   "pnpm": {
     "overrides": {
+      "@ag-ui/langgraph": "0.0.36",
       "@copilotkit/web-inspector>@copilotkit/core": "latest"
     }
   }

--- a/showcase/integrations/langgraph-typescript/package-lock.json
+++ b/showcase/integrations/langgraph-typescript/package-lock.json
@@ -92,6 +92,11 @@
         "rxjs": "7.8.1"
       }
     },
+    "node_modules/@ag-ui/a2ui-toolkit": {
+      "version": "0.0.1-alpha.3",
+      "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-toolkit/-/a2ui-toolkit-0.0.1-alpha.3.tgz",
+      "integrity": "sha512-9U4DtwJ6rHO4vn4ixYVnRJGrO7u07phT/AjgsHymLf4cvPw57PNZACc4y6eTtayG0IcySNqRGW/wE+qjlXzgzw=="
+    },
     "node_modules/@ag-ui/client": {
       "version": "0.0.53",
       "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.53.tgz",
@@ -127,10 +132,11 @@
       }
     },
     "node_modules/@ag-ui/langgraph": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.34.tgz",
-      "integrity": "sha512-3BV3/X9iRXL3EOFq1DxAZffbh2V6bJ2G8aoNJP6wHx40jbPdJT7aDvZb4DmzlFmXVWJ2kzfD4AnvxLAx9ooPLQ==",
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.36.tgz",
+      "integrity": "sha512-0m8WRj3kYGCI8SPk30oo7PHVnbhAZBIxBuwSdBjl8VQu1OWAnQrzUqUvEI+X6JTXk1Y9sviF8TIPCq3qsmD1cA==",
       "dependencies": {
+        "@ag-ui/a2ui-toolkit": "0.0.1-alpha.3",
         "@langchain/core": "^1.1.40",
         "@langchain/langgraph-sdk": "^1.8.8",
         "langchain": ">=1.2.0",
@@ -3331,7 +3337,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0"
@@ -6004,7 +6010,6 @@
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7934,7 +7939,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11167,7 +11171,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -11186,7 +11190,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -12910,7 +12914,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/showcase/integrations/langgraph-typescript/package.json
+++ b/showcase/integrations/langgraph-typescript/package.json
@@ -56,6 +56,7 @@
     "typescript": "^5.7.0"
   },
   "overrides": {
+    "@ag-ui/langgraph": "0.0.36",
     "@copilotkit/web-inspector": {
       "@copilotkit/core": "latest"
     }


### PR DESCRIPTION
## Summary

Carries [ag-ui PR #1784](https://github.com/ag-ui-protocol/ag-ui/pull/1784) ("fix(langgraph): skip regeneration check when `command.resume` is set") into the three langgraph showcase stacks, greening the `gen-ui-interrupt` D6 cell.

- ag-ui `@ag-ui/langgraph` 0.0.35 (and earlier) incorrectly ran the regenerate path on a **resumed** run, tripping the regeneration trap and breaking gen-ui-interrupt. `0.0.36` adds the `command.resume` guard so a resume skips the regeneration check.
- Pins `@ag-ui/langgraph` `0.0.36` via npm `overrides` (it is a **transitive** dep of `@copilotkit/runtime`) in `langgraph-python`, `langgraph-typescript`, and `langgraph-fastapi`.
- Regenerates each integration's `package-lock.json` (python/fastapi regenerated with `--legacy-peer-deps`, matching their Dockerfile `npm ci --legacy-peer-deps`).

## Files changed

- `showcase/integrations/langgraph-typescript/{package.json,package-lock.json}`
- `showcase/integrations/langgraph-python/{package.json,package-lock.json}`
- `showcase/integrations/langgraph-fastapi/{package.json,package-lock.json}`

Lockfiles flip `@ag-ui/langgraph` 0.0.34 → 0.0.36 and pull in 0.0.36's new transitive dep `@ag-ui/a2ui-toolkit@0.0.1-alpha.3`.

## Verification

- `@ag-ui/langgraph@0.0.36` is published to npm `latest`; its `dist/index.js` contains the `!command?.resume` regeneration guard from #1784.
- All three regenerated lockfiles resolve `node_modules/@ag-ui/langgraph` to `0.0.36`.

## Test plan

- [ ] CI green
- [ ] gen-ui-interrupt D6 cell green for langgraph-python, langgraph-typescript, langgraph-fastapi after showcase rebuild + re-run