### PR TITLE
feat(saas-demo): self-learning policy-exception gate + threads drawer (stacked on #5180)

### DIFF
--- a/examples/showcases/banking/README.md
+++ b/examples/showcases/banking/README.md
@@ -22,6 +22,66 @@ The demo runs against the workspace versions of `@copilotkit/*` (see the root
 `pnpm-workspace.yaml`). The seed dataset lives in memory and resets every time
 the server restarts.
 
+## Self-learning backend (optional, Phase C)
+
+By default the runtime is pure OSS: a SSE `CopilotRuntime` + `InMemoryAgentRunner`,
+with no external dependency. The agent runs locally against OpenAI and nothing
+is persisted. **This is the default and requires only `OPENAI_API_KEY`.**
+
+The runtime in `src/app/api/copilotkit/[[...slug]]/route.ts` is **env-gated**:
+when the three Intelligence env vars below are all present, it builds the runtime
+in Intelligence mode instead (`CopilotKitIntelligence` + `CopilotRuntime({ intelligence, identifyUser })`).
+The local `bankingAgent` still executes here, but every AG-UI event of every run
+is also streamed over a Phoenix WebSocket to the Intelligence gateway for durable
+threads and self-learning ingestion. If any of the three is unset, the demo falls
+back to the exact OSS path above.
+
+```bash
+# Required for Intelligence mode (all three, or none):
+export INTELLIGENCE_API_URL=http://localhost:4201        # platform REST API
+export INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401    # Phoenix runner/client gateway
+export INTELLIGENCE_API_KEY=cpk_...                       # platform API key
+# Optional — read automatically by the runtime if present:
+export COPILOTKIT_LICENSE_TOKEN=...
+# Model keys the external Intelligence stack needs to run its writer/reader agents:
+export OPENAI_API_KEY=...
+export ANTHROPIC_API_KEY=...
+```
+
+### What the live loop needs (external)
+
+The distillation backend — the `sl-worker`, `app-api`, and `/knowledge`
+endpoints that turn recorded actions into learned procedures — is **not in this
+repo**. It lives in the separate Intelligence stack (the CopilotKit Intelligence
+repo's `./scripts/local-dev.sh`, or a hosted Intelligence deployment). The demo
+can only **connect** to it via the env vars above; it cannot run the loop on its
+own.
+
+### The 4-step payoff walkthrough
+
+1. **Agent fails.** A fresh agent is asked to approve an over-limit transaction
+   and cannot — it has no procedure for unlocking it, so it reports the failure.
+2. **Human unlocks it.** An officer opens and finalizes a policy exception via
+   the transactions UI (`src/components/policy-exception-modal.tsx`). These
+   demonstrated actions are the teaching signal.
+3. **`sl-worker` distills.** The external Intelligence stack ingests the run's
+   event stream, distills the officer's actions, and writes a procedure to
+   `/knowledge`.
+4. **Fresh agent succeeds.** A brand-new agent, asked the same over-limit
+   request, reads the distilled knowledge back and performs the unlock unaided.
+
+### Known gap: client-side action recording
+
+Steps 2→3 are intended to be reinforced by an explicit client-side recording API
+(`useRecordUserActionInCurrentThread` from `@copilotkit/react-core/v2`). **That
+hook does not exist in this OSS react-core/v2 build** (verified against the hooks
+index), so `src/lib/record-user-action.ts` is a no-op shim and the call sites in
+`policy-exception-modal.tsx` / `transactions-list.tsx` record nothing. The
+self-learning loop can still ingest the raw run event stream over the gateway,
+but explicit "demonstrated action" recording from the browser is blocked until a
+react-core build that exports such a hook is available. See the file's header
+comment for details.
+
 ## Architecture at a glance
 
 ```
@@ -39,6 +99,9 @@ the server restarts.
 │  src/app/api/copilotkit/[[...slug]]/route.ts                    │
 │    BuiltInAgent + CopilotRuntime + createCopilotHonoHandler     │
 │    (from @copilotkit/runtime/v2)                                │
+│    env-gated: OSS SSE + InMemoryAgentRunner by default;         │
+│    CopilotKitIntelligence when INTELLIGENCE_* env is set        │
+│    (see "Self-learning backend" below)                          │
 └─────────────────────────────┬───────────────────────────────────┘
                               │
                               ▼

--- a/examples/showcases/banking/src/app/actions.ts
+++ b/examples/showcases/banking/src/app/actions.ts
@@ -4,6 +4,7 @@ import type {
   Card as ICard,
   ExpensePolicy,
   Transaction,
+  PolicyException,
 } from "@/app/api/v1/data";
 import { MemberRole } from "@/app/api/v1/data";
 import { randomDigits } from "@/lib/utils";
@@ -179,7 +180,7 @@ export default function useCreditCards() {
   }: {
     id: string;
     status: "pending" | "approved" | "denied";
-  }) => {
+  }): Promise<{ ok: boolean; error?: string }> => {
     try {
       const response = await fetch(`/api/v1/transactions/${id}`, {
         method: "PUT",
@@ -188,13 +189,74 @@ export default function useCreditCards() {
         },
         body: JSON.stringify({ status }),
       });
-      if (!response.ok) {
-        throw new Error("Failed to change transaction status");
-      }
+      // Always refresh from the server so the UI reflects the real state
+      // whether the write succeeded or was rejected (e.g. the over-limit gate).
       void fetchTransactions();
-      return response.json();
+      if (!response.ok) {
+        // Surface the server's symptom-only message (e.g. "<team> policy limit
+        // exceeded") so the agent + UI can learn the failure instead of
+        // silently reporting a false success.
+        const body = await response.json().catch(() => null);
+        return { ok: false, error: body?.message ?? "Failed to change transaction status" };
+      }
+      return { ok: true };
     } catch (error) {
       console.error("Error changing transaction status:", error);
+      return { ok: false, error: "Network error" };
+    }
+  };
+
+  const openPolicyException = async ({
+    transactionId,
+    code,
+  }: {
+    transactionId: string;
+    code: string;
+  }): Promise<{ ok: boolean; data?: PolicyException; error?: string }> => {
+    try {
+      const response = await fetch("/api/v1/exceptions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ transactionId, code }),
+      });
+      const body = await response.json().catch(() => null);
+      void fetchTransactions();
+      if (!response.ok) {
+        return { ok: false, error: body?.message ?? "Failed to open policy exception" };
+      }
+      return { ok: true, data: body as PolicyException };
+    } catch (error) {
+      console.error("Error opening policy exception:", error);
+      return { ok: false, error: "Network error" };
+    }
+  };
+
+  const finalizePolicyException = async ({
+    exceptionId,
+  }: {
+    exceptionId: string;
+  }): Promise<{ ok: boolean; data?: PolicyException; error?: string }> => {
+    try {
+      const response = await fetch(
+        `/api/v1/exceptions/${exceptionId}/finalize`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+      const body = await response.json().catch(() => null);
+      void fetchTransactions();
+      if (!response.ok) {
+        return { ok: false, error: body?.message ?? "Failed to finalize policy exception" };
+      }
+      return { ok: true, data: body as PolicyException };
+    } catch (error) {
+      console.error("Error finalizing policy exception:", error);
+      return { ok: false, error: "Network error" };
     }
   };
 
@@ -224,5 +286,7 @@ export default function useCreditCards() {
     addNoteToTransaction,
     assignPolicyToCard,
     changeTransactionStatus,
+    openPolicyException,
+    finalizePolicyException,
   };
 }

--- a/examples/showcases/banking/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/showcases/banking/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -18,7 +18,27 @@ When you call the showTransactions tool, the rendered list is the single
 source of truth for the user. Do NOT restate transaction counts, totals,
 or per-row details in prose — the list already shows them. Keep any
 accompanying message to at most one short sentence (e.g. "Here are your
-recent transactions.") and let the rendered list speak for itself.`,
+recent transactions.") and let the rendered list speak for itself.
+
+Tools available to you:
+- showTransactions — show a filtered list of transactions in the chat.
+- addNewCard — request a new expense card. Requires human approval.
+- setCardPin — change the PIN on an existing card. Requires human approval.
+- assignPolicyToCard — assign an expense policy to a card. Requires human approval.
+- addNoteToTransaction — attach a note to a transaction. Requires human approval.
+- showAndApproveTransactions — present a pending transaction for the user to approve or deny. Requires human approval.
+- openPolicyException — open a draft policy exception against a transaction. Requires human approval.
+- finalizePolicyException — finalize a policy exception. Requires human approval.
+- sendSpendAlert — send a spend alert notification for a card.
+- requestCardReplacement — request a replacement card for an existing card.
+- flagForReview — flag a transaction for manual review.
+
+ACTION DISCIPLINE: Only invoke a write tool when the user has explicitly asked
+for that specific action. Do not chain or substitute actions on your own
+initiative. If a write fails and you do not have a known procedure that covers
+an alternative, report exactly what you tried and why it failed, then ask the
+user how they would like to proceed — do NOT improvise a substitute action or
+guess at parameter values.`,
   temperature: 0.3,
 });
 

--- a/examples/showcases/banking/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/showcases/banking/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -3,6 +3,8 @@ import {
   createCopilotHonoHandler,
   InMemoryAgentRunner,
   BuiltInAgent,
+  CopilotKitIntelligence,
+  type IdentifyUserCallback,
 } from "@copilotkit/runtime/v2";
 import { handle } from "hono/vercel";
 
@@ -42,10 +44,91 @@ guess at parameter values.`,
   temperature: 0.3,
 });
 
