### PR TITLE
fix(showcase): make Railway promote flow fault-tolerant

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -117,6 +117,14 @@ jobs:
               exit 1
             fi
             CSV=$(jq -r '.services[] | select(.probe.prod == true) | .name' "$GENERATED" | sort -u | tr '\n' ',' | sed 's/,$//')
+            # Fail loud if 'all' resolved to nothing (e.g. an SSOT regression
+            # dropped every probe.prod entry). An empty CSV would otherwise
+            # propagate downstream with exit 0; mirror the single-service
+            # branch's fail-loud style.
+            if [ -z "$CSV" ]; then
+              echo "::error::'all' resolved to zero prod-eligible services"
+              exit 1
+            fi
           else
             # Capture the FULL match set (no `head` — that would silently mask
             # an ambiguous match, and piping jq into head under pipefail can
@@ -178,12 +186,31 @@ jobs:
 
   promote:
     needs: [resolve-targets, verify-staging-precondition]
+    # Do NOT hard-depend on verify-staging-precondition's RESULT. That job
+    # probes the FULL requested set all-or-nothing, so a single staging-red
+    # service (e.g. a chronically-broken integration in `all`) fails it and
+    # — under the default `if: success()` — would SKIP promote entirely,
+    # re-blocking the whole fleet. bin/railway enforces staging-green
+    # PER-SERVICE (spec §7 P2 = latest staging deploy must be SUCCESS, P3 =
+    # live staging probe, default-on), so a red service is refused on its own
+    # and lands in promote-fleet.sh's failed set (reds the run) without
+    # taking the greens down with it. verify-staging-precondition therefore
+    # stays as an advisory early signal surfaced in the notify payload, not a
+    # hard blocker. `!cancelled()` keeps a human-cancelled run from promoting;
+    # mirrors the verify-prod gate idiom below.
+    if: ${{ !cancelled() && needs.resolve-targets.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: railway
     permissions:
       contents: read
       packages: read
+    outputs:
+      # CSV of the services that ACTUALLY promoted (best-effort: a partial
+      # failure still exposes the succeeded subset). verify-prod scopes its
+      # prod verification to exactly this set so a single failed service can't
+      # red the verification of the services that did promote.
+      succeeded_csv: ${{ steps.promote.outputs.succeeded_csv }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -200,6 +227,7 @@ jobs:
           npm ci
           npx tsx emit-railway-envs-json.ts
       - name: bin/railway promote
+        id: promote
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -211,22 +239,30 @@ jobs:
             echo "::error::RAILWAY_TOKEN is not set"
             exit 1
           fi
-          # The local promote runs each service in turn; bin/railway
-          # handles spec §7 preconditions (P1..P6). --require-staging-green
-          # is default-on; the prior job already established staging is
-          # green but we keep the script-level guard as defense in depth.
-          IFS=',' read -ra SVCS <<< "$SERVICES_CSV"
-          for svc in "${SVCS[@]}"; do
-            args=(promote "$svc" --yes --non-interactive)
-            if [ -n "${DIGEST:-}" ]; then
-              args+=(--digest "$DIGEST")
-            fi
-            echo "==> showcase/bin/railway ${args[*]}"
-            showcase/bin/railway "${args[@]}"
-          done
+          # promote-fleet.sh runs each service in turn BEST-EFFORT: a single
+          # red service (e.g. a chronically-broken integration in the `all`
+          # set) must not abort promotion of the rest of the fleet. The script
+          # attempts every service, aggregates the succeeded/failed sets, emits
+          # a step summary, and exits non-zero iff ANY service failed (so the
+          # notify job still fires) — but only AFTER attempting all of them.
+          # bin/railway itself handles spec §7 preconditions (P1..P6);
+          # --require-staging-green is default-on and the prior job already
+          # established staging is green (defense in depth). We deliberately do
+          # NOT pass --confirm-divergence: WARN-divergence refusals are a real
+          # signal that must fail the run.
+          RAILWAY_BIN="showcase/bin/railway" \
+            showcase/scripts/promote-fleet.sh
 
   verify-prod:
     needs: [resolve-targets, promote]
+    # Run whenever promote actually RAN — success OR partial failure — so the
+    # services that DID promote still get prod verification. `!cancelled()`
+    # excludes a human-cancelled run; `needs.promote.result != 'skipped'`
+    # excludes the case where promote never ran (e.g. an upstream abort/skip).
+    # Under the default `if: success()` this job was SKIPPED on any partial
+    # promote failure, leaving the promoted services with zero prod
+    # verification — that is the bug this gate fixes.
+    if: ${{ !cancelled() && needs.promote.result != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: railway
@@ -244,11 +280,26 @@ jobs:
       - name: Run verify-deploy --env prod
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          SERVICES_CSV: ${{ needs.resolve-targets.outputs.services_csv }}
+          # Scope verification to the services that ACTUALLY promoted (from the
+          # promote job's best-effort succeeded set), NOT the full requested set
+          # (resolve-targets) — verifying a service that failed to promote would
+          # guarantee a red verify and mask the health of the ones that did
+          # promote.
+          SERVICES_CSV: ${{ needs.promote.outputs.succeeded_csv }}
         run: |
           if [ -z "$RAILWAY_TOKEN" ]; then
             echo "::error::RAILWAY_TOKEN is not set"
             exit 1
+          fi
+          # If NOTHING promoted (every requested service failed, so the
+          # succeeded set is empty), there is nothing to verify — skip with a
+          # clear log line rather than calling verify-deploy.ts with an empty
+          # --services (which would either error or vacuously pass). The promote
+          # job already exited non-zero in that case, so the overall run is red
+          # via the notify state machine regardless.
+          if [ -z "$SERVICES_CSV" ]; then
+            echo "::notice::succeeded_csv is empty (no services promoted, or promote did not run); skipping prod verification. The run is red via the promote job result if anything failed."
+            exit 0
           fi
           npx tsx showcase/scripts/verify-deploy.ts --env prod --services "$SERVICES_CSV"
 
@@ -264,6 +315,17 @@ jobs:
     env:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
     steps:
+      # Best-effort promote invariant (do NOT reintroduce a PRE gate below):
+      #   resolve-targets              = HARD precondition (must succeed).
+      #   verify-staging-precondition  = ADVISORY only — surfaced in the Slack
+      #                                  payload (`pre-staging`), never gates
+      #                                  promote or run success. bin/railway
+      #                                  enforces staging-green per-service, so
+      #                                  PRE is a leading indicator, not a gate.
+      #   promote                      = best-effort (exits non-zero iff a
+      #                                  service failed).
+      #   verify-prod                  = verifies the succeeded subset.
+      #   run success                  = PROMOTE == success AND PROD == success.
       - name: Compute state
         id: state
         env:
@@ -281,7 +343,12 @@ jobs:
             # This is NOT a failed promote — emit a neutral state so no red
             # alert pages #oss-alerts.
             STATE="aborted"; ICON=":heavy_minus_sign:"
-          elif [ "$PRE" = "success" ] && [ "$PROMOTE" = "success" ] && [ "$PROD" = "success" ]; then
+          elif [ "$PROMOTE" = "success" ] && [ "$PROD" = "success" ]; then
+            # PRE (verify-staging-precondition) is ADVISORY and intentionally
+            # NOT in this gate: bin/railway enforces staging-green per-service,
+            # so a service that was staging-red at precondition time but still
+            # promoted+verified cleanly must not red the run. PRE remains
+            # surfaced in the Slack payload as the `pre-staging` field.
             STATE="success"; ICON=":white_check_mark:"
           elif [ "$RESOLVE" = "cancelled" ] || [ "$PRE" = "cancelled" ] || [ "$PROMOTE" = "cancelled" ] || [ "$PROD" = "cancelled" ]; then
             # A human cancelled the run (e.g. via the Actions UI). This is a

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -528,6 +528,35 @@ jobs:
         run: |
           echo "::warning::showcase_validate failed on push but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."
 
+  shell-script-tests:
+    name: Shell script tests (bats + shellcheck)
+    # Separate job (mirrors python-unit-tests) so the showcase shell-script
+    # regression suite runs independently of the JS/TS validate job. Runs on
+    # ubuntu-latest where shellcheck is preinstalled; bats is apt-installed.
+    # These tests gate the promote-fleet.sh best-effort loop + succeeded_csv
+    # export that the promote → verify-prod handoff depends on.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install bats
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+
+      - name: Shellcheck promote-fleet.sh
+        # shellcheck is preinstalled on ubuntu-latest.
+        run: shellcheck showcase/scripts/promote-fleet.sh
+
+      - name: Run bats suite
+        run: bats showcase/scripts/__tests__/
+
   python-unit-tests:
     name: Python unit tests (${{ matrix.python-version }})
     # Separate job so pre-existing `validate-parity` failures don't mask new
@@ -641,11 +670,12 @@ jobs:
     # red runs surface uniformly across the showcase pipeline. The validate
     # job has its own inline (and richer) push-only notifier that extracts
     # the failing step + error excerpt; this job is the workflow-level
-    # safety net that also covers the python-unit-tests matrix job — which
-    # otherwise had no Slack signal at all. Webhook empty-guard mirrors
-    # promote.yml so an unset SLACK_WEBHOOK_OSS_ALERTS secret does not
-    # break the shell or red the workflow on this step.
-    needs: [validate, python-unit-tests]
+    # safety net that also covers the python-unit-tests matrix job and the
+    # shell-script-tests job — which otherwise had no Slack signal at all.
+    # Webhook empty-guard mirrors promote.yml so an unset
+    # SLACK_WEBHOOK_OSS_ALERTS secret does not break the shell or red the
+    # workflow on this step.
+    needs: [validate, python-unit-tests, shell-script-tests]
     if: always() && github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 3
@@ -660,9 +690,10 @@ jobs:
         env:
           VALIDATE: ${{ needs.validate.result }}
           PYTEST: ${{ needs.python-unit-tests.result }}
+          SHELL: ${{ needs.shell-script-tests.result }}
         run: |
           set -euo pipefail
-          if [ "$VALIDATE" = "success" ] && [ "$PYTEST" = "success" ]; then
+          if [ "$VALIDATE" = "success" ] && [ "$PYTEST" = "success" ] && [ "$SHELL" = "success" ]; then
             STATE="success"; ICON=":white_check_mark:"
           else
             STATE="failure"; ICON=":x:"
@@ -680,11 +711,12 @@ jobs:
           payload: |
             {
               "text": ${{ toJSON(format(
-                '{0} *showcase_validate failed on {1}*\nvalidate={2} python-unit-tests={3}\n<{4}/{5}/actions/runs/{6}|View run>',
+                '{0} *showcase_validate failed on {1}*\nvalidate={2} python-unit-tests={3} shell-script-tests={4}\n<{5}/{6}/actions/runs/{7}|View run>',
                 steps.state.outputs.icon,
                 github.ref,
                 needs.validate.result,
                 needs.python-unit-tests.result,
+                needs.shell-script-tests.result,
                 github.server_url,
                 github.repository,
                 github.run_id

--- a/showcase/integrations/ag2/src/agents/gen_ui_agent.py
+++ b/showcase/integrations/ag2/src/agents/gen_ui_agent.py
@@ -26,8 +26,6 @@ AG2 specifics:
   ContextVariables slot, isolated from the shared default agent.
 """
 
-from __future__ import annotations
-
 import logging
 from textwrap import dedent
 from typing import Annotated, List

--- a/showcase/integrations/ag2/tests/python/test_gen_ui_agent_import.py
+++ b/showcase/integrations/ag2/tests/python/test_gen_ui_agent_import.py
@@ -1,0 +1,108 @@
+"""Regression test: gen_ui_agent must import/construct without raising.
+
+Reproduces the crash-on-import that took down `showcase-ag2` staging
+deploys since 76874f06d. Importing `agents.gen_ui_agent` constructs the
+`ConversableAgent` at module scope, which registers `set_steps` as an LLM
+tool. AG2 runs every tool parameter through pydantic
+`TypeAdapter(param).json_schema()`. When `set_steps` carries
+`from __future__ import annotations`, its `context_variables: ContextVariables`
+parameter is seen as an unresolved `ForwardRef('ContextVariables')`, and
+schema generation raises `pydantic.errors.PydanticUserError` at import time
+-> importing this agent module aborts server startup -> the service never
+comes up -> the Railway healthcheck (`/health`, owned by the integration's
+top-level entrypoint, not this module) fails.
+
+The success criterion mirrors the failed healthcheck: the module imports
+cleanly and the agent object (with its registered tools) is built.
+"""
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+
+# ConversableAgent construction validates that an LLM config / key is
+# present. The crash we are guarding against happens during tool-schema
+# generation, which is reached only after that validation, so seed a dummy
+# key. No network call is made at import time.
+os.environ.setdefault("OPENAI_API_KEY", "test-key-not-used")
+
+
+def _gen_ui_agent_source_path() -> Path:
+    """Resolve src/agents/gen_ui_agent.py relative to this test file.
+
+    This test lives at <integration>/tests/python/, so the integration root
+    is two levels up; the source then sits under src/agents/. Resolving via
+    __file__ keeps the guard working regardless of where the repo is checked
+    out (no hardcoded absolute path).
+    """
+    integration_root = Path(__file__).resolve().parents[2]
+    return integration_root / "src" / "agents" / "gen_ui_agent.py"
+
+
+def test_gen_ui_agent_source_has_no_future_annotations():
+    """The source must NOT carry `from __future__ import annotations`.
+
+    This is the load-bearing regression pin. `from __future__ import
+    annotations` makes Python stringify every annotation (PEP 563), so the
+    `set_steps` tool's `context_variables: ContextVariables` parameter is seen
+    by AG2 as an unresolved `ForwardRef('ContextVariables')`. AG2 runs each
+    tool parameter through pydantic `TypeAdapter(param).json_schema()`, which
+    then raises `PydanticUserError` at import time -> importing this agent
+    module aborts server startup -> the service never comes up -> the
+    Railway/staging healthcheck (`/health`, owned by the entrypoint, not this
+    module) fails (regression 76874f06d).
+
+    Asserting on the source text (not just "import didn't crash") makes this a
+    TRUE guard: it fails the instant someone re-adds the future-import, even if
+    a future AG2/pydantic happens to resolve the forward-ref gracefully and the
+    import would no longer crash on its own.
+    """
+    source_path = _gen_ui_agent_source_path()
+    assert source_path.is_file(), f"could not locate source at {source_path}"
+
+    offending = "from __future__ import annotations"
+    source_lines = source_path.read_text(encoding="utf-8").splitlines()
+    matches = [
+        f"  line {i}: {line!r}"
+        for i, line in enumerate(source_lines, start=1)
+        if line.strip() == offending
+    ]
+    assert not matches, (
+        f"{source_path} must NOT contain `{offending}`.\n"
+        "PEP 563 stringifies annotations, turning the set_steps tool's "
+        "`context_variables: ContextVariables` into an unresolved ForwardRef; "
+        "AG2's pydantic tool-schema generation then raises PydanticUserError "
+        "at import time, so importing this agent module aborts server startup "
+        "and the service never comes up, failing the Railway healthcheck "
+        "(`/health`, owned by the entrypoint, not this module) (regression "
+        "76874f06d). Remove the future-import.\nFound at:\n" + "\n".join(matches)
+    )
+
+
+def test_gen_ui_agent_imports_without_pydantic_error():
+    """Importing the module must not raise PydanticUserError (or anything).
+
+    Proves the crash path is actually clear on the *installed* AG2/pydantic
+    (complements the static source guard above, which is version-independent).
+    """
+    try:
+        module = importlib.import_module("agents.gen_ui_agent")
+    except Exception:  # noqa: BLE001 - re-raise so the verbatim traceback is kept
+        # Let the original exception propagate with its full traceback intact:
+        # for a deep pydantic schema-gen crash the verbatim stack IS the
+        # load-bearing diagnostic, which a re-wrapped pytest.fail string loses.
+        pytest.fail(
+            "gen_ui_agent failed to import (see traceback below)",
+            pytrace=True,
+        )
+
+    # The agent and its ASGI app must be constructed (i.e. tool registration,
+    # where the crash occurred, completed).
+    assert module.agent is not None
+    assert module.gen_ui_agent_app is not None
+    # set_steps must be registered as a tool on the agent.
+    tool_names = {t.name for t in module.agent.tools}
+    assert "set_steps" in tool_names

--- a/showcase/scripts/__tests__/promote-fleet.bats
+++ b/showcase/scripts/__tests__/promote-fleet.bats
@@ -1,0 +1,235 @@
+#!/usr/bin/env bats
+# Tests for promote-fleet.sh — the per-service promote loop extracted from
+# .github/workflows/showcase_promote.yml.
+#
+# Core invariant under test (the bug this script fixes): a single red service
+# must NOT abort the fleet. Every service in the CSV is attempted regardless of
+# individual failures; the run aggregates a failed-set + succeeded-set, prints a
+# summary, and exits non-zero iff ANY service failed.
+#
+# The real `bin/railway` is replaced on PATH-independent terms via RAILWAY_BIN,
+# pointed at a stub that succeeds/fails per service name.
+#
+# NB on assertion gating: bats does NOT run test bodies under `set -e` (errexit).
+# Only the FINAL command's exit status decides whether a test passes — a non-zero
+# command on any earlier line does NOT abort the test. So a bare `[[ ... ]]` on a
+# non-final line is a silent no-op: if it's false, nothing fails. That is why every
+# substantive / non-final assertion MUST be written `[[ ... ]] || fail "message"`.
+# The `|| fail` is what actually forces the hard failure (and supplies the
+# diagnostic MESSAGE) when the check is violated — e.g. a service missing from
+# $GITHUB_OUTPUT reports WHY it failed instead of being silently passed over.
+# Dropping the `|| fail` from an intermediate assertion turns it into a false-green.
+
+# fail <msg> — print the message to the bats failure stream and abort the test.
+fail() {
+  echo "$1" >&2
+  return 1
+}
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../promote-fleet.sh"
+  STUB_DIR="$BATS_TEST_TMPDIR/stub"
+  mkdir -p "$STUB_DIR"
+
+  # Capture the per-step GitHub Actions output to a temp file so the script's
+  # `$GITHUB_OUTPUT` append (succeeded_csv=...) runs exactly as it would in CI.
+  # Each test reads this file to assert the exported succeeded set.
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/github_output"
+  : > "$GITHUB_OUTPUT"
+
+  # Stub `railway`: invoked as `railway promote <svc> [flags...]`.
+  # Succeeds for A and C, fails (exit 7) for B. Echoes its service so we can
+  # assert every service was attempted (including C, AFTER B failed). Also
+  # asserts the FIRST positional arg is literally `promote` so an arg-order
+  # regression in the script (e.g. dropping the subcommand) is caught.
+  cat > "$STUB_DIR/railway" <<'STUB'
+#!/usr/bin/env bash
+# args: promote <svc> --yes --non-interactive [--digest REF]
+[ "$1" = "promote" ] || { echo "expected first arg 'promote', got '$1'" >&2; exit 99; }
+svc="$2"
+echo "STUB called for: $svc"
+case "$svc" in
+  svc-b) exit 7 ;;   # chronically-red service (the abort trigger pre-fix)
+  *)     exit 0 ;;
+esac
+STUB
+  chmod +x "$STUB_DIR/railway"
+  export RAILWAY_BIN="$STUB_DIR/railway"
+
+  # All-green stub for the success case.
+  cat > "$STUB_DIR/railway-green" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "promote" ] || { echo "expected first arg 'promote', got '$1'" >&2; exit 99; }
+echo "STUB called for: $2"
+exit 0
+STUB
+  chmod +x "$STUB_DIR/railway-green"
+}
+
+@test "attempts every service even after one fails, and exits non-zero" {
+  run env SERVICES_CSV="svc-a,svc-b,svc-c" bash "$SCRIPT"
+
+  # (1) all three attempted — C runs even though B failed before it
+  [[ "$output" == *"STUB called for: svc-a"* ]] || fail "svc-a not attempted: $output"
+  [[ "$output" == *"STUB called for: svc-b"* ]] || fail "svc-b not attempted: $output"
+  [[ "$output" == *"STUB called for: svc-c"* ]] || fail "svc-c not attempted: $output"
+
+  # (2) non-zero aggregate exit because at least one service failed
+  [ "$status" -ne 0 ] || fail "expected non-zero exit, got $status"
+
+  # (3) summary classifies B as failed, A and C as succeeded. Anchor to the
+  #     EXACT summary lines (not bare substrings) so a misclassification (e.g.
+  #     svc-b leaking into the succeeded set) is actually caught.
+  [[ "$output" == *"FAILED (1): svc-b=7"* ]] || fail "wrong FAILED summary line: $output"
+  [[ "$output" == *"SUCCEEDED (2): svc-a svc-c"* ]] || fail "wrong SUCCEEDED summary line: $output"
+
+  # (4) the succeeded set is exported to $GITHUB_OUTPUT for verify-prod scoping.
+  #     Only the services that actually promoted (a and c) — never the failed b.
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"succeeded_csv=svc-a,svc-c"* ]] || fail "missing/wrong succeeded_csv: $output"
+  [[ "$output" != *"svc-b"* ]] || fail "failed svc-b leaked into GITHUB_OUTPUT: $output"
+}
+
+@test "all-green fleet exits zero" {
+  export RAILWAY_BIN="$STUB_DIR/railway-green"
+  run env SERVICES_CSV="svc-a,svc-b,svc-c" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+  [[ "$output" == *"STUB called for: svc-a"* ]] || fail "svc-a not attempted: $output"
+  [[ "$output" == *"STUB called for: svc-b"* ]] || fail "svc-b not attempted: $output"
+  [[ "$output" == *"STUB called for: svc-c"* ]] || fail "svc-c not attempted: $output"
+
+  # All three exported as the succeeded set.
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"succeeded_csv=svc-a,svc-b,svc-c"* ]] || fail "wrong succeeded_csv: $output"
+}
+
+@test "stray/trailing commas in CSV are skipped; real services still attempted" {
+  export RAILWAY_BIN="$STUB_DIR/railway-green"
+  run env SERVICES_CSV="svc-a,,svc-c" bash "$SCRIPT"
+
+  # Both non-empty services attempted; empty token between the commas ignored.
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+  [[ "$output" == *"STUB called for: svc-a"* ]] || fail "svc-a not attempted: $output"
+  [[ "$output" == *"STUB called for: svc-c"* ]] || fail "svc-c not attempted: $output"
+  [[ "$output" == *"SUCCEEDED (2): svc-a svc-c"* ]] || fail "wrong SUCCEEDED summary line: $output"
+
+  # The "Attempted N" count must reflect services ACTUALLY attempted (2), not
+  # the raw CSV token count (3, including the empty token between the commas).
+  [[ "$output" == *"Attempted 2 service(s)"* ]] || fail "wrong Attempted count (should skip empty token): $output"
+
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"succeeded_csv=svc-a,svc-c"* ]] || fail "wrong succeeded_csv: $output"
+}
+
+@test "single failing service still fails the run" {
+  run env SERVICES_CSV="svc-b" bash "$SCRIPT"
+
+  [ "$status" -ne 0 ] || fail "expected non-zero exit, got $status"
+  [[ "$output" == *"STUB called for: svc-b"* ]] || fail "svc-b not attempted: $output"
+  [[ "$output" == *"FAILED (1): svc-b=7"* ]] || fail "wrong FAILED summary line: $output"
+}
+
+@test "all-fail run still exports an EMPTY succeeded_csv to GITHUB_OUTPUT" {
+  # verify-prod's empty-guard depends on the key being present-but-empty on the
+  # all-fail-via-promote path (the loop ran, every service failed, zero
+  # promoted) — an absent key (vs an empty value) is a different contract and
+  # would break downstream scoping. NB this empty-but-present contract holds for
+  # the all-fail path only; the script's early-exit guards (empty CSV / missing
+  # RAILWAY_BIN / all-empty-token) exit BEFORE the $GITHUB_OUTPUT write, so no
+  # key is emitted there. Assert key present, value empty.
+  run env SERVICES_CSV="svc-b" bash "$SCRIPT"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit, got $status: $output"
+
+  run grep '^succeeded_csv=' "$GITHUB_OUTPUT"
+  [ "$status" -eq 0 ] || fail "succeeded_csv key missing from GITHUB_OUTPUT"
+  # The value must be EMPTY: the line is exactly `succeeded_csv=` (no service).
+  [ "$output" = "succeeded_csv=" ] || fail "succeeded_csv should be empty on all-fail, got: $output"
+}
+
+@test "single succeeding service exits zero" {
+  run env SERVICES_CSV="svc-a" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+  [[ "$output" == *"STUB called for: svc-a"* ]] || fail "svc-a not attempted: $output"
+}
+
+@test "passes --digest through to railway for a single service" {
+  # Stub that asserts --digest is forwarded AND the first arg is `promote`.
+  cat > "$STUB_DIR/railway-digest" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "promote" ] || { echo "expected first arg 'promote', got '$1'" >&2; exit 99; }
+echo "ARGS: $*"
+[[ "$*" == *"--digest sha256:deadbeef"* ]] || { echo "missing digest" >&2; exit 9; }
+exit 0
+STUB
+  chmod +x "$STUB_DIR/railway-digest"
+  export RAILWAY_BIN="$STUB_DIR/railway-digest"
+
+  run env SERVICES_CSV="svc-a" DIGEST="sha256:deadbeef" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+  # Anchor to the STUB's received-args marker (`ARGS: ...`), NOT the script's
+  # pre-invocation `==> ...` echo. The pre-invocation echo would pass even if
+  # the script dropped --digest before actually invoking railway; only the
+  # stub's ARGS line proves the flag was forwarded to the real invocation.
+  [[ "$output" == *"ARGS: "*"--digest sha256:deadbeef"* ]] || fail "digest not forwarded to railway invocation: $output"
+}
+
+@test "empty CSV fails loud rather than silently succeeding" {
+  run env SERVICES_CSV="" bash "$SCRIPT"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on empty CSV, got $status"
+}
+
+@test "all-empty-token CSV fails loud rather than silently no-op succeeding" {
+  # A non-empty CSV that parses to ONLY empty tokens (e.g. ",,") must NOT exit 0
+  # claiming success — every token is skipped, zero services are attempted, and
+  # that is a false success the empty-string guard alone does not catch.
+  export RAILWAY_BIN="$STUB_DIR/railway-green"
+  run env SERVICES_CSV=",," bash "$SCRIPT"
+
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on all-empty-token CSV, got $status: $output"
+  [[ "$output" != *"STUB called for:"* ]] || fail "no service should have been attempted: $output"
+  [[ "$output" == *"::error::"* ]] || fail "expected an ::error:: for zero-attempted CSV: $output"
+}
+
+@test "missing/non-executable RAILWAY_BIN fails loud before attempting any service" {
+  # A bad RAILWAY_BIN would otherwise make every iteration fail with 126/127 and
+  # misreport a single environment error as N per-service promote failures.
+  run env RAILWAY_BIN="$STUB_DIR/does-not-exist" SERVICES_CSV="svc-a,svc-c" bash "$SCRIPT"
+
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on missing RAILWAY_BIN, got $status: $output"
+  [[ "$output" == *"::error::"* ]] || fail "expected a distinct ::error:: naming the missing binary: $output"
+  [[ "$output" == *"does-not-exist"* ]] || fail "error should name the missing binary: $output"
+  # The guard fires BEFORE the loop: no per-service promote was attempted.
+  [[ "$output" != *"==> "* ]] || fail "no service promote should have been attempted: $output"
+  [[ "$output" != *"promote failed for"* ]] || fail "env error misattributed as per-service failure: $output"
+}
+
+@test "whitespace around tokens is trimmed; trimmed names are attempted" {
+  # `IFS=',' read` does not trim, so "svc-a, svc-c" yields a literal " svc-c"
+  # (leading space). The script must trim so the REAL service name is promoted.
+  export RAILWAY_BIN="$STUB_DIR/railway-green"
+  run env SERVICES_CSV="svc-a, svc-c" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+  [[ "$output" == *"STUB called for: svc-a"* ]] || fail "svc-a not attempted: $output"
+  # Trimmed: stub receives `svc-c`, NOT ` svc-c`.
+  [[ "$output" == *"STUB called for: svc-c"* ]] || fail "svc-c not attempted (trimmed): $output"
+  [[ "$output" != *"STUB called for:  svc-c"* ]] || fail "leading space not trimmed from token: $output"
+  [[ "$output" == *"SUCCEEDED (2): svc-a svc-c"* ]] || fail "wrong SUCCEEDED summary line: $output"
+
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"succeeded_csv=svc-a,svc-c"* ]] || fail "wrong succeeded_csv (trimmed): $output"
+}
+
+@test "whitespace-only token is correctly skipped" {
+  # A token of only whitespace (the middle " " in "svc-a, ,svc-c") must be
+  # treated like an empty token and skipped — not promoted as a blank service.
+  export RAILWAY_BIN="$STUB_DIR/railway-green"
+  run env SERVICES_CSV="svc-a, ,svc-c" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+  [[ "$output" == *"SUCCEEDED (2): svc-a svc-c"* ]] || fail "whitespace-only token not skipped: $output"
+  [[ "$output" == *"Attempted 2 service(s)"* ]] || fail "wrong Attempted count: $output"
+}

--- a/showcase/scripts/promote-fleet.sh
+++ b/showcase/scripts/promote-fleet.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# promote-fleet.sh — run `bin/railway promote <svc>` for every service in a
+# CSV, best-effort, and aggregate the result.
+#
+# Extracted from .github/workflows/showcase_promote.yml so the loop is
+# unit-testable (see __tests__/promote-fleet.bats). The bug this fixes: the
+# inline workflow loop ran under `set -e`, so the FIRST service whose promote
+# exited non-zero aborted the entire loop — every later service in the CSV was
+# left unpromoted. With `service=all`, one chronically-red service (e.g.
+# showcase-ag2) blocked promoting the whole fleet.
+#
+# Behavior:
+#   * Attempt EVERY service in the CSV regardless of individual failures.
+#   * Capture each service's exit code into a succeeded-set / failed-set.
+#   * Emit a clear end-of-run summary (stdout + GitHub Step Summary when
+#     $GITHUB_STEP_SUMMARY is set).
+#   * Exit non-zero iff ANY service failed — but only AFTER attempting all of
+#     them. Exit zero only when every attempted service succeeded.
+#
+# Usage:
+#   SERVICES_CSV="a,b,c" [DIGEST=ref] scripts/promote-fleet.sh
+#
+# Env:
+#   SERVICES_CSV  (required)  comma-separated service names to promote.
+#   DIGEST        (optional)  digest override; forwarded as `--digest <ref>`.
+#                             Upstream resolve-targets already rejects
+#                             --digest + 'all', so a populated DIGEST here
+#                             always pairs with a single-service CSV.
+#   RAILWAY_BIN   (optional)  path to the railway CLI (default: sibling
+#                             ../bin/railway). Overridable for testing.
+#
+# NOTE: we intentionally do NOT pass --confirm-divergence; WARN-divergence
+# refusals from bin/railway are a real signal and must fail the run.
+
+# NB: deliberately NOT `set -e` — a non-zero `bin/railway promote` for one
+# service must not abort the loop. We capture each exit code explicitly and
+# compute the aggregate result ourselves. `set -uo pipefail` is still safe and
+# catches unset-variable / pipeline bugs in our own logic.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHOWCASE_DIR="$(dirname "$HERE")"
+RAILWAY_BIN="${RAILWAY_BIN:-$SHOWCASE_DIR/bin/railway}"
+
+if [ -z "${SERVICES_CSV:-}" ]; then
+  echo "::error::promote-fleet: SERVICES_CSV is empty; nothing to promote." >&2
+  exit 1
+fi
+
+IFS=',' read -ra SVCS <<< "$SERVICES_CSV"
+
+# Validate the railway CLI up front. Without this, a missing/non-executable
+# binary makes EVERY iteration fail with 126/127, misattributing a single
+# environment error as N per-service promote failures. `-x` covers an absolute
+# path; `command -v` covers RAILWAY_BIN being a bare PATH command name.
+if [ ! -x "$RAILWAY_BIN" ] && ! command -v "$RAILWAY_BIN" >/dev/null 2>&1; then
+  echo "::error::promote-fleet: RAILWAY_BIN '$RAILWAY_BIN' is missing or not executable; cannot promote." >&2
+  exit 1
+fi
+
+succeeded=()
+failed=()        # "svc=exitcode" entries
+
+for svc in "${SVCS[@]}"; do
+  # Trim leading/trailing whitespace: `IFS=',' read` does NOT trim, so a CSV
+  # like "svc-a, svc-c" yields a literal " svc-c" (leading space) that would be
+  # promoted as a bogus service name. Trim BEFORE the empty-check so a
+  # whitespace-only token is also correctly skipped.
+  svc="${svc#"${svc%%[![:space:]]*}"}"   # strip leading whitespace
+  svc="${svc%"${svc##*[![:space:]]}"}"   # strip trailing whitespace
+
+  # Guard against empty tokens from a stray/trailing comma (or a whitespace-only
+  # token) in the CSV.
+  [ -n "$svc" ] || continue
+
+  args=(promote "$svc" --yes --non-interactive)
+  if [ -n "${DIGEST:-}" ]; then
+    args+=(--digest "$DIGEST")
+  fi
+
+  echo "==> $RAILWAY_BIN ${args[*]}"
+  "$RAILWAY_BIN" "${args[@]}"
+  rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    echo "    OK: $svc"
+    succeeded+=("$svc")
+  else
+    echo "::error::promote failed for '$svc' (exit $rc)"
+    failed+=("$svc=$rc")
+  fi
+done
+
+# Guard against a non-empty CSV that parsed to ONLY empty/whitespace tokens
+# (e.g. ",," or " , "). Such input passes the SERVICES_CSV empty-check, skips
+# every token in the loop, and would otherwise exit 0 claiming "All services
+# promoted successfully" — a silent no-op false success. If zero services were
+# actually attempted, fail loud.
+attempted=$(( ${#succeeded[@]} + ${#failed[@]} ))
+if [ "$attempted" -eq 0 ]; then
+  echo "::error::promote-fleet: SERVICES_CSV contained no usable service names (only empty/whitespace tokens); nothing was promoted." >&2
+  exit 1
+fi
+
+# ── Step output ────────────────────────────────────────────────────────────
+# Export the SUCCEEDED set (comma-joined) so the downstream verify-prod job can
+# scope its prod verification to only the services that actually promoted — not
+# the full requested set (which would include any failed service and guarantee
+# a red verify) and not nothing (which would skip verification of the services
+# that DID promote). Guarded so a local/bats run with no $GITHUB_OUTPUT is a
+# no-op. Uses the same `key=value >> "$GITHUB_OUTPUT"` idiom as the workflow.
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  succeeded_csv=""
+  if [ "${#succeeded[@]}" -gt 0 ]; then
+    succeeded_csv=$(IFS=,; echo "${succeeded[*]}")
+  fi
+  # Fail loud on a failed redirect. Under `set -uo pipefail` (no `-e`) a failed
+  # append would otherwise be silently discarded, leaving verify-prod scoping
+  # unreliable (an absent succeeded_csv key it depends on).
+  if ! echo "succeeded_csv=$succeeded_csv" >> "$GITHUB_OUTPUT"; then
+    echo "::error::promote-fleet: failed to write succeeded_csv to \$GITHUB_OUTPUT ('$GITHUB_OUTPUT')." >&2
+    exit 1
+  fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────
+emit() {
+  # Echo to stdout AND, when running in GitHub Actions, append to the step
+  # summary so the result is visible in the run UI.
+  echo "$1"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "$1" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+emit "## Promote fleet summary"
+# Report services ACTUALLY attempted (succeeded + failed), not the raw CSV
+# token count — which would over-count empty/whitespace tokens skipped above.
+emit "Attempted ${attempted} service(s) from SERVICES_CSV."
+
+if [ "${#succeeded[@]}" -gt 0 ]; then
+  emit "SUCCEEDED (${#succeeded[@]}): ${succeeded[*]}"
+else
+  emit "SUCCEEDED (0): (none)"
+fi
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  emit "FAILED (${#failed[@]}): ${failed[*]}"
+  emit ""
+  emit "One or more services failed to promote; marking the run failed so the notify job fires."
+  exit 1
+fi
+
+emit "FAILED (0): (none)"
+emit ""
+emit "All services promoted successfully."
+exit 0


### PR DESCRIPTION
## Summary

The showcase Railway promote CI flow could not promote the fleet: an `all` promote was blocked end-to-end whenever a single service was red, and the reported failure traced to `showcase-ag2` being chronically red on staging.

Root causes and fixes:

- **ag2 crash-on-import (the red service).** `gen_ui_agent.py` carried `from __future__ import annotations`, which stringified the `set_steps` tool's `context_variables: ContextVariables` parameter into an unresolved `ForwardRef`. AG2's tool-schema generation then raised `PydanticUserError` at import time, so the process never came up and the staging healthcheck failed on every deploy since 2026-05-31. Removed the import (matching the working sibling agents) and added a regression test that statically asserts the future-import stays absent (version-independent) plus a live import check.

- **Promote loop was all-or-nothing.** The per-service loop ran under `set -euo pipefail`, so the first failing service aborted the whole `all` promote, leaving the rest unpromoted. Extracted the loop into `showcase/scripts/promote-fleet.sh`, which attempts every service, accumulates succeeded/failed sets, exits non-zero only after attempting all, and exports `succeeded_csv`.

- **`verify-prod` defeated the best-effort design.** It was skipped on any non-zero promote and verified the full requested set. It now runs `if: !cancelled()` and scopes `--services` to the succeeded set.

- **Staging precondition blocked the fleet.** `verify-staging-precondition` failed the whole `all` promote when any one service was staging-red. It is now advisory — `promote` runs regardless, and `bin/railway`'s per-service P2/P3 staging-green gates authoritatively refuse red services while green services promote. `notify` success keys on PROMOTE && PROD.

- **Regression tests now gate in CI.** Added a `shell-script-tests` job (bats + shellcheck) to `showcase_validate.yml`, plus input-validation hardening in the script (fail-loud on empty / all-empty CSV, `RAILWAY_BIN` executability check, whitespace trim).

## Test plan

- [x] ag2 regression test passes in the 3.12 venv (`PYTHONPATH=".:src" pytest tests/python/`) — 2/2
- [x] `promote-fleet.bats` — 12/12 (best-effort loop, succeeded_csv export, empty/whitespace/missing-binary guards, digest forwarding)
- [x] `shellcheck promote-fleet.sh` clean; `actionlint` clean on both workflows
- [ ] CI green on this PR