### PR TITLE
fix(react-core): type active-run completion contract + close suggestion-path in-flight gap

### DIFF
--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -1,11 +1,13 @@
-import {
-  AbstractAgent,
+import type {
   RunAgentInput,
   RunAgentParameters,
   RunAgentResult,
   AgentSubscriber,
-  EventType,
   BaseEvent,
+} from "@ag-ui/client";
+import {
+  AbstractAgent,
+  EventType,
   randomUUID,
   transformChunks,
   structuredClone_,
@@ -15,7 +17,6 @@ import {
   EMPTY,
   Subject,
   Notification,
-  Observable,
   defer,
   dematerialize,
   lastValueFrom,
@@ -23,7 +24,7 @@ import {
   switchMap,
   throwError,
 } from "rxjs";
-import type { ObservableNotification } from "rxjs";
+import type { ObservableNotification, Observable } from "rxjs";
 import {
   catchError,
   endWith,
@@ -42,12 +43,14 @@ import { phoenixExponentialBackoff } from "@copilotkit/shared";
 import {
   ɵphoenixChannel$,
   ɵphoenixSocket$,
-  type ɵPhoenixChannelSession,
-  type ɵPhoenixSocketSession,
   ɵjoinPhoenixChannel$,
   ɵobservePhoenixSocketSignals$,
   ɵobservePhoenixSocketHealth$,
   ɵobservePhoenixEvent$,
+} from "./utils/phoenix-observable";
+import type {
+  ɵPhoenixChannelSession,
+  ɵPhoenixSocketSession,
 } from "./utils/phoenix-observable";
 
 const CLIENT_AG_UI_EVENT = "ag_ui_event";
@@ -78,6 +81,45 @@ export class AgentThreadLockedError extends Error {
   }
 }
 
+/**
+ * Typed contract for agents that expose the completion promise of their
+ * currently in-flight run.
+ *
+ * `IntelligenceAgent` resolves this promise once a run's observable pipeline
+ * finalizes (see {@link IntelligenceAgent.connectAgent}). Consumers (e.g. the
+ * v2 `CopilotChat` send-serialization path) await it to let an in-flight run —
+ * notably an interrupt RESUME — finish before dispatching a new run, instead
+ * of pre-empting it.
+ *
+ * The base `AbstractAgent` from `@ag-ui/client` does NOT declare this property,
+ * so it is reachable only through this contract plus the
+ * {@link isRunCompletionAware} type guard. This keeps callers off `as unknown`
+ * casts while still degrading safely for agents that don't implement it.
+ */
+export interface RunCompletionAware {
+  /**
+   * Resolves when the active run's pipeline finalizes (completes, errors, or is
+   * detached). `undefined` when no run is in flight.
+   */
+  readonly activeRunCompletionPromise?: Promise<void>;
+}
+
+/**
+ * Type guard for {@link RunCompletionAware}. Returns true when `agent` exposes
+ * an `activeRunCompletionPromise` property, so callers can await an in-flight
+ * run without an `as unknown as` cast. Returns false for agents that don't
+ * implement the contract, letting the caller skip the await and degrade safely.
+ */
+export function isRunCompletionAware(
+  agent: unknown,
+): agent is RunCompletionAware {
+  return (
+    typeof agent === "object" &&
+    agent !== null &&
+    "activeRunCompletionPromise" in agent
+  );
+}
+
 export interface IntelligenceAgentConfig {
   /** Phoenix websocket URL, e.g. "ws://localhost:4000/socket" */
   url: string;
@@ -93,12 +135,21 @@ export interface IntelligenceAgentConfig {
   credentials?: RequestCredentials;
 }
 
-export class IntelligenceAgent extends AbstractAgent {
+export class IntelligenceAgent
+  extends AbstractAgent
+  implements RunCompletionAware
+{
   private config: IntelligenceAgentConfig;
   private socket: Socket | null = null;
   private activeChannel: Channel | null = null;
   private canonicalRunId: string | null = null;
   private sharedState: IntelligenceAgentSharedState;
+  /**
+   * Resolves when the active run's pipeline finalizes; `undefined` between runs.
+   * Set/cleared inside {@link connectAgent}'s observable lifecycle. Declared
+   * here so {@link RunCompletionAware} consumers can read it without a cast.
+   */
+  activeRunCompletionPromise?: Promise<void>;
 
   constructor(
     config: IntelligenceAgentConfig,
@@ -177,7 +228,7 @@ export class IntelligenceAgent extends AbstractAgent {
 
       self.activeRunDetach$ = new Subject<void>();
       let resolveCompletion: (() => void) | undefined;
-      self.activeRunCompletionPromise = new Promise<void>((resolve) => {
+      this.activeRunCompletionPromise = new Promise<void>((resolve) => {
         resolveCompletion = resolve;
       });
 
@@ -202,7 +253,7 @@ export class IntelligenceAgent extends AbstractAgent {
             this.onFinalize(input, subscribers);
             resolveCompletion?.();
             resolveCompletion = undefined;
-            self.activeRunCompletionPromise = undefined;
+            this.activeRunCompletionPromise = undefined;
             self.activeRunDetach$ = undefined;
           }),
         ),

--- a/packages/react-core/src/v2/__tests__/utils/test-helpers.tsx
+++ b/packages/react-core/src/v2/__tests__/utils/test-helpers.tsx
@@ -4,25 +4,38 @@ import { CopilotKitProvider } from "../../providers/CopilotKitProvider";
 import { CopilotChat } from "../../components/chat/CopilotChat";
 import { CopilotChatConfigurationProvider } from "../../providers/CopilotChatConfigurationProvider";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
-import {
-  AbstractAgent,
-  EventType,
-  type BaseEvent,
-  type RunAgentInput,
-} from "@ag-ui/client";
-import { Observable, Subject, from, delay } from "rxjs";
-import {
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import type { Observable } from "rxjs";
+import { Subject, from, delay } from "rxjs";
+import type { RunCompletionAware } from "@copilotkit/core";
+import type {
   ReactActivityMessageRenderer,
   ReactToolCallRenderer,
 } from "../../types";
-import { ReactCustomMessageRenderer } from "../../types/react-custom-message-renderer";
+import type { ReactCustomMessageRenderer } from "../../types/react-custom-message-renderer";
 
 /**
  * A controllable mock agent for deterministic E2E testing.
  * Exposes emit() and complete() methods to drive agent events step-by-step.
+ *
+ * Implements {@link RunCompletionAware} so tests can open the send-serialization
+ * await window (`onSubmitInput`/`handleSelectSuggestion` await this before
+ * dispatching) by assigning a controllable completion promise — without an
+ * `as unknown as` cast.
  */
-export class MockStepwiseAgent extends AbstractAgent {
+export class MockStepwiseAgent
+  extends AbstractAgent
+  implements RunCompletionAware
+{
   private subject = new Subject<BaseEvent>();
+
+  /**
+   * Resolves when the active run's pipeline finalizes; `undefined` between runs.
+   * Tests set this to a controllable promise to exercise the await-then-send
+   * serialization path. Mirrors the real `IntelligenceAgent` contract.
+   */
+  activeRunCompletionPromise?: Promise<void>;
 
   /**
    * Emit a single agent event

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -16,6 +16,7 @@ import {
 } from "@copilotkit/shared";
 import type { AttachmentsConfig, InputContent } from "@copilotkit/shared";
 import type { Suggestion, CopilotKitCoreErrorCode } from "@copilotkit/core";
+import { isRunCompletionAware } from "@copilotkit/core";
 import React, {
   useCallback,
   useEffect,
@@ -295,6 +296,43 @@ export function CopilotChat({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resolvedThreadId, agent, resolvedAgentId, hasExplicitThreadId]);
 
+  // Serializes consecutive sends: if a run is already in flight, let it finish
+  // before dispatching the next message instead of pre-empting it.
+  // `copilotkit.runAgent` would otherwise call `agent.detachActiveRun()` and
+  // ABORT the in-flight run. That abort is harmful when the in-flight run is an
+  // interrupt RESUME: the resume re-enters and completes the paused agent
+  // graph, and aborting it mid-flight leaves the graph paused — so the new
+  // message lands as another resume of the SAME paused graph (re-interrupting
+  // with no fresh payload) instead of starting a clean new turn. This is the
+  // consecutive-interrupt regression: pick turn-1's slot (kicks off the
+  // resume), then immediately send turn-2's message — without waiting, turn-2
+  // aborts the resume and the 2nd interrupt's card never mounts. Awaiting the
+  // active run's completion serializes the two turns so the resume finishes
+  // (graph completes) before the new message starts a fresh run.
+  //
+  // The completion promise lives only on `IntelligenceAgent` (via the
+  // `RunCompletionAware` contract), not on the `AbstractAgent` type held here —
+  // so it is reached through a type guard, not a cast. Agents that don't
+  // implement the contract degrade safely (the await is skipped).
+  const waitForActiveRunToSettle = useCallback(async () => {
+    if (
+      agent.isRunning &&
+      isRunCompletionAware(agent) &&
+      agent.activeRunCompletionPromise
+    ) {
+      try {
+        await agent.activeRunCompletionPromise;
+      } catch (error) {
+        // The in-flight run rejected — proceed with the new send anyway,
+        // but log so a chronically-failing in-flight run is observable.
+        console.error(
+          "CopilotChat: in-flight run rejected while queuing send",
+          error,
+        );
+      }
+    }
+  }, [agent]);
+
   const onSubmitInput = useCallback(
     async (value: string) => {
       // Block if uploads in progress (fast fail against current state before
@@ -318,40 +356,8 @@ export function CopilotChat({
       setInputValue("");
 
       // If a run is already in flight, let it finish before sending the new
-      // message instead of pre-empting it. `copilotkit.runAgent` would
-      // otherwise call `agent.detachActiveRun()` and ABORT the in-flight run.
-      // That abort is harmful when the in-flight run is an interrupt RESUME:
-      // the resume re-enters and completes the paused agent graph, and
-      // aborting it mid-flight leaves the graph paused — so this new message
-      // lands as another resume of the SAME paused graph (re-interrupting
-      // with no fresh payload) instead of starting a clean new turn. This is
-      // the consecutive-interrupt regression: pick turn-1's slot (kicks off
-      // the resume), then immediately send turn-2's message — without waiting,
-      // turn-2 aborts the resume and the 2nd interrupt's card never mounts.
-      // Awaiting the active run's completion serializes the two turns so the
-      // resume finishes (graph completes) before the new message starts a
-      // fresh run.
-      if (
-        agent.isRunning &&
-        "activeRunCompletionPromise" in agent &&
-        (agent as unknown as { activeRunCompletionPromise?: Promise<unknown> })
-          .activeRunCompletionPromise
-      ) {
-        try {
-          await (
-            agent as unknown as {
-              activeRunCompletionPromise?: Promise<unknown>;
-            }
-          ).activeRunCompletionPromise;
-        } catch (error) {
-          // The in-flight run rejected — proceed with the new send anyway,
-          // but log so a chronically-failing in-flight run is observable.
-          console.error(
-            "CopilotChat: in-flight run rejected while queuing send",
-            error,
-          );
-        }
-      }
+      // message instead of pre-empting it (see waitForActiveRunToSettle).
+      await waitForActiveRunToSettle();
 
       // Re-check the uploading guard against LIVE attachment state: an upload
       // can start (or stay in flight) during the await above, so a snapshot
@@ -409,11 +415,17 @@ export function CopilotChat({
     },
     // copilotkit is intentionally excluded — it is a stable ref that never changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [agent, consumeAttachments],
+    [agent, consumeAttachments, waitForActiveRunToSettle],
   );
 
   const handleSelectSuggestion = useCallback(
     async (suggestion: Suggestion) => {
+      // Mirror onSubmitInput's send-serialization: if a run is in flight, wait
+      // for it to settle before dispatching, so selecting a suggestion mid-run
+      // does NOT pre-empt/abort the active run (the same #5195 fix the
+      // typed-Enter path got — here for the suggestion path).
+      await waitForActiveRunToSettle();
+
       agent.addMessage({
         id: randomUUID(),
         role: "user",
@@ -430,7 +442,7 @@ export function CopilotChat({
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [agent],
+    [agent, waitForActiveRunToSettle],
   );
 
   const stopCurrentRun = useCallback(() => {

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.attachments.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.attachments.test.tsx
@@ -221,9 +221,7 @@ describe("CopilotChat attachments", () => {
         await waitFor(() => {
           expect(agent.isRunning).toBe(true);
         });
-        (
-          agent as unknown as { activeRunCompletionPromise?: Promise<void> }
-        ).activeRunCompletionPromise = inFlight;
+        agent.activeRunCompletionPromise = inFlight;
 
         // No attachments yet — the pre-await guard passes. Fire the send; it
         // parks on the in-flight run's completion promise.

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.e2e.test.tsx
@@ -816,6 +816,116 @@ describe("CopilotChat E2E - Chat Basics and Streaming Patterns", () => {
         { timeout: 5000 },
       );
     });
+
+    // Regression for the suggestion-path in-flight gap (deferred from PR #5195).
+    // `onSubmitInput` awaits an in-flight run before dispatching, but selecting
+    // a suggestion mid-run used to call runAgent() directly, pre-empting/aborting
+    // the active run — the same consecutive-interrupt bug #5195 fixed for the
+    // typed-Enter path. Selecting a suggestion while a run is in flight must
+    // NOT abort it; the suggestion send must be QUEUED until the run settles.
+    it("queues a selected suggestion until the in-flight run settles (does not abort it)", async () => {
+      const consumerAgent = new MockStepwiseAgent();
+      const providerAgent = new SuggestionsProviderAgent();
+
+      providerAgent.setSuggestions([
+        { title: "Option A", message: "Take action A" },
+        { title: "Option B", message: "Take action B" },
+      ]);
+
+      let suggestionsReady = false;
+
+      renderWithCopilotKit({
+        agents: {
+          default: consumerAgent,
+          "suggestions-provider": providerAgent,
+        },
+        agentId: "default",
+        children: (
+          <div style={{ height: 400 }}>
+            <ChatWithSuggestions
+              consumerAgentId="default"
+              providerAgentId="suggestions-provider"
+              onReady={() => {
+                suggestionsReady = true;
+              }}
+            />
+          </div>
+        ),
+      });
+
+      await waitFor(() => {
+        expect(suggestionsReady).toBe(true);
+      });
+
+      // Prime a turn so suggestions surface.
+      const input = await screen.findByRole("textbox");
+      fireEvent.change(input, { target: { value: "Help me" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+      await waitFor(() => {
+        expect(screen.getByText("Help me")).toBeDefined();
+      });
+
+      const messageId = testId("msg");
+      consumerAgent.emit(runStartedEvent());
+      consumerAgent.emit(textChunkEvent(messageId, "I can help with that."));
+      consumerAgent.emit(runFinishedEvent());
+      consumerAgent.complete();
+
+      await waitFor(() => {
+        expect(screen.getByText(/I can help with that/)).toBeDefined();
+      });
+
+      await waitFor(
+        () => {
+          expect(screen.getByText("Option A")).toBeDefined();
+        },
+        { timeout: 5000 },
+      );
+
+      // A new run goes in flight on the consumer agent (e.g. an interrupt
+      // RESUME still streaming). Attach a controllable completion promise so
+      // the suggestion send must park on it — exactly the typed-Enter contract.
+      const stopSpy = vi.spyOn(consumerAgent, "abortRun");
+      const addMessageSpy = vi.spyOn(consumerAgent, "addMessage");
+      consumerAgent.emit(runStartedEvent());
+      await waitFor(() => {
+        expect(consumerAgent.isRunning).toBe(true);
+      });
+      let resolveInFlight: () => void = () => {};
+      const inFlight = new Promise<void>((resolve) => {
+        resolveInFlight = resolve;
+      });
+      consumerAgent.activeRunCompletionPromise = inFlight;
+
+      addMessageSpy.mockClear();
+
+      // Select a suggestion while the run is in flight.
+      fireEvent.click(screen.getByText("Option A"));
+
+      // The in-flight run was NOT aborted by selecting the suggestion.
+      expect(stopSpy).not.toHaveBeenCalled();
+
+      // The suggestion send is PARKED on the in-flight promise: not dispatched
+      // and not in the transcript while the promise is unresolved. Goes RED if
+      // handleSelectSuggestion dispatches immediately (the pre-fix behavior).
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(addMessageSpy).not.toHaveBeenCalled();
+      expect(screen.queryByText("Take action A")).toBeNull();
+
+      // Release the in-flight run — only now does the queued suggestion dispatch.
+      await act(async () => {
+        resolveInFlight();
+        await Promise.resolve();
+      });
+      consumerAgent.emit(runFinishedEvent());
+      consumerAgent.complete();
+      await waitFor(() => {
+        expect(addMessageSpy).toHaveBeenCalled();
+        expect(screen.getByText("Take action A")).toBeDefined();
+      });
+    });
   });
 
   describe("Reasoning Message Flow", () => {
@@ -1279,9 +1389,7 @@ describe("CopilotChat E2E - Chat Basics and Streaming Patterns", () => {
       const inFlight = new Promise<void>((resolve) => {
         resolveInFlight = resolve;
       });
-      (
-        agent as unknown as { activeRunCompletionPromise?: Promise<void> }
-      ).activeRunCompletionPromise = inFlight;
+      agent.activeRunCompletionPromise = inFlight;
 
       addMessageSpy.mockClear();
 

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
@@ -30,6 +30,11 @@ const getSendButton = (container: HTMLElement) =>
     .querySelector("svg.lucide-arrow-up")
     ?.closest("button") as HTMLButtonElement | null;
 
+const getStopButton = (container: HTMLElement) =>
+  container
+    .querySelector("svg.lucide-square")
+    ?.closest("button") as HTMLButtonElement | null;
+
 const getAddMenuButton = (container: HTMLElement) =>
   container
     .querySelector("svg.lucide-plus")
@@ -1022,6 +1027,50 @@ describe("CopilotChatInput", () => {
 
       expect(mockOnSubmitMessage).toHaveBeenCalledWith("hello world");
       expect(mockOnChange).toHaveBeenCalledWith("");
+    });
+  });
+
+  // Pins the intentional Enter-vs-button divergence while a run is in flight.
+  // These two routes diverge on purpose (today only a comment binds them):
+  //   - Enter with sendable text => SEND a new message (not stop). This is what
+  //     unblocks consecutive interrupt pills (#5195): a non-empty composer is
+  //     unambiguous "send" intent even mid-run.
+  //   - The send/stop button while running => ALWAYS STOP, regardless of
+  //     composer contents (it renders as a Stop/Square affordance).
+  // Asserting BOTH together means a future refactor can't silently re-converge
+  // them (e.g. making the button also send, or Enter also stop) without a RED.
+  describe("Enter-vs-button routing while running (contract)", () => {
+    it("routes Enter to SEND but the button to STOP when a run is in flight with sendable text", () => {
+      const onSubmitMessage = vi.fn();
+      const onStop = vi.fn();
+
+      const { container } = renderWithProvider(
+        <CopilotChatInput
+          value="a brand new message"
+          onChange={vi.fn()}
+          onSubmitMessage={onSubmitMessage}
+          onStop={onStop}
+          isRunning
+        />,
+      );
+
+      // While running, the send/stop button renders as a Stop (Square) control.
+      const stopButton = getStopButton(container);
+      expect(stopButton).not.toBeNull();
+
+      // Enter with sendable text during a run => SEND (not stop).
+      const input = screen.getByRole("textbox");
+      fireEvent.keyDown(input, { key: "Enter", shiftKey: false });
+      expect(onSubmitMessage).toHaveBeenCalledWith("a brand new message");
+      expect(onStop).not.toHaveBeenCalled();
+
+      onSubmitMessage.mockClear();
+
+      // The button during a run => STOP, even though the composer holds
+      // sendable text (the divergence from Enter).
+      fireEvent.click(stopButton!);
+      expect(onStop).toHaveBeenCalledTimes(1);
+      expect(onSubmitMessage).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Deferred tech-debt from the CR of #5195 (the v2 interrupt `@chat` fix), grouped under one cohesive concern: **chat send-serialization robustness**.

- **Typed run-completion contract (no more casts).** CopilotChat used a runtime `"activeRunCompletionPromise" in agent` probe plus a double `as unknown as` cast (and the same cast in tests) to reach the in-flight run's completion promise — a property that lives only on `IntelligenceAgent`, not the `AbstractAgent` the chat holds. Introduces a `RunCompletionAware` interface + `isRunCompletionAware` type guard (exported from `@copilotkit/core`); `IntelligenceAgent` now declares the property and `implements RunCompletionAware`. All access sites (prod + the attachments/e2e tests + `MockStepwiseAgent`) use the typed accessor — zero casts. Non-Intelligence agents still degrade safely via the guard (the await is skipped).
- **Suggestion-path in-flight gap closed.** `onSubmitInput` awaited an in-flight run before dispatching, but `handleSelectSuggestion` called `runAgent` directly — so selecting a suggestion mid-run pre-empted/aborted the active run (e.g. an interrupt RESUME), the exact bug #5195 fixed for the typed-Enter path. The await-then-send logic is factored into a shared `waitForActiveRunToSettle` helper called from BOTH paths.
- **Enter-vs-button contract pinned.** CopilotChatInput intentionally diverges while running (Enter-with-sendable-text SENDS; the button always STOPS). Previously only a comment bound them. Adds a regression test asserting both together so a future refactor can't silently re-converge them.

## Test plan

- [x] Red-green for both new behavioral tests (suggestion-path serialization; Enter-vs-button contract) — each verified failing against a targeted mutation, then green.
- [x] `@copilotkit/react-core` full suite: 1203 passed.
- [x] `@copilotkit/core` full suite: 430 passed.
- [x] `@copilotkit/react-core` build (tsc declaration emit over prod source through the `@copilotkit/core` typed contract): green.
- [x] oxfmt + oxlint on changed files: clean (0 errors).
- [ ] CI green.

Note: a pre-existing `@copilotkit/shared:check-types` failure (missing `LicenseContextValue`/`LicenseMode` exports from `@copilotkit/license-verifier`, plus a telemetry index-signature error) exists on the worktree baseline — in files/packages untouched by this PR.