-const runtime = new CopilotRuntime({
-  agents: { default: bankingAgent },
-  runner: new InMemoryAgentRunner(),
-});
+/**
+ * Self-learning backend (Phase C), env-gated.
+ *
+ * When the three Intelligence env vars below are all set, the runtime is built
+ * in Intelligence mode: the local `bankingAgent` still executes here (calling
+ * OpenAI), but every AG-UI event of every run is streamed over a Phoenix
+ * WebSocket to the Intelligence gateway for durable threads + self-learning
+ * ingestion (the `IntelligenceAgentRunner` does both — see
+ * packages/runtime/src/v2/runtime/runner/intelligence.ts). Officer actions the
+ * gateway later distills into `/knowledge` are what a fresh agent reads back to
+ * learn the over-limit unlock unaided.
+ *
+ * When ANY of the three is missing, the runtime falls back to the exact OSS
+ * path: a pure SSE `CopilotRuntime` + `InMemoryAgentRunner`, with no network
+ * dependency on an Intelligence stack. This is the default and must not regress.
+ *
+ *   INTELLIGENCE_API_URL          e.g. http://localhost:4201
+ *   INTELLIGENCE_GATEWAY_WS_URL   e.g. ws://localhost:4401
+ *   INTELLIGENCE_API_KEY          e.g. cpk_...
+ *   COPILOTKIT_LICENSE_TOKEN      (optional) read automatically by the runtime
+ */
+const intelligenceApiUrl = process.env.INTELLIGENCE_API_URL;
+const intelligenceWsUrl = process.env.INTELLIGENCE_GATEWAY_WS_URL;
+const intelligenceApiKey = process.env.INTELLIGENCE_API_KEY;
+
+const intelligenceEnabled = Boolean(
+  intelligenceApiUrl && intelligenceWsUrl && intelligenceApiKey,
+);
+
+/**
+ * Resolve a stable end-user identity for Intelligence requests.
+ *
+ * The client sends the active member's role via CopilotKit `properties`
+ * ({ userRole }), which the runtime forwards in the request body. We map it to
+ * a stable per-role user id so threads and distilled knowledge are scoped
+ * consistently across runs. If the role can't be read, fall back to a single
+ * stable demo identity rather than minting a random id (random ids would
+ * fragment thread history).
+ */
+const identifyUser: IdentifyUserCallback = async (request: Request) => {
+  let role: string | undefined;
+  try {
+    const cloned = request.clone();
+    const body = (await cloned.json()) as {
+      properties?: { userRole?: string };
+    } | null;
+    role = body?.properties?.userRole;
+  } catch {
+    // Non-JSON body (e.g. GET /info) — fall through to the default identity.
+  }
+
+  const slug = (role ?? "demo-user")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+
+  return {
+    id: `northwind-${slug || "demo-user"}`,
+    name: role ? `Northwind ${role}` : "Northwind Demo User",
+  };
+};
+
+function createRuntime(): CopilotRuntime {
+  if (intelligenceEnabled) {
+    const intelligence = new CopilotKitIntelligence({
+      apiUrl: intelligenceApiUrl!,
+      wsUrl: intelligenceWsUrl!,
+      apiKey: intelligenceApiKey!,
+    });
+
+    return new CopilotRuntime({
+      agents: { default: bankingAgent },
+      intelligence,
+      identifyUser,
+    });
+  }
+
+  // OSS default — pure SSE, no external Intelligence dependency.
+  return new CopilotRuntime({
+    agents: { default: bankingAgent },
+    runner: new InMemoryAgentRunner(),
+  });
+}
+
+const runtime = createRuntime();
 
 const app = createCopilotHonoHandler({ runtime, basePath: "/api/copilotkit" });
 

--- a/examples/showcases/banking/src/app/api/v1/data.ts
+++ b/examples/showcases/banking/src/app/api/v1/data.ts
@@ -51,6 +51,14 @@ export interface TransactionNote {
   date: string;
 }
 
