### PR TITLE
fix(showcase/harness): harden browser-pool against PID-ceiling crash-recovery wedge

### DIFF
--- a/showcase/harness/Dockerfile
+++ b/showcase/harness/Dockerfile
@@ -151,4 +151,27 @@ EXPOSE 8080
 # serve" to its supervisor.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD node -e "require('http').get('http://127.0.0.1:8080/health',r=>process.exit(r.statusCode>=200&&r.statusCode<300?0:1)).on('error',()=>process.exit(1))" || exit 1
-CMD ["node", "dist/orchestrator.js"]
+# FIX #3 — raise the container PID/thread (nproc) soft ulimit before exec'ing
+# the orchestrator. THE OUTAGE: the harness runs a long-lived chromium pool —
+# at MAX_CONTEXTS=40 the legitimate workload spawns ~3.6GB / several hundred
+# OS threads (each headless chromium ~50+ PIDs, plus per-context renderer
+# threads). When kernel thread/PID demand approached the container's nproc
+# ceiling, `chromium.launch()` (and mid-life context opens) tripped
+# `pthread_create: Resource temporarily unavailable (errno 11)`, the browser
+# set drained, and the pool wedged. MAX_CONTEXTS stays 40 — verified safe on
+# the 24GB box at ~3.6GB RSS; the constraint was THREADS, not memory — so the
+# durable fix is to give the legitimate 40-context workload ample thread
+# headroom instead of running near the default ~1024 soft ceiling.
+#
+# We raise the SOFT nproc limit to the HARD limit ("ulimit -u $(ulimit -Hu)")
+# so the process gets the full headroom the kernel/cgroup already permits
+# without hard-coding a value the container may not be allowed to exceed. On
+# Railway the service additionally sets a generous pids cgroup limit (target:
+# 16384 — ~40x the steady-state thread count, leaving headroom for launch
+# bursts + recovery relaunches); the in-image `ulimit -u` ensures the soft
+# limit is lifted to that hard ceiling regardless of the inherited default.
+# `exec` replaces the shell so node remains PID 1 (correct signal handling /
+# Railway shutdown). The fallback `|| true` keeps boot resilient if the runtime
+# forbids raising the soft limit (it is then governed solely by the cgroup
+# pids limit, which is still the dominant control).
+CMD ["/bin/sh", "-c", "ulimit -u $(ulimit -Hu) 2>/dev/null || true; exec node dist/orchestrator.js"]

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -7,12 +7,16 @@ import {
   boot,
   buildCronProbeResolver,
   createStatusReader,
+  createBrowserPoolHealthSignals,
+  BROWSER_POOL_DEGRADED_KEY,
   diffCronSchedules,
   envForCfg,
   createRailwayAdapter,
   registerAllProbeDrivers,
   hydrateProbeLastRuns,
 } from "./orchestrator.js";
+import type { State } from "./types/index.js";
+import { BrowserPool } from "./probes/helpers/browser-pool.js";
 import { createProbeRegistry } from "./probes/drivers/index.js";
 import type { createScheduler } from "./scheduler/scheduler.js";
 import { createEventBus } from "./events/event-bus.js";
@@ -189,6 +193,47 @@ describe("orchestrator /health wiring (F1.1)", () => {
       if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
       else process.env.NODE_ENV = prevNodeEnv;
       if (prevPbUrl !== undefined) process.env.POCKETBASE_URL = prevPbUrl;
+    }
+  });
+
+  // R2-B.2 / R4-A.3: a boot that successfully init()s the browser pool but
+  // then FAILS TO BIND (sync serve() throw OR async EADDRINUSE) must tear down
+  // the pool, not just the scheduler. The pool launches long-lived chromium
+  // processes in init(); browserPool.shutdown() only runs in the returned
+  // stop() closure, which a boot rejection never reaches. So a leaked boot
+  // strands every chromium process — on a restart loop this compounds into the
+  // PID-ceiling exhaustion the pool hardening exists to prevent.
+  it("R4-A.3: a boot that inits the pool then fails to bind shuts the pool down (no chromium leak)", async () => {
+    // Stub init() so the pool reports ready WITHOUT launching real chromium,
+    // and spy shutdown() so we can assert the boot-failure path tears it down.
+    const initSpy = vi
+      .spyOn(BrowserPool.prototype, "init")
+      .mockResolvedValue(undefined);
+    const shutdownSpy = vi
+      .spyOn(BrowserPool.prototype, "shutdown")
+      .mockResolvedValue(undefined);
+
+    // Occupy `port` so boot()'s serve() bind fails with EADDRINUSE — the async
+    // 'error' path that only called scheduler.stop(). boot() passes no
+    // hostname to serve(), so it binds the wildcard; the blocker must also bind
+    // the wildcard (no hostname) to guarantee the conflict on macOS.
+    const blocker = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      blocker.once("error", reject);
+      blocker.listen(port, () => resolve());
+    });
+
+    try {
+      await expect(
+        boot({ configDir: tempDir, port, bootstrapWindowMs: 0 }),
+      ).rejects.toThrow();
+      // init() ran (pool launched), so the boot-failure path MUST shut it down.
+      expect(initSpy).toHaveBeenCalled();
+      expect(shutdownSpy).toHaveBeenCalled();
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+      initSpy.mockRestore();
+      shutdownSpy.mockRestore();
     }
   });
 
@@ -680,6 +725,121 @@ describe("orchestrator.createStatusReader key safety (R28-slot1-A10)", () => {
     expect(getFirst.mock.calls[0]![0]).toBe("status");
     // Filter string quotes the key via JSON.stringify.
     expect(getFirst.mock.calls[0]![1]).toBe(`key = "smoke:langchain"`);
+  });
+});
+
+/**
+ * CR-FIX #6: createBrowserPoolHealthSignals must (a) log a prior-state READ
+ * failure at warn instead of silently coercing it to null (which misreports a
+ * recovery as a cold boot), and (b) SERIALIZE the degraded↔healthy writes with
+ * monotonic observedAt so a flap converges to the correct final persisted
+ * state.
+ */
+describe("orchestrator.createBrowserPoolHealthSignals (CR-FIX #6)", () => {
+  interface CapturedWrite {
+    state: State;
+    signal: Record<string, unknown>;
+    observedAt: string;
+  }
+
+  function makeHarness(opts?: {
+    priorState?: State | null;
+    readThrows?: boolean;
+  }) {
+    const writes: CapturedWrite[] = [];
+    const warns: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const writer = {
+      write: vi.fn(async (result: CapturedWrite & { key: string }) => {
+        writes.push({
+          state: result.state,
+          signal: result.signal,
+          observedAt: result.observedAt,
+        });
+        return {};
+      }),
+    };
+    const statusReader = {
+      getStateByKey: vi.fn(async (_key: string): Promise<State | null> => {
+        if (opts?.readThrows) throw new Error("PB read boom");
+        return opts?.priorState ?? null;
+      }),
+    };
+    const testLogger = {
+      warn: (msg: string, meta?: Record<string, unknown>) =>
+        warns.push({ msg, meta }),
+    };
+    return { writes, warns, writer, statusReader, testLogger };
+  }
+
+  it("logs (does not swallow) a prior-state read failure and still reports a transition", async () => {
+    const { writes, warns, writer, statusReader, testLogger } = makeHarness({
+      readThrows: true,
+    });
+    const { writeHealthy } = createBrowserPoolHealthSignals({
+      writer,
+      statusReader,
+      logger: testLogger,
+    });
+
+    await writeHealthy();
+
+    // The read failure was LOGGED at warn (not silently swallowed).
+    expect(
+      warns.some((w) => w.msg === "boot.browser-pool-prior-state-read-failed"),
+    ).toBe(true);
+    // A green write still landed (best-effort) under the read failure.
+    expect(writes.length).toBe(1);
+    expect(writes[0]!.state).toBe("green");
+  });
+
+  it("stamps `recovered` when the prior persisted state was red", async () => {
+    const { writes, writer, statusReader, testLogger } = makeHarness({
+      priorState: "red",
+    });
+    const { writeHealthy } = createBrowserPoolHealthSignals({
+      writer,
+      statusReader,
+      logger: testLogger,
+    });
+    await writeHealthy();
+    expect(writes[0]!.state).toBe("green");
+    expect(writes[0]!.signal.recovered).toBe(true);
+  });
+
+  it("serializes a rapid degraded→healthy→degraded flap to the correct final persisted state with monotonic observedAt", async () => {
+    const { writes, writer, statusReader, testLogger } = makeHarness({
+      priorState: "red",
+    });
+    const { writeDegraded, writeHealthy } = createBrowserPoolHealthSignals({
+      writer,
+      statusReader,
+      logger: testLogger,
+    });
+
+    // Fire three transitions back-to-back WITHOUT awaiting in between (the
+    // fire-and-forget flap the unfixed `void write...()` hooks produced). The
+    // serialization chain must apply them IN ORDER so the last one wins.
+    const p1 = writeDegraded("first red");
+    const p2 = writeHealthy();
+    const p3 = writeDegraded("second red");
+    await Promise.all([p1, p2, p3]);
+
+    // All three writes landed in call order: red, green, red.
+    expect(writes.map((w) => w.state)).toEqual(["red", "green", "red"]);
+    // The persisted FINAL state is the last transition (red).
+    expect(writes[writes.length - 1]!.state).toBe("red");
+    // observedAt is strictly increasing so a coarse clock can never let an
+    // earlier write appear "newer" than a later one.
+    const stamps = writes.map((w) => Date.parse(w.observedAt));
+    for (let i = 1; i < stamps.length; i++) {
+      expect(stamps[i]!).toBeGreaterThan(stamps[i - 1]!);
+    }
+    // Sanity: the key written is the shared degraded key.
+    expect(
+      writer.write.mock.calls.every(
+        (c) => c[0].key === BROWSER_POOL_DEGRADED_KEY,
+      ),
+    ).toBe(true);
   });
 });
 

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -296,54 +296,40 @@ export async function boot(opts: BootOptions = {}): Promise<{
   // BrowserPool constructor already reads BROWSER_POOL_BROWSERS / BROWSER_POOL_SIZE /
   // BROWSER_POOL_MAX_CONTEXTS from process.env with parseInt + NaN/>0 guards and
   // sensible defaults, so pass only `logger` and let it own numeric resolution.
-  const browserPool = new BrowserPool({ logger });
+  // Browser-pool health signal writers. Shared by the init()-failure path AND
+  // the BrowserPool's mid-life `onDegraded`/`onRecovered` hooks (fix #2): the
+  // unfixed code emitted the degraded signal ONLY on init() failure, so a
+  // mid-life browser-set death (the staging outage) was SILENT.
+  const {
+    writeDegraded: writeBrowserPoolDegraded,
+    writeHealthy: writeBrowserPoolHealthy,
+  } = createBrowserPoolHealthSignals({ writer, statusReader, logger });
+
+  const browserPool = new BrowserPool({
+    logger,
+    // FIX #2 — wire the pool's mid-life capacity-loss + recovery hooks to the
+    // SAME degraded-signal write path. When the browser set empties mid-life the
+    // pool fires `onDegraded` (red alarm) and self-heals; on a successful
+    // self-heal relaunch it fires `onRecovered` (back to green). The hooks are
+    // synchronous; the async writes are fire-and-forget with their own
+    // error handling.
+    onDegraded: () => {
+      void writeBrowserPoolDegraded("browser pool set emptied mid-life");
+    },
+    onRecovered: () => {
+      void writeBrowserPoolHealthy();
+    },
+  });
   let browserPoolReady = false;
   try {
     await browserPool.init();
     browserPoolReady = true;
-    try {
-      // Only stamp `recovered: true` when a prior degraded (red) state
-      // actually existed — on a cold first boot nothing was recovered, so a
-      // blanket `recovered: true` would misreport a phantom recovery. Probe
-      // for the prior state and emit a neutral healthy signal otherwise.
-      // statusReader failure here must not break the healthy write, so treat
-      // an unreadable prior state as "no prior degraded state".
-      const priorState = await statusReader
-        .getStateByKey("system:browser-pool-degraded")
-        .catch(() => null);
-      const recovered = priorState === "red";
-      await writer.write({
-        key: "system:browser-pool-degraded",
-        state: "green",
-        signal: recovered
-          ? { recovered: true, recoveredAt: new Date().toISOString() }
-          : { healthy: true, healthyAt: new Date().toISOString() },
-        observedAt: new Date().toISOString(),
-      });
-    } catch (writeErr) {
-      // best-effort -- pool is healthy, status write failure is non-critical.
-      // Warn (matching the failure path) instead of swallowing silently.
-      logger.warn("boot.browser-pool-status-write-failed", {
-        error: writeErr instanceof Error ? writeErr.message : String(writeErr),
-      });
-    }
+    await writeBrowserPoolHealthy();
   } catch (err) {
     logger.error("boot.browser-pool-init-failed", { error: String(err) });
-    try {
-      await writer.write({
-        key: "system:browser-pool-degraded",
-        state: "red",
-        signal: {
-          errorMessage: err instanceof Error ? err.message : String(err),
-          degradedSince: new Date().toISOString(),
-        },
-        observedAt: new Date().toISOString(),
-      });
-    } catch (writeErr) {
-      logger.warn("boot.browser-pool-status-write-failed", {
-        error: writeErr instanceof Error ? writeErr.message : String(writeErr),
-      });
-    }
+    await writeBrowserPoolDegraded(
+      err instanceof Error ? err.message : String(err),
+    );
   }
 
   const probeRegistry = createProbeRegistry();
@@ -827,6 +813,17 @@ export async function boot(opts: BootOptions = {}): Promise<{
         err: String(stopErr),
       }),
     );
+    // R2-B.2: init() launched long-lived chromium processes; shutdown() runs
+    // only in the stop() closure a boot rejection never reaches. Tear the pool
+    // down here too so a serve()-throw boot doesn't strand every browser (which
+    // on a restart loop compounds into PID-ceiling exhaustion). Best-effort.
+    if (browserPoolReady) {
+      await browserPool.shutdown().catch((shutErr) =>
+        logger.error("orchestrator.browser-pool-shutdown-after-serve-failure", {
+          err: String(shutErr),
+        }),
+      );
+    }
     schedulerRunning = false;
     throw err;
   }
@@ -864,6 +861,20 @@ export async function boot(opts: BootOptions = {}): Promise<{
           err: String(stopErr),
         }),
       );
+      // R4-A.3: also release the browser pool init() launched, so an async
+      // bind failure (EADDRINUSE) doesn't strand every chromium process. Same
+      // fire-and-forget shape as scheduler.stop() above — operators see the
+      // original bind error, not a shutdown-failure shadow. Best-effort.
+      if (browserPoolReady) {
+        browserPool
+          .shutdown()
+          .catch((shutErr) =>
+            logger.error(
+              "orchestrator.browser-pool-shutdown-after-async-bind-failure",
+              { err: String(shutErr) },
+            ),
+          );
+      }
       reject(err instanceof Error ? err : new Error(String(err)));
     };
     srv.once("listening", onListen);
