### PR TITLE
fix(react-core): route turn-2 Enter to send during interrupt-resume

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -191,6 +191,15 @@ export function CopilotChat({
     consumeAttachments,
   } = useAttachments({ config: attachmentsConfig });
 
+  // onSubmitInput awaits an in-flight run before sending the new message, so
+  // it must re-check the "uploading" guard against FRESH state AFTER the await
+  // — the closure-captured `selectedAttachments` is stale across the await
+  // (an upload can start during the wait).
+  const selectedAttachmentsRef = useRef(selectedAttachments);
+  useEffect(() => {
+    selectedAttachmentsRef.current = selectedAttachments;
+  }, [selectedAttachments]);
+
   // Check if transcription is enabled
   const isTranscriptionEnabled = copilotkit.audioFileTranscriptionEnabled;
 
@@ -288,14 +297,77 @@ export function CopilotChat({
 
   const onSubmitInput = useCallback(
     async (value: string) => {
-      // Block if uploads in progress
-      const hasUploading = selectedAttachments.some(
-        (a) => a.status === "uploading",
-      );
-      if (hasUploading) {
+      // Block if uploads in progress (fast fail against current state before
+      // the value is committed — re-checked against live state after the
+      // await below, since an upload can start during the wait).
+      if (
+        selectedAttachmentsRef.current.some((a) => a.status === "uploading")
+      ) {
         console.error(
-          "[CopilotKit] Cannot send while attachments are uploading",
+          "[CopilotKit] Cannot send while attachments are uploading (pre-await guard)",
         );
+        setTranscriptionError("Cannot send while attachments are uploading.");
+        return;
+      }
+
+      // Clear the input immediately so the composer reflects the accepted send
+      // even though the actual dispatch may be deferred behind the in-flight
+      // run. If the post-await guard later BLOCKS the send (e.g. an upload
+      // starts during the await), the typed text is RESTORED to the composer
+      // below so it is never silently lost.
+      setInputValue("");
+
+      // If a run is already in flight, let it finish before sending the new
+      // message instead of pre-empting it. `copilotkit.runAgent` would
+      // otherwise call `agent.detachActiveRun()` and ABORT the in-flight run.
+      // That abort is harmful when the in-flight run is an interrupt RESUME:
+      // the resume re-enters and completes the paused agent graph, and
+      // aborting it mid-flight leaves the graph paused — so this new message
+      // lands as another resume of the SAME paused graph (re-interrupting
+      // with no fresh payload) instead of starting a clean new turn. This is
+      // the consecutive-interrupt regression: pick turn-1's slot (kicks off
+      // the resume), then immediately send turn-2's message — without waiting,
+      // turn-2 aborts the resume and the 2nd interrupt's card never mounts.
+      // Awaiting the active run's completion serializes the two turns so the
+      // resume finishes (graph completes) before the new message starts a
+      // fresh run.
+      if (
+        agent.isRunning &&
+        "activeRunCompletionPromise" in agent &&
+        (agent as unknown as { activeRunCompletionPromise?: Promise<unknown> })
+          .activeRunCompletionPromise
+      ) {
+        try {
+          await (
+            agent as unknown as {
+              activeRunCompletionPromise?: Promise<unknown>;
+            }
+          ).activeRunCompletionPromise;
+        } catch (error) {
+          // The in-flight run rejected — proceed with the new send anyway,
+          // but log so a chronically-failing in-flight run is observable.
+          console.error(
+            "CopilotChat: in-flight run rejected while queuing send",
+            error,
+          );
+        }
+      }
+
+      // Re-check the uploading guard against LIVE attachment state: an upload
+      // can start (or stay in flight) during the await above, so a snapshot
+      // taken before the await could consume an attachment with an incomplete
+      // source. On block, RESTORE the typed text to the composer (it was
+      // optimistically cleared on accept) so the user's input is not silently
+      // lost, and surface a user-visible banner — console.error alone is
+      // invisible to the user.
+      if (
+        selectedAttachmentsRef.current.some((a) => a.status === "uploading")
+      ) {
+        console.error(
+          "[CopilotKit] Cannot send while attachments are uploading (post-await re-check)",
+        );
+        setTranscriptionError("Cannot send while attachments are uploading.");
+        setInputValue(value);
         return;
       }
 
@@ -329,8 +401,6 @@ export function CopilotChat({
         });
       }
 
-      // Clear input after submitting
-      setInputValue("");
       try {
         await copilotkit.runAgent({ agent });
       } catch (error) {
@@ -339,7 +409,7 @@ export function CopilotChat({
     },
     // copilotkit is intentionally excluded — it is a stable ref that never changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [agent, selectedAttachments, consumeAttachments],
+    [agent, consumeAttachments],
   );
 
   const handleSelectSuggestion = useCallback(

--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -1,8 +1,7 @@
+import type { KeyboardEvent, ChangeEvent } from "react";
 import React, {
   useState,
   useRef,
-  KeyboardEvent,
-  ChangeEvent,
   useEffect,
   useLayoutEffect,
   forwardRef,
@@ -13,8 +12,8 @@ import React, {
 import { twMerge } from "tailwind-merge";
 import { Plus, Mic, ArrowUp, X, Check, Square, Loader2 } from "lucide-react";
 
+import type { CopilotChatLabels } from "../../providers/CopilotChatConfigurationProvider";
 import {
-  CopilotChatLabels,
   useCopilotChatConfiguration,
   CopilotChatDefaultLabels,
 } from "../../providers/CopilotChatConfigurationProvider";
@@ -36,7 +35,8 @@ import {
 } from "../../components/ui/dropdown-menu";
 
 import { CopilotChatAudioRecorder } from "./CopilotChatAudioRecorder";
-import { renderSlot, WithSlots } from "../../lib/slots";
+import type { WithSlots } from "../../lib/slots";
+import { renderSlot } from "../../lib/slots";
 import { cn } from "../../lib/utils";
 
 export type CopilotChatInputMode = "input" | "transcribe" | "processing";
@@ -456,7 +456,15 @@ export function CopilotChatInput({
 
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      if (isProcessing) {
+      // When the composer holds sendable text, Enter ALWAYS sends — even
+      // while a run is in flight. A non-empty composer is unambiguous intent
+      // to send a new message, not to stop the agent. This is what unblocks
+      // consecutive interrupt pills: after picking turn-1's slot the resume
+      // run is still streaming (`isProcessing` true) when the user types and
+      // Enters turn-2's prompt; routing that Enter to `onStop` aborted the
+      // run and the next interrupt never surfaced. Stop stays reachable via
+      // Enter only when the composer is empty (the genuine stop affordance).
+      if (isProcessing && !canSend) {
         onStop?.();
       } else {
         send();
@@ -510,6 +518,10 @@ export function CopilotChatInput({
   const canStop = !!onStop;
 
   const handleSendButtonClick = () => {
+    // The send/stop button is an explicit control: when a run is in flight it
+    // renders as a Stop (Square) button, so a click maps to stop regardless of
+    // composer contents. The Enter key behaves differently (see handleKeyDown):
+    // a non-empty composer + Enter sends a new message rather than stopping.
     if (isProcessing) {
       onStop?.();
       return;

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.attachments.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.attachments.test.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor, act } from "@testing-library/react";
 import {
   MockStepwiseAgent,
   renderWithCopilotKit,
+  runStartedEvent,
 } from "../../../__tests__/utils/test-helpers";
 import { CopilotChat } from "../CopilotChat";
 import type { AttachmentUploadError } from "@copilotkit/shared";
-import { type BaseEvent, type RunAgentInput } from "@ag-ui/client";
-import { Observable, EMPTY } from "rxjs";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import type { Observable } from "rxjs";
+import { EMPTY } from "rxjs";
 
 class NoopAgent extends MockStepwiseAgent {
   run(_input: RunAgentInput): Observable<BaseEvent> {
@@ -163,6 +165,124 @@ describe("CopilotChat attachments", () => {
       // Give time for any async processing
       await new Promise((r) => setTimeout(r, 100));
       expect(onUploadFailed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("uploading guard across the in-flight-run await", () => {
+    it("blocks the send and restores the typed text when an upload starts during the await window", async () => {
+      // onSubmitInput checks the uploading guard, then (if a run is in flight)
+      // awaits the run's completion before consuming attachments. If an upload
+      // starts DURING that await, a guard taken only before the await would
+      // miss it and consume/drop the in-progress attachment. The guard must be
+      // re-checked against LIVE state after the await — blocking the send while
+      // any attachment is still uploading, and RESTORING the optimistically
+      // cleared composer text so the user's input is never silently lost.
+      const agent = new MockStepwiseAgent();
+
+      // Open the await window: a run is in flight with a settleable
+      // completion promise. (Attached after the run is in flight below so the
+      // connect/run setup does not overwrite it.)
+      let resolveInFlight: () => void = () => {};
+      const inFlight = new Promise<void>((resolve) => {
+        resolveInFlight = resolve;
+      });
+
+      // Upload that we keep pending so the attachment stays "uploading".
+      let resolveUpload: (v: {
+        type: "url";
+        value: string;
+        mimeType?: string;
+      }) => void = () => {};
+      const onUpload = () =>
+        new Promise<{ type: "url"; value: string; mimeType?: string }>(
+          (resolve) => {
+            resolveUpload = resolve;
+          },
+        );
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const addMessageSpy = vi.spyOn(agent, "addMessage");
+
+      try {
+        const { container } = renderWithCopilotKit({
+          agent,
+          children: (
+            <CopilotChat
+              welcomeScreen={false}
+              attachments={{ enabled: true, onUpload }}
+            />
+          ),
+        });
+
+        const input = await screen.findByRole("textbox");
+
+        // Run goes in flight (so the send will await its completion).
+        agent.emit(runStartedEvent());
+        await waitFor(() => {
+          expect(agent.isRunning).toBe(true);
+        });
+        (
+          agent as unknown as { activeRunCompletionPromise?: Promise<void> }
+        ).activeRunCompletionPromise = inFlight;
+
+        // No attachments yet — the pre-await guard passes. Fire the send; it
+        // parks on the in-flight run's completion promise.
+        fireEvent.change(input, {
+          target: { value: "Send with no files yet" },
+        });
+        fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+        // DURING the await, the user drops a file that begins uploading.
+        const dropTarget = container.querySelector(
+          '[data-testid="copilot-chat"]',
+        );
+        if (!dropTarget) throw new Error("no drop target");
+        const file = createFile("late.png", 50, "image/png");
+        await act(async () => {
+          fireEvent.drop(dropTarget, {
+            dataTransfer: { files: [file], types: ["Files"] },
+          });
+        });
+
+        // The attachment is now "uploading" (onUpload still pending).
+        await waitFor(() => {
+          expect(
+            container.querySelector('[data-testid="copilot-chat"]'),
+          ).toBeTruthy();
+        });
+
+        // Release the in-flight run so the queued send resumes past the await.
+        await act(async () => {
+          resolveInFlight();
+          await Promise.resolve();
+        });
+
+        // The re-checked guard blocks the send: the POST-AWAIT re-check fires
+        // (distinct log message proves it ran after the await, not the
+        // pre-await fast-fail) and no message is dispatched while the
+        // attachment is still uploading.
+        await waitFor(() => {
+          expect(errorSpy).toHaveBeenCalledWith(
+            "[CopilotKit] Cannot send while attachments are uploading (post-await re-check)",
+          );
+        });
+        expect(addMessageSpy).not.toHaveBeenCalled();
+
+        // The typed text is PRESERVED in the composer (restored on the blocked
+        // path) so the user's input is never silently lost.
+        await waitFor(() => {
+          const composer = screen.getByRole("textbox") as HTMLTextAreaElement;
+          expect(composer.value).toBe("Send with no files yet");
+        });
+
+        // Cleanup: let the pending upload resolve.
+        await act(async () => {
+          resolveUpload({ type: "url", value: "https://example.com/late.png" });
+          await Promise.resolve();
+        });
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.e2e.test.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from "react";
 import { screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { z } from "zod";
-import { defineToolCallRenderer, ReactToolCallRenderer } from "../../../types";
+import type { ReactToolCallRenderer } from "../../../types";
+import { defineToolCallRenderer } from "../../../types";
 import {
   MockStepwiseAgent,
   SuggestionsProviderAgent,
@@ -1233,6 +1234,127 @@ describe("CopilotChat E2E - Chat Basics and Streaming Patterns", () => {
           .getByText(/Thought for/)
           .closest("button");
         expect(expandedButton?.getAttribute("aria-expanded")).toBe("true");
+      });
+    });
+  });
+
+  describe("Enter routing while a background run is in flight", () => {
+    // Repro for the consecutive-interrupt bug: in gen-ui-interrupt, the
+    // user picks turn-1's time slot, which flips the card to "Booked"
+    // immediately, then resolves the interrupt ~500ms later — kicking off
+    // a resume run that streams the confirmation. While that resume run is
+    // still in flight (`agent.isRunning === true`), the user types a brand
+    // new message (turn-2's pill) and presses Enter. Enter MUST send the
+    // new message, not be hijacked into stopping the in-flight run — the
+    // composer has sendable text, so the user's clear intent is "send".
+    it("routes Enter to send (not stop) while a run is in flight, queuing the new message until the run settles", async () => {
+      const agent = new MockStepwiseAgent();
+      const stopSpy = vi.spyOn(agent, "abortRun");
+      const addMessageSpy = vi.spyOn(agent, "addMessage");
+      renderWithCopilotKit({ agent });
+
+      const input = await screen.findByRole("textbox");
+
+      // Turn 1: send a message, agent starts running.
+      fireEvent.change(input, { target: { value: "Book a sales call" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+      await waitFor(() => {
+        expect(screen.getByText("Book a sales call")).toBeDefined();
+      });
+
+      // The (resume) run is in flight: RUN_STARTED but NOT yet finished —
+      // `agent.isRunning` is true (exactly the turn-2-Enter window).
+      agent.emit(runStartedEvent());
+      await waitFor(() => {
+        expect(agent.isRunning).toBe(true);
+      });
+
+      // Open the await window: attach a controllable completion promise to the
+      // in-flight run. `onSubmitInput` awaits THIS before dispatching the new
+      // message, so the queued send must NOT land until we resolve it. Without
+      // this the await-branch is skipped entirely and the test would pass even
+      // if the whole await-block were deleted (false confidence). Attached
+      // AFTER the run is in flight so the run setup does not overwrite it.
+      let resolveInFlight: () => void = () => {};
+      const inFlight = new Promise<void>((resolve) => {
+        resolveInFlight = resolve;
+      });
+      (
+        agent as unknown as { activeRunCompletionPromise?: Promise<void> }
+      ).activeRunCompletionPromise = inFlight;
+
+      addMessageSpy.mockClear();
+
+      // Turn 2: the user composes a brand-new message and presses Enter while
+      // the run is still active. A non-empty composer is unambiguous "send"
+      // intent — Enter must NOT route to onStop (the pre-fix bug aborted the
+      // run and swallowed the message). Instead the new message is QUEUED:
+      // CopilotChat awaits the in-flight run's completion before sending, so
+      // an interrupt RESUME finishes (graph completes) before the new turn
+      // starts a fresh run — the fix for the 2nd interrupt's card never
+      // mounting.
+      fireEvent.change(input, {
+        target: { value: "Schedule a 1:1 with Alice" },
+      });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      // The in-flight run was NOT stopped/aborted by the Enter press.
+      expect(stopSpy).not.toHaveBeenCalled();
+      // The composer cleared immediately (the send was accepted, not routed
+      // to stop), even though the actual dispatch is deferred until the run
+      // settles.
+      await waitFor(() => {
+        expect((input as HTMLTextAreaElement).value).toBe("");
+      });
+
+      // The queued message is PARKED on the in-flight promise: it has NOT been
+      // dispatched (addMessage not called) and is NOT in the transcript while
+      // the promise is unresolved. This is the actual await-path assertion —
+      // it goes RED if onSubmitInput's await-block is removed (the message
+      // would dispatch immediately).
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(addMessageSpy).not.toHaveBeenCalled();
+      expect(screen.queryByText("Schedule a 1:1 with Alice")).toBeNull();
+
+      // Release the in-flight run — only now does the queued message dispatch.
+      await act(async () => {
+        resolveInFlight();
+        await Promise.resolve();
+      });
+      agent.emit(runFinishedEvent());
+      agent.complete();
+      await waitFor(() => {
+        expect(addMessageSpy).toHaveBeenCalled();
+        expect(screen.getByText("Schedule a 1:1 with Alice")).toBeDefined();
+      });
+    });
+
+    it("still routes Enter to stop when the composer is empty during a run", async () => {
+      const agent = new MockStepwiseAgent();
+      const stopSpy = vi.spyOn(agent, "abortRun");
+      renderWithCopilotKit({ agent });
+
+      const input = await screen.findByRole("textbox");
+
+      // Send a message; agent starts running.
+      fireEvent.change(input, { target: { value: "Tell me a story" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+      await waitFor(() => {
+        expect(screen.getByText("Tell me a story")).toBeDefined();
+      });
+
+      agent.emit(runStartedEvent());
+      await waitFor(() => {
+        expect(agent.isRunning).toBe(true);
+      });
+
+      // Composer is empty — Enter should stop the genuinely-running agent.
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(stopSpy).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes the **consecutive-interrupt** regression: after picking turn-1's interrupt option, the resume run is still streaming, so pressing **Enter** to send turn-2 was routed to **STOP** and aborted the in-flight run — the second interrupt's card never surfaced.

Two-part fix in `@copilotkit/react-core` v2 chat:
- **`CopilotChatInput`** — Enter now routes to **send** whenever the composer holds sendable text (`isProcessing && !canSend` → stop). Stop stays reachable via Enter only when the composer is empty. The send/stop **button** is unchanged (always stops during a run).
- **`CopilotChat.onSubmitInput`** — awaits the in-flight run's `activeRunCompletionPromise` before dispatching the new message, instead of pre-empting it via `runAgent`/`detachActiveRun`. The two turns serialize: the resume finishes before the new message starts a fresh run. Typed text is optimistically cleared and restored on a blocked send.

Scope is intentionally the react-core fix only (4 files).

## Verification

- **Isolated-D6 e2e (dist-overlay):** both pills green — `langgraph-typescript` and `langgraph-python`, each `turnsCompleted: 2`, `state: green`.
- react-core suite: **1201 passed** (95 files). Red-green confirmed for the Enter-routing + queuing tests (they fail without the fix).
- Typecheck: zero new errors in touched files. Build: publishable dist.
- 7-agent code review converged to zero subject-scoped findings.

## Follow-ups (separate PRs)

- **Send-queue serialization** + suggestion-path in-flight guard (robust completion-promise via core `RunHandler`).
- **gen-ui-interrupt demo matrix**: DRY the duplicated demo pages into a shared component (thin per-hook adapters), migrate non-LangGraph integrations off the dead-on-Strategy-B `useInterrupt` to `useHumanInTheLoop`, and minimize the strands/langroid backends.

Release: standard `release / create-pr` → merge → `release / publish` (OIDC) flow — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)