### PR TITLE
docs: route all documentation authoring to shell-docs

### DIFF
--- a/.claude/docs/documentation.md
+++ b/.claude/docs/documentation.md
@@ -8,12 +8,12 @@ silently never reaches the live site. Read this before editing any docs.
 All CopilotKit documentation is authored in **`showcase/shell-docs/src/content/`**, which
 builds and serves **docs.copilotkit.ai**:
 
-| Content type | Location |
-| --- | --- |
-| Guide / how-to / concept pages | `showcase/shell-docs/src/content/docs/` |
-| API reference | `showcase/shell-docs/src/content/reference/` |
-| Reusable snippets (shared MDX) | `showcase/shell-docs/src/content/snippets/` |
-| Framework overview pages | `showcase/shell-docs/src/content/framework-overviews/` |
+| Content type                   | Location                                               |
+| ------------------------------ | ------------------------------------------------------ |
+| Guide / how-to / concept pages | `showcase/shell-docs/src/content/docs/`                |
+| API reference                  | `showcase/shell-docs/src/content/reference/`           |
+| Reusable snippets (shared MDX) | `showcase/shell-docs/src/content/snippets/`            |
+| Framework overview pages       | `showcase/shell-docs/src/content/framework-overviews/` |
 
 When you add a **guide page** under `docs/`, also update that section's `meta.json` so it
 appears in navigation.

