### PR TITLE
feat(react-core): robust per-agent send serialization for CopilotChat

### DIFF
--- a/packages/core/src/core/__tests__/run-handler-completion.test.ts
+++ b/packages/core/src/core/__tests__/run-handler-completion.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { CopilotKitCore } from "../core";
+import { MockAgent } from "../../__tests__/test-utils";
+
+/**
+ * Tests for the synchronously-exposed run-completion promise.
+ *
+ * The root cause these tests guard against: in `intelligence-agent.ts`,
+ * `activeRunCompletionPromise` is only assigned AFTER `await onInitialize`,
+ * so any caller that wants to observe a run's completion at the moment it
+ * is started (before RUN_STARTED) has no synchronous handle. The send queue
+ * in CopilotChat needs exactly such a handle to serialize sends.
+ *
+ * `RunHandler.runAgent` must therefore capture the inner run promise BEFORE
+ * any `await`, register a normalized completion promise in a per-agent
+ * WeakMap, and expose it via `runCompletion(agent)`. `CopilotKitCore`
+ * surfaces it as `runAgentCompletion(agent)`.
+ */
+
+/**
+ * A controllable agent whose `runAgent` resolves only when the test calls
+ * `resolveRun()` (or rejects via `rejectRun()`). Lets us assert that the
+ * completion promise is observable synchronously and settles correctly.
+ */
+class ControllableAgent extends MockAgent {
+  public runStarted = false;
+  private _resolve?: (value: { newMessages: [] }) => void;
+  private _reject?: (err: unknown) => void;
+
+  override async runAgent(): Promise<{ newMessages: [] }> {
+    this.runStarted = true;
+    return new Promise<{ newMessages: [] }>((resolve, reject) => {
+      this._resolve = resolve;
+      this._reject = reject;
+    });
+  }
+
+  resolveRun(): void {
+    this._resolve?.({ newMessages: [] });
+  }
+
+  rejectRun(err: unknown): void {
+    this._reject?.(err);
+  }
+
+  override async detachActiveRun(): Promise<void> {}
+}
+
+describe("RunHandler run-completion promise (synchronous exposure)", () => {
+  let core: CopilotKitCore;
+
+  beforeEach(() => {
+    core = new CopilotKitCore({});
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes a completion promise synchronously, BEFORE any await in runAgent", () => {
+    const agent = new ControllableAgent({ agentId: "test" });
+    core.addAgent__unsafe_dev_only({ id: "test", agent: agent as any });
+
+    // Kick off the run but do NOT await it. The promise handle must be
+    // registered synchronously by the time runAgent() returns its promise,
+    // which is the same microtask. We immediately query the completion.
+    void core.runAgent({ agent: agent as any });
+
+    const completion = core.runAgentCompletion(agent as any);
+    expect(completion).toBeDefined();
+    expect(completion).toBeInstanceOf(Promise);
+  });
+
+  it("completion settles (resolves) when the underlying run resolves", async () => {
+    const agent = new ControllableAgent({ agentId: "test" });
+    core.addAgent__unsafe_dev_only({ id: "test", agent: agent as any });
+
+    void core.runAgent({ agent: agent as any });
+    const completion = core.runAgentCompletion(agent as any);
+    expect(completion).toBeDefined();
+
+    let settled = false;
+    completion!.then(() => {
+      settled = true;
+    });
+
+    // Not settled until the run resolves.
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    // Flush microtasks so `_runAgentInner` has installed the deferred handle
+    // (it awaits `detachActiveRun()` first), then resolve the run.
+    await Promise.resolve();
+    await Promise.resolve();
+    agent.resolveRun();
+    await completion;
+    expect(settled).toBe(true);
+  });
+
+  it("completion settles (does NOT reject) even when the underlying run REJECTS before RUN_STARTED", async () => {
+    const agent = new ControllableAgent({ agentId: "test" });
+    core.addAgent__unsafe_dev_only({ id: "test", agent: agent as any });
+
+    // runAgent catches errors internally and emits via emitError, so the
+    // public runAgent never rejects. But the completion promise must settle
+    // regardless — model a pre-RUN_STARTED rejection by rejecting the inner
+    // run promise; the normalized completion must resolve, not reject.
+    const runPromise = core.runAgent({ agent: agent as any });
+    const completion = core.runAgentCompletion(agent as any);
+    expect(completion).toBeDefined();
+
+    // `_runAgentInner` awaits `agent.detachActiveRun()` before calling
+    // `agent.runAgent`, so the deferred reject handle is only installed a
+    // microtask later. Flush microtasks before rejecting.
+    await Promise.resolve();
+    await Promise.resolve();
+    agent.rejectRun(new Error("boom before RUN_STARTED"));
+
+    // The completion promise must resolve (never reject).
+    await expect(completion).resolves.toBeUndefined();
+    // And the public runAgent promise itself does not reject (errors are
+    // funneled through emitError).
+    await expect(runPromise).resolves.toBeDefined();
+  });
+
+  it("returns undefined for an agent that has never been run", () => {
+    const agent = new ControllableAgent({ agentId: "never-run" });
+    core.addAgent__unsafe_dev_only({ id: "never-run", agent: agent as any });
+
+    expect(core.runAgentCompletion(agent as any)).toBeUndefined();
+  });
+
+  it("keys completion per-agent (WeakMap) — distinct agents get distinct promises", () => {
+    const agentA = new ControllableAgent({ agentId: "a" });
+    const agentB = new ControllableAgent({ agentId: "b" });
+    core.addAgent__unsafe_dev_only({ id: "a", agent: agentA as any });
+    core.addAgent__unsafe_dev_only({ id: "b", agent: agentB as any });
+
+    void core.runAgent({ agent: agentA as any });
+    void core.runAgent({ agent: agentB as any });
+
+    const compA = core.runAgentCompletion(agentA as any);
+    const compB = core.runAgentCompletion(agentB as any);
+    expect(compA).toBeDefined();
+    expect(compB).toBeDefined();
+    expect(compA).not.toBe(compB);
+
+    agentA.resolveRun();
+    agentB.resolveRun();
+  });
+
+  it("does NOT register a fresh completion for follow-up (recursive, non-top-level) runs", async () => {
+    // The completion promise registered for the top-level run must remain
+    // the one observable to callers; a recursive follow-up run (depth > 0,
+    // e.g. after tool execution) must NOT overwrite it. We assert the
+    // top-level completion does not settle until the entire chain (including
+    // any follow-up) finishes.
+    const agent = new MockAgent({ agentId: "test" });
+    core.addAgent__unsafe_dev_only({ id: "test", agent: agent as any });
+
+    // A plain MockAgent run resolves immediately with no follow-up, so the
+    // top-level completion should settle after the run finishes. We assert
+    // the completion promise tracks the TOP-LEVEL run: it is defined while
+    // running and resolves once.
+    const runPromise = core.runAgent({ agent: agent as any });
+    const completion = core.runAgentCompletion(agent as any);
+    expect(completion).toBeDefined();
+
+    await runPromise;
+    await expect(completion).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -1027,6 +1027,28 @@ export class CopilotKitCore {
   }
 
   /**
+   * Get the run-completion promise for an agent, or `undefined` if the agent
+   * has never been run.
+   *
+   * The promise resolves (never rejects) once the agent's most recent
+   * top-level run has fully settled — on success OR on failure, including a
+   * rejection before RUN_STARTED. It is registered synchronously by
+   * `runAgent()` before any await, so a caller can capture this handle
+   * immediately after starting a run and await it to know when the run is
+   * genuinely done.
+   *
+   * The CopilotChat send queue uses this to serialize sends: it holds a slot
+   * until the prior run's completion settles, so the next run's internal
+   * `await agent.detachActiveRun()` is a clean no-op rather than racing the
+   * prior run's event pipeline.
+   */
+  runAgentCompletion(
+    agent: import("@ag-ui/client").AbstractAgent,
+  ): Promise<void> | undefined {
+    return this.runHandler.runCompletion(agent);
+  }
+
+  /**
    * Programmatically execute a registered frontend tool without going through an LLM turn.
    * The handler runs, render components show up in the UI, and both the tool call and
    * result messages are added to `agent.messages`.

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -92,6 +92,29 @@ export class RunHandler {
   private _runDepth = 0;
 
   /**
+   * Per-agent run-completion promises, keyed by the agent instance.
+   *
+   * The promise resolves (never rejects) once the top-level run for that
+   * agent has fully settled — on success OR on failure, including a
+   * pre-RUN_STARTED rejection. It is registered SYNCHRONOUSLY at the top of
+   * `runAgent()` (before any `await`) by capturing the inner run promise, so
+   * callers can observe completion at the exact moment a run is started.
+   *
+   * This closes the structural seam in `intelligence-agent.ts`, where
+   * `activeRunCompletionPromise` is only assigned AFTER `await onInitialize`
+   * — too late for a serialization queue to gate on. By exposing a
+   * synchronous handle here, the CopilotChat send queue can hold a slot
+   * until the prior run genuinely finishes, so the next run's
+   * `await agent.detachActiveRun()` is a clean no-op.
+   *
+   * A `WeakMap` avoids leaking entries for agents that are garbage
+   * collected. Only top-level runs (`_runDepth === 0`) register here;
+   * recursive follow-up runs (after tool execution) must not overwrite the
+   * top-level entry.
+   */
+  private _runCompletions = new WeakMap<AbstractAgent, Promise<void>>();
+
+  /**
    * Tracks the threadId of the most recent `connectAgent` call so we
    * can distinguish a fresh thread restore (different threadId than
    * last time — chat is rebuilding state from scratch, must clear
@@ -281,9 +304,54 @@ export class RunHandler {
   }
 
   /**
-   * Run an agent
+   * Run an agent.
+   *
+   * This is a thin SYNCHRONOUS wrapper around `_runAgentInner`. Before any
+   * `await` runs, it captures the inner run promise so that — for top-level
+   * runs only — it can register a normalized completion promise in
+   * `_runCompletions`. Callers can then observe completion synchronously via
+   * `runCompletion(agent)` (surfaced as `CopilotKitCore.runAgentCompletion`).
+   *
+   * Splitting the method is what makes the completion handle observable at
+   * the moment the run starts: an `async` method's body does not begin
+   * executing until the first `await`, but the wrapper's synchronous prologue
+   * (capturing `runPromise` and registering it) runs immediately on call.
    */
-  async runAgent({
+  runAgent(params: CopilotKitCoreRunAgentParams): Promise<RunAgentResult> {
+    // `_runDepth` is incremented INSIDE `_runAgentInner`, so at this point it
+    // still reflects the caller's depth. Depth 0 means this is a top-level
+    // run (not a recursive follow-up from `processAgentResult`); only those
+    // register a fresh completion handle.
+    const isTopLevel = this._runDepth === 0;
+
+    const runPromise = this._runAgentInner(params);
+
+    if (isTopLevel) {
+      // Normalize to a promise that always RESOLVES (never rejects) once the
+      // run settles either way. `_runAgentInner` already funnels errors
+      // through `emitError` and resolves, but we also guard against a
+      // pre-RUN_STARTED rejection (the seam in intelligence-agent.ts) by
+      // swallowing rejections here too.
+      const completion = runPromise.then(
+        () => undefined,
+        () => undefined,
+      );
+      this._runCompletions.set(params.agent, completion);
+    }
+
+    return runPromise;
+  }
+
+  /**
+   * Get the run-completion promise for an agent, or `undefined` if the agent
+   * has never been run. The promise resolves once the top-level run settles
+   * (success or failure). See `_runCompletions` for details.
+   */
+  runCompletion(agent: AbstractAgent): Promise<void> | undefined {
+    return this._runCompletions.get(agent);
+  }
+
+  private async _runAgentInner({
     agent,
     forwardedProps,
   }: CopilotKitCoreRunAgentParams): Promise<RunAgentResult> {

--- a/packages/react-core/src/v2/__tests__/utils/test-helpers.tsx
+++ b/packages/react-core/src/v2/__tests__/utils/test-helpers.tsx
@@ -75,6 +75,168 @@ export class MockStepwiseAgent extends AbstractAgent {
 }
 
 /**
+ * A tiny externally-resolvable promise. Lets a test hold a gate closed and
+ * open it (resolve) / fail it (reject) at a precise moment.
+ */
+export class Deferred<T = void> {
+  public readonly promise: Promise<T>;
+  public resolve!: (value: T) => void;
+  public reject!: (reason?: unknown) => void;
+  private _settled = false;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.resolve = (value: T) => {
+        this._settled = true;
+        resolve(value);
+      };
+      this.reject = (reason?: unknown) => {
+        this._settled = true;
+        reject(reason);
+      };
+    });
+  }
+
+  get settled(): boolean {
+    return this._settled;
+  }
+}
+
+/**
+ * A mock agent that reproduces the real run lifecycle's controllable timing,
+ * which the Subject-based {@link MockStepwiseAgent} cannot.
+ *
+ * It overrides `runAgent` (the method `CopilotKitCore` / `RunHandler` await)
+ * directly, rather than emitting through `run()`/a Subject. This lets a test
+ * independently control:
+ *   - WHEN the run "starts" (gateRunStarted) — i.e. when RUN_STARTED-equivalent
+ *     side effects happen and `isRunning` flips true.
+ *   - WHEN the run completes (gateCompletion) — i.e. when the `runAgent` promise
+ *     resolves and the completion handle settles.
+ *   - Whether the run FAILS before starting (failBeforeStart) — reproducing a
+ *     pre-RUN_STARTED rejection.
+ *
+ * It also records the order of `runAgent` invocations and the messages present
+ * at each invocation, so tests can assert serialization (no overlap) and that
+ * each send's message was added before its run started.
+ */
+export class MockRunLifecycleAgent extends AbstractAgent {
+  /** Records, in order, each runAgent invocation with a snapshot of messages. */
+  public readonly runLog: Array<{
+    index: number;
+    messageCount: number;
+    messageContents: string[];
+  }> = [];
+
+  /** Number of runAgent calls currently in flight (must never exceed 1 when serialized). */
+  public concurrentRuns = 0;
+  public maxConcurrentRuns = 0;
+
+  // Per-run controllable gates. Each runAgent call shifts the next gate off
+  // these queues; if none is queued, a fresh open gate is created so the run
+  // proceeds immediately.
+  private _startGates: Deferred[] = [];
+  private _completionGates: Deferred[] = [];
+  private _failBeforeStartFlags: boolean[] = [];
+  private _runIndex = 0;
+
+  /**
+   * Queue a controllable lifecycle for the NEXT runAgent call.
+   * Returns the gates so the test can open them at the right moment.
+   */
+  enqueueRun(opts?: { failBeforeStart?: boolean }): {
+    gateRunStarted: Deferred;
+    gateCompletion: Deferred;
+  } {
+    const gateRunStarted = new Deferred();
+    const gateCompletion = new Deferred();
+    this._startGates.push(gateRunStarted);
+    this._completionGates.push(gateCompletion);
+    this._failBeforeStartFlags.push(opts?.failBeforeStart ?? false);
+    return { gateRunStarted, gateCompletion };
+  }
+
+  override async runAgent(): Promise<any> {
+    const index = this._runIndex++;
+    this.concurrentRuns++;
+    this.maxConcurrentRuns = Math.max(
+      this.maxConcurrentRuns,
+      this.concurrentRuns,
+    );
+
+    this.runLog.push({
+      index,
+      messageCount: this.messages.length,
+      messageContents: this.messages.map((m) =>
+        typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+      ),
+    });
+
+    const startGate = this._startGates.shift();
+    const completionGate = this._completionGates.shift();
+    const failBeforeStart = this._failBeforeStartFlags.shift() ?? false;
+
+    try {
+      if (failBeforeStart) {
+        // Reject BEFORE RUN_STARTED — isRunning never flips true.
+        if (startGate) await startGate.promise;
+        throw new Error("run failed before RUN_STARTED");
+      }
+
+      // Wait for the test to open the start gate (or proceed immediately if
+      // none was queued), then flip running on. State changes are wrapped in
+      // `act()` so React flushes the resulting re-render inside an act scope —
+      // exactly like MockStepwiseAgent. Tests must enable React's act
+      // environment (`IS_REACT_ACT_ENVIRONMENT = true`); otherwise these
+      // microtask-deferred updates leak past the test boundary and wedge the
+      // renderer for subsequent tests.
+      if (startGate) await startGate.promise;
+      act(() => {
+        this.isRunning = true;
+      });
+
+      // Hold until the test opens the completion gate.
+      if (completionGate) await completionGate.promise;
+
+      act(() => {
+        this.isRunning = false;
+      });
+      return { newMessages: [] };
+    } finally {
+      this.concurrentRuns--;
+    }
+  }
+
+  override clone(): this {
+    const cloned = new (this
+      .constructor as new () => MockRunLifecycleAgent)() as this;
+    cloned.agentId = this.agentId;
+    // Share mutable controller state so the test's original reference keeps
+    // driving the agent even after CopilotKitCore clones it.
+    const shared = this as unknown as MockRunLifecycleAgent;
+    const target = cloned as unknown as MockRunLifecycleAgent;
+    (target as any).runLog = shared.runLog;
+    (target as any)._startGates = shared._startGates;
+    (target as any)._completionGates = shared._completionGates;
+    (target as any)._failBeforeStartFlags = shared._failBeforeStartFlags;
+    // _runIndex / concurrency counters live on the instance actually invoked;
+    // tests read them off whichever instance runs. Mirror via getters is
+    // overkill — RunHandler invokes the stored agent instance directly.
+    return cloned;
+  }
+
+  // No-op: there is no Subject/pipeline to tear down. Returning a resolved
+  // promise also models the "clean no-op detach" the completion-gated queue
+  // relies on.
+  override async detachActiveRun(): Promise<void> {}
+
+  override run(_input: RunAgentInput): Observable<BaseEvent> {
+    // Not used — runAgent is overridden directly — but AbstractAgent requires it.
+    return new Subject<BaseEvent>().asObservable();
+  }
+}
+
+/**
  * A mock agent that supports both run() and connect() for testing reconnection scenarios.
  * On run(), emits events and stores them.
  * On connect(), replays stored events (simulating thread history replay).

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -286,6 +286,55 @@ export function CopilotChat({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resolvedThreadId, agent, resolvedAgentId, hasExplicitThreadId]);
 
+  // Per-agent send-serialization queue.
+  //
+  // A bare `await copilotkit.runAgent()` does NOT serialize sends against the
+  // prior run's full lifecycle: in `intelligence-agent.ts` the run-completion
+  // promise is only assigned AFTER `await onInitialize`, so a second send can
+  // begin (add its message, kick a new run) while the prior run's event
+  // pipeline is still mid-flight — the source of the gen-ui / event-timing
+  // races. We serialize per agent: each send chains off the previous send for
+  // the SAME agent and holds its slot until the prior run's completion handle
+  // settles. Keying by the agent instance means switching agents starts a
+  // fresh, independent chain (a new agent is a new WeakMap key).
+  const sendChainsRef = useRef<WeakMap<AbstractAgent, Promise<void>>>(
+    new WeakMap(),
+  );
+
+  const enqueueSend = useCallback(
+    (doSend: () => void): Promise<void> => {
+      // Capture the agent at enqueue time so an agent change mid-send routes to
+      // the correct chain.
+      const thisAgent = agent;
+      const prior =
+        sendChainsRef.current.get(thisAgent) ?? Promise.resolve();
+
+      // Swallow the prior chain's rejection so one failed send never breaks the
+      // chain for subsequent sends.
+      const next = prior
+        .catch(() => undefined)
+        .then(async () => {
+          // Add the user message, then kick (or observe) the run and hold the
+          // slot until the run genuinely completes.
+          doSend();
+          // `runAgent` registers the completion handle synchronously, but call
+          // it to actually start the run if it isn't already in flight, then
+          // prefer the synchronously-registered completion handle.
+          const runPromise = copilotkit.runAgent({ agent: thisAgent });
+          const completion =
+            copilotkit.runAgentCompletion(thisAgent) ?? runPromise;
+          // Never reject — a failed run still releases the slot.
+          await completion.catch(() => undefined);
+        });
+
+      sendChainsRef.current.set(thisAgent, next);
+      return next;
+    },
+    // copilotkit is intentionally excluded — it is a stable ref that never changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [agent],
+  );
+
   const onSubmitInput = useCallback(
     async (value: string) => {
       // Block if uploads in progress
@@ -301,57 +350,65 @@ export function CopilotChat({
 
       const readyAttachments = consumeAttachments();
 
-      if (readyAttachments.length > 0) {
-        const contentParts: InputContent[] = [];
-        if (value.trim()) {
-          contentParts.push({ type: "text", text: value });
+      // Build the user message now (while attachments/value are in scope), but
+      // defer adding it + running until the per-agent queue releases the slot,
+      // so concurrent sends serialize against the prior run's completion.
+      const doSend = () => {
+        if (readyAttachments.length > 0) {
+          const contentParts: InputContent[] = [];
+          if (value.trim()) {
+            contentParts.push({ type: "text", text: value });
+          }
+          for (const att of readyAttachments) {
+            contentParts.push({
+              type: att.type,
+              source: att.source,
+              metadata: {
+                ...(att.filename ? { filename: att.filename } : {}),
+                ...att.metadata,
+              },
+            } as InputContent);
+          }
+          agent.addMessage({
+            id: randomUUID(),
+            role: "user",
+            content: contentParts,
+          });
+        } else {
+          agent.addMessage({
+            id: randomUUID(),
+            role: "user",
+            content: value,
+          });
         }
-        for (const att of readyAttachments) {
-          contentParts.push({
-            type: att.type,
-            source: att.source,
-            metadata: {
-              ...(att.filename ? { filename: att.filename } : {}),
-              ...att.metadata,
-            },
-          } as InputContent);
-        }
-        agent.addMessage({
-          id: randomUUID(),
-          role: "user",
-          content: contentParts,
-        });
-      } else {
-        agent.addMessage({
-          id: randomUUID(),
-          role: "user",
-          content: value,
-        });
-      }
+      };
 
       // Clear input after submitting
       setInputValue("");
       try {
-        await copilotkit.runAgent({ agent });
+        await enqueueSend(doSend);
       } catch (error) {
         console.error("CopilotChat: runAgent failed", error);
       }
     },
     // copilotkit is intentionally excluded — it is a stable ref that never changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [agent, selectedAttachments, consumeAttachments],
+    [agent, selectedAttachments, consumeAttachments, enqueueSend],
   );
 
   const handleSelectSuggestion = useCallback(
     async (suggestion: Suggestion) => {
-      agent.addMessage({
-        id: randomUUID(),
-        role: "user",
-        content: suggestion.message,
-      });
-
+      // Route through the same per-agent queue as text sends so a suggestion
+      // click that lands while a prior run is still in flight serializes
+      // instead of racing it.
       try {
-        await copilotkit.runAgent({ agent });
+        await enqueueSend(() => {
+          agent.addMessage({
+            id: randomUUID(),
+            role: "user",
+            content: suggestion.message,
+          });
+        });
       } catch (error) {
         console.error(
           "CopilotChat: runAgent failed after selecting suggestion",
@@ -360,7 +417,7 @@ export function CopilotChat({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [agent],
+    [agent, enqueueSend],
   );
 
   const stopCurrentRun = useCallback(() => {

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -306,8 +306,7 @@ export function CopilotChat({
       // Capture the agent at enqueue time so an agent change mid-send routes to
       // the correct chain.
       const thisAgent = agent;
-      const prior =
-        sendChainsRef.current.get(thisAgent) ?? Promise.resolve();
+      const prior = sendChainsRef.current.get(thisAgent) ?? Promise.resolve();
 
       // Swallow the prior chain's rejection so one failed send never breaks the
       // chain for subsequent sends.

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.sendQueue.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.sendQueue.e2e.test.tsx
@@ -1,0 +1,312 @@
+import React from "react";
+import { render, act } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+import { CopilotChat } from "../CopilotChat";
+import type { Suggestion } from "@copilotkit/core";
+import { MockRunLifecycleAgent } from "../../../__tests__/utils/test-helpers";
+
+/**
+ * E2E tests for the per-agent send-serialization queue in CopilotChat.
+ *
+ * These reproduce the four event-timing races rooted in
+ * `intelligence-agent.ts`, where `activeRunCompletionPromise` is assigned only
+ * AFTER `await onInitialize` — so a bare `await copilotkit.runAgent()` in the
+ * send path does NOT serialize a send against the prior run's full lifecycle.
+ *
+ * The Subject-based MockStepwiseAgent cannot reproduce these because it has no
+ * controllable gap between "run started" and "run completed" at the
+ * runAgent-promise level. {@link MockRunLifecycleAgent} overrides `runAgent`
+ * with independently controllable start/completion gates and records
+ * invocation order + concurrency.
+ *
+ * The send handlers are captured off the chat view slot and invoked directly,
+ * which is the faithful reproduction: the races fire on rapid PROGRAMMATIC
+ * sends (e.g. suggestion selection, or sends issued before `isRunning`
+ * propagates to disable the input). Driving through the textbox Enter key would
+ * instead exercise the input's separate `isProcessing` Enter-gate, which is a
+ * different concern and not what the queue fixes.
+ *
+ * RED (current master, no queue): each handler does a bare
+ * `await copilotkit.runAgent()`, so two rapid sends BOTH call `runAgent`
+ * before the first completes → maxConcurrentRuns >= 2.
+ * GREEN (with queue): the 2nd send awaits the 1st run's completion handle, so
+ * maxConcurrentRuns === 1 and runs are strictly ordered.
+ *
+ * Harness note: the queue produces microtask/async state updates as runs
+ * settle. Every send and gate-open is wrapped in `await act(async () => { ...;
+ * await tick(); })` so React flushes the resulting re-render INSIDE an act
+ * scope. A trailing update firing outside act wedges the renderer for the next
+ * test, which is why we avoid `waitFor` (it polls outside act) and always tick
+ * via a real macrotask.
+ */
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+/** Run `fn` then flush microtasks + one macrotask, all inside an act scope. */
+async function actTick(fn?: () => void): Promise<void> {
+  await act(async () => {
+    fn?.();
+    await tick();
+  });
+}
+
+interface CapturedHandlers {
+  onSubmitMessage?: (value: string) => void;
+  onSelectSuggestion?: (suggestion: Suggestion, index: number) => void;
+}
+
+/**
+ * A chatView slot that captures the send handlers CopilotChat passes down, so
+ * the test can invoke them directly (bypassing the input's Enter-gate, which is
+ * an orthogonal concern).
+ */
+function makeCaptureView(sink: CapturedHandlers) {
+  return function CaptureView(props: {
+    onSubmitMessage?: (value: string) => void;
+    onSelectSuggestion?: (suggestion: Suggestion, index: number) => void;
+  }) {
+    sink.onSubmitMessage = props.onSubmitMessage;
+    sink.onSelectSuggestion = props.onSelectSuggestion;
+    return <div data-testid="capture-view" />;
+  };
+}
+
+function renderChat(
+  agents: Record<string, MockRunLifecycleAgent>,
+  agentId: string,
+  sink: CapturedHandlers,
+) {
+  return render(
+    <CopilotKitProvider agents__unsafe_dev_only={agents}>
+      <CopilotChatConfigurationProvider agentId={agentId} threadId="t">
+        <div style={{ height: 400 }}>
+          <CopilotChat
+            agentId={agentId}
+            welcomeScreen={false}
+            chatView={makeCaptureView(sink) as any}
+          />
+        </div>
+      </CopilotChatConfigurationProvider>
+    </CopilotKitProvider>,
+  );
+}
+
+describe("CopilotChat send queue — race reproduction (E2E)", () => {
+  it("race1: 2nd send waits for 1st run's COMPLETION, not just RUN_STARTED", async () => {
+    const agent = new MockRunLifecycleAgent();
+    const run1 = agent.enqueueRun();
+    const run2 = agent.enqueueRun();
+    const sink: CapturedHandlers = {};
+    renderChat({ default: agent }, "default", sink);
+    await actTick();
+    expect(sink.onSubmitMessage).toBeDefined();
+
+    // Send #1 — start it (RUN_STARTED-equiv) but hold completion open.
+    await actTick(() => sink.onSubmitMessage!("first"));
+    await actTick(() => run1.gateRunStarted.resolve());
+
+    // Send #2 while run #1 is started-but-not-completed.
+    await actTick(() => sink.onSubmitMessage!("second"));
+    await actTick(() => run2.gateRunStarted.resolve());
+
+    // With completion-gating, run #2 must NOT have started while run #1 is
+    // still in flight. (RED: no queue → both ran → maxConcurrentRuns === 2.)
+    expect(agent.maxConcurrentRuns).toBe(1);
+    expect(agent.runLog.length).toBe(1);
+
+    // Complete run #1 → run #2 is released.
+    await actTick(() => run1.gateCompletion.resolve());
+    expect(agent.runLog.length).toBe(2);
+    await actTick(() => run2.gateCompletion.resolve());
+
+    expect(agent.concurrentRuns).toBe(0);
+    expect(agent.maxConcurrentRuns).toBe(1);
+    expect(agent.runLog[0].messageContents).toContain("first");
+    expect(agent.runLog[1].messageContents).toContain("second");
+  });
+
+  it("race2: a 3rd send arriving between start and completion stays serialized", async () => {
+    const agent = new MockRunLifecycleAgent();
+    const r1 = agent.enqueueRun();
+    const r2 = agent.enqueueRun();
+    const r3 = agent.enqueueRun();
+    const sink: CapturedHandlers = {};
+    renderChat({ default: agent }, "default", sink);
+    await actTick();
+    expect(sink.onSubmitMessage).toBeDefined();
+
+    await actTick(() => sink.onSubmitMessage!("one"));
+    await actTick(() => r1.gateRunStarted.resolve());
+
+    // Fire #2 and #3 between #1's start and completion.
+    await actTick(() => sink.onSubmitMessage!("two"));
+    await actTick(() => sink.onSubmitMessage!("three"));
+    await actTick(() => {
+      r2.gateRunStarted.resolve();
+      r3.gateRunStarted.resolve();
+    });
+
+    expect(agent.maxConcurrentRuns).toBe(1);
+    expect(agent.runLog.length).toBe(1);
+
+    await actTick(() => r1.gateCompletion.resolve());
+    expect(agent.runLog.length).toBe(2);
+    await actTick(() => r2.gateCompletion.resolve());
+    expect(agent.runLog.length).toBe(3);
+    await actTick(() => r3.gateCompletion.resolve());
+
+    expect(agent.concurrentRuns).toBe(0);
+    expect(agent.maxConcurrentRuns).toBe(1);
+    expect(agent.runLog.map((r) => r.index)).toEqual([0, 1, 2]);
+    expect(agent.runLog[0].messageContents).toContain("one");
+    expect(agent.runLog[1].messageContents).toContain("two");
+    expect(agent.runLog[2].messageContents).toContain("three");
+  });
+
+  it("race3: switching agents mid-send uses a fresh chain (no cross-agent block)", async () => {
+    const agentA = new MockRunLifecycleAgent();
+    const agentB = new MockRunLifecycleAgent();
+    const a1 = agentA.enqueueRun();
+    const b1 = agentB.enqueueRun();
+    const sinkA: CapturedHandlers = {};
+    const sinkB: CapturedHandlers = {};
+
+    // Two chats, one per agent — each CopilotChat keys its own queue by its
+    // agent instance, so a different agent uses a fresh, independent chain.
+    render(
+      <CopilotKitProvider
+        agents__unsafe_dev_only={{ default: agentA, other: agentB }}
+      >
+        <CopilotChatConfigurationProvider agentId="default" threadId="ta">
+          <CopilotChat
+            agentId="default"
+            welcomeScreen={false}
+            chatView={makeCaptureView(sinkA) as any}
+          />
+        </CopilotChatConfigurationProvider>
+        <CopilotChatConfigurationProvider agentId="other" threadId="tb">
+          <CopilotChat
+            agentId="other"
+            welcomeScreen={false}
+            chatView={makeCaptureView(sinkB) as any}
+          />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+    await actTick();
+    expect(sinkA.onSubmitMessage).toBeDefined();
+    expect(sinkB.onSubmitMessage).toBeDefined();
+
+    // Send on agent A, start it, leave it uncompleted.
+    await actTick(() => sinkA.onSubmitMessage!("for-A"));
+    await actTick(() => a1.gateRunStarted.resolve());
+    expect(agentA.runLog.length).toBe(1);
+
+    // Send on agent B — its chain is independent of A's in-flight run, so B's
+    // run starts despite A being unfinished.
+    await actTick(() => sinkB.onSubmitMessage!("for-B"));
+    await actTick(() => b1.gateRunStarted.resolve());
+    expect(agentB.runLog.length).toBe(1);
+    expect(agentB.runLog[0].messageContents).toContain("for-B");
+
+    await actTick(() => {
+      a1.gateCompletion.resolve();
+      b1.gateCompletion.resolve();
+    });
+    expect(agentA.concurrentRuns).toBe(0);
+    expect(agentB.concurrentRuns).toBe(0);
+  });
+
+  it("race4: a run that REJECTS before RUN_STARTED still releases the queue", async () => {
+    const agent = new MockRunLifecycleAgent();
+    const r1 = agent.enqueueRun({ failBeforeStart: true });
+    const r2 = agent.enqueueRun();
+    const sink: CapturedHandlers = {};
+    renderChat({ default: agent }, "default", sink);
+    await actTick();
+    expect(sink.onSubmitMessage).toBeDefined();
+
+    // Fire send #1 (which will fail) and IMMEDIATELY fire send #2 while #1 is
+    // still in flight — without the queue both runAgent calls fire and overlap
+    // (the rejection has not happened yet). With the queue, #2 is held until
+    // #1's completion handle settles, even though #1 settles via REJECTION.
+    await actTick(() => sink.onSubmitMessage!("will-fail"));
+    await actTick(() => sink.onSubmitMessage!("after-fail"));
+
+    // Only #1 should be in flight under the queue.
+    expect(agent.maxConcurrentRuns).toBe(1);
+    expect(agent.runLog.length).toBe(1);
+
+    // Release the failing run #1 — it rejects before RUN_STARTED. The queue
+    // must NOT deadlock: the completion handle resolves on reject too, so #2
+    // proceeds.
+    await actTick(() => r1.gateRunStarted.resolve());
+    expect(agent.runLog.length).toBe(2);
+    await actTick(() => r2.gateRunStarted.resolve());
+    await actTick(() => r2.gateCompletion.resolve());
+
+    expect(agent.concurrentRuns).toBe(0);
+    expect(agent.maxConcurrentRuns).toBe(1);
+    expect(agent.runLog[1].messageContents).toContain("after-fail");
+  });
+
+  it("abort releases the queue: a settled run lets the next send proceed", async () => {
+    const agent = new MockRunLifecycleAgent();
+    const r1 = agent.enqueueRun();
+    const r2 = agent.enqueueRun();
+    const sink: CapturedHandlers = {};
+    renderChat({ default: agent }, "default", sink);
+    await actTick();
+    expect(sink.onSubmitMessage).toBeDefined();
+
+    // Send #1, start it, then fire send #2 WHILE #1 is still in flight.
+    // Without the queue both runs overlap; with it, #2 is held.
+    await actTick(() => sink.onSubmitMessage!("send-then-stop"));
+    await actTick(() => r1.gateRunStarted.resolve());
+    await actTick(() => sink.onSubmitMessage!("after-stop"));
+
+    expect(agent.maxConcurrentRuns).toBe(1);
+    expect(agent.runLog.length).toBe(1);
+
+    // Simulate the run ending due to an abort/stop (completion settles). This
+    // must release the queued #2.
+    await actTick(() => r1.gateCompletion.resolve());
+    expect(agent.runLog.length).toBe(2);
+    await actTick(() => r2.gateRunStarted.resolve());
+    await actTick(() => r2.gateCompletion.resolve());
+
+    expect(agent.concurrentRuns).toBe(0);
+    expect(agent.maxConcurrentRuns).toBe(1);
+  });
+
+  it("race1 via suggestion selection: handleSelectSuggestion also serializes", async () => {
+    const agent = new MockRunLifecycleAgent();
+    const run1 = agent.enqueueRun();
+    const run2 = agent.enqueueRun();
+    const sink: CapturedHandlers = {};
+    renderChat({ default: agent }, "default", sink);
+    await actTick();
+    expect(sink.onSelectSuggestion).toBeDefined();
+
+    const sugg = (msg: string): Suggestion =>
+      ({ title: msg, message: msg }) as Suggestion;
+
+    await actTick(() => sink.onSelectSuggestion!(sugg("sugg-1"), 0));
+    await actTick(() => run1.gateRunStarted.resolve());
+
+    await actTick(() => sink.onSelectSuggestion!(sugg("sugg-2"), 0));
+    await actTick(() => run2.gateRunStarted.resolve());
+
+    expect(agent.maxConcurrentRuns).toBe(1);
+    expect(agent.runLog.length).toBe(1);
+
+    await actTick(() => run1.gateCompletion.resolve());
+    expect(agent.runLog.length).toBe(2);
+    await actTick(() => run2.gateCompletion.resolve());
+
+    expect(agent.concurrentRuns).toBe(0);
+    expect(agent.maxConcurrentRuns).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the bare-`await` send path in `CopilotChat` with a **per-agent chained send queue** backed by a new **synchronously-exposed run-completion handle** on core. This is the robust follow-up to the minimal gen-ui cell fix and eliminates the four event-timing races at their root.

### Root cause

`packages/core/src/intelligence-agent.ts` assigns `activeRunCompletionPromise` only AFTER `await onInitialize`. A caller that wants to serialize against a run's full lifecycle therefore has no synchronous handle to gate on — a second send can add its message and kick a new run while the prior run's event pipeline is still mid-flight.

### Part A — core (additive, no signature changes)

- Split `RunHandler.runAgent` into a synchronous public wrapper + private `_runAgentInner`, capturing the inner run promise BEFORE any `await`.
- For top-level runs only (`_runDepth === 0`), register a normalized completion promise in a `WeakMap<AbstractAgent, Promise<void>>`; expose `runCompletion(agent)`.
- Surface `runAgentCompletion(agent)` on `CopilotKitCore`. The handle resolves (never rejects) on success OR failure, including a pre-RUN_STARTED rejection.

### Part B — react-core

- `sendChainsRef = useRef<WeakMap<AbstractAgent, Promise<void>>>`. `enqueueSend(doSend)` captures the agent at enqueue, chains off the prior send (swallowing rejections so the chain never breaks), runs `doSend()` (the `addMessage`), then holds the slot on `runAgentCompletion(agent) ?? runAgent(...)` until the run genuinely finishes.
- `onSubmitInput` and `handleSelectSuggestion` both route through `enqueueSend`. Agent change mid-send is handled by WeakMap keying (new agent = fresh chain).

Because the queue gates on completion, by the time a later run reaches `await agent.detachActiveRun()` the prior run has fully settled → detach is a clean no-op (the seam closes structurally).

### Tests (TDD red→green)

New `MockRunLifecycleAgent` + `Deferred` in `test-helpers.tsx` with controllable `gateRunStarted`/`gateCompletion`, `failBeforeStart()`, and call-order/concurrency recording — the Subject-based `MockStepwiseAgent` cannot reproduce these races.

- **core** `run-handler-completion.test.ts` (6 tests): completion defined synchronously after `runAgent()` before any await; settles on reject; not registered for follow-up runs; per-agent WeakMap.
- **react-core** `CopilotChat.sendQueue.e2e.test.tsx` (6 tests): race1 (settles-before-RUN_STARTED), race2 (3rd send between start+completion), race3 (agent change → fresh chain), race4 (reject before RUN_STARTED), abort-releases-queue, plus a suggestion-path variant.

Red-green evidence: with the queue stashed, race1/race2/race4/abort/suggestion fail with overlapping runs (`maxConcurrentRuns` = 2–3); all pass with the queue. The core suite (6/6) is RED with `runAgentCompletion is not a function` before the impl. race3 is a per-agent-keying correctness guard (a naive single-chain queue would fail it).

## Relationship to the minimal cell-fix PR

> **This PR SUPERSEDES the minimal gen-ui cell fix's bare-`await` serialization** and must be reconciled at integration: **keep** the minimal fix's `canSend` Enter-gate and its demo sync-resolve / guards; **replace only** the bare-`await` serialization with this completion-gated queue.

## Test plan

- [x] `nx run @copilotkit/core:test` — 436/436 pass (incl. 6 new completion tests)
- [x] `CopilotChat.sendQueue.e2e.test.tsx` — 6/6 pass; clean RED with queue stashed
- [x] `tsc --noEmit` (core + react-core) — no new errors in changed files (pre-existing phoenix/web-inspector/zod errors unrelated)
- [ ] CI green