### PR TITLE
fix(examples): restore starter @chat usability (default agent key + useSingleEndpoint=false)

### DIFF
--- a/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -8,7 +8,7 @@ import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    my_agent: new HttpAgent({
+    default: new HttpAgent({
       url: process.env.AGENT_URL || "http://localhost:8000/",
     }),
   },

--- a/examples/integrations/adk/src/app/layout.tsx
+++ b/examples/integrations/adk/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+        {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+          useSingleEndpoint={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/adk/src/app/page.tsx
+++ b/examples/integrations/adk/src/app/page.tsx
@@ -77,7 +77,7 @@ export default function CopilotKitPage() {
 function YourMainContent({ themeColor }: { themeColor: string }) {
   // 🪁 Shared State: https://docs.copilotkit.ai/adk/shared-state
   const { agent } = useAgent({
-    agentId: "my_agent",
+    agentId: "default",
   });
   const state = (agent.state ?? {
     proverbs: [

--- a/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -8,7 +8,7 @@ import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    agno_agent: new HttpAgent({
+    default: new HttpAgent({
       url: (process.env.AGENT_URL || "http://localhost:8000") + "/agui",
     }),
   },

--- a/examples/integrations/agno/src/app/layout.tsx
+++ b/examples/integrations/agno/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="agno_agent">
+        {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+          useSingleEndpoint={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -10,7 +10,7 @@ import { handle } from "hono/vercel";
 //    integration to setup the connection.
 const runtime = new CopilotRuntime({
   agents: {
-    starterAgent: new CrewAIAgent({
+    default: new CrewAIAgent({
       url: process.env.AGENT_URL || "http://localhost:8000/",
     }),
   },

--- a/examples/integrations/crewai-crews/src/app/layout.tsx
+++ b/examples/integrations/crewai-crews/src/app/layout.tsx
@@ -17,7 +17,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="starterAgent">
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+          useSingleEndpoint={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/crewai-crews/src/app/page.tsx
+++ b/examples/integrations/crewai-crews/src/app/page.tsx
@@ -25,7 +25,7 @@ export default function CopilotKitPage() {
 
 function YourMainContent({ themeColor }: { themeColor: string }) {
   const { agent } = useAgent({
-    agentId: "starterAgent",
+    agentId: "default",
   });
 
   useEffect(() => {

--- a/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -8,7 +8,7 @@ import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    sample_agent: new LlamaIndexAgent({
+    default: new LlamaIndexAgent({
       url: (process.env.AGENT_URL || "http://127.0.0.1:9000") + "/run",
     }),
   },

--- a/examples/integrations/llamaindex/src/app/layout.tsx
+++ b/examples/integrations/llamaindex/src/app/layout.tsx
@@ -17,7 +17,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent">
+        {/* Force REST (path-based) transport so runtime-info and the threads
+            REST API both hit the multi-route endpoint. Auto-detect probes
+            GET /info first, which races the lazily-compiled API route in
+            `next dev` and can fall back to single-route (no threads support). */}
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+          useSingleEndpoint={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/llamaindex/src/app/page.tsx
+++ b/examples/integrations/llamaindex/src/app/page.tsx
@@ -54,7 +54,7 @@ type AgentState = {
 function YourMainContent({ themeColor }: { themeColor: string }) {
   // 🪁 Shared State: https://docs.copilotkit.ai/coagents/shared-state
   const { state, setState } = useAgent<AgentState>({
-    name: "sample_agent",
+    name: "default",
     initialState: {
       proverbs: [
         "CopilotKit may be new, but its the best thing since sliced bread.",

--- a/examples/integrations/mastra/src/app/layout.tsx
+++ b/examples/integrations/mastra/src/app/layout.tsx
@@ -29,7 +29,14 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="weatherAgent">
+        {/* Force REST (path-based) transport so runtime-info and the threads
+            REST API both hit the multi-route endpoint. Auto-detect probes
+            GET /info first, which races the lazily-compiled API route in
+            `next dev` and can fall back to single-route (no threads support). */}
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+          useSingleEndpoint={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/mastra/src/app/page.tsx
+++ b/examples/integrations/mastra/src/app/page.tsx
@@ -79,7 +79,7 @@ export default function CopilotKitPage() {
 function YourMainContent({ themeColor }: { themeColor: string }) {
   // 🪁 Shared State: https://docs.copilotkit.ai/mastra/shared-state/in-app-agent-read
   const { state, setState } = useAgent<AgentState>({
-    name: "weatherAgent",
+    name: "default",
     initialState: {
       proverbs: [
         "CopilotKit may be new, but its the best thing since sliced bread.",

--- a/examples/integrations/mastra/src/mastra/index.ts
+++ b/examples/integrations/mastra/src/mastra/index.ts
@@ -7,7 +7,7 @@ const LOG_LEVEL = (process.env.LOG_LEVEL as LogLevel) || "info";
 
 export const mastra = new Mastra({
   agents: {
-    weatherAgent,
+    default: weatherAgent,
   },
   storage: new LibSQLStore({
     id: "mastra-storage",

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -8,7 +8,7 @@ import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    my_agent: new HttpAgent({
+    default: new HttpAgent({
       url: process.env.AGENT_URL || "http://localhost:8000/",
     }),
   },

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/layout.tsx
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+        {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+          useSingleEndpoint={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/page.tsx
@@ -80,7 +80,7 @@ export default function CopilotKitPage() {
 function YourMainContent({ themeColor }: { themeColor: string }) {
   // 🪁 Shared State: https://docs.copilotkit.ai/pydantic-ai/shared-state
   const { state, setState } = useAgent<AgentState>({
-    name: "my_agent",
+    name: "default",
     initialState: {
       proverbs: [
         "CopilotKit may be new, but its the best thing since sliced bread.",

--- a/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -11,7 +11,7 @@ import { handle } from "hono/vercel";
 const runtime = new CopilotRuntime({
   agents: {
     // Our FastAPI endpoint URL
-    my_agent: new HttpAgent({
+    default: new HttpAgent({
       url: process.env.AGENT_URL || "http://localhost:8000/",
     }),
   },

--- a/examples/integrations/ms-agent-framework-python/src/app/layout.tsx
+++ b/examples/integrations/ms-agent-framework-python/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+        {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+          useSingleEndpoint={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/ms-agent-framework-python/src/app/page.tsx
+++ b/examples/integrations/ms-agent-framework-python/src/app/page.tsx
@@ -83,7 +83,7 @@ export default function CopilotKitPage() {
 function YourMainContent({ themeColor }: { themeColor: string }) {
   // 🪁 Shared State: https://docs.copilotkit.ai/microsoft-agent-framework/shared-state
   const { state, setState } = useAgent<AgentState>({
-    name: "my_agent",
+    name: "default",
     initialState: {
       proverbs: [
         "CopilotKit may be new, but its the best thing since sliced bread.",

--- a/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -11,7 +11,7 @@ import { handle } from "hono/vercel";
 const runtime = new CopilotRuntime({
   agents: {
     // Our FastAPI endpoint URL
-    my_agent: new HttpAgent({
+    default: new HttpAgent({
       url: process.env.AGENT_URL || "http://localhost:8000/",
     }),
   },

--- a/examples/integrations/pydantic-ai/src/app/layout.tsx
+++ b/examples/integrations/pydantic-ai/src/app/layout.tsx
@@ -17,7 +17,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+          useSingleEndpoint={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/pydantic-ai/src/app/page.tsx
+++ b/examples/integrations/pydantic-ai/src/app/page.tsx
@@ -83,7 +83,7 @@ export default function CopilotKitPage() {
 function YourMainContent({ themeColor }: { themeColor: string }) {
   // 🪁 Shared State: https://docs.copilotkit.ai/pydantic-ai/shared-state
   const { state, setState } = useAgent<AgentState>({
-    name: "my_agent",
+    name: "default",
     initialState: {
       proverbs: [
         "CopilotKit may be new, but its the best thing since sliced bread.",


### PR DESCRIPTION
## Summary

Re-applies the starter `@chat` usability fix that was collaterally reverted, **fully decoupled from the Intelligence-threads feature.**

- **PR #5210** standardized starter agent registry keys to `"default"`.
- **PR #5151 (ENT-679)** had added `useSingleEndpoint={false}` to the starter `<CopilotKit>` layouts.
- Together these two halves fixed the **"@chat: No assistant response"** blocker. Without them, the client auto-detects single-endpoint transport and POSTs to a route that 404s instead of the per-agent endpoint keyed `default`.
- The ENT-679 revert (**#5217**, commit `3721e7b36`) backed out **both** halves as collateral, so starters on `main` are broken again (`adk` key `my_agent`, `agno` `agno_agent`, etc., and no `useSingleEndpoint={false}`).

This PR re-applies **only** the usability fix. It does **not** reintroduce any Intelligence/threads scaffolding — no threads-drawer, no `_intelligence` overlay, no `CopilotKitIntelligence` runtime block / PATCH+DELETE handlers, no ghcr composite images, no `package.json`/version changes.

## Per-file changes (per affected starter)

- `route.ts` (or `mastra/src/mastra/index.ts`): agents registry key → `default`
- `layout.tsx`: add `useSingleEndpoint={false}` to `<CopilotKit>`, drop the `agent=` prop so it falls back to `"default"`
- `page.tsx`: `useAgent({ name|agentId: ... })` literal → `"default"`

Agent **semantic** names/exports are intentionally unchanged (e.g. mastra `weatherAgent` export, the Python backend's internal `my_agent` variable). Only the runtime registry KEY and the frontend agentId become `"default"`, exactly as #5210 did.

## Affected starters

adk, agno, crewai-crews, llamaindex, ms-agent-framework-dotnet, ms-agent-framework-python, pydantic-ai, mastra.

(`agno`'s `page.tsx` is unchanged because it has no `useAgent` reference; `langgraph-*` were already on the `default` key and are untouched. `langgraph-python-threads` is untouched.)

## Test plan

- [ ] CI `smoke-starter` matrix — the `@chat` legs must go green (this is the authoritative verification; the smoke harness boots each starter and exercises the chat round-trip)