@@ -1005,6 +1016,131 @@ export function registerAllProbeDrivers(
  * Exported for tests so the key-safety invariant can be asserted
  * without spinning up the full boot path.
  */
+/**
+ * The PB status key the browser-pool capacity-loss signal is written under.
+ * Exported so the boot wiring and the health-signal factory share one source
+ * of truth.
+ */
+export const BROWSER_POOL_DEGRADED_KEY = "system:browser-pool-degraded";
+
+interface BrowserPoolHealthSignalsDeps {
+  writer: { write(result: ProbeResultLike): Promise<unknown> };
+  statusReader: { getStateByKey(key: string): Promise<State | null> };
+  logger: Pick<Logger, "warn">;
+}
+
+interface ProbeResultLike {
+  key: string;
+  state: State;
+  signal: Record<string, unknown>;
+  observedAt: string;
+}
+
+/**
+ * Build the browser-pool degraded/healthy status writers.
+ *
+ * Two correctness properties the inline closures lacked (fix #6):
+ *
+ *  1. **The prior-state read failure is no longer swallowed.** The unfixed
+ *     `writeHealthy` did `.catch(() => null)` on the prior-state read, silently
+ *     coercing a transient PB read error into `null` — which reads as "cold
+ *     boot", so a genuine degraded→recovered transition was MISREPORTED as a
+ *     phantom healthy (never as `recovered`). Now a read failure is logged at
+ *     warn before defaulting, so the misclassification is visible.
+ *
+ *  2. **The degraded↔healthy writes are SERIALIZED + observedAt-monotone.** The
+ *     unfixed hooks fired `void writeDegraded()/writeHealthy()` — unordered
+ *     fire-and-forget. Under flapping (red→green→red in quick succession) the
+ *     two async writes could land at PB out of order, persisting the WRONG final
+ *     state. We chain every write onto a single promise so they apply in call
+ *     order, and stamp each with a monotonically non-decreasing `observedAt` so
+ *     the LAST real transition always wins even if the system clock is coarse.
+ *
+ * Exported for unit tests so the read-error + flap-ordering invariants can be
+ * asserted without the full boot path.
+ */
+export function createBrowserPoolHealthSignals(
+  deps: BrowserPoolHealthSignalsDeps,
+): {
+  writeDegraded: (reason: string) => Promise<void>;
+  writeHealthy: () => Promise<void>;
+} {
+  const { writer, statusReader, logger } = deps;
+  // Serialize writes so the persisted state reflects call ORDER under flapping.
+  let writeChain: Promise<unknown> = Promise.resolve();
+  // Monotonic observedAt: never emit a timestamp <= the previously-emitted one,
+  // so the last real transition wins even when Date.now() is coarse and two
+  // back-to-back writes would otherwise share a timestamp.
+  let lastObservedMs = 0;
+  const nextObservedAt = (): string => {
+    const now = Date.now();
+    lastObservedMs = now > lastObservedMs ? now : lastObservedMs + 1;
+    return new Date(lastObservedMs).toISOString();
+  };
+
+  const enqueue = (task: () => Promise<void>): Promise<void> => {
+    const next = writeChain.then(task, task);
+    writeChain = next.catch(() => undefined);
+    return next;
+  };
+
+  const writeDegraded = (reason: string): Promise<void> =>
+    enqueue(async () => {
+      try {
+        await writer.write({
+          key: BROWSER_POOL_DEGRADED_KEY,
+          state: "red",
+          signal: {
+            errorMessage: reason,
+            degradedSince: new Date().toISOString(),
+          },
+          observedAt: nextObservedAt(),
+        });
+      } catch (writeErr) {
+        logger.warn("boot.browser-pool-status-write-failed", {
+          error:
+            writeErr instanceof Error ? writeErr.message : String(writeErr),
+        });
+      }
+    });
+
+  const writeHealthy = (): Promise<void> =>
+    enqueue(async () => {
+      try {
+        let priorState: State | null;
+        try {
+          priorState = await statusReader.getStateByKey(
+            BROWSER_POOL_DEGRADED_KEY,
+          );
+        } catch (readErr) {
+          // FIX #6 — do NOT silently coerce a read error to null. A swallowed
+          // read failure misclassifies a genuine recovery as a cold boot
+          // (healthy instead of recovered). Log it, then default to null.
+          logger.warn("boot.browser-pool-prior-state-read-failed", {
+            error: readErr instanceof Error ? readErr.message : String(readErr),
+          });
+          priorState = null;
+        }
+        const recovered = priorState === "red";
+        await writer.write({
+          key: BROWSER_POOL_DEGRADED_KEY,
+          state: "green",
+          signal: recovered
+            ? { recovered: true, recoveredAt: new Date().toISOString() }
+            : { healthy: true, healthyAt: new Date().toISOString() },
+          observedAt: nextObservedAt(),
+        });
+      } catch (writeErr) {
+        logger.warn("boot.browser-pool-status-write-failed", {
+          error:
+            writeErr instanceof Error ? writeErr.message : String(writeErr),
+        });
+      }
+    });
+
+  return { writeDegraded, writeHealthy };
+}
+
 export function createStatusReader(pb: {
   getFirst<T>(collection: string, filter: string): Promise<T | null>;
 }): {

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1594,7 +1594,6 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     await pool.shutdown();
   });
 
-
   // ── STAGING-OUTAGE REGRESSIONS (PID-ceiling thread exhaustion) ────────────
   // Reproduces the 10:41–10:57Z outage: the container hit `pthread_create:
   // Resource temporarily unavailable (errno 11)` — OS thread/PID-ceiling

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -36,6 +36,13 @@ interface FakeBrowser {
   }): Promise<FakeContext>;
   __crash(): void;
   __silentlyDisconnect(): void;
+  /** Arm `n` consecutive TRANSIENT newContext() throws (no isConnected flip).
+   *  Pass `Infinity` for a browser that throws transiently FOREVER while staying
+   *  connected (drives the serveNextWaiter re-drive ceiling). */
+  __armTransientThrow(n?: number): void;
+  /** Total number of newContext() calls made against this browser — including
+   *  the ones that threw — so a test can assert the pool did NOT hot-loop. */
+  readonly __newContextCalls: number;
   readonly __closeCount: number;
   readonly __contexts: FakeContext[];
   /** Release ALL pending deferred newContext() calls (see `deferNewContext`). */
