### PR TITLE
fix(examples): resolve starter smoke failures (v2 tool params + langgraph-js CLI)

### DIFF
--- a/examples/integrations/a2a-middleware/components/chat.tsx
+++ b/examples/integrations/a2a-middleware/components/chat.tsx
@@ -14,6 +14,7 @@ import {
 // NOTE: useCopilotChat has no v2 equivalent; kept on v1 import path
 import { useCopilotChat } from "@copilotkit/react-core";
 import "@copilotkit/react-core/v2/styles.css";
+import { z } from "zod";
 import { MessageToA2A } from "./a2a/MessageToA2A";
 import { MessageFromA2A } from "./a2a/MessageFromA2A";
 
@@ -89,18 +90,12 @@ const ChatInner = ({ onResearchUpdate, onAnalysisUpdate }: ChatProps) => {
     name: "send_message_to_a2a_agent",
     description: "Sends a message to an A2A agent",
     available: "frontend",
-    parameters: [
-      {
-        name: "agentName",
-        type: "string",
-        description: "The name of the A2A agent to send the message to",
-      },
-      {
-        name: "task",
-        type: "string",
-        description: "The message to send to the A2A agent",
-      },
-    ],
+    parameters: z.object({
+      agentName: z
+        .string()
+        .describe("The name of the A2A agent to send the message to"),
+      task: z.string().describe("The message to send to the A2A agent"),
+    }),
     render: (actionRenderProps) => {
       return (
         <>

--- a/examples/integrations/a2a-middleware/package.json
+++ b/examples/integrations/a2a-middleware/package.json
@@ -22,7 +22,8 @@
     "hono": "^4",
     "next": "15.5.15",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/examples/integrations/adk/package.json
+++ b/examples/integrations/adk/package.json
@@ -21,7 +21,8 @@
     "next": "16.1.1",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "shiki": "^3.19.0"
+    "shiki": "^3.19.0",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/examples/integrations/adk/src/app/page.tsx
+++ b/examples/integrations/adk/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
   CopilotSidebar,
 } from "@copilotkit/react-core/v2";
 import React, { useState } from "react";
+import { z } from "zod";
 
 export default function CopilotKitPage() {
   const [themeColor, setThemeColor] = useState("#6366f1");
@@ -19,13 +20,11 @@ export default function CopilotKitPage() {
   // 🪁 Frontend Actions: https://docs.copilotkit.ai/adk/frontend-actions
   useFrontendTool({
     name: "setThemeColor",
-    parameters: [
-      {
-        name: "themeColor",
-        description: "The theme color to set. Make sure to pick nice colors.",
-        required: true,
-      },
-    ],
+    parameters: z.object({
+      themeColor: z
+        .string()
+        .describe("The theme color to set. Make sure to pick nice colors."),
+    }),
     handler({ themeColor }) {
       setThemeColor(themeColor);
     },

--- a/examples/integrations/agno/src/app/page.tsx
+++ b/examples/integrations/agno/src/app/page.tsx
@@ -7,6 +7,7 @@ import {
   CopilotSidebar,
 } from "@copilotkit/react-core/v2";
 import React, { useState } from "react";
+import { z } from "zod";
 import { DefaultToolComponent } from "@/components/default-tool-ui";
 import { WeatherCard } from "@/components/weather";
 
@@ -16,13 +17,11 @@ export default function CopilotKitPage() {
   // 🪁 Frontend Actions: https://docs.copilotkit.ai/guides/frontend-actions
   useFrontendTool({
     name: "set_theme_color",
-    parameters: [
-      {
-        name: "theme_color",
-        description: "The theme color to set. Make sure to pick nice colors.",
-        required: true,
-      },
-    ],
+    parameters: z.object({
+      theme_color: z
+        .string()
+        .describe("The theme color to set. Make sure to pick nice colors."),
+    }),
     handler({ theme_color }) {
       setThemeColor(theme_color);
     },
@@ -79,13 +78,11 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
   // 🪁 Frontend Actions: https://docs.copilotkit.ai/agno/frontend-tools
   useFrontendTool({
     name: "add_proverb",
-    parameters: [
-      {
-        name: "proverb",
-        description: "The proverb to add. Make it witty, short and concise.",
-        required: true,
-      },
-    ],
+    parameters: z.object({
+      proverb: z
+        .string()
+        .describe("The proverb to add. Make it witty, short and concise."),
+    }),
     handler: ({ proverb }) => {
       setState({
         ...state,

--- a/examples/integrations/langgraph-js/agent/package.json
+++ b/examples/integrations/langgraph-js/agent/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "dev": "npx @langchain/langgraph-cli@1.2.1 dev --port 8123 --no-browser"
+    "dev": "langgraphjs dev --port 8123 --no-browser"
   },
   "dependencies": {
     "@copilotkit/sdk-js": "1.56.5",
@@ -18,6 +18,7 @@
     "langchain": "1.3.4"
   },
   "devDependencies": {
+    "@langchain/langgraph-cli": "1.2.4",
     "@types/html-to-text": "^9.0.4",
     "@types/node": "^22.9.0",
     "typescript": "^5.6.3"

--- a/examples/integrations/llamaindex/src/app/page.tsx
+++ b/examples/integrations/llamaindex/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { z } from "zod";
 import { WeatherCard } from "@/components/WeatherCard";
 
 import {
@@ -15,13 +16,11 @@ export default function CopilotKitPage() {
   // 🪁 Frontend Actions: https://docs.copilotkit.ai/guides/frontend-actions
   useFrontendTool({
     name: "change_theme_color",
-    parameters: [
-      {
-        name: "theme_color",
-        description: "The theme color to set. Make sure to pick nice colors.",
-        required: true,
-      },
-    ],
+    parameters: z.object({
+      theme_color: z
+        .string()
+        .describe("The theme color to set. Make sure to pick nice colors."),
+    }),
     handler({ theme_color }) {
       setThemeColor(theme_color);
     },
@@ -66,13 +65,11 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
   // 🪁 Frontend Actions: https://docs.copilotkit.ai/coagents/frontend-actions
   useFrontendTool({
     name: "add_proverb",
-    parameters: [
-      {
-        name: "proverb",
-        description: "The proverb to add. Make it witty, short and concise.",
-        required: true,
-      },
-    ],
+    parameters: z.object({
+      proverb: z
+        .string()
+        .describe("The proverb to add. Make it witty, short and concise."),
+    }),
     handler: ({ proverb }) => {
       setState({
         ...state,
@@ -86,7 +83,9 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
     name: "get_weather",
     description: "Get the weather for a given location.",
     available: "disabled",
-    parameters: [{ name: "location", type: "string", required: true }],
+    parameters: z.object({
+      location: z.string(),
+    }),
     render: ({ args }) => {
       return <WeatherCard location={args.location} themeColor={themeColor} />;
     },

--- a/examples/integrations/mastra/src/app/page.tsx
+++ b/examples/integrations/mastra/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
   CopilotSidebar,
 } from "@copilotkit/react-core/v2";
 import { useState } from "react";
+import { z } from "zod";
 
 export default function CopilotKitPage() {
   const [themeColor, setThemeColor] = useState("#6366f1");
@@ -18,13 +19,11 @@ export default function CopilotKitPage() {
   // 🪁 Frontend Actions: https://docs.copilotkit.ai/mastra/frontend-actions
   useFrontendTool({
     name: "setThemeColor",
-    parameters: [
-      {
-        name: "themeColor",
-        description: "The theme color to set. Make sure to pick nice colors.",
-        required: true,
-      },
-    ],
+    parameters: z.object({
+      themeColor: z
+        .string()
+        .describe("The theme color to set. Make sure to pick nice colors."),
+    }),
     handler({ themeColor }) {
       setThemeColor(themeColor);
     },
@@ -94,7 +93,9 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
       name: "weatherTool",
       description: "Get the weather for a given location.",
       available: "disabled",
-      parameters: [{ name: "location", type: "string", required: true }],
+      parameters: z.object({
+        location: z.string(),
+      }),
       render: ({ args }) => {
         return <WeatherCard location={args.location} themeColor={themeColor} />;
       },

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
   CopilotSidebar,
 } from "@copilotkit/react-core/v2";
 import { useState } from "react";
+import { z } from "zod";
 import { AgentState } from "@/lib/types";
 
 export default function CopilotKitPage() {
@@ -19,14 +20,11 @@ export default function CopilotKitPage() {
   useFrontendTool({
     name: "setThemeColor",
     description: "Set the theme color of the application",
-    parameters: [
-      {
-        name: "themeColor",
-        type: "string",
-        description: "The theme color to set. Make sure to pick nice colors.",
-        required: true,
-      },
-    ],
+    parameters: z.object({
+      themeColor: z
+        .string()
+        .describe("The theme color to set. Make sure to pick nice colors."),
+    }),
     handler: async ({ themeColor }) => {
       setThemeColor(themeColor);
     },
@@ -96,7 +94,9 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
       name: "get_weather",
       description: "Get the weather for a given location.",
       available: "disabled",
-      parameters: [{ name: "location", type: "string", required: true }],
+      parameters: z.object({
+        location: z.string(),
+      }),
       render: ({ args }) => {
         return <WeatherCard location={args.location} themeColor={themeColor} />;
       },

--- a/examples/integrations/ms-agent-framework-python/src/app/page.tsx
+++ b/examples/integrations/ms-agent-framework-python/src/app/page.tsx
@@ -15,6 +15,7 @@ import {
   CopilotSidebar,
 } from "@copilotkit/react-core/v2";
 import { useState } from "react";
+import { z } from "zod";
 
 export default function CopilotKitPage() {
   const [themeColor, setThemeColor] = useState("#6366f1");
@@ -22,13 +23,11 @@ export default function CopilotKitPage() {
   // 🪁 Frontend Actions: https://docs.copilotkit.ai/microsoft-agent-framework/frontend-actions
   useFrontendTool({
     name: "setThemeColor",
-    parameters: [
-      {
-        name: "themeColor",
-        description: "The theme color to set. Make sure to pick nice colors.",
-        required: true,
-      },
-    ],
+    parameters: z.object({
+      themeColor: z
+        .string()
+        .describe("The theme color to set. Make sure to pick nice colors."),
+    }),
     handler({ themeColor }) {
       setThemeColor(themeColor);
     },
@@ -97,7 +96,9 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
     {
       name: "get_weather",
       description: "Get the weather for a given location.",
-      parameters: [{ name: "location", type: "string", required: true }],
+      parameters: z.object({
+        location: z.string(),
+      }),
       render: ({ args }) => {
         return <WeatherCard location={args.location} themeColor={themeColor} />;
       },

--- a/examples/integrations/pydantic-ai/src/app/page.tsx
+++ b/examples/integrations/pydantic-ai/src/app/page.tsx
@@ -15,6 +15,7 @@ import {
   CopilotSidebar,
 } from "@copilotkit/react-core/v2";
 import { useState } from "react";
+import { z } from "zod";
 
 export default function CopilotKitPage() {
   const [themeColor, setThemeColor] = useState("#6366f1");
@@ -22,13 +23,11 @@ export default function CopilotKitPage() {
   // 🪁 Frontend Actions: https://docs.copilotkit.ai/pydantic-ai/frontend-actions
   useFrontendTool({
     name: "setThemeColor",
-    parameters: [
-      {
-        name: "themeColor",
-        description: "The theme color to set. Make sure to pick nice colors.",
-        required: true,
-      },
-    ],
+    parameters: z.object({
+      themeColor: z
+        .string()
+        .describe("The theme color to set. Make sure to pick nice colors."),
+    }),
     handler({ themeColor }) {
       setThemeColor(themeColor);
     },
@@ -97,7 +96,9 @@ function YourMainContent({ themeColor }: { themeColor: string }) {
     {
       name: "get_weather",
       description: "Get the weather for a given location.",
-      parameters: [{ name: "location", type: "string", required: true }],
+      parameters: z.object({
+        location: z.string(),
+      }),
       render: ({ args, result }) => {
         return <WeatherCard location={args.location} themeColor={themeColor} />;
       },


### PR DESCRIPTION
## Summary

Fixes two distinct starter smoke-test failure classes in `examples/integrations`.

### Issue A — v2 migration left tool `parameters` in the old v1 array shape

The v1→v2 migration (commit 23af69041) moved starters to v2 hooks but left tool
`parameters` as `[{ name, type, description, required }]`, which does not satisfy
v2's `FrontendTool.parameters?: StandardSchemaV1` (Zod) contract. This produced:

```
Type error: Property '"~standard"' is missing in type
'{ name; type; description; required }[]'
but required in type 'StandardSchemaV1<any, Record<string, unknown>>'.
```

…failing the Next.js build for starters whose Docker smoke build runs full
TypeScript checking (mastra, ms-agent-framework-python, adk — their Dockerfiles
do NOT patch `ignoreBuildErrors`).

**Fix:** convert each tool's `parameters` array to a `z.object({...})` schema
(matching the v2 contract) so typed `args`/handler arguments resolve. Added `zod`
as a dependency to the two starters that lacked it (adk, a2a-middleware).

Affected starters / tools:
- **adk** — `setThemeColor`
- **agno** — `set_theme_color`, `add_proverb`
- **llamaindex** — `change_theme_color`, `add_proverb`, `get_weather`
- **mastra** — `setThemeColor`, `weatherTool`
- **pydantic-ai** — `setThemeColor`, `get_weather`
- **ms-agent-framework-dotnet** — `setThemeColor`, `get_weather`
- **ms-agent-framework-python** — `setThemeColor`, `get_weather`
- **a2a-middleware** — `send_message_to_a2a_agent`

### Issue B — langgraph-js agent crash (upstream drift)

The agent `dev` script ran `npx @langchain/langgraph-cli@1.2.1`, which resolves
its own isolated dependency tree. `@langchain/langgraph-api` declares
`@langchain/langgraph` as a **peer** dependency, so that isolated tree pulled a
1.2.x langgraph — but the API hard-imports `STREAM_EVENTS_V3_MODES` from
`@langchain/langgraph/web`, a symbol only present in langgraph **1.3.0+**.
Result: SyntaxError at agent startup (observed in the `testybara-copilotkit`
smoke repo).

**Fix:** install `@langchain/langgraph-cli@1.2.4` as a devDependency and invoke
the local `langgraphjs` binary, so the peer `@langchain/langgraph` resolves from
the agent's own pinned `1.3.0` (which exports the symbol). No `1.3.x` CLI line
exists on npm, and `langgraph-api@1.2.4`'s peer range explicitly accepts 1.3.x.

## Verification

- **Issue A (red/green typecheck, at the starter's actual pinned `@copilotkit/react-core`):**
  reverting one tool back to the array shape reproduces
  `error TS2741: Property '"~standard"' is missing … StandardSchemaV1`; the Zod
  schema makes it disappear and types `args` correctly. Confirmed across all 8 starters.
  `mastra` `next build` → `Compiled successfully`.
- **Issue B:** booted the agent with the new `dev` invocation — LangGraph.js banner,
  `Registering graph with id 'sample_agent'`, API on `:8123`, **no SyntaxError**.
  Verified `@langchain/langgraph/web` exports `STREAM_EVENTS_V3_MODES` in the
  resolved 1.3.0 (present in 1.3.0, absent in 1.2.1).

Resolves the starter smoke alerts for the affected integrations.

## Notes / out of scope

Several starters (mastra, ms-agent-framework-python, adk) pin an older
`@copilotkit/react-core` (1.55.2 / 1.56.4) than the newer v2 API the migration
targets (`labels.title`, `suggestions`, the `useAgent` `{ agent }` shape,
async tool handlers). Those produce unrelated type errors against newer react-core
versions and are a separate version-pin drift — not addressed here.

## Test plan
- [ ] CI green on the smoke build for adk / agno / llamaindex / mastra / pydantic-ai / ms-agent-framework-dotnet / ms-agent-framework-python / a2a-middleware
- [ ] langgraph-js agent starts in the smoke run without the `STREAM_EVENTS_V3_MODES` SyntaxError