### PR TITLE
fix(core): make setRuntimeTransport idempotent on the requested transport mode

### DIFF
--- a/packages/core/src/__tests__/agent-registry-resync.test.ts
+++ b/packages/core/src/__tests__/agent-registry-resync.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CopilotKitCore } from "../core";
+import { waitForCondition } from "./test-utils";
+
+/**
+ * `setRuntimeTransport` must be idempotent on the requested transport MODE.
+ * Auto-detect resolves "auto" → a concrete transport ("rest"/"single") and
+ * writes that back, so a guard comparing the resolved value would treat a
+ * re-applied "auto" (which the provider effect does on every render) as a
+ * change and re-run the entire `/info` handshake — needlessly rebuilding the
+ * runtime agents mid-session. Guard on the requested mode instead.
+ */
+describe("CopilotKitCore runtime re-sync", () => {
+  const originalFetch = global.fetch;
+  const originalWindow = (global as unknown as { window?: unknown }).window;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (global as unknown as { window?: unknown }).window = {};
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (global as typeof globalThis & { fetch?: typeof fetch }).fetch;
+    }
+    if (originalWindow === undefined) {
+      delete (global as unknown as { window?: unknown }).window;
+    } else {
+      (global as unknown as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  it("re-applying the 'auto' transport after auto-detect does not refetch /info", async () => {
+    // `setRuntimeTransport` must be idempotent on the requested MODE. Auto-detect
+    // resolves "auto" → a concrete transport ("rest") and writes that back; the
+    // guard must not treat a re-applied "auto" as a change (which would re-run
+    // the whole /info handshake every time the provider effect re-renders).
+    const info = {
+      version: "1.0.0",
+      agents: { default: { description: "assistant", capabilities: {} } },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(info),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    // Default transport is "auto" → first connect auto-detects and resolves to REST.
+    const core = new CopilotKitCore({ runtimeUrl: "https://runtime.example" });
+    await waitForCondition(() => fetchMock.mock.calls.length >= 1);
+    const callsAfterConnect = fetchMock.mock.calls.length;
+
+    // The provider effect re-applies the SAME requested mode on every render.
+    core.setRuntimeTransport("auto");
+    core.setRuntimeTransport("auto");
+    await new Promise((r) => setTimeout(r, 30));
+
+    // No additional /info handshake was triggered.
+    expect(fetchMock.mock.calls.length).toBe(callsAfterConnect);
+  });
+});

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -63,6 +63,12 @@ export class AgentRegistry {
   private _runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus =
     CopilotKitCoreRuntimeConnectionStatus.Disconnected;
   private _runtimeTransport: CopilotRuntimeTransport = "auto";
+  // The transport MODE last requested via `setRuntimeTransport` (e.g. "auto").
+  // Distinct from `_runtimeTransport`, which auto-detect overwrites with the
+  // RESOLVED value ("rest"/"single"). The idempotency guard compares against
+  // this so re-applying the same mode (the provider effect re-applies "auto"
+  // on every render) is a no-op instead of re-running the /info handshake.
+  private _requestedTransport: CopilotRuntimeTransport = "auto";
   private _audioFileTranscriptionEnabled: boolean = false;
   private _runtimeMode: RuntimeMode = RUNTIME_MODE_SSE;
   private _intelligence?: IntelligenceRuntimeInfo;
@@ -151,10 +157,15 @@ export class AgentRegistry {
   }
 
   setRuntimeTransport(runtimeTransport: CopilotRuntimeTransport): void {
-    if (this._runtimeTransport === runtimeTransport) {
+    // Guard on the requested MODE, not the resolved value: after auto-detect
+    // writes `_runtimeTransport = "rest"`, re-applying the same requested
+    // "auto" must not be treated as a change (otherwise every provider
+    // re-render re-runs the /info handshake and rebuilds agents).
+    if (this._requestedTransport === runtimeTransport) {
       return;
     }
 
+    this._requestedTransport = runtimeTransport;
     this._runtimeTransport = runtimeTransport;
     void this.updateRuntimeConnection();
   }


### PR DESCRIPTION
## Summary

`setRuntimeTransport` was not idempotent on the **requested** transport mode. Auto-detect resolves the requested `"auto"` to a concrete transport (`"rest"`/`"single"`) and writes that back to `_runtimeTransport`; the guard then compared against that **resolved** value. So re-applying the same requested mode — which the provider effect does on **every render** — compared unequal and **re-ran the entire `/info` handshake**, rebuilding the runtime agents mid-session.

When that re-sync lands during a turn, `useAgent` hands the UI a freshly-rebuilt (empty) agent for a render, **blanking the whole transcript** (and any per-message UI bound to it — e.g. the intelligence indicator) until it replays.

## Fix

Track the **requested** mode separately (`_requestedTransport`) and guard on it. Re-applying an unchanged requested transport — including `"auto"` after auto-detect has resolved it — is now a no-op, so no redundant `/info` re-sync fires.

## Tests

`packages/core/src/__tests__/agent-registry-resync.test.ts`: re-applying `"auto"` after auto-detect resolves it does **not** refetch `/info`.

## Scope / risk

Touches only `packages/core` (`core/agent-registry.ts` + the test). **No public API change.** Genuine transport *changes* still re-sync exactly as before; only redundant re-applications of the same requested mode are skipped.

> **Verified live:** this idempotency guard *alone* eliminates the mid-turn re-sync in the e-commerce intelligence demo — instrumentation shows no `/info` handshake fires during a turn, and the transcript/indicator no longer flickers. (An earlier draft also made the re-sync itself non-destructive as defense-in-depth; that was dropped because, with this guard, no mid-turn re-sync occurs for it to protect against.)