### PR TITLE
feat(showcase): add Intelligence threads to AG2

### DIFF
--- a/scripts/__tests__/showcase-ag2-intelligence-migration.test.ts
+++ b/scripts/__tests__/showcase-ag2-intelligence-migration.test.ts
@@ -1,0 +1,113 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+
+const showcaseRoot = join(process.cwd(), "showcase", "integrations", "ag2");
+
+function readShowcaseFile(path: string): string {
+  return readFileSync(join(showcaseRoot, path), "utf8");
+}
+
+test("ag2 main runtime route is an optional catch-all for Threads APIs", () => {
+  expect(
+    existsSync(join(showcaseRoot, "src/app/api/copilotkit/route.ts")),
+  ).toBe(false);
+  expect(
+    existsSync(
+      join(showcaseRoot, "src/app/api/copilotkit/[[...slug]]/route.ts"),
+    ),
+  ).toBe(true);
+});
+
+test("ag2 main runtime route is gated for Intelligence threads", () => {
+  const route = readShowcaseFile("src/app/api/copilotkit/[[...slug]]/route.ts");
+
+  expect(route).toContain("CopilotKitIntelligence");
+  expect(route).toContain("process.env.COPILOTKIT_LICENSE_TOKEN");
+  expect(route).toContain("process.env.INTELLIGENCE_API_KEY");
+  expect(route).toContain("process.env.INTELLIGENCE_API_URL");
+  expect(route).toContain("process.env.INTELLIGENCE_GATEWAY_WS_URL");
+  expect(route).toContain('id: "demo-user"');
+  expect(route).toContain("licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN");
+  expect(route).toContain(": { runner: new InMemoryAgentRunner() }");
+  expect(route).toContain("createCopilotEndpoint");
+  expect(route).toContain("export const GET = handle(app);");
+  expect(route).toContain("export const POST = handle(app);");
+  expect(route).toContain("export const PATCH = handle(app);");
+  expect(route).toContain("export const DELETE = handle(app);");
+  expect(route).not.toContain("copilotRuntimeNextJSAppRouterEndpoint");
+});
+
+test("ag2 shared CopilotKit wrapper exposes Threads drawer and REST transport", () => {
+  const wrapper = readShowcaseFile(
+    "src/components/showcase-copilotkit/showcase-copilotkit.tsx",
+  );
+
+  expect(wrapper).toContain("ThreadsDrawer");
+  expect(wrapper).toContain("ThreadsPanelGate");
+  expect(wrapper).toContain("CopilotChatConfigurationProvider");
+  expect(wrapper).toContain("const [threadId, setThreadId]");
+  expect(wrapper).toContain("useSingleEndpoint={false}");
+  expect(wrapper).toContain("threadId={threadId}");
+  expect(wrapper).toContain("hasExplicitThreadId={threadId !== undefined}");
+  expect(wrapper).toContain("agentId={agentId}");
+});
+
+test("ag2 demos that use the main runtime go through the shared Threads wrapper", () => {
+  const demoPages = [
+    "src/app/demos/agentic-chat/page.tsx",
+    "src/app/demos/frontend-tools/page.tsx",
+    "src/app/demos/gen-ui-agent/page.tsx",
+    "src/app/demos/shared-state-read/page.tsx",
+    "src/app/demos/shared-state-read-write/page.tsx",
+    "src/app/demos/tool-rendering/page.tsx",
+  ];
+
+  for (const demoPage of demoPages) {
+    const page = readShowcaseFile(demoPage);
+    expect(page).toContain("ShowcaseCopilotKit");
+    expect(page).not.toContain('runtimeUrl="/api/copilotkit"');
+  }
+});
+
+test("ag2 exposes local Intelligence env documentation", () => {
+  const envExample = readShowcaseFile(".env.example");
+  const gitignore = readShowcaseFile(".gitignore");
+
+  expect(envExample).toContain("OPENAI_API_KEY=");
+  expect(envExample).toContain("COPILOTKIT_LICENSE_TOKEN=");
+  expect(envExample).toContain("INTELLIGENCE_API_KEY=");
+  expect(envExample).toContain("INTELLIGENCE_API_URL=http://localhost:4201");
+  expect(envExample).toContain(
+    "INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401",
+  );
+  expect(gitignore).toContain("!.env.example");
+});
+
+test("ag2 package is pinned to the Intelligence-ready CopilotKit SDK", () => {
+  const packageJson = JSON.parse(readShowcaseFile("package.json")) as {
+    dependencies: Record<string, string>;
+    overrides?: Record<string, string | Record<string, string>>;
+    pnpm?: { overrides?: Record<string, string> };
+  };
+
+  expect(packageJson.dependencies["@copilotkit/a2ui-renderer"]).toBe("1.59.1");
+  expect(packageJson.dependencies["@copilotkit/react-core"]).toBe("1.59.1");
+  expect(packageJson.dependencies["@copilotkit/runtime"]).toBe("1.59.1");
+  expect(packageJson.dependencies["@copilotkit/shared"]).toBe("1.59.1");
+  expect(packageJson.dependencies["@copilotkit/voice"]).toBe("1.59.1");
+  expect(packageJson.overrides?.["@copilotkit/web-inspector"]).toEqual({
+    "@copilotkit/core": "1.59.1",
+  });
+  expect(
+    packageJson.pnpm?.overrides?.["@copilotkit/web-inspector>@copilotkit/core"],
+  ).toBe("1.59.1");
+});
+
+test("ag2 Next config enables the Threads feature flag", () => {
+  const nextConfig = readShowcaseFile("next.config.ts");
+
+  expect(nextConfig).toContain('output: "standalone"');
+  expect(nextConfig).toContain("NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED");
+  expect(nextConfig).toContain("process.env.COPILOTKIT_LICENSE_TOKEN");
+});

--- a/showcase/integrations/ag2/.env.example
+++ b/showcase/integrations/ag2/.env.example
@@ -5,5 +5,11 @@ ANTHROPIC_API_KEY=replace-with-your-key
 # Agent backend URL (for the CopilotKit runtime proxy)
 AGENT_URL=http://localhost:8000
 
+# Optional CopilotKit Intelligence threads
+COPILOTKIT_LICENSE_TOKEN=
+INTELLIGENCE_API_KEY=
+INTELLIGENCE_API_URL=http://localhost:4201
+INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
+
 # Showcase
 NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/showcase/integrations/ag2/.gitignore
+++ b/showcase/integrations/ag2/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .next/
 .env.local
 .env
+!.env.example
 *.pyc
 __pycache__/
 .venv/

--- a/showcase/integrations/ag2/next.config.ts
+++ b/showcase/integrations/ag2/next.config.ts
@@ -1,6 +1,12 @@
 import type { NextConfig } from "next";
 
