### PR TITLE
feat(react-core,runtime): general /annotate + learning-containers hooks + /project default (refs RD-8)

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action-in-current-thread.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action-in-current-thread.test.tsx
@@ -93,7 +93,7 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     vi.clearAllMocks();
   });
 
-  it("pre-fills threadId from the chat configuration", async () => {
+  it("POSTs to ${runtimeUrl}/annotate with type:user_action and pre-fills threadId from chat config", async () => {
     installCopilotKit();
     installChatConfig("thread-from-context");
     const { calls, fetch } = mockFetch([
@@ -107,6 +107,10 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     await result.current({ title: "Clicked rename" });
 
     expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      "https://bff.example.com/api/copilotkit/annotate",
+    );
+    expect(calls[0]!.body!.type).toBe("user_action");
     expect(calls[0]!.body!.threadId).toBe("thread-from-context");
   });
 
@@ -167,7 +171,7 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     );
   });
 
-  it("forwards all other fields verbatim", async () => {
+  it("nests title, description, and data inside payload", async () => {
     installCopilotKit();
     installChatConfig("thread-1");
     const { calls, fetch } = mockFetch([
@@ -182,19 +186,23 @@ describe("useLearnFromUserActionInCurrentThread", () => {
       title: "Renamed project",
       description: "User renamed Foo to Bar",
       data: { previous: { name: "Foo" }, next: { name: "Bar" } },
-      metadata: { source: "settings-page" },
     });
 
     expect(calls[0]!.body).toMatchObject({
+      type: "user_action",
       threadId: "thread-1",
-      title: "Renamed project",
-      description: "User renamed Foo to Bar",
-      data: { previous: { name: "Foo" }, next: { name: "Bar" } },
-      metadata: { source: "settings-page" },
+      payload: {
+        title: "Renamed project",
+        description: "User renamed Foo to Bar",
+        data: { previous: { name: "Foo" }, next: { name: "Bar" } },
+      },
     });
+    // learningContainer and metadata must not appear anywhere in the body
+    expect(calls[0]!.body).not.toHaveProperty("learningContainer");
+    expect(calls[0]!.body).not.toHaveProperty("metadata");
   });
 
-  it("threads learningContainer through to the underlying call", async () => {
+  it("does not accept learningContainer or metadata — both are removed from the input type", async () => {
     installCopilotKit();
     installChatConfig("thread-1");
     const { calls, fetch } = mockFetch([
@@ -207,10 +215,10 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     );
     await result.current({
       title: "Renamed project",
-      learningContainer: ["user", "organization"],
     });
 
-    expect(calls[0]!.body!.learningContainer).toEqual(["user", "organization"]);
+    expect(calls[0]!.body).not.toHaveProperty("learningContainer");
+    expect(calls[0]!.body).not.toHaveProperty("metadata");
   });
 
   it("allows omitting all optional fields", async () => {
@@ -228,7 +236,12 @@ describe("useLearnFromUserActionInCurrentThread", () => {
     await result.current({});
 
     expect(calls[0]!.body!.threadId).toBe("thread-1");
-    expect(calls[0]!.body).not.toHaveProperty("title");
-    expect(calls[0]!.body).not.toHaveProperty("description");
+    expect(calls[0]!.body!.type).toBe("user_action");
+    // payload may be present but should not have title/description
+    const payload = calls[0]!.body!.payload as Record<string, unknown> | undefined;
+    if (payload) {
+      expect(payload).not.toHaveProperty("title");
+      expect(payload).not.toHaveProperty("description");
+    }
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learn-from-user-action.test.tsx
@@ -82,7 +82,7 @@ describe("useLearnFromUserAction", () => {
     vi.clearAllMocks();
   });
 
-  it("POSTs to ${runtimeUrl}/user-actions with the body and returns the platform result", async () => {
+  it("POSTs to ${runtimeUrl}/annotate with type:user_action, payload, and returns the platform result", async () => {
     installCopilotKit();
     const { calls, fetch } = mockFetch([
       { status: 200, body: { id: "42", duplicate: false } },
@@ -99,13 +99,16 @@ describe("useLearnFromUserAction", () => {
     expect(recorded).toEqual({ id: "42", duplicate: false });
     expect(calls).toHaveLength(1);
     expect(calls[0]!.url).toBe(
-      "https://bff.example.com/api/copilotkit/user-actions",
+      "https://bff.example.com/api/copilotkit/annotate",
     );
     expect(calls[0]!.init?.method).toBe("POST");
     expect(calls[0]!.body).toMatchObject({
+      type: "user_action",
       threadId: "thread-1",
-      title: "Renamed project",
-      data: { previous: { name: "Foo" }, next: { name: "Bar" } },
+      payload: {
+        title: "Renamed project",
+        data: { previous: { name: "Foo" }, next: { name: "Bar" } },
+      },
     });
     expect(typeof calls[0]!.body!.clientEventId).toBe("string");
     expect((calls[0]!.body!.clientEventId as string).length).toBeGreaterThan(0);
@@ -212,27 +215,17 @@ describe("useLearnFromUserAction", () => {
       title: "x",
     });
 
-    expect(calls[0]!.body).not.toHaveProperty("description");
-    expect(calls[0]!.body).not.toHaveProperty("data");
+    // Top-level body should not contain these removed fields
     expect(calls[0]!.body).not.toHaveProperty("learningContainer");
     expect(calls[0]!.body).not.toHaveProperty("metadata");
     expect(calls[0]!.body).not.toHaveProperty("occurredAt");
+    // Payload should not have description or data when absent
+    const payload = calls[0]!.body!.payload as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("description");
+    expect(payload).not.toHaveProperty("data");
   });
 
-  it("forwards learningContainer (string) in the request body", async () => {
-    installCopilotKit();
-    const { calls, fetch } = mockFetch([
-      { status: 200, body: { id: "1", duplicate: false } },
-    ]);
-    globalThis.fetch = fetch;
-
-    const { result } = renderHook(() => useLearnFromUserAction());
-    await result.current({ threadId: "t1", learningContainer: "user" });
-
-    expect(calls[0]!.body!.learningContainer).toBe("user");
-  });
-
-  it("forwards learningContainer (array) in the request body", async () => {
+  it("nests title, description, and data inside payload", async () => {
     installCopilotKit();
     const { calls, fetch } = mockFetch([
       { status: 200, body: { id: "1", duplicate: false } },
@@ -241,10 +234,54 @@ describe("useLearnFromUserAction", () => {
 
     const { result } = renderHook(() => useLearnFromUserAction());
     await result.current({
-      threadId: "t1",
-      learningContainer: ["user", "organization"],
+      threadId: "t",
+      title: "My title",
+      description: "Some description",
+      data: { key: "value" },
     });
 
-    expect(calls[0]!.body!.learningContainer).toEqual(["user", "organization"]);
+    expect(calls[0]!.body!.payload).toEqual({
+      title: "My title",
+      description: "Some description",
+      data: { key: "value" },
+    });
+  });
+
+  it("does not include learningContainer or metadata in the request body", async () => {
+    // learningContainer and metadata are removed from the input type entirely.
+    // Verify they are never present in the outgoing request body.
+    installCopilotKit();
+    const { calls, fetch } = mockFetch([
+      { status: 200, body: { id: "1", duplicate: false } },
+    ]);
+    globalThis.fetch = fetch;
+
+    const { result } = renderHook(() => useLearnFromUserAction());
+    await result.current({ threadId: "t", title: "x" });
+
+    expect(calls[0]!.body).not.toHaveProperty("learningContainer");
+    expect(calls[0]!.body).not.toHaveProperty("metadata");
+    const payload = calls[0]!.body!.payload as Record<string, unknown> | undefined;
+    if (payload) {
+      expect(payload).not.toHaveProperty("learningContainer");
+      expect(payload).not.toHaveProperty("metadata");
+    }
+  });
+
+  it("forwards occurredAt in the request body when provided", async () => {
+    installCopilotKit();
+    const { calls, fetch } = mockFetch([
+      { status: 200, body: { id: "1", duplicate: false } },
+    ]);
+    globalThis.fetch = fetch;
+
+    const { result } = renderHook(() => useLearnFromUserAction());
+    await result.current({
+      threadId: "t",
+      title: "x",
+      occurredAt: "2024-01-01T00:00:00Z",
+    });
+
+    expect(calls[0]!.body!.occurredAt).toBe("2024-01-01T00:00:00Z");
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-learning-containers.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learning-containers.test.tsx
@@ -1,0 +1,339 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { useCopilotKit } from "../../context";
+import { useCopilotChatConfiguration } from "../../providers";
+import { useLearningContainers } from "../use-learning-containers";
+import { useLearningContainersInCurrentThread } from "../use-learning-containers-in-current-thread";
+
+vi.mock("../../context", () => ({
+  useCopilotKit: vi.fn(),
+}));
+
+vi.mock("../../providers", () => ({
+  useCopilotChatConfiguration: vi.fn(),
+}));
+
+const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;
+const mockUseCopilotChatConfiguration =
+  useCopilotChatConfiguration as ReturnType<typeof vi.fn>;
+
+/** Shared fetch-call tracking type. */
+interface FetchCall {
+  url: string;
+  body: Record<string, unknown> | null;
+}
+
+/**
+ * Install a mock `globalThis.fetch` that records all calls and returns the
+ * provided canned responses in order (repeating the last one indefinitely).
+ */
+const mockFetch = (
+  responses: Array<{ status: number; body: unknown }>,
+): { calls: FetchCall[]; restore: () => void } => {
+  const calls: FetchCall[] = [];
+  let index = 0;
+  const original = globalThis.fetch;
+  const fake = vi.fn(async (url: unknown, init: RequestInit | undefined) => {
+    let parsedBody: Record<string, unknown> | null = null;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        parsedBody = JSON.parse(init.body);
+      } catch {
+        parsedBody = null;
+      }
+    }
+    calls.push({ url: String(url), body: parsedBody });
+    const response = responses[index++] ?? responses[responses.length - 1]!;
+    return new Response(JSON.stringify(response.body), {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  globalThis.fetch = fake as unknown as typeof globalThis.fetch;
+  return { calls, restore: () => { globalThis.fetch = original; } };
+};
+
+/** Set up the copilotkit context mock with a runtimeUrl. */
+const installCopilotKit = (runtimeUrl: string | null = "https://bff.example.com/api/copilotkit") => {
+  mockUseCopilotKit.mockReturnValue({
+    copilotkit: { runtimeUrl, headers: undefined },
+  });
+};
+
+/** Set up the chat-config context mock. */
+const installChatConfig = (threadId: string | null | undefined) => {
+  if (threadId == null) {
+    mockUseCopilotChatConfiguration.mockReturnValue(null);
+    return;
+  }
+  mockUseCopilotChatConfiguration.mockReturnValue({
+    threadId,
+    agentId: "agent-1",
+    labels: {},
+    isModalOpen: false,
+    setModalOpen: () => undefined,
+    hasExplicitThreadId: true,
+  });
+};
+
+// ─── useLearningContainers ────────────────────────────────────────────────────
+
+test("mount with default [organization] → NO emit", () => {
+  installCopilotKit();
+  const { calls, restore } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+  ]);
+
+  renderHook(() =>
+    useLearningContainers({ threadId: "t1", learningContainers: ["organization"] }),
+  );
+
+  expect(calls).toHaveLength(0);
+  restore();
+});
+
+test("mount with [team] → ONE emit with type:set_learning_containers and containers:[team]", async () => {
+  installCopilotKit();
+  const { calls, restore } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+  ]);
+
+  renderHook(() =>
+    useLearningContainers({ threadId: "t1", learningContainers: ["team"] }),
+  );
+
+  // Fire-and-forget; wait a tick for the promise to settle.
+  await act(async () => {});
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.url).toBe("https://bff.example.com/api/copilotkit/annotate");
+  expect(calls[0]!.body!.type).toBe("set_learning_containers");
+  expect((calls[0]!.body!.payload as Record<string, unknown>).containers).toEqual(["team"]);
+  expect(calls[0]!.body!.threadId).toBe("t1");
+  restore();
+});
+
+test("change [team]→[dept] → emits dept; rerender same [dept] (new array, same content) → NO additional emit", async () => {
+  installCopilotKit();
+  const { calls, restore } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+    { status: 200, body: { id: "2", duplicate: false } },
+    { status: 200, body: { id: "3", duplicate: false } },
+  ]);
+
+  const { rerender, unmount } = renderHook(
+    ({ containers }: { containers: string[] }) =>
+      useLearningContainers({ threadId: "t1", learningContainers: containers }),
+    { initialProps: { containers: ["team"] } },
+  );
+
+  await act(async () => {});
+  // Should have emitted once for mount with "team".
+  expect(calls).toHaveLength(1);
+  expect((calls[0]!.body!.payload as Record<string, unknown>).containers).toEqual(["team"]);
+
+  // Change to ["dept"].
+  rerender({ containers: ["dept"] });
+  await act(async () => {});
+  expect(calls).toHaveLength(2);
+  expect((calls[1]!.body!.payload as Record<string, unknown>).containers).toEqual(["dept"]);
+
+  // Rerender with a NEW array that has the same content → no extra emit.
+  rerender({ containers: ["dept"] });
+  await act(async () => {});
+  expect(calls).toHaveLength(2);
+
+  // Clean up (unmount resets, but we don't count that here).
+  unmount();
+  restore();
+});
+
+test("change [team]→[organization] mid-mount → emits [organization] (a real switch is recorded)", async () => {
+  installCopilotKit();
+  const { calls, restore } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+    { status: 200, body: { id: "2", duplicate: false } },
+    { status: 200, body: { id: "3", duplicate: false } },
+  ]);
+
+  const { rerender, unmount } = renderHook(
+    ({ containers }: { containers: string[] }) =>
+      useLearningContainers({ threadId: "t1", learningContainers: containers }),
+    { initialProps: { containers: ["team"] } },
+  );
+
+  await act(async () => {});
+  expect(calls).toHaveLength(1);
+
+  // Switch back to the default — this is a deliberate change and must emit.
+  rerender({ containers: ["organization"] });
+  await act(async () => {});
+
+  // Two emits so far (team on mount, organization on switch).
+  expect(calls).toHaveLength(2);
+  expect((calls[1]!.body!.payload as Record<string, unknown>).containers).toEqual(["organization"]);
+
+  unmount();
+  restore();
+});
+
+test("unmount → emits reset [organization] for the captured threadId", async () => {
+  installCopilotKit();
+  const { calls, restore } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+    { status: 200, body: { id: "2", duplicate: false } },
+  ]);
+
+  const { unmount } = renderHook(() =>
+    useLearningContainers({ threadId: "thread-xyz", learningContainers: ["team"] }),
+  );
+
+  await act(async () => {});
+  // 1 emit on mount.
+  expect(calls).toHaveLength(1);
+
+  unmount();
+  await act(async () => {});
+
+  // 1 more emit for the reset.
+  expect(calls).toHaveLength(2);
+  expect(calls[1]!.body!.type).toBe("set_learning_containers");
+  expect((calls[1]!.body!.payload as Record<string, unknown>).containers).toEqual(["organization"]);
+  expect(calls[1]!.body!.threadId).toBe("thread-xyz");
+  restore();
+});
+
+test("threadId change → resets old thread then syncs new thread", async () => {
+  installCopilotKit();
+  const { calls, restore } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+    { status: 200, body: { id: "2", duplicate: false } },
+    { status: 200, body: { id: "3", duplicate: false } },
+  ]);
+
+  const { rerender, unmount } = renderHook(
+    ({ threadId }: { threadId: string }) =>
+      useLearningContainers({ threadId, learningContainers: ["team"] }),
+    { initialProps: { threadId: "old-thread" } },
+  );
+
+  await act(async () => {});
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.body!.threadId).toBe("old-thread");
+
+  rerender({ threadId: "new-thread" });
+  await act(async () => {});
+
+  // Cleanup reset for old-thread + emit for new-thread.
+  expect(calls).toHaveLength(3);
+  expect(calls[1]!.body!.threadId).toBe("old-thread");
+  expect((calls[1]!.body!.payload as Record<string, unknown>).containers).toEqual(["organization"]);
+  expect(calls[2]!.body!.threadId).toBe("new-thread");
+  expect((calls[2]!.body!.payload as Record<string, unknown>).containers).toEqual(["team"]);
+
+  unmount();
+  restore();
+});
+
+test("failing emit does not throw from render", async () => {
+  installCopilotKit();
+  const original = globalThis.fetch;
+  globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("network fail")) as unknown as typeof globalThis.fetch;
+
+  // Should not throw.
+  const { unmount } = renderHook(() =>
+    useLearningContainers({ threadId: "t1", learningContainers: ["team"] }),
+  );
+
+  await act(async () => {});
+  // No throw — test passes.
+
+  unmount();
+  globalThis.fetch = original;
+});
+
+test("runtimeUrl absent → all emits silently skipped", async () => {
+  installCopilotKit(null);
+  const { calls, restore } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+  ]);
+
+  const { unmount } = renderHook(() =>
+    useLearningContainers({ threadId: "t1", learningContainers: ["team"] }),
+  );
+
+  await act(async () => {});
+  unmount();
+  await act(async () => {});
+
+  expect(calls).toHaveLength(0);
+  restore();
+});
+
+// ─── useLearningContainersInCurrentThread ─────────────────────────────────────
+
+test("useLearningContainersInCurrentThread with no current thread → throws", () => {
+  installCopilotKit();
+  installChatConfig(null);
+
+  expect(() =>
+    renderHook(() =>
+      useLearningContainersInCurrentThread({ learningContainers: ["team"] }),
+    ),
+  ).toThrow(/no active threadId/);
+});
+
+test("useLearningContainersInCurrentThread with empty threadId → throws", () => {
+  installCopilotKit();
+  installChatConfig("");
+
+  expect(() =>
+    renderHook(() =>
+      useLearningContainersInCurrentThread({ learningContainers: ["team"] }),
+    ),
+  ).toThrow(/no active threadId/);
+});
+
+test("useLearningContainersInCurrentThread delegates to useLearningContainers with config threadId", async () => {
+  installCopilotKit();
+  installChatConfig("thread-from-config");
+  const { calls, restore } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+  ]);
+
+  renderHook(() =>
+    useLearningContainersInCurrentThread({ learningContainers: ["team"] }),
+  );
+
+  await act(async () => {});
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.body!.threadId).toBe("thread-from-config");
+  expect((calls[0]!.body!.payload as Record<string, unknown>).containers).toEqual(["team"]);
+  restore();
+});
+
+test("useLearningContainersInCurrentThread with default containers → NO emit", async () => {
+  installCopilotKit();
+  installChatConfig("thread-from-config");
+  const { calls, restore } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+  ]);
+
+  renderHook(() =>
+    useLearningContainersInCurrentThread({ learningContainers: ["organization"] }),
+  );
+
+  await act(async () => {});
+
+  expect(calls).toHaveLength(0);
+  restore();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});

--- a/packages/react-core/src/v2/hooks/__tests__/use-learning-containers.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learning-containers.test.tsx
@@ -235,10 +235,11 @@ test("threadId change → resets old thread then syncs new thread", async () => 
   restore();
 });
 
-test("failing emit does not throw from render", async () => {
+test("failing emit does not throw from render and warns via console.warn", async () => {
   installCopilotKit();
   const original = globalThis.fetch;
   globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("network fail")) as unknown as typeof globalThis.fetch;
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
   // Should not throw.
   const { unmount } = renderHook(() =>
@@ -246,28 +247,44 @@ test("failing emit does not throw from render", async () => {
   );
 
   await act(async () => {});
-  // No throw — test passes.
+  // No throw and a warning was emitted.
+  expect(warnSpy).toHaveBeenCalledWith(
+    expect.stringContaining("failed to record set_learning_containers"),
+    expect.any(TypeError),
+  );
 
   unmount();
   globalThis.fetch = original;
+  warnSpy.mockRestore();
 });
 
-test("runtimeUrl absent → all emits silently skipped", async () => {
+test("runtimeUrl absent → all emits skipped and warns once", async () => {
   installCopilotKit(null);
   const { calls, restore } = mockFetch([
     { status: 200, body: { id: "1", duplicate: false } },
   ]);
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
-  const { unmount } = renderHook(() =>
+  const { rerender, unmount } = renderHook(() =>
     useLearningContainers({ threadId: "t1", learningContainers: ["team"] }),
   );
 
+  await act(async () => {});
+  // Rerender to confirm the warning is not emitted a second time.
+  rerender();
   await act(async () => {});
   unmount();
   await act(async () => {});
 
   expect(calls).toHaveLength(0);
+  // Warning emitted exactly once (guarded by ref).
+  const missingUrlWarns = warnSpy.mock.calls.filter((args) =>
+    String(args[0]).includes("runtimeUrl not configured"),
+  );
+  expect(missingUrlWarns).toHaveLength(1);
+
   restore();
+  warnSpy.mockRestore();
 });
 
 // ─── useLearningContainersInCurrentThread ─────────────────────────────────────

--- a/packages/react-core/src/v2/hooks/__tests__/use-learning-containers.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learning-containers.test.tsx
@@ -165,7 +165,7 @@ test("change [team]→[organization] mid-mount → emits [organization] (a real 
   await act(async () => {});
   expect(calls).toHaveLength(1);
 
-  // Switch back to the default — this is a deliberate change and must emit.
+  // Switch to a different non-default value — a deliberate change always emits.
   rerender({ containers: ["organization"] });
   await act(async () => {});
 

--- a/packages/react-core/src/v2/hooks/__tests__/use-learning-containers.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-learning-containers.test.tsx
@@ -78,14 +78,14 @@ const installChatConfig = (threadId: string | null | undefined) => {
 
 // ─── useLearningContainers ────────────────────────────────────────────────────
 
-test("mount with default [organization] → NO emit", () => {
+test("mount with default [project] → NO emit", () => {
   installCopilotKit();
   const { calls, restore } = mockFetch([
     { status: 200, body: { id: "1", duplicate: false } },
   ]);
 
   renderHook(() =>
-    useLearningContainers({ threadId: "t1", learningContainers: ["organization"] }),
+    useLearningContainers({ threadId: "t1", learningContainers: ["project"] }),
   );
 
   expect(calls).toHaveLength(0);
@@ -177,7 +177,7 @@ test("change [team]→[organization] mid-mount → emits [organization] (a real 
   restore();
 });
 
-test("unmount → emits reset [organization] for the captured threadId", async () => {
+test("unmount → emits reset [project] for the captured threadId", async () => {
   installCopilotKit();
   const { calls, restore } = mockFetch([
     { status: 200, body: { id: "1", duplicate: false } },
@@ -198,7 +198,7 @@ test("unmount → emits reset [organization] for the captured threadId", async (
   // 1 more emit for the reset.
   expect(calls).toHaveLength(2);
   expect(calls[1]!.body!.type).toBe("set_learning_containers");
-  expect((calls[1]!.body!.payload as Record<string, unknown>).containers).toEqual(["organization"]);
+  expect((calls[1]!.body!.payload as Record<string, unknown>).containers).toEqual(["project"]);
   expect(calls[1]!.body!.threadId).toBe("thread-xyz");
   restore();
 });
@@ -227,7 +227,7 @@ test("threadId change → resets old thread then syncs new thread", async () => 
   // Cleanup reset for old-thread + emit for new-thread.
   expect(calls).toHaveLength(3);
   expect(calls[1]!.body!.threadId).toBe("old-thread");
-  expect((calls[1]!.body!.payload as Record<string, unknown>).containers).toEqual(["organization"]);
+  expect((calls[1]!.body!.payload as Record<string, unknown>).containers).toEqual(["project"]);
   expect(calls[2]!.body!.threadId).toBe("new-thread");
   expect((calls[2]!.body!.payload as Record<string, unknown>).containers).toEqual(["team"]);
 
@@ -338,7 +338,7 @@ test("useLearningContainersInCurrentThread with default containers → NO emit",
   ]);
 
   renderHook(() =>
-    useLearningContainersInCurrentThread({ learningContainers: ["organization"] }),
+    useLearningContainersInCurrentThread({ learningContainers: ["project"] }),
   );
 
   await act(async () => {});

--- a/packages/react-core/src/v2/hooks/index.ts
+++ b/packages/react-core/src/v2/hooks/index.ts
@@ -33,3 +33,7 @@ export type {
   UseAttachmentsProps,
   UseAttachmentsReturn,
 } from "./use-attachments";
+export { useLearningContainers } from "./use-learning-containers";
+export type { UseLearningContainersArgs } from "./use-learning-containers";
+export { useLearningContainersInCurrentThread } from "./use-learning-containers-in-current-thread";
+export type { UseLearningContainersInCurrentThreadArgs } from "./use-learning-containers-in-current-thread";

--- a/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
+++ b/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
@@ -6,7 +6,7 @@ import { recordAnnotation } from "../lib/record-annotation";
  * Input to {@link UseLearnFromUserActionRecorder}, the function returned
  * by {@link useLearnFromUserAction}. Captures a single UI interaction that
  * the Intelligence platform's auto-curated knowledge base loop will distill
- * into the team's `/knowledge` notes.
+ * into the team's `/project` notes.
  */
 export interface LearnFromUserActionInput {
   /** Thread the action is associated with. May be unknown to the platform. */
@@ -45,7 +45,7 @@ export type UseLearnFromUserActionRecorder = (
  * Record a user UI interaction in the Intelligence platform's user-actions
  * stream. The platform's auto-curated knowledge base agent reads these
  * (alongside finished agent runs) and writes free-form Obsidian-flavored
- * markdown to `/knowledge`, where any agent in the same project can later
+ * markdown to `/project`, where any agent in the same project can later
  * read it via the `copilotkit_knowledge_base_shell` MCP tool.
  *
  * The hook returns a stable function. Calling it issues a request to the

--- a/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
+++ b/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
@@ -1,6 +1,6 @@
-import { randomUUID } from "@copilotkit/shared";
 import { useCallback } from "react";
 import { useCopilotKit } from "../context";
+import { recordAnnotation } from "../lib/record-annotation";
 
 /**
  * Input to {@link UseLearnFromUserActionRecorder}, the function returned
@@ -17,19 +17,10 @@ export interface LearnFromUserActionInput {
   description?: string | null;
   /** Free-form, JSON-serializable snapshot describing the action. Optional. */
   data?: unknown;
-  /**
-   * Learning container(s) this action is routed to. Accepts a single
-   * container name or an array of names. Defaults to `["organization"]`
-   * server-side when omitted. (Routing is not yet honored by the offline
-   * learner; the value is recorded for the forthcoming learner.)
-   */
-  learningContainer?: string | string[];
-  /** Optional caller-defined metadata. Stored verbatim. */
-  metadata?: Record<string, unknown> | null;
   /** ISO-8601 client-asserted timestamp. Defaults to server NOW() when absent. */
   occurredAt?: string;
   /**
-   * Caller-supplied idempotency key. When omitted, the hook generates a
+   * Caller-supplied idempotency key. When omitted, `recordAnnotation` generates a
    * fresh UUID per call so retries collapse to the original row at the
    * platform. Supply your own to keep a single semantic event idempotent
    * across calls (e.g. a React re-render or a manual retry button).
@@ -58,12 +49,12 @@ export type UseLearnFromUserActionRecorder = (
  * read it via the `copilotkit_knowledge_base_shell` MCP tool.
  *
  * The hook returns a stable function. Calling it issues a request to the
- * customer's CopilotKit runtime (`POST ${runtimeUrl}/user-actions`), which
+ * customer's CopilotKit runtime (`POST ${runtimeUrl}/annotate`), which
  * resolves the Intel user from the BFF's auth and forwards to the
  * platform — the Intel API key never reaches the browser.
  *
- * If `clientEventId` is omitted the hook generates a UUID per call, so a
- * naive double-call (e.g. React 18 strict-mode double-mount, or a retry
+ * If `clientEventId` is omitted `recordAnnotation` generates a UUID per call,
+ * so a naive double-call (e.g. React 18 strict-mode double-mount, or a retry
  * after a network blip on a fresh Promise) is naturally safe. Supply your
  * own key when a single semantic event must remain idempotent across
  * multiple `learnFromUserAction(...)` calls.
@@ -80,7 +71,6 @@ export type UseLearnFromUserActionRecorder = (
  *       threadId,
  *       title: "Renamed project",
  *       data: { previous: { name: oldName }, next: { name: newName } },
- *       learningContainer: "organization",
  *     });
  *   };
  * }
@@ -100,43 +90,23 @@ export function useLearnFromUserAction(): UseLearnFromUserActionRecorder {
         );
       }
 
-      const clientEventId = input.clientEventId ?? randomUUID();
-      const body = {
-        clientEventId,
-        threadId: input.threadId,
+      const payload: Record<string, unknown> = {
         ...(input.title !== undefined ? { title: input.title } : {}),
         ...(input.description !== undefined
           ? { description: input.description }
           : {}),
         ...(input.data !== undefined ? { data: input.data } : {}),
-        ...(input.learningContainer !== undefined
-          ? { learningContainer: input.learningContainer }
-          : {}),
-        ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
-        ...(input.occurredAt !== undefined
-          ? { occurredAt: input.occurredAt }
-          : {}),
       };
 
-      const response = await fetch(`${runtimeUrl}/user-actions`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(copilotkit.headers ?? {}),
-        },
-        body: JSON.stringify(body),
+      return recordAnnotation({
+        runtimeUrl,
+        headers: copilotkit.headers ?? {},
+        type: "user_action",
+        payload: Object.keys(payload).length > 0 ? payload : undefined,
+        threadId: input.threadId,
+        clientEventId: input.clientEventId,
+        occurredAt: input.occurredAt,
       });
-
-      if (!response.ok) {
-        const text = await response.text().catch(() => "");
-        throw new Error(
-          `useLearnFromUserAction: request failed (${response.status})${
-            text ? `: ${text}` : ""
-          }`,
-        );
-      }
-
-      return (await response.json()) as LearnFromUserActionResult;
     },
     [copilotkit],
   );

--- a/packages/react-core/src/v2/hooks/use-learning-containers-in-current-thread.tsx
+++ b/packages/react-core/src/v2/hooks/use-learning-containers-in-current-thread.tsx
@@ -1,0 +1,62 @@
+import { useCopilotChatConfiguration } from "../providers";
+import {
+  UseLearningContainersArgs,
+  useLearningContainers,
+} from "./use-learning-containers";
+
+/**
+ * Arguments for {@link useLearningContainersInCurrentThread}.
+ * Same as {@link UseLearningContainersArgs} minus `threadId`, which is
+ * sourced from the surrounding `<CopilotChatConfigurationProvider>` at
+ * render time.
+ */
+export type UseLearningContainersInCurrentThreadArgs = Omit<
+  UseLearningContainersArgs,
+  "threadId"
+>;
+
+/**
+ * Declaratively keeps the **current chat thread's** learning containers in
+ * sync. The `threadId` is sourced from the surrounding
+ * `<CopilotChatConfigurationProvider>` (the same provider `<CopilotChat>`,
+ * `<CopilotSidebar>`, and friends set up), so callers in a chat-aware
+ * subtree don't need to thread an id through manually.
+ *
+ * **Throws on render** when there is no chat-config provider in scope or
+ * when the provider does not yet have an active `threadId`. Mount the hook
+ * inside a subtree that is guaranteed to have a thread context.
+ *
+ * If you need to manage an explicit thread, use {@link useLearningContainers}
+ * directly — two hooks, two crisp contracts, no mode confusion.
+ *
+ * @throws When no `CopilotChatConfigurationProvider` is in scope or when the
+ *         active `threadId` is absent/empty.
+ *
+ * @example
+ * ```tsx
+ * function ThreadPanel({ scope }: Props) {
+ *   useLearningContainersInCurrentThread({
+ *     learningContainers: [scope],
+ *   });
+ *   // ...
+ * }
+ * ```
+ */
+export function useLearningContainersInCurrentThread({
+  learningContainers,
+}: UseLearningContainersInCurrentThreadArgs): void {
+  const config = useCopilotChatConfiguration();
+  const threadId = config?.threadId;
+
+  if (!threadId) {
+    throw new Error(
+      "useLearningContainersInCurrentThread must be used within a thread context (no active threadId). " +
+        "Wrap the component in <CopilotChat>, <CopilotSidebar>, or <CopilotChatConfigurationProvider>, " +
+        "or use `useLearningContainers()` and pass `threadId` explicitly.",
+    );
+  }
+
+  // Delegate to the base hook. The threadId is stable from the config context.
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useLearningContainers({ threadId, learningContainers });
+}

--- a/packages/react-core/src/v2/hooks/use-learning-containers.tsx
+++ b/packages/react-core/src/v2/hooks/use-learning-containers.tsx
@@ -3,7 +3,7 @@ import { useCopilotKit } from "../context";
 import { recordAnnotation } from "../lib/record-annotation";
 
 /** The default learning containers value. Matches the backend default. */
-const DEFAULT_CONTAINERS: string[] = ["organization"];
+const DEFAULT_CONTAINERS: string[] = ["project"];
 
 /**
  * Arguments for {@link useLearningContainers}.
@@ -13,7 +13,7 @@ export interface UseLearningContainersArgs {
   threadId: string;
   /**
    * The ordered list of learning container identifiers to activate for this
-   * thread. Defaults to `["organization"]` on the backend when absent.
+   * thread. Defaults to `["project"]` on the backend when absent.
    */
   learningContainers: readonly string[];
 }
@@ -24,12 +24,12 @@ export interface UseLearningContainersArgs {
  * endpoint (`POST ${runtimeUrl}/annotate`).
  *
  * **Emit rules:**
- * - On mount with `["organization"]` (the backend default) → does NOT emit.
+ * - On mount with `["project"]` (the backend default) → does NOT emit.
  *   Absence of an annotation equals the default, so the round-trip is skipped.
  * - On mount with any other value → emits immediately.
  * - On any subsequent content change (including a switch back to
- *   `["organization"]`) → emits (a deliberate switch is always recorded).
- * - On unmount or threadId change → emits a reset to `["organization"]`
+ *   `["project"]`) → emits (a deliberate switch is always recorded).
+ * - On unmount or threadId change → emits a reset to `["project"]`
  *   so the backend is left in a clean state for the next consumer.
  *   Changing `learningContainers` within the same thread does NOT reset the
  *   thread; only the new value is emitted.

--- a/packages/react-core/src/v2/hooks/use-learning-containers.tsx
+++ b/packages/react-core/src/v2/hooks/use-learning-containers.tsx
@@ -15,7 +15,7 @@ export interface UseLearningContainersArgs {
    * The ordered list of learning container identifiers to activate for this
    * thread. Defaults to `["organization"]` on the backend when absent.
    */
-  learningContainers: string[];
+  learningContainers: readonly string[];
 }
 
 /**
@@ -61,7 +61,10 @@ export function useLearningContainers({
    * (fresh array, same values) do not fire a redundant emit.
    * `null` = nothing synced yet (initial state or after a threadId reset).
    */
-  const lastSyncedRef = useRef<string[] | null>(null);
+  const lastSyncedRef = useRef<readonly string[] | null>(null);
+
+  /** Guards the missing-runtimeUrl warning so it fires at most once per hook instance. */
+  const warnedMissingUrlRef = useRef(false);
 
   // Keep a ref to the latest transport values so the cleanup effect can read
   // them without being added to its dep array (which would cause it to re-run
@@ -86,16 +89,31 @@ export function useLearningContainers({
 
     /**
      * Fire-and-forget emit; errors must not surface in render.
+     * Failures are logged as warnings so they are diagnosable without
+     * propagating into the React render cycle.
      */
-    const emit = (containers: string[]): void => {
-      if (!runtimeUrl) return;
+    const emit = (containers: readonly string[]): void => {
+      if (!runtimeUrl) {
+        if (!warnedMissingUrlRef.current) {
+          warnedMissingUrlRef.current = true;
+          console.warn(
+            "useLearningContainers: runtimeUrl not configured; learning-container sync disabled",
+          );
+        }
+        return;
+      }
       recordAnnotation({
         runtimeUrl,
         headers,
         type: "set_learning_containers",
         payload: { containers },
         threadId,
-      }).catch(() => {});
+      }).catch((err) => {
+        console.warn(
+          "useLearningContainers: failed to record set_learning_containers",
+          err,
+        );
+      });
     };
 
     if (lastSyncedRef.current === null) {
@@ -137,7 +155,12 @@ export function useLearningContainers({
           type: "set_learning_containers",
           payload: { containers: DEFAULT_CONTAINERS },
           threadId: capturedThreadId,
-        }).catch(() => {});
+        }).catch((err) => {
+          console.warn(
+            "useLearningContainers: failed to record set_learning_containers",
+            err,
+          );
+        });
       }
 
       // Reset tracking so the next effect run (new threadId) starts fresh.

--- a/packages/react-core/src/v2/hooks/use-learning-containers.tsx
+++ b/packages/react-core/src/v2/hooks/use-learning-containers.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef } from "react";
+import { useCopilotKit } from "../context";
+import { recordAnnotation } from "../lib/record-annotation";
+
+/** The default learning containers value. Matches the backend default. */
+const DEFAULT_CONTAINERS: string[] = ["organization"];
+
+/**
+ * Arguments for {@link useLearningContainers}.
+ */
+export interface UseLearningContainersArgs {
+  /** Thread to apply the learning-container selection to. */
+  threadId: string;
+  /**
+   * The ordered list of learning container identifiers to activate for this
+   * thread. Defaults to `["organization"]` on the backend when absent.
+   */
+  learningContainers: string[];
+}
+
+/**
+ * Declaratively keeps a thread's learning containers in sync by emitting
+ * `set_learning_containers` annotations via the CopilotKit runtime annotate
+ * endpoint (`POST ${runtimeUrl}/annotate`).
+ *
+ * **Emit rules:**
+ * - On mount with `["organization"]` (the backend default) → does NOT emit.
+ *   Absence of an annotation equals the default, so the round-trip is skipped.
+ * - On mount with any other value → emits immediately.
+ * - On any subsequent content change (including a switch back to
+ *   `["organization"]`) → emits (a deliberate switch is always recorded).
+ * - On unmount or threadId change → emits a reset to `["organization"]`
+ *   so the backend is left in a clean state for the next consumer.
+ *   Changing `learningContainers` within the same thread does NOT reset the
+ *   thread; only the new value is emitted.
+ *
+ * Content-equality is evaluated via `JSON.stringify` so a fresh array literal
+ * with the same items does NOT trigger a redundant emit.
+ *
+ * If `runtimeUrl` is absent, all emits are silently skipped.
+ *
+ * @example
+ * ```tsx
+ * function ThreadPane({ threadId, userScope }: Props) {
+ *   useLearningContainers({
+ *     threadId,
+ *     learningContainers: [userScope],
+ *   });
+ *   // ...
+ * }
+ * ```
+ */
+export function useLearningContainers({
+  threadId,
+  learningContainers,
+}: UseLearningContainersArgs): void {
+  const { copilotkit } = useCopilotKit();
+
+  /**
+   * Tracks the last-synced container list so content-identical rerenders
+   * (fresh array, same values) do not fire a redundant emit.
+   * `null` = nothing synced yet (initial state or after a threadId reset).
+   */
+  const lastSyncedRef = useRef<string[] | null>(null);
+
+  // Keep a ref to the latest transport values so the cleanup effect can read
+  // them without being added to its dep array (which would cause it to re-run
+  // and re-register on every render).
+  const runtimeUrlRef = useRef<string | null | undefined>(copilotkit.runtimeUrl);
+  const headersRef = useRef<Record<string, string>>(copilotkit.headers ?? {});
+  runtimeUrlRef.current = copilotkit.runtimeUrl;
+  headersRef.current = copilotkit.headers ?? {};
+
+  // Content-stable dependency: same items in same order → same key string.
+  const key = JSON.stringify(learningContainers);
+  const defaultKey = JSON.stringify(DEFAULT_CONTAINERS);
+
+  // ── Effect 1: sync containers ──────────────────────────────────────────────
+  // Fires on mount, on threadId change, and on container-content change.
+  // Does NOT emit a reset on cleanup — container changes within the same thread
+  // are direct transitions, not reset-then-set.
+  // threadId changes are handled by Effect 2's cleanup.
+  useEffect(() => {
+    const runtimeUrl = copilotkit.runtimeUrl;
+    const headers = copilotkit.headers ?? {};
+
+    /**
+     * Fire-and-forget emit; errors must not surface in render.
+     */
+    const emit = (containers: string[]): void => {
+      if (!runtimeUrl) return;
+      recordAnnotation({
+        runtimeUrl,
+        headers,
+        type: "set_learning_containers",
+        payload: { containers },
+        threadId,
+      }).catch(() => {});
+    };
+
+    if (lastSyncedRef.current === null) {
+      // First run (or after a threadId reset): skip if already on the default.
+      if (key === defaultKey) {
+        lastSyncedRef.current = learningContainers;
+        return;
+      }
+      emit(learningContainers);
+      lastSyncedRef.current = learningContainers;
+    } else {
+      // Subsequent runs: only emit when the content actually changed.
+      const lastKey = JSON.stringify(lastSyncedRef.current);
+      if (key !== lastKey) {
+        emit(learningContainers);
+        lastSyncedRef.current = learningContainers;
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [threadId, key]);
+
+  // ── Effect 2: unmount / threadId-change reset ──────────────────────────────
+  // Runs whenever threadId changes and on unmount.
+  // The cleanup emits the reset for the OLD threadId before the new one takes
+  // over (or on final unmount). We intentionally do NOT re-run this effect when
+  // runtimeUrl or headers change — we read the latest values via refs instead.
+  useEffect(() => {
+    // Capture the threadId that was active when this effect ran.
+    const capturedThreadId = threadId;
+
+    return () => {
+      const capturedRuntimeUrl = runtimeUrlRef.current;
+      const capturedHeaders = headersRef.current;
+
+      if (capturedRuntimeUrl) {
+        recordAnnotation({
+          runtimeUrl: capturedRuntimeUrl,
+          headers: capturedHeaders,
+          type: "set_learning_containers",
+          payload: { containers: DEFAULT_CONTAINERS },
+          threadId: capturedThreadId,
+        }).catch(() => {});
+      }
+
+      // Reset tracking so the next effect run (new threadId) starts fresh.
+      lastSyncedRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [threadId]);
+}

--- a/packages/react-core/src/v2/lib/__tests__/record-annotation.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/record-annotation.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { recordAnnotation } from "../record-annotation";
+
+// Override randomUUID with a counter so each call produces a distinct,
+// predictable value (mirrors the pattern used in the hook tests).
+let uuidCounter = 0;
+vi.mock("@copilotkit/shared", async () => {
+  const actual =
+    await vi.importActual<Record<string, unknown>>("@copilotkit/shared");
+  return {
+    ...actual,
+    randomUUID: vi.fn(() => `uuid-${++uuidCounter}`),
+  };
+});
+
+interface FetchCall {
+  url: string;
+  init: RequestInit | undefined;
+  body: Record<string, unknown> | null;
+}
+
+const mockFetch = (
+  responses: Array<{ status: number; body: unknown }>,
+): { calls: FetchCall[]; fetch: typeof globalThis.fetch } => {
+  const calls: FetchCall[] = [];
+  let index = 0;
+  const fetch = vi.fn(async (url, init) => {
+    let parsedBody: Record<string, unknown> | null = null;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        parsedBody = JSON.parse(init.body);
+      } catch {
+        parsedBody = null;
+      }
+    }
+    calls.push({ url: String(url), init, body: parsedBody });
+    const response = responses[index++] ?? responses[responses.length - 1]!;
+    return new Response(JSON.stringify(response.body), {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  return { calls, fetch: fetch as unknown as typeof globalThis.fetch };
+};
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  uuidCounter = 0;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+it("POSTs the correct wire body to ${runtimeUrl}/connector/annotate", async () => {
+  const { calls, fetch } = mockFetch([
+    { status: 200, body: { id: "evt-1", duplicate: false } },
+  ]);
+  globalThis.fetch = fetch;
+
+  const result = await recordAnnotation({
+    runtimeUrl: "https://bff.example.com/api/copilotkit",
+    headers: {},
+    type: "user_action",
+    payload: { title: "Renamed project", data: { old: "Foo" } },
+    threadId: "thread-1",
+    userId: "user-42",
+  });
+
+  expect(result).toEqual({ id: "evt-1", duplicate: false });
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.url).toBe(
+    "https://bff.example.com/api/copilotkit/connector/annotate",
+  );
+  expect(calls[0]!.init?.method).toBe("POST");
+  expect(calls[0]!.body).toMatchObject({
+    type: "user_action",
+    payload: { title: "Renamed project", data: { old: "Foo" } },
+    threadId: "thread-1",
+    userId: "user-42",
+  });
+  expect(typeof calls[0]!.body!.clientEventId).toBe("string");
+  expect((calls[0]!.body!.clientEventId as string).length).toBeGreaterThan(0);
+});
+
+it("uses the caller-supplied clientEventId verbatim when provided", async () => {
+  const { calls, fetch } = mockFetch([
+    { status: 200, body: { id: "evt-2", duplicate: true } },
+  ]);
+  globalThis.fetch = fetch;
+
+  await recordAnnotation({
+    runtimeUrl: "https://bff.example.com/api/copilotkit",
+    headers: {},
+    type: "set_learning_containers",
+    payload: { containers: ["org", "user"] },
+    threadId: "t",
+    userId: "u",
+    clientEventId: "my-stable-id",
+  });
+
+  expect(calls[0]!.body!.clientEventId).toBe("my-stable-id");
+});
+
+it("auto-generates a distinct clientEventId per call when not supplied", async () => {
+  const { calls, fetch } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+    { status: 200, body: { id: "2", duplicate: false } },
+  ]);
+  globalThis.fetch = fetch;
+
+  const base = {
+    runtimeUrl: "https://bff.example.com/api/copilotkit",
+    headers: {},
+    type: "user_action",
+    threadId: "t",
+    userId: "u",
+  } as const;
+
+  await recordAnnotation(base);
+  await recordAnnotation(base);
+
+  expect(calls).toHaveLength(2);
+  expect(calls[0]!.body!.clientEventId).not.toBe(calls[1]!.body!.clientEventId);
+});
+
+it("forwards the caller-supplied occurredAt in the body", async () => {
+  const { calls, fetch } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+  ]);
+  globalThis.fetch = fetch;
+
+  await recordAnnotation({
+    runtimeUrl: "https://bff.example.com/api/copilotkit",
+    headers: {},
+    type: "user_action",
+    threadId: "t",
+    userId: "u",
+    occurredAt: "2026-01-01T00:00:00.000Z",
+  });
+
+  expect(calls[0]!.body!.occurredAt).toBe("2026-01-01T00:00:00.000Z");
+});
+
+it("omits occurredAt from the body when not supplied", async () => {
+  const { calls, fetch } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+  ]);
+  globalThis.fetch = fetch;
+
+  await recordAnnotation({
+    runtimeUrl: "https://bff.example.com/api/copilotkit",
+    headers: {},
+    type: "user_action",
+    threadId: "t",
+    userId: "u",
+  });
+
+  expect(calls[0]!.body).not.toHaveProperty("occurredAt");
+});
+
+it("includes Content-Type and forwards customer headers", async () => {
+  const { calls, fetch } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+  ]);
+  globalThis.fetch = fetch;
+
+  await recordAnnotation({
+    runtimeUrl: "https://bff.example.com/api/copilotkit",
+    headers: { "X-Customer": "tenant-abc" },
+    type: "user_action",
+    threadId: "t",
+    userId: "u",
+  });
+
+  const headers = calls[0]!.init?.headers as Record<string, string>;
+  expect(headers["Content-Type"]).toBe("application/json");
+  expect(headers["X-Customer"]).toBe("tenant-abc");
+});
+
+it("propagates fetch rejections (network error) to the caller", async () => {
+  globalThis.fetch = vi
+    .fn()
+    .mockRejectedValue(
+      new TypeError("network request failed"),
+    ) as unknown as typeof globalThis.fetch;
+
+  await expect(
+    recordAnnotation({
+      runtimeUrl: "https://bff.example.com/api/copilotkit",
+      headers: {},
+      type: "user_action",
+      threadId: "t",
+      userId: "u",
+    }),
+  ).rejects.toThrow(/network request failed/);
+});
+
+it("throws with the HTTP status when the response is not ok", async () => {
+  const { fetch } = mockFetch([{ status: 422, body: { error: "bad input" } }]);
+  globalThis.fetch = fetch;
+
+  await expect(
+    recordAnnotation({
+      runtimeUrl: "https://bff.example.com/api/copilotkit",
+      headers: {},
+      type: "user_action",
+      threadId: "t",
+      userId: "u",
+    }),
+  ).rejects.toThrow(/422/);
+});
+
+it("accepts undefined payload and omits it from the body", async () => {
+  const { calls, fetch } = mockFetch([
+    { status: 200, body: { id: "1", duplicate: false } },
+  ]);
+  globalThis.fetch = fetch;
+
+  await recordAnnotation({
+    runtimeUrl: "https://bff.example.com/api/copilotkit",
+    headers: {},
+    type: "user_action",
+    threadId: "t",
+    userId: "u",
+    payload: undefined,
+  });
+
+  expect(calls[0]!.body).not.toHaveProperty("payload");
+});

--- a/packages/react-core/src/v2/lib/__tests__/record-annotation.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/record-annotation.test.ts
@@ -55,7 +55,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-it("POSTs the correct wire body to ${runtimeUrl}/connector/annotate", async () => {
+it("POSTs the correct wire body to ${runtimeUrl}/annotate", async () => {
   const { calls, fetch } = mockFetch([
     { status: 200, body: { id: "evt-1", duplicate: false } },
   ]);
@@ -67,21 +67,20 @@ it("POSTs the correct wire body to ${runtimeUrl}/connector/annotate", async () =
     type: "user_action",
     payload: { title: "Renamed project", data: { old: "Foo" } },
     threadId: "thread-1",
-    userId: "user-42",
   });
 
   expect(result).toEqual({ id: "evt-1", duplicate: false });
   expect(calls).toHaveLength(1);
   expect(calls[0]!.url).toBe(
-    "https://bff.example.com/api/copilotkit/connector/annotate",
+    "https://bff.example.com/api/copilotkit/annotate",
   );
   expect(calls[0]!.init?.method).toBe("POST");
   expect(calls[0]!.body).toMatchObject({
     type: "user_action",
     payload: { title: "Renamed project", data: { old: "Foo" } },
     threadId: "thread-1",
-    userId: "user-42",
   });
+  expect(calls[0]!.body).not.toHaveProperty("userId");
   expect(typeof calls[0]!.body!.clientEventId).toBe("string");
   expect((calls[0]!.body!.clientEventId as string).length).toBeGreaterThan(0);
 });
@@ -98,11 +97,11 @@ it("uses the caller-supplied clientEventId verbatim when provided", async () => 
     type: "set_learning_containers",
     payload: { containers: ["org", "user"] },
     threadId: "t",
-    userId: "u",
     clientEventId: "my-stable-id",
   });
 
   expect(calls[0]!.body!.clientEventId).toBe("my-stable-id");
+  expect(calls[0]!.body).not.toHaveProperty("userId");
 });
 
 it("auto-generates a distinct clientEventId per call when not supplied", async () => {
@@ -117,7 +116,6 @@ it("auto-generates a distinct clientEventId per call when not supplied", async (
     headers: {},
     type: "user_action",
     threadId: "t",
-    userId: "u",
   } as const;
 
   await recordAnnotation(base);
@@ -125,6 +123,8 @@ it("auto-generates a distinct clientEventId per call when not supplied", async (
 
   expect(calls).toHaveLength(2);
   expect(calls[0]!.body!.clientEventId).not.toBe(calls[1]!.body!.clientEventId);
+  expect(calls[0]!.body).not.toHaveProperty("userId");
+  expect(calls[1]!.body).not.toHaveProperty("userId");
 });
 
 it("forwards the caller-supplied occurredAt in the body", async () => {
@@ -138,11 +138,11 @@ it("forwards the caller-supplied occurredAt in the body", async () => {
     headers: {},
     type: "user_action",
     threadId: "t",
-    userId: "u",
     occurredAt: "2026-01-01T00:00:00.000Z",
   });
 
   expect(calls[0]!.body!.occurredAt).toBe("2026-01-01T00:00:00.000Z");
+  expect(calls[0]!.body).not.toHaveProperty("userId");
 });
 
 it("omits occurredAt from the body when not supplied", async () => {
@@ -156,10 +156,10 @@ it("omits occurredAt from the body when not supplied", async () => {
     headers: {},
     type: "user_action",
     threadId: "t",
-    userId: "u",
   });
 
   expect(calls[0]!.body).not.toHaveProperty("occurredAt");
+  expect(calls[0]!.body).not.toHaveProperty("userId");
 });
 
 it("includes Content-Type and forwards customer headers", async () => {
@@ -173,12 +173,12 @@ it("includes Content-Type and forwards customer headers", async () => {
     headers: { "X-Customer": "tenant-abc" },
     type: "user_action",
     threadId: "t",
-    userId: "u",
   });
 
   const headers = calls[0]!.init?.headers as Record<string, string>;
   expect(headers["Content-Type"]).toBe("application/json");
   expect(headers["X-Customer"]).toBe("tenant-abc");
+  expect(calls[0]!.body).not.toHaveProperty("userId");
 });
 
 it("propagates fetch rejections (network error) to the caller", async () => {
@@ -194,7 +194,6 @@ it("propagates fetch rejections (network error) to the caller", async () => {
       headers: {},
       type: "user_action",
       threadId: "t",
-      userId: "u",
     }),
   ).rejects.toThrow(/network request failed/);
 });
@@ -209,7 +208,6 @@ it("throws with the HTTP status when the response is not ok", async () => {
       headers: {},
       type: "user_action",
       threadId: "t",
-      userId: "u",
     }),
   ).rejects.toThrow(/422/);
 });
@@ -225,9 +223,9 @@ it("accepts undefined payload and omits it from the body", async () => {
     headers: {},
     type: "user_action",
     threadId: "t",
-    userId: "u",
     payload: undefined,
   });
 
   expect(calls[0]!.body).not.toHaveProperty("payload");
+  expect(calls[0]!.body).not.toHaveProperty("userId");
 });

--- a/packages/react-core/src/v2/lib/__tests__/record-annotation.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/record-annotation.test.ts
@@ -229,3 +229,39 @@ it("accepts undefined payload and omits it from the body", async () => {
   expect(calls[0]!.body).not.toHaveProperty("payload");
   expect(calls[0]!.body).not.toHaveProperty("userId");
 });
+
+// ── F1 guard: empty body ───────────────────────────────────────────────────────
+
+it("throws a contextual error when the runtime returns 200 with an empty body", async () => {
+  // Return a Response whose body is the empty string (no JSON).
+  const fakeFetch = vi.fn(async () =>
+    new Response("", { status: 200, headers: { "Content-Type": "application/json" } }),
+  );
+  globalThis.fetch = fakeFetch as unknown as typeof globalThis.fetch;
+
+  await expect(
+    recordAnnotation({
+      runtimeUrl: "https://bff.example.com/api/copilotkit",
+      headers: {},
+      type: "user_action",
+      threadId: "t",
+    }),
+  ).rejects.toThrow(/empty body/);
+});
+
+it("throws a contextual error when the runtime returns 200 with a non-JSON body", async () => {
+  // Return a Response whose body is non-JSON text.
+  const fakeFetch = vi.fn(async () =>
+    new Response("OK", { status: 200, headers: { "Content-Type": "text/plain" } }),
+  );
+  globalThis.fetch = fakeFetch as unknown as typeof globalThis.fetch;
+
+  await expect(
+    recordAnnotation({
+      runtimeUrl: "https://bff.example.com/api/copilotkit",
+      headers: {},
+      type: "user_action",
+      threadId: "t",
+    }),
+  ).rejects.toThrow(/non-JSON body/);
+});

--- a/packages/react-core/src/v2/lib/record-annotation.ts
+++ b/packages/react-core/src/v2/lib/record-annotation.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from "@copilotkit/shared";
+
+/**
+ * The result shape returned by the Intelligence `/connector/annotate` endpoint.
+ */
+export interface RecordAnnotationResult {
+  /** Platform-assigned id of the annotation row. */
+  id: string;
+  /** `true` when the platform recognized this `clientEventId` as a retry. */
+  duplicate: boolean;
+}
+
+/**
+ * Arguments for {@link recordAnnotation}.
+ *
+ * The transport dependencies (`runtimeUrl`, `headers`) mirror what the
+ * `useLearnFromUserAction` hook reads from `copilotkit` context, so the hook
+ * can pass them through without any structural change.
+ */
+export interface RecordAnnotationArgs {
+  /**
+   * Base URL of the customer's CopilotKit runtime
+   * (e.g. `https://bff.example.com/api/copilotkit`).
+   * The function appends `/connector/annotate`.
+   */
+  runtimeUrl: string;
+  /**
+   * Extra HTTP headers forwarded from `copilotkit.headers` — typically used
+   * for customer auth tokens that the BFF needs to identify the user.
+   */
+  headers: Record<string, string>;
+  /**
+   * The annotation discriminant understood by the Intelligence platform.
+   * Known values: `"user_action"`, `"set_learning_containers"`.
+   */
+  type: string;
+  /**
+   * Free-form, JSON-serializable payload whose shape depends on `type`.
+   * Omit (or pass `undefined`) for annotation types with no payload body.
+   */
+  payload?: unknown;
+  /** Thread the annotation is associated with. */
+  threadId: string;
+  /** Platform user id. */
+  userId: string;
+  /**
+   * Caller-supplied idempotency key. When omitted, a UUID is generated so
+   * every call is naturally safe against platform-level duplicate processing.
+   * Supply your own key when the same semantic event must stay idempotent
+   * across multiple calls (e.g. a retry button or a React strict-mode
+   * double-mount).
+   */
+  clientEventId?: string;
+  /**
+   * ISO-8601 client-asserted timestamp.
+   * Defaults to server `NOW()` when absent.
+   */
+  occurredAt?: string;
+}
+
+/**
+ * Low-level function that posts an arbitrary annotation to the Intelligence
+ * platform's general annotation endpoint (`POST /connector/annotate`).
+ *
+ * This is the single transport entry point for all annotation types. Higher-
+ * level hooks (e.g. `useLearnFromUserAction`) build the `type`/`payload` pair
+ * for their specific annotation shape and delegate the HTTP call here.
+ *
+ * The function uses the same transport as `useLearnFromUserAction`:
+ * - `runtimeUrl` from `copilotkit.runtimeUrl` (BFF proxies to the platform)
+ * - `headers` from `copilotkit.headers` (customer auth forwarded to BFF)
+ * - `clientEventId` auto-generated via `randomUUID()` when omitted
+ * - Errors propagate to the caller (fire-and-propagate, not fire-and-forget)
+ *
+ * @param args - Transport dependencies plus annotation fields.
+ * @returns The platform result containing the annotation row `id` and a
+ *          `duplicate` flag.
+ * @throws When the network request fails or the platform returns a non-2xx
+ *         status. Callers that want fire-and-forget behavior should `.catch`
+ *         at the call site.
+ */
+export async function recordAnnotation(
+  args: RecordAnnotationArgs,
+): Promise<RecordAnnotationResult> {
+  const {
+    runtimeUrl,
+    headers,
+    type,
+    payload,
+    threadId,
+    userId,
+    occurredAt,
+  } = args;
+
+  const clientEventId = args.clientEventId ?? randomUUID();
+
+  const body: Record<string, unknown> = {
+    type,
+    threadId,
+    userId,
+    clientEventId,
+    ...(payload !== undefined ? { payload } : {}),
+    ...(occurredAt !== undefined ? { occurredAt } : {}),
+  };
+
+  const response = await fetch(`${runtimeUrl}/connector/annotate`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `recordAnnotation: request failed (${response.status})${text ? `: ${text}` : ""}`,
+    );
+  }
+
+  return (await response.json()) as RecordAnnotationResult;
+}

--- a/packages/react-core/src/v2/lib/record-annotation.ts
+++ b/packages/react-core/src/v2/lib/record-annotation.ts
@@ -119,5 +119,17 @@ export async function recordAnnotation(
     );
   }
 
-  return (await response.json()) as RecordAnnotationResult;
+  const text = await response.text();
+  if (!text) {
+    throw new Error(
+      `recordAnnotation: runtime ${runtimeUrl}/annotate returned ${response.status} with an empty body`,
+    );
+  }
+  try {
+    return JSON.parse(text) as RecordAnnotationResult;
+  } catch {
+    throw new Error(
+      `recordAnnotation: runtime ${runtimeUrl}/annotate returned a non-JSON body (status ${response.status})`,
+    );
+  }
 }

--- a/packages/react-core/src/v2/lib/record-annotation.ts
+++ b/packages/react-core/src/v2/lib/record-annotation.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "@copilotkit/shared";
 
 /**
- * The result shape returned by the Intelligence `/connector/annotate` endpoint.
+ * The result shape returned by the CopilotKit runtime `/annotate` endpoint.
  */
 export interface RecordAnnotationResult {
   /** Platform-assigned id of the annotation row. */
@@ -16,12 +16,15 @@ export interface RecordAnnotationResult {
  * The transport dependencies (`runtimeUrl`, `headers`) mirror what the
  * `useLearnFromUserAction` hook reads from `copilotkit` context, so the hook
  * can pass them through without any structural change.
+ *
+ * `userId` is intentionally absent — the runtime resolves the user from BFF
+ * auth server-side and the browser must never send it.
  */
 export interface RecordAnnotationArgs {
   /**
    * Base URL of the customer's CopilotKit runtime
    * (e.g. `https://bff.example.com/api/copilotkit`).
-   * The function appends `/connector/annotate`.
+   * The function appends `/annotate`.
    */
   runtimeUrl: string;
   /**
@@ -41,8 +44,6 @@ export interface RecordAnnotationArgs {
   payload?: unknown;
   /** Thread the annotation is associated with. */
   threadId: string;
-  /** Platform user id. */
-  userId: string;
   /**
    * Caller-supplied idempotency key. When omitted, a UUID is generated so
    * every call is naturally safe against platform-level duplicate processing.
@@ -59,8 +60,8 @@ export interface RecordAnnotationArgs {
 }
 
 /**
- * Low-level function that posts an arbitrary annotation to the Intelligence
- * platform's general annotation endpoint (`POST /connector/annotate`).
+ * Low-level function that posts an arbitrary annotation to the CopilotKit
+ * runtime's general annotation endpoint (`POST /annotate`).
  *
  * This is the single transport entry point for all annotation types. Higher-
  * level hooks (e.g. `useLearnFromUserAction`) build the `type`/`payload` pair
@@ -70,12 +71,13 @@ export interface RecordAnnotationArgs {
  * - `runtimeUrl` from `copilotkit.runtimeUrl` (BFF proxies to the platform)
  * - `headers` from `copilotkit.headers` (customer auth forwarded to BFF)
  * - `clientEventId` auto-generated via `randomUUID()` when omitted
+ * - `userId` is resolved server-side by the runtime; the client never sends it
  * - Errors propagate to the caller (fire-and-propagate, not fire-and-forget)
  *
  * @param args - Transport dependencies plus annotation fields.
  * @returns The platform result containing the annotation row `id` and a
  *          `duplicate` flag.
- * @throws When the network request fails or the platform returns a non-2xx
+ * @throws When the network request fails or the runtime returns a non-2xx
  *         status. Callers that want fire-and-forget behavior should `.catch`
  *         at the call site.
  */
@@ -88,7 +90,6 @@ export async function recordAnnotation(
     type,
     payload,
     threadId,
-    userId,
     occurredAt,
   } = args;
 
@@ -97,13 +98,12 @@ export async function recordAnnotation(
   const body: Record<string, unknown> = {
     type,
     threadId,
-    userId,
     clientEventId,
     ...(payload !== undefined ? { payload } : {}),
     ...(occurredAt !== undefined ? { occurredAt } : {}),
   };
 
-  const response = await fetch(`${runtimeUrl}/connector/annotate`, {
+  const response = await fetch(`${runtimeUrl}/annotate`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/packages/runtime/src/v2/runtime/__tests__/fetch-router.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/fetch-router.test.ts
@@ -55,9 +55,9 @@ describe("fetch-router", () => {
       expect(result).toEqual({ method: "threads/list" });
     });
 
-    it("matches POST /user-actions", () => {
-      const result = matchRoute("/api/copilotkit/user-actions", basePath);
-      expect(result).toEqual({ method: "user-actions/record" });
+    it("matches POST /annotate", () => {
+      const result = matchRoute("/api/copilotkit/annotate", basePath);
+      expect(result).toEqual({ method: "annotate" });
     });
 
     it("matches POST /threads/subscribe", () => {
@@ -236,9 +236,9 @@ describe("fetch-router", () => {
       expect(result).toEqual({ method: "threads/list" });
     });
 
-    it("matches /user-actions suffix", () => {
-      const result = matchRoute("/anything/user-actions");
-      expect(result).toEqual({ method: "user-actions/record" });
+    it("matches /annotate suffix", () => {
+      const result = matchRoute("/anything/annotate");
+      expect(result).toEqual({ method: "annotate" });
     });
 
     it("matches /threads/subscribe suffix", () => {

--- a/packages/runtime/src/v2/runtime/__tests__/handle-user-actions.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-user-actions.test.ts
@@ -1,307 +1,267 @@
-import { describe, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
 
-import { handleRecordUserAction } from "../handlers/handle-user-actions";
+import { handleAnnotate } from "../handlers/handle-user-actions";
 import { CopilotRuntime } from "../core/runtime";
 import { PlatformRequestError } from "../intelligence-platform/client";
 
-describe("handleRecordUserAction", () => {
-  const createIdentifyUser = () =>
-    vi.fn().mockResolvedValue({ id: "user-1", name: "User One" });
+const createIdentifyUser = () =>
+  vi.fn().mockResolvedValue({ id: "user-1", name: "User One" });
 
-  const createIntelligenceRuntime = (options?: {
-    identifyUser?: (
-      request: Request,
-    ) => { id: string; name: string } | Promise<{ id: string; name: string }>;
-    intelligence?: Record<string, unknown>;
-  }) =>
-    ({
-      agents: Promise.resolve({}),
-      transcriptionService: undefined,
-      beforeRequestMiddleware: undefined,
-      afterRequestMiddleware: undefined,
-      runner: {
-        run: vi.fn(),
-        connect: vi.fn(),
-        isRunning: vi.fn(),
-        stop: vi.fn(),
-      },
-      mode: "intelligence",
-      generateThreadNames: false,
-      identifyUser: options?.identifyUser ?? createIdentifyUser(),
-      intelligence: options?.intelligence,
-    }) as unknown as CopilotRuntime;
+const createIntelligenceRuntime = (options?: {
+  identifyUser?: (
+    request: Request,
+  ) => { id: string; name: string } | Promise<{ id: string; name: string }>;
+  intelligence?: Record<string, unknown>;
+}) =>
+  ({
+    agents: Promise.resolve({}),
+    transcriptionService: undefined,
+    beforeRequestMiddleware: undefined,
+    afterRequestMiddleware: undefined,
+    runner: {
+      run: vi.fn(),
+      connect: vi.fn(),
+      isRunning: vi.fn(),
+      stop: vi.fn(),
+    },
+    mode: "intelligence",
+    generateThreadNames: false,
+    identifyUser: options?.identifyUser ?? createIdentifyUser(),
+    intelligence: options?.intelligence,
+  }) as unknown as CopilotRuntime;
 
-  const validBody = () => ({
-    clientEventId: "0190a1b2-c3d4-7890-abcd-ef1234567890",
+const validBody = () => ({
+  type: "user_action",
+  payload: { previous: { name: "Foo" }, next: { name: "Bar" } },
+  threadId: "thread-1",
+  clientEventId: "0190a1b2-c3d4-7890-abcd-ef1234567890",
+  occurredAt: "2026-01-01T00:00:00.000Z",
+});
+
+const buildRequest = (body: Record<string, unknown>) =>
+  new Request("https://example.com/annotate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+it("returns 422 when intelligence is not configured", async () => {
+  const runtime = new CopilotRuntime({ agents: {} });
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(validBody()),
+  });
+  expect(response.status).toBe(422);
+});
+
+it("forwards to intelligence.annotate with the resolved userId", async () => {
+  const annotate = vi.fn().mockResolvedValue({ id: "42", duplicate: false });
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const body = validBody();
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(body),
+  });
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({ id: "42", duplicate: false });
+  expect(annotate).toHaveBeenCalledWith(
+    expect.objectContaining({
+      userId: "user-1",
+      threadId: "thread-1",
+      type: "user_action",
+      payload: { previous: { name: "Foo" }, next: { name: "Bar" } },
+      clientEventId: "0190a1b2-c3d4-7890-abcd-ef1234567890",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+});
+
+it("resolves userId server-side (not from the request body)", async () => {
+  const annotate = vi.fn().mockResolvedValue({ id: "1", duplicate: false });
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  // Body contains NO userId field — server must inject it from auth
+  const bodyWithoutUserId = {
+    type: "user_action",
     threadId: "thread-1",
-    title: "Renamed project",
-    description: "User renamed Foo to Bar",
-    data: { previous: { name: "Foo" }, next: { name: "Bar" } },
-    metadata: { source: "settings-page" },
+  };
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(bodyWithoutUserId),
   });
+  expect(response.status).toBe(200);
+  expect(annotate).toHaveBeenCalledWith(
+    expect.objectContaining({ userId: "user-1" }),
+  );
+});
 
-  const buildRequest = (body: Record<string, unknown>) =>
-    new Request("https://example.com/user-actions", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-
-  it("returns 422 when intelligence is not configured", async () => {
-    const runtime = new CopilotRuntime({ agents: {} });
-    const response = await handleRecordUserAction({
-      runtime,
-      request: buildRequest(validBody()),
-    });
-    expect(response.status).toBe(422);
+it("returns 400 when threadId is missing", async () => {
+  const annotate = vi.fn();
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const { threadId: _drop, ...rest } = validBody();
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(rest),
   });
+  expect(response.status).toBe(400);
+  expect(annotate).not.toHaveBeenCalled();
+});
 
-  it("forwards to intelligence.recordUserAction with the resolved userId", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockResolvedValue({ id: "42", duplicate: false });
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    const body = validBody();
-    const response = await handleRecordUserAction({
-      runtime,
-      request: buildRequest(body),
-    });
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      id: "42",
-      duplicate: false,
-    });
-    expect(recordUserAction).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId: "user-1",
-        threadId: "thread-1",
-        title: "Renamed project",
-        description: "User renamed Foo to Bar",
-        data: { previous: { name: "Foo" }, next: { name: "Bar" } },
-        metadata: { source: "settings-page" },
-        clientEventId: "0190a1b2-c3d4-7890-abcd-ef1234567890",
-      }),
-    );
+it("returns 400 when threadId is empty string", async () => {
+  const annotate = vi.fn();
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest({ ...validBody(), threadId: "" }),
   });
+  expect(response.status).toBe(400);
+  expect(annotate).not.toHaveBeenCalled();
+});
 
-  it("returns 400 when threadId is missing", async () => {
-    const recordUserAction = vi.fn();
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    const { threadId: _drop, ...rest } = validBody();
-    const response = await handleRecordUserAction({
-      runtime,
-      request: buildRequest(rest),
-    });
-    expect(response.status).toBe(400);
-    expect(recordUserAction).not.toHaveBeenCalled();
+it("returns 400 when type is missing", async () => {
+  const annotate = vi.fn();
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const { type: _drop, ...rest } = validBody();
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(rest),
   });
+  expect(response.status).toBe(400);
+  expect(annotate).not.toHaveBeenCalled();
+});
 
-  it("returns 400 when clientEventId is missing", async () => {
-    const recordUserAction = vi.fn();
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    const { clientEventId: _drop, ...rest } = validBody();
-    const response = await handleRecordUserAction({
-      runtime,
-      request: buildRequest(rest),
-    });
-    expect(response.status).toBe(400);
-    expect(recordUserAction).not.toHaveBeenCalled();
+it("returns 400 when type is empty string", async () => {
+  const annotate = vi.fn();
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest({ ...validBody(), type: "" }),
   });
+  expect(response.status).toBe(400);
+  expect(annotate).not.toHaveBeenCalled();
+});
 
-  it("succeeds when title is omitted (title is optional)", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockResolvedValue({ id: "1", duplicate: false });
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    const { title: _drop, ...rest } = validBody();
-    const response = await handleRecordUserAction({
-      runtime,
-      request: buildRequest(rest),
-    });
-    expect(response.status).toBe(200);
-    expect(recordUserAction).toHaveBeenCalledWith(
-      expect.objectContaining({ threadId: "thread-1" }),
-    );
-    // Title is absent or undefined when the body didn't carry one.
-    expect(recordUserAction.mock.calls[0]![0].title).toBeUndefined();
+it("succeeds when payload is omitted (payload is optional)", async () => {
+  const annotate = vi.fn().mockResolvedValue({ id: "1", duplicate: false });
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const { payload: _drop, ...rest } = validBody();
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(rest),
   });
+  expect(response.status).toBe(200);
+  expect(annotate).toHaveBeenCalledWith(
+    expect.objectContaining({ type: "user_action", threadId: "thread-1" }),
+  );
+  expect(annotate.mock.calls[0]![0].payload).toBeUndefined();
+});
 
-  it("returns 502 with the expected error body when the platform call fails", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockRejectedValue(new Error("platform exploded"));
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    const response = await handleRecordUserAction({
-      runtime,
-      request: buildRequest(validBody()),
-    });
-    expect(response.status).toBe(502);
-    await expect(response.json()).resolves.toEqual({
-      error: "Failed to record user action",
-    });
+it("succeeds when clientEventId is omitted (optional)", async () => {
+  const annotate = vi.fn().mockResolvedValue({ id: "1", duplicate: false });
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const { clientEventId: _drop, ...rest } = validBody();
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(rest),
   });
+  expect(response.status).toBe(200);
+  expect(annotate).toHaveBeenCalledWith(
+    expect.objectContaining({ type: "user_action", threadId: "thread-1" }),
+  );
+  expect(annotate.mock.calls[0]![0].clientEventId).toBeUndefined();
+});
 
-  it("forwards 4xx PlatformRequestError statuses verbatim (not collapsed into 502)", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockRejectedValue(new PlatformRequestError("bad threadId", 400));
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    const response = await handleRecordUserAction({
-      runtime,
-      request: buildRequest(validBody()),
-    });
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toMatchObject({
-      error: expect.stringContaining("bad threadId"),
-    });
+it("succeeds when occurredAt is omitted (optional)", async () => {
+  const annotate = vi.fn().mockResolvedValue({ id: "1", duplicate: false });
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const { occurredAt: _drop, ...rest } = validBody();
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(rest),
   });
+  expect(response.status).toBe(200);
+  expect(annotate.mock.calls[0]![0].occurredAt).toBeUndefined();
+});
 
-  it("collapses 5xx PlatformRequestError into a 502 (upstream is genuinely at fault)", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockRejectedValue(
-        new PlatformRequestError("internal server error", 503),
-      );
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    const response = await handleRecordUserAction({
-      runtime,
-      request: buildRequest(validBody()),
-    });
-    expect(response.status).toBe(502);
+it("returns 400 for malformed JSON body", async () => {
+  const annotate = vi.fn();
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const request = new Request("https://example.com/annotate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "not-json{{{",
   });
+  const response = await handleAnnotate({ runtime, request });
+  expect(response.status).toBe(400);
+  expect(annotate).not.toHaveBeenCalled();
+});
 
-  it("silently drops an empty-string title (coerced to undefined)", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockResolvedValue({ id: "1", duplicate: false });
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    await handleRecordUserAction({
-      runtime,
-      request: buildRequest({ ...validBody(), title: "" }),
-    });
-    // Empty string is treated as "no title" — the handler coerces via
-    // `isNonEmptyString`. Pin this contract so a future change that
-    // started rejecting empty strings instead is intentional, not
-    // accidental.
-    expect(recordUserAction.mock.calls[0]![0].title).toBeUndefined();
+it("returns 502 with the expected error body when the platform call fails", async () => {
+  const annotate = vi.fn().mockRejectedValue(new Error("platform exploded"));
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(validBody()),
   });
+  expect(response.status).toBe(502);
+  await expect(response.json()).resolves.toEqual({
+    error: "Failed to annotate",
+  });
+});
 
-  it("rejects an array as metadata (typeof [] === 'object' footgun)", async () => {
-    const recordUserAction = vi.fn();
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    await handleRecordUserAction({
-      runtime,
-      request: buildRequest({ ...validBody(), metadata: [1, 2, 3] }),
-    });
-    // Arrays are not valid metadata; the handler drops them rather
-    // than passing through as a record. Pin this so a future refactor
-    // can't accidentally re-introduce the bug.
-    expect(recordUserAction.mock.calls[0]![0].metadata).toBeUndefined();
+it("forwards 4xx PlatformRequestError statuses verbatim (not collapsed into 502)", async () => {
+  const annotate = vi
+    .fn()
+    .mockRejectedValue(new PlatformRequestError("bad threadId", 400));
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(validBody()),
   });
+  expect(response.status).toBe(400);
+  await expect(response.json()).resolves.toMatchObject({
+    error: expect.stringContaining("bad threadId"),
+  });
+});
 
-  it("forwards learningContainer (string) through to intelligence.recordUserAction", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockResolvedValue({ id: "1", duplicate: false });
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    await handleRecordUserAction({
-      runtime,
-      request: buildRequest({ ...validBody(), learningContainer: "user" }),
-    });
-    expect(recordUserAction).toHaveBeenCalledWith(
-      expect.objectContaining({ learningContainer: "user" }),
-    );
+it("collapses 5xx PlatformRequestError into a 502 (upstream is genuinely at fault)", async () => {
+  const annotate = vi
+    .fn()
+    .mockRejectedValue(new PlatformRequestError("internal server error", 503));
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(validBody()),
   });
+  expect(response.status).toBe(502);
+});
 
-  it("forwards learningContainer (array) through to intelligence.recordUserAction", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockResolvedValue({ id: "1", duplicate: false });
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    await handleRecordUserAction({
-      runtime,
-      request: buildRequest({
-        ...validBody(),
-        learningContainer: ["user", "organization"],
-      }),
-    });
-    expect(recordUserAction).toHaveBeenCalledWith(
-      expect.objectContaining({
-        learningContainer: ["user", "organization"],
-      }),
-    );
+it("returns the duplicate=true payload verbatim from the platform", async () => {
+  const annotate = vi.fn().mockResolvedValue({ id: "42", duplicate: true });
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const response = await handleAnnotate({
+    runtime,
+    request: buildRequest(validBody()),
   });
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({ id: "42", duplicate: true });
+});
 
-  it("omits learningContainer from the forward call when not provided", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockResolvedValue({ id: "1", duplicate: false });
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    await handleRecordUserAction({
-      runtime,
-      request: buildRequest(validBody()),
-    });
-    expect(
-      recordUserAction.mock.calls[0]![0].learningContainer,
-    ).toBeUndefined();
+it("forwards payload verbatim (any shape) to intelligence.annotate", async () => {
+  const annotate = vi.fn().mockResolvedValue({ id: "1", duplicate: false });
+  const runtime = createIntelligenceRuntime({ intelligence: { annotate } });
+  const customPayload = { containers: ["user", "organization"] };
+  await handleAnnotate({
+    runtime,
+    request: buildRequest({
+      ...validBody(),
+      type: "set_learning_containers",
+      payload: customPayload,
+    }),
   });
-
-  it("forwards a malformed learningContainer (non-string, non-array) verbatim so the platform's Zod boundary is the single source of validation", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockResolvedValue({ id: "1", duplicate: false });
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    await handleRecordUserAction({
-      runtime,
-      request: buildRequest({ ...validBody(), learningContainer: 123 }),
-    });
-    // The runtime no longer silently rewrites bad input to `undefined`
-    // (which would silently land the platform default). The malformed
-    // value flows through; Intelligence's Zod rejects it with 400.
-    expect(recordUserAction.mock.calls[0]![0].learningContainer).toBe(123);
-  });
-
-  it("returns the duplicate=true payload verbatim from the platform", async () => {
-    const recordUserAction = vi
-      .fn()
-      .mockResolvedValue({ id: "42", duplicate: true });
-    const runtime = createIntelligenceRuntime({
-      intelligence: { recordUserAction },
-    });
-    const response = await handleRecordUserAction({
-      runtime,
-      request: buildRequest(validBody()),
-    });
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      id: "42",
-      duplicate: true,
-    });
-  });
+  expect(annotate).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "set_learning_containers",
+      payload: customPayload,
+    }),
+  );
 });

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -58,7 +58,7 @@ import {
   handleGetThreadEvents,
   handleGetThreadState,
 } from "../handlers/handle-threads";
-import { handleRecordUserAction } from "../handlers/handle-user-actions";
+import { handleAnnotate } from "../handlers/handle-user-actions";
 import {
   parseMethodCall,
   createJsonRequest,
@@ -361,8 +361,8 @@ function dispatchRoute(
         request,
         threadId: route.threadId,
       });
-    case "user-actions/record":
-      return handleRecordUserAction({ runtime, request });
+    case "annotate":
+      return handleAnnotate({ runtime, request });
     case "cpk-debug-events":
       return Promise.resolve(handleDebugEvents({ runtime, request }));
   }

--- a/packages/runtime/src/v2/runtime/core/fetch-router.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-router.ts
@@ -199,9 +199,9 @@ function matchSegments(path: string): RouteInfo | null {
     return { method: "threads/list" };
   }
 
-  // /user-actions (1 segment) — record a UI interaction
-  if (len >= 1 && segments[len - 1] === "user-actions") {
-    return { method: "user-actions/record" };
+  // /annotate (1 segment) — annotate a thread event
+  if (len >= 1 && segments[len - 1] === "annotate") {
+    return { method: "annotate" };
   }
 
   return null;

--- a/packages/runtime/src/v2/runtime/core/hooks.ts
+++ b/packages/runtime/src/v2/runtime/core/hooks.ts
@@ -47,7 +47,7 @@ export type RouteInfo =
   | { method: "threads/events"; threadId: string }
   | { method: "threads/state"; threadId: string }
   | { method: "threads/clear" }
-  | { method: "user-actions/record" }
+  | { method: "annotate" }
   | { method: "cpk-debug-events" };
 
 /* ------------------------------------------------------------------------------------------------

--- a/packages/runtime/src/v2/runtime/handlers/handle-user-actions.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-user-actions.ts
@@ -1,1 +1,1 @@
-export { handleRecordUserAction } from "./intelligence/user-actions";
+export { handleAnnotate } from "./intelligence/annotate";

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/annotate.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/annotate.ts
@@ -57,7 +57,7 @@ function isNonEmptyString(value: unknown): value is string {
  * `POST /annotate` handler.
  *
  * Three-tier flow:
- *   useAnnotate() (frontend)
+ *   recordAnnotation() (frontend lib; called by useLearnFromUserAction / useLearningContainers)
  *     → POST ${runtimeUrl}/annotate
  *     → this handler resolves the Intel user from BFF auth
  *     → intelligence.annotate(...)

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/annotate.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/annotate.ts
@@ -8,27 +8,22 @@ import { PlatformRequestError } from "../../intelligence-platform/client";
 import { errorResponse, isHandlerResponse } from "../shared/json-response";
 import { resolveIntelligenceUser } from "../shared/resolve-intelligence-user";
 
-interface UserActionsHandlerParams {
+interface AnnotateHandlerParams {
   runtime: CopilotRuntimeLike;
   request: Request;
 }
 
-interface RecordUserActionBody {
+interface AnnotateBody {
+  /** Discriminator identifying the annotation type (e.g. `"user_action"`). */
+  type: string;
+  /** Type-specific payload. Shape varies by `type`. */
+  payload?: unknown;
+  /** The thread the annotation is associated with. */
   threadId: string;
-  title?: string | null;
-  description?: string | null;
-  data?: unknown;
-  /**
-   * Forwarded verbatim to the platform; Intelligence is the single
-   * authoritative validator and rejects malformed values (non-string,
-   * non-array, empty string, empty array, array with empty elements)
-   * with 400. The runtime intentionally does not type-guard this field
-   * to avoid silently rewriting bad input into the platform default.
-   */
-  learningContainer?: unknown;
-  metadata?: Record<string, unknown> | null;
+  /** Caller-supplied idempotency key. Optional — platform auto-generates one when absent. */
+  clientEventId?: string;
+  /** ISO-8601 client-asserted timestamp. Defaults to server NOW() when absent. */
   occurredAt?: string;
-  clientEventId: string;
 }
 
 async function parseJsonBody(
@@ -37,7 +32,7 @@ async function parseJsonBody(
   try {
     return (await request.json()) as Record<string, unknown>;
   } catch (error) {
-    logger.error({ err: error }, "Malformed JSON in record-user-action body");
+    logger.error({ err: error }, "Malformed JSON in annotate body");
     return errorResponse("Invalid request body", 400);
   }
 }
@@ -47,7 +42,7 @@ function requireIntelligenceRuntime(
 ): CopilotIntelligenceRuntimeLike | Response {
   if (!isIntelligenceRuntime(runtime)) {
     return errorResponse(
-      "Missing CopilotKitIntelligence configuration. recordUserAction requires a CopilotKitIntelligence instance to be provided in CopilotRuntime options.",
+      "Missing CopilotKitIntelligence configuration. annotate requires a CopilotKitIntelligence instance to be provided in CopilotRuntime options.",
       422,
     );
   }
@@ -59,23 +54,23 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 /**
- * `POST /user-actions` handler.
+ * `POST /annotate` handler.
  *
  * Three-tier flow:
- *   useLearnFromUserAction() (frontend)
- *     → POST ${runtimeUrl}/user-actions
+ *   useAnnotate() (frontend)
+ *     → POST ${runtimeUrl}/annotate
  *     → this handler resolves the Intel user from BFF auth
- *     → intelligence.recordUserAction(...)
- *     → PUT ${apiUrl}/connector/user-actions/record/:clientEventId
+ *     → intelligence.annotate(...)
+ *     → PUT ${apiUrl}/connector/annotate/:clientEventId
  *
- * The frontend hook auto-generates a UUID `clientEventId` per call,
+ * The frontend hook may auto-generate a UUID `clientEventId` per call
  * so retries are idempotent end-to-end (the platform collapses to the
  * original row).
  */
-export async function handleRecordUserAction({
+export async function handleAnnotate({
   runtime,
   request,
-}: UserActionsHandlerParams): Promise<Response> {
+}: AnnotateHandlerParams): Promise<Response> {
   const intelligenceRuntime = requireIntelligenceRuntime(runtime);
   if (isHandlerResponse(intelligenceRuntime)) return intelligenceRuntime;
 
@@ -88,27 +83,24 @@ export async function handleRecordUserAction({
   });
   if (isHandlerResponse(user)) return user;
 
-  const parsed = parseRecordUserActionBody(body);
+  const parsed = parseAnnotateBody(body);
   if (isHandlerResponse(parsed)) return parsed;
 
   try {
-    const result = await intelligenceRuntime.intelligence.recordUserAction({
+    const result = await intelligenceRuntime.intelligence.annotate({
       userId: user.id,
       threadId: parsed.threadId,
-      title: parsed.title,
-      description: parsed.description,
-      data: parsed.data,
-      learningContainer: parsed.learningContainer,
-      metadata: parsed.metadata,
-      occurredAt: parsed.occurredAt,
+      type: parsed.type,
+      payload: parsed.payload,
       clientEventId: parsed.clientEventId,
+      occurredAt: parsed.occurredAt,
     });
     return new Response(JSON.stringify(result), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
   } catch (err) {
-    logger.error({ err }, "recordUserAction: platform call failed");
+    logger.error({ err }, "annotate: platform call failed");
     // Forward the platform's HTTP status when it's a client error
     // (4xx) so the SDK author sees an actionable response instead of
     // a generic 502. 5xx and non-platform errors collapse to 502
@@ -120,48 +112,26 @@ export async function handleRecordUserAction({
     ) {
       return errorResponse(err.message, err.status);
     }
-    return errorResponse("Failed to record user action", 502);
+    return errorResponse("Failed to annotate", 502);
   }
 }
 
-function parseRecordUserActionBody(
+function parseAnnotateBody(
   body: Record<string, unknown>,
-): RecordUserActionBody | Response {
+): AnnotateBody | Response {
   if (!isNonEmptyString(body.threadId)) {
     return errorResponse("Valid threadId is required", 400);
   }
-  if (!isNonEmptyString(body.clientEventId)) {
-    return errorResponse("Valid clientEventId is required", 400);
+  if (!isNonEmptyString(body.type)) {
+    return errorResponse("Valid type is required", 400);
   }
   return {
+    type: body.type,
+    payload: body.payload,
     threadId: body.threadId,
-    title:
-      body.title === undefined
-        ? undefined
-        : body.title === null
-          ? null
-          : isNonEmptyString(body.title)
-            ? body.title
-            : undefined,
-    description:
-      body.description === undefined
-        ? undefined
-        : body.description === null
-          ? null
-          : isNonEmptyString(body.description)
-            ? body.description
-            : undefined,
-    data: body.data,
-    learningContainer: body.learningContainer,
-    metadata:
-      body.metadata === undefined
-        ? undefined
-        : body.metadata === null
-          ? null
-          : typeof body.metadata === "object" && !Array.isArray(body.metadata)
-            ? (body.metadata as Record<string, unknown>)
-            : undefined,
+    clientEventId: isNonEmptyString(body.clientEventId)
+      ? body.clientEventId
+      : undefined,
     occurredAt: isNonEmptyString(body.occurredAt) ? body.occurredAt : undefined,
-    clientEventId: body.clientEventId,
   };
 }

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -599,59 +599,87 @@ describe("CopilotKitIntelligence", () => {
     });
   });
 
-  describe("recordUserAction", () => {
+  describe("annotate", () => {
     const validParams = {
       userId: "user-1",
       threadId: "thread-1",
-      title: "Renamed project",
-      data: { previous: { name: "Foo" }, next: { name: "Bar" } },
-      metadata: { source: "settings-page" },
+      type: "user_action",
+      payload: { title: "Renamed project", data: { previous: { name: "Foo" }, next: { name: "Bar" } } },
       clientEventId: "0190a1b2-c3d4-7890-abcd-ef1234567890",
     };
 
     it("uses PUT (idempotent) and URL-encodes the clientEventId in the path", async () => {
       fetchMock.mockReturnValue(jsonResponse({ id: "42", duplicate: false }));
 
-      const result = await client.recordUserAction(validParams);
+      const result = await client.annotate(validParams);
 
       expect(result).toEqual({ id: "42", duplicate: false });
       const [url, opts] = fetchMock.mock.calls[0];
       expect(url).toBe(
-        "https://api.example.com/connector/user-actions/record/0190a1b2-c3d4-7890-abcd-ef1234567890",
+        "https://api.example.com/connector/annotate/0190a1b2-c3d4-7890-abcd-ef1234567890",
       );
       expect(opts.method).toBe("PUT");
     });
 
-    it("sends clientEventId in the body for the connector's URL/body parity check", async () => {
+    it("auto-generates a clientEventId (UUID) when omitted and includes it in the path", async () => {
       fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
 
-      await client.recordUserAction(validParams);
+      const { clientEventId: _omit, ...paramsWithoutId } = validParams;
+      await client.annotate(paramsWithoutId);
 
-      const [, opts] = fetchMock.mock.calls[0];
-      const body = JSON.parse(opts.body);
-      expect(body.clientEventId).toBe(validParams.clientEventId);
+      const [url] = fetchMock.mock.calls[0];
+      // Path must end with /connector/annotate/<uuid>
+      expect(url).toMatch(
+        /^https:\/\/api\.example\.com\/connector\/annotate\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
     });
 
-    it("forwards all action fields verbatim", async () => {
+    it("sends type, payload, userId, threadId in the body", async () => {
       fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
 
-      await client.recordUserAction(validParams);
+      await client.annotate(validParams);
 
       const [, opts] = fetchMock.mock.calls[0];
       expect(JSON.parse(opts.body)).toMatchObject({
+        type: "user_action",
+        payload: { title: "Renamed project", data: { previous: { name: "Foo" }, next: { name: "Bar" } } },
         userId: "user-1",
         threadId: "thread-1",
-        title: "Renamed project",
-        data: { previous: { name: "Foo" }, next: { name: "Bar" } },
-        metadata: { source: "settings-page" },
-        clientEventId: validParams.clientEventId,
       });
+    });
+
+    it("does not send clientEventId in the body", async () => {
+      fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
+
+      await client.annotate(validParams);
+
+      const [, opts] = fetchMock.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.clientEventId).toBeUndefined();
+    });
+
+    it("forwards occurredAt in the body when provided", async () => {
+      fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
+
+      await client.annotate({ ...validParams, occurredAt: "2026-01-01T00:00:00.000Z" });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(JSON.parse(opts.body).occurredAt).toBe("2026-01-01T00:00:00.000Z");
+    });
+
+    it("omits occurredAt from the body when not provided", async () => {
+      fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
+
+      await client.annotate(validParams);
+
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(JSON.parse(opts.body).occurredAt).toBeUndefined();
     });
 
     it("sends Authorization Bearer with the configured apiKey", async () => {
       fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
 
-      await client.recordUserAction(validParams);
+      await client.annotate(validParams);
 
       const [, opts] = fetchMock.mock.calls[0];
       expect(opts.headers.Authorization).toBe("Bearer test-key");
@@ -661,21 +689,21 @@ describe("CopilotKitIntelligence", () => {
     it("encodes special characters in clientEventId path segments", async () => {
       fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
 
-      await client.recordUserAction({
+      await client.annotate({
         ...validParams,
         clientEventId: "id/with?special&chars",
       });
 
       const [url] = fetchMock.mock.calls[0];
       expect(url).toBe(
-        "https://api.example.com/connector/user-actions/record/id%2Fwith%3Fspecial%26chars",
+        "https://api.example.com/connector/annotate/id%2Fwith%3Fspecial%26chars",
       );
     });
 
     it("throws PlatformRequestError on non-2xx with the platform's status", async () => {
       fetchMock.mockReturnValue(jsonResponse({ error: "bad" }, 400));
 
-      await expect(client.recordUserAction(validParams)).rejects.toMatchObject({
+      await expect(client.annotate(validParams)).rejects.toMatchObject({
         status: 400,
       });
     });
@@ -683,7 +711,7 @@ describe("CopilotKitIntelligence", () => {
     it("throws PlatformRequestError 502 when the platform returns an empty body", async () => {
       fetchMock.mockReturnValue(emptyResponse(200));
 
-      await expect(client.recordUserAction(validParams)).rejects.toMatchObject({
+      await expect(client.annotate(validParams)).rejects.toMatchObject({
         status: 502,
       });
     });
@@ -703,45 +731,9 @@ describe("CopilotKitIntelligence", () => {
         } as Response),
       );
 
-      await expect(client.recordUserAction(validParams)).rejects.toMatchObject({
+      await expect(client.annotate(validParams)).rejects.toMatchObject({
         status: 502,
       });
-    });
-
-    it("forwards learningContainer (string) verbatim in the request body", async () => {
-      fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
-
-      await client.recordUserAction({
-        ...validParams,
-        learningContainer: "user",
-      });
-
-      const [, opts] = fetchMock.mock.calls[0];
-      expect(JSON.parse(opts.body).learningContainer).toBe("user");
-    });
-
-    it("forwards learningContainer (array) verbatim in the request body", async () => {
-      fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
-
-      await client.recordUserAction({
-        ...validParams,
-        learningContainer: ["user", "organization"],
-      });
-
-      const [, opts] = fetchMock.mock.calls[0];
-      expect(JSON.parse(opts.body).learningContainer).toEqual([
-        "user",
-        "organization",
-      ]);
-    });
-
-    it("omits learningContainer from the body when not provided", async () => {
-      fetchMock.mockReturnValue(jsonResponse({ id: "1", duplicate: false }));
-
-      await client.recordUserAction(validParams);
-
-      const [, opts] = fetchMock.mock.calls[0];
-      expect(JSON.parse(opts.body).learningContainer).toBeUndefined();
     });
   });
 });

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -1,4 +1,5 @@
 import { logger } from "@copilotkit/shared";
+import { randomUUID } from "crypto";
 
 /**
  * Header name carrying the per-call end-user identity that the CopilotKit
@@ -199,47 +200,42 @@ export interface AcquireThreadLockResponse extends ThreadConnectionResponse {
 }
 
 /**
- * Parameters for recording a user UI interaction via
- * {@link CopilotKitIntelligence.recordUserAction}. The runtime resolves
- * `userId` from the customer's BFF auth before calling this; the
- * platform prefixes it with the project id at write time.
+ * Parameters for annotating a thread event via
+ * {@link CopilotKitIntelligence.annotate}. The runtime resolves `userId`
+ * from the customer's BFF auth before calling this; the platform prefixes
+ * it with the project id at write time.
+ *
+ * Known `type` values and their `payload` shapes:
+ * - `"user_action"` — `{ title?, description?, data? }`
+ * - `"set_learning_containers"` — `{ containers: string[] }`
  */
-export interface RecordUserActionRequest {
-  /** The user the action belongs to. */
+export interface AnnotateParams {
+  /** The user the annotation belongs to. */
   userId: string;
-  /** The thread the action is associated with. May be unknown to the platform. */
+  /** The thread the annotation is associated with. May be unknown to the platform. */
   threadId: string;
-  /** Short, agent-readable summary of what the user did. Optional. */
-  title?: string | null;
-  /** Optional longer explanation. */
-  description?: string | null;
-  /** Free-form JSON-serializable snapshot describing the action. */
-  data?: unknown;
   /**
-   * Learning container(s) for this action. Forwarded verbatim to the
-   * platform, which is the single authoritative validator: well-formed
-   * input is `string | string[]` (non-empty strings, non-empty array);
-   * the platform defaults to `["organization"]` when the field is
-   * omitted entirely, and 400s on malformed values.
+   * Discriminator identifying the annotation type.
+   * Must match a type known to the Intelligence platform
+   * (e.g. `"user_action"`, `"set_learning_containers"`).
    */
-  learningContainer?: unknown;
-  /** Optional caller-defined metadata. Stored verbatim. */
-  metadata?: Record<string, unknown> | null;
+  type: string;
+  /** Type-specific payload. Shape varies by `type`. */
+  payload?: unknown;
+  /**
+   * Caller-supplied idempotency key (any RFC-compliant UUID). When omitted,
+   * a UUID is auto-generated. Every call hits the platform's idempotent
+   * `PUT /connector/annotate/:clientEventId` endpoint; a retry with the
+   * same id collapses to the original row.
+   */
+  clientEventId?: string;
   /** ISO-8601 client-asserted timestamp. Defaults to server NOW() when absent. */
   occurredAt?: string;
-  /**
-   * Caller-supplied idempotency key (any RFC-compliant UUID; the
-   * frontend hook `useLearnFromUserAction` auto-generates one per call,
-   * so retries are safe by default). Every call hits the platform's
-   * idempotent PUT endpoint; a retry with the same id collapses to
-   * the original row.
-   */
-  clientEventId: string;
 }
 
-/** Response from {@link CopilotKitIntelligence.recordUserAction}. */
-export interface RecordUserActionResponse {
-  /** Database id of the user-action row (BIGINT, returned as a string). */
+/** Response from {@link CopilotKitIntelligence.annotate}. */
+export interface AnnotateResponse {
+  /** Database id of the annotation row (BIGINT, returned as a string). */
   id: string;
   /**
    * True when the platform recognized the `clientEventId` as a retry of
@@ -764,44 +760,56 @@ export class CopilotKitIntelligence {
   }
 
   /**
-   * Record a user UI interaction in the Intelligence platform's user-actions
-   * stream. Used by the auto-curated knowledge base loop: a background agent
-   * distills these actions (and finished agent runs) into a per-(org, project)
-   * markdown knowledge base.
+   * Annotate a thread event on the Intelligence platform's general annotation
+   * endpoint (`PUT /connector/annotate/:clientEventId`).
+   *
+   * This is the generalized replacement for the old
+   * `PUT /connector/user-actions/record/:clientEventId` endpoint. It supports
+   * multiple annotation types via the `type` discriminator:
+   * - `"user_action"` — records a user UI interaction for the self-learning loop.
+   * - `"set_learning_containers"` — sets the learning containers for a thread.
    *
    * `userId` must be resolved on the runtime side before calling this — the
    * platform prefixes it with the project id from the API key.
    *
-   * Always hits the idempotent `PUT /connector/user-actions/record/:clientEventId`
+   * Always hits the idempotent `PUT /connector/annotate/:clientEventId`
    * endpoint. A retry with the same `clientEventId` returns
    * `{ id: <original>, duplicate: true }` instead of creating a new row.
-   *
-   * `clientEventId` is also included in the request body for the connector's
-   * URL/body parity check — the platform 400s if the two don't match. Sending
-   * both is intentional, not a redundancy.
+   * When `clientEventId` is omitted, a UUID is auto-generated for this call.
    *
    * @throws {@link PlatformRequestError} on non-2xx responses, OR when the
    *   platform returns an empty 2xx body (which would otherwise corrupt the
    *   caller's typed result).
    */
-  async recordUserAction(
-    params: RecordUserActionRequest,
-  ): Promise<RecordUserActionResponse> {
-    const { clientEventId, ...rest } = params;
-    const path = `/connector/user-actions/record/${encodeURIComponent(clientEventId)}`;
-    const response = await this.#request<
-      RecordUserActionResponse | null | undefined
-    >("PUT", path, { ...rest, clientEventId });
+  async annotate(params: AnnotateParams): Promise<AnnotateResponse> {
+    const clientEventId = params.clientEventId ?? randomUUID();
+    const path = `/connector/annotate/${encodeURIComponent(clientEventId)}`;
+    const body: Record<string, unknown> = {
+      type: params.type,
+      userId: params.userId,
+      threadId: params.threadId,
+    };
+    if (params.payload !== undefined) {
+      body.payload = params.payload;
+    }
+    if (params.occurredAt !== undefined) {
+      body.occurredAt = params.occurredAt;
+    }
+    const response = await this.#request<AnnotateResponse | null | undefined>(
+      "PUT",
+      path,
+      body,
+    );
     // `== null` catches both `undefined` (empty body from `#request`)
     // and JSON `null` (which would otherwise corrupt the typed result
     // and surface as a `TypeError` deep in caller code).
     if (response == null) {
       logger.error(
         { path },
-        "recordUserAction: Intelligence platform returned 200 with empty or null body",
+        "annotate: Intelligence platform returned 200 with empty or null body",
       );
       throw new PlatformRequestError(
-        "recordUserAction: empty or null response body from Intelligence platform",
+        "annotate: empty or null response body from Intelligence platform",
         502,
       );
     }

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -205,9 +205,11 @@ export interface AcquireThreadLockResponse extends ThreadConnectionResponse {
  * from the customer's BFF auth before calling this; the platform prefixes
  * it with the project id at write time.
  *
- * Known `type` values and their `payload` shapes:
- * - `"user_action"` — `{ title?, description?, data? }`
- * - `"set_learning_containers"` — `{ containers: string[] }`
+ * `payload` is the type-specific JSON blob for the annotation (e.g. a
+ * `"user_action"` event carries the recorded fields, a
+ * `"set_learning_containers"` event carries the container list). The exact
+ * shape per type is validated by the Intelligence backend; canonical shapes
+ * are documented on the Intelligence react-core side.
  */
 export interface AnnotateParams {
   /** The user the annotation belongs to. */


### PR DESCRIPTION
## Summary

CopilotKit-side companion to the Intelligence `sl_annotations` + learning-containers work. Generalizes user-action forwarding into a general annotate path and adds declarative learning-container hooks. Base: `mme/learn-from-user-activity` (clean fast-forward, 0 conflicts, 0 behind).

### What's in here (11 commits)
- **General `recordAnnotation` client** posting to `${runtimeUrl}/annotate` (no client-side `userId`; empty-body guard).
- **Runtime `/annotate` route + handler** — generalizes the user-actions route; `userId` resolved server-side (not body-spoofable); forwards to Intelligence `/connector/annotate`.
- **`useLearnFromUserAction`** records a `user_action` annotation via `recordAnnotation` (dropped `learningContainer`/`metadata`).
- **`useLearningContainers` + `useLearningContainersInCurrentThread`** — declarative hooks emitting `set_learning_containers`; skip-emit on default, content-diff, unmount/threadId-change reset.
- **Default learning container** `organization` → **`project`** (matches the backend default); `/knowledge` → `/project` doc mentions.

### Test status
- `@copilotkit/runtime` + `@copilotkit/react-core`: **1212/1212 green**.
- Latest `/project` + default-container change passed a scoped CR loop (6 Opus agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
