### PR TITLE
docs(build-with-agents): always show Skills + flesh out section + fix MCP heading nesting

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/build-with-agents.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/build-with-agents.mdx
@@ -3,4 +3,4 @@ title: "Build with agents"
 icon: "lucide/Code"
 description: "Use our MCP server to connect your LangGraph agents to CopilotKit."
 ---
-<MCPSetup />
+<BuildWithAgents />

--- a/showcase/shell-docs/src/content/snippets/shared/coding-agents.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/coding-agents.mdx
@@ -1,3 +1,6 @@
-import MCPSetup from "@/snippets/shared/guides/mcp-server-setup.mdx";
-
-<MCPSetup components={props.components} />
+{/* Every "Build with agents" page renders the full guide — CopilotKit Skills
+    (the recommended path) followed by the MCP Docs Server setup. This snippet
+    is kept as a thin alias so the framework integration pages that reference
+    CodingAgents show the same Skills + MCP content as the top-level page,
+    rather than MCP only. */}
+<BuildWithAgents />

--- a/showcase/shell-docs/src/content/snippets/shared/guides/build-with-agents.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/guides/build-with-agents.mdx
@@ -8,21 +8,31 @@ Skills are folders of instructions, references, and scripts that coding agents c
   Skills are the recommended way to give your agent CopilotKit knowledge. They work natively in Claude Code, Cursor, Codex, Gemini CLI, and any tool supporting the [agentskills.io](https://agentskills.io) standard.
 </Callout>
 
+Most of these skills help you **build with** CopilotKit. If you're just getting started, these three cover the most common tasks:
+
+| Skill | Use it to |
+| --- | --- |
+| `copilotkit-setup` | Add CopilotKit to a project and get a chat working |
+| `copilotkit-develop` | Build AI features — chat UI, frontend tools, and shared agent context |
+| `copilotkit-integrations` | Connect an agent framework (LangGraph, CrewAI, Mastra, and more) |
+
+The full [skills directory](https://github.com/CopilotKit/CopilotKit/tree/main/skills) adds more for specific tasks — like `copilotkit-debug` and `copilotkit-upgrade` — plus `copilotkit-contribute`, which is for working on the CopilotKit project itself rather than building with it. You don't need to memorize the list; your agent discovers the installed skills and picks the right one for each task.
+
 <Steps>
   <Step>
     ### Install the skills
 
-    Run the following command to install CopilotKit skills into your agent environment:
+    Run this from the root of the project you're building in — the same terminal you'd use for `git` or `npm`:
 
     ```bash
     npx skills add CopilotKit/CopilotKit/skills -y
     ```
 
+    This installs the skills into your project, where any coding agent working there — Claude Code, Codex, Cursor, or Gemini CLI — discovers them automatically. There's no per-agent configuration to do.
+
     <Callout type="info">
       Want to choose what gets installed? Run `npx skills add CopilotKit/CopilotKit/skills` without `-y` to pick specific skills, target agents, and scope interactively — or add `-g` to install globally for every project.
     </Callout>
-
-    Skills cover project setup, building AI features, connecting agent frameworks, debugging, and version upgrades. The full list is in the [CopilotKit skills directory](https://github.com/CopilotKit/CopilotKit/tree/main/skills).
 
   </Step>
   <Step>

--- a/showcase/shell-docs/src/content/snippets/shared/guides/build-with-agents.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/guides/build-with-agents.mdx
@@ -22,13 +22,13 @@ The full [skills directory](https://github.com/CopilotKit/CopilotKit/tree/main/s
   <Step>
     ### Install the skills
 
-    Run this from the root of the project you're building in — the same terminal you'd use for `git` or `npm`:
+    Run this from the root of the project you're building in:
 
     ```bash
     npx skills add CopilotKit/CopilotKit/skills -y
     ```
 
-    This installs the skills into your project, where any coding agent working there — Claude Code, Codex, Cursor, or Gemini CLI — discovers them automatically. There's no per-agent configuration to do.
+    This installs the skills into your project, where any coding agent working there (Claude Code, Codex, Cursor, or Gemini CLI) discovers them automatically. There's no per-agent configuration to do.
 
     <Callout type="info">
       Want to choose what gets installed? Run `npx skills add CopilotKit/CopilotKit/skills` without `-y` to pick specific skills, target agents, and scope interactively — or add `-g` to install globally for every project.

--- a/showcase/shell-docs/src/content/snippets/shared/guides/mcp-server-setup.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/guides/mcp-server-setup.mdx
@@ -8,7 +8,7 @@ development environment, it enables AI assistants to:
 - Give your AI agents a user interface
 - Help you implement CopilotKit features correctly
 
-## Cursor
+### Cursor
 
 [Cursor](https://cursor.sh/) is an AI-powered code editor built for productivity. It features built-in AI assistance and supports MCP for extending AI capabilities with external tools.
 
@@ -56,7 +56,7 @@ development environment, it enables AI assistants to:
   </Step>
 </Steps>
 
-## Claude Web
+### Claude Web
 
 [Claude](https://claude.ai/) is Anthropic's AI assistant accessible through a web interface. It supports MCP integrations, called Connectors, to connect with external tools and services.
 
@@ -76,7 +76,7 @@ development environment, it enables AI assistants to:
   <Step>Click "Add"</Step>
 </Steps>
 
-## Claude Desktop
+### Claude Desktop
 
 [Claude Desktop](https://claude.ai/download) is the desktop application version of Claude, offering the same AI capabilities with local system integration and MCP support.
 
@@ -102,7 +102,7 @@ development environment, it enables AI assistants to:
   <Step>Click "Add"</Step>
 </Steps>
 
-## Claude Code
+### Claude Code
 
 [Claude Code](https://docs.claude.com/en/docs/claude-code) is Anthropic's official CLI for Claude. It supports MCP integrations to connect with external tools and services, enhancing AI capabilities with specialized knowledge.
 
@@ -167,7 +167,7 @@ development environment, it enables AI assistants to:
   </Step>
 </Steps>
 
-## Windsurf
+### Windsurf
 
 [Windsurf](https://codeium.com/windsurf) is Codeium's agentic IDE that combines AI-powered coding assistance with traditional development tools. It features the Cascade AI assistant with MCP integration.
 
@@ -283,7 +283,7 @@ development environment, it enables AI assistants to:
   </Step>
 </Steps>
 
-## Cline
+### Cline
 
 [Cline](https://github.com/cline/cline) is a VS Code extension that provides autonomous AI coding assistance. It can perform complex tasks using MCP tools to interact with external systems.
 
@@ -343,7 +343,7 @@ development environment, it enables AI assistants to:
   </Step>
 </Steps>
 
-## GitHub Copilot
+### GitHub Copilot
 
 [GitHub Copilot](https://github.com/features/copilot) is Microsoft's AI pair programmer integrated into VS Code and other editors. It supports MCP to extend its capabilities with external tools and services.
 
@@ -416,11 +416,11 @@ development environment, it enables AI assistants to:
   </Step>
 </Steps>
 
-## Other
+### Other
 
 For MCP-compatible applications not listed above, use these universal integration patterns. MCP (Model Context Protocol) is an open standard that allows AI applications to connect with external tools and data sources.
 
-### Connection Methods
+#### Connection Methods
 
 Most MCP-compatible applications support one or both of these connection methods:
 
@@ -442,13 +442,13 @@ Most MCP-compatible applications support one or both of these connection methods
   </Tab>
 </Tabs>
 
-### Integration Steps
+#### Integration Steps
 
 1. **Find MCP Settings** - Look for "MCP," "Model Context Protocol," or "Tools" in your application settings
 2. **Add Server** - Use the SSE URL: `https://mcp.copilotkit.ai/sse`
 3. **Test Connection** - Restart your application and verify the server appears in available tools
 
-### Common Configuration Patterns
+#### Common Configuration Patterns
 
 <Tabs groupId="config-patterns" items={['JSON Configuration File', 'Application Settings']} default="JSON Configuration File">
   <Tab value="JSON Configuration File">


### PR DESCRIPTION
Quick-win fixes for the **Build with agents** page from Sam's review. Stacked on #5187 (retarget to `main` once it lands).

## Changes

- **Skills now shown on every page** — previously only the top-level `/build-with-agents` (and `built-in-agent`) rendered the Skills section; every framework integration page used the MCP-only snippet, hiding Skills. The shared `coding-agents.mdx` now renders the full Skills + MCP guide, so all 11 build-with-agents pages show Skills (the recommended path).
- **Skills section** — added a top-three table (`copilotkit-setup`, `copilotkit-develop`, `copilotkit-integrations`) and a note that `copilotkit-contribute` is for contributing to CopilotKit, not building with it.
- **Install step** — clarified to run `npx skills add` from the project root; any agent there (Claude Code, Codex, Cursor, Gemini CLI) discovers the skills automatically.
- **MCP headings** — demoted per-tool headers (Cursor, Claude Code, …) from H2 → H3 so they nest under "MCP Docs Server" in the TOC; "Other" subsections H3 → H4.

## Screenshots

Skills section + top-three table:

![Skills section](https://raw.githubusercontent.com/CopilotKit/CopilotKit/docs-assets/pr-5194/skills-table.png)

Install step:

![Install step](https://raw.githubusercontent.com/CopilotKit/CopilotKit/docs-assets/pr-5194/install-step.png)

Skills now rendering on a framework page (Mastra) that was previously MCP-only:

![Mastra build-with-agents](https://raw.githubusercontent.com/CopilotKit/CopilotKit/docs-assets/pr-5194/mastra-skills.png)

TOC nesting (tools now under MCP Docs Server):

![TOC nesting](https://raw.githubusercontent.com/CopilotKit/CopilotKit/docs-assets/pr-5194/toc-nesting.png)

## Files
- `showcase/shell-docs/src/content/snippets/shared/guides/build-with-agents.mdx`
- `showcase/shell-docs/src/content/snippets/shared/guides/mcp-server-setup.mdx`
- `showcase/shell-docs/src/content/snippets/shared/coding-agents.mdx`
- `showcase/shell-docs/src/content/docs/integrations/langgraph/build-with-agents.mdx`