+const threadsEnabled = process.env.COPILOTKIT_LICENSE_TOKEN ? "true" : "false";
+
 const nextConfig: NextConfig = {
+  output: "standalone",
+  env: {
+    NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED: threadsEnabled,
+  },
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [

--- a/showcase/integrations/ag2/package-lock.json
+++ b/showcase/integrations/ag2/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@ag-ui/client": "^0.0.43",
-        "@copilotkit/a2ui-renderer": "1.59.2",
-        "@copilotkit/react-core": "1.59.2",
-        "@copilotkit/runtime": "1.59.2",
-        "@copilotkit/shared": "1.59.2",
-        "@copilotkit/voice": "1.59.2",
+        "@copilotkit/a2ui-renderer": "1.59.1",
+        "@copilotkit/react-core": "1.59.1",
+        "@copilotkit/runtime": "1.59.1",
+        "@copilotkit/shared": "1.59.1",
+        "@copilotkit/voice": "1.59.1",
         "@hashbrownai/core": "0.5.0-beta.4",
         "@hashbrownai/react": "0.5.0-beta.4",
         "@json-render/core": "0.18.0",
@@ -456,9 +456,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@copilotkit/a2ui-renderer": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.59.2.tgz",
-      "integrity": "sha512-uiTbBDbfX3clB7cDV4at1e1HlmWfg1QOzwY9+xouZ7cShROh6knX9GsPZitmICCZFc2sx2TRBXKPCS/sgOisxA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.59.1.tgz",
+      "integrity": "sha512-jRltYlLKqwWREiS430pJ0ukpA1L7hralerVFYlsgtkMhRMf9DzSMl+Gbt48FDGt/QteS7YwsT+nZrUWanOXJXg==",
       "license": "MIT",
       "dependencies": {
         "@a2ui/web_core": "0.9.0",
@@ -472,12 +472,12 @@
       }
     },
     "node_modules/@copilotkit/core": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.59.2.tgz",
-      "integrity": "sha512-tH7X/wEJBr5fi2iAAod+LBzdG5vUDCoWa8ET4hh7Un6FPCLLoXPGK+kXJZX9YoqDWuTn91ewbuUcA86JHhh96A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.59.1.tgz",
+      "integrity": "sha512-i1cdGADVNR/TkkZcMWGyrInBMutnHlCVxvLoujet9x8OkgMVOF/T6w9Ep7PNNY5Wwlu+i2XwGQPz5bb1/NyUdw==",
       "dependencies": {
         "@ag-ui/client": "0.0.53",
-        "@copilotkit/shared": "1.59.2",
+        "@copilotkit/shared": "1.59.1",
         "@tanstack/pacer": "^0.20.1",
         "phoenix": "^1.8.4",
         "rxjs": "7.8.1",
@@ -538,18 +538,18 @@
       "license": "MIT"
     },
     "node_modules/@copilotkit/react-core": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.59.2.tgz",
-      "integrity": "sha512-HaaYCEc4z8Q5TX26SzV2tZpiGkggI3pNMEYexoWjV56zwgu05xV0Cu8Wrjrvfw6xBKZiciiOfYTH3vL4rTeDwQ==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.59.1.tgz",
+      "integrity": "sha512-vteM29uKKhN1IfS9iKIMDw28IUGMSuUJd3eB6gAJhE2lI4GUr0K02vytUclqHKxR1/vUZpsvqvPJuDLCFO4ujw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.53",
         "@ag-ui/core": "0.0.53",
-        "@copilotkit/a2ui-renderer": "1.59.2",
-        "@copilotkit/core": "1.59.2",
-        "@copilotkit/runtime-client-gql": "1.59.2",
-        "@copilotkit/shared": "1.59.2",
-        "@copilotkit/web-inspector": "1.59.2",
+        "@copilotkit/a2ui-renderer": "1.59.1",
+        "@copilotkit/core": "1.59.1",
+        "@copilotkit/runtime-client-gql": "1.59.1",
+        "@copilotkit/shared": "1.59.1",
+        "@copilotkit/web-inspector": "1.59.1",
         "@jetbrains/websandbox": "^1.1.3",
         "@lit-labs/react": "^2.0.2",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -1349,9 +1349,9 @@
       }
     },
     "node_modules/@copilotkit/runtime": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.59.2.tgz",
-      "integrity": "sha512-Qxc5BvWNrtd69Un9IapGVCSEvfif7p56MjD1O9f88uZsFELIwdHCtJq3SCuJbpScysekelrAJV6tBwa7L/B1Rw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.59.1.tgz",
+      "integrity": "sha512-0Rl+8i2xj3dGiy+NG6tnItg0wGgXxOnB8BVkMsHC6PxRQp7am3PqUNrOQTFI67i7bvXfEPNdZINm97djzOvVSQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/a2ui-middleware": "0.0.5",
@@ -1366,7 +1366,7 @@
         "@ai-sdk/mcp": "^1.0.21",
         "@ai-sdk/openai": "^3.0.36",
         "@copilotkit/license-verifier": "~0.4.2",
-        "@copilotkit/shared": "1.59.2",
+        "@copilotkit/shared": "1.59.1",
         "@graphql-yoga/plugin-defer-stream": "^3.3.1",
         "@hono/node-server": "^1.13.5",
         "@modelcontextprotocol/sdk": "^1.18.2",
@@ -1438,12 +1438,12 @@
       }
     },
     "node_modules/@copilotkit/runtime-client-gql": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.59.2.tgz",
-      "integrity": "sha512-wJnEA13SGUGNMAqoLm8Br+iI4qK7bLnQrmHJLmDM9cZ+CsozbyTLO7c0JIblcIgCICrDWzjI3KWnxMju+tkbQg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.59.1.tgz",
+      "integrity": "sha512-JLBDy5Y37LiZhKWIwSm4ETQBOzy3vHDUvbvjtxDzF6kxsddswyXEMtjQUEc93RDwDCh1XuH2FLnd1ha48kmOLQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "1.59.2",
+        "@copilotkit/shared": "1.59.1",
         "@urql/core": "^5.0.3",
         "untruncate-json": "^0.0.1",
         "urql": "^4.1.0"
@@ -1524,9 +1524,9 @@
       }
     },
     "node_modules/@copilotkit/shared": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.59.2.tgz",
-      "integrity": "sha512-W5YUsIBwe0utd8kX50cqt8X+nSvd3PnKXqgE5pfq9DdmoNYsiNNYyNiq8ENOsxgEUXzFG+itfI2WlJzxcdGJGQ==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.59.1.tgz",
+      "integrity": "sha512-vCJB4bao5Tu54mc7D/h/vLfUZsDECl/kgW/GVli2soMzIJW6UAHFhtt2D9MN206xDtE6gXqBnBIMKNG+JO61SQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.53",
@@ -1589,9 +1589,9 @@
       }
     },
     "node_modules/@copilotkit/voice": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/@copilotkit/voice/-/voice-1.59.2.tgz",
-      "integrity": "sha512-ZhYvjqHQ7eQjZznPCk6SHTfIDZcDssOScZHTNX1LrDRItq3VwqImbv1op1YQPi5reZrCNUmihCGOLLOmFrPfDw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/voice/-/voice-1.59.1.tgz",
+      "integrity": "sha512-CbKTe7JZ2lLb/a6MEFphL6WKk2bHA8LLBHOU3uyox9rKIfkwJF5bGs9umOSFV9UVJJO2xMWfLffKuGvnbbNJMw==",
       "dependencies": {
         "openai": "^5.9.0"
       },
@@ -1599,16 +1599,16 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@copilotkit/runtime": "1.59.2"
+        "@copilotkit/runtime": "1.59.1"
       }
     },
     "node_modules/@copilotkit/web-inspector": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.59.2.tgz",
-      "integrity": "sha512-f8kYH0AkdjP6xqtprzGqc75R7EItIkSBzvliNDKwDXTarLrbza/ZxJmufIvFvKZZALnKwDqG3KGFqrHqLzVCMw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.59.1.tgz",
+      "integrity": "sha512-vA+xhTiXLh7x0IKP84O7neAAZfx6FYzzwGAr1lVPBLDABGb8Ax2ZuSGywMEEtAiu9r5ravPTN+oT71yRNjD4yA==",
       "dependencies": {
         "@ag-ui/client": "0.0.53",
-        "@copilotkit/core": "1.59.2",
+        "@copilotkit/core": "1.59.1",
         "lit": "^3.2.0",
         "lucide": "^0.525.0",
         "marked": "^12.0.2"
@@ -8250,9 +8250,9 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
-      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.1.tgz",
+      "integrity": "sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"

--- a/showcase/integrations/ag2/package.json
+++ b/showcase/integrations/ag2/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "@ag-ui/client": "^0.0.43",
-    "@copilotkit/a2ui-renderer": "1.59.2",
-    "@copilotkit/react-core": "1.59.2",
-    "@copilotkit/runtime": "1.59.2",
-    "@copilotkit/shared": "1.59.2",
-    "@copilotkit/voice": "1.59.2",
+    "@copilotkit/a2ui-renderer": "1.59.1",
+    "@copilotkit/react-core": "1.59.1",
+    "@copilotkit/runtime": "1.59.1",
+    "@copilotkit/shared": "1.59.1",
+    "@copilotkit/voice": "1.59.1",
     "@hashbrownai/core": "0.5.0-beta.4",
     "@hashbrownai/react": "0.5.0-beta.4",
     "@json-render/core": "0.18.0",
@@ -51,12 +51,12 @@
   },
   "overrides": {
     "@copilotkit/web-inspector": {
-      "@copilotkit/core": "1.59.2"
+      "@copilotkit/core": "1.59.1"
     }
   },
   "pnpm": {
     "overrides": {
-      "@copilotkit/web-inspector>@copilotkit/core": "1.59.2"
+      "@copilotkit/web-inspector>@copilotkit/core": "1.59.1"
     }
   }
 }