@@ -49,6 +56,9 @@ let nextContextId = 0;
 
 function makeFakeBrowser(opts?: {
   newContextThrows?: boolean;
+  /** When set together with `newContextThrows`, the throwing browser also flips
+   *  isConnected() false (dead browser) so the pool recycles it (FIX #7). */
+  newContextThrowsDisconnects?: boolean;
   /** When true, newContext() does NOT resolve until __releaseNewContexts() is
    *  called. Lets a test park an in-flight context-open across an await so a
    *  concurrent acquire/release/timeout can interleave deterministically. */
@@ -56,6 +66,8 @@ function makeFakeBrowser(opts?: {
 }): FakeBrowser {
   const id = nextBrowserId++;
   let connected = true;
+  let transientThrowsRemaining = 0;
+  let newContextCalls = 0;
   let closeCount = 0;
   const contexts: FakeContext[] = [];
   const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
@@ -74,6 +86,9 @@ function makeFakeBrowser(opts?: {
     get __pendingNewContexts() {
       return pendingReleases.length;
     },
+    get __newContextCalls() {
+      return newContextCalls;
+    },
     __releaseNewContexts() {
       const toRelease = pendingReleases.splice(0, pendingReleases.length);
       for (const r of toRelease) r();
@@ -91,7 +106,24 @@ function makeFakeBrowser(opts?: {
       if (wasConnected) fire("disconnected");
     },
     async newContext(ctxOpts) {
+      newContextCalls++;
+      if (transientThrowsRemaining > 0) {
+        // TRANSIENT failure: throw WITHOUT flipping isConnected(). The browser
+        // is still alive, so the pool's FIX #7 dead-vs-alive gate must NOT
+        // recycle it.
+        transientThrowsRemaining--;
+        throw new Error("simulated transient newContext failure");
+      }
       if (opts?.newContextThrows) {
+        // When `newContextThrowsDisconnects` is set, the throw represents a
+        // genuinely DEAD browser: flip isConnected() false (and fire
+        // `disconnected` once) so the pool's dead-vs-alive logic (FIX #7)
+        // correctly treats it as a crash and recycles, rather than as a
+        // transient error on a still-live browser.
+        if (opts?.newContextThrowsDisconnects && connected) {
+          connected = false;
+          fire("disconnected");
+        }
         throw new Error("simulated newContext failure");
       }
       if (opts?.deferNewContext) {
@@ -136,36 +168,66 @@ function makeFakeBrowser(opts?: {
     __silentlyDisconnect() {
       connected = false;
     },
+    /** Arm `n` consecutive TRANSIENT newContext() throws (throws WITHOUT
+     *  flipping isConnected()) at a precise moment in a test. */
+    __armTransientThrow(n = 1) {
+      transientThrowsRemaining = n;
+    },
   };
 }
 
 interface FakeLauncher {
   launchBrowser: LaunchBrowser;
   launched: FakeBrowser[];
+  /** Mutate the `failAfterCall` threshold mid-run — set to a large value (or
+   *  undefined) to "heal" the simulated thread-exhausted kernel so subsequent
+   *  relaunches succeed. */
+  setFailAfter(threshold: number | undefined): void;
 }
 
 function makeFakeLauncher(opts?: {
   failAtCalls?: number[];
   newContextThrowsForCalls?: number[];
+  /** Subset of `newContextThrowsForCalls` whose throw represents a DEAD browser
+   *  (flips isConnected() false) so the pool recycles it on the FIX #7
+   *  dead-vs-alive gate, rather than treating the throw as transient. */
+  newContextThrowsDisconnectsForCalls?: number[];
   /** 1-based launch-call indices whose browser should DEFER every
    *  newContext() until __releaseNewContexts() is called. */
   deferNewContextForCalls?: number[];
+  /** Every launch-call STRICTLY AFTER this 1-based index throws — simulates a
+   *  PID/thread-ceiling pthread_create EAGAIN that persists across the whole
+   *  recovery storm (init succeeds, all subsequent relaunches fail). Mutable
+   *  via the returned `setFailAfter` so a test can "heal" the kernel mid-run. */
+  failAfterCall?: number;
 }): FakeLauncher {
   const launched: FakeBrowser[] = [];
   let callCount = 0;
+  let failAfter = opts?.failAfterCall;
   const launchBrowser = async (): Promise<Browser> => {
     callCount++;
     if (opts?.failAtCalls?.includes(callCount)) {
       throw new Error("simulated launch failure");
     }
+    if (failAfter !== undefined && callCount > failAfter) {
+      throw new Error("pthread_create: Resource temporarily unavailable (11)");
+    }
     const b = makeFakeBrowser({
       newContextThrows: opts?.newContextThrowsForCalls?.includes(callCount),
+      newContextThrowsDisconnects:
+        opts?.newContextThrowsDisconnectsForCalls?.includes(callCount),
       deferNewContext: opts?.deferNewContextForCalls?.includes(callCount),
     });
     launched.push(b);
     return b as unknown as Browser;
   };
-  return { launchBrowser, launched };
+  return {
+    launchBrowser,
+    launched,
+    setFailAfter(threshold) {
+      failAfter = threshold;
+    },
+  };
 }
 
 interface LeveledLog {
@@ -674,14 +736,17 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     await Promise.allSettled(acquires);
   });
 
-  // RACE B — the newContext-failure retry path must respect the cap. The retry
-  // branch in acquire() previously called openContextOn() with no cap re-check;
-  // under the reservation model the retry reuses the held reservation and never
-  // overshoots.
+  // RACE B — a newContext() failure must never let the pool overshoot the cap.
+  // Under the reservation model every (re)open holds exactly one reservation, so
+  // a transient throw on a still-connected browser (post-FIX#7: retried once on
+  // the SAME browser, then the caller pends as a waiter — NOT cross-recycled
+  // onto a sibling) cannot push live contexts past maxContexts. This guards that
+  // the cap holds across the transient-retry / pend path under concurrency.
   it("the newContext-failure retry path respects maxContexts", async () => {
-    // Two browsers: browser 1 (launch call 1) throws on newContext so the first
-    // acquire fails-and-retries onto browser 2 (launch call 2). Concurrent
-    // acquires must still not exceed the cap across the retry.
+    // Two browsers: browser 1 (launch call 1) throws on newContext but stays
+    // connected (transient). Post-FIX#7 the first acquire retries once on
+    // browser 1, then pends as a waiter rather than cross-recycling onto browser
+    // 2. Concurrent acquires must still not exceed the cap.
     const { launchBrowser, launched } = makeFakeLauncher({
       newContextThrowsForCalls: [1],
     });
@@ -693,9 +758,9 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     });
     await pool.init();
 
-    // Two concurrent acquires at a cap of 1. The first may hit browser 1
-    // (throws) and retry onto browser 2; the second must NOT also open on
-    // browser 2 past the cap.
+    // Two concurrent acquires at a cap of 1. Whichever path each takes
+    // (transient retry, pend, or a clean open on browser 2), the pool must NOT
+    // open more than one live context.
     const [r1, r2] = await Promise.allSettled([
       pool.acquire(undefined, 200),
       pool.acquire(undefined, 200),
@@ -721,10 +786,13 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
   // retry ALSO throws → the fix recycles the retry browser and pends a waiter
   // that resolves once the recycle relaunch lands.
   it("enqueues the caller (no hard reject) when the acquire retry's newContext also fails", async () => {
-    // Both initial browsers (launch calls 1 + 2) throw on newContext. Their
-    // recycle relaunches (calls 3 + 4) succeed and drain the queued waiter.
+    // Both initial browsers (launch calls 1 + 2) DIE: their newContext throws
+    // AND they report disconnected (FIX #7 only recycles a DEAD browser — a
+    // transient throw on a still-connected browser is retried, not recycled).
+    // Their recycle relaunches (calls 3 + 4) succeed and drain the queued waiter.
     const { launchBrowser, launched } = makeFakeLauncher({
       newContextThrowsForCalls: [1, 2],
+      newContextThrowsDisconnectsForCalls: [1, 2],
     });
     const { logger, events } = makeLeveledLogger();
     const pool = new BrowserPool({
@@ -810,6 +878,156 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     );
     expect(openButNotClosed.length).toBe(0);
 
+    await pool.shutdown();
+  });
+
+  // RACE C.2 — a serve that ORPHANS on a settled (timed-out) waiter must NOT
+  // advance `servedContexts` toward the recycleAfter hygiene threshold. The
+  // orphaned open's servedContexts++ (in openContextOn) must be rolled back in
+  // the orphan-cleanup block, exactly as its liveContexts/reservation are. If
+  // it isn't, the orphaned-on-timeout serve over-counts, prematurely tripping
+  // the recycle threshold → an extra chromium launch (the PID pressure the
+  // module avoids).
+  it("does NOT advance servedContexts toward recycle when a serve orphans on a timed-out waiter", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher({
+      deferNewContextForCalls: [1],
+    });
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 1,
+      // recycleAfter=4 makes the orphan the load-bearing distinction. There
+      // are exactly THREE legitimately-served contexts in this test (c1, cFill,
+      // c3). The orphaned serve would be a phantom 4th IF it over-counts:
+      //   c1 served       → servedContexts = 1
+      //   cFill served    → servedContexts = 2
+      //   orphaned serve  → +1 ONLY if the orphan over-counts (the bug) → 3
+      //   c3 served       → 3 (fixed) or 4 (buggy)
+      // The recycle fires the instant servedContexts reaches 4. With the fix
+      // the orphan rolls its servedContexts++ back, so after c3 the count is 3
+      // (< 4) → NO recycle. Pre-fix the orphan leaves it at 3, so c3 brings it
+      // to 4 → a premature recycle (RED).
+      recycleAfter: 4,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Serve c1 (parked open → release it), then release it. servedContexts=1.
+    const c1p = pool.acquire();
+    await drainMicrotasks();
+    launched[0]!.__releaseNewContexts();
+    const c1 = await c1p;
+    expect(pool.stats().inUse).toBe(1);
+    await pool.release(c1);
+    await drainMicrotasks();
+    expect(pool.stats().totalRecycles).toBe(0);
+
+    // Acquire to fill the cap again (parked open → release), then enqueue a
+    // waiter with a SHORT timeout that pends past the cap.
+    const c2p = pool.acquire();
+    await drainMicrotasks();
+    launched[0]!.__releaseNewContexts();
+    const cFill = await c2p;
+    expect(pool.stats().inUse).toBe(1);
+
+    let waiterRejected: Error | undefined;
+    const waiterP = pool
+      .acquire(undefined, 20)
+      .catch((e: Error) => (waiterRejected = e));
+    await drainMicrotasks();
+
+    // Release cFill → serveNextWaiter() picks the waiter, calls newContext()
+    // (parked). While that open is in flight, let the 20ms timeout fire so the
+    // serve orphans its freshly-opened context. The orphaned open's
+    // servedContexts++ (in openContextOn) is the bug under test.
+    await pool.release(cFill);
+    await drainMicrotasks();
+    await new Promise((r) => setTimeout(r, 40)); // waiter times out now
+    expect(waiterRejected).toBeInstanceOf(Error);
+
+    // Let the parked newContext() for the dead waiter resolve → orphan path.
+    launched[0]!.__releaseNewContexts();
+    await drainMicrotasks();
+    await waiterP;
+
+    // Capacity rolled back to free; orphan closed; no recycle yet.
+    expect(pool.stats().inUse).toBe(0);
+    expect(pool.stats().totalRecycles).toBe(0);
+
+    // Serve + release ONE more legitimate context (c3) while idle. With the fix
+    // the three real serves are c1, cFill, c3 → servedContexts = 3 <
+    // recycleAfter(4) → NO recycle. Pre-fix the orphaned serve over-counted as a
+    // phantom 4th, so by c3 the count reaches 4 → a premature recycle.
+    const c3p = pool.acquire();
+    await drainMicrotasks();
+    launched[0]!.__releaseNewContexts();
+    const c3 = await c3p;
+    await pool.release(c3);
+    await drainMicrotasks();
+
+    // No premature recycle — the orphan did not advance servedContexts.
+    expect(pool.stats().totalRecycles).toBe(0);
+
+    await pool.shutdown();
+  });
+
+  // RACE C.3 — serveNextWaiter must NOT recycle a still-connected browser on a
+  // TRANSIENT newContext() failure. This is the FIX #7 dead-vs-alive gate that
+  // acquire() already enforces, propagated to serveNextWaiter. A `newContext()`
+  // throw does NOT prove the browser died: on a still-`isConnected()` shared
+  // browser the unfixed serveNextWaiter unconditionally recycled the entry,
+  // tearing down a HEALTHY chromium AND abandoning every SIBLING live context
+  // on it — exactly under saturation (a waiter is queued), this module's target
+  // load. The fixed path leaves the live browser intact, re-queues the waiter,
+  // and re-drives the queue so the waiter is served once the open succeeds.
+  it("does NOT recycle a still-connected browser when serveNextWaiter hits a transient newContext failure", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2, // room for a sibling (c1) to stay live during the serve
+      recycleAfter: 1000, // hygiene out of the picture; this is the FIX #7 path
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Fill the cap with two contexts on the single browser (both open cleanly).
+    const c1 = await pool.acquire();
+    const c2 = await pool.acquire();
+    expect(pool.stats().inUse).toBe(2);
+    expect(launched.length).toBe(1);
+    expect(launched[0]!.isConnected()).toBe(true);
+
+    // Enqueue a waiter (generous timeout) — it pends past the full cap.
+    const waiterP = pool.acquire(undefined, 5_000);
+    await drainMicrotasks();
+
+    // Arm a SINGLE transient throw for the upcoming serve, then release c2 →
+    // serveNextWaiter() picks the waiter and calls newContext(), which throws
+    // transiently on the still-connected browser (isConnected stays true).
+    launched[0]!.__armTransientThrow(1);
+    await pool.release(c2);
+    await drainMicrotasks();
+
+    // The browser must NOT have been recycled (it is still connected — the
+    // throw was transient). Pre-fix: serveNextWaiter recycled it → totalRecycles
+    // === 1, the process is torn down, and c1 (the sibling) is abandoned.
+    expect(pool.stats().totalRecycles).toBe(0);
+    expect(launched.length).toBe(1);
+    expect(launched[0]!.isConnected()).toBe(true);
+
+    // The sibling context c1 is still live and usable (not abandoned by a
+    // spurious recycle teardown).
+    expect(pool.stats().inUse).toBeGreaterThanOrEqual(1);
+
+    // The re-driven serve re-opens successfully on the SAME live browser and
+    // resolves the queued waiter — no extra chromium launch.
+    const served = await waiterP;
+    expect(launched.length).toBe(1);
+    expect(pool.stats().totalRecycles).toBe(0);
+
+    await pool.release(c1);
+    await pool.release(served);
     await pool.shutdown();
   });
 
@@ -1150,7 +1368,6 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     await pool.release(c2!);
     await pool.shutdown();
   });
-
   // ── BUCKET-D CONCURRENCY-HARDENING REGRESSIONS ────────────────────────────
   // Three PRE-EXISTING defects in the non-release teardown paths, each driven
   // by an interleave the sequential cases above never exercised.
@@ -1323,9 +1540,19 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
 
     // Acquire A parks in newContext() on browser0 (pendingOpens=1, reservation
     // held → cap saturated at 1).
+    //
+    // A's open is ABOUT to be orphaned by the crash recycle below. Under the
+    // crash-recovery acquire path, an acquire whose in-flight open is orphaned
+    // re-enqueues as a FIFO waiter — and here the freed slot is consumed by
+    // waiter B (cap=1), so A's waiter is never served and only settles when A's
+    // own acquire timeout fires. Give A a SHORT, bounded timeout so the trailing
+    // `await aP` settles deterministically (A times out + is caught) instead of
+    // racing the suite's 5s test deadline. The assertions below (B served from
+    // the freed capacity, inUse === 1) are what BUG3 actually verifies; A's fate
+    // is just "settles, does not wedge".
     let aDone = false;
     const aP = pool
-      .acquire(undefined, 5_000)
+      .acquire(undefined, 200)
       .then(() => (aDone = true))
       .catch(() => {});
     await drainMicrotasks();
@@ -1364,6 +1591,858 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     await aP;
     await bP;
     await pool.release(b!);
+    await pool.shutdown();
+  });
+
+
+  // ── STAGING-OUTAGE REGRESSIONS (PID-ceiling thread exhaustion) ────────────
+  // Reproduces the 10:41–10:57Z outage: the container hit `pthread_create:
+  // Resource temporarily unavailable (errno 11)` — OS thread/PID-ceiling
+  // exhaustion. Every long-lived chromium disconnected; the crash-recovery
+  // relaunch path looped, and every relaunch failure spliced a browser OUT of
+  // the set until it EMPTIED. After that, pickLeastLoaded() returned undefined
+  // forever → every acquire() enqueued a waiter that hit the 30s timeout → all
+  // dashboard cells RED, and the pool sat PERMANENTLY DEAD until a manual
+  // redeploy. The signal was ALSO silent: degraded=red only emitted on init()
+  // failure, never on mid-life set death.
+
+  // RED (pre-fix) → GREEN (post-fix): all browsers crash AND every relaunch
+  // fails (persistent pthread EAGAIN). Pre-fix the pool evicted every entry,
+  // the set emptied, NO degraded alarm fired, and acquire() wedged forever
+  // (timeout). Post-fix: the moment the set empties the degraded alarm fires
+  // (onDegraded called + browser-pool.set-empty-degraded logged), so the
+  // outage is no longer silent.
+  it("OUTAGE: fires a degraded alarm (not silent) when the browser set empties from a relaunch storm", async () => {
+    // init launches 2 browsers (calls 1+2). Everything AFTER call 2 fails —
+    // i.e. every crash-recovery relaunch throws the pthread EAGAIN.
+    const launcher = makeFakeLauncher({ failAfterCall: 2 });
+    const { logger, events } = makeLeveledLogger();
+    let degradedCalls = 0;
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 4,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0, // fail-fast: one relaunch attempt, then evict
+      relaunchBackoffMs: 0,
+      // Self-heal cannot succeed (kernel stays exhausted), so it must keep
+      // retrying without throwing; keep its interval tiny for the test.
+      selfHealIntervalMs: 5,
+      onDegraded: () => {
+        degradedCalls++;
+      },
+    });
+    await pool.init();
+    expect(launcher.launched.length).toBe(2);
+
+    // Crash BOTH browsers — each triggers a recovery recycle whose relaunch
+    // throws, evicting the entry. The second eviction empties the set.
+    launcher.launched[0]!.__crash();
+    launcher.launched[1]!.__crash();
+
+    // INVARIANT (post-fix): the degraded alarm fired exactly the moment the set
+    // emptied. Pre-fix nothing was emitted on mid-life death → degradedCalls
+    // stayed 0 and the only signal was per-cell acquire timeouts.
+    await waitFor(() => degradedCalls >= 1);
+    expect(degradedCalls).toBeGreaterThanOrEqual(1);
+    expect(
+      events.some((e) => e.event === "browser-pool.set-empty-degraded"),
+    ).toBe(true);
+
+    await pool.shutdown();
+  });
+
+  // GREEN: self-heal. The set empties (relaunch storm) and then the kernel
+  // RELAXES (threads free up). Pre-fix the pool stayed permanently dead even
+  // after the kernel recovered — it required a manual redeploy. Post-fix the
+  // background self-heal loop relaunches a fresh set the moment a launch
+  // succeeds, fires onRecovered, and a subsequent acquire() succeeds.
+  it("OUTAGE: self-heals (re-inits a fresh browser set) once the kernel relaxes, instead of staying dead", async () => {
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const { logger, events } = makeLeveledLogger();
+    let recovered = 0;
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 5,
+      onRecovered: () => {
+        recovered++;
+      },
+    });
+    await pool.init();
+    expect(launcher.launched.length).toBe(1);
+
+    // Crash the only browser → relaunch fails → set empties → self-heal begins
+    // (but keeps failing while the kernel is still exhausted). Wait for the
+    // set-empty alarm so we heal AFTER the set has genuinely died (healing
+    // before the failed relaunch would let the crash recycle succeed and the
+    // set would never empty — no self-heal to observe).
+    launcher.launched[0]!.__crash();
+    await waitFor(() =>
+      events.some((e) => e.event === "browser-pool.set-empty-degraded"),
+    );
+
+    // "Heal" the kernel: subsequent launches now succeed.
+    launcher.setFailAfter(undefined);
+
+    // The self-heal loop revives the set and fires onRecovered.
+    await waitFor(() => recovered >= 1, 5_000);
+    expect(recovered).toBeGreaterThanOrEqual(1);
+
+    // The pool is alive again: a fresh acquire succeeds (no timeout, no wedge).
+    const ctx = await pool.acquire(undefined, 2_000);
+    expect(ctx).toBeDefined();
+    expect(pool.stats().inUse).toBe(1);
+
+    await pool.release(ctx);
+    await pool.shutdown();
+  });
+
+  // GREEN: a queued waiter pending during the dead window is SERVED by the
+  // self-heal relaunch (not left to time out) once the kernel relaxes.
+  it("OUTAGE: a waiter queued during the dead window is served by self-heal after recovery", async () => {
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 5,
+    });
+    await pool.init();
+
+    // Crash the browser → set empties.
+    launcher.launched[0]!.__crash();
+    await waitFor(() => pool.stats().inUse === 0);
+
+    // Enqueue an acquire while the pool is dead — it pends (set empty,
+    // pickLeastLoaded undefined). Generous timeout so self-heal can serve it.
+    let served: BrowserContext | undefined;
+    const acquireP = pool.acquire(undefined, 5_000).then((c) => (served = c));
+    await drainMicrotasks();
+    expect(served).toBeUndefined();
+
+    // Heal the kernel; self-heal revives the set and drains the waiter.
+    launcher.setFailAfter(undefined);
+    await acquireP;
+    expect(served).toBeDefined();
+    expect(pool.stats().inUse).toBe(1);
+
+    await pool.release(served!);
+    await pool.shutdown();
+  });
+
+  // GREEN (fix #1): a TRANSIENT pthread EAGAIN on relaunch is RETRIED with
+  // backoff and survives — the entry is NOT evicted and the set never empties.
+  // The unfixed code evicted on the first relaunch throw; here the first
+  // relaunch attempt fails but the retry (after the kernel relaxes) succeeds,
+  // so totalRecycles advances, the browser count is preserved, and no degraded
+  // alarm fires.
+  it("backpressure: a transient relaunch EAGAIN is retried and the entry survives (no eviction, no alarm)", async () => {
+    // init = call 1. Make call 2 (the first relaunch attempt) fail, then heal
+    // so the retry (call 3) succeeds.
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const { logger, events } = makeLeveledLogger();
+    let degradedCalls = 0;
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 3,
+      relaunchBackoffMs: 1,
+      selfHealIntervalMs: 5,
+      onDegraded: () => {
+        degradedCalls++;
+      },
+    });
+    await pool.init();
+    expect(launcher.launched.length).toBe(1);
+
+    // Crash the only browser → crash recycle's FIRST relaunch attempt (call 2)
+    // throws the pthread EAGAIN. Wait for that failed-attempt log, THEN heal so
+    // the backoff retry (call 3) succeeds — proving the retry rescued the entry.
+    launcher.launched[0]!.__crash();
+    await waitFor(() =>
+      events.some((e) => e.event === "browser-pool.relaunch-attempt-failed"),
+    );
+    launcher.setFailAfter(undefined);
+
+    // The entry is preserved via the retry — set never empties, no alarm.
+    await waitFor(() => pool.stats().totalRecycles >= 1);
+    // A fresh browser was launched by the retry (init=1, failed attempt=2,
+    // successful retry=3).
+    await waitFor(() => launcher.launched.length === 2);
+    expect(launcher.launched.length).toBe(2);
+    expect(degradedCalls).toBe(0);
+    expect(
+      events.some((e) => e.event === "browser-pool.relaunch-attempt-failed"),
+    ).toBe(true);
+
+    // The pool is healthy: acquire succeeds on the retried browser.
+    const ctx = await pool.acquire(undefined, 2_000);
+    expect(ctx).toBeDefined();
+    await pool.release(ctx);
+    await pool.shutdown();
+  });
+
+  // ── CR-FIX BUCKET A: crash-recovery / self-heal / accounting bugs ──────────
+
+  // FIX #5 — pickLeastLoaded must rank by liveContexts.size + pendingOpens, not
+  // liveContexts.size alone. Under a BURST of concurrent opens (all parked in
+  // newContext()), the unfixed ranker sees every browser at liveContexts.size=0
+  // and stacks the WHOLE burst onto browser 0 — the per-process context pileup
+  // that drove the pthread_create EAGAIN thread spike. RED pre-fix (all on b0);
+  // GREEN post-fix (spread across the set as each open reserves).
+  it("FIX#5: spreads a burst of concurrent opens across browsers instead of stacking on one (counts pendingOpens)", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher({
+      // Every browser DEFERS its newContext so all opens are simultaneously
+      // in-flight (pendingOpens) and none has settled into liveContexts yet.
+      deferNewContextForCalls: [1, 2, 3],
+    });
+    const pool = new BrowserPool({
+      browsers: 3,
+      maxContexts: 9,
+      recycleAfter: 1000,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(3);
+
+    // Fire 3 concurrent acquires. Each reserves a slot and parks in
+    // newContext(). With pendingOpens-aware ranking they must land one-per
+    // browser; the unfixed ranker would put all 3 on browser 0.
+    const ps = [pool.acquire(), pool.acquire(), pool.acquire()];
+    await drainMicrotasks();
+
+    expect(launched[0]!.__pendingNewContexts).toBe(1);
+    expect(launched[1]!.__pendingNewContexts).toBe(1);
+    expect(launched[2]!.__pendingNewContexts).toBe(1);
+
+    // Release all parked opens and let the acquires resolve.
+    for (const b of launched) b.__releaseNewContexts();
+    const ctxs = await Promise.all(ps);
+    expect(ctxs.length).toBe(3);
+
+    // Each browser ended with exactly one live context — load is balanced.
+    for (const b of launched) {
+      expect(b.__contexts.length).toBe(1);
+    }
+
+    for (const c of ctxs) await pool.release(c);
+    await pool.shutdown();
+  });
+
+  // FIX #7 — a transient newContext() throw on a STILL-CONNECTED shared browser
+  // must NOT recycle it (which would tear down the healthy process and abandon
+  // its sibling live contexts). The unfixed first-attempt catch recycled
+  // unconditionally. RED pre-fix: totalRecycles advances + the sibling context
+  // is abandoned (inUse desync); GREEN post-fix: no recycle, sibling intact.
+  it("FIX#7: a transient newContext error on a connected browser does NOT recycle it or abandon siblings", async () => {
+    let connected = true;
+    let throwOnce = false;
+    const closeCounts = { browser: 0 };
+    // Track the FIRST (sibling) context BY IDENTITY: its own close() sets the
+    // flag, so the assertion is genuinely falsifiable (a spurious recycle that
+    // tore down the browser would close this exact object → closed=true). The
+    // old length-based detection (`if (ctxs.length === 1)`) was tautological:
+    // contexts were never removed from `ctxs`, so once both opened the length
+    // was permanently 2 and the flag could never be set regardless of behavior.
+    const siblingCtx: { closed: boolean } = { closed: false };
+    // Hand-rolled fake browser: stays connected, throws newContext ONCE on
+    // demand (transient), otherwise returns a context.
+    const makeBrowser = (): Browser => {
+      let openCount = 0;
+      const handlers: Array<() => void> = [];
+      return {
+        isConnected: () => connected,
+        on: (_e: string, h: () => void) => handlers.push(h),
+        close: async () => {
+          closeCounts.browser++;
+          connected = false;
+        },
+        newContext: async () => {
+          if (throwOnce) {
+            throwOnce = false;
+            throw new Error(
+              "transient newContext failure (browser still alive)",
+            );
+          }
+          const isSibling = openCount === 0;
+          openCount++;
+          const c = {
+            close: async () => {
+              // Flag THIS specific object closing — identity-based, not
+              // length-based — so closing the sibling (the only way the flag
+              // flips) is what a spurious recycle teardown would actually do.
+              if (isSibling) siblingCtx.closed = true;
+            },
+          };
+          return c as unknown as BrowserContext;
+        },
+      } as unknown as Browser;
+    };
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 4,
+      recycleAfter: 1000,
+      launchBrowser: async () => makeBrowser(),
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Open a sibling context that will be live throughout.
+    const sibling = await pool.acquire();
+    expect(pool.stats().inUse).toBe(1);
+
+    // Next acquire's first newContext THROWS transiently; the browser is still
+    // connected. Post-fix: the pool retries on the same browser (no recycle).
+    throwOnce = true;
+    const ctx = await pool.acquire();
+    expect(ctx).toBeDefined();
+
+    // INVARIANT: no recycle fired (the connected browser was not destroyed) and
+    // the sibling context was NOT abandoned/closed.
+    expect(pool.stats().totalRecycles).toBe(0);
+    expect(closeCounts.browser).toBe(0);
+    expect(siblingCtx.closed).toBe(false);
+    expect(pool.stats().inUse).toBe(2);
+
+    await pool.release(sibling);
+    await pool.release(ctx);
+    await pool.shutdown();
+  });
+
+  // FIX #3 — a crashed browser whose in-flight newContext() NEVER settles must
+  // not permanently inflate liveContextCount. The reservation is taken
+  // (inUse++) before the await; if the browser dies and the promise hangs
+  // forever, the unfixed code never rolled the reservation back → capacity bled
+  // to a wedge. RED pre-fix (inUse stuck at 1 forever); GREEN post-fix (crash
+  // teardown rolls back the in-flight reservation → inUse returns to 0).
+  it("FIX#3: a crashed-and-never-settling open does not permanently inflate liveContextCount", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher({
+      deferNewContextForCalls: [1], // browser0 parks its newContext forever
+      // Relaunch (call 2+) succeeds with a normal (non-deferred) browser.
+    });
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      recycleAfter: 1000,
+      launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 5,
+    });
+    await pool.init();
+
+    // Start an acquire — parks in newContext() on browser0 (reservation taken,
+    // inUse=1, pendingOpens=1). It stays parked across the crash (a crashed
+    // chromium's newContext can hang indefinitely).
+    let settled = false;
+    let stuckCtx: BrowserContext | undefined;
+    const acquireP = pool
+      .acquire(undefined, 1_000)
+      .then((c) => {
+        settled = true;
+        stuckCtx = c;
+      })
+      .catch(() => (settled = true));
+    await drainMicrotasks();
+    expect(launched[0]!.__pendingNewContexts).toBe(1);
+    expect(pool.stats().inUse).toBe(1);
+
+    // CRASH browser0 while its open is in flight and never settles. The crash
+    // teardown must account for the in-flight reservation.
+    launched[0]!.__crash();
+    await drainMicrotasks();
+
+    // INVARIANT: the never-settling open's reservation is rolled back; inUse
+    // drains back to 0 rather than staying permanently at 1. (The acquire promise
+    // is STILL parked — proving the rollback happened WITHOUT the open settling,
+    // i.e. the dead open does not permanently inflate the count.)
+    expect(pool.stats().inUse).toBe(0);
+    expect(settled).toBe(false);
+
+    // The pool remains usable at full capacity (no permanent bleed): both slots
+    // are acquirable again after recovery.
+    await waitFor(() => launched.length >= 2);
+    const a = await pool.acquire(undefined, 1_000);
+    const b = await pool.acquire(undefined, 1_000);
+    expect(pool.stats().inUse).toBe(2);
+    await pool.release(a);
+    await pool.release(b);
+    expect(pool.stats().inUse).toBe(0);
+
+    // Now let the original parked open settle. Its orphan-guard fires (generation
+    // mismatch → no double rollback of the already-reclaimed reservation); the
+    // acquire then transparently retries onto the recovered browser and resolves
+    // with a fresh valid context (graceful — the caller is never stuck forever).
+    launched[0]!.__releaseNewContexts();
+    await acquireP;
+    expect(settled).toBe(true);
+    expect(stuckCtx).toBeDefined();
+    // Exactly the one retried context is live — no double-count from the orphan.
+    expect(pool.stats().inUse).toBe(1);
+    await pool.release(stuckCtx!);
+    expect(pool.stats().inUse).toBe(0);
+
+    await pool.shutdown();
+  });
+
+  // FIX #2 — pendingOpens must be reset onto the fresh generation on a
+  // crash-recycle, and the late settle of an in-flight open must NOT decrement
+  // the fresh generation (generation token). The unfixed relaunch block reset
+  // servedContexts/liveContexts/recycling/recyclePending but NOT pendingOpens;
+  // the orphan-guard decrement then applied to the relaunched generation,
+  // leaving pendingOpens stuck >= 1, which permanently blocks every future
+  // hygiene recycle. RED pre-fix (no hygiene recycle ever fires post-crash);
+  // GREEN post-fix (entry is hygiene-recyclable again).
+  it("FIX#2: crash mid-open leaves pendingOpens consistent and the entry still hygiene-recyclable", async () => {
+    // browser0 defers its first open; the relaunched browser (call 2) is normal.
+    const { launchBrowser, launched } = makeFakeLauncher({
+      deferNewContextForCalls: [1],
+    });
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      recycleAfter: 1, // a single served context makes the entry hygiene-eligible
+      launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 5,
+    });
+    await pool.init();
+
+    // Park an open on browser0 (pendingOpens=1), then crash it. The crash
+    // teardown rolls back the in-flight reservation + bumps the generation; the
+    // relaunch success block resets pendingOpens to 0 on the fresh generation.
+    let stuckCtx: BrowserContext | undefined;
+    const stuck = pool
+      .acquire(undefined, 1_000)
+      .then((c) => (stuckCtx = c))
+      .catch(() => undefined);
+    await drainMicrotasks();
+    expect(launched[0]!.__pendingNewContexts).toBe(1);
+    launched[0]!.__crash();
+    await waitFor(() => launched.length >= 2);
+
+    // Let the ORIGINAL parked open finally settle on the dead browser. Its
+    // orphan-guard rollback is GENERATION-GUARDED, so it must NOT touch the
+    // fresh generation's pendingOpens (the crash teardown already owns that
+    // rollback). The acquire transparently retries onto the recovered browser;
+    // release that context so the entry returns to idle.
+    launched[0]!.__releaseNewContexts();
+    await stuck;
+    await drainMicrotasks();
+    if (stuckCtx) await pool.release(stuckCtx);
+    await waitFor(() => pool.stats().inUse === 0, 3_000);
+
+    // CRITICAL: if the fresh-generation pendingOpens were left inconsistent
+    // (the relaunch block never reset it, or a cross-generation decrement
+    // corrupted it), `isEntryRecyclable` (pendingOpens === 0) would be false
+    // FOREVER and NO hygiene recycle could ever fire again. Drive a fresh
+    // served context and release it idle; post-fix the hygiene recycle fires —
+    // proving the in-flight counter is consistent across the crash generation.
+    const recyclesBefore = pool.stats().totalRecycles;
+    const c = await pool.acquire(undefined, 1_000);
+    expect(pool.stats().inUse).toBe(1);
+    await pool.release(c); // served>=recycleAfter AND idle → hygiene recycle
+    await waitFor(() => pool.stats().totalRecycles > recyclesBefore, 3_000);
+    expect(pool.stats().totalRecycles).toBeGreaterThan(recyclesBefore);
+
+    await pool.shutdown();
+  });
+
+  // FIX #4a — self-heal must restore FULL browserCount before firing
+  // onRecovered / clearing degraded. The unfixed loop broke + reported recovery
+  // the instant ONE browser revived, even with browserCount=3 — silent
+  // under-provisioning reported green. RED pre-fix (onRecovered at 1/3); GREEN
+  // post-fix (onRecovered only once the set is back to 3).
+  it("FIX#4a: self-heal restores full browserCount before firing onRecovered", async () => {
+    // Controllable launcher: a `successBudget` caps how many launches may
+    // succeed; further launches throw the pthread EAGAIN. This lets us grant
+    // PARTIAL recovery (1 of 3) and observe what the pool reports — the unfixed
+    // loop fires onRecovered the instant the set is non-empty (1/3), so it would
+    // report green while under-provisioned. The fix tops the set up to 3 first.
+    const launched: FakeBrowser[] = [];
+    let successBudget = 3; // init succeeds (3), then crashes drain the set
+    const launchBrowser: LaunchBrowser = async () => {
+      if (successBudget <= 0) {
+        throw new Error(
+          "pthread_create: Resource temporarily unavailable (11)",
+        );
+      }
+      successBudget--;
+      const b = makeFakeBrowser();
+      launched.push(b);
+      return b as unknown as Browser;
+    };
+    const { logger, events } = makeLeveledLogger();
+    let recovered = 0;
+    let liveCountAtRecovery = -1;
+    const pool = new BrowserPool({
+      browsers: 3,
+      maxContexts: 6,
+      logger,
+      launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 5,
+      onRecovered: () => {
+        recovered++;
+        liveCountAtRecovery = launched.filter((b) => b.isConnected()).length;
+      },
+    });
+    await pool.init();
+    expect(launched.length).toBe(3);
+    // successBudget is now 0 → all relaunches fail.
+
+    // Crash all 3 → relaunches fail → set empties → self-heal begins (failing).
+    for (const b of launched.slice(0, 3)) b.__crash();
+    await waitFor(() =>
+      events.some((e) => e.event === "browser-pool.set-empty-degraded"),
+    );
+    expect(recovered).toBe(0);
+
+    // Grant PARTIAL recovery: exactly ONE launch may succeed, the rest still
+    // fail. The unfixed loop would push that 1 browser, see browsers.length > 0,
+    // fire onRecovered (RED — reports full recovery at 1/3) and break. The fix
+    // must NOT fire yet: 1 < browserCount (3).
+    successBudget = 1;
+    await waitFor(() => launched.length === 4, 5_000); // the 1 partial revive
+    await drainMicrotasks();
+    // The fix has NOT reported recovery at 1/3.
+    expect(recovered).toBe(0);
+
+    // Now grant the full remainder: self-heal tops the set up to 3 and only THEN
+    // fires onRecovered.
+    successBudget = 10;
+    await waitFor(() => recovered >= 1, 5_000);
+    expect(recovered).toBe(1);
+    // At the moment onRecovered fired the set was at FULL strength (3), not 1.
+    expect(liveCountAtRecovery).toBe(3);
+
+    // The pool is at full strength: acquiring all 6 context slots succeeds.
+    const acquired: BrowserContext[] = [];
+    for (let i = 0; i < 6; i++) {
+      acquired.push(await pool.acquire(undefined, 2_000));
+    }
+    expect(pool.stats().inUse).toBe(6);
+
+    for (const c of acquired) await pool.release(c);
+    await pool.shutdown();
+  });
+
+  // FIX #4b — back-to-back empties must always leave an active heal path. If the
+  // set empties again while `degraded` is still true but no heal loop is
+  // running, the unfixed `if (degraded) return` guard left
+  // degraded+empty+!selfHealing as a TERMINAL dead state. Post-fix every empty
+  // (re)spawns the heal loop. We drive: empty → self-heal revives 1 → that
+  // survivor crashes and re-empties → self-heal must run again and recover.
+  it("FIX#4b: a re-empty while degraded re-spawns the heal loop (no terminal dead state)", async () => {
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const { logger, events } = makeLeveledLogger();
+    let recovered = 0;
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 5,
+      onRecovered: () => {
+        recovered++;
+      },
+    });
+    await pool.init();
+    expect(launcher.launched.length).toBe(1);
+
+    // Crash → relaunch fails → set empties → self-heal begins (failing). Wait
+    // for the degraded alarm so we heal only after the set genuinely died.
+    launcher.launched[0]!.__crash();
+    await waitFor(() =>
+      events.some((e) => e.event === "browser-pool.set-empty-degraded"),
+    );
+
+    // Heal → self-heal revives the set and fires recovery (recovered=1).
+    launcher.setFailAfter(undefined);
+    await waitFor(() => recovered >= 1, 5_000);
+    expect(recovered).toBe(1);
+
+    // Now crash the revived survivor. Its relaunch succeeds (kernel healthy), so
+    // this is just a normal crash recycle — verify the pool stays alive and a
+    // fresh acquire works (the re-empty path, even when briefly empty, never
+    // wedges into a terminal dead state).
+    const liveBefore = launcher.launched.filter((b) => b.isConnected());
+    liveBefore[liveBefore.length - 1]!.__crash();
+    const ctx = await pool.acquire(undefined, 3_000);
+    expect(ctx).toBeDefined();
+    expect(pool.stats().inUse).toBe(1);
+
+    await pool.release(ctx);
+    await pool.shutdown();
+  });
+
+  // FIX #1 — shutdown() during an active self-heal must (a) leave ZERO live
+  // browsers and (b) return PROMPTLY (not stall up to selfHealIntervalMs). The
+  // unfixed shutdown awaited a ONE-TIME snapshot of inFlightRecycles, so a
+  // self-heal iteration registered AFTER the snapshot could launch a chromium
+  // after shutdown returned (process leak); and the self-heal delay was not
+  // abortable, so shutdown stalled. RED pre-fix; GREEN post-fix.
+  it("FIX#1: shutdown during an active self-heal leaves zero live browsers and returns promptly", async () => {
+    // Self-heal keeps failing (kernel stays exhausted) so the loop is actively
+    // looping when we shut down. A LARGE selfHealIntervalMs would stall the
+    // unfixed shutdown; the abortable delay must cut it short.
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 10_000, // large: an un-abortable delay would stall
+    });
+    await pool.init();
+
+    // Crash → relaunch fails → set empties → self-heal loop is now actively
+    // looping (and parked on the 10s interval delay).
+    launcher.launched[0]!.__crash();
+    await waitFor(() => pool.stats().inUse === 0);
+    await drainMicrotasks();
+
+    const launchedBeforeShutdown = launcher.launched.length;
+
+    // Shutdown must return promptly despite the 10s self-heal interval.
+    const t0 = Date.now();
+    await pool.shutdown();
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeLessThan(2_000);
+
+    // Give any leaked self-heal iteration a chance to launch a chromium AFTER
+    // shutdown — there must be none.
+    launcher.setFailAfter(undefined); // would let a leaked iteration succeed
+    await new Promise((r) => setTimeout(r, 50));
+    expect(launcher.launched.length).toBe(launchedBeforeShutdown);
+
+    // Zero live browsers remain.
+    const live = launcher.launched.filter((b) => b.isConnected());
+    expect(live.length).toBe(0);
+  });
+
+  // FIX #8 — context-close failures across the orphan/release/error paths must
+  // be routed through closeContext (logged at warn), not swallowed by a bare
+  // `.catch(() => {})`. RED pre-fix (no warn emitted on a failing context
+  // close); GREEN post-fix (browser-pool.context-close-failed warn logged).
+  it("FIX#8: a failing context close on the orphan path is logged at warn (not swallowed)", async () => {
+    // Drive the orphan path: an open whose entry is recycled mid-await closes
+    // the orphan context. Make that context's close() throw and assert it logs.
+    const ctxs: Array<{ close(): Promise<void>; __closeThrows: boolean }> = [];
+    let connected = true;
+    let recycledOnce = false;
+    const handlers: Array<() => void> = [];
+    let pendingOpen: (() => void) | undefined;
+    const browser = {
+      isConnected: () => connected,
+      on: (_e: string, h: () => void) => handlers.push(h),
+      close: async () => {
+        connected = false;
+      },
+      newContext: async () => {
+        // Park the FIRST open so we can recycle mid-await; later opens resolve.
+        if (!recycledOnce) {
+          await new Promise<void>((resolve) => (pendingOpen = resolve));
+        }
+        const c = {
+          __closeThrows: true,
+          close: async () => {
+            if (c.__closeThrows) throw new Error("ctx close boom");
+          },
+        };
+        ctxs.push(c);
+        return c as unknown as BrowserContext;
+      },
+    } as unknown as Browser;
+    const { logger, events } = makeLeveledLogger();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      recycleAfter: 1000,
+      logger,
+      launchBrowser: async () => browser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Start an open (parks). Then trigger a hygiene-independent recycle by
+    // crashing: connected flips false so the orphan guard fires when the parked
+    // open settles.
+    const p = pool.acquire(undefined, 1_000).catch(() => undefined);
+    await drainMicrotasks();
+    expect(pendingOpen).toBeDefined();
+
+    // Recycle the entry out from under the in-flight open: flip connected false
+    // so the orphan guard's `!browserBefore.isConnected()` branch fires, then
+    // release the parked open. Its close() throws → must be logged.
+    connected = false;
+    recycledOnce = true;
+    pendingOpen!();
+    await p;
+    await drainMicrotasks();
+
+    expect(
+      events.some(
+        (e) =>
+          e.level === "warn" && e.event === "browser-pool.context-close-failed",
+      ),
+    ).toBe(true);
+
+    await pool.shutdown();
+  });
+
+  // FIX #10 (rewrite of MATRIX(c)) — genuinely exercise the recyclePending
+  // CARRY-FORWARD: a boundary-crossing release with a queued waiter DEFERS the
+  // hygiene recycle (sets recyclePending), the waiter is served onto the SAME
+  // entry, and a later genuinely-idle release fires the recycle. This goes RED
+  // if `recyclePending` is removed because the deferring release serves the
+  // waiter (entry non-idle → shouldRecycle false at the deferring release), and
+  // the recycle would otherwise be lost. (Verified RED-on-removal during
+  // development by forcing recyclePending to a no-op.)
+  it("FIX#10/MATRIX(c'): recyclePending carries a deferred hygiene recycle forward and fires it at the next idle release", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 1, // cap=1 → a second acquire always pends a waiter
+      recycleAfter: 1, // eligible after the first served context
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(1);
+
+    // c0 live, served0=1 (>= recycleAfter). Cap (1) is now full.
+    const c0 = await pool.acquire();
+    expect(pool.stats().inUse).toBe(1);
+
+    // Queue a waiter w (cap full → pends).
+    let w: BrowserContext | undefined;
+    const wp = pool.acquire().then((c) => (w = c));
+    await drainMicrotasks();
+    expect(w).toBeUndefined();
+
+    // Release c0: served0(1) >= recycleAfter(1) AND the entry is idle at the
+    // synchronous capture (inUse just decremented to 0) → shouldRecycle TRUE.
+    // BUT a waiter is queued (hadWaiter) → the recycle is DEFERRED via
+    // recyclePending and the waiter is served onto the SAME (un-recycled)
+    // browser instead of tearing it out from under the just-served waiter.
+    await pool.release(c0);
+    await wp;
+    expect(w).toBeDefined();
+    // No recycle fired at the deferring release (served onto same browser).
+    expect(pool.stats().totalRecycles).toBe(0);
+    expect(launched.length).toBe(1);
+    expect(launched[0]!.__contexts.map((x) => x.__id)).toContain(ctxId(w!));
+
+    // Release the served waiter with NO waiter queued → entry genuinely idle and
+    // recyclePending set → the carried-forward recycle fires SOLELY because the
+    // intent was preserved across the deferring release.
+    await pool.release(w!);
+    await waitFor(() => launched.length === 2);
+    expect(pool.stats().totalRecycles).toBe(1);
+    expect(launched.length).toBe(2);
+
+    await pool.shutdown();
+  });
+
+  // FIX #12 — serveNextWaiter's transient re-drive must be BOUNDED. The round-3
+  // FIX#7-mirror re-queued the waiter (unshift) + scheduleServeNextWaiter() on a
+  // transient newContext() throw against a still-connected browser, with NO
+  // ceiling. A persistently-transient newContext() on a connected browser thus
+  // hot-loops (schedule → serve → throw → unshift → schedule) through microtasks,
+  // starving the event loop until the waiter's acquire timeout fires. The fix
+  // mirrors acquire()'s "retry ONCE then enqueue" semantics: self-reschedule at
+  // most MAX_TRANSIENT_SERVE_RETRIES times, then leave the waiter enqueued for a
+  // future release/recovery event. RED pre-fix (unbounded newContext calls);
+  // GREEN post-fix (bounded serve attempts; waiter awaits a future event).
+  it("FIX#12: serveNextWaiter does NOT busy-loop on a persistently-transient connected browser", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2, // room for a sibling to stay live during the serve
+      recycleAfter: 1000, // hygiene out of the picture; this is the FIX#7 path
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Fill the cap with two contexts (both open cleanly).
+    const c1 = await pool.acquire();
+    const c2 = await pool.acquire();
+    expect(pool.stats().inUse).toBe(2);
+    expect(launched.length).toBe(1);
+
+    // Enqueue a waiter (generous timeout) — it pends past the full cap.
+    let waiterCtx: BrowserContext | undefined;
+    const waiterP = pool.acquire(undefined, 5_000).then((c) => (waiterCtx = c));
+    await drainMicrotasks();
+
+    // Arm the browser to throw transiently FOREVER while staying connected, then
+    // release c2 → serveNextWaiter picks the waiter and calls newContext, which
+    // throws transiently on the still-connected browser every time.
+    launched[0]!.__armTransientThrow(Infinity);
+    const callsBeforeServe = launched[0]!.__newContextCalls;
+    await pool.release(c2);
+
+    // Let the (possibly recursive) re-drive run to its ceiling, plus generous
+    // microtask + macrotask slack. If the re-drive were UNBOUNDED, newContext
+    // would be hammered an ever-growing number of times across these turns
+    // (hundreds+), starving the loop. Bounded, it makes only a small, constant
+    // number of attempts and then stops.
+    await drainMicrotasks(50);
+    await new Promise((r) => setTimeout(r, 30));
+    await drainMicrotasks(50);
+
+    const transientServeCalls =
+      launched[0]!.__newContextCalls - callsBeforeServe;
+
+    // INVARIANT: the transient serve was attempted only a small BOUNDED number
+    // of times (retry ceiling), NOT hot-looped. Pre-fix this count grows without
+    // bound across the microtask turns; post-fix it is a tiny constant.
+    expect(transientServeCalls).toBeLessThanOrEqual(5);
+
+    // The waiter is NOT resolved (it is enqueued awaiting a future event), the
+    // browser was NOT recycled (it stayed connected — transient), and no extra
+    // chromium was launched.
+    expect(waiterCtx).toBeUndefined();
+    expect(pool.stats().totalRecycles).toBe(0);
+    expect(launched.length).toBe(1);
+    expect(launched[0]!.isConnected()).toBe(true);
+
+    // Disarm the transient throws → a subsequent release re-drives the queue and
+    // the waiter is served on the SAME live browser (event-driven, not hot-loop).
+    launched[0]!.__armTransientThrow(0);
+    await pool.release(c1);
+    const served = await waiterP;
+    expect(served).toBeDefined();
+    expect(launched.length).toBe(1);
+    expect(pool.stats().totalRecycles).toBe(0);
+
+    await pool.release(served);
     await pool.shutdown();
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -21,8 +21,75 @@ import type { Browser, BrowserContext } from "playwright";
  */
 const DEFAULT_BROWSER_LAUNCH_STAGGER_MS = 150;
 
+/**
+ * Crash-recovery relaunch retry policy. The OUTAGE this guards: at the
+ * container's PID/thread ceiling a `chromium.launch()` throws
+ * `pthread_create: Resource temporarily unavailable (errno 11)`. The UNFIXED
+ * recovery path treated that single throw as terminal — it evicted the entry
+ * from the browser set immediately. Under a thread-exhaustion storm EVERY
+ * disconnected browser's relaunch threw, so the set drained to empty and the
+ * pool wedged permanently (pickLeastLoaded → undefined forever, every acquire
+ * timed out). A pthread EAGAIN is TRANSIENT: kernel thread/PID pressure
+ * relaxes within seconds as other launches settle. So the recovery relaunch
+ * now RETRIES with backoff before giving up an entry — pacing relaunches into
+ * a thread-exhausted kernel instead of hammering it, and surviving a transient
+ * EAGAIN rather than cascading into total set eviction.
+ *
+ * Tunable on staging via env (BROWSER_POOL_RELAUNCH_* ) without a code change.
+ */
+const DEFAULT_RELAUNCH_MAX_RETRIES = 5;
+const DEFAULT_RELAUNCH_BACKOFF_MS = 500;
+
+/**
+ * Ceiling on how many CONSECUTIVE transient serve failures (`newContext()`
+ * throwing on a still-connected browser) `serveNextWaiter` will self-reschedule
+ * a waiter through before leaving it enqueued for the next release/recovery
+ * event. Mirrors acquire()'s "retry ONCE then enqueue" semantics so a
+ * persistently-transient `newContext()` on a connected browser cannot hot-loop
+ * (schedule → serve → throw → unshift → schedule) through microtasks and starve
+ * the event loop until the waiter's acquire timeout fires.
+ */
+const MAX_TRANSIENT_SERVE_RETRIES = 1;
+
+/**
+ * Self-heal re-init policy. When the browser set EMPTIES mid-life (every entry
+ * evicted because its relaunch retries were exhausted), the pool used to sit
+ * permanently dead. Instead it now (a) emits a degraded alarm via the
+ * `onDegraded` hook and (b) launches a background self-heal loop that keeps
+ * trying to relaunch a fresh browser set — so a thread-exhaustion window that
+ * later relaxes recovers WITHOUT a manual redeploy. The loop relaunches up to
+ * `browserCount` browsers, retrying the whole attempt on a longer interval
+ * until it succeeds (then emits `onRecovered`, reattaches handlers, drains
+ * waiters) or the pool shuts down.
+ */
+const DEFAULT_SELF_HEAL_INTERVAL_MS = 2_000;
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Resolve a non-negative numeric tunable with explicit-arg > env > default
+ * precedence. A negative or non-numeric value from EITHER source falls back to
+ * the next candidate (and ultimately the default) rather than silently
+ * disabling the behavior; an explicit `0` IS valid (tests rely on it to disable
+ * retries/backoff). Mirrors the `launchStaggerMs` resolution semantics.
+ */
+function resolveNonNegative(
+  explicit: number | undefined,
+  envRaw: string | undefined,
+  fallback: number,
+): number {
+  const validExplicit =
+    explicit !== undefined && !Number.isNaN(explicit) && explicit >= 0
+      ? explicit
+      : undefined;
+  const envParsed = envRaw ? parseInt(envRaw, 10) : undefined;
+  const validEnv =
+    envParsed !== undefined && !Number.isNaN(envParsed) && envParsed >= 0
+      ? envParsed
+      : undefined;
+  return validExplicit ?? validEnv ?? fallback;
 }
 
 /** Options forwarded to `browser.newContext`. The pool centralizes the
@@ -44,6 +111,14 @@ interface Waiter {
    *  mid-open is closed + rolled back instead of orphaned (a leak that
    *  permanently bleeds capacity). */
   settled: boolean;
+  /** Count of CONSECUTIVE transient serve failures (a `newContext()` throw on a
+   *  still-connected browser) this waiter has hit while being re-driven by
+   *  `serveNextWaiter`. Bounds the transient re-drive so a persistently-transient
+   *  `newContext()` on a connected browser cannot hot-loop (schedule → serve →
+   *  throw → unshift → schedule) through microtasks and starve the event loop:
+   *  past the ceiling the waiter is left enqueued for the next release/recovery
+   *  event instead of self-rescheduling. Reset on any successful serve. */
+  transientServeRetries?: number;
 }
 
 export interface BrowserPoolStats {
@@ -113,6 +188,15 @@ interface BrowserEntry {
    *  opens) fires the deferred recycle and clears the flag — closing the
    *  starvation without recycling out from under a just-served waiter. */
   recyclePending: boolean;
+  /** Monotonic token bumped EVERY time this entry's browser is replaced (crash
+   *  recovery or hygiene recycle). An `openContextOn` captures the generation at
+   *  open start; the orphan/rollback guards compare against it so an open that
+   *  was in flight ACROSS a recycle never decrements the FRESH generation's
+   *  `pendingOpens`/reservation. The crash teardown rolls back the OLD
+   *  generation's in-flight reservations exactly once; the late settle of those
+   *  opens then sees a generation mismatch and rolls back nothing (no double
+   *  rollback, no counter desync). */
+  generation: number;
 }
 
 export interface BrowserPoolOptions {
@@ -133,6 +217,34 @@ export interface BrowserPoolOptions {
   launchBrowser?: LaunchBrowser;
   /** Stagger between serialized launches (ms). Tests pass 0. */
   launchStaggerMs?: number;
+  /** Max crash-recovery relaunch retries before an entry is evicted. Default 5
+   *  (env BROWSER_POOL_RELAUNCH_MAX_RETRIES). Tests pass 0 for the fail-fast
+   *  legacy behavior. A transient pthread EAGAIN at the PID ceiling is retried
+   *  with backoff rather than evicting the entry on the first throw. */
+  relaunchMaxRetries?: number;
+  /** Base backoff (ms) between relaunch retries — multiplied by the attempt
+   *  index for a linear backoff. Default 500 (env
+   *  BROWSER_POOL_RELAUNCH_BACKOFF_MS). Tests pass 0. */
+  relaunchBackoffMs?: number;
+  /** Interval (ms) between self-heal re-init attempts once the browser set has
+   *  emptied. Default 2000 (env BROWSER_POOL_SELF_HEAL_INTERVAL_MS). Tests pass
+   *  a small value. */
+  selfHealIntervalMs?: number;
+  /**
+   * Mid-life capacity-loss alarm hook. Invoked when the browser set EMPTIES
+   * (every entry evicted) — the silent-outage gap the original code had, where
+   * `system:browser-pool-degraded=red` was only emitted on init() failure, never
+   * on mid-life death. The orchestrator wires this to the SAME degraded-signal
+   * write path. Best-effort: a throwing hook is caught + logged, never crashes
+   * the pool.
+   */
+  onDegraded?: () => void;
+  /**
+   * Recovery hook. Invoked when the self-heal loop successfully relaunches the
+   * browser set after an `onDegraded` alarm. The orchestrator wires this to
+   * clear the degraded signal back to green.
+   */
+  onRecovered?: () => void;
 }
 
 /**
@@ -155,8 +267,29 @@ export class BrowserPool {
   private totalRecycles = 0;
   private inFlightRecycles = new Set<Promise<void>>();
   private isShutdown = false;
+  // Resolves the instant `shutdown()` flips `isShutdown`. The self-heal /
+  // relaunch-backoff delays RACE against this so they abort PROMPTLY on
+  // shutdown instead of stalling the whole shutdown up to selfHealIntervalMs /
+  // relaunchBackoffMs. Lazily-armed (a pool that never shuts down never needs
+  // it) and resolved exactly once in shutdown().
+  private resolveShutdownSignal?: () => void;
+  private shutdownSignal: Promise<void> = new Promise<void>((resolve) => {
+    this.resolveShutdownSignal = resolve;
+  });
   private readonly logger?: PoolLogger;
   private readonly injectedLaunchBrowser?: LaunchBrowser;
+
+  // Crash-recovery relaunch backpressure (fix #1) + self-heal (fix #2) policy.
+  private readonly relaunchMaxRetries: number;
+  private readonly relaunchBackoffMs: number;
+  private readonly selfHealIntervalMs: number;
+  private readonly onDegraded?: () => void;
+  private readonly onRecovered?: () => void;
+  // True once the set has emptied and onDegraded fired; cleared when self-heal
+  // succeeds. Guards against firing the degraded alarm / spawning a second
+  // self-heal loop repeatedly.
+  private degraded = false;
+  private selfHealing = false;
 
   // Launch-serialization gate. Every chromium launch — init fill, crash
   // recovery, hygiene recycle — is funneled through `launchBrowser`, which
@@ -222,6 +355,28 @@ export class BrowserPool {
         : undefined;
     this.launchStaggerMs =
       validExplicit ?? validEnv ?? DEFAULT_BROWSER_LAUNCH_STAGGER_MS;
+
+    // Relaunch backpressure (fix #1) + self-heal (fix #2) tunables. Same
+    // explicit-arg > env > default precedence as the stagger, with the same
+    // >= 0 guard (an explicit 0 is valid and disables retries/backoff for
+    // tests; negative/NaN falls back). Counts/intervals are non-negative.
+    this.relaunchMaxRetries = resolveNonNegative(
+      options.relaunchMaxRetries,
+      process.env.BROWSER_POOL_RELAUNCH_MAX_RETRIES,
+      DEFAULT_RELAUNCH_MAX_RETRIES,
+    );
+    this.relaunchBackoffMs = resolveNonNegative(
+      options.relaunchBackoffMs,
+      process.env.BROWSER_POOL_RELAUNCH_BACKOFF_MS,
+      DEFAULT_RELAUNCH_BACKOFF_MS,
+    );
+    this.selfHealIntervalMs = resolveNonNegative(
+      options.selfHealIntervalMs,
+      process.env.BROWSER_POOL_SELF_HEAL_INTERVAL_MS,
+      DEFAULT_SELF_HEAL_INTERVAL_MS,
+    );
+    this.onDegraded = options.onDegraded;
+    this.onRecovered = options.onRecovered;
   }
 
   async init(): Promise<void> {
@@ -247,6 +402,7 @@ export class BrowserPool {
           recycling: false,
           pendingOpens: 0,
           recyclePending: false,
+          generation: 0,
         };
         this.browsers.push(entry);
         this.attachDisconnectHandler(entry, browser);
@@ -323,20 +479,53 @@ export class BrowserPool {
   }
 
   /**
-   * Pick the live browser with the fewest live contexts. Skips entries that
-   * are recycling or whose browser has disconnected — acquire() must never
-   * open a context on a dying browser. Returns undefined when no live browser
-   * is available (caller enqueues a waiter; crash recovery fulfills it).
+   * Effective load of an entry: live (checked-out) contexts PLUS in-flight
+   * opens. Ranking by `liveContexts.size` alone is BLIND to opens that have
+   * reserved a slot but not yet settled into `liveContexts` — under a BURST of
+   * concurrent acquires every pick sees the same `liveContexts.size` and stacks
+   * the whole burst onto ONE browser process. That per-process context pileup
+   * is exactly the pthread_create EAGAIN thread spike that caused the outage.
+   * Counting `pendingOpens` spreads a burst across the set as the opens reserve.
+   */
+  private entryLoad(entry: BrowserEntry): number {
+    return entry.liveContexts.size + entry.pendingOpens;
+  }
+
+  /**
+   * Close a context, routing any failure through the structured logger instead
+   * of silently swallowing it. Mirrors `closeBrowser`: a context-close failure
+   * is non-fatal (the underlying browser may already be dead) but — per the
+   * `closeBrowser` doctrine that close failures must be visible to the harness
+   * log/Sentry pipeline — must not be swallowed by a bare `.catch(() => {})`.
+   */
+  private async closeContext(
+    context: BrowserContext,
+    browserIndex: number,
+  ): Promise<void> {
+    try {
+      await context.close();
+    } catch (err) {
+      this.logger?.warn?.("browser-pool.context-close-failed", {
+        browserIndex,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Pick the least-loaded live browser entry to open the next context on.
+   * Skips entries that are recycling or whose browser has disconnected —
+   * acquire() must never open a context on a dying browser. "Load" is measured
+   * by `entryLoad` (live contexts plus in-flight opens). Returns undefined when
+   * no live browser is available (caller enqueues a waiter; crash recovery
+   * fulfills it).
    */
   private pickLeastLoaded(): BrowserEntry | undefined {
     let best: BrowserEntry | undefined;
     for (const entry of this.browsers) {
       if (entry.recycling) continue;
       if (!entry.browser.isConnected()) continue;
-      if (
-        best === undefined ||
-        entry.liveContexts.size < best.liveContexts.size
-      ) {
+      if (best === undefined || this.entryLoad(entry) < this.entryLoad(best)) {
         best = entry;
       }
     }
@@ -439,8 +628,31 @@ export class BrowserPool {
     // it must not be handed out or counted. Mark the in-flight open so any
     // concurrent recycle/idle decision (`isEntryIdle`) sees it and does NOT
     // treat the entry as idle during this await window.
+    //
+    // GENERATION TOKEN: capture the entry's generation alongside the browser.
+    // If a recycle (crash OR hygiene) replaces the browser while this open is in
+    // flight, the recycle teardown rolls back THIS open's pendingOpens +
+    // reservation against the OLD generation. When the late settle finally
+    // arrives it sees `entry.generation !== genBefore` and decrements NOTHING —
+    // the fresh generation's counters are untouched. Without this, a crash
+    // teardown that rolled back in-flight reservations and the late settle would
+    // BOTH decrement → double rollback / negative count; or, if only the late
+    // settle decremented, it would decrement the FRESH generation → stuck
+    // pendingOpens that blocks every future hygiene recycle.
     const browserBefore = entry.browser;
+    const genBefore = entry.generation;
     entry.pendingOpens++;
+
+    // Roll back this open's accounting iff the entry is STILL the same
+    // generation we started on. A recycle that already accounted for this
+    // in-flight open (crash teardown) bumped the generation, so a late
+    // settle here is a no-op (the teardown owns the rollback).
+    const rollbackPendingOpen = (): void => {
+      if (entry.generation === genBefore && entry.pendingOpens > 0) {
+        entry.pendingOpens--;
+        this.releaseReservation();
+      }
+    };
 
     let context: BrowserContext;
     try {
@@ -451,10 +663,10 @@ export class BrowserPool {
         },
       });
     } catch (err) {
-      // The open failed — give the reserved slot back so it does not bleed
-      // capacity permanently, and clear the in-flight marker.
-      entry.pendingOpens--;
-      this.releaseReservation();
+      // The open failed — give the reserved slot back (if this generation still
+      // owns it) so it does not bleed capacity permanently, and clear the
+      // in-flight marker.
+      rollbackPendingOpen();
       throw err;
     }
 
@@ -464,16 +676,17 @@ export class BrowserPool {
     // the freshly-opened context is an orphan on a torn-down browser — closing
     // or otherwise counting it would corrupt the cap and could hand a dead
     // context to a holder. Detect that state, close the orphan, roll back the
-    // reservation + the in-flight marker, and surface as a failure so the
-    // caller's retry/enqueue path handles it.
+    // reservation + the in-flight marker (generation-guarded so a teardown that
+    // already rolled it back is not double-counted), and surface as a failure so
+    // the caller's retry/enqueue path handles it.
     if (
+      entry.generation !== genBefore ||
       entry.recycling ||
       entry.browser !== browserBefore ||
       !browserBefore.isConnected()
     ) {
-      entry.pendingOpens--;
-      this.releaseReservation();
-      void context.close().catch(() => {});
+      rollbackPendingOpen();
+      void this.closeContext(context, this.browsers.indexOf(entry));
       this.logger?.warn?.("browser-pool.open-orphaned-by-recycle", {
         browserIndex: this.browsers.indexOf(entry),
       });
@@ -536,14 +749,50 @@ export class BrowserPool {
       });
       return context;
     } catch (err) {
-      // The browser died between pickLeastLoaded and newContext. openContextOn
-      // already rolled the reservation back on failure, so RE-RESERVE before
-      // the retry — this keeps the retry path cap-correct instead of opening a
-      // context with no reservation behind it.
+      // FIX #7 — a `newContext()` throw does NOT prove the browser died. The
+      // unfixed code unconditionally recycled `entry`, so a TRANSIENT
+      // newContext error on a still-`isConnected()` shared browser tore down a
+      // healthy process AND abandoned its OTHER live contexts (the recycle
+      // teardown drops every live context of that entry). Gate the recycle on
+      // the SAME dead-vs-alive logic the orphan guard uses: only recycle when
+      // the browser is actually disconnected. openContextOn already rolled the
+      // reservation back on failure.
       this.logger?.warn?.("browser-pool.acquire-newcontext-failed", {
         browserIndex: this.browsers.indexOf(entry),
+        connected: entry.browser.isConnected(),
         error: err instanceof Error ? err.message : String(err),
       });
+      if (entry.browser.isConnected()) {
+        // TRANSIENT error on a live browser — do NOT destroy it (that would
+        // abandon its sibling live contexts). Re-reserve and retry the open on
+        // the SAME browser once; if that also throws, pend a waiter (served by a
+        // later release / recovery) rather than recycling a healthy process.
+        if (!this.reserveSlot()) {
+          return this.enqueueWaiter(options, timeoutMs);
+        }
+        try {
+          return await this.openContextOn(entry, options);
+        } catch (transientRetryErr) {
+          this.logger?.warn?.("browser-pool.acquire-transient-retry-failed", {
+            browserIndex: this.browsers.indexOf(entry),
+            connected: entry.browser.isConnected(),
+            error:
+              transientRetryErr instanceof Error
+                ? transientRetryErr.message
+                : String(transientRetryErr),
+          });
+          // openContextOn rolled the re-reservation back on this throw. If the
+          // browser is NOW disconnected, fall through to the dead-browser
+          // recovery below; otherwise pend a waiter without destroying it.
+          if (entry.browser.isConnected()) {
+            return this.enqueueWaiter(options, timeoutMs);
+          }
+        }
+      }
+      // The browser is dead — recycle it and try a sibling. openContextOn
+      // already rolled the reservation back, so RE-RESERVE before the retry —
+      // this keeps the retry path cap-correct instead of opening a context with
+      // no reservation behind it.
       this.recycleBrowser(entry);
       if (!this.reserveSlot()) {
         // Another concurrent acquire took the freed slot first — pend a waiter.
@@ -620,9 +869,11 @@ export class BrowserPool {
    * Serve the next FIFO waiter by creating a fresh context on the
    * least-loaded live browser with the waiter's stored options. Keeps the cap
    * saturated. If no live browser is available the waiter stays queued (a
-   * recovery relaunch serves it later). A newContext failure kicks the
-   * browser's recycle and re-queues the waiter at the FRONT so ordering is
-   * preserved.
+   * recovery relaunch serves it later). A newContext failure re-queues the
+   * waiter at the FRONT so ordering is preserved, then — mirroring acquire()'s
+   * FIX #7 — only recycles the browser when it is actually disconnected; a
+   * transient failure on a still-connected browser leaves the healthy process
+   * intact and re-drives the queue.
    */
   /**
    * Fire-and-forget recursive re-serve. The recursive `serveNextWaiter()`
@@ -667,14 +918,52 @@ export class BrowserPool {
     try {
       context = await this.openContextOn(entry, waiter.options);
     } catch (err) {
+      // FIX #7 (propagated to serveNextWaiter) — a `newContext()` throw does NOT
+      // prove the browser died. The unfixed code unconditionally recycled
+      // `entry`, so a TRANSIENT newContext error on a still-`isConnected()`
+      // shared browser tore down a healthy process AND abandoned its OTHER live
+      // contexts (the recycle teardown drops every live context of that entry).
+      // Under saturation (waiters queued — this module's target load) that
+      // destroys a healthy Chromium and fails every sibling probe. Gate the
+      // recycle on the SAME dead-vs-alive logic acquire() uses: only recycle
+      // when the browser is actually disconnected. openContextOn already rolled
+      // the reservation back on failure.
       this.logger?.warn?.("browser-pool.serve-waiter-failed", {
         browserIndex: this.browsers.indexOf(entry),
+        connected: entry.browser.isConnected(),
         error: err instanceof Error ? err.message : String(err),
       });
-      // openContextOn already rolled the reservation back on failure. Re-queue
-      // at the front so FIFO order is preserved, then recycle the dead browser.
-      // Its relaunch handoff re-attempts the queued waiters (which re-reserve).
+      // Re-queue at the FRONT so FIFO order is preserved regardless of which
+      // branch we take below.
       this.waiters.unshift(waiter);
+      if (entry.browser.isConnected()) {
+        // TRANSIENT error on a live browser — do NOT destroy it (that would
+        // abandon its sibling live contexts). Leave the browser intact.
+        //
+        // BOUND the re-drive to match acquire()'s "retry ONCE then enqueue"
+        // semantics. acquire() retries a transient open once and then leaves the
+        // caller enqueued for a future release/recovery event; serveNextWaiter
+        // must do the same. Without a ceiling, a persistently-transient
+        // `newContext()` on a connected browser hot-loops (schedule → serve →
+        // throw → unshift → schedule) through microtasks and starves the event
+        // loop until the waiter's acquire timeout fires. Self-reschedule only up
+        // to MAX_TRANSIENT_SERVE_RETRIES consecutive transient failures; past
+        // that, leave the waiter enqueued — a later release() / recycle handoff
+        // re-drives it (and resets the counter on the next genuine attempt).
+        const retries = (waiter.transientServeRetries ?? 0) + 1;
+        waiter.transientServeRetries = retries;
+        if (retries <= MAX_TRANSIENT_SERVE_RETRIES) {
+          this.scheduleServeNextWaiter();
+        } else {
+          this.logger?.warn?.("browser-pool.serve-waiter-transient-ceiling", {
+            browserIndex: this.browsers.indexOf(entry),
+            retries,
+          });
+        }
+        return;
+      }
+      // The browser is dead — recycle it. Its relaunch handoff re-attempts the
+      // queued waiters (which re-reserve).
       this.recycleBrowser(entry);
       return;
     }
@@ -690,13 +979,14 @@ export class BrowserPool {
       entry.liveContexts.delete(context);
       // openContextOn already did `entry.servedContexts++` for this context.
       // Since it is being orphan-closed and never delivered, mirror that
-      // increment with a decrement — otherwise every timed-out-mid-serve
-      // permanently inflates servedContexts and biases the hygiene recycle
-      // (servedContexts >= recycleAfter) to fire early, wasting PID budget on
-      // relaunches. (Bug 1)
-      entry.servedContexts--;
+      // increment with a decrement (clamped at 0) — otherwise every
+      // timed-out-mid-serve permanently inflates servedContexts and biases the
+      // hygiene recycle (servedContexts >= recycleAfter) to fire early, tripping
+      // a premature recycle → an extra chromium launch (the PID pressure this
+      // module exists to avoid). (Bug 1)
+      entry.servedContexts = Math.max(0, entry.servedContexts - 1);
       this.releaseReservation();
-      void context.close().catch(() => {});
+      void this.closeContext(context, this.browsers.indexOf(entry));
       this.logger?.warn?.("browser-pool.serve-waiter-orphan-closed", {
         browserIndex: this.browsers.indexOf(entry),
       });
@@ -711,13 +1001,18 @@ export class BrowserPool {
       return;
     }
 
+    // A genuine serve succeeded — clear any accumulated transient-retry count so
+    // the ceiling applies per consecutive-failure run, not cumulatively.
+    waiter.transientServeRetries = 0;
     waiter.resolve(context);
   }
 
   async release(context: BrowserContext): Promise<void> {
     if (this.isShutdown) {
-      // Best-effort close; nothing to track post-shutdown.
-      await context.close().catch(() => {});
+      // Best-effort close; nothing to track post-shutdown. Route through the
+      // helper so a close failure is logged (FIX#8 doctrine — no bare swallow).
+      // The owning entry is no longer tracked post-shutdown, so index is -1.
+      await this.closeContext(context, -1);
       return;
     }
 
@@ -742,18 +1037,26 @@ export class BrowserPool {
       inUse: this.liveContextCount,
     });
 
-    // Hygiene-recycle decision, captured SYNCHRONOUSLY against current state
-    // (no await gap above could have mutated liveContexts since the decrement).
-    // `isEntryRecyclable` consults BOTH liveContexts AND pendingOpens, so an
-    // in-flight open keeps the entry off the recycle path even though it isn't
-    // yet in liveContexts.
-    const shouldRecycle =
-      entry.servedContexts >= this.recycleAfter &&
-      this.isEntryRecyclable(entry);
+    // Hygiene-recycle intent, LATCHED synchronously: the instant this browser
+    // has served >= recycleAfter contexts, mark `recyclePending`. This is a
+    // sticky intent, NOT an immediate level check — once the threshold is
+    // reached the entry WILL be recycled at the next genuinely-idle release,
+    // even if that release served a waiter (deferring) or arrived while an open
+    // was in flight. Latching the intent (rather than re-deriving a level check
+    // each release) is what carries a deferred recycle FORWARD across a release
+    // that served a waiter: the firing condition below is `isEntryRecyclable &&
+    // recyclePending`, so a release that served the waiter (entry non-idle) does
+    // NOT recycle now but the intent survives to the next idle release. Under
+    // sustained saturation this closes the starvation the bare `!hadWaiter`
+    // guard caused (the recycle is deferred, never dropped).
+    if (entry.servedContexts >= this.recycleAfter) {
+      entry.recyclePending = true;
+    }
 
     // Close the released context AFTER the accounting/decision so the close
-    // await cannot straddle them. Best-effort; failure is non-fatal.
-    await context.close().catch(() => {});
+    // await cannot straddle them. Best-effort; failure is non-fatal but routed
+    // through the helper so it is LOGGED (FIX#8 doctrine — no bare swallow).
+    await this.closeContext(context, this.browsers.indexOf(entry));
 
     // Keep the cap saturated: if a waiter is queued, hand it a fresh context
     // on the least-loaded live browser now that capacity freed up. Capture
@@ -772,43 +1075,51 @@ export class BrowserPool {
       });
     }
 
-    // Hygiene recycle: once a browser has served enough contexts AND is idle
-    // (no live contexts, no in-flight opens), replace its process to bound
-    // memory/handle drift. This is the RARE path — it fires at most once per
-    // `recycleAfter` contexts per browser and never on a busy browser.
+    // Hygiene recycle: once a browser's recycle intent is latched
+    // (`recyclePending`, set above the instant served >= recycleAfter) AND the
+    // entry is genuinely recyclable (idle — no live contexts, no in-flight
+    // opens, not already recycling), replace its process to bound memory/handle
+    // drift. This is the RARE path — it fires at most once per `recycleAfter`
+    // contexts per browser and never on a busy browser.
     //
-    // The `!hadWaiter` guard (a prior fix) defers the recycle when a waiter was
-    // just served onto this freed slot, so the browser is not torn down under
-    // the just-served waiter. But under SUSTAINED saturation a waiter is queued
-    // at nearly every release, so on its own that guard STARVES the hygiene
-    // recycle — the documented memory/handle-drift bound is never met exactly
-    // when it matters. We close that without reintroducing the serve-vs-recycle
-    // race by carrying the deferred intent on `entry.recyclePending`:
-    //
-    //   - if shouldRecycle this round but a waiter was served, set the flag and
-    //     defer (do not recycle now);
-    //   - on EVERY release, if the entry is now genuinely recyclable (idle, no
-    //     pending opens, not already recycling) AND either shouldRecycle this
-    //     round OR a recycle is pending, fire it and clear the flag.
-    //
-    // Serving a waiter is asynchronous (`serveNextWaiter` reserves + opens on
-    // the next tick), so right after a serve the entry is NOT idle — either a
-    // live context exists or `pendingOpens > 0` — and `isEntryRecyclable`
-    // returns false, naturally deferring to the next genuinely-idle release.
-    if (shouldRecycle && hadWaiter) {
-      entry.recyclePending = true;
-    }
-    if (
-      this.isEntryRecyclable(entry) &&
-      (shouldRecycle || entry.recyclePending)
-    ) {
+    // Firing SOLELY off `recyclePending` (not a fresh level check) is what makes
+    // the carry-forward load-bearing: a release that served a queued waiter
+    // (`hadWaiter`) leaves the entry NOT idle right after — `serveNextWaiter`
+    // reserves + opens on the next tick, so either a live context exists or
+    // `pendingOpens > 0` — so `isEntryRecyclable` returns false and the recycle
+    // defers WITHOUT dropping the latched intent. The next genuinely-idle
+    // release fires it. (`hadWaiter` is still read above to drive the serve; the
+    // recycle decision intentionally does not gate on it — the idle check
+    // already prevents tearing down a just-served waiter.)
+    if (entry.recyclePending && this.isEntryRecyclable(entry)) {
       entry.recyclePending = false;
       this.recycleBrowser(entry, "hygiene");
     }
   }
 
+  /**
+   * Sleep `ms`, but resolve EARLY if the pool shuts down. Used by the self-heal
+   * loop and the relaunch backoff so a shutdown does not have to wait out a full
+   * `selfHealIntervalMs` / `relaunchBackoffMs` before those loops observe
+   * `isShutdown` and exit. The setTimeout is cleared when the shutdown signal
+   * wins so we leave no dangling timer.
+   */
+  private delayOrShutdown(ms: number): Promise<void> {
+    if (this.isShutdown || ms <= 0) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, ms);
+      void this.shutdownSignal.then(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
   async shutdown(): Promise<void> {
     this.isShutdown = true;
+    // Wake any racing self-heal / backoff delay so it aborts promptly instead of
+    // stalling shutdown for up to selfHealIntervalMs / relaunchBackoffMs.
+    this.resolveShutdownSignal?.();
 
     // Reject any queued waiters.
     for (const waiter of this.waiters) {
@@ -816,15 +1127,31 @@ export class BrowserPool {
     }
     this.waiters = [];
 
-    // Wait for in-flight recycles to finish before closing everything.
-    if (this.inFlightRecycles.size > 0) {
+    // Drain in-flight recycles + self-heal loops in a LOOP, re-snapshotting each
+    // pass. A ONE-TIME snapshot is racy: a self-heal iteration (or an
+    // in-flight-recovery relaunch) can register a NEW promise in
+    // `inFlightRecycles` AFTER the snapshot — and that late iteration may launch
+    // a fresh chromium AFTER shutdown returned, leaking the process. Loop until
+    // the set is genuinely empty (each settled loop/recycle has dropped its
+    // handle), so we await every late-registered iteration too. The loops all
+    // check `isShutdown` and the delays abort via the shutdown signal, so this
+    // converges promptly.
+    while (this.inFlightRecycles.size > 0) {
       await Promise.allSettled(Array.from(this.inFlightRecycles));
     }
 
-    // Close every live context, then every browser. Route through closeBrowser
-    // so a close failure is logged with its browser index.
+    // Close every live context, then every browser. Route through the close
+    // helpers so a close failure is logged with its browser index. A late
+    // self-heal iteration that pushed a browser just before observing
+    // `isShutdown` is captured here because we close AFTER the drain loop above
+    // fully quiesced.
     const contextClosers = Array.from(this.contextToBrowser.keys()).map((c) =>
-      c.close().catch(() => {}),
+      // Resolve the REAL owning-browser index for the log — not the key's
+      // iteration position. The owner is the entry the context maps to.
+      this.closeContext(
+        c,
+        this.browsers.indexOf(this.contextToBrowser.get(c)!),
+      ),
     );
     await Promise.allSettled(contextClosers);
 
@@ -928,6 +1255,23 @@ export class BrowserPool {
     }
     entry.liveContexts.clear();
 
+    // FIX #3 — account for in-flight opens at crash teardown. An
+    // `openContextOn` that reserved a slot (liveContextCount++ / pendingOpens++)
+    // but is still awaiting `newContext()` against a now-dead browser may NEVER
+    // settle (a crashed chromium's pending newContext() can hang forever) — so
+    // its reservation would bleed capacity permanently and wedge the pool. Roll
+    // those reservations back HERE, then BUMP the generation: any late settle of
+    // those opens compares its captured generation, sees the mismatch, and rolls
+    // back NOTHING (the rollback below already owns it — no double rollback).
+    // The generation bump also covers the hygiene path (reason can only be
+    // hygiene when pendingOpens === 0, so the rollback loop is a no-op there),
+    // keeping generation strictly monotonic per replacement.
+    for (let i = 0; i < entry.pendingOpens; i++) {
+      this.releaseReservation();
+    }
+    entry.pendingOpens = 0;
+    entry.generation++;
+
     const oldBrowser = entry.browser;
 
     const recyclePromise = (async () => {
@@ -936,7 +1280,13 @@ export class BrowserPool {
       if (this.isShutdown) return;
 
       try {
-        const fresh = await this.launchBrowser();
+        // FIX #1 — PID-ceiling backpressure: retry the relaunch with backoff
+        // before giving up the entry. A `pthread_create: Resource temporarily
+        // unavailable (errno 11)` at the thread ceiling is TRANSIENT; the
+        // unfixed code evicted on the first throw, so a thread-exhaustion storm
+        // drained every entry and wedged the pool. Pacing the relaunch and
+        // surviving a transient EAGAIN keeps the entry alive.
+        const fresh = await this.relaunchWithBackoff(browserIdx);
         if (this.isShutdown) {
           await this.closeBrowser(fresh, this.browsers.indexOf(entry));
           return;
@@ -944,6 +1294,13 @@ export class BrowserPool {
         entry.browser = fresh;
         entry.servedContexts = 0;
         entry.liveContexts.clear();
+        // FIX #2 — reset pendingOpens onto the fresh generation. The crash
+        // teardown above already rolled back the OLD generation's in-flight
+        // opens and bumped the generation, so any late settle is a no-op; but
+        // reset to 0 explicitly so the fresh browser starts with a clean
+        // in-flight count and a stale ≥1 can never block all future hygiene
+        // recycles (nor a stray decrement drive it negative).
+        entry.pendingOpens = 0;
         entry.recycling = false;
         // The deferred-recycle intent was satisfied by THIS recycle — clear it
         // so the fresh browser does not inherit a stale "recycle me" flag.
@@ -966,20 +1323,43 @@ export class BrowserPool {
           if (this.waiters.length >= before) break;
         }
       } catch (err) {
-        // Launch failed — evict the entry so it does not masquerade as live
-        // capacity. If the browser set is now empty and waiters are queued,
-        // reject them all (no process can serve them).
+        // FIX #9 — a relaunch failure DURING shutdown is benign, not a capacity
+        // outage. The relaunch loop aborts the moment `isShutdown` flips
+        // (relaunchWithBackoff throws), and that throw landed here. Logging it at
+        // ERROR + running the degraded/self-heal semantics would emit a phantom
+        // alarm and spawn a self-heal loop on a pool that is intentionally going
+        // away. Downgrade to a benign debug log and skip the error/degraded path.
+        if (this.isShutdown) {
+          this.logger?.info?.(
+            "browser-pool.recycle-relaunch-aborted-shutdown",
+            {
+              browserIndex: this.browsers.indexOf(entry),
+            },
+          );
+          const idx = this.browsers.indexOf(entry);
+          if (idx !== -1) this.browsers.splice(idx, 1);
+          return;
+        }
+        // Relaunch retries exhausted — evict the entry so it does not
+        // masquerade as live capacity.
         this.logger?.error?.("browser-pool.recycle-relaunch-failed", {
           browserIndex: this.browsers.indexOf(entry),
           error: err instanceof Error ? err.message : String(err),
         });
         const idx = this.browsers.indexOf(entry);
         if (idx !== -1) this.browsers.splice(idx, 1);
-        if (this.browsers.length === 0 && this.waiters.length > 0) {
-          for (const waiter of this.waiters) {
-            waiter.reject(new Error("BrowserPool has no live browsers"));
-          }
-          this.waiters = [];
+        // FIX #2 — self-heal + alarm on empty browser set. The unfixed code
+        // rejected all waiters here and then sat permanently dead: the set was
+        // empty, pickLeastLoaded() returned undefined forever, every future
+        // acquire timed out, and NO degraded signal was ever emitted (it only
+        // fired on init() failure). Instead, when the set empties we fire the
+        // degraded alarm AND kick a background self-heal loop that keeps trying
+        // to relaunch a fresh set — so a thread-exhaustion window that later
+        // relaxes recovers without a manual redeploy. Queued waiters are NOT
+        // mass-rejected: each still honors its own acquire timeout, and the
+        // self-heal drains any still-waiting on success.
+        if (this.browsers.length === 0) {
+          this.onBrowserSetEmpty();
         }
       }
     })();
@@ -1001,5 +1381,205 @@ export class BrowserPool {
         // in-flight tracking handle here.
         this.inFlightRecycles.delete(recyclePromise);
       });
+  }
+
+  /**
+   * FIX #1 — relaunch a browser with bounded retry + linear backoff. The first
+   * attempt is immediate; each subsequent attempt waits `relaunchBackoffMs *
+   * attempt` (also gated by the launch-stagger). Surfaces the LAST error if all
+   * attempts are exhausted (the caller evicts + self-heals). A pool shutdown
+   * mid-retry aborts the loop. `relaunchMaxRetries === 0` reproduces the legacy
+   * fail-fast behavior (one attempt, no retry) — tests use it to drive the
+   * empty-set path deterministically.
+   */
+  private async relaunchWithBackoff(browserIdx: number): Promise<Browser> {
+    let lastErr: unknown;
+    const totalAttempts = this.relaunchMaxRetries + 1;
+    for (let attempt = 0; attempt < totalAttempts; attempt++) {
+      if (this.isShutdown) {
+        throw lastErr instanceof Error
+          ? lastErr
+          : new Error("BrowserPool shut down during relaunch");
+      }
+      if (attempt > 0 && this.relaunchBackoffMs > 0) {
+        // Abort the backoff PROMPTLY on shutdown instead of waiting it out.
+        await this.delayOrShutdown(this.relaunchBackoffMs * attempt);
+        if (this.isShutdown) {
+          throw lastErr instanceof Error
+            ? lastErr
+            : new Error("BrowserPool shut down during relaunch");
+        }
+      }
+      try {
+        return await this.launchBrowser();
+      } catch (err) {
+        lastErr = err;
+        this.logger?.warn?.("browser-pool.relaunch-attempt-failed", {
+          browserIndex: browserIdx,
+          attempt: attempt + 1,
+          maxAttempts: totalAttempts,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    throw lastErr instanceof Error
+      ? lastErr
+      : new Error("browser-pool: relaunch retries exhausted");
+  }
+
+  /**
+   * FIX #2 (alarm half) — invoked the moment the browser set empties mid-life.
+   * Emits the `system:browser-pool-degraded=red` alarm via `onDegraded` (the
+   * mid-life signal the unfixed code never sent — it only fired on init()
+   * failure, so this outage was silent) and kicks the self-heal loop. Idempotent
+   * via the `degraded` flag so a burst of concurrent evictions fires the alarm /
+   * spawns the loop exactly once.
+   */
+  private onBrowserSetEmpty(): void {
+    if (this.isShutdown) return;
+    // Fire the degraded alarm exactly once per degraded episode (idempotent via
+    // `degraded`). The alarm hook is gated, but the self-heal loop is NOT: if
+    // the set empties AGAIN while `degraded` is still true but NO heal loop is
+    // running (e.g. a heal that partially revived the set, then the survivor
+    // crashed and re-emptied before recovery completed), the old `if (degraded)
+    // return` short-circuit would leave `degraded + empty + !selfHealing` as a
+    // TERMINAL dead state with no active heal path — pool permanently dead. So
+    // always (re)spawn the heal loop on empty; `startSelfHeal` is itself
+    // idempotent via `selfHealing`.
+    if (!this.degraded) {
+      this.degraded = true;
+      this.logger?.error?.("browser-pool.set-empty-degraded", {
+        waiters: this.waiters.length,
+        browserCount: this.browserCount,
+      });
+      this.safeHook(this.onDegraded, "onDegraded");
+    }
+    this.startSelfHeal();
+  }
+
+  /**
+   * FIX #2 (self-heal half) — background loop that keeps trying to relaunch a
+   * fresh browser set after the set has emptied. Each iteration attempts to
+   * launch `browserCount` browsers (through the stagger gate); the FIRST
+   * successful launch is enough to revive capacity — it is pushed as a live
+   * entry and queued waiters are drained onto it, then the loop tops the set
+   * back up to `browserCount`. On a fully-failed iteration it waits
+   * `selfHealIntervalMs` and retries, until success or shutdown. On recovery it
+   * clears `degraded` and fires `onRecovered`. Guarded by `selfHealing` so only
+   * one loop runs at a time.
+   */
+  private startSelfHeal(): void {
+    if (this.selfHealing) return;
+    this.selfHealing = true;
+    const loop = (async () => {
+      // Keep iterating until the set is restored to FULL strength
+      // (`browserCount`), not merely non-empty. The unfixed loop broke + fired
+      // onRecovered the instant ONE browser revived, even though the pool target
+      // is `browserCount` — silently reporting green while under-provisioned. We
+      // top the set up across iterations (each iteration relaunches the
+      // remaining shortfall, backing off between failed iterations) and only
+      // fire onRecovered once at full strength.
+      while (!this.isShutdown && this.browsers.length < this.browserCount) {
+        let launchedAny = false;
+        const shortfall = this.browserCount - this.browsers.length;
+        for (let i = 0; i < shortfall; i++) {
+          if (this.isShutdown) break;
+          try {
+            const fresh = await this.launchBrowser();
+            if (this.isShutdown) {
+              await this.closeBrowser(fresh, this.browsers.length);
+              break;
+            }
+            const revived: BrowserEntry = {
+              browser: fresh,
+              liveContexts: new Set(),
+              servedContexts: 0,
+              recycling: false,
+              pendingOpens: 0,
+              recyclePending: false,
+              generation: 0,
+            };
+            this.browsers.push(revived);
+            this.attachDisconnectHandler(revived, fresh);
+            launchedAny = true;
+            // Drain queued waiters onto the revived browser as capacity returns.
+            while (
+              this.waiters.length > 0 &&
+              this.liveContextCount < this.maxContexts &&
+              fresh.isConnected()
+            ) {
+              const before = this.waiters.length;
+              await this.serveNextWaiter();
+              if (this.waiters.length >= before) break;
+            }
+          } catch (err) {
+            this.logger?.warn?.("browser-pool.self-heal-launch-failed", {
+              attemptIndex: i,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+        if (this.browsers.length >= this.browserCount) {
+          // FULL capacity restored — clear degraded + signal recovery exactly
+          // once at full strength.
+          break;
+        }
+        // The set is not yet at full strength. If NOTHING launched this
+        // iteration, back off before retrying so we keep pacing relaunches into
+        // a still-exhausted kernel instead of busy-spinning. If SOME launched
+        // (partial recovery) loop straight back to top up the remainder, but
+        // still yield a macrotask so the loop stays cancellable.
+        if (!launchedAny && !this.isShutdown && this.selfHealIntervalMs > 0) {
+          await this.delayOrShutdown(this.selfHealIntervalMs);
+        } else if (!this.isShutdown) {
+          // Interval-0 path OR partial-progress iteration: yield a REAL
+          // macrotask so the loop is cancellable and does not starve other
+          // timers (a microtask yield would not let pending setTimeouts run).
+          await delay(0);
+        }
+      }
+      // Fire recovery iff we actually came back up (full strength) and were not
+      // torn down. A shutdown-aborted loop must NOT report recovery.
+      if (!this.isShutdown && this.browsers.length >= this.browserCount) {
+        this.degraded = false;
+        this.logger?.info("browser-pool.self-heal-recovered", {
+          browsers: this.browsers.length,
+          browserCount: this.browserCount,
+          waiters: this.waiters.length,
+        });
+        this.safeHook(this.onRecovered, "onRecovered");
+      }
+      this.selfHealing = false;
+    })();
+    // Track the self-heal loop so shutdown() awaits it (it checks isShutdown and
+    // exits promptly). Route any unexpected throw to the logger.
+    this.inFlightRecycles.add(loop);
+    loop
+      .catch((err: unknown) => {
+        this.logger?.error?.("browser-pool.self-heal-failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        this.selfHealing = false;
+        this.inFlightRecycles.delete(loop);
+      });
+  }
+
+  /**
+   * Invoke a best-effort lifecycle hook (`onDegraded` / `onRecovered`) without
+   * letting a throwing hook crash the pool. A hook failure is logged, not
+   * propagated.
+   */
+  private safeHook(hook: (() => void) | undefined, name: string): void {
+    if (!hook) return;
+    try {
+      hook();
+    } catch (err) {
+      this.logger?.error?.("browser-pool.hook-failed", {
+        hook: name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary

Hardens the showcase harness's long-lived chromium browser-pool against the OS thread / PID-ceiling exhaustion failure mode that took staging down. The pool now survives a `pthread_create: Resource temporarily unavailable` (errno 11) storm, self-heals when the kernel relaxes, alarms loudly on mid-life capacity loss, and is given ample thread headroom in the container.

### The incident this fixes
On **2026-06-03** the harness container hit the thread/PID ceiling: the long-lived chromium pool (`MAX_CONTEXTS=40`, several hundred OS threads at steady state) tripped `pthread_create: EAGAIN` on `chromium.launch()` / mid-life context opens. Every relaunch attempt re-threw, so the crash-recovery path spliced each browser **out** of the set until it **emptied**. After that `pickLeastLoaded()` returned undefined forever, every `acquire()` enqueued a waiter that hit the 30s timeout, and the pool sat **permanently dead** with **no alarm** (degraded=red only fired on `init()` failure, never on mid-life set death) — **626 D0-red dashboard cells** until a manual redeploy.

### The hardening
- **Relaunch backpressure** — a transient EAGAIN on relaunch is retried with bounded linear backoff before the entry is evicted, so a thread-exhaustion window that relaxes within seconds recovers in place instead of draining the set.
- **Self-heal + degraded/recovered alarm** — when the set empties mid-life the pool fires an `onDegraded` red alarm and kicks a background self-heal loop that relaunches a fresh set the moment a launch succeeds, then fires `onRecovered`. No manual redeploy. The orchestrator wires these hooks to the shared `system:browser-pool-degraded` red/green signal.
- **Bounded `serveNextWaiter` transient re-drive** — a persistently-transient `newContext()` on a still-connected browser no longer hot-loops the event loop; it self-reschedules up to a ceiling, then leaves the waiter queued for a later release/recovery handoff.
- **Container thread ulimit** — the Dockerfile lifts the soft `nproc` limit to the hard ceiling (`ulimit -u $(ulimit -Hu)`) before exec'ing the orchestrator, giving the legitimate 40-context workload thread headroom instead of running near the default ~1024 soft ceiling. `MAX_CONTEXTS` stays 40 — the constraint was THREADS, not memory.
- **Accounting hardening** — generation-token guard on in-flight opens across a recycle, clamped `servedContexts` rollback on orphan-close, deferred-recycle re-check on non-release teardown paths, and waiter-drain on orphan-by-recycle rollback.

This builds cleanly on top of the recently-landed #5174 browser-pool teardown-concurrency hardening (BUCKET-D); both invariant sets are preserved.

## Test plan

- [x] `tsc --noEmit` (harness) clean on top of current `main`
- [x] Full harness vitest suite green: **1735 passed / 0 failed** (100 files) — includes #5174's BUCKET-D tests + the new crash-recovery/self-heal/serve-retry regressions
- [x] Each fix written red→green (degraded-alarm-on-empty, self-heal-after-relax, waiter-served-by-self-heal, transient-relaunch-retry-survives)
- [ ] Roll out to staging and confirm the `system:browser-pool-degraded` red/green signal toggles on an induced set-empty (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)