### PR TITLE
fix(angular): add types condition to package.json exports map

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -14,6 +14,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/fesm2022/copilotkitnext-angular.mjs"
     },
     "./styles.css": "./dist/styles.css"


### PR DESCRIPTION
Fixes #3319

## What does this PR do?

The `@copilotkitnext/angular` package dropped the `"types"` condition from its `exports` map starting in v1.52.0. When a package defines `exports`, TypeScript resolves declarations through that map and ignores the top-level `"types"` field, so consumers building with `moduleResolution` set to `bundler`, `node16`, or `nodenext` hit `TS7016: Could not find a declaration file for module '@copilotkitnext/angular'` even though `dist/index.d.ts` ships in the published tarball.

This adds the `"types"` condition back on the `.` entry, pointing at the existing `dist/index.d.ts`. It is placed before `"import"` so the type resolver picks it up first. There are no build output changes since the declaration file is already published. The v1.51.4 map had this condition and resolved correctly, from v1.52.0 onward only `"import"` was kept.

## Related PRs and Issues

- Issue #3319
- Same one-line fix for `@copilotkitnext/react` in #3403

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