--- a/showcase/integrations/ag2/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -1,10 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
 import {
+  CopilotKitIntelligence,
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  InMemoryAgentRunner,
+  createCopilotEndpoint,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
+import { handle } from "hono/vercel";
 
 // The agent backend runs as a separate process on port 8000.
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
@@ -82,67 +84,33 @@ console.log(
   `[copilotkit/route] Registered ${Object.keys(agents).length} agent names: ${Object.keys(agents).join(", ")}`,
 );
 
-export const POST = async (req: NextRequest) => {
-  const url = req.url;
-  const contentType = req.headers.get("content-type");
-  console.log(`[copilotkit/route] POST ${url} (content-type: ${contentType})`);
-
-  try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
-      runtime: new CopilotRuntime({
-        // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
-        agents,
+const intelligenceRuntimeConfig = process.env.COPILOTKIT_LICENSE_TOKEN
+  ? {
+      intelligence: new CopilotKitIntelligence({
+        apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
+        apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
+        wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
       }),
-    });
-
-    const response = await handleRequest(req);
-    console.log(`[copilotkit/route] Response status: ${response.status}`);
-    return response;
-  } catch (error: unknown) {
-    // Log full details server-side (operators grep `errorId` to correlate),
-    // but never echo `err.message` / `err.stack` back to the HTTP client —
-    // that leaks internal paths, dependency versions, and stack traces.
-    const err = error instanceof Error ? error : new Error(String(error));
-    const errorId = crypto.randomUUID();
-    console.error(
-      JSON.stringify({
-        at: new Date().toISOString(),
-        level: "error",
-        scope: "copilotkit/route",
-        errorId,
-        message: err.message,
-        stack: err.stack,
+      identifyUser: async () => ({
+        id: "demo-user",
+        name: "Demo User",
       }),
-    );
-    return NextResponse.json(
-      { error: "internal runtime error", errorId },
-      { status: 500 },
-    );
-  }
-};
+      licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
+    }
+  : { runner: new InMemoryAgentRunner() };
 
-export const GET = async () => {
-  console.log("[copilotkit/route] GET /api/copilotkit (health probe)");
+const runtime = new CopilotRuntime({
+  // @ts-expect-error -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
+  agents,
+  ...intelligenceRuntimeConfig,
+});
 
-  let agentStatus = "unknown";
-  try {
-    const res = await fetch(`${AGENT_URL}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    agentStatus = res.ok ? "reachable" : `error (${res.status})`;
-  } catch (e: unknown) {
-    agentStatus = `unreachable (${(e as Error).message})`;
-  }
+const app = createCopilotEndpoint({
+  runtime,
+  basePath: "/api/copilotkit",
+});
 
-  return NextResponse.json({
-    status: "ok",
-    agent_url: AGENT_URL,
-    agent_status: agentStatus,
-    env: {
-      OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-      NODE_ENV: process.env.NODE_ENV,
-    },
-  });
-};
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);

--- a/showcase/integrations/ag2/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/agentic-chat/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import React from "react";
-import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import { CopilotChat } from "@copilotkit/react-core/v2";
+import { ShowcaseCopilotKit } from "@/components/showcase-copilotkit";
 import { useAgenticChatSuggestions } from "./suggestions";
 
 export default function AgenticChatDemo() {
   return (
     // @region[provider-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <ShowcaseCopilotKit agentId="agentic_chat">
       <Chat />
-    </CopilotKit>
+    </ShowcaseCopilotKit>
     // @endregion[provider-setup]
   );
 }

--- a/showcase/integrations/ag2/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/frontend-tools/page.tsx
@@ -2,11 +2,8 @@
 
 // @region[frontend-tool-registration]
 import React, { useState } from "react";
-import {
-  CopilotKit,
-  CopilotSidebar,
-  useFrontendTool,
-} from "@copilotkit/react-core/v2";
+import { CopilotSidebar, useFrontendTool } from "@copilotkit/react-core/v2";
+import { ShowcaseCopilotKit } from "@/components/showcase-copilotkit";
 import { z } from "zod";
 import { Background, DEFAULT_BACKGROUND } from "./background";
 import { useFrontendToolsSuggestions } from "./suggestions";
@@ -43,8 +40,8 @@ function Chat() {
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <ShowcaseCopilotKit agentId="frontend_tools">
       <Chat />
-    </CopilotKit>
+    </ShowcaseCopilotKit>
   );
 }

--- a/showcase/integrations/ag2/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/gen-ui-agent/page.tsx
@@ -3,10 +3,10 @@
 import React from "react";
 import {
   CopilotChat,
-  CopilotKit,
   useAgent,
   UseAgentUpdate,
 } from "@copilotkit/react-core/v2";
+import { ShowcaseCopilotKit } from "@/components/showcase-copilotkit";
 import type { Step } from "./InlineAgentStateCard";
 import { MessageListWithState } from "./message-list-with-state";
 import { useSuggestions } from "./suggestions";
@@ -31,13 +31,13 @@ import { useSuggestions } from "./suggestions";
  */
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <ShowcaseCopilotKit agentId="gen-ui-agent">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />
         </div>
       </div>
-    </CopilotKit>
+    </ShowcaseCopilotKit>
   );
 }
 

--- a/showcase/integrations/ag2/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/shared-state-read-write/page.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import React, { useEffect } from "react";
-import {
-  CopilotKit,
-  useAgent,
-  UseAgentUpdate,
-} from "@copilotkit/react-core/v2";
+import { useAgent, UseAgentUpdate } from "@copilotkit/react-core/v2";
+import { ShowcaseCopilotKit } from "@/components/showcase-copilotkit";
 
-import { Preferences } from "./preferences-card";
+import type { Preferences } from "./preferences-card";
 import { DemoLayout } from "./demo-layout";
 import { useSharedStateReadWriteSuggestions } from "./suggestions";
 
@@ -29,9 +26,9 @@ interface RWAgentState {
 
 export default function SharedStateReadWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read-write">
+    <ShowcaseCopilotKit agentId="shared-state-read-write">
       <DemoContent />
-    </CopilotKit>
+    </ShowcaseCopilotKit>
   );
 }
 

--- a/showcase/integrations/ag2/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/shared-state-read/page.tsx
@@ -11,23 +11,20 @@
 
 import React, { useEffect } from "react";
 import {
-  CopilotKit,
   CopilotSidebar,
   useAgent,
   UseAgentUpdate,
   useConfigureSuggestions,
   useCopilotKit,
 } from "@copilotkit/react-core/v2";
+import { ShowcaseCopilotKit } from "@/components/showcase-copilotkit";
 import { RecipeCard } from "./recipe-card";
-import {
-  INITIAL_RECIPE,
-  type RecipeAgentState,
-  type RecipeData,
-} from "./types";
+import { INITIAL_RECIPE } from "./types";
+import type { RecipeAgentState, RecipeData } from "./types";
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <ShowcaseCopilotKit agentId="shared-state-read">
       <div className="min-h-screen w-full bg-gray-50">
         <div className="mx-auto max-w-2xl px-4 py-8 md:py-12">
           <Recipe />
@@ -37,7 +34,7 @@ export default function SharedStateReadDemo() {
           labels={{ modalHeaderTitle: "AI Recipe Assistant" }}
         />
       </div>
-    </CopilotKit>
+    </ShowcaseCopilotKit>
   );
 }
 

--- a/showcase/integrations/ag2/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/tool-rendering/page.tsx
@@ -16,20 +16,19 @@
 // @region[render-weather-tool]
 import React from "react";
 import {
-  CopilotKit,
   CopilotChat,
   useRenderTool,
   useDefaultRenderTool,
 } from "@copilotkit/react-core/v2";
+import { ShowcaseCopilotKit } from "@/components/showcase-copilotkit";
 import { z } from "zod";
 import { WeatherCard } from "./weather-card";
-import { FlightListCard, type Flight } from "./flight-list-card";
+import { FlightListCard } from "./flight-list-card";
+import type { Flight } from "./flight-list-card";
 import { StockCard } from "./stock-card";
 import { D20Card } from "./d20-card";
-import {
-  CustomCatchallRenderer,
-  type CatchallToolStatus,
-} from "./custom-catchall-renderer";
+import { CustomCatchallRenderer } from "./custom-catchall-renderer";
+import type { CatchallToolStatus } from "./custom-catchall-renderer";
 import { parseJsonResult } from "../_shared/parse-json-result";
 import { useSuggestions } from "./suggestions";
 
@@ -61,13 +60,13 @@ interface D20Result {
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <ShowcaseCopilotKit agentId="tool-rendering">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />
         </div>
       </div>
-    </CopilotKit>
+    </ShowcaseCopilotKit>
   );
 }
 

--- a/showcase/integrations/ag2/src/app/globals.css
+++ b/showcase/integrations/ag2/src/app/globals.css
@@ -6,6 +6,25 @@
   --copilot-kit-primary-color: #0066ff;
   --copilot-kit-response-button-background-color: #f5f5f3;
   --copilot-kit-response-button-color: #1a1a18;
+
+  --background: #fafaf9;
+  --foreground: #1a1a18;
+  --card: #ffffff;
+  --card-foreground: #1a1a18;
+  --primary: #1a1a18;
+  --primary-foreground: #ffffff;
+  --secondary: #ededf5;
+  --secondary-foreground: #1a1a18;
+  --muted: #ededf5;
+  --muted-foreground: #57575b;
+  --accent: #eee6fe;
+  --accent-foreground: #1a1a18;
+  --destructive: #fa5f67;
+  --destructive-foreground: #ffffff;
+  --border: #dbdbe5;
+  --input: #dbdbe5;
+  --ring: #bec2ff;
+  --radius: 0.75rem;
 }
 
 * {
@@ -21,4 +40,10 @@ body {
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;
   color: #1a1a18;
+}
+
+.threadsLayout,
+body > [role="presentation"] {
+  --foreground: oklch(0.145 0 0);
+  --background: oklch(1 0 0);
 }

--- a/showcase/integrations/ag2/src/components/showcase-copilotkit/index.ts
+++ b/showcase/integrations/ag2/src/components/showcase-copilotkit/index.ts
@@ -1,0 +1,1 @@
+export { ShowcaseCopilotKit } from "./showcase-copilotkit";

--- a/showcase/integrations/ag2/src/components/showcase-copilotkit/showcase-copilotkit.module.css
+++ b/showcase/integrations/ag2/src/components/showcase-copilotkit/showcase-copilotkit.module.css
@@ -1,0 +1,11 @@
+.layout {
+  min-height: 100vh;
+  width: 100%;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.content {
+  min-height: 100vh;
+  width: 100%;
+}

--- a/showcase/integrations/ag2/src/components/showcase-copilotkit/showcase-copilotkit.tsx
+++ b/showcase/integrations/ag2/src/components/showcase-copilotkit/showcase-copilotkit.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import {
+  CopilotKit,
+  CopilotChatConfigurationProvider,
+} from "@copilotkit/react-core/v2";
+import { ThreadsDrawer, ThreadsPanelGate } from "@/components/threads-drawer";
+import styles from "./showcase-copilotkit.module.css";
+
+type ShowcaseCopilotKitProps = {
+  agentId: string;
+  children: ReactNode;
+  runtimeUrl?: string;
+};
+
+export function ShowcaseCopilotKit({
+  agentId,
+  children,
+  runtimeUrl = "/api/copilotkit",
+}: ShowcaseCopilotKitProps) {
+  const [threadId, setThreadId] = useState<string | undefined>();
+
+  return (
+    <CopilotKit
+      runtimeUrl={runtimeUrl}
+      agent={agentId}
+      useSingleEndpoint={false}
+    >
+      <div className={`${styles.layout} threadsLayout`}>
+        <ThreadsPanelGate>
+          <ThreadsDrawer
+            agentId={agentId}
+            threadId={threadId}
+            onThreadChange={setThreadId}
+          />
+        </ThreadsPanelGate>
+        <div className={styles.content} key={threadId ?? "new-thread"}>
+          <CopilotChatConfigurationProvider
+            agentId={agentId}
+            hasExplicitThreadId={threadId !== undefined}
+            threadId={threadId}
+          >
+            {children}
+          </CopilotChatConfigurationProvider>
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}

--- a/showcase/integrations/ag2/src/components/threads-drawer/THEME.md
+++ b/showcase/integrations/ag2/src/components/threads-drawer/THEME.md
@@ -1,0 +1,45 @@
+# Threads Panel — Design Notes (mastra)
+
+These are mastra's **bespoke** copies of the threads panel. They are no longer a
+shared/tokenized base component — they are styled to read as one product with
+mastra's `CopilotSidebar` (the right-side chat from `@copilotkit/react-core/v2`).
+
+## Design source of truth
+
+All surfaces, borders, radii, and type ramps are lifted from CopilotKit's V2
+design system: `@copilotkit/react-core/src/v2/styles/globals.css` plus the chat
+components (`CopilotModalHeader`, `CopilotChatSuggestionPill`,
+`CopilotChatInput`, `CopilotSidebarView`). The tokens are mirrored verbatim into
+`src/app/globals.css`:
+
+| Token                                  | Value (V2 light)                | Role in the panel                                                                                                                       |
+| -------------------------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `--card` / `--background`              | `oklch(1 0 0)` (white)          | Panel + card surfaces                                                                                                                   |
+| `--foreground`                         | `oklch(0.145 0 0)`              | Titles, thread titles, dialog text                                                                                                      |
+| `--muted` / `--secondary` / `--accent` | `oklch(0.97 0 0)`               | Hover/active surfaces, segment track, archived chip, code well                                                                          |
+| `--muted-foreground`                   | `oklch(0.556 0 0)`              | Meta text, idle icons, descriptions, placeholders                                                                                       |
+| `--border` / `--input`                 | `oklch(0.922 0 0)`              | All hairline borders                                                                                                                    |
+| `--primary`                            | `oklch(0.205 0 0)` (near-black) | New-thread pill, selected accent, primary CTA — the V2 sidebar's primary buttons are charcoal/black, **not** a brand accent             |
+| `--primary-foreground`                 | `oklch(0.985 0 0)`              | Primary button text                                                                                                                     |
+| `--destructive`                        | `oklch(0.577 0.245 27.325)`     | Delete hover                                                                                                                            |
+| `--ring`                               | `oklch(0.708 0 0)`              | Focus rings (2px box-shadow)                                                                                                            |
+| `--radius`                             | `0.625rem` (+ sm/md/lg/xl)      | Rectangular controls; icon buttons / pills / segments use `999px` to echo the sidebar's close button, suggestion pills, and send button |
+
+## Forced light
+
+mastra's `CopilotSidebar` is always light regardless of OS color scheme. The
+panel must match it, so `src/app/globals.css` re-pins `--foreground` and
+`--background` to the V2 light values on `.threadsLayout` (the layout wrapper)
+and on `body > [role="presentation"]` (the confirm dialog renders in a portal on
+`<body>`). The dark-mode `@media (prefers-color-scheme: dark)` block only flips
+the bare page `--background`/`--foreground`; the panel overrides win because
+they are scoped to the layout/portal roots.
+
+## Typography
+
+Geist (the app font, via `--font-body` / `--font-code`). Sizes/weights track the
+sidebar: header title `1rem / 500 / tracking-tight`, thread titles
+`0.8125rem / 500`, meta `0.6875rem`, all medium-weight — no heavy `700`s.
+
+Edit these files freely; they are mastra-owned and not shared with other
+examples.

--- a/showcase/integrations/ag2/src/components/threads-drawer/index.tsx
+++ b/showcase/integrations/ag2/src/components/threads-drawer/index.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export { default as ThreadsDrawer } from "./threads-drawer";
+export { ThreadsPanelGate } from "./locked-state";
+export type { ThreadsDrawerProps } from "./threads-drawer";

--- a/showcase/integrations/ag2/src/components/threads-drawer/locked-state.tsx
+++ b/showcase/integrations/ag2/src/components/threads-drawer/locked-state.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+import { Lock } from "lucide-react";
+import styles from "./threads-drawer.module.css";
+
+export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
+  // The Threads drawer reads a client-only external store (useThreads /
+  // useSyncExternalStore) with no server snapshot, so it must not render during
+  // SSR/prerender — Next would fail to prerender "/". Defer to client mount.
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  if (process.env.NEXT_PUBLIC_COPILOTKIT_THREADS_ENABLED === "true") {
+    if (!mounted) {
+      // SSR / first-paint placeholder: matches the open drawer's footprint +
+      // surface (and collapses to nothing on mobile) so the panel doesn't flash
+      // a bare-background column or shift the content when the drawer mounts.
+      return <div className={styles.drawerPlaceholder} aria-hidden />;
+    }
+    return <>{children}</>;
+  }
+
+  return (
+    <aside aria-label="Threads (locked)" className={styles.lockedPanel}>
+      <div className={styles.drawerHeader}>
+        <div className={styles.drawerHeaderMain}>
+          <h2 className={styles.drawerTitle}>Threads</h2>
+        </div>
+      </div>
+      <div className={styles.lockedBody}>
+        <div className={styles.lockedCard}>
+          <span aria-hidden className={styles.lockedIcon}>
+            <Lock size={18} />
+          </span>
+          <div className={styles.lockedHeading}>
+            <h3 className={styles.lockedTitle}>
+              Threads is a licensed feature
+            </h3>
+            <p className={styles.lockedDescription}>
+              Unlock persistent conversation history, multi-session context, and
+              thread management with CopilotKit Intelligence.
+            </p>
+          </div>
+          <p className={styles.lockedDescription}>
+            Add it to your project with:
+          </p>
+          <div className={styles.lockedCommand}>
+            <code className={styles.lockedCommandCode}>
+              copilotkit add-intelligence
+            </code>
+          </div>
+          <button
+            type="button"
+            className={styles.lockedCta}
+            onClick={() =>
+              window.open(
+                "https://docs.copilotkit.ai/intelligence",
+                "_blank",
+                "noopener,noreferrer",
+              )
+            }
+          >
+            Learn more
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/showcase/integrations/ag2/src/components/threads-drawer/threads-drawer.module.css
+++ b/showcase/integrations/ag2/src/components/threads-drawer/threads-drawer.module.css
@@ -1,0 +1,891 @@
+/* Threads panel — a left-side companion to mastra's CopilotSidebar.
+   Every surface, border, radius, and type ramp here is lifted from CopilotKit's
+   V2 design system (@copilotkit/react-core/src/v2) so the panel reads as the
+   same product as the chat on the right:
+     - surfaces: white card on a white app; borders are the --border hairline
+     - radius: --radius (0.625rem) for rectangular controls; rounded-full
+       (999px) for icon buttons, the segmented control, and the New-thread
+       affordance — echoing the sidebar's close button, suggestion pills, and
+       send button
+     - type: 0.875rem base / font-medium / tracking-tight, matching the
+       sidebar header + pills (no heavy 700 weights)
+     - primary action color is the sidebar's near-black --primary, NOT a brand
+       accent — the V2 sidebar's primary buttons render bg-black/text-white */
+
+.layout {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  min-height: 100vh;
+  min-height: 100svh;
+  height: 100dvh;
+  width: 100%;
+  overflow: hidden;
+}
+
+.drawer {
+  position: relative;
+  display: flex;
+  min-height: 100vh;
+  min-height: 100svh;
+  height: 100dvh;
+  background: var(--card);
+  border-right: 1px solid var(--border);
+  font-family: var(--font-body);
+  transition:
+    width 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.drawerOpen {
+  width: 18rem;
+}
+
+.drawerClosed {
+  width: 3.5rem;
+}
+
+/* First-paint placeholder (rendered by ThreadsPanelGate before the client-only
+   drawer mounts). Matches the open drawer's footprint + surface so there's no
+   bare-background column flash and no content shift on mount. On mobile the
+   real drawer floats (no grid footprint), so the placeholder reserves nothing. */
+.drawerPlaceholder {
+  width: 18rem;
+  flex-shrink: 0;
+  min-height: 100vh;
+  min-height: 100svh;
+  height: 100dvh;
+  background: var(--card);
+  border-right: 1px solid var(--border);
+}
+
+.drawerSurface {
+  display: flex;
+  flex: 1;
+  height: 100%;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Header — mirrors CopilotModalHeader: hairline bottom border, generous
+   px-4 py-4 rhythm, medium-weight tracking-tight title (not bold). */
+.drawerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.drawerHeaderMain {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.drawerTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+/* Icon button — the sidebar's close button: size-8, rounded-full, muted
+   foreground, hover lifts to bg-muted + foreground. */
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 0;
+  border-radius: 999px;
+  color: var(--muted-foreground);
+  background: transparent;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
+  cursor: pointer;
+}
+
+.iconButton:hover,
+.iconButton:focus-visible {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.iconButton:focus-visible,
+.threadItem:focus-visible,
+.newThreadButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--ring);
+}
+
+/* New-thread affordance — a compact pill in the sidebar's near-black
+   --primary, echoing the send button (bg-black, rounded-full, medium text). */
+.newThreadButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  height: 2rem;
+  padding: 0 0.75rem;
+  border: 0;
+  border-radius: 999px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    opacity 140ms ease;
+}
+
+.newThreadButton:hover {
+  opacity: 0.9;
+}
+
+.filterBar {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+}
+
+/* Segmented control — a single muted track with a white "lifted" active tab,
+   the same surface relationship the suggestion pills use (bg over muted). */
+.segmented {
+  display: inline-flex;
+  width: 100%;
+  padding: 0.1875rem;
+  border-radius: 999px;
+  background: var(--muted);
+  gap: 0.1875rem;
+}
+
+.segmentedOption {
+  flex: 1;
+  min-height: 1.75rem;
+  padding: 0.3rem 0.75rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.segmentedOption:hover {
+  color: var(--foreground);
+}
+
+.segmentedOption:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--ring);
+}
+
+.segmentedOptionActive {
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.08);
+}
+
+.drawerContent {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.threadList {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: 0.125rem;
+  overflow-y: auto;
+  /* Reserve scrollbar space so the list doesn't shift horizontally
+     when the scrollbar appears during the thread-enter animation. */
+  scrollbar-gutter: stable;
+  padding: 0.25rem 0.5rem 0.75rem;
+}
+
+.threadRow {
+  position: relative;
+}
+
+/* Thread row — a quiet hover/selected surface in the sidebar's accent gray,
+   --radius corners, no hairline rule between rows (the chat list is borderless
+   too). */
+.threadItem {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 0.625rem;
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    padding-right 140ms ease;
+}
+
+.threadItem:hover,
+.threadItem:focus-visible {
+  background: var(--accent);
+}
+
+.threadRow:hover .threadItem,
+.threadRow:focus-within .threadItem {
+  padding-right: 3.5rem;
+}
+
+.threadItemSelected,
+.threadItemSelected:hover {
+  background: var(--accent);
+}
+
+.threadItemAnimatingIn {
+  animation: threadItemEnter 420ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* A slim left accent rail; muted by default, fills to --primary when selected
+   — the same charcoal that drives the primary action buttons. */
+.threadAccent {
+  flex: none;
+  width: 0.1875rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: transparent;
+  transition: background 140ms ease;
+}
+
+.threadItemSelected .threadAccent {
+  background: var(--primary);
+}
+
+.threadBody {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.threadTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.3;
+  color: var(--foreground);
+}
+
+.threadTitlePlaceholder {
+  color: var(--muted-foreground);
+  font-weight: 400;
+}
+
+.threadTitleAnimated {
+  display: inline-block;
+  animation: generatedTitleReveal 360ms cubic-bezier(0.22, 1, 0.36, 1);
+  transform-origin: left center;
+}
+
+.threadMeta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.6875rem;
+  line-height: 1.3;
+  color: var(--muted-foreground);
+}
+
+.threadItemArchived .threadTitle {
+  color: var(--muted-foreground);
+  font-weight: 400;
+}
+
+.threadItemArchived .threadAccent {
+  opacity: 0.5;
+}
+
+/* Archived chip — a muted pill, the same surface/type as the suggestion
+   pills (bg muted, font-medium, tiny). */
+.archivedBadge {
+  display: inline-block;
+  margin-left: 0.375rem;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 999px;
+  background: var(--muted);
+  font-size: 0.625rem;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  vertical-align: middle;
+}
+
+/* Load-more — a full-width outline pill, the sidebar's suggestion-pill
+   treatment (border, bg-background, hover to accent). */
+.loadMoreButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 2rem;
+  margin-top: 0.375rem;
+  padding: 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--card);
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
+}
+
+.loadMoreButton:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--foreground);
+}
+
+.loadMoreButton:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.threadActions {
+  position: absolute;
+  right: 0.375rem;
+  top: 50%;
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  transform: translateY(-50%) scale(0.96);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+}
+
+.threadRow:hover .threadActions,
+.threadRow:focus-within .threadActions {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(-50%) scale(1);
+}
+
+.threadActionButton {
+  width: 1.75rem;
+  height: 1.75rem;
+}
+
+.tooltip {
+  position: relative;
+}
+
+/* Tooltip — matches the V2 dropdown/popover surface (white card, hairline
+   border, soft shadow, rounded-md), not an inverted chip. */
+.tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  /* Render below the trigger: a CSS pseudo-tooltip can't escape the drawer's
+     overflow containers, and "above" clips on the top row / collapsed rail. */
+  top: calc(100% + 0.35rem);
+  left: 50%;
+  transform: translateX(-50%) translateY(-2px);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--foreground);
+  font-family: var(--font-body);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.12);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 110ms ease 200ms,
+    transform 110ms ease 200ms;
+  z-index: 20;
+}
+
+.tooltip:hover::after,
+.tooltip:focus-visible::after {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.deleteButton {
+  color: var(--muted-foreground);
+}
+
+.deleteButton:hover,
+.deleteButton:focus-visible {
+  background: color-mix(in oklch, var(--destructive) 10%, transparent);
+  color: var(--destructive);
+}
+
+.loadingList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.25rem 0;
+}
+
+.loadingRow {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 0.625rem;
+  border-radius: var(--radius);
+}
+
+.loadingAccent {
+  flex: none;
+  width: 0.1875rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: var(--muted);
+  animation: threadsDrawerPulse 1.4s ease-in-out infinite;
+}
+
+.loadingBody {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.loadingTitleBar {
+  height: 0.6rem;
+  width: 60%;
+  border-radius: 999px;
+  background: var(--muted);
+  animation: threadsDrawerPulse 1.4s ease-in-out infinite;
+}
+
+.loadingMetaBar {
+  height: 0.45rem;
+  width: 35%;
+  border-radius: 999px;
+  background: var(--muted);
+  animation: threadsDrawerPulse 1.4s ease-in-out infinite;
+  animation-delay: 140ms;
+}
+
+@keyframes threadsDrawerPulse {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 0.9;
+  }
+}
+
+.emptyState {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+/* Empty/error card — clean white card with hairline border and the V2
+   radius-lg, same card vocabulary as the locked state. */
+.emptyCard {
+  display: flex;
+  max-width: 13rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--card);
+  font-family: var(--font-body);
+}
+
+.emptyTitle {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+}
+
+.emptyMessage {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--muted-foreground);
+}
+
+/* Locked state — same panel chrome (white surface, hairline right border,
+   header rhythm) as the unlocked drawer, with a single clean card that speaks
+   the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
+   add-intelligence command in a muted code well, and a near-black primary CTA
+   pill matching the sidebar's send button. */
+.lockedPanel {
+  display: flex;
+  width: 20rem;
+  flex-shrink: 0;
+  flex-direction: column;
+  height: 100dvh;
+  background: var(--card);
+  border-right: 1px solid var(--border);
+  font-family: var(--font-body);
+}
+
+.lockedBody {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.lockedCard {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--card);
+}
+
+.lockedIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+}
+
+.lockedHeading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.lockedTitle {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+}
+
+.lockedDescription {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--muted-foreground);
+}
+
+.lockedCommand {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--muted);
+}
+
+.lockedCommandCode {
+  font-family: var(--font-code);
+  font-size: 0.75rem;
+  white-space: nowrap;
+  color: var(--secondary-foreground);
+}
+
+.lockedCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 0.875rem;
+  border: 0;
+  border-radius: 999px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition: opacity 140ms ease;
+}
+
+.lockedCta:hover {
+  opacity: 0.9;
+}
+
+.lockedCta:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--ring);
+}
+
+.collapsedRail {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 0.5rem;
+}
+
+.mainPanel {
+  min-width: 0;
+  min-height: 100vh;
+  min-height: 100svh;
+  height: 100dvh;
+  overflow: auto;
+}
+
+.dialogOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgb(0 0 0 / 0.4);
+  backdrop-filter: blur(2px);
+  animation: dialogOverlayEnter 140ms ease-out;
+}
+
+/* Confirm dialog — the V2 popover/card surface: white, hairline border,
+   radius-xl, soft elevated shadow. */
+.dialog {
+  width: 100%;
+  max-width: 22rem;
+  padding: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: 0 20px 50px rgb(0 0 0 / 0.18);
+  font-family: var(--font-body);
+  animation: dialogEnter 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.dialogTitle {
+  margin: 0 0 0.4rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+}
+
+.dialogDescription {
+  margin: 0 0 1.1rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--muted-foreground);
+}
+
+.dialogActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.dialogButton {
+  min-height: 2.25rem;
+  padding: 0.5rem 0.95rem;
+  border: 0;
+  border-radius: var(--radius);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    opacity 140ms ease;
+}
+
+.dialogButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--ring);
+}
+
+.dialogButtonSecondary {
+  background: var(--card);
+  border: 1px solid var(--border);
+  color: var(--foreground);
+}
+
+.dialogButtonSecondary:hover {
+  background: var(--accent);
+}
+
+.dialogButtonPrimary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.dialogButtonPrimary:hover {
+  opacity: 0.9;
+}
+
+.dialogButtonDestructive {
+  background: var(--destructive);
+  color: var(--destructive-foreground);
+}
+
+.dialogButtonDestructive:hover {
+  opacity: 0.9;
+}
+
+@keyframes dialogOverlayEnter {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes dialogEnter {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes threadItemEnter {
+  0% {
+    opacity: 0;
+    transform: translateX(-10px);
+    background: var(--accent);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+    background: transparent;
+  }
+}
+
+@keyframes generatedTitleReveal {
+  0% {
+    opacity: 0;
+    filter: blur(6px);
+    transform: translateY(4px);
+  }
+  100% {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+}
+
+/* Tablet + phone: the threads panel goes off-canvas so the content and the
+   (full-screen) chat get the whole width instead of squeezing into a column. */
+@media (max-width: 1024px) {
+  .layout {
+    position: relative;
+    isolation: isolate;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  /* The mounted drawer floats on mobile, so the first-paint placeholder must
+     reserve no column (otherwise content shifts left when the drawer mounts). */
+  .drawerPlaceholder {
+    display: none;
+  }
+
+  /* No-license locked panel: hide on mobile (no interactive drawer to launch,
+     and a fixed-width panel leaves a dead column). */
+  .lockedPanel {
+    display: none;
+  }
+
+  /* Collapsed: a small floating launcher pinned top-left, above the full-screen
+     mobile chat (z-index 1200) so threads stay reachable over it. */
+  .drawer.drawerClosed {
+    position: fixed;
+    top: 0.5rem;
+    left: 0.5rem;
+    width: auto;
+    height: auto;
+    /* Override the base drawer's full-viewport height + chrome so the closed
+       state shrinks to a small floating launcher. */
+    min-height: 0;
+    border-right: 0;
+    background: transparent;
+    z-index: 1300;
+  }
+
+  .drawerClosed .collapsedRail {
+    flex-direction: row;
+    width: auto;
+    height: auto;
+    gap: 0.25rem;
+    padding: 0.25rem;
+    overflow: visible;
+    border-radius: 999px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 0.16);
+  }
+
+  /* Open: full-height off-canvas panel from the left, above the chat. */
+  .drawer.drawerOpen {
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 1300;
+    width: min(20rem, 92vw);
+    box-shadow: 0 20px 50px rgb(0 0 0 / 0.25);
+  }
+
+  .mainPanel {
+    grid-column: 1;
+    position: relative;
+    z-index: 1;
+  }
+}

--- a/showcase/integrations/ag2/src/components/threads-drawer/threads-drawer.tsx
+++ b/showcase/integrations/ag2/src/components/threads-drawer/threads-drawer.tsx
@@ -1,0 +1,586 @@
+"use client";
+
+import {
+  Archive,
+  ArchiveRestore,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useThreads } from "@copilotkit/react-core/v2";
+import styles from "./threads-drawer.module.css";
+
+export interface ThreadsDrawerProps {
+  agentId: string;
+  threadId: string | undefined;
+  onThreadChange: (threadId: string | undefined) => void;
+}
+
+interface DrawerThread {
+  id: string;
+  name: string | null;
+  updatedAt: string;
+  archived: boolean;
+  lastRunAt?: string;
+}
+
+const THREAD_ENTRY_ANIMATION_MS = 420;
+const TITLE_ANIMATION_MS = 360;
+const UNTITLED_THREAD_LABEL = "New thread";
+const RUNTIME_BASE_PATH = "/api/copilotkit";
+
+function formatThreadTimestamp(updatedAt: string): string {
+  const timestamp = new Date(updatedAt);
+  if (Number.isNaN(timestamp.getTime())) return "Updated recently";
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(timestamp);
+}
+
+function cx(...classNames: Array<string | false | undefined>): string {
+  return classNames.filter(Boolean).join(" ");
+}
+
+export default function ThreadsDrawer({
+  agentId,
+  threadId,
+  onThreadChange,
+}: ThreadsDrawerProps) {
+  const [showArchived, setShowArchived] = useState(false);
+  // Start collapsed on narrow screens (tablet + phone) so the panel — which
+  // becomes an off-canvas overlay below 1024px — doesn't cover the content +
+  // chat on load. The drawer is client-mounted, so reading window here is safe
+  // and won't cause a hydration mismatch.
+  const [isOpen, setIsOpen] = useState(
+    () => typeof window === "undefined" || window.innerWidth > 1024,
+  );
+  const [pendingDelete, setPendingDelete] = useState<{
+    id: string;
+    title: string;
+  } | null>(null);
+  const deleteTriggerRef = useRef<HTMLElement | null>(null);
+
+  const {
+    threads,
+    archiveThread,
+    deleteThread,
+    error,
+    isLoading,
+    hasMoreThreads,
+    isFetchingMoreThreads,
+    fetchMoreThreads,
+  } = useThreads({
+    agentId,
+    includeArchived: showArchived,
+    limit: 20,
+  });
+
+  const restoreThread = useCallback(
+    async (id: string) => {
+      const response = await fetch(
+        `${RUNTIME_BASE_PATH}/threads/${encodeURIComponent(id)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agentId, archived: false }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(
+          `Restore failed: ${response.status} ${response.statusText}`,
+        );
+      }
+    },
+    [agentId],
+  );
+
+  const hasMountedRef = useRef(false);
+  const hasLoadedOnceRef = useRef(false);
+  const stableThreadsRef = useRef<DrawerThread[]>(threads);
+  const previousThreadIdsRef = useRef<Set<string>>(new Set());
+  const previousNamesRef = useRef<Map<string, string | null>>(new Map());
+  const entryTimeoutsRef = useRef<Map<string, number>>(new Map());
+  const titleTimeoutsRef = useRef<Map<string, number>>(new Map());
+
+  if (!isLoading) {
+    hasLoadedOnceRef.current = true;
+    stableThreadsRef.current = threads;
+  }
+  const displayThreads: DrawerThread[] =
+    isLoading && hasLoadedOnceRef.current ? stableThreadsRef.current : threads;
+  const [enteringThreadIds, setEnteringThreadIds] = useState<
+    Record<string, true>
+  >({});
+  const [revealedTitleIds, setRevealedTitleIds] = useState<
+    Record<string, true>
+  >({});
+
+  useEffect(() => {
+    return () => {
+      for (const timeoutId of entryTimeoutsRef.current.values()) {
+        window.clearTimeout(timeoutId);
+      }
+      for (const timeoutId of titleTimeoutsRef.current.values()) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    // Skip diffing while the store is refetching (e.g. after a filter change
+    // clears the list). Otherwise every thread would be treated as newly
+    // added once the new page lands.
+    if (isLoading) return;
+
+    const nextThreadIds = new Set(threads.map((t) => t.id));
+
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      previousThreadIdsRef.current = nextThreadIds;
+      previousNamesRef.current = new Map(threads.map((t) => [t.id, t.name]));
+      return;
+    }
+
+    const addedThreadIds = threads
+      .filter((t) => !previousThreadIdsRef.current.has(t.id))
+      .map((t) => t.id);
+
+    if (addedThreadIds.length > 0) {
+      setEnteringThreadIds((current) => {
+        const next = { ...current };
+        for (const id of addedThreadIds) {
+          next[id] = true;
+          const existing = entryTimeoutsRef.current.get(id);
+          if (existing !== undefined) window.clearTimeout(existing);
+          const tid = window.setTimeout(() => {
+            setEnteringThreadIds((s) => {
+              const updated = { ...s };
+              delete updated[id];
+              return updated;
+            });
+            entryTimeoutsRef.current.delete(id);
+          }, THREAD_ENTRY_ANIMATION_MS);
+          entryTimeoutsRef.current.set(id, tid);
+        }
+        return next;
+      });
+    }
+
+    const renamedThreadIds = threads
+      .filter((t) => {
+        // Only reveal when an already-tracked thread's name transitions from
+        // null → named. Threads appearing for the first time (e.g. on a
+        // filter switch) already have their final name and should not trigger
+        // the title reveal animation — that would layer a blur/translateY
+        // onto the row's enter animation and produce a visible jitter.
+        if (!previousNamesRef.current.has(t.id)) return false;
+        const prev = previousNamesRef.current.get(t.id) ?? null;
+        return prev === null && t.name !== null;
+      })
+      .map((t) => t.id);
+
+    if (renamedThreadIds.length > 0) {
+      setRevealedTitleIds((current) => {
+        const next = { ...current };
+        for (const id of renamedThreadIds) {
+          next[id] = true;
+          const existing = titleTimeoutsRef.current.get(id);
+          if (existing !== undefined) window.clearTimeout(existing);
+          const tid = window.setTimeout(() => {
+            setRevealedTitleIds((s) => {
+              const updated = { ...s };
+              delete updated[id];
+              return updated;
+            });
+            titleTimeoutsRef.current.delete(id);
+          }, TITLE_ANIMATION_MS);
+          titleTimeoutsRef.current.set(id, tid);
+        }
+        return next;
+      });
+    }
+
+    previousThreadIdsRef.current = nextThreadIds;
+    previousNamesRef.current = new Map(threads.map((t) => [t.id, t.name]));
+  }, [threads, isLoading]);
+
+  const isInitialLoading = isLoading && !hasLoadedOnceRef.current;
+  if (error) {
+    console.error("Unable to load threads", error);
+  }
+
+  if (!isOpen) {
+    return (
+      <aside
+        aria-label="Threads drawer"
+        className={cx(styles.drawer, styles.drawerClosed)}
+      >
+        <div className={styles.collapsedRail}>
+          {/* Native title here (not the styled ::after): the collapsed rail
+              sits at the viewport's left edge where a centered tooltip clips. */}
+          <button
+            aria-label="Open threads drawer"
+            title="Expand"
+            className={styles.iconButton}
+            type="button"
+            onClick={() => setIsOpen(true)}
+          >
+            <ChevronRight size={18} />
+          </button>
+          <button
+            aria-label="Create thread"
+            title="New thread"
+            className={styles.iconButton}
+            type="button"
+            onClick={() => onThreadChange(crypto.randomUUID())}
+          >
+            <Plus size={18} />
+          </button>
+        </div>
+      </aside>
+    );
+  }
+
+  const closeDeleteDialog = () => {
+    setPendingDelete(null);
+    const trigger = deleteTriggerRef.current;
+    deleteTriggerRef.current = null;
+    trigger?.focus?.();
+  };
+
+  return (
+    <>
+      <aside
+        aria-label="Threads drawer"
+        className={cx(styles.drawer, styles.drawerOpen)}
+      >
+        <div className={styles.drawerSurface}>
+          <div className={styles.drawerHeader}>
+            <div className={styles.drawerHeaderMain}>
+              <h2 className={styles.drawerTitle}>Threads</h2>
+            </div>
+            <div className={styles.headerActions}>
+              <button
+                aria-label="Create thread"
+                className={styles.newThreadButton}
+                type="button"
+                onClick={() => onThreadChange(crypto.randomUUID())}
+              >
+                <Plus size={14} />
+                <span>New thread</span>
+              </button>
+              <button
+                aria-label="Collapse threads drawer"
+                className={styles.iconButton}
+                type="button"
+                onClick={() => setIsOpen(false)}
+              >
+                <ChevronLeft size={18} />
+              </button>
+            </div>
+          </div>
+
+          <div className={styles.filterBar}>
+            <div
+              aria-label="Thread filter"
+              className={styles.segmented}
+              role="tablist"
+            >
+              <button
+                aria-selected={!showArchived}
+                className={cx(
+                  styles.segmentedOption,
+                  !showArchived && styles.segmentedOptionActive,
+                )}
+                role="tab"
+                type="button"
+                onClick={() => setShowArchived(false)}
+              >
+                Active
+              </button>
+              <button
+                aria-selected={showArchived}
+                className={cx(
+                  styles.segmentedOption,
+                  showArchived && styles.segmentedOptionActive,
+                )}
+                role="tab"
+                type="button"
+                onClick={() => setShowArchived(true)}
+              >
+                All
+              </button>
+            </div>
+          </div>
+
+          <div className={styles.drawerContent}>
+            {error ? (
+              <div className={styles.emptyState}>
+                <div className={styles.emptyCard}>
+                  <p className={styles.emptyTitle}>
+                    Couldn&rsquo;t load threads
+                  </p>
+                  <p className={styles.emptyMessage}>
+                    The thread list failed to load. Try reloading the page.
+                  </p>
+                  <button
+                    className={styles.loadMoreButton}
+                    type="button"
+                    onClick={() => window.location.reload()}
+                  >
+                    Reload
+                  </button>
+                </div>
+              </div>
+            ) : isInitialLoading ? (
+              <div
+                aria-busy="true"
+                aria-label="Loading threads"
+                className={styles.loadingList}
+                role="status"
+              >
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className={styles.loadingRow}>
+                    <span className={styles.loadingAccent} />
+                    <span className={styles.loadingBody}>
+                      <span className={styles.loadingTitleBar} />
+                      <span className={styles.loadingMetaBar} />
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : displayThreads.length === 0 ? (
+              <div className={styles.emptyState}>
+                <div className={styles.emptyCard}>
+                  <p className={styles.emptyTitle}>No threads yet</p>
+                  <p className={styles.emptyMessage}>
+                    Create a thread to start a fresh conversation.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className={styles.threadList}>
+                {displayThreads.map((thread) => {
+                  const hasTitle = thread.name !== null;
+                  const title = thread.name ?? UNTITLED_THREAD_LABEL;
+
+                  return (
+                    <div key={thread.id} className={styles.threadRow}>
+                      <button
+                        aria-current={
+                          threadId === thread.id ? "page" : undefined
+                        }
+                        className={cx(
+                          styles.threadItem,
+                          threadId === thread.id && styles.threadItemSelected,
+                          enteringThreadIds[thread.id] &&
+                            styles.threadItemAnimatingIn,
+                          thread.archived && styles.threadItemArchived,
+                        )}
+                        type="button"
+                        onClick={() => onThreadChange(thread.id)}
+                      >
+                        <span aria-hidden className={styles.threadAccent} />
+                        <span className={styles.threadBody}>
+                          <span
+                            className={cx(
+                              styles.threadTitle,
+                              !hasTitle && styles.threadTitlePlaceholder,
+                              revealedTitleIds[thread.id] &&
+                                styles.threadTitleAnimated,
+                            )}
+                          >
+                            {title}
+                            {thread.archived && (
+                              <span className={styles.archivedBadge}>
+                                Archived
+                              </span>
+                            )}
+                          </span>
+                          <span className={styles.threadMeta}>
+                            {formatThreadTimestamp(
+                              thread.lastRunAt ?? thread.updatedAt,
+                            )}
+                          </span>
+                        </span>
+                      </button>
+                      <div className={styles.threadActions}>
+                        {thread.archived ? (
+                          <button
+                            aria-label={`Restore ${title}`}
+                            className={cx(
+                              styles.iconButton,
+                              styles.threadActionButton,
+                              styles.tooltip,
+                            )}
+                            data-tooltip="Restore thread"
+                            type="button"
+                            onClick={() => {
+                              restoreThread(thread.id).catch((err: unknown) => {
+                                console.error("Unable to restore thread", err);
+                              });
+                            }}
+                          >
+                            <ArchiveRestore size={14} />
+                          </button>
+                        ) : (
+                          <button
+                            aria-label={`Archive ${title}`}
+                            className={cx(
+                              styles.iconButton,
+                              styles.threadActionButton,
+                              styles.tooltip,
+                            )}
+                            data-tooltip="Archive thread"
+                            type="button"
+                            onClick={() => {
+                              if (threadId === thread.id)
+                                onThreadChange(undefined);
+                              archiveThread(thread.id).catch((err: unknown) => {
+                                console.error("Unable to archive thread", err);
+                              });
+                            }}
+                          >
+                            <Archive size={14} />
+                          </button>
+                        )}
+                        <button
+                          aria-label={`Delete ${title}`}
+                          className={cx(
+                            styles.iconButton,
+                            styles.threadActionButton,
+                            styles.deleteButton,
+                            styles.tooltip,
+                          )}
+                          data-tooltip="Delete thread"
+                          type="button"
+                          onClick={(e) => {
+                            deleteTriggerRef.current = e.currentTarget;
+                            setPendingDelete({ id: thread.id, title });
+                          }}
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+                {hasMoreThreads && (
+                  <button
+                    className={styles.loadMoreButton}
+                    disabled={isFetchingMoreThreads}
+                    type="button"
+                    onClick={fetchMoreThreads}
+                  >
+                    {isFetchingMoreThreads ? "Loading\u2026" : "Load more"}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </aside>
+      {pendingDelete && (
+        <ConfirmDialog
+          confirmLabel="Delete"
+          description={`Delete "${pendingDelete.title}"? This cannot be undone.`}
+          destructive
+          title="Delete thread"
+          onCancel={closeDeleteDialog}
+          onConfirm={() => {
+            const { id } = pendingDelete;
+            closeDeleteDialog();
+            if (threadId === id) onThreadChange(undefined);
+            deleteThread(id).catch((err: unknown) => {
+              console.error("Unable to delete thread", err);
+            });
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+interface ConfirmDialogProps {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function ConfirmDialog({
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = "Cancel",
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const titleId = useId();
+  const descId = useId();
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className={styles.dialogOverlay}
+      role="presentation"
+      onClick={onCancel}
+    >
+      <div
+        aria-describedby={descId}
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className={styles.dialog}
+        role="dialog"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className={styles.dialogTitle} id={titleId}>
+          {title}
+        </h3>
+        <p className={styles.dialogDescription} id={descId}>
+          {description}
+        </p>
+        <div className={styles.dialogActions}>
+          <button
+            autoFocus
+            className={cx(styles.dialogButton, styles.dialogButtonSecondary)}
+            type="button"
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            className={cx(
+              styles.dialogButton,
+              destructive
+                ? styles.dialogButtonDestructive
+                : styles.dialogButtonPrimary,
+            )}
+            type="button"
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
## Summary
- migrates the AG2 showcase runtime to the v2 optional catch-all endpoint so `/api/copilotkit/threads` and related Intelligence routes are served
- gates Intelligence with `COPILOTKIT_LICENSE_TOKEN`, documents local Intelligence env vars, and keeps an in-memory runner fallback when no license token is present
- adds the mobile-friendly Threads drawer/shared `ShowcaseCopilotKit` wrapper and wires the main AG2 demos through it
- pins CopilotKit showcase dependencies to `1.59.1`
- adds a focused contract test for the AG2 Intelligence migration shape

## Verification
- `pnpm exec vitest run scripts/__tests__/showcase-ag2-intelligence-migration.test.ts`
- `pnpm exec oxfmt --check 'scripts/__tests__/showcase-ag2-intelligence-migration.test.ts' 'showcase/integrations/ag2/src/components/showcase-copilotkit/showcase-copilotkit.tsx' 'showcase/integrations/ag2/src/app/api/copilotkit/[[...slug]]/route.ts' 'showcase/integrations/ag2/next.config.ts' 'showcase/integrations/ag2/src/components/threads-drawer/threads-drawer.tsx' 'showcase/integrations/ag2/src/app/globals.css'`
- `git diff --check`
- `npm run build` in `showcase/integrations/ag2`

## Manual smoke
- Started the local Intelligence stack from the existing `test-signups4` setup and seeded `demo-user` / `1_demo-user`.
- Started the AG2 Next dev server with the copied local env. The package `dev` script still calls `python`, which is not present on this machine, so the bundled Python process exits immediately; for the main `agentic_chat` smoke I used a temporary root-only AG2 ASGI server backed by the existing `agents.agent` module.
- Opened `http://127.0.0.1:3001/demos/agentic-chat` in the in-app browser.
- Verified Threads UI rendered, created/listed a thread, ran `agentic_chat`, and confirmed:
  - `/api/copilotkit/info` returned `1.59.1`
  - `/api/copilotkit/threads?agentId=agentic_chat&limit=20` returned the persisted thread
  - `/api/copilotkit/threads/<thread-id>/messages` returned the persisted user and assistant messages

## Notes / caveats
- Targeting `main` because PR #5151 has been merged and `ben1/ent-679-intelligence-ready-north-star` is no longer an open remote branch.
- Pre-commit was bypassed after its repo-wide package test hook failed in unrelated `@copilotkit/react-core:test` cases (`CopilotChatPerf.e2e.test.tsx` timeouts and `IntelligenceIndicator.e2e.test.tsx` missing test id assertions). The AG2-specific test, formatter check, diff check, and AG2 production build passed.
- `npm run build` emits the pre-existing HashBrown dynamic `require` warning from `declarative-hashbrown`.
- In local smoke, selecting the persisted thread hid the welcome state and called `/agent/agentic_chat/connect`, but the transcript did not visibly repaint in the chat even though the messages endpoint returned the persisted messages. I did not add an AG2-only workaround for this because the route/list/run/persistence path is functioning and the replay behavior appears to be SDK/runtime-side rather than example wiring.
