### PR TITLE
chore: fix formatter drift on main

### DIFF
--- a/examples/showcases/a2ui-pdf-analyst/agent/main.py
+++ b/examples/showcases/a2ui-pdf-analyst/agent/main.py
@@ -5,6 +5,7 @@
 
 Run with:  uvicorn main:app --port 8123 --reload
 """
+
 from __future__ import annotations
 
 import os

--- a/examples/showcases/a2ui-pdf-analyst/agent/src/dynamic_agent.py
+++ b/examples/showcases/a2ui-pdf-analyst/agent/src/dynamic_agent.py
@@ -32,6 +32,7 @@ listens for. No frontend tool stripping. No orphan. No turn-2 crash.
 `web/src/app/api/copilotkit/route.ts` sets `injectA2UITool: false` to
 match.
 """
+
 from __future__ import annotations
 
 import json
@@ -110,12 +111,8 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
         "comparison, etc.)."
     )
 
-    model_with_tool = _RENDER_MODEL.bind_tools(
-        [render_a2ui], tool_choice="render_a2ui"
-    )
-    response = model_with_tool.invoke(
-        [SystemMessage(content=prompt), *messages]
-    )
+    model_with_tool = _RENDER_MODEL.bind_tools([render_a2ui], tool_choice="render_a2ui")
+    response = model_with_tool.invoke([SystemMessage(content=prompt), *messages])
 
     if not response.tool_calls:
         return json.dumps({"error": "secondary LLM did not call render_a2ui"})

--- a/examples/showcases/a2ui-pdf-analyst/agent/src/fixed_agent.py
+++ b/examples/showcases/a2ui-pdf-analyst/agent/src/fixed_agent.py
@@ -7,6 +7,7 @@ pass. The dashboard surface includes an interactive scope-chips strip
 that the agent populates from the document. Clicking a chip fires a
 user action back to the agent, which re-renders with the new scope.
 """
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/examples/showcases/a2ui-pdf-analyst/agent/src/multimodal_middleware.py
+++ b/examples/showcases/a2ui-pdf-analyst/agent/src/multimodal_middleware.py
@@ -28,6 +28,7 @@ rest of the multimodal pipeline keeps working for real images.
 
 Call ``install()`` once at agent startup. It's idempotent.
 """
+
 from __future__ import annotations
 
 from typing import Any, List

--- a/examples/showcases/a2ui-pdf-analyst/agent/src/pdf_tools.py
+++ b/examples/showcases/a2ui-pdf-analyst/agent/src/pdf_tools.py
@@ -1,4 +1,5 @@
 """Shared agent tools: PDF text → structured data for the catalog."""
+
 from __future__ import annotations
 
 import json
@@ -86,7 +87,9 @@ Return JSON with this shape:
 Return ONLY the JSON object.
 """
     out = _EXTRACTOR.invoke([("system", sys), ("user", user)])
-    raw = _strip_to_json(out.content if isinstance(out.content, str) else str(out.content))
+    raw = _strip_to_json(
+        out.content if isinstance(out.content, str) else str(out.content)
+    )
     # Validate. fall back to a tiny placeholder if the LLM produced invalid JSON.
     try:
         data = json.loads(raw)
@@ -96,8 +99,14 @@ Return ONLY the JSON object.
             "title": document_name or "Untitled",
             "subtitle": "Could not extract structured data from this document.",
             "kpis": [
-                {"label": "Status", "value": "n/a", "delta": "", "caption": "extraction failed"}
-            ] * 4,
+                {
+                    "label": "Status",
+                    "value": "n/a",
+                    "delta": "",
+                    "caption": "extraction failed",
+                }
+            ]
+            * 4,
             "trend": [],
             "share": [],
             "rows": [],
@@ -142,7 +151,9 @@ Return JSON shaped like:
 }}
 """
     out = _EXTRACTOR.invoke([("system", sys), ("user", user)])
-    raw = _strip_to_json(out.content if isinstance(out.content, str) else str(out.content))
+    raw = _strip_to_json(
+        out.content if isinstance(out.content, str) else str(out.content)
+    )
     try:
         json.loads(raw)  # validate
         return raw


### PR DESCRIPTION
## What drifted

The `static / quality` → `format` CI job runs in **check** mode on push to `main` and was failing (run 26905656419, HEAD `0c5a2d37df`). The `oxfmt --check .` (JS/TS/JSON/MD) step passes — that drift was already auto-fixed by the prior `style: auto-fix formatting` bot commit. The remaining failure is **`ruff format --check .`**, which flagged 5 unformatted Python files under `examples/showcases/a2ui-pdf-analyst/agent`:

- `main.py`
- `src/dynamic_agent.py`
- `src/fixed_agent.py`
- `src/multimodal_middleware.py`
- `src/pdf_tools.py`

## Why

The source is **ruff (Python) drift in the a2ui-pdf-analyst showcase**, not the suspected `showcase/harness/src/orchestrator.ts` (oxfmt is already clean for it). These Python files landed without passing through a PR's ruff auto-fix step.

## Fix

Ran `ruff format` pinned to **0.15.13** (the exact CI-pinned version) on only the changed files. The diff is **formatting-only** — blank line after module docstrings, call/argument line-wrapping, and dict/list literal reformatting. No logic changes. Both `oxfmt --check .` and `ruff format --check .` now pass clean repo-wide.