### PR TITLE
feat(integrations): add _intelligence activation overlay (unblocks CLI #253)

### DIFF
--- a/examples/integrations/_intelligence/.env.intelligence
+++ b/examples/integrations/_intelligence/.env.intelligence
@@ -1,0 +1,5 @@
+# Appended by `copilotkit add-intelligence`
+COPILOTKIT_LICENSE_TOKEN=
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
+INTELLIGENCE_API_KEY=cpk_sPRVSEED_seed0privat0longtoken00

--- a/examples/integrations/_intelligence/README.md
+++ b/examples/integrations/_intelligence/README.md
@@ -1,0 +1,47 @@
+# `_intelligence/` — CopilotKit Intelligence Activation Overlay
+
+This directory is the **framework-agnostic** overlay consumed by `copilotkit init -i` and
+`copilotkit add-intelligence`. It contains everything needed to run the CopilotKit Intelligence
+stack locally, independent of which framework template your project uses.
+
+## Assets
+
+### `docker-compose.yml`
+
+Starts three services:
+
+- **postgres** — relational store used by the Intelligence runtime
+- **redis** — cache and pub/sub broker
+- **`ghcr.io/copilotkit/intelligence/composite`** — the all-in-one Intelligence container (app-api
+  on 4201, realtime-gateway on 4401, thread-culler, and a db-migrations oneshot)
+
+Bring the stack up with:
+
+```bash
+docker compose up -d --wait
+```
+
+### `.env.intelligence`
+
+A fragment of environment variables appended to your project's `.env` when you run
+`copilotkit add-intelligence`. It wires the scaffolded app to the local stack:
+
+```
+COPILOTKIT_LICENSE_TOKEN=
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
+INTELLIGENCE_API_KEY=cpk_sPRVSEED_seed0privat0longtoken00
+```
+
+`INTELLIGENCE_API_KEY` is pre-seeded with the local-dev value the bundled composite
+container expects. To activate Intelligence, set `COPILOTKIT_LICENSE_TOKEN` (server-side
+secret, from your CopilotKit dashboard); each base template's runtime wires Intelligence
+from that token (see the per-framework dormant wiring below). The stack runs locally once
+the token is set.
+
+## Framework independence
+
+This overlay is **not tied to any specific framework template**. The per-framework dormant
+runtime wiring (e.g. the `CopilotRuntime` provider, route handler, and hook configuration)
+lives in each base template. The overlay only supplies the Docker stack and the env-key
+fragment that activates it.

--- a/examples/integrations/_intelligence/docker-compose.yml
+++ b/examples/integrations/_intelligence/docker-compose.yml
@@ -1,0 +1,122 @@
+# Framework-agnostic CopilotKit Intelligence activation overlay.
+#
+# Starts postgres, redis, and the all-in-one intelligence composite
+# container (runs app-api, realtime-gateway, thread-culler, and the
+# db-migrations oneshot internally under s6-overlay).
+#
+# Usage:
+#   docker compose up -d --wait
+#
+# Then start the app services on the host:
+#   npm run dev
+
+name: copilotkit-intelligence
+
+services:
+  # ---------------------------------------------------------------------------
+  # Infrastructure
+  # ---------------------------------------------------------------------------
+
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
+    environment:
+      POSTGRES_USER: intelligence
+      POSTGRES_PASSWORD: intelligence
+      POSTGRES_DB: postgres
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./docker/init-db:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U intelligence -d postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - intelligence
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "${REDIS_HOST_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - intelligence
+
+  # ---------------------------------------------------------------------------
+  # Intelligence composite (app-api + realtime-gateway + thread-culler +
+  # db-migrations, all in one container under s6-overlay)
+  # ---------------------------------------------------------------------------
+
+  intelligence:
+    image: ghcr.io/copilotkit/intelligence/composite:0.2.0
+    ports:
+      - "${APP_API_HOST_PORT:-4201}:4201"
+      - "${REALTIME_GATEWAY_HOST_PORT:-4401}:4401"
+    environment:
+      DATABASE_URL: postgresql://intelligence:intelligence@postgres:5432/intelligence_app
+      REDIS_URL: redis://redis:6379
+      AUTH_SECRET: local-dev-secret-must-be-at-least-32-chars
+      RUNNER_AUTH_SECRET: dev-runner-secret
+      SECRET_KEY_BASE: local-realtime-gateway-secret-key-base-at-least-64-bytes-long-for-dev
+      DEFAULT_ORGANIZATION_ID: casa-de-erlang
+      # Local dev: the web app runs on http://localhost:<port>, not the gateway's
+      # configured https://localhost, so disable Phoenix origin checking on the
+      # realtime-gateway websocket (otherwise client WS connects get a 403).
+      CHECK_ORIGIN: "false"
+      COPILOTKIT_LICENSE_TOKEN: "${COPILOTKIT_LICENSE_TOKEN:-}"
+      THREAD_STALE_HOURS: "${THREAD_STALE_HOURS:-3}"
+      THREAD_CULL_BATCH_SIZE: "${THREAD_CULL_BATCH_SIZE:-1000}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - intelligence
+
+  # ---------------------------------------------------------------------------
+  # Demo user provisioning (one-shot)
+  # ---------------------------------------------------------------------------
+  # Ensures the runtime's identifyUser id (COPILOTKIT_DEMO_USER_ID, default
+  # "demo-user") exists in cpki.users so created threads can attach to it.
+  # Idempotent; mirrors the two-row pattern the composite's startup seed uses:
+  # a bare id (membership checks) plus a per-project scoped alias
+  # "<projectId>_<userId>" (the threads_user_id_fkey target). Runs once after the
+  # composite is healthy (schema + org/projects seeded), then exits.
+  provision-user:
+    image: postgres:16-alpine
+    depends_on:
+      intelligence:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: intelligence
+      DEMO_USER_ID: "${COPILOTKIT_DEMO_USER_ID:-demo-user}"
+      ORG_ID: "${COPILOTKIT_ORGANIZATION_ID:-casa-de-erlang}"
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        psql -h postgres -U intelligence -d intelligence_app -v ON_ERROR_STOP=1 \
+          -c "INSERT INTO cpki.users (id, organization_id) VALUES ('$$DEMO_USER_ID', '$$ORG_ID') ON CONFLICT (id) DO NOTHING;" \
+          -c "INSERT INTO cpki.users (id, organization_id) SELECT p.id || '_' || '$$DEMO_USER_ID', '$$ORG_ID' FROM cpki.projects p WHERE p.organization_id = '$$ORG_ID' AND p.deleted_at IS NULL ON CONFLICT (id) DO NOTHING;"
+    restart: "no"
+    networks:
+      - intelligence
+
+volumes:
+  postgres-data:
+  redis-data:
+
+networks:
+  intelligence:
+    driver: bridge

--- a/examples/integrations/_intelligence/docker/init-db/01-create-databases.sql
+++ b/examples/integrations/_intelligence/docker/init-db/01-create-databases.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE intelligence_app;
+CREATE DATABASE intelligence_app_shadow;


### PR DESCRIPTION
## What

Adds the framework-agnostic Intelligence activation overlay at `examples/integrations/_intelligence/`:

- `docker-compose.yml` — local Intelligence stack (postgres + redis + `ghcr.io/copilotkit/intelligence/composite`)
- `.env.intelligence` — env keys appended into a scaffolded project's `.env`
- `docker/init-db/01-create-databases.sql`
- `README.md`

## Why

The CopilotKit CLI (`copilotkit init -i` / `copilotkit add-intelligence`, in **CopilotKit/Intelligence#253**) sparse-checkouts `examples/integrations/_intelligence` from **`main`** at runtime. Splitting this overlay out of #5151 lets it land on `main` on its own, so the CLI PR can merge and the CLI can be released without waiting for the full north-star template work in #5151.

## Notes

- **Additive only** — one new directory; no existing files change.
- All values in the compose/env are **local-dev placeholders** (`POSTGRES_PASSWORD: intelligence`, `AUTH_SECRET: local-dev-secret-…`, `INTELLIGENCE_API_KEY=cpk_sPRVSEED_…` dev seed key).
- Byte-identical to the `_intelligence/` directory on #5151 (`ben1/ent-679-intelligence-ready-north-star`); #5151 retains the rest of its north-star template work.

Unblocks CopilotKit/Intelligence#253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