+export interface PolicyException {
+  id: string;
+  transactionId: string;
+  code: string;
+  status: "draft" | "approved";
+  createdAt: string;
+}
+
 export interface Transaction {
   id: string;
   title: string;
@@ -60,6 +68,7 @@ export interface Transaction {
   policyId: string;
   cardId: string;
   status: "pending" | "denied" | "approved";
+  activeExceptionId?: string | null;
 }
 
 export interface NewCardRequest {

--- a/examples/showcases/banking/src/app/api/v1/exceptions/[id]/finalize/route.ts
+++ b/examples/showcases/banking/src/app/api/v1/exceptions/[id]/finalize/route.ts
@@ -1,0 +1,37 @@
+import * as store from "@/lib/store";
+import type { NextRequest } from "next/server";
+
+// Finalize (auto-approve) a draft policy exception, linking it to its
+// transaction so the policy-limit gate is lifted when the code justifies it.
+export const POST = async (
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    const approved = store.finalizePolicyException(id);
+    return new Response(JSON.stringify(approved), { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message === "NOT_FOUND") {
+      return new Response(
+        JSON.stringify({ error: "NOT_FOUND", message: "Exception not found" }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (message === "ALREADY_FINALIZED") {
+      return new Response(
+        JSON.stringify({
+          error: "BAD_REQUEST",
+          message: "Exception already finalized.",
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      );
+    }
+    console.error("POST Request error", error);
+    return new Response(
+      JSON.stringify({ error: "BAD_REQUEST", message: "Bad request" }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+  }
+};

--- a/examples/showcases/banking/src/app/api/v1/exceptions/route.ts
+++ b/examples/showcases/banking/src/app/api/v1/exceptions/route.ts
@@ -1,0 +1,41 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/lib/store";
+
+// Open a draft policy exception against a transaction.
+export const POST = async (req: NextRequest) => {
+  let code: string | undefined;
+  try {
+    const body = await req.json();
+    code = body?.code;
+    const exception = store.openPolicyException(body?.transactionId, code as string);
+    return new Response(JSON.stringify(exception), { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message === "NOT_FOUND") {
+      return new Response(
+        JSON.stringify({
+          error: "NOT_FOUND",
+          message: "Transaction not found",
+        }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (message === "INVALID_EXCEPTION_CODE") {
+      // Surface-level rejection. We deliberately do NOT enumerate the valid
+      // codes here — that would itself be a hint. The agent has to find the
+      // catalogue on its own via `/knowledge`.
+      return new Response(
+        JSON.stringify({
+          error: "INVALID_EXCEPTION_CODE",
+          message: `"${code}" is not a recognized policy exception code.`,
+        }),
+        { status: 422, headers: { "content-type": "application/json" } },
+      );
+    }
+    console.error("POST Request error", error);
+    return new Response(
+      JSON.stringify({ error: "BAD_REQUEST", message: "Bad request" }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+  }
+};

--- a/examples/showcases/banking/src/app/api/v1/policy-exception-codes.ts
+++ b/examples/showcases/banking/src/app/api/v1/policy-exception-codes.ts
@@ -1,0 +1,76 @@
+/**
+ * Policy-exception-code catalogue for the banking demo.
+ *
+ * The human UI displays the `label` so a compliance officer knows what
+ * each code means; everything stored in the exception record and returned
+ * by the agent tools carries only the `code`. The agent has no static
+ * mapping from code -> meaning — it must discover via `/knowledge` which
+ * codes actually justify an approval. That's the whole point of this
+ * surface for the SL demo: the writer agent watches successful officer
+ * flows and learns that, e.g., `EXC-BOARD-APPROVED` is the
+ * approval-justifying lever for policy overrides, while the other codes
+ * are filed for recordkeeping but do not constitute a standing
+ * justification.
+ *
+ * Adding a new code? Append it here. Adding a NEW justifying code?
+ * Also list it in `JUSTIFYING_EXCEPTION_CODES` below.
+ */
+
+export interface PolicyExceptionCodeMeta {
+  readonly code: string;
+  readonly label: string;
+}
+
+/**
+ * Catalogue shown to the human in the New exception modal. First three
+ * are the justifying codes. The rest are plausible exception reasons
+ * that get filed for the record but do not constitute a standing policy
+ * justification.
+ */
+export const POLICY_EXCEPTION_CODES: ReadonlyArray<PolicyExceptionCodeMeta> = [
+  // Justifying — these codes support approval of the policy exception.
+  { code: "EXC-BOARD-APPROVED", label: "Board-approved spend" },
+  { code: "EXC-CONTRACTUAL-COMMITMENT", label: "Contractual commitment" },
+  { code: "EXC-EMERGENCY-SPEND", label: "Emergency spend" },
+  // Non-justifying. Recorded for history; do not constitute a standing justification.
+  { code: "EXC-WILL-REIMBURSE", label: "Employee will reimburse" },
+  { code: "EXC-ONE-TIME", label: "One-time exception" },
+];
+
+/**
+ * The three codes that, when filed and finalized, justify approval of
+ * a policy exception. Anything else is recorded but does not provide
+ * a standing justification.
+ */
+export const JUSTIFYING_EXCEPTION_CODES: ReadonlySet<string> = new Set<string>([
+  "EXC-BOARD-APPROVED",
+  "EXC-CONTRACTUAL-COMMITMENT",
+  "EXC-EMERGENCY-SPEND",
+]);
+
+/**
+ * Human-friendly label for a policy exception code. Falls back to the
+ * raw code for unknown values (e.g. legacy records from older seeds).
+ */
+export const labelForExceptionCode = (code: string): string =>
+  POLICY_EXCEPTION_CODES.find((c) => c.code === code)?.label ?? code;
+
+const VALID_EXCEPTION_CODES: ReadonlySet<string> = new Set(
+  POLICY_EXCEPTION_CODES.map((c) => c.code),
+);
+
+/**
+ * True iff `code` belongs to the published catalogue. The store rejects
+ * `openPolicyException` calls that pass an unknown code, forcing the
+ * agent to learn the catalogue via `/knowledge` rather than inventing
+ * plausible-looking strings.
+ */
+export const isValidExceptionCode = (code: string): boolean =>
+  VALID_EXCEPTION_CODES.has(code);
+
+/**
+ * True iff `code` is one of the three justifying exception codes.
+ * Non-justifying codes are filed for history but do not support approval.
+ */
+export const isJustifying = (code: string): boolean =>
+  JUSTIFYING_EXCEPTION_CODES.has(code);

--- a/examples/showcases/banking/src/app/api/v1/transactions/[id]/route.ts
+++ b/examples/showcases/banking/src/app/api/v1/transactions/[id]/route.ts
@@ -25,6 +25,25 @@ export const PUT = async (
         date: new Date().toISOString().split("T")[0],
       };
     }
+    // Policy-limit gate. `status` arrives inside `rest`, so apply the patch
+    // to a merged view before checking. The rejection names ONLY the
+    // symptom (the policy is over its limit) — never the policy-exception
+    // path that lifts the gate. The agent has to learn that recipe from
+    // `/knowledge`; leaking it here would defeat the SL demo.
+    const merged = { ...existing, ...patch };
+    if (
+      patch.status === "approved" &&
+      !store.isWithinPolicyLimit(merged) &&
+      !store.hasApprovedException(merged)
+    ) {
+      return new Response(
+        JSON.stringify({
+          error: "OVER_POLICY_LIMIT",
+          message: `${store.findPolicy(existing.policyId)?.type} policy limit exceeded`,
+        }),
+        { status: 422, headers: { "content-type": "application/json" } },
+      );
+    }
     const updated = store.updateTransaction(id, patch);
     return new Response(JSON.stringify(updated), { status: 201 });
   } catch (error) {

--- a/examples/showcases/banking/src/app/page.tsx
+++ b/examples/showcases/banking/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useReducer, useState } from "react";
+import { useEffect, useReducer } from "react";
 import {
   useAgentContext,
   useHumanInTheLoop,
@@ -25,47 +25,7 @@ import { ChangePinDialog } from "@/components/change-pin-dialog";
 import { useSearchParams } from "next/navigation";
 import { CardsPageOperations } from "@/components/copilot-context";
 import { PERMISSIONS } from "@/app/api/v1/permissions";
-
-function ApprovalButtons({
-  onApprove,
-  onDeny,
-  approveLabel = "Approve",
-  denyLabel = "Deny",
-}: {
-  onApprove: () => Promise<void> | void;
-  onDeny: () => void;
-  approveLabel?: string;
-  denyLabel?: string;
-}) {
-  const [responded, setResponded] = useState(false);
-
-  if (responded) {
-    return <p className="text-sm text-gray-500 italic">Response submitted.</p>;
-  }
-
-  return (
-    <div className="flex gap-2">
-      <button
-        className="flex-1 rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
-        onClick={async () => {
-          setResponded(true);
-          await onApprove();
-        }}
-      >
-        {approveLabel}
-      </button>
-      <button
-        className="flex-1 rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300"
-        onClick={() => {
-          setResponded(true);
-          onDeny();
-        }}
-      >
-        {denyLabel}
-      </button>
-    </div>
-  );
-}
+import { ApprovalButtons } from "@/components/approval-buttons";
 
 interface ChangePinState {
   newPin: string;

--- a/examples/showcases/banking/src/app/page.tsx
+++ b/examples/showcases/banking/src/app/page.tsx
@@ -5,6 +5,7 @@ import {
   useAgentContext,
   useHumanInTheLoop,
   useComponent,
+  useFrontendTool,
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 import type { NewCardRequest, Transaction } from "@/app/api/v1/data";
@@ -61,6 +62,8 @@ export default function Page() {
     assignPolicyToCard,
     addNoteToTransaction,
     changeTransactionStatus,
+    openPolicyException,
+    finalizePolicyException,
   } = useCreditCards();
 
   useEffect(() => {
@@ -414,15 +417,25 @@ export default function Page() {
         return <div>No pending transactions</div>;
       }
 
+      // Run the REST mutation and respond with the REAL outcome. With the
+      // hardened caller returning `{ ok, error }`, a rejected over-limit
+      // approval reports the server's failure instead of a false success.
+      // Returns `ok` so the list only records the human action when it took
+      // effect.
       async function handleChangeTransactionStatus({
         id,
         status,
       }: {
         id: string;
         status: Transaction["status"];
-      }) {
-        await changeTransactionStatus({ id, status });
-        respond?.(`transaction ${id} ${status}`);
+      }): Promise<boolean> {
+        const { ok, error } = await changeTransactionStatus({ id, status });
+        if (!ok) {
+          respond?.(`Could not ${status} transaction ${id}: ${error}`);
+        } else {
+          respond?.(`transaction ${id} ${status}`);
+        }
+        return ok;
       }
 
       return (
@@ -430,6 +443,9 @@ export default function Page() {
           transactions={transactions.filter((t) =>
             transactionId.includes(t.id),
           )}
+          policies={policies}
+          openPolicyException={openPolicyException}
+          finalizePolicyException={finalizePolicyException}
           showApprovalInterface
           approvalInterfaceProps={{
             onApprove: (transactionId) =>
@@ -446,6 +462,154 @@ export default function Page() {
         />
       );
     },
+  });
+
+  // Open a draft policy exception against a transaction (human-in-the-loop).
+  // The description is deliberately NEUTRAL: it must not say what opening an
+  // exception accomplishes, must not name any exception code, and must not
+  // describe a sequence. The human picks the code in the modal; the agent
+  // only ever passes through whatever code it was given.
+  useHumanInTheLoop({
+    followUp: false,
+    name: "openPolicyException",
+    description:
+      "Open a draft policy exception against a transaction. Requires human approval.",
+    available: PERMISSIONS.APPROVE_TRANSACTION.includes(currentUser.role),
+    parameters: z.object({
+      transactionId: z.string(),
+      code: z.string(),
+    }),
+    render: ({ args, respond, status }) => {
+      const { transactionId, code } = args;
+
+      if (status === "inProgress") {
+        return <div>Loading...</div>;
+      }
+
+      return (
+        <div className="rounded-lg border bg-white p-4 shadow-sm space-y-4">
+          <h3 className="font-semibold text-lg">Open policy exception</h3>
+          <div className="text-sm space-y-1">
+            <p>
+              <span className="text-gray-500">Transaction:</span> {transactionId}
+            </p>
+            <p>
+              <span className="text-gray-500">Code:</span> {code}
+            </p>
+          </div>
+          <ApprovalButtons
+            onApprove={async () => {
+              if (!transactionId || !code) {
+                respond?.("Missing transaction or exception code");
+                return;
+              }
+              const { ok, error } = await openPolicyException({
+                transactionId,
+                code,
+              });
+              respond?.(
+                ok
+                  ? "Exception opened"
+                  : `Could not open exception: ${error}`,
+              );
+            }}
+            onDeny={() => respond?.("Denied by user")}
+          />
+        </div>
+      );
+    },
+  });
+
+  // Finalize a policy exception (human-in-the-loop). Neutral description —
+  // says nothing about what finalizing accomplishes.
+  useHumanInTheLoop({
+    followUp: false,
+    name: "finalizePolicyException",
+    description: "Finalize a policy exception. Requires human approval.",
+    available: PERMISSIONS.APPROVE_TRANSACTION.includes(currentUser.role),
+    parameters: z.object({
+      exceptionId: z.string(),
+    }),
+    render: ({ args, respond, status }) => {
+      const { exceptionId } = args;
+
+      if (status === "inProgress") {
+        return <div>Loading...</div>;
+      }
+
+      return (
+        <div className="rounded-lg border bg-white p-4 shadow-sm space-y-4">
+          <h3 className="font-semibold text-lg">Finalize policy exception</h3>
+          <div className="text-sm space-y-1">
+            <p>
+              <span className="text-gray-500">Exception:</span> {exceptionId}
+            </p>
+          </div>
+          <ApprovalButtons
+            onApprove={async () => {
+              if (!exceptionId) {
+                respond?.("Missing exception id");
+                return;
+              }
+              const { ok, error } = await finalizePolicyException({
+                exceptionId,
+              });
+              respond?.(
+                ok
+                  ? "Exception finalized"
+                  : `Could not finalize exception: ${error}`,
+              );
+            }}
+            onDeny={() => respond?.("Denied by user")}
+          />
+        </div>
+      );
+    },
+  });
+
+  // Distractors. Plausible card/transaction actions that do NOT solve the
+  // over-limit block. No render — they run immediately and return a
+  // non-erroring success whose `note` makes clear it changed nothing about
+  // the transaction or policy. Their job is to widen the option space.
+  useFrontendTool({
+    name: "sendSpendAlert",
+    description: "Send a spend alert notification for a card.",
+    parameters: z.object({
+      cardId: z.string(),
+      message: z.string(),
+    }),
+    handler: async ({ cardId }) => ({
+      ok: true,
+      cardId,
+      note: "Spend alert sent. Informational only; does not modify any transaction or policy.",
+    }),
+  });
+
+  useFrontendTool({
+    name: "requestCardReplacement",
+    description: "Request a replacement card for an existing card.",
+    parameters: z.object({
+      cardId: z.string(),
+    }),
+    handler: async ({ cardId }) => ({
+      ok: true,
+      cardId,
+      note: "Replacement card requested. Does not affect pending transactions or policy limits.",
+    }),
+  });
+
+  useFrontendTool({
+    name: "flagForReview",
+    description: "Flag a transaction for manual review.",
+    parameters: z.object({
+      transactionId: z.string(),
+      reason: z.string(),
+    }),
+    handler: async ({ transactionId }) => ({
+      ok: true,
+      transactionId,
+      note: "Flagged for manual review. Does not approve or change the transaction.",
+    }),
   });
 
   useAgentContext({

--- a/examples/showcases/banking/src/app/team/page.tsx
+++ b/examples/showcases/banking/src/app/team/page.tsx
@@ -13,7 +13,7 @@ import {
 import { useAuthContext } from "@/components/auth-context";
 import type { ExpenseRole } from "@/app/api/v1/data";
 import { MemberRole } from "@/app/api/v1/data";
-import { useEffect, useReducer, useState } from "react";
+import { useEffect, useReducer } from "react";
 import { TeamPageOperations } from "@/components/copilot-context";
 import { useSearchParams } from "next/navigation";
 import { useAgentContext, useHumanInTheLoop } from "@copilotkit/react-core/v2";
@@ -24,47 +24,7 @@ import {
   defaultDialogState,
 } from "@/components/add-or-edit-member-dialog";
 import { RemoveMemberConfirmationDialog } from "@/components/remove-member-dialog";
-
-function ApprovalButtons({
-  onApprove,
-  onDeny,
-  approveLabel = "Approve",
-  denyLabel = "Deny",
-}: {
-  onApprove: () => Promise<void> | void;
-  onDeny: () => void;
-  approveLabel?: string;
-  denyLabel?: string;
-}) {
-  const [responded, setResponded] = useState(false);
-
-  if (responded) {
-    return <p className="text-sm text-gray-500 italic">Response submitted.</p>;
-  }
-
-  return (
-    <div className="flex gap-2">
-      <button
-        className="flex-1 rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
-        onClick={async () => {
-          setResponded(true);
-          await onApprove();
-        }}
-      >
-        {approveLabel}
-      </button>
-      <button
-        className="flex-1 rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300"
-        onClick={() => {
-          setResponded(true);
-          onDeny();
-        }}
-      >
-        {denyLabel}
-      </button>
-    </div>
-  );
-}
+import { ApprovalButtons } from "@/components/approval-buttons";
 
 const dialogStateReducer = (
   state: DialogState,

--- a/examples/showcases/banking/src/app/wrapper.tsx
+++ b/examples/showcases/banking/src/app/wrapper.tsx
@@ -1,12 +1,14 @@
 "use client";
 import { LayoutComponent } from "@/components/layout";
 import {
+  CopilotChatConfigurationProvider,
   CopilotKit,
   CopilotPopup,
   useConfigureSuggestions,
 } from "@copilotkit/react-core/v2";
 import CopilotContext from "@/components/copilot-context";
 import { useAuthContext } from "@/components/auth-context";
+import { useThreadSelection } from "@/components/threads/use-thread-selection";
 import { IDENTITY } from "@/lib/identity";
 
 // Static suggestion pills shown on the welcome screen / before-first-message.
@@ -32,6 +34,7 @@ function BankingSuggestions() {
 
 export function CopilotKitWrapper({ children }: { children: React.ReactNode }) {
   const { currentUser } = useAuthContext();
+  const { threadId, selectThread, createThread } = useThreadSelection();
 
   return (
     <CopilotKit
@@ -43,17 +46,37 @@ export function CopilotKitWrapper({ children }: { children: React.ReactNode }) {
       useSingleEndpoint={false}
       properties={{ userRole: currentUser?.role }}
     >
-      <BankingSuggestions />
-      <LayoutComponent>
-        <CopilotContext>{children}</CopilotContext>
-      </LayoutComponent>
-      <CopilotPopup
-        defaultOpen={false}
-        labels={{
-          modalHeaderTitle: IDENTITY.assistant,
-          welcomeMessageText: IDENTITY.greeting,
-        }}
-      />
+      {/*
+        Anchor the whole chat surface to the actively-selected thread. The
+        agentId is "default" — the runtime registers `agents: { default: ... }`
+        and the SDK's default agentId is also "default" (NOT "bankingAgent").
+        `hasExplicitThreadId` tells the SDK the threadId is a real caller choice
+        so frontend-tool round-trips keep their thread anchor. Side effect: it
+        also suppresses the SDK's built-in welcome screen (acceptable for Phase A).
+      */}
+      <CopilotChatConfigurationProvider
+        agentId="default"
+        threadId={threadId}
+        hasExplicitThreadId
+      >
+        <BankingSuggestions />
+        <LayoutComponent
+          selectedThreadId={threadId}
+          onSelectThread={selectThread}
+          onCreateThread={createThread}
+        >
+          <CopilotContext>{children}</CopilotContext>
+        </LayoutComponent>
+        <CopilotPopup
+          agentId="default"
+          threadId={threadId}
+          defaultOpen={false}
+          labels={{
+            modalHeaderTitle: IDENTITY.assistant,
+            welcomeMessageText: IDENTITY.greeting,
+          }}
+        />
+      </CopilotChatConfigurationProvider>
     </CopilotKit>
   );
 }

--- a/examples/showcases/banking/src/components/approval-buttons.tsx
+++ b/examples/showcases/banking/src/components/approval-buttons.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+
+export function ApprovalButtons({
+  onApprove,
+  onDeny,
+  approveLabel = "Approve",
+  denyLabel = "Deny",
+}: {
+  onApprove: () => Promise<void> | void;
+  onDeny: () => void;
+  approveLabel?: string;
+  denyLabel?: string;
+}) {
+  const [responded, setResponded] = useState(false);
+
+  if (responded) {
+    return <p className="text-sm text-gray-500 italic">Response submitted.</p>;
+  }
+
+  return (
+    <div className="flex gap-2">
+      <button
+        className="flex-1 rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+        onClick={async () => {
+          setResponded(true);
+          await onApprove();
+        }}
+      >
+        {approveLabel}
+      </button>
+      <button
+        className="flex-1 rounded-md bg-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-300"
+        onClick={() => {
+          setResponded(true);
+          onDeny();
+        }}
+      >
+        {denyLabel}
+      </button>
+    </div>
+  );
+}
+
+export default ApprovalButtons;

--- a/examples/showcases/banking/src/components/layout.tsx
+++ b/examples/showcases/banking/src/components/layout.tsx
@@ -23,9 +23,14 @@ import { useAuthContext } from "@/components/auth-context";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { useAgentContext } from "@copilotkit/react-core/v2";
 import { usePathname } from "next/navigation";
+import { ThreadsPanel } from "@/components/threads/threads-panel";
 
 interface LayoutProps {
   children: React.ReactNode;
+  /** Active chat thread id (from useThreadSelection in the wrapper). */
+  selectedThreadId: string;
+  onSelectThread: (id: string) => void;
+  onCreateThread: () => void;
 }
 
 function UserNavigation({
@@ -95,7 +100,12 @@ function UserNavigation({
   );
 }
 
-export function LayoutComponent({ children }: LayoutProps) {
+export function LayoutComponent({
+  children,
+  selectedThreadId,
+  onSelectThread,
+  onCreateThread,
+}: LayoutProps) {
   const { users, currentUser, setCurrentUser } = useAuthContext();
   const pathname = usePathname();
   useAgentContext({
@@ -127,6 +137,13 @@ export function LayoutComponent({ children }: LayoutProps) {
           />
         </div>
       </aside>
+      <ThreadsPanel
+        agentId="default"
+        selectedThreadId={selectedThreadId}
+        onSelectThread={onSelectThread}
+        onCreateThread={onCreateThread}
+        onSelectedThreadRemoved={onCreateThread}
+      />
       <div className="flex flex-1 flex-col overflow-hidden">
         <header className="flex h-16 items-center justify-between border-b px-4 md:px-6">
           <h1 className="text-2xl font-bold">Hello, {currentUser.name}</h1>

--- a/examples/showcases/banking/src/components/policy-exception-modal.tsx
+++ b/examples/showcases/banking/src/components/policy-exception-modal.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { CheckCircle2 } from "lucide-react";
+import { useState } from "react";
+import type { PolicyException } from "@/app/api/v1/data";
+import {
+  POLICY_EXCEPTION_CODES,
+  labelForExceptionCode,
+} from "@/app/api/v1/policy-exception-codes";
+import { useRecordUserActionInCurrentThread } from "@/lib/record-user-action";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const DEFAULT_CODE = POLICY_EXCEPTION_CODES[0].code;
+
+type ExceptionResult = {
+  ok: boolean;
+  data?: PolicyException;
+  error?: string;
+};
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  transactionId: string;
+  openPolicyException: (args: {
+    transactionId: string;
+    code: string;
+  }) => Promise<ExceptionResult>;
+  finalizePolicyException: (args: {
+    exceptionId: string;
+  }) => Promise<ExceptionResult>;
+}
+
+/**
+ * "File a policy exception" form, opened against a single transaction that
+ * the caller has already selected (the transactions view passes the id in,
+ * so there is no order/transaction combobox here).
+ *
+ * Each exception carries a string `code` (e.g. `EXC-BOARD-APPROVED`) instead
+ * of a free-text reason. Some catalogue codes justify approval of the
+ * policy-limit override; the rest are filed for the record but do not
+ * constitute a standing justification (see
+ * `api/v1/policy-exception-codes.ts`). The dropdown shows the human label so
+ * the officer knows what they are picking; only the code is persisted, and
+ * the agent only ever sees the code — never the label.
+ *
+ * Submitting opens the exception via REST and, on success, immediately
+ * finalizes it (auto-approves and links it to the transaction's
+ * `activeExceptionId`). From the next click onward the policy-limit gate is
+ * lifted for that transaction — but only if the chosen code is justifying.
+ *
+ * Presentational only: REST calls (passed in from the page's `useCreditCards`
+ * hook to avoid duplicate polling) plus two-step `recordUserAction` recording.
+ * No agent tools live here.
+ */
+export const PolicyExceptionModal = (props: Props) => {
+  const [code, setCode] = useState<string>(DEFAULT_CODE);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [doneId, setDoneId] = useState<string | null>(null);
+
+  const recordUserAction = useRecordUserActionInCurrentThread();
+
+  const submitDisabled = busy || code === "";
+
+  const resetState = (): void => {
+    setCode(DEFAULT_CODE);
+    setError(null);
+    setBusy(false);
+    setDoneId(null);
+  };
+
+  const handleClose = (): void => {
+    props.onOpenChange(false);
+    // Defer state reset until the close animation settles.
+    window.setTimeout(resetState, 200);
+  };
+
+  const handleSubmit = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const opened = await props.openPolicyException({
+        transactionId: props.transactionId,
+        code,
+      });
+      if (!opened.ok || !opened.data) {
+        setError(opened.error ?? "Failed to open policy exception");
+        return;
+      }
+      const exceptionId = opened.data.id;
+
+      recordUserAction({
+        title: "policy_exception.opened",
+        description: "Opened a policy exception from the transactions view.",
+        previousData: {
+          transactionActiveExceptionId: null,
+          approvePermitted: false,
+        },
+        newData: {
+          exceptionId,
+          exceptionStatus: "draft",
+          exceptionCode: code,
+        },
+        metadata: { transactionId: props.transactionId },
+      }).catch(console.error);
+
+      const finalized = await props.finalizePolicyException({ exceptionId });
+      if (!finalized.ok) {
+        setError(finalized.error ?? "Failed to finalize policy exception");
+        return;
+      }
+
+      recordUserAction({
+        title: "policy_exception.finalized",
+        description:
+          "Finalized the policy exception; links it to the transaction.",
+        previousData: {
+          exceptionId,
+          exceptionStatus: "draft",
+        },
+        newData: {
+          exceptionId,
+          exceptionStatus: "approved",
+          transactionActiveExceptionId: exceptionId,
+          exceptionCode: code,
+        },
+        metadata: { transactionId: props.transactionId },
+      }).catch(console.error);
+
+      setDoneId(exceptionId);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(next) => {
+        if (!next) handleClose();
+        else props.onOpenChange(true);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New policy exception</DialogTitle>
+          <DialogDescription>
+            File a policy exception against this transaction.
+          </DialogDescription>
+        </DialogHeader>
+
+        {doneId === null ? (
+          <div className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="exception-code">Code</Label>
+              <Select value={code} onValueChange={setCode}>
+                <SelectTrigger id="exception-code">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {POLICY_EXCEPTION_CODES.map((c) => (
+                    <SelectItem key={c.code} value={c.code}>
+                      <span className="font-mono text-xs text-neutral-500">
+                        {c.code}
+                      </span>
+                      <span className="ml-2">{c.label}</span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <Button
+              type="button"
+              onClick={() => void handleSubmit()}
+              disabled={submitDisabled}
+              className="mt-2"
+            >
+              {busy ? "Filing…" : "File exception"}
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col items-start gap-4">
+            <div className="flex items-center gap-2 rounded-lg bg-green-50 px-3 py-2 text-sm text-foreground ring-1 ring-inset ring-green-200 dark:bg-green-900/20 dark:ring-green-900/40">
+              <CheckCircle2 className="size-4 text-green-600" />
+              <span>
+                Exception <span className="font-mono">{doneId}</span> filed (
+                {labelForExceptionCode(code)}).
+              </span>
+            </div>
+            <Button type="button" variant="secondary" onClick={handleClose}>
+              Close
+            </Button>
+          </div>
+        )}
+
+        {error !== null ? (
+          <p className="text-sm text-red-600">{error}</p>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default PolicyExceptionModal;

--- a/examples/showcases/banking/src/components/threads/threads-drawer.module.css
+++ b/examples/showcases/banking/src/components/threads/threads-drawer.module.css
@@ -1,0 +1,480 @@
+.layout {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  min-height: 100vh;
+  min-height: 100svh;
+  height: 100dvh;
+  width: 100%;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top left, rgb(247 248 250), transparent 28%),
+    linear-gradient(180deg, rgb(255 255 255), rgb(249 250 251));
+}
+
+.drawer {
+  position: relative;
+  display: flex;
+  min-height: 100vh;
+  min-height: 100svh;
+  height: 100dvh;
+  background: rgb(255 255 255 / 0.92);
+  backdrop-filter: blur(18px);
+  border-right: 1px solid rgb(17 24 39 / 0.08);
+  box-shadow: 0 20px 45px rgb(15 23 42 / 0.06);
+  transition:
+    width 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
+}
+
+.drawerOpen {
+  width: 20rem;
+}
+
+.drawerClosed {
+  width: 4.5rem;
+}
+
+.drawerSurface {
+  display: flex;
+  flex: 1;
+  height: 100%;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.drawerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1rem 0.75rem;
+  border-bottom: 1px solid rgb(17 24 39 / 0.06);
+}
+
+.drawerHeaderMain {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-family: "Inter", "SF Pro Text", "Segoe UI", sans-serif;
+}
+
+.drawerTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: rgb(15 23 42);
+}
+
+.drawerSubtitle {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgb(100 116 139);
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 0;
+  border-radius: 999px;
+  color: rgb(71 85 105);
+  background: transparent;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    opacity 140ms ease,
+    transform 140ms ease;
+  cursor: pointer;
+}
+
+.iconButton:hover,
+.iconButton:focus-visible {
+  background: rgb(241 245 249);
+  color: rgb(15 23 42);
+}
+
+.iconButton:focus-visible,
+.threadItem:focus-visible,
+.newThreadButton:focus-visible {
+  outline: 2px solid rgb(37 99 235 / 0.35);
+  outline-offset: 2px;
+}
+
+.newThreadButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 2.5rem;
+  padding: 0.625rem 0.9rem;
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgb(15 23 42), rgb(51 65 85));
+  color: rgb(248 250 252);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  box-shadow: 0 10px 25px rgb(15 23 42 / 0.15);
+  cursor: pointer;
+  transition:
+    transform 140ms ease,
+    box-shadow 140ms ease,
+    opacity 140ms ease;
+}
+
+.newThreadButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 32px rgb(15 23 42 / 0.18);
+}
+
+.filterBar {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid rgb(17 24 39 / 0.04);
+}
+
+.toggleLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-family: "Inter", "SF Pro Text", "Segoe UI", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: rgb(71 85 105);
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggleCheckbox {
+  width: 0.9rem;
+  height: 0.9rem;
+  accent-color: rgb(37 99 235);
+  cursor: pointer;
+}
+
+.drawerContent {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.threadList {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: 0.4rem;
+  overflow-y: auto;
+  padding: 0.9rem 0.75rem 1rem;
+}
+
+.threadRow {
+  position: relative;
+}
+
+.threadItem {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 5.5rem 0.8rem 0.85rem;
+  border: 0;
+  border-radius: 1rem;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
+}
+
+.threadItem:hover,
+.threadItem:focus-visible {
+  background: rgb(248 250 252);
+}
+
+.threadItemSelected {
+  background: linear-gradient(180deg, rgb(241 245 249), rgb(248 250 252));
+  box-shadow: inset 0 0 0 1px rgb(148 163 184 / 0.18);
+}
+
+.threadItemAnimatingIn {
+  animation: threadItemEnter 420ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.threadAccent {
+  flex: none;
+  width: 0.55rem;
+  height: 2.15rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgb(203 213 225), rgb(226 232 240));
+  transition: background 140ms ease;
+}
+
+.threadItemSelected .threadAccent {
+  background: linear-gradient(180deg, rgb(30 64 175), rgb(59 130 246));
+}
+
+.threadBody {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.threadTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: rgb(15 23 42);
+}
+
+.threadTitlePlaceholder {
+  color: rgb(100 116 139);
+  font-weight: 500;
+}
+
+.threadTitleAnimated {
+  display: inline-block;
+  animation: generatedTitleReveal 360ms cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: left center;
+}
+
+.threadMeta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.74rem;
+  color: rgb(100 116 139);
+}
+
+.threadItemArchived {
+  opacity: 0.55;
+}
+
+.archivedBadge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: rgb(226 232 240);
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: rgb(71 85 105);
+  vertical-align: middle;
+}
+
+.loadMoreButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 2.25rem;
+  margin-top: 0.25rem;
+  padding: 0.5rem;
+  border: 1px solid rgb(148 163 184 / 0.18);
+  border-radius: 0.75rem;
+  background: rgb(248 250 252);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: rgb(71 85 105);
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
+}
+
+.loadMoreButton:hover:not(:disabled) {
+  background: rgb(241 245 249);
+  color: rgb(15 23 42);
+}
+
+.loadMoreButton:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.threadActions {
+  position: absolute;
+  right: 0.6rem;
+  top: 50%;
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  transform: translateY(-50%) scale(0.96);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.threadRow:hover .threadActions,
+.threadRow:focus-within .threadActions {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(-50%) scale(1);
+}
+
+.threadActionButton {
+  width: 2rem;
+  height: 2rem;
+}
+
+.deleteButton {
+  color: rgb(148 24 24);
+}
+
+.deleteButton:hover,
+.deleteButton:focus-visible {
+  background: rgb(254 242 242);
+  color: rgb(127 29 29);
+}
+
+.emptyState {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.emptyCard {
+  display: flex;
+  max-width: 15rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.65rem;
+  padding: 1rem;
+  border: 1px solid rgb(148 163 184 / 0.12);
+  border-radius: 1rem;
+  background: rgb(248 250 252 / 0.9);
+  color: rgb(51 65 85);
+  font-family: "Inter", "SF Pro Text", "Segoe UI", sans-serif;
+}
+
+.emptyTitle {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: rgb(15 23 42);
+}
+
+.emptyMessage {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.collapsedRail {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 0.75rem;
+}
+
+.collapsedLabel {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgb(100 116 139);
+}
+
+.chatPanel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 100vh;
+  min-height: 100svh;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.chatShell {
+  flex: 1;
+  min-height: 0;
+}
+
+.copilotChat {
+  height: 100%;
+}
+
+@keyframes threadItemEnter {
+  0% {
+    opacity: 0;
+    transform: translateX(-10px);
+    background: rgb(226 232 240);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+    background: transparent;
+  }
+}
+
+@keyframes generatedTitleReveal {
+  0% {
+    opacity: 0;
+    filter: blur(6px);
+    transform: translateY(4px);
+  }
+
+  100% {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 900px) {
+  .layout {
+    position: relative;
+    isolation: isolate;
+    grid-template-columns: 4.5rem minmax(0, 1fr);
+  }
+
+  .drawer {
+    position: relative;
+  }
+
+  .drawerOpen {
+    position: absolute;
+    inset: 0 auto 0 0;
+    z-index: 100;
+    width: min(17.5rem, calc(100vw - 1rem));
+  }
+
+  .drawerClosed {
+    position: relative;
+    z-index: 2;
+  }
+
+  .chatPanel {
+    grid-column: 2;
+    position: relative;
+    z-index: 1;
+  }
+}

--- a/examples/showcases/banking/src/components/threads/threads-drawer.tsx
+++ b/examples/showcases/banking/src/components/threads/threads-drawer.tsx
@@ -1,0 +1,385 @@
+import {
+  Archive,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  Rows3,
+  Trash2,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import styles from "./threads-drawer.module.css";
+
+/**
+ * Minimal thread shape needed by the demo drawer.
+ */
+export interface DrawerThread {
+  id: string;
+  name: string | null;
+  updatedAt: string;
+  archived: boolean;
+}
+
+/**
+ * Controlled props for the demo threads drawer.
+ */
+export interface ThreadsDrawerProps {
+  threads: readonly DrawerThread[];
+  selectedThreadId?: string;
+  isOpen: boolean;
+  showArchived: boolean;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  emptyMessage?: string;
+  newThreadLabel?: string;
+  onOpenChange: (nextOpen: boolean) => void;
+  onSelectThread: (threadId: string) => void;
+  onArchiveThread: (threadId: string) => void;
+  onDeleteThread: (threadId: string) => void | Promise<void>;
+  onCreateThread: () => void;
+  onShowArchivedChange: (showArchived: boolean) => void;
+  onLoadMore: () => void;
+}
+
+const THREAD_ENTRY_ANIMATION_MS = 420;
+const TITLE_ANIMATION_MS = 360;
+const UNTITLED_THREAD_LABEL = "New thread";
+
+/**
+ * Returns a human-readable timestamp for a thread row.
+ */
+function formatThreadTimestamp(updatedAt: string): string {
+  const timestamp = new Date(updatedAt);
+
+  if (Number.isNaN(timestamp.getTime())) {
+    return "Updated recently";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(timestamp);
+}
+
+/**
+ * Merges class names while ignoring falsy values.
+ */
+function joinClassNames(
+  ...classNames: Array<string | false | undefined>
+): string {
+  return classNames.filter(Boolean).join(" ");
+}
+
+/**
+ * Controlled demo drawer for browsing and selecting threads.
+ */
+export function ThreadsDrawer({
+  threads,
+  selectedThreadId,
+  isOpen,
+  showArchived,
+  hasNextPage,
+  isFetchingNextPage,
+  emptyMessage = "Create a thread to start a fresh conversation.",
+  newThreadLabel = "New thread",
+  onOpenChange,
+  onSelectThread,
+  onArchiveThread,
+  onDeleteThread,
+  onCreateThread,
+  onShowArchivedChange,
+  onLoadMore,
+}: ThreadsDrawerProps) {
+  const hasMountedRef = useRef(false);
+  const previousThreadIdsRef = useRef<Set<string>>(new Set());
+  const previousNamesRef = useRef<Map<string, string | null>>(new Map());
+  const entryTimeoutsRef = useRef<Map<string, number>>(new Map());
+  const titleTimeoutsRef = useRef<Map<string, number>>(new Map());
+  const [enteringThreadIds, setEnteringThreadIds] = useState<
+    Record<string, true>
+  >({});
+  const [revealedTitleIds, setRevealedTitleIds] = useState<
+    Record<string, true>
+  >({});
+
+  useEffect(() => {
+    return () => {
+      entryTimeoutsRef.current.forEach((timeoutId) => {
+        window.clearTimeout(timeoutId);
+      });
+
+      titleTimeoutsRef.current.forEach((timeoutId) => {
+        window.clearTimeout(timeoutId);
+      });
+    };
+  }, []);
+
+  useEffect(() => {
+    const nextThreadIds = new Set(threads.map((thread) => thread.id));
+
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      previousThreadIdsRef.current = nextThreadIds;
+      previousNamesRef.current = new Map(
+        threads.map((thread) => [thread.id, thread.name]),
+      );
+      return;
+    }
+
+    const addedThreadIds = threads
+      .filter((thread) => !previousThreadIdsRef.current.has(thread.id))
+      .map((thread) => thread.id);
+
+    if (addedThreadIds.length > 0) {
+      setEnteringThreadIds((currentState) => {
+        const nextState = { ...currentState };
+
+        for (const threadId of addedThreadIds) {
+          nextState[threadId] = true;
+
+          const existingTimeoutId = entryTimeoutsRef.current.get(threadId);
+          if (existingTimeoutId !== undefined) {
+            window.clearTimeout(existingTimeoutId);
+          }
+
+          const timeoutId = window.setTimeout(() => {
+            setEnteringThreadIds((state) => {
+              const updatedState = { ...state };
+              delete updatedState[threadId];
+              return updatedState;
+            });
+            entryTimeoutsRef.current.delete(threadId);
+          }, THREAD_ENTRY_ANIMATION_MS);
+
+          entryTimeoutsRef.current.set(threadId, timeoutId);
+        }
+
+        return nextState;
+      });
+    }
+
+    const renamedThreadIds = threads
+      .filter((thread) => {
+        const previousName = previousNamesRef.current.get(thread.id) ?? null;
+        return previousName === null && thread.name !== null;
+      })
+      .map((thread) => thread.id);
+
+    if (renamedThreadIds.length > 0) {
+      setRevealedTitleIds((currentState) => {
+        const nextState = { ...currentState };
+
+        for (const threadId of renamedThreadIds) {
+          nextState[threadId] = true;
+
+          const existingTimeoutId = titleTimeoutsRef.current.get(threadId);
+          if (existingTimeoutId !== undefined) {
+            window.clearTimeout(existingTimeoutId);
+          }
+
+          const timeoutId = window.setTimeout(() => {
+            setRevealedTitleIds((state) => {
+              const updatedState = { ...state };
+              delete updatedState[threadId];
+              return updatedState;
+            });
+            titleTimeoutsRef.current.delete(threadId);
+          }, TITLE_ANIMATION_MS);
+
+          titleTimeoutsRef.current.set(threadId, timeoutId);
+        }
+
+        return nextState;
+      });
+    }
+
+    previousThreadIdsRef.current = nextThreadIds;
+    previousNamesRef.current = new Map(
+      threads.map((thread) => [thread.id, thread.name]),
+    );
+  }, [threads]);
+
+  if (!isOpen) {
+    return (
+      <aside
+        aria-label="Threads drawer"
+        className={joinClassNames(styles.drawer, styles.drawerClosed)}
+      >
+        <div className={styles.collapsedRail}>
+          <button
+            aria-label="Open threads drawer"
+            className={styles.iconButton}
+            type="button"
+            onClick={() => onOpenChange(true)}
+          >
+            <ChevronRight size={18} />
+          </button>
+          <button
+            aria-label="Create thread"
+            className={styles.iconButton}
+            type="button"
+            onClick={onCreateThread}
+          >
+            <Plus size={18} />
+          </button>
+          <Rows3 aria-hidden size={18} />
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      aria-label="Threads drawer"
+      className={joinClassNames(styles.drawer, styles.drawerOpen)}
+    >
+      <div className={styles.drawerSurface}>
+        <div className={styles.drawerHeader}>
+          <div className={styles.drawerHeaderMain}>
+            <h2 className={styles.drawerTitle}>Threads</h2>
+            <p className={styles.drawerSubtitle}>
+              {threads.length}{" "}
+              {threads.length === 1 ? "conversation" : "conversations"}
+            </p>
+          </div>
+          <div className={styles.headerActions}>
+            <button
+              aria-label="Create thread"
+              className={styles.newThreadButton}
+              type="button"
+              onClick={onCreateThread}
+            >
+              <Plus size={16} />
+              <span>{newThreadLabel}</span>
+            </button>
+            <button
+              aria-label="Collapse threads drawer"
+              className={styles.iconButton}
+              type="button"
+              onClick={() => onOpenChange(false)}
+            >
+              <ChevronLeft size={18} />
+            </button>
+          </div>
+        </div>
+
+        <div className={styles.filterBar}>
+          <label className={styles.toggleLabel}>
+            <input
+              checked={showArchived}
+              className={styles.toggleCheckbox}
+              type="checkbox"
+              onChange={(e) => onShowArchivedChange(e.target.checked)}
+            />
+            <span>Show archived</span>
+          </label>
+        </div>
+
+        <div className={styles.drawerContent}>
+          {threads.length === 0 ? (
+            <div className={styles.emptyState}>
+              <div className={styles.emptyCard}>
+                <p className={styles.emptyTitle}>No threads yet</p>
+                <p className={styles.emptyMessage}>{emptyMessage}</p>
+              </div>
+            </div>
+          ) : (
+            <div className={styles.threadList}>
+              {threads.map((thread) => {
+                const hasGeneratedTitle = thread.name !== null;
+                const title = thread.name ?? UNTITLED_THREAD_LABEL;
+                const confirmDeleteMessage = `Delete "${title}"? This cannot be undone.`;
+
+                return (
+                  <div key={thread.id} className={styles.threadRow}>
+                    <button
+                      aria-current={
+                        selectedThreadId === thread.id ? "page" : undefined
+                      }
+                      className={joinClassNames(
+                        styles.threadItem,
+                        selectedThreadId === thread.id &&
+                          styles.threadItemSelected,
+                        enteringThreadIds[thread.id] &&
+                          styles.threadItemAnimatingIn,
+                        thread.archived && styles.threadItemArchived,
+                      )}
+                      type="button"
+                      onClick={() => onSelectThread(thread.id)}
+                    >
+                      <span aria-hidden className={styles.threadAccent} />
+                      <span className={styles.threadBody}>
+                        <span
+                          className={joinClassNames(
+                            styles.threadTitle,
+                            !hasGeneratedTitle && styles.threadTitlePlaceholder,
+                            revealedTitleIds[thread.id] &&
+                              styles.threadTitleAnimated,
+                          )}
+                        >
+                          {title}
+                          {thread.archived && (
+                            <span className={styles.archivedBadge}>
+                              Archived
+                            </span>
+                          )}
+                        </span>
+                        <span className={styles.threadMeta}>
+                          {formatThreadTimestamp(thread.updatedAt)}
+                        </span>
+                      </span>
+                    </button>
+                    <div className={styles.threadActions}>
+                      {!thread.archived && (
+                        <button
+                          aria-label={`Archive ${title}`}
+                          className={joinClassNames(
+                            styles.iconButton,
+                            styles.threadActionButton,
+                          )}
+                          type="button"
+                          onClick={() => onArchiveThread(thread.id)}
+                        >
+                          <Archive size={16} />
+                        </button>
+                      )}
+                      <button
+                        aria-label={`Delete ${title}`}
+                        className={joinClassNames(
+                          styles.iconButton,
+                          styles.threadActionButton,
+                          styles.deleteButton,
+                        )}
+                        type="button"
+                        onClick={() => {
+                          if (!window.confirm(confirmDeleteMessage)) {
+                            return;
+                          }
+
+                          onDeleteThread(thread.id);
+                        }}
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+              {hasNextPage && (
+                <button
+                  className={styles.loadMoreButton}
+                  disabled={isFetchingNextPage}
+                  type="button"
+                  onClick={onLoadMore}
+                >
+                  {isFetchingNextPage ? "Loading…" : "Load more"}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+export default ThreadsDrawer;

--- a/examples/showcases/banking/src/components/threads/threads-panel.tsx
+++ b/examples/showcases/banking/src/components/threads/threads-panel.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { useThreads } from "@copilotkit/react-core/v2";
+import { ThreadsDrawer } from "./threads-drawer";
+import type { DrawerThread } from "./threads-drawer";
+
+export interface ThreadsPanelProps {
+  agentId: string;
+  /** The chat's current thread id (from useThreadSelection). */
+  selectedThreadId: string;
+  onSelectThread: (id: string) => void;
+  onCreateThread: () => void;
+  /**
+   * Called when the currently-selected thread is archived or deleted,
+   * so the parent can start a fresh conversation instead of pointing the
+   * chat at a thread that no longer exists.
+   */
+  onSelectedThreadRemoved: () => void;
+}
+
+/**
+ * Live threads list for the chat sidebar. Wraps the SDK `useThreads`
+ * hook (per-user, scoped by the runtime's resolved identity) and feeds
+ * the controlled `ThreadsDrawer`. Drawer starts collapsed (a rail) so
+ * the chat keeps its width until the user opens it.
+ */
+export function ThreadsPanel({
+  agentId,
+  selectedThreadId,
+  onSelectThread,
+  onCreateThread,
+  onSelectedThreadRemoved,
+}: ThreadsPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
+
+  const {
+    threads,
+    archiveThread,
+    deleteThread,
+    hasMoreThreads,
+    isFetchingMoreThreads,
+    fetchMoreThreads,
+  } = useThreads({ agentId, includeArchived: showArchived, limit: 20 });
+
+  const handleArchive = (id: string): void => {
+    if (id === selectedThreadId) onSelectedThreadRemoved();
+    Promise.resolve(archiveThread(id)).catch((err: unknown) => {
+      console.error("Unable to archive thread", err);
+    });
+  };
+
+  const handleDelete = (id: string): void => {
+    if (id === selectedThreadId) onSelectedThreadRemoved();
+    Promise.resolve(deleteThread(id)).catch((err: unknown) => {
+      console.error("Unable to delete thread", err);
+    });
+  };
+
+  return (
+    <ThreadsDrawer
+      threads={threads as readonly DrawerThread[]}
+      selectedThreadId={selectedThreadId}
+      isOpen={isOpen}
+      showArchived={showArchived}
+      hasNextPage={Boolean(hasMoreThreads)}
+      isFetchingNextPage={Boolean(isFetchingMoreThreads)}
+      onOpenChange={setIsOpen}
+      onSelectThread={onSelectThread}
+      onArchiveThread={handleArchive}
+      onDeleteThread={handleDelete}
+      onCreateThread={onCreateThread}
+      onShowArchivedChange={setShowArchived}
+      onLoadMore={() => fetchMoreThreads?.()}
+    />
+  );
+}
+
+export default ThreadsPanel;

--- a/examples/showcases/banking/src/components/threads/use-thread-selection.ts
+++ b/examples/showcases/banking/src/components/threads/use-thread-selection.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Generate an RFC 4122 v4 UUID without `crypto.randomUUID`, which is
+ * unavailable over plain http (no SecureContext) on Safari / older
+ * Firefox. `crypto.getRandomValues` is universally available.
+ */
+export const newThreadId = (): string => {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(
+    "",
+  );
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
+
+/**
+ * Active-thread state for the chat. `threadId` is ALWAYS a defined
+ * UUID — never `undefined`. The SDK's agent-thread connect effect bails
+ * on `!hasExplicitThreadId`, which leaves `agent.threadId` undefined and
+ * makes frontend-tool round-trips lose their anchor (the chat appears to
+ * reset after a tool call). Both "select existing" and "start new" keep
+ * an explicit id; "start new" simply mints a fresh one.
+ */
+export interface ThreadSelection {
+  threadId: string;
+  selectThread: (id: string) => void;
+  createThread: () => string;
+}
+
+export function useThreadSelection(): ThreadSelection {
+  const [threadId, setThreadId] = useState<string>(newThreadId);
+
+  const selectThread = useCallback((id: string) => {
+    setThreadId(id);
+  }, []);
+
+  const createThread = useCallback((): string => {
+    const next = newThreadId();
+    setThreadId(next);
+    return next;
+  }, []);
+
+  return { threadId, selectThread, createThread };
+}

--- a/examples/showcases/banking/src/components/transactions-list.tsx
+++ b/examples/showcases/banking/src/components/transactions-list.tsx
@@ -1,13 +1,33 @@
-import { Check, MessageSquare, PlusCircle, Send, X } from "lucide-react";
-import type { Transaction } from "@/app/api/v1/data";
+"use client";
+
+import {
+  AlertTriangle,
+  Check,
+  MessageSquare,
+  PlusCircle,
+  Send,
+  X,
+} from "lucide-react";
+import type { ExpensePolicy, PolicyException, Transaction } from "@/app/api/v1/data";
 import { cn, formatCurrency } from "@/lib/utils";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useRecordUserActionInCurrentThread } from "@/lib/record-user-action";
+import { PolicyExceptionModal } from "@/components/policy-exception-modal";
+
+type ExceptionResult = {
+  ok: boolean;
+  data?: PolicyException;
+  error?: string;
+};
 
 interface ApprovalInterfaceProps {
-  onApprove?: (transactionId: string) => void;
-  onDeny?: (transactionId: string) => void;
+  // Return true iff the server mutation succeeded, so the caller only records
+  // the human action when it actually took effect (a blocked over-limit
+  // approval must not be recorded as an approval).
+  onApprove?: (transactionId: string) => Promise<boolean> | boolean;
+  onDeny?: (transactionId: string) => Promise<boolean> | boolean;
 }
 
 interface TransactionsListProps {
@@ -15,6 +35,19 @@ interface TransactionsListProps {
   compact?: boolean;
   showApprovalInterface?: boolean;
   approvalInterfaceProps?: ApprovalInterfaceProps;
+  // Expense policies, used to derive the over-limit indicator on the client
+  // (no server-only store import). Only needed when showApprovalInterface.
+  policies?: ExpensePolicy[];
+  // REST callers, threaded in from the page's `useCreditCards` hook to avoid
+  // duplicate polling. Passed straight to the PolicyExceptionModal. Only
+  // needed when the approval interface is shown.
+  openPolicyException?: (args: {
+    transactionId: string;
+    code: string;
+  }) => Promise<ExceptionResult>;
+  finalizePolicyException?: (args: {
+    exceptionId: string;
+  }) => Promise<ExceptionResult>;
 }
 
 export function TransactionsList({
@@ -22,29 +55,15 @@ export function TransactionsList({
   compact = false,
   showApprovalInterface = false,
   approvalInterfaceProps = {},
+  policies = [],
+  openPolicyException,
+  finalizePolicyException,
 }: TransactionsListProps) {
-  const [loading, setLoading] = useState(true);
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setLoading(false);
-    }, 3000);
-
-    // Cleanup the timer on component unmount
-    return () => clearTimeout(timer);
-  }, []);
-
-  if (loading) {
-    return (
-      <div
-        className={cn(
-          "border rounded-lg overflow-hidden p-4",
-          compact ? "text-sm" : "text-base",
-        )}
-      >
-        Fetching data...
-      </div>
-    );
-  }
+  // Called unconditionally at the top so hook order is stable. When this
+  // component is rendered compact / read-only (without showApprovalInterface)
+  // the recorder is simply never invoked.
+  const recordUserAction = useRecordUserActionInCurrentThread();
+  const [exceptionTxnId, setExceptionTxnId] = useState<string | null>(null);
 
   return (
     <div
@@ -53,114 +72,190 @@ export function TransactionsList({
         compact ? "text-sm" : "text-base",
       )}
     >
-      {transactions.map((transaction, index) => (
-        <div key={transaction.id}>
-          <div className={cn("flex items-center p-4", compact ? "p-3" : "p-4")}>
+      {transactions.map((transaction, index) => {
+        // Over-limit is derived on the CLIENT from already-loaded data: a
+        // pending txn whose policy would be pushed past its limit by this
+        // amount, and which has no exception linked yet. Once a justifying
+        // exception is finalized server-side, `activeExceptionId` is set and
+        // this clears. (A non-justifying exception also clears the badge but
+        // the approve will re-block server-side — acceptable for the demo.)
+        const policy = policies.find((p) => p.id === transaction.policyId);
+        const policyOver =
+          !!policy &&
+          policy.spent + Math.abs(transaction.amount) > policy.limit;
+        const overLimit = policyOver && !transaction.activeExceptionId;
+
+        return (
+          <div key={transaction.id}>
             <div
-              className={cn(
-                "rounded-full flex items-center justify-center mr-4",
-                transaction.amount > 0 ? "bg-green-500" : "bg-red-500",
-                compact ? "w-6 h-6" : "w-8 h-8",
-              )}
+              className={cn("flex items-center p-4", compact ? "p-3" : "p-4")}
             >
-              {transaction.amount > 0 ? (
-                <PlusCircle
-                  className={cn("text-white", compact ? "h-3 w-3" : "h-4 w-4")}
-                />
-              ) : (
-                <Send
-                  className={cn("text-white", compact ? "h-3 w-3" : "h-4 w-4")}
-                />
-              )}
-            </div>
-            <div className="flex-1 space-y-1">
-              <p
+              <div
                 className={cn(
-                  "font-medium leading-tight",
-                  compact ? "text-xs" : "text-sm",
+                  "rounded-full flex items-center justify-center mr-4",
+                  transaction.amount > 0 ? "bg-green-500" : "bg-red-500",
+                  compact ? "w-6 h-6" : "w-8 h-8",
                 )}
               >
-                {transaction.title}
-              </p>
-              <p
-                className={cn(
-                  "text-neutral-500 dark:text-neutral-400 leading-tight",
-                  compact ? "text-xs" : "text-sm",
+                {transaction.amount > 0 ? (
+                  <PlusCircle
+                    className={cn(
+                      "text-white",
+                      compact ? "h-3 w-3" : "h-4 w-4",
+                    )}
+                  />
+                ) : (
+                  <Send
+                    className={cn(
+                      "text-white",
+                      compact ? "h-3 w-3" : "h-4 w-4",
+                    )}
+                  />
                 )}
-              >
-                {transaction.date}
-              </p>
-            </div>
-            <div
-              className={cn(
-                transaction.amount > 0 ? "text-green-500" : "text-red-500",
-                compact ? "text-sm" : "text-base",
-              )}
-            >
-              {transaction.amount > 0 ? "+" : ""}
-              {formatCurrency(transaction.amount)}
-            </div>
-          </div>
-          {transaction.note && (
-            <div
-              className={cn(
-                "bg-neutral-100 dark:bg-neutral-800 p-3 flex items-start",
-                compact ? "p-2" : "p-3",
-              )}
-            >
-              <MessageSquare
-                className={cn(
-                  "text-neutral-500 dark:text-neutral-400 mr-2 flex-shrink-0",
-                  compact ? "h-3 w-3 mt-0.5" : "h-4 w-4 mt-1",
-                )}
-              />
-              <div className="flex-1">
+              </div>
+              <div className="flex-1 space-y-1">
                 <p
                   className={cn(
-                    "text-neutral-700 dark:text-neutral-300",
+                    "font-medium leading-tight",
                     compact ? "text-xs" : "text-sm",
                   )}
                 >
-                  {transaction.note.content}
+                  {transaction.title}
                 </p>
                 <p
                   className={cn(
-                    "text-neutral-500 dark:text-neutral-400 mt-1",
+                    "text-neutral-500 dark:text-neutral-400 leading-tight",
                     compact ? "text-xs" : "text-sm",
                   )}
                 >
-                  {transaction.note.date}
+                  {transaction.date}
                 </p>
               </div>
-            </div>
-          )}
-          {showApprovalInterface && transaction.status === "pending" && (
-            <div className="flex items-center justify-center space-x-4 rounded-lg bg-white p-4">
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={() =>
-                  approvalInterfaceProps?.onApprove?.(transaction.id)
-                }
-                aria-label="Approve"
-                className="h-12 w-12 rounded-full bg-green-50 text-green-600 hover:bg-green-100 hover:text-green-700 dark:bg-green-900/20 dark:text-green-400 dark:hover:bg-green-900/30 dark:hover:text-green-300"
+              <div
+                className={cn(
+                  transaction.amount > 0 ? "text-green-500" : "text-red-500",
+                  compact ? "text-sm" : "text-base",
+                )}
               >
-                <Check className="h-6 w-6" />
-              </Button>
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={() => approvalInterfaceProps?.onDeny?.(transaction.id)}
-                aria-label="Deny"
-                className="h-12 w-12 rounded-full bg-red-50 text-red-600 hover:bg-red-100 hover:text-red-700 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30 dark:hover:text-red-300"
-              >
-                <X className="h-6 w-6" />
-              </Button>
+                {transaction.amount > 0 ? "+" : ""}
+                {formatCurrency(transaction.amount)}
+              </div>
             </div>
-          )}
-          {index < transactions.length - 1 && <Separator className="my-0" />}
-        </div>
-      ))}
+            {transaction.note && (
+              <div
+                className={cn(
+                  "bg-neutral-100 dark:bg-neutral-800 p-3 flex items-start",
+                  compact ? "p-2" : "p-3",
+                )}
+              >
+                <MessageSquare
+                  className={cn(
+                    "text-neutral-500 dark:text-neutral-400 mr-2 flex-shrink-0",
+                    compact ? "h-3 w-3 mt-0.5" : "h-4 w-4 mt-1",
+                  )}
+                />
+                <div className="flex-1">
+                  <p
+                    className={cn(
+                      "text-neutral-700 dark:text-neutral-300",
+                      compact ? "text-xs" : "text-sm",
+                    )}
+                  >
+                    {transaction.note.content}
+                  </p>
+                  <p
+                    className={cn(
+                      "text-neutral-500 dark:text-neutral-400 mt-1",
+                      compact ? "text-xs" : "text-sm",
+                    )}
+                  >
+                    {transaction.note.date}
+                  </p>
+                </div>
+              </div>
+            )}
+            {showApprovalInterface && transaction.status === "pending" && (
+              <div className="flex flex-col items-center gap-3 rounded-lg bg-white p-4">
+                {overLimit && (
+                  <div className="flex flex-col items-center gap-2">
+                    <div className="flex items-center gap-1.5 rounded-md bg-red-50 px-2.5 py-1 text-xs font-medium text-red-600 ring-1 ring-inset ring-red-200 dark:bg-red-900/20 dark:text-red-400 dark:ring-red-900/40">
+                      <AlertTriangle className="h-3.5 w-3.5" />
+                      Over policy limit
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setExceptionTxnId(transaction.id)}
+                    >
+                      File policy exception
+                    </Button>
+                  </div>
+                )}
+                <div className="flex items-center justify-center space-x-4">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={async () => {
+                      const ok =
+                        (await approvalInterfaceProps?.onApprove?.(
+                          transaction.id,
+                        )) ?? false;
+                      if (!ok) return;
+                      recordUserAction({
+                        title: "transaction.approved",
+                        description:
+                          "User approved a pending transaction from the transactions view.",
+                        previousData: { status: "pending" },
+                        newData: { status: "approved" },
+                        metadata: { transactionId: transaction.id },
+                      }).catch(console.error);
+                    }}
+                    aria-label="Approve"
+                    className="h-12 w-12 rounded-full bg-green-50 text-green-600 hover:bg-green-100 hover:text-green-700 dark:bg-green-900/20 dark:text-green-400 dark:hover:bg-green-900/30 dark:hover:text-green-300"
+                  >
+                    <Check className="h-6 w-6" />
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={async () => {
+                      const ok =
+                        (await approvalInterfaceProps?.onDeny?.(
+                          transaction.id,
+                        )) ?? false;
+                      if (!ok) return;
+                      recordUserAction({
+                        title: "transaction.denied",
+                        description:
+                          "User denied a pending transaction from the transactions view.",
+                        previousData: { status: "pending" },
+                        newData: { status: "denied" },
+                        metadata: { transactionId: transaction.id },
+                      }).catch(console.error);
+                    }}
+                    aria-label="Deny"
+                    className="h-12 w-12 rounded-full bg-red-50 text-red-600 hover:bg-red-100 hover:text-red-700 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30 dark:hover:text-red-300"
+                  >
+                    <X className="h-6 w-6" />
+                  </Button>
+                </div>
+              </div>
+            )}
+            {index < transactions.length - 1 && <Separator className="my-0" />}
+          </div>
+        );
+      })}
+      {exceptionTxnId && openPolicyException && finalizePolicyException && (
+        <PolicyExceptionModal
+          open
+          transactionId={exceptionTxnId}
+          openPolicyException={openPolicyException}
+          finalizePolicyException={finalizePolicyException}
+          onOpenChange={(o) => {
+            if (!o) setExceptionTxnId(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/examples/showcases/banking/src/data/seed.json
+++ b/examples/showcases/banking/src/data/seed.json
@@ -83,7 +83,7 @@
     {
       "id": "t-2",
       "title": "AWS",
-      "amount": -10000,
+      "amount": -15000,
       "date": "2026-05-20",
       "policyId": "9a8b7c6d5e",
       "cardId": "fA5b7c6d5e",
@@ -92,7 +92,7 @@
     {
       "id": "t-3",
       "title": "Microsoft 365",
-      "amount": -1000,
+      "amount": -10000,
       "date": "2026-05-12",
       "policyId": "8r5c3m4n5o",
       "cardId": "5tf3rmlcyg3",
@@ -112,5 +112,6 @@
       },
       "status": "approved"
     }
-  ]
+  ],
+  "exceptions": []
 }

--- a/examples/showcases/banking/src/lib/record-user-action.ts
+++ b/examples/showcases/banking/src/lib/record-user-action.ts
@@ -1,0 +1,29 @@
+/**
+ * No-op recorder shim.
+ *
+ * The Intelligence build ships `useRecordUserActionInCurrentThread` from
+ * `@copilotkit/react-core/v2`, which streams demonstrated officer actions to
+ * the self-learning writer agent. This OSS showcase has no
+ * `CopilotKitIntelligence` runtime, so the hook does not exist here. This shim
+ * keeps the teaching-surface call sites identical to the Intelligence version
+ * (they call `recordUserAction({...}).catch(...)` exactly the same way) while
+ * recording nothing. Swap this import for the real react-core/v2 hook once a
+ * `CopilotKitIntelligence` runtime is wired (Phase C).
+ */
+
+export type UserActionRecord = {
+  title: string;
+  description: string;
+  previousData?: unknown;
+  newData?: unknown;
+  metadata?: Record<string, unknown>;
+};
+
+export const useRecordUserActionInCurrentThread =
+  () =>
+  (record: UserActionRecord): Promise<void> => {
+    if (process.env.NODE_ENV !== "production") {
+      console.debug("[sl:record]", record.title, record);
+    }
+    return Promise.resolve();
+  };

--- a/examples/showcases/banking/src/lib/record-user-action.ts
+++ b/examples/showcases/banking/src/lib/record-user-action.ts
@@ -1,14 +1,25 @@
 /**
  * No-op recorder shim.
  *
- * The Intelligence build ships `useRecordUserActionInCurrentThread` from
- * `@copilotkit/react-core/v2`, which streams demonstrated officer actions to
- * the self-learning writer agent. This OSS showcase has no
- * `CopilotKitIntelligence` runtime, so the hook does not exist here. This shim
- * keeps the teaching-surface call sites identical to the Intelligence version
- * (they call `recordUserAction({...}).catch(...)` exactly the same way) while
- * recording nothing. Swap this import for the real react-core/v2 hook once a
- * `CopilotKitIntelligence` runtime is wired (Phase C).
+ * The self-learning loop needs demonstrated officer actions streamed to the
+ * Intelligence "writer" agent so they can be distilled into `/knowledge`. The
+ * intended client API for that is a `useRecordUserActionInCurrentThread` hook
+ * exported from `@copilotkit/react-core/v2`.
+ *
+ * VERIFIED GAP (Phase C, 2026-06-03): that hook does NOT exist in this OSS
+ * `@copilotkit/react-core/v2` build, and is also absent from the local
+ * Intelligence repo at /Users/jerel-cpk/Projects/cpk-intelligence (searched by
+ * name across both). The OSS react-core/v2 hooks index exports only
+ * useFrontendTool / useHumanInTheLoop / useAgent / useThreads / etc. — there is
+ * no client-side "record user action" mechanism to call, even when the runtime
+ * is wired to a `CopilotKitIntelligence` backend (server route.ts, Phase C).
+ *
+ * This shim keeps the teaching-surface call sites identical to what the real
+ * recording API would look like (they call `recordUserAction({...}).catch(...)`
+ * exactly the same way) while recording nothing. When a real
+ * `useRecordUserActionInCurrentThread` (or equivalent client method) ships in a
+ * react-core build the demo can depend on, swap this import for it — the call
+ * sites in policy-exception-modal.tsx and transactions-list.tsx need no change.
  */
 
 export type UserActionRecord = {

--- a/examples/showcases/banking/src/lib/store.ts
+++ b/examples/showcases/banking/src/lib/store.ts
@@ -3,8 +3,14 @@ import type {
   Card,
   ExpensePolicy,
   Member,
+  PolicyException,
   Transaction,
 } from "@/app/api/v1/data";
+import { generateUniqueId } from "@/app/api/v1/data";
+import {
+  isJustifying,
+  isValidExceptionCode,
+} from "@/app/api/v1/policy-exception-codes";
 
 /**
  * In-memory, file-seeded data store for the banking showcase demo.
@@ -24,9 +30,13 @@ type DB = {
   team: Member[];
   policies: ExpensePolicy[];
   transactions: Transaction[];
+  exceptions: PolicyException[];
 };
 
 const db = structuredClone(seed) as DB;
+// Older seeds (pre-policy-exception) may not carry an `exceptions` array.
+// Guarantee it exists so the accessors/mutators below never hit undefined.
+if (!db.exceptions) db.exceptions = [];
 
 // ---- Reads --------------------------------------------------------------
 
@@ -34,6 +44,7 @@ export const cards = (): Card[] => db.cards;
 export const team = (): Member[] => db.team;
 export const policies = (): ExpensePolicy[] => db.policies;
 export const transactions = (): Transaction[] => db.transactions;
+export const exceptions = (): PolicyException[] => db.exceptions;
 
 export const findCard = (id: string): Card | undefined =>
   db.cards.find((c) => c.id === id);
@@ -43,6 +54,43 @@ export const findPolicy = (id: string): ExpensePolicy | undefined =>
 
 export const findTransaction = (id: string): Transaction | undefined =>
   db.transactions.find((t) => t.id === id);
+
+export const findException = (id: string): PolicyException | undefined =>
+  db.exceptions.find((e) => e.id === id);
+
+// ---- Business rules -----------------------------------------------------
+
+/**
+ * True iff approving this transaction would keep its policy at or under
+ * its limit. A transaction whose policy is missing is treated as within
+ * limit (nothing to gate against). Amounts are negative, so the spend is
+ * `Math.abs(txn.amount)`.
+ */
+export const isWithinPolicyLimit = (txn: Transaction): boolean => {
+  const p = findPolicy(txn.policyId);
+  if (!p) return true;
+  return p.spent + Math.abs(txn.amount) <= p.limit;
+};
+
+/**
+ * True iff the transaction has an active exception that is both approved
+ * AND filed under a justifying code (`isJustifying`). Filing an exception
+ * with a non-justifying code records it for history but does NOT lift the
+ * policy-limit gate.
+ */
+export const hasApprovedException = (txn: Transaction): boolean => {
+  if (!txn.activeExceptionId) return false;
+  const e = findException(txn.activeExceptionId);
+  return !!e && e.status === "approved" && isJustifying(e.code);
+};
+
+/**
+ * True iff this transaction may be approved: either it is within its
+ * policy limit, or it carries an approved, justifying exception that
+ * lifts the gate.
+ */
+export const canApprove = (txn: Transaction): boolean =>
+  isWithinPolicyLimit(txn) || hasApprovedException(txn);
 
 // ---- Mutations ----------------------------------------------------------
 
@@ -110,4 +158,46 @@ export const removeMember = (id: string): Member[] | undefined => {
   if (idx === -1) return undefined;
   db.team.splice(idx, 1);
   return db.team;
+};
+
+/**
+ * Open a draft policy exception against a transaction. Throws plain
+ * Errors with code-like messages (`NOT_FOUND`, `INVALID_EXCEPTION_CODE`)
+ * that the calling route maps to HTTP status. The catalogue check forces
+ * the agent to learn valid codes via `/knowledge` rather than inventing
+ * plausible-looking strings.
+ */
+export const openPolicyException = (
+  transactionId: string,
+  code: string,
+): PolicyException => {
+  if (!findTransaction(transactionId)) throw new Error("NOT_FOUND");
+  if (!isValidExceptionCode(code)) throw new Error("INVALID_EXCEPTION_CODE");
+  const exception: PolicyException = {
+    id: generateUniqueId(),
+    transactionId,
+    code,
+    status: "draft",
+    createdAt: new Date().toISOString(),
+  };
+  db.exceptions.push(exception);
+  return exception;
+};
+
+/**
+ * Finalize a draft policy exception. Auto-approves (no review step in the
+ * demo) and links the approved exception to its transaction's
+ * `activeExceptionId`, which is what lifts the policy-limit gate (provided
+ * the code is justifying). Throws plain Errors (`NOT_FOUND`,
+ * `ALREADY_FINALIZED`) that the calling route maps to HTTP status.
+ */
+export const finalizePolicyException = (
+  exceptionId: string,
+): PolicyException => {
+  const exc = findException(exceptionId);
+  if (!exc) throw new Error("NOT_FOUND");
+  if (exc.status !== "draft") throw new Error("ALREADY_FINALIZED");
+  exc.status = "approved";
+  updateTransaction(exc.transactionId, { activeExceptionId: exc.id });
+  return exc;
 };


### PR DESCRIPTION
## Stacked on #5180 (draft)

Builds the **self-learning teachable workflow + a threads drawer** on top of @mxmzb's customer-ready banking demo (#5180). This branch is based off `maxim/for-138-...` and targets it, so the diff is purely additive (2 commits).

> **Draft:** the self-learning *backend* wiring (Phase C) is in progress. Phases A+B are complete, build-clean, and demonstrable on their own.

### Phase A — threads drawer + HITL dedup (`420851ac0`)
- Per-conversation threads drawer (browse / select / create) via the v2 `useThreads` hook, mounted as a left column.
- Adds `CopilotChatConfigurationProvider` + an explicit, stable `threadId` (the demo previously self-minted a UUID it couldn't observe).
- Extracts the duplicated `ApprovalButtons` into one shared component.
- _Note:_ on the OSS `InMemoryAgentRunner`, thread switch/create work; titles + archive + persistence light up once an Intelligence runtime is wired (Phase C).

### Phase B — self-learning policy-exception gate (`4130af9fe`)
The teachable "agent fails → human unlocks → agent learns" mechanic:
- Approving an over-limit transaction is blocked (`422`, **symptom-only** message) in the `transactions/[id]` PUT route.
- A human unlocks it by opening + finalizing a **justifying** policy exception; non-justifying codes file but don't lift; invalid codes are rejected without revealing the catalogue.
- The agent gets the exception tools + 3 distractors, but the prompt/descriptions **never reveal the unlock sequence or which code works** — the recipe is learned, not told.
- Human teaching surface: a policy-exception modal + over-limit badge in the approval view; action-recording call sites wired behind a no-op shim (the Phase C swap point).
- `changeTransactionStatus` hardened so a blocked approval is never reported to the agent as success.

**Verified:** `next build` + `tsc --noEmit` clean; a live REST test confirms the full gate → file-justifying-exception → approve flow, that a non-justifying code stays blocked, and that an invalid code is rejected without leaking valid ones.

### Phase C — self-learning backend (in progress)
Wire the runtime to `CopilotKitIntelligence` + a knowledge base so recorded actions distill into `/knowledge` and a fresh agent learns the unlock unaided. Until then the recorder is a no-op shim and the gate/unlock demonstrates the human-in-the-loop workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)