### PR TITLE
fix(showcase): migrate Strategy-B gen-ui-interrupt demos from useInterrupt to useHumanInTheLoop

### DIFF
--- a/showcase/integrations/ag2/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/gen-ui-interrupt/page.tsx
@@ -4,8 +4,9 @@
 import {
   CopilotKit,
   CopilotChat,
-  useInterrupt,
+  useHumanInTheLoop,
 } from "@copilotkit/react-core/v2";
+import { z } from "zod";
 import type { TimeSlot } from "./_components/time-picker-card";
 import { TimePickerCard } from "./_components/time-picker-card";
 import { generateFallbackSlots } from "../_shared/interrupt-fallback-slots";
@@ -26,41 +27,48 @@ export default function GenUiInterruptDemo() {
 function Chat() {
   useGenUiInterruptSuggestions();
 
-  // `useInterrupt` is the low-level primitive for handling LangGraph
-  // `interrupt(...)` events. The backend's `schedule_meeting` tool surfaces
-  // a structured payload — `{ topic, attendee, slots }` — which we render
-  // inline in the chat as a message bubble. Calling `resolve(...)` resumes
-  // the LangGraph run with the user's selection.
-  useInterrupt({
+  // This framework has no LangGraph-style `interrupt()` primitive, so the
+  // LangGraph showcase's `useInterrupt({ renderInChat: true })` hook is
+  // silently dead here — it listens for AG-UI `interrupt` events that this
+  // backend never emits, leaving the chat stuck on the "[Scheduling...]"
+  // tool-call placeholder.
+  //
+  // The backend instead exposes `schedule_meeting` as a tool the model is
+  // instructed to call (Strategy B); the frontend registers a matching
+  // `useHumanInTheLoop` here, renders the picker inline, and resolves the
+  // call via `respond(...)`. UX matches LGP's interrupt-rendered card; the
+  // mechanism differs.
+  useHumanInTheLoop({
     agentId: "gen-ui-interrupt",
-    renderInChat: true,
-    render: ({ event, resolve }) => {
-      // The AG-UI adapter JSON-stringifies interrupt values, so parse
-      // when needed to extract the structured payload.
-      const raw = event.value ?? {};
-      const payload = (typeof raw === "string" ? JSON.parse(raw) : raw) as {
-        topic?: string;
-        attendee?: string;
-        slots?: TimeSlot[];
-      };
-      const slots =
-        payload.slots && payload.slots.length > 0
-          ? payload.slots
-          : generateFallbackSlots();
+    name: "schedule_meeting",
+    description:
+      "Ask the user to pick a meeting time. The picker renders inline in " +
+      "the chat; the chosen slot is returned to the agent so it can confirm.",
+    parameters: z.object({
+      topic: z
+        .string()
+        .describe("What the meeting is about (e.g. 'Intro with sales')"),
+      attendee: z
+        .string()
+        .optional()
+        .describe("Who the meeting is with (e.g. 'Alice')"),
+    }),
+    render: ({ args, respond }: any) => {
+      // `TimePickerCard` here is the gen-ui-interrupt-specific variant
+      // (under `_components/`) that gates buttons on its own internal
+      // `picked`/`cancelled` state — it doesn't take a `status` prop like
+      // the hitl-in-chat version. That's fine: the buttons stay clickable
+      // until the user makes a choice and `respond(...)` resolves the
+      // tool call.
+      const topic = (args?.topic as string | undefined) ?? "a call";
+      const attendee = args?.attendee as string | undefined;
+      const slots = generateFallbackSlots();
       return (
         <TimePickerCard
-          topic={payload.topic ?? "a call"}
-          attendee={payload.attendee}
+          topic={topic}
+          attendee={attendee}
           slots={slots}
-          onSubmit={(result) => {
-            // Defer resolve so React commits the picked/cancelled state
-            // before useInterrupt clears the interrupt element. A single
-            // requestAnimationFrame is not reliable — rAF fires before
-            // React's commit in some scheduling scenarios. Using a short
-            // setTimeout ensures the commit lands first and the user sees
-            // the "Booked"/"Cancelled" badge before the card unmounts.
-            setTimeout(() => resolve(result), 500);
-          }}
+          onSubmit={(result) => respond?.(result)}
         />
       );
     },

--- a/showcase/integrations/agno/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/gen-ui-interrupt/page.tsx
@@ -4,8 +4,9 @@
 import {
   CopilotKit,
   CopilotChat,
-  useInterrupt,
+  useHumanInTheLoop,
 } from "@copilotkit/react-core/v2";
+import { z } from "zod";
 import type { TimeSlot } from "./_components/time-picker-card";
 import { TimePickerCard } from "./_components/time-picker-card";
 import { generateFallbackSlots } from "../_shared/interrupt-fallback-slots";
@@ -26,41 +27,48 @@ export default function GenUiInterruptDemo() {
 function Chat() {
   useGenUiInterruptSuggestions();
 
-  // `useInterrupt` is the low-level primitive for handling LangGraph
-  // `interrupt(...)` events. The backend's `schedule_meeting` tool surfaces
-  // a structured payload — `{ topic, attendee, slots }` — which we render
-  // inline in the chat as a message bubble. Calling `resolve(...)` resumes
-  // the LangGraph run with the user's selection.
-  useInterrupt({
+  // This framework has no LangGraph-style `interrupt()` primitive, so the
+  // LangGraph showcase's `useInterrupt({ renderInChat: true })` hook is
+  // silently dead here — it listens for AG-UI `interrupt` events that this
+  // backend never emits, leaving the chat stuck on the "[Scheduling...]"
+  // tool-call placeholder.
+  //
+  // The backend instead exposes `schedule_meeting` as a tool the model is
+  // instructed to call (Strategy B); the frontend registers a matching
+  // `useHumanInTheLoop` here, renders the picker inline, and resolves the
+  // call via `respond(...)`. UX matches LGP's interrupt-rendered card; the
+  // mechanism differs.
+  useHumanInTheLoop({
     agentId: "gen-ui-interrupt",
-    renderInChat: true,
-    render: ({ event, resolve }) => {
-      // The AG-UI adapter JSON-stringifies interrupt values, so parse
-      // when needed to extract the structured payload.
-      const raw = event.value ?? {};
-      const payload = (typeof raw === "string" ? JSON.parse(raw) : raw) as {
-        topic?: string;
-        attendee?: string;
-        slots?: TimeSlot[];
-      };
-      const slots =
-        payload.slots && payload.slots.length > 0
-          ? payload.slots
-          : generateFallbackSlots();
+    name: "schedule_meeting",
+    description:
+      "Ask the user to pick a meeting time. The picker renders inline in " +
+      "the chat; the chosen slot is returned to the agent so it can confirm.",
+    parameters: z.object({
+      topic: z
+        .string()
+        .describe("What the meeting is about (e.g. 'Intro with sales')"),
+      attendee: z
+        .string()
+        .optional()
+        .describe("Who the meeting is with (e.g. 'Alice')"),
+    }),
+    render: ({ args, respond }: any) => {
+      // `TimePickerCard` here is the gen-ui-interrupt-specific variant
+      // (under `_components/`) that gates buttons on its own internal
+      // `picked`/`cancelled` state — it doesn't take a `status` prop like
+      // the hitl-in-chat version. That's fine: the buttons stay clickable
+      // until the user makes a choice and `respond(...)` resolves the
+      // tool call.
+      const topic = (args?.topic as string | undefined) ?? "a call";
+      const attendee = args?.attendee as string | undefined;
+      const slots = generateFallbackSlots();
       return (
         <TimePickerCard
-          topic={payload.topic ?? "a call"}
-          attendee={payload.attendee}
+          topic={topic}
+          attendee={attendee}
           slots={slots}
-          onSubmit={(result) => {
-            // Defer resolve so React commits the picked/cancelled state
-            // before useInterrupt clears the interrupt element. A single
-            // requestAnimationFrame is not reliable — rAF fires before
-            // React's commit in some scheduling scenarios. Using a short
-            // setTimeout ensures the commit lands first and the user sees
-            // the "Booked"/"Cancelled" badge before the card unmounts.
-            setTimeout(() => resolve(result), 500);
-          }}
+          onSubmit={(result) => respond?.(result)}
         />
       );
     },

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/gen-ui-interrupt/page.tsx
@@ -4,8 +4,9 @@
 import {
   CopilotKit,
   CopilotChat,
-  useInterrupt,
+  useHumanInTheLoop,
 } from "@copilotkit/react-core/v2";
+import { z } from "zod";
 import type { TimeSlot } from "./_components/time-picker-card";
 import { TimePickerCard } from "./_components/time-picker-card";
 import { generateFallbackSlots } from "../_shared/interrupt-fallback-slots";
@@ -26,41 +27,48 @@ export default function GenUiInterruptDemo() {
 function Chat() {
   useGenUiInterruptSuggestions();
 
-  // `useInterrupt` is the low-level primitive for handling LangGraph
-  // `interrupt(...)` events. The backend's `schedule_meeting` tool surfaces
-  // a structured payload — `{ topic, attendee, slots }` — which we render
-  // inline in the chat as a message bubble. Calling `resolve(...)` resumes
-  // the LangGraph run with the user's selection.
-  useInterrupt({
+  // This framework has no LangGraph-style `interrupt()` primitive, so the
+  // LangGraph showcase's `useInterrupt({ renderInChat: true })` hook is
+  // silently dead here — it listens for AG-UI `interrupt` events that this
+  // backend never emits, leaving the chat stuck on the "[Scheduling...]"
+  // tool-call placeholder.
+  //
+  // The backend instead exposes `schedule_meeting` as a tool the model is
+  // instructed to call (Strategy B); the frontend registers a matching
+  // `useHumanInTheLoop` here, renders the picker inline, and resolves the
+  // call via `respond(...)`. UX matches LGP's interrupt-rendered card; the
+  // mechanism differs.
+  useHumanInTheLoop({
     agentId: "gen-ui-interrupt",
-    renderInChat: true,
-    render: ({ event, resolve }) => {
-      // The AG-UI adapter JSON-stringifies interrupt values, so parse
-      // when needed to extract the structured payload.
-      const raw = event.value ?? {};
-      const payload = (typeof raw === "string" ? JSON.parse(raw) : raw) as {
-        topic?: string;
-        attendee?: string;
-        slots?: TimeSlot[];
-      };
-      const slots =
-        payload.slots && payload.slots.length > 0
-          ? payload.slots
-          : generateFallbackSlots();
+    name: "schedule_meeting",
+    description:
+      "Ask the user to pick a meeting time. The picker renders inline in " +
+      "the chat; the chosen slot is returned to the agent so it can confirm.",
+    parameters: z.object({
+      topic: z
+        .string()
+        .describe("What the meeting is about (e.g. 'Intro with sales')"),
+      attendee: z
+        .string()
+        .optional()
+        .describe("Who the meeting is with (e.g. 'Alice')"),
+    }),
+    render: ({ args, respond }: any) => {
+      // `TimePickerCard` here is the gen-ui-interrupt-specific variant
+      // (under `_components/`) that gates buttons on its own internal
+      // `picked`/`cancelled` state — it doesn't take a `status` prop like
+      // the hitl-in-chat version. That's fine: the buttons stay clickable
+      // until the user makes a choice and `respond(...)` resolves the
+      // tool call.
+      const topic = (args?.topic as string | undefined) ?? "a call";
+      const attendee = args?.attendee as string | undefined;
+      const slots = generateFallbackSlots();
       return (
         <TimePickerCard
-          topic={payload.topic ?? "a call"}
-          attendee={payload.attendee}
+          topic={topic}
+          attendee={attendee}
           slots={slots}
-          onSubmit={(result) => {
-            // Defer resolve so React commits the picked/cancelled state
-            // before useInterrupt clears the interrupt element. A single
-            // requestAnimationFrame is not reliable — rAF fires before
-            // React's commit in some scheduling scenarios. Using a short
-            // setTimeout ensures the commit lands first and the user sees
-            // the "Booked"/"Cancelled" badge before the card unmounts.
-            setTimeout(() => resolve(result), 500);
-          }}
+          onSubmit={(result) => respond?.(result)}
         />
       );
     },

--- a/showcase/integrations/crewai-crews/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/gen-ui-interrupt/page.tsx
@@ -4,8 +4,9 @@
 import {
   CopilotKit,
   CopilotChat,
-  useInterrupt,
+  useHumanInTheLoop,
 } from "@copilotkit/react-core/v2";
+import { z } from "zod";
 import type { TimeSlot } from "./_components/time-picker-card";
 import { TimePickerCard } from "./_components/time-picker-card";
 import { generateFallbackSlots } from "../_shared/interrupt-fallback-slots";
@@ -26,41 +27,48 @@ export default function GenUiInterruptDemo() {
 function Chat() {
   useGenUiInterruptSuggestions();
 
-  // `useInterrupt` is the low-level primitive for handling LangGraph
-  // `interrupt(...)` events. The backend's `schedule_meeting` tool surfaces
-  // a structured payload — `{ topic, attendee, slots }` — which we render
-  // inline in the chat as a message bubble. Calling `resolve(...)` resumes
-  // the LangGraph run with the user's selection.
-  useInterrupt({
+  // This framework has no LangGraph-style `interrupt()` primitive, so the
+  // LangGraph showcase's `useInterrupt({ renderInChat: true })` hook is
+  // silently dead here — it listens for AG-UI `interrupt` events that this
+  // backend never emits, leaving the chat stuck on the "[Scheduling...]"
+  // tool-call placeholder.
+  //
+  // The backend instead exposes `schedule_meeting` as a tool the model is
+  // instructed to call (Strategy B); the frontend registers a matching
+  // `useHumanInTheLoop` here, renders the picker inline, and resolves the
+  // call via `respond(...)`. UX matches LGP's interrupt-rendered card; the
+  // mechanism differs.
+  useHumanInTheLoop({
     agentId: "gen-ui-interrupt",
-    renderInChat: true,
-    render: ({ event, resolve }) => {
-      // The AG-UI adapter JSON-stringifies interrupt values, so parse
-      // when needed to extract the structured payload.
-      const raw = event.value ?? {};
-      const payload = (typeof raw === "string" ? JSON.parse(raw) : raw) as {
-        topic?: string;
-        attendee?: string;
-        slots?: TimeSlot[];
-      };
-      const slots =
-        payload.slots && payload.slots.length > 0
-          ? payload.slots
-          : generateFallbackSlots();
+    name: "schedule_meeting",
+    description:
+      "Ask the user to pick a meeting time. The picker renders inline in " +
+      "the chat; the chosen slot is returned to the agent so it can confirm.",
+    parameters: z.object({
+      topic: z
+        .string()
+        .describe("What the meeting is about (e.g. 'Intro with sales')"),
+      attendee: z
+        .string()
+        .optional()
+        .describe("Who the meeting is with (e.g. 'Alice')"),
+    }),
+    render: ({ args, respond }: any) => {
+      // `TimePickerCard` here is the gen-ui-interrupt-specific variant
+      // (under `_components/`) that gates buttons on its own internal
+      // `picked`/`cancelled` state — it doesn't take a `status` prop like
+      // the hitl-in-chat version. That's fine: the buttons stay clickable
+      // until the user makes a choice and `respond(...)` resolves the
+      // tool call.
+      const topic = (args?.topic as string | undefined) ?? "a call";
+      const attendee = args?.attendee as string | undefined;
+      const slots = generateFallbackSlots();
       return (
         <TimePickerCard
-          topic={payload.topic ?? "a call"}
-          attendee={payload.attendee}
+          topic={topic}
+          attendee={attendee}
           slots={slots}
-          onSubmit={(result) => {
-            // Defer resolve so React commits the picked/cancelled state
-            // before useInterrupt clears the interrupt element. A single
-            // requestAnimationFrame is not reliable — rAF fires before
-            // React's commit in some scheduling scenarios. Using a short
-            // setTimeout ensures the commit lands first and the user sees
-            // the "Booked"/"Cancelled" badge before the card unmounts.
-            setTimeout(() => resolve(result), 500);
-          }}
+          onSubmit={(result) => respond?.(result)}
         />
       );
     },

--- a/showcase/integrations/llamaindex/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/gen-ui-interrupt/page.tsx
@@ -4,8 +4,9 @@
 import {
   CopilotKit,
   CopilotChat,
-  useInterrupt,
+  useHumanInTheLoop,
 } from "@copilotkit/react-core/v2";
+import { z } from "zod";
 import type { TimeSlot } from "./_components/time-picker-card";
 import { TimePickerCard } from "./_components/time-picker-card";
 import { generateFallbackSlots } from "../_shared/interrupt-fallback-slots";
@@ -26,41 +27,48 @@ export default function GenUiInterruptDemo() {
 function Chat() {
   useGenUiInterruptSuggestions();
 
-  // `useInterrupt` is the low-level primitive for handling LangGraph
-  // `interrupt(...)` events. The backend's `schedule_meeting` tool surfaces
-  // a structured payload — `{ topic, attendee, slots }` — which we render
-  // inline in the chat as a message bubble. Calling `resolve(...)` resumes
-  // the LangGraph run with the user's selection.
-  useInterrupt({
+  // This framework has no LangGraph-style `interrupt()` primitive, so the
+  // LangGraph showcase's `useInterrupt({ renderInChat: true })` hook is
+  // silently dead here — it listens for AG-UI `interrupt` events that this
+  // backend never emits, leaving the chat stuck on the "[Scheduling...]"
+  // tool-call placeholder.
+  //
+  // The backend instead exposes `schedule_meeting` as a tool the model is
+  // instructed to call (Strategy B); the frontend registers a matching
+  // `useHumanInTheLoop` here, renders the picker inline, and resolves the
+  // call via `respond(...)`. UX matches LGP's interrupt-rendered card; the
+  // mechanism differs.
+  useHumanInTheLoop({
     agentId: "gen-ui-interrupt",
-    renderInChat: true,
-    render: ({ event, resolve }) => {
-      // The AG-UI adapter JSON-stringifies interrupt values, so parse
-      // when needed to extract the structured payload.
-      const raw = event.value ?? {};
-      const payload = (typeof raw === "string" ? JSON.parse(raw) : raw) as {
-        topic?: string;
-        attendee?: string;
-        slots?: TimeSlot[];
-      };
-      const slots =
-        payload.slots && payload.slots.length > 0
-          ? payload.slots
-          : generateFallbackSlots();
+    name: "schedule_meeting",
+    description:
+      "Ask the user to pick a meeting time. The picker renders inline in " +
+      "the chat; the chosen slot is returned to the agent so it can confirm.",
+    parameters: z.object({
+      topic: z
+        .string()
+        .describe("What the meeting is about (e.g. 'Intro with sales')"),
+      attendee: z
+        .string()
+        .optional()
+        .describe("Who the meeting is with (e.g. 'Alice')"),
+    }),
+    render: ({ args, respond }: any) => {
+      // `TimePickerCard` here is the gen-ui-interrupt-specific variant
+      // (under `_components/`) that gates buttons on its own internal
+      // `picked`/`cancelled` state — it doesn't take a `status` prop like
+      // the hitl-in-chat version. That's fine: the buttons stay clickable
+      // until the user makes a choice and `respond(...)` resolves the
+      // tool call.
+      const topic = (args?.topic as string | undefined) ?? "a call";
+      const attendee = args?.attendee as string | undefined;
+      const slots = generateFallbackSlots();
       return (
         <TimePickerCard
-          topic={payload.topic ?? "a call"}
-          attendee={payload.attendee}
+          topic={topic}
+          attendee={attendee}
           slots={slots}
-          onSubmit={(result) => {
-            // Defer resolve so React commits the picked/cancelled state
-            // before useInterrupt clears the interrupt element. A single
-            // requestAnimationFrame is not reliable — rAF fires before
-            // React's commit in some scheduling scenarios. Using a short
-            // setTimeout ensures the commit lands first and the user sees
-            // the "Booked"/"Cancelled" badge before the card unmounts.
-            setTimeout(() => resolve(result), 500);
-          }}
+          onSubmit={(result) => respond?.(result)}
         />
       );
     },

--- a/showcase/integrations/mastra/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/integrations/mastra/src/app/demos/gen-ui-interrupt/page.tsx
@@ -4,8 +4,9 @@
 import {
   CopilotKit,
   CopilotChat,
-  useInterrupt,
+  useHumanInTheLoop,
 } from "@copilotkit/react-core/v2";
+import { z } from "zod";
 import type { TimeSlot } from "./_components/time-picker-card";
 import { TimePickerCard } from "./_components/time-picker-card";
 import { generateFallbackSlots } from "../_shared/interrupt-fallback-slots";
@@ -26,41 +27,48 @@ export default function GenUiInterruptDemo() {
 function Chat() {
   useGenUiInterruptSuggestions();
 
-  // `useInterrupt` is the low-level primitive for handling LangGraph
-  // `interrupt(...)` events. The backend's `schedule_meeting` tool surfaces
-  // a structured payload — `{ topic, attendee, slots }` — which we render
-  // inline in the chat as a message bubble. Calling `resolve(...)` resumes
-  // the LangGraph run with the user's selection.
-  useInterrupt({
+  // This framework has no LangGraph-style `interrupt()` primitive, so the
+  // LangGraph showcase's `useInterrupt({ renderInChat: true })` hook is
+  // silently dead here — it listens for AG-UI `interrupt` events that this
+  // backend never emits, leaving the chat stuck on the "[Scheduling...]"
+  // tool-call placeholder.
+  //
+  // The backend instead exposes `schedule_meeting` as a tool the model is
+  // instructed to call (Strategy B); the frontend registers a matching
+  // `useHumanInTheLoop` here, renders the picker inline, and resolves the
+  // call via `respond(...)`. UX matches LGP's interrupt-rendered card; the
+  // mechanism differs.
+  useHumanInTheLoop({
     agentId: "gen-ui-interrupt",
-    renderInChat: true,
-    render: ({ event, resolve }) => {
-      // The AG-UI adapter JSON-stringifies interrupt values, so parse
-      // when needed to extract the structured payload.
-      const raw = event.value ?? {};
-      const payload = (typeof raw === "string" ? JSON.parse(raw) : raw) as {
-        topic?: string;
-        attendee?: string;
-        slots?: TimeSlot[];
-      };
-      const slots =
-        payload.slots && payload.slots.length > 0
-          ? payload.slots
-          : generateFallbackSlots();
+    name: "schedule_meeting",
+    description:
+      "Ask the user to pick a meeting time. The picker renders inline in " +
+      "the chat; the chosen slot is returned to the agent so it can confirm.",
+    parameters: z.object({
+      topic: z
+        .string()
+        .describe("What the meeting is about (e.g. 'Intro with sales')"),
+      attendee: z
+        .string()
+        .optional()
+        .describe("Who the meeting is with (e.g. 'Alice')"),
+    }),
+    render: ({ args, respond }: any) => {
+      // `TimePickerCard` here is the gen-ui-interrupt-specific variant
+      // (under `_components/`) that gates buttons on its own internal
+      // `picked`/`cancelled` state — it doesn't take a `status` prop like
+      // the hitl-in-chat version. That's fine: the buttons stay clickable
+      // until the user makes a choice and `respond(...)` resolves the
+      // tool call.
+      const topic = (args?.topic as string | undefined) ?? "a call";
+      const attendee = args?.attendee as string | undefined;
+      const slots = generateFallbackSlots();
       return (
         <TimePickerCard
-          topic={payload.topic ?? "a call"}
-          attendee={payload.attendee}
+          topic={topic}
+          attendee={attendee}
           slots={slots}
-          onSubmit={(result) => {
-            // Defer resolve so React commits the picked/cancelled state
-            // before useInterrupt clears the interrupt element. A single
-            // requestAnimationFrame is not reliable — rAF fires before
-            // React's commit in some scheduling scenarios. Using a short
-            // setTimeout ensures the commit lands first and the user sees
-            // the "Booked"/"Cancelled" badge before the card unmounts.
-            setTimeout(() => resolve(result), 500);
-          }}
+          onSubmit={(result) => respond?.(result)}
         />
       );
     },

--- a/showcase/integrations/pydantic-ai/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/gen-ui-interrupt/page.tsx
@@ -4,8 +4,9 @@
 import {
   CopilotKit,
   CopilotChat,
-  useInterrupt,
+  useHumanInTheLoop,
 } from "@copilotkit/react-core/v2";
+import { z } from "zod";
 import type { TimeSlot } from "./_components/time-picker-card";
 import { TimePickerCard } from "./_components/time-picker-card";
 import { generateFallbackSlots } from "../_shared/interrupt-fallback-slots";
@@ -26,41 +27,48 @@ export default function GenUiInterruptDemo() {
 function Chat() {
   useGenUiInterruptSuggestions();
 
-  // `useInterrupt` is the low-level primitive for handling LangGraph
-  // `interrupt(...)` events. The backend's `schedule_meeting` tool surfaces
-  // a structured payload — `{ topic, attendee, slots }` — which we render
-  // inline in the chat as a message bubble. Calling `resolve(...)` resumes
-  // the LangGraph run with the user's selection.
-  useInterrupt({
+  // This framework has no LangGraph-style `interrupt()` primitive, so the
+  // LangGraph showcase's `useInterrupt({ renderInChat: true })` hook is
+  // silently dead here — it listens for AG-UI `interrupt` events that this
+  // backend never emits, leaving the chat stuck on the "[Scheduling...]"
+  // tool-call placeholder.
+  //
+  // The backend instead exposes `schedule_meeting` as a tool the model is
+  // instructed to call (Strategy B); the frontend registers a matching
+  // `useHumanInTheLoop` here, renders the picker inline, and resolves the
+  // call via `respond(...)`. UX matches LGP's interrupt-rendered card; the
+  // mechanism differs.
+  useHumanInTheLoop({
     agentId: "gen-ui-interrupt",
-    renderInChat: true,
-    render: ({ event, resolve }) => {
-      // The AG-UI adapter JSON-stringifies interrupt values, so parse
-      // when needed to extract the structured payload.
-      const raw = event.value ?? {};
-      const payload = (typeof raw === "string" ? JSON.parse(raw) : raw) as {
-        topic?: string;
-        attendee?: string;
-        slots?: TimeSlot[];
-      };
-      const slots =
-        payload.slots && payload.slots.length > 0
-          ? payload.slots
-          : generateFallbackSlots();
+    name: "schedule_meeting",
+    description:
+      "Ask the user to pick a meeting time. The picker renders inline in " +
+      "the chat; the chosen slot is returned to the agent so it can confirm.",
+    parameters: z.object({
+      topic: z
+        .string()
+        .describe("What the meeting is about (e.g. 'Intro with sales')"),
+      attendee: z
+        .string()
+        .optional()
+        .describe("Who the meeting is with (e.g. 'Alice')"),
+    }),
+    render: ({ args, respond }: any) => {
+      // `TimePickerCard` here is the gen-ui-interrupt-specific variant
+      // (under `_components/`) that gates buttons on its own internal
+      // `picked`/`cancelled` state — it doesn't take a `status` prop like
+      // the hitl-in-chat version. That's fine: the buttons stay clickable
+      // until the user makes a choice and `respond(...)` resolves the
+      // tool call.
+      const topic = (args?.topic as string | undefined) ?? "a call";
+      const attendee = args?.attendee as string | undefined;
+      const slots = generateFallbackSlots();
       return (
         <TimePickerCard
-          topic={payload.topic ?? "a call"}
-          attendee={payload.attendee}
+          topic={topic}
+          attendee={attendee}
           slots={slots}
-          onSubmit={(result) => {
-            // Defer resolve so React commits the picked/cancelled state
-            // before useInterrupt clears the interrupt element. A single
-            // requestAnimationFrame is not reliable — rAF fires before
-            // React's commit in some scheduling scenarios. Using a short
-            // setTimeout ensures the commit lands first and the user sees
-            // the "Booked"/"Cancelled" badge before the card unmounts.
-            setTimeout(() => resolve(result), 500);
-          }}
+          onSubmit={(result) => respond?.(result)}
         />
       );
     },

--- a/showcase/integrations/spring-ai/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/gen-ui-interrupt/page.tsx
@@ -4,8 +4,9 @@
 import {
   CopilotKit,
   CopilotChat,
-  useInterrupt,
+  useHumanInTheLoop,
 } from "@copilotkit/react-core/v2";
+import { z } from "zod";
 import type { TimeSlot } from "./_components/time-picker-card";
 import { TimePickerCard } from "./_components/time-picker-card";
 import { generateFallbackSlots } from "../_shared/interrupt-fallback-slots";
@@ -26,41 +27,48 @@ export default function GenUiInterruptDemo() {
 function Chat() {
   useGenUiInterruptSuggestions();
 
-  // `useInterrupt` is the low-level primitive for handling LangGraph
-  // `interrupt(...)` events. The backend's `schedule_meeting` tool surfaces
-  // a structured payload — `{ topic, attendee, slots }` — which we render
-  // inline in the chat as a message bubble. Calling `resolve(...)` resumes
-  // the LangGraph run with the user's selection.
-  useInterrupt({
+  // This framework has no LangGraph-style `interrupt()` primitive, so the
+  // LangGraph showcase's `useInterrupt({ renderInChat: true })` hook is
+  // silently dead here — it listens for AG-UI `interrupt` events that this
+  // backend never emits, leaving the chat stuck on the "[Scheduling...]"
+  // tool-call placeholder.
+  //
+  // The backend instead exposes `schedule_meeting` as a tool the model is
+  // instructed to call (Strategy B); the frontend registers a matching
+  // `useHumanInTheLoop` here, renders the picker inline, and resolves the
+  // call via `respond(...)`. UX matches LGP's interrupt-rendered card; the
+  // mechanism differs.
+  useHumanInTheLoop({
     agentId: "gen-ui-interrupt",
-    renderInChat: true,
-    render: ({ event, resolve }) => {
-      // The AG-UI adapter JSON-stringifies interrupt values, so parse
-      // when needed to extract the structured payload.
-      const raw = event.value ?? {};
-      const payload = (typeof raw === "string" ? JSON.parse(raw) : raw) as {
-        topic?: string;
-        attendee?: string;
-        slots?: TimeSlot[];
-      };
-      const slots =
-        payload.slots && payload.slots.length > 0
-          ? payload.slots
-          : generateFallbackSlots();
+    name: "schedule_meeting",
+    description:
+      "Ask the user to pick a meeting time. The picker renders inline in " +
+      "the chat; the chosen slot is returned to the agent so it can confirm.",
+    parameters: z.object({
+      topic: z
+        .string()
+        .describe("What the meeting is about (e.g. 'Intro with sales')"),
+      attendee: z
+        .string()
+        .optional()
+        .describe("Who the meeting is with (e.g. 'Alice')"),
+    }),
+    render: ({ args, respond }: any) => {
+      // `TimePickerCard` here is the gen-ui-interrupt-specific variant
+      // (under `_components/`) that gates buttons on its own internal
+      // `picked`/`cancelled` state — it doesn't take a `status` prop like
+      // the hitl-in-chat version. That's fine: the buttons stay clickable
+      // until the user makes a choice and `respond(...)` resolves the
+      // tool call.
+      const topic = (args?.topic as string | undefined) ?? "a call";
+      const attendee = args?.attendee as string | undefined;
+      const slots = generateFallbackSlots();
       return (
         <TimePickerCard
-          topic={payload.topic ?? "a call"}
-          attendee={payload.attendee}
+          topic={topic}
+          attendee={attendee}
           slots={slots}
-          onSubmit={(result) => {
-            // Defer resolve so React commits the picked/cancelled state
-            // before useInterrupt clears the interrupt element. A single
-            // requestAnimationFrame is not reliable — rAF fires before
-            // React's commit in some scheduling scenarios. Using a short
-            // setTimeout ensures the commit lands first and the user sees
-            // the "Booked"/"Cancelled" badge before the card unmounts.
-            setTimeout(() => resolve(result), 500);
-          }}
+          onSubmit={(result) => respond?.(result)}
         />
       );
     },


### PR DESCRIPTION
## Summary

The gen-ui-interrupt demo pages for the non-LangGraph integrations were calling the low-level `useInterrupt` primitive from `@copilotkit/react-core/v2`. These backends never emit AG-UI `interrupt` events, so the hook was silently dead and the demo got stuck on the `[Scheduling...]` tool-call placeholder.

This migrates them to **Strategy B**: the backend exposes `schedule_meeting` as a tool the model is instructed to call, and the frontend registers a matching `useHumanInTheLoop` that renders the time-picker inline and resolves the tool call via `respond(...)`. The UX matches the LangGraph showcase's interrupt-rendered card; only the underlying mechanism differs.

This is intentionally a **byte-identical** migration across the affected pages — no shared component is extracted (DRY refactor deliberately deferred per the accepted design).

## Integrations migrated (8)

- ag2
- agno
- claude-sdk-typescript
- crewai-crews
- llamaindex
- mastra
- pydantic-ai
- spring-ai

Scope is exactly one file per integration: `src/app/demos/gen-ui-interrupt/page.tsx` (8 files, +320/-256, single commit).

## Explicitly excluded

**langroid** and **strands** are NOT touched. Their interrupt-headless demo is a genuinely separate, load-bearing demo and is out of scope for this migration.

## Verification

- Rebased cleanly onto latest `origin/main` (no conflicts).
- Confirmed `useHumanInTheLoop` is exported from the pinned published `@copilotkit/react-core@1.59.2` v2 barrel.
- `npm ci --legacy-peer-deps && npm run build` (the exact CI/Docker path) passes on representative integrations **ag2** and **mastra** (both exit 0, gen-ui-interrupt route builds + static pages generate).

## Test plan

- [ ] CI green across all 8 affected showcase integration builds
- [ ] Manually exercise each gen-ui-interrupt demo: model calls `schedule_meeting`, picker renders inline, selection resolves and the agent confirms