--- a/.claude/docs/documentation.md
+++ b/.claude/docs/documentation.md
@@ -1,0 +1,57 @@
+# Documentation — where to author it
+
+There are **two** documentation domains. Putting a change in the wrong place means it
+silently never reaches the live site. Read this before editing any docs.
+
+## 1. CopilotKit product docs → `showcase/shell-docs/`
+
+All CopilotKit documentation is authored in **`showcase/shell-docs/src/content/`**, which
+builds and serves **docs.copilotkit.ai**:
+
+| Content type | Location |
+| --- | --- |
+| Guide / how-to / concept pages | `showcase/shell-docs/src/content/docs/` |
+| API reference | `showcase/shell-docs/src/content/reference/` |
+| Reusable snippets (shared MDX) | `showcase/shell-docs/src/content/snippets/` |
+| Framework overview pages | `showcase/shell-docs/src/content/framework-overviews/` |
+
+When you add a **guide page** under `docs/`, also update that section's `meta.json` so it
+appears in navigation.
+
+**API reference is different.** The v2 reference (`reference/{components,hooks,sdk}/`) has
+**no `meta.json`** — navigation is generated automatically by walking the tree and reading
+each page's `title`/`description` frontmatter (see
+`showcase/shell-docs/src/lib/reference-items.ts`). To add a reference page, drop an `.mdx`
+file with frontmatter into the right subdirectory; it appears in nav on its own. Only the
+legacy `reference/v1/` tree uses `meta.json`. For the full new-hook checklist see
+[Hook Development](hooks.md).
+
+**The top-level `docs/` folder is retired. Never author there.**
+`docs/content/docs/` and the `docs/` Next app no longer publish anything. The
+`showcase/scripts/sync-docs-from-main.ts` script is legacy — it only ever copied
+`docs/` → shell-docs in one direction, and editing `docs/` today does nothing for the
+live site. Treat the whole top-level `docs/` tree as read-only history.
+
+## 2. AG-UI protocol docs → upstream `ag-ui-protocol/ag-ui`
+
+The AG-UI protocol docs (the `showcase/shell-docs/src/content/ag-ui/` tree) are **not**
+authored in this repo. Their canonical source is the upstream repo
+**[`ag-ui-protocol/ag-ui`](https://github.com/ag-ui-protocol/ag-ui)** under its `docs/`
+directory, which publishes to **docs.ag-ui.com**.
+
+The `content/ag-ui/` copy here is a **downstream mirror** rendered on the CopilotKit docs
+host. To change AG-UI protocol docs, make the change upstream in `ag-ui-protocol/ag-ui`;
+it then needs to be synced back into the CopilotKit copy.
+
+> **Do not author AG-UI content changes directly in `content/ag-ui/`** — they would diverge
+> from upstream and never reach docs.ag-ui.com.
+
+**Caveat (known, out of scope here):** there is currently no automated sync for the
+`content/ag-ui/` mirror, so it can drift from upstream. Upstream is canonical — don't try to
+change that process as part of unrelated work.
+
+## Quick decision
+
+- Changing a CopilotKit guide, reference, snippet, or framework page? → `showcase/shell-docs/src/content/`
+- Changing AG-UI protocol docs? → upstream `ag-ui-protocol/ag-ui`, then sync
+- Tempted to edit `docs/content/docs/`? → stop, it's retired; use `showcase/shell-docs/`

--- a/.claude/docs/hooks.md
+++ b/.claude/docs/hooks.md
@@ -5,4 +5,7 @@ When creating a new hook, always complete **all** of the following:
 1. **Implementation**: Create the hook in `@copilotkit/react-core`. If backward compatibility shims are needed, add them in the package's `v1/` directory.
 2. **JSDoc**: Add JSDoc on top of the hook implementation, including usage examples.
 3. **Tests**: Write extensive tests covering behavior, edge cases, and lifecycle (mount/unmount/re-render).
-4. **Documentation**: Add a dedicated docs page under `/docs` and update the relevant docs metadata file(s) so the page appears in navigation.
+4. **API reference**: Add a reference page at `showcase/shell-docs/src/content/reference/hooks/<hookName>.mdx` with `title` and `description` frontmatter. The v2 reference navigation is generated automatically by walking the `reference/` tree and reading frontmatter (see `showcase/shell-docs/src/lib/reference-items.ts`) — there is **no `meta.json`** to edit for v2 reference; the file and its frontmatter are the metadata. (Only the legacy `reference/v1/` tree uses `meta.json`.)
+5. **Conceptual docs (if needed)**: If the hook needs usage/how-to documentation beyond the API reference, add a guide page under `showcase/shell-docs/src/content/docs/` and update that section's `meta.json` so it appears in navigation.
+
+Never author docs in the retired top-level `docs/` folder. See [Documentation](documentation.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ AI agent framework with three layers: **Frontend** (React/Angular/Vanilla) → *
 - **Flat package structure** — all packages live directly under `packages/` (no `v1/` or `v2/` subdirectories). Every package uses the `@copilotkit/` scope.
 - **Simplicity** — prefer the simplest correct solution. For non-trivial changes, consider if there's a cleaner approach before committing.
 - **Worktrees** — always work in a git worktree for isolation. See [Git & PRs](.claude/docs/git.md) for the full workflow.
+- **Documentation lives in shell-docs** — author all CopilotKit docs in `showcase/shell-docs/src/content/`. The top-level `docs/` folder is retired; never edit it. AG-UI protocol docs are authored upstream in `ag-ui-protocol/ag-ui`, not here. See [Documentation](.claude/docs/documentation.md).
 
 ## Reference (read when relevant to your task)
 
@@ -30,3 +31,4 @@ AI agent framework with three layers: **Frontend** (React/Angular/Vanilla) → *
 - [Hook Development](.claude/docs/hooks.md) — checklist for creating new hooks (docs, tests, JSDoc)
 - [Workflow & Process](.claude/docs/workflow.md) — when to plan, when to fix autonomously, verification, self-improvement loop, this should be your default mindset when working on any task
 - [Git & PRs](.claude/docs/git.md) — worktree workflow, branching, creating PRs
+- [Documentation](.claude/docs/documentation.md) — where to author docs (CopilotKit → shell-docs; AG-UI → upstream); `docs/` is retired

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,13 @@ So, you've got an awesome feature in mind? Throw it over to us by [creating an i
 
 If you don't feel ready to make a code contribution yet, no problem! You can also check out the [documentation issues](https://github.com/CopilotKit/CopilotKit/issues?q=is%3Aopen+is%3Aissue+label%3Adocumentation).
 
+## Contributing to documentation
+
+There are two documentation domains — make sure your change goes to the right place, or it won't reach the live site:
+
+- **CopilotKit docs** (docs.copilotkit.ai) are authored in **`showcase/shell-docs/src/content/`** (`docs/`, `reference/`, `snippets/`, `framework-overviews/`). When adding a page, update the relevant `meta.json` so it appears in navigation. The top-level `docs/` folder is **retired** — do not edit it.
+- **AG-UI protocol docs** (docs.ag-ui.com) are authored upstream in [`ag-ui-protocol/ag-ui`](https://github.com/ag-ui-protocol/ag-ui), not in this repo. The `showcase/shell-docs/src/content/ag-ui/` copy is a downstream mirror.
+
 # How do I make a code contribution?
 
 ## Good first issues

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,24 @@
-# fumadocs-test
+# ⛔ This docs app is retired — do not edit files here
+
+**CopilotKit documentation is now authored in [`showcase/shell-docs/`](../showcase/shell-docs/).**
+
+This top-level `docs/` Next app and its `content/docs/` MDX tree no longer publish to the
+live site. Changes made here will **not** reach docs.copilotkit.ai. The
+`showcase/scripts/sync-docs-from-main.ts` script is legacy (one-direction, `docs/` → shell-docs)
+and should not be relied on.
+
+- **CopilotKit docs** → author in `showcase/shell-docs/src/content/`
+  (`docs/`, `reference/`, `snippets/`, `framework-overviews/`).
+- **AG-UI protocol docs** → author upstream in
+  [`ag-ui-protocol/ag-ui`](https://github.com/ag-ui-protocol/ag-ui) (publishes to docs.ag-ui.com),
+  then sync back into the mirror at `showcase/shell-docs/src/content/ag-ui/`.
+
+See [.claude/docs/documentation.md](../.claude/docs/documentation.md) for the full rule.
+
+---
+
+<details>
+<summary>Legacy README (retained for history)</summary>
 
 This is a Next.js application generated with
 [Create Fumadocs](https://github.com/fuma-nama/fumadocs).
@@ -48,3 +68,5 @@ Recommended Vercel project setting:
 
 - Disable automatic Git-based deployments for the docs project and let the
   GitHub Actions workflow handle production deploys.
+
+</details>


### PR DESCRIPTION
## Problem

The top-level `docs/` app is retired, but nothing in the repo said so, and contributors (and agents) kept editing it. Two parallel docs trees plus a one-directional legacy sync script made it ambiguous where documentation should be authored:

- `docs/content/docs/` — the old Fumadocs app, no longer publishing
- `showcase/shell-docs/src/content/docs/` — the live source for docs.copilotkit.ai

Two instruction surfaces actively pointed the wrong way: `CLAUDE.md` said nothing about docs at all, and `.claude/docs/hooks.md` told contributors to "add a docs page under `/docs`" (the retired location).

## Change

Establish one canonical rule and reduce the other surfaces to pointers:

- **`.claude/docs/documentation.md`** (new) — source of truth. CopilotKit docs are authored in `showcase/shell-docs/src/content/` (`docs/`, `reference/`, `snippets/`, `framework-overviews/`); the top-level `docs/` folder is retired; AG-UI protocol docs are authored upstream in `ag-ui-protocol/ag-ui` (publishing to docs.ag-ui.com) and mirrored into `content/ag-ui/`.
- **`CLAUDE.md`** — adds an Essentials hard-rule and a Reference link.
- **`docs/README.md`** — replaces boilerplate with a retired/STOP banner; legacy README retained under a `<details>`.
- **`.claude/docs/hooks.md`** — fixes the stale `/docs` pointer and clarifies that a hook's API reference page lives in `reference/hooks/<hookName>.mdx`, where v2 reference navigation is generated automatically from frontmatter (no `meta.json`); conceptual guide pages under `docs/` still use `meta.json`.
- **`CONTRIBUTING.md`** — adds a two-domain documentation section for human contributors.

## Notes

- Two docs domains: **CopilotKit docs** → shell-docs; **AG-UI protocol docs** → upstream `ag-ui-protocol/ag-ui`, then synced into the in-repo mirror.
- Instructions-only change; no enforcement hook or sync-process change.
- Markdown only; no package code touched.