### PR TITLE
docs: fix broken links in self-hosting guide

### DIFF
--- a/docs/snippets/shared/premium/self-hosting.mdx
+++ b/docs/snippets/shared/premium/self-hosting.mdx
@@ -51,13 +51,13 @@ Both paths use the same install commands described below — pick whichever fits
 
 ## Prerequisites
 
-Before starting, make sure the following are in place. The [How the Intelligence Platform Works](/learn/intelligence-platform) page explains the layering in more depth.
+Before starting, make sure the following are in place. The [How the Intelligence Platform Works](/premium/intelligence-platform) page explains the layering in more depth.
 
 **License and registry access:**
 
 - A valid CopilotKit Intelligence Platform license key (contact your CopilotKit account team if you do not have one)
 - Read access to the chart OCI registry at `oci://ghcr.io/copilotkit/charts/intelligence` (anonymous pulls are allowed for the released chart)
-- The latest released chart version. Check the [chart releases](https://github.com/CopilotKit/Intelligence/pkgs/container/charts%2Fintelligence) on GHCR; substitute the value into the `<chart-version>` placeholder used throughout this guide (e.g. `0.1.0-rc.16`).
+- The latest released chart version. Check the [chart releases](https://github.com/orgs/CopilotKit/packages/container/package/charts%2Fintelligence) on GHCR; substitute the value into the `<chart-version>` placeholder used throughout this guide (e.g. `0.1.0-rc.16`).
 
 **Cluster and tooling:**
 
@@ -600,6 +600,6 @@ Per-service keys `podDisruptionBudget`, `podAntiAffinity`, and `networkPolicy` a
 
 ## Next steps
 
-- **Understand how it works:** [How the Intelligence Platform Works](/learn/intelligence-platform) — architecture, multi-tenancy model, platform layering, and the decision between hosted and self-hosted
+- **Understand how it works:** [How the Intelligence Platform Works](/premium/intelligence-platform) — architecture, multi-tenancy model, platform layering, and the decision between hosted and self-hosted
 - **Premium features overview:** [CopilotKit Premium](/premium/overview) — all premium capabilities that require an Intelligence license
 - **Use threads in your app:** [Threads](/threads) — the persistent-conversation surface powered by the Intelligence Platform you just deployed


### PR DESCRIPTION
## Summary

Two body links on the **Self-Hosting Intelligence** page (`/<framework>/premium/self-hosting`, rendered from the shared snippet `docs/snippets/shared/premium/self-hosting.mdx`) were broken in production:

- **"How the Intelligence Platform Works"** (Prerequisites + Next steps) linked `/learn/intelligence-platform`. The `NavigationLink` rewriter (`docs/components/react/subdocs-menu.tsx`) makes absolute links section-relative, so under each framework it became `/<framework>/learn/intelligence-platform` → **404**. The page is served at `/premium/intelligence-platform` in every section (verified live across built-in-agent, langgraph, mastra, crewai, agno, and root). Changed both occurrences to `/premium/intelligence-platform`, matching the sibling premium links (`/premium/overview`).
- **"chart releases" (GHCR)** used the repo-scoped package URL for the private `CopilotKit/Intelligence` repo → **404** for public readers. Switched to the public org-scoped package URL `github.com/orgs/CopilotKit/packages/container/package/charts%2Fintelligence` (200). The `oci://ghcr.io/...` pull itself was already fine — only the web link was broken.

The other two body links (`/premium/overview`, `/threads`) and all in-page anchors were already valid.

## Why this shipped broken

`scripts/check-broken-links.js` only scans `content/docs` and `components` — it never looks at `snippets/`, so links in shared snippets are completely unvalidated. Extending the checker to cover `snippets/` (and to model the section-relative rewriting) would catch this class of bug. Not included here to keep this PR focused — happy to follow up.

## Test plan

- [x] `/built-in-agent/premium/intelligence-platform` returns 200 (verified across built-in-agent, langgraph, mastra, crewai, agno, and root prefixes)
- [x] Org-scoped GHCR package URL returns 200
- [x] Pre-commit hooks pass (`test-and-check-packages`, `commitlint`)
- [ ] Confirm on docs preview deploy that both links resolve from the rendered page