### PR TITLE
feat(release): automated #engr Slack notification per release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -636,16 +636,16 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ===========================================================================
-  # Slack #oss-alerts notification
+  # Slack #engr notification
   #
-  # A single concise post to #oss-alerts when a release publishes (or fails).
+  # A single concise post to #engr when a release publishes (or fails).
   # Runs after both lanes regardless of their outcome (`if: always()`). The
   # load-bearing truth table lives in the unit-tested pure builder at
   # scripts/release/lib/build-release-notification.ts; this job only feeds it the
   # needs.* signals and posts what it returns. Suppressed entirely for canaries
   # (mode=prerelease) and dry-runs — the builder returns should_post=false there.
   # Webhook empty-guard mirrors showcase_validate.yml so an unset
-  # SLACK_WEBHOOK_OSS_ALERTS secret does not break the shell or red this step.
+  # SLACK_WEBHOOK_ENGR secret does not break the shell or red this step.
   # ===========================================================================
   notify:
     needs: [build, publish, build-python, publish-python]
@@ -661,7 +661,7 @@ jobs:
     permissions:
       contents: read
     env:
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ENGR }}
     steps:
       # Determine release intent IN THIS JOB, from the github.event payload +
       # the PR changed-files API — NOT from needs.build*/needs.build-python
@@ -790,11 +790,11 @@ jobs:
           PY_URL: ${{ needs.build-python.outputs.version && format('https://pypi.org/project/copilotkit/{0}/', needs.build-python.outputs.version) || 'https://pypi.org/project/copilotkit/' }}
         run: pnpm tsx scripts/release/build-release-notification.ts
 
-      - name: Post to #oss-alerts
+      - name: Post to #engr
         if: ${{ steps.build.outputs.should_post == 'true' && env.SLACK_WEBHOOK != '' && inputs.dry-run != true }}
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_ENGR }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -804,7 +804,7 @@ jobs:
       - name: Log (no Slack — webhook unset)
         if: ${{ steps.build.outputs.should_post == 'true' && env.SLACK_WEBHOOK == '' }}
         run: |
-          echo "::warning::A release notification was ready to post but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."
+          echo "::warning::A release notification was ready to post but SLACK_WEBHOOK_ENGR is not set; no Slack notification sent."
 
       # Self-watchdog: if any earlier step in THIS job failed (e.g. the
       # dependency install or the builder crashed), the notifier itself is the
@@ -837,7 +837,7 @@ jobs:
         if: ${{ failure() && env.SLACK_WEBHOOK != '' && inputs.dry-run != true && (steps.intent.outputs.npm_intended == 'true' || steps.intent.outputs.py_intended == 'true') }}
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_ENGR }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -386,6 +386,13 @@ jobs:
             echo "- Publish step was skipped; no npm publish, no git tag, no GitHub Release."
           } >> "$GITHUB_STEP_SUMMARY"
 
+    # Populated only on a stable, non-dry-run success (the publish/tag steps are
+    # gated on mode != prerelease && dry-run != true). On prerelease, dry-run, or
+    # failure these are empty — the notify job gates on that emptiness.
+    outputs:
+      version: ${{ steps.publish.outputs.version }}
+      tag: ${{ steps.tag.outputs.tag }}
+
   # ===========================================================================
   # Python SDK publish lane
   #
@@ -411,6 +418,13 @@ jobs:
       should_publish: ${{ steps.detect.outputs.should_publish }}
       version: ${{ steps.detect.outputs.version }}
       name: ${{ steps.detect.outputs.name }}
+      # Earliest Python-release intent signal: emitted by the `changed` step
+      # BEFORE any failure-prone step (setup-python, detect, build). The notify
+      # job gates the PyPI FAILURE alert on this (not should_publish, which is
+      # emitted only at the END of detect) so a build-python failure at/before
+      # detect on a genuine release still pages instead of being silently
+      # swallowed.
+      pyproject_changed: ${{ steps.changed.outputs.pyproject_changed }}
     steps:
       - name: Checkout merged main
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -620,3 +634,212 @@ jobs:
             echo "- \`copilotkit@${PY_VERSION}\`"
             echo "- https://pypi.org/project/copilotkit/${PY_VERSION}/"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ===========================================================================
+  # Slack #oss-alerts notification
+  #
+  # A single concise post to #oss-alerts when a release publishes (or fails).
+  # Runs after both lanes regardless of their outcome (`if: always()`). The
+  # load-bearing truth table lives in the unit-tested pure builder at
+  # scripts/release/lib/build-release-notification.ts; this job only feeds it the
+  # needs.* signals and posts what it returns. Suppressed entirely for canaries
+  # (mode=prerelease) and dry-runs — the builder returns should_post=false there.
+  # Webhook empty-guard mirrors showcase_validate.yml so an unset
+  # SLACK_WEBHOOK_OSS_ALERTS secret does not break the shell or red this step.
+  # ===========================================================================
+  notify:
+    needs: [build, publish, build-python, publish-python]
+    # always() so we still report on a failed lane, but guard on a real release
+    # context: a workflow_dispatch (manual release) OR a *merged* PR. A
+    # closed-unmerged PR is not a release attempt and must not notify.
+    if: >
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+        github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+    steps:
+      # Determine release intent IN THIS JOB, from the github.event payload +
+      # the PR changed-files API — NOT from needs.build*/needs.build-python
+      # outputs. The build jobs emit their intent signals (should_publish,
+      # pyproject_changed) AFTER failure-prone steps (SHA guards, setup-python,
+      # the PyPI version-compare), so a build job that dies before emitting them
+      # on a REAL release would leave the intent empty → no alert. Computing
+      # intent here, independent of whether the build jobs ran at all, closes
+      # that silent-swallow class. The builder gates the npm/PyPI FAILURE arms on
+      # these signals.
+      #
+      # This step runs FIRST — before Checkout/Setup/Install — on purpose:
+      # computing intent before any infra step means steps.intent.outputs.* are
+      # always populated even if a later infra step (the dependency install,
+      # checkout, or setup) fails. The failure() self-alert below gates its
+      # best-effort Slack post on these outputs, so running intent first
+      # guarantees that gate can still fire when the notify job dies during
+      # install — exactly the silent-swallow the self-watchdog exists to prevent.
+      # It needs only `gh api` (preinstalled), the github.event context, and
+      # GITHUB_TOKEN (in its own env), so it has no dependency on checkout/deps.
+      - name: Determine release intent
+        id: intent
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # npm intent: a manual dispatch, or a merged release/publish/* PR.
+          # Computed purely from event-context expressions (no API needed).
+          NPM_INTENDED="${{ (github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/publish/'))) && 'true' || 'false' }}"
+          echo "npm_intended=$NPM_INTENDED" >> "$GITHUB_OUTPUT"
+
+          # Python intent: a python_publish dispatch, OR a merged PR that changed
+          # sdk-python/pyproject.toml (per the GitHub PR changed-files API —
+          # robust to an uncomputed local merge_commit_sha). Default false.
+          PY_INTENDED="false"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ inputs.python_publish }}" = "true" ]; then PY_INTENDED="true"; fi
+          elif [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+            # Query the merged PR's changed files. Fail TOWARD paging: if the API
+            # call fails on a merged PR, default PY_INTENDED=true (never toward
+            # silence) and emit a ::warning::.
+            if FILES="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename' 2>/dev/null)"; then
+              if printf '%s\n' "$FILES" | grep -qx 'sdk-python/pyproject.toml'; then PY_INTENDED="true"; fi
+            else
+              echo "::warning::Could not list changed files for PR #${{ github.event.pull_request.number }} via the GitHub API — defaulting py_intended=true (fail toward paging, never toward silence)."
+              PY_INTENDED="true"
+            fi
+          fi
+          echo "py_intended=$PY_INTENDED" >> "$GITHUB_OUTPUT"
+          echo "npm_intended=$NPM_INTENDED py_intended=$PY_INTENDED"
+
+      - name: Checkout Repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+
+      # Restore node_modules so `pnpm tsx` (and the release-config import the
+      # notifier does) resolves. The build/publish jobs install before running
+      # tsx for the same reason; without this the notify step fails and NO
+      # release notification can ever post.
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Compute the scope-correct npm URL: the monorepo packages live under the
+      # @copilotkit org page, but the angular release is a single package.
+      - name: Resolve npm URL for scope
+        id: npmurl
+        env:
+          SCOPE: ${{ needs.build.outputs.scope }}
+        run: |
+          set -euo pipefail
+          case "$SCOPE" in
+            angular)
+              NPM_URL="https://www.npmjs.com/package/@copilotkitnext/angular"
+              ;;
+            *)
+              NPM_URL="https://www.npmjs.com/org/copilotkit"
+              ;;
+          esac
+          echo "npm_url=$NPM_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Build notification message
+        id: build
+        env:
+          MODE: ${{ needs.build.outputs.mode }}
+          NPM_RESULT: ${{ needs.publish.result }}
+          NPM_VER: ${{ needs.publish.outputs.version }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          # Event-derived release intent computed in the `intent` step above
+          # (independent of the build jobs). The builder gates the npm/PyPI
+          # FAILURE arms on these so a build-job failure on a genuine release
+          # always pages, even if the build jobs emitted no usable outputs.
+          NPM_INTENDED: ${{ steps.intent.outputs.npm_intended }}
+          PY_INTENDED: ${{ steps.intent.outputs.py_intended }}
+          # should_publish still legitimately gates the PyPI SUCCESS arm (a real
+          # success means detect ran and emitted it).
+          PY_PUB: ${{ needs.build-python.outputs.should_publish }}
+          PY_RESULT: ${{ needs.publish-python.result }}
+          PY_BUILD_RESULT: ${{ needs.build-python.result }}
+          PY_VER: ${{ needs.build-python.outputs.version }}
+          SCOPE: ${{ needs.build.outputs.scope }}
+          DRY_RUN: ${{ inputs.dry-run }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Empty when no tag was created (non-stable / dry-run). The builder's
+          # empty-releaseUrl guard that consumes this is retained as
+          # DEFENSE-IN-DEPTH: the empty-releaseUrl-on-SUCCESS state is NOT
+          # currently reachable — the tag step is `if: success()`, so a tag-step
+          # failure flips the publish JOB to `failure` and routes to the failure
+          # arm rather than rendering an empty link. The guard protects against a
+          # FUTURE change making the tag step continue-on-error (publish success
+          # + empty tag output), which would otherwise render a broken empty
+          # "<|Release notes>" / "/releases/tag/" link — do NOT remove it.
+          RELEASE_URL: ${{ needs.publish.outputs.tag && format('{0}/{1}/releases/tag/{2}', github.server_url, github.repository, needs.publish.outputs.tag) || '' }}
+          NPM_URL: ${{ steps.npmurl.outputs.npm_url }}
+          # Empty-version guard, mirroring RELEASE_URL above: with no version
+          # the per-version PyPI URL would be a broken ".../copilotkit//" link,
+          # so fall back to the project root page.
+          PY_URL: ${{ needs.build-python.outputs.version && format('https://pypi.org/project/copilotkit/{0}/', needs.build-python.outputs.version) || 'https://pypi.org/project/copilotkit/' }}
+        run: pnpm tsx scripts/release/build-release-notification.ts
+
+      - name: Post to #oss-alerts
+        if: ${{ steps.build.outputs.should_post == 'true' && env.SLACK_WEBHOOK != '' && inputs.dry-run != true }}
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ${{ toJSON(steps.build.outputs.message) }}
+            }
+
+      - name: Log (no Slack — webhook unset)
+        if: ${{ steps.build.outputs.should_post == 'true' && env.SLACK_WEBHOOK == '' }}
+        run: |
+          echo "::warning::A release notification was ready to post but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."
+
+      # Self-watchdog: if any earlier step in THIS job failed (e.g. the
+      # dependency install or the builder crashed), the notifier itself is the
+      # thing that broke — so a real release alert could be silently swallowed.
+      # Emit a ::error:: and, when the webhook is configured, a minimal
+      # best-effort Slack post so the failure isn't completely invisible.
+      - name: Notifier failed — self-alert
+        if: ${{ failure() }}
+        run: |
+          echo "::error::The release notify job failed before it could post — a release alert may have been swallowed. Check this run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Notifier failed — best-effort Slack
+        # Guard on dry-run: the self-watchdog Slack post must honor the same
+        # silence invariant as the real notification — a dry-run is silent
+        # EVERYWHERE, so a notify-job failure during one must not post a false
+        # red page.
+        #
+        # ALSO guard on real-release-context via the robust, build-job-INDEPENDENT
+        # intent computed in the `intent` step: the notify job runs on EVERY
+        # merged PR (always()), so a routine non-release merge whose notify job
+        # hits a transient install/builder flake would otherwise self-page even
+        # though no release was attempted. Only self-alert when a release was
+        # actually in flight (npm_intended OR py_intended). This replaces the old
+        # npm-biased `mode != 'prerelease'` + should_publish/pyproject_changed
+        # heuristic — which both relied on the build jobs' outputs (the very
+        # signals that may be empty if a build job died) AND would have suppressed
+        # a python_publish self-alert under a prerelease-mode dispatch. The intent
+        # gate is correct and robust. (The ::error:: echo step above stays
+        # unconditional — only the Slack POST needs these guards.)
+        if: ${{ failure() && env.SLACK_WEBHOOK != '' && inputs.dry-run != true && (steps.intent.outputs.npm_intended == 'true' || steps.intent.outputs.py_intended == 'true') }}
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ${{ toJSON(format('🔴 *CopilotKit release notifier failed* — a release alert may have been swallowed · <{0}/{1}/actions/runs/{2}|View run>', github.server_url, github.repository, github.run_id)) }}
+            }

--- a/scripts/release/build-release-notification.ts
+++ b/scripts/release/build-release-notification.ts
@@ -1,0 +1,225 @@
+/**
+ * CLI wrapper for the post-release #oss-alerts Slack notification builder.
+ *
+ * Thin glue around the pure buildReleaseNotification() function in
+ * ./lib/build-release-notification.ts. The truth-table logic lives (and is
+ * unit-tested) there; this file only:
+ *   1. reads the release signals from env vars (set by the notify job from
+ *      needs.* outputs/results + workflow inputs),
+ *   2. resolves the npm-scope package count from release.config.json
+ *      (defensively — a cosmetic count must never suppress a real alert),
+ *   3. calls the pure builder, and
+ *   4. writes `message=` and `should_post=` to GITHUB_OUTPUT.
+ *
+ * Env vars (all optional; absent → empty string):
+ *   MODE                needs.build.outputs.mode            ("stable" | "prerelease" | "")
+ *   NPM_RESULT          needs.publish.result                ("success" | "failure" | "skipped" | ...)
+ *   NPM_VER             needs.publish.outputs.version
+ *   BUILD_RESULT        needs.build.result                  (catches npm build-stage failures)
+ *   NPM_INTENDED        notify-job event-derived npm release intent ("true" | ...)  (gates the npm FAILURE arm)
+ *   PY_PUB              needs.build-python.outputs.should_publish ("true" | ...)
+ *   PY_INTENDED         notify-job event-derived Python release intent ("true" | ...)  (gates the PyPI FAILURE arm)
+ *   PY_RESULT           needs.publish-python.result
+ *   PY_BUILD_RESULT     needs.build-python.result            (catches PyPI build-stage failures)
+ *   PY_VER              needs.build-python.outputs.version
+ *   SCOPE               needs.build.outputs.scope           ("monorepo" | "angular")
+ *   DRY_RUN             inputs.dry-run                       ("true" | "false" | "")
+ *   RUN_URL             this workflow run URL
+ *   RELEASE_URL         GitHub Release URL (npm release notes)
+ *   NPM_URL             scope-correct npm package/org page URL
+ *   PY_URL              PyPI project page URL
+ *
+ * Usage: pnpm tsx scripts/release/build-release-notification.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { randomBytes } from "crypto";
+import { fileURLToPath } from "url";
+import { buildReleaseNotification } from "./lib/build-release-notification.js";
+import type {
+  ReleaseMode,
+  JobResult,
+  BuildReleaseNotificationResult,
+} from "./lib/build-release-notification.js";
+import { getScopeConfig } from "./lib/config.js";
+import type { ReleaseScope } from "./lib/config.js";
+
+function env(name: string): string {
+  return process.env[name] ?? "";
+}
+
+const KNOWN_MODES: readonly ReleaseMode[] = ["stable", "prerelease", ""];
+
+const KNOWN_JOB_RESULTS: readonly JobResult[] = [
+  "success",
+  "failure",
+  "cancelled",
+  "skipped",
+  "",
+];
+
+/**
+ * Validate a raw GitHub Actions job-result env value against the known
+ * JobResult set, degrading LOUDLY to "failure" (page-on-uncertainty) on any
+ * unrecognized value. A mis-wired `needs.<job>.result` env (typo, renamed job,
+ * an Actions value we don't model) must not be cast through unchecked.
+ *
+ * DIRECTION ASYMMETRY (intentional): RESULT values drive FAILURE-gating, and
+ * for a status notifier whose thesis is "never swallow a real failure" an
+ * unknown result is anomalous and must err toward PAGING, not silence — so it
+ * degrades to "failure". This is safe precisely because the failure arms are
+ * intent-gated (npmIntended/pyIntended): a degraded result only pages on a real
+ * release attempt, never on a routine non-release merge. By contrast
+ * resolveModeSafe degrades to "" — MODE drives SUCCESS-gating, where fabricating
+ * "stable" would falsely claim a publish that didn't happen. The ::warning::
+ * makes the degradation visible in the run log either way.
+ */
+export function resolveJobResultSafe(raw: string): JobResult {
+  if ((KNOWN_JOB_RESULTS as readonly string[]).includes(raw)) {
+    return raw as JobResult;
+  }
+  console.warn(
+    `::warning::resolveJobResultSafe: unrecognized job result "${raw}" (expected one of: success, failure, cancelled, skipped, or empty) — coercing to "failure" (page-on-uncertainty; the intent gates ensure this only pages on a real release).`,
+  );
+  return "failure";
+}
+
+/**
+ * Validate the raw MODE env value against the known ReleaseMode set, degrading
+ * LOUDLY to "" (treated as "npm lane didn't run" — the neutral, safe default)
+ * on any unrecognized value. A typo'd MODE must not be cast through unchecked.
+ *
+ * DIRECTION ASYMMETRY (intentional, opposite of resolveJobResultSafe): MODE
+ * drives the npm SUCCESS-gating (success requires mode==="stable"). Degrading a
+ * typo to a fabricated "stable" would FALSELY claim a publish that may not have
+ * happened, so MODE degrades to the neutral "" — never inventing a success.
+ * This does NOT swallow failures: the npm-failure arm keys off the event-derived
+ * npmIntended + the job RESULTS (gated only by the canary suppression), so a real
+ * stable failure still pages even with a degraded MODE. RESULT values, by
+ * contrast, drive FAILURE-gating and so degrade toward "failure"
+ * (page-on-uncertainty) in resolveJobResultSafe. The ::warning:: surfaces either
+ * degradation in the run log.
+ */
+export function resolveModeSafe(raw: string): ReleaseMode {
+  if ((KNOWN_MODES as readonly string[]).includes(raw)) {
+    return raw as ReleaseMode;
+  }
+  console.warn(
+    `::warning::resolveModeSafe: unrecognized MODE "${raw}" (expected one of: stable, prerelease, or empty) — coercing to "" (treated as "npm lane did not run").`,
+  );
+  return "";
+}
+
+/**
+ * Resolve the npm-scope package count from release.config.json, degrading to 0
+ * on ANY error (unknown scope, missing/corrupt config, etc.). A cosmetic
+ * package count must NEVER throw and suppress a real release alert.
+ */
+export function resolvePackageCountSafe(scope: string): number {
+  try {
+    // Only the two known scopes have a package list; anything else (e.g. a
+    // python-only run with an empty scope) has no npm packages to count.
+    if (scope === "monorepo" || scope === "angular") {
+      return getScopeConfig(scope as ReleaseScope).packages.length;
+    }
+    return 0;
+  } catch (err) {
+    // Degrade to 0 — the message simply omits the count rather than crashing a
+    // status notifier over a cosmetic detail. But surface the error in the run
+    // log (don't swallow silently): a corrupt/missing release.config.json
+    // should be visible, and the builder will render "published to npm
+    // (`latest`)" with no count parenthetical (never "0 packages").
+    console.warn(
+      `::warning::resolvePackageCountSafe: failed to resolve npm package count for scope "${scope}" — rendering without a package count. ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return 0;
+  }
+}
+
+/**
+ * Serialize the builder result to a GITHUB_OUTPUT file using a per-write RANDOM
+ * heredoc delimiter (GitHub's documented pattern), so message content can never
+ * collide with / prematurely terminate the heredoc.
+ */
+export function writeGithubOutput(
+  outputPath: string,
+  result: BuildReleaseNotificationResult,
+): void {
+  const delimiter = `EOF_${randomBytes(8).toString("hex")}`;
+  fs.appendFileSync(
+    outputPath,
+    `message<<${delimiter}\n${result.message}\n${delimiter}\n`,
+  );
+  fs.appendFileSync(outputPath, `should_post=${result.shouldPost}\n`);
+}
+
+function main(): void {
+  const scope = env("SCOPE");
+
+  const result = buildReleaseNotification({
+    mode: resolveModeSafe(env("MODE")),
+    npmResult: resolveJobResultSafe(env("NPM_RESULT")),
+    npmVer: env("NPM_VER"),
+    buildResult: resolveJobResultSafe(env("BUILD_RESULT")),
+    npmIntended: env("NPM_INTENDED"),
+    pyPub: env("PY_PUB"),
+    pyIntended: env("PY_INTENDED"),
+    pyResult: resolveJobResultSafe(env("PY_RESULT")),
+    pyBuildResult: resolveJobResultSafe(env("PY_BUILD_RESULT")),
+    pyVer: env("PY_VER"),
+    scope,
+    dryRun: env("DRY_RUN") === "true",
+    packageCount: resolvePackageCountSafe(scope),
+    runUrl: env("RUN_URL"),
+    releaseUrl: env("RELEASE_URL"),
+    npmUrl: env("NPM_URL"),
+    pyUrl: env("PY_URL"),
+  });
+
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    writeGithubOutput(outputPath, result);
+  } else if (process.env.GITHUB_ACTIONS === "true") {
+    // A status notifier that cannot write its `should_post`/`message` outputs
+    // is broken: the Post step gates on those outputs, so silently no-op'ing
+    // would swallow a real release alert. Fail loud under Actions.
+    console.error(
+      "::error::GITHUB_OUTPUT is unset under GitHub Actions — cannot emit should_post/message for the release notification.",
+    );
+    process.exit(1);
+  }
+
+  // Console echo (always useful in logs; the sole output channel for an
+  // explicit local/no-Actions invocation).
+  console.log(`should_post=${result.shouldPost}`);
+  if (result.message) {
+    console.log(`message:\n${result.message}`);
+  }
+}
+
+// Only run when invoked directly as a CLI, not when imported by tests.
+// Apply fs.realpathSync to BOTH sides so a symlinked checkout (where the module
+// path and argv[1] resolve to the same real file through different symlinks)
+// can't make main() silently not run. But realpathSync THROWS (ENOENT) if
+// argv[1] doesn't resolve on disk — which would crash before main() and
+// swallow a real release alert. So guard it: on a realpath throw, fall back to
+// a path.resolve()-normalized compare (no disk resolution) so the normal
+// direct-invoke path still runs the notifier. Normalize BOTH sides with
+// path.resolve — modulePath is already absolute (fileURLToPath), but argv[1]
+// may be relative, so a bare string compare could spuriously fail and silently
+// skip main() on a realpath throw.
+function isInvokedDirectly(): boolean {
+  if (process.argv[1] == null) return false;
+  const modulePath = fileURLToPath(import.meta.url);
+  try {
+    return fs.realpathSync(modulePath) === fs.realpathSync(process.argv[1]);
+  } catch {
+    return path.resolve(modulePath) === path.resolve(process.argv[1]);
+  }
+}
+if (isInvokedDirectly()) {
+  main();
+}

--- a/scripts/release/build-release-notification.ts
+++ b/scripts/release/build-release-notification.ts
@@ -1,5 +1,5 @@
 /**
- * CLI wrapper for the post-release #oss-alerts Slack notification builder.
+ * CLI wrapper for the post-release #engr Slack notification builder.
  *
  * Thin glue around the pure buildReleaseNotification() function in
  * ./lib/build-release-notification.ts. The truth-table logic lives (and is

--- a/scripts/release/lib/build-release-notification.test.ts
+++ b/scripts/release/lib/build-release-notification.test.ts
@@ -1,0 +1,705 @@
+import { describe, it, expect } from "vitest";
+import { buildReleaseNotification } from "./build-release-notification.js";
+import type { BuildReleaseNotificationInput } from "./build-release-notification.js";
+
+const RUN_URL = "https://github.com/CopilotKit/CopilotKit/actions/runs/123";
+const RELEASE_URL =
+  "https://github.com/CopilotKit/CopilotKit/releases/tag/v1.2.3";
+const NPM_URL = "https://www.npmjs.com/org/copilotkit";
+const ANGULAR_NPM_URL = "https://www.npmjs.com/package/@copilotkitnext/angular";
+const PY_URL = "https://pypi.org/project/copilotkit/0.9.0/";
+
+// A neutral baseline where nothing has acted. Each test overrides only the
+// fields relevant to its truth-table row.
+function base(
+  overrides: Partial<BuildReleaseNotificationInput> = {},
+): BuildReleaseNotificationInput {
+  return {
+    mode: "",
+    npmResult: "skipped",
+    npmVer: "",
+    buildResult: "skipped",
+    npmIntended: "false",
+    pyPub: "false",
+    pyIntended: "false",
+    pyResult: "skipped",
+    pyBuildResult: "skipped",
+    pyVer: "",
+    scope: "monorepo",
+    dryRun: false,
+    packageCount: 15,
+    runUrl: RUN_URL,
+    releaseUrl: RELEASE_URL,
+    npmUrl: NPM_URL,
+    pyUrl: PY_URL,
+    ...overrides,
+  };
+}
+
+describe("buildReleaseNotification", () => {
+  // ---- dry-run --------------------------------------------------------------
+  it("suppresses dry-run — no post", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmResult: "success",
+        npmVer: "1.2.3",
+        dryRun: true,
+      }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  // ---- npm lane: prerelease canary fully suppressed -------------------------
+  it("suppresses prerelease (canary) success — no post", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "prerelease",
+        npmResult: "success",
+        npmVer: "1.2.3-canary.1",
+        buildResult: "success",
+      }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  it("suppresses prerelease (canary) npm failure — no post", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "prerelease",
+        npmIntended: "true",
+        npmResult: "failure",
+        buildResult: "success",
+      }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  it("suppresses prerelease (canary) build failure — no post (would otherwise fire)", () => {
+    // Slot-6 strengthening: this row would emit a lane-level failure if the
+    // prerelease suppression on the npm lane regressed. buildResult=failure
+    // alone fires the alert UNLESS mode === "prerelease".
+    const r = buildReleaseNotification(
+      base({
+        mode: "prerelease",
+        npmIntended: "true",
+        npmResult: "skipped",
+        buildResult: "failure",
+      }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  // ---- npm lane: stable success --------------------------------------------
+  it("stable npm success → npm success line (monorepo, N packages)", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmResult: "success",
+        npmVer: "1.2.3",
+        buildResult: "success",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      "🚀 *CopilotKit monorepo v1.2.3* published to npm (`latest`, 15 packages) · " +
+        `<${RELEASE_URL}|Release notes> · <${NPM_URL}|npm>`,
+    );
+  });
+
+  it("stable npm success with empty releaseUrl → success line, NO broken Release-notes link", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmResult: "success",
+        npmVer: "1.2.3",
+        buildResult: "success",
+        releaseUrl: "",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      "🚀 *CopilotKit monorepo v1.2.3* published to npm (`latest`, 15 packages) · " +
+        `<${NPM_URL}|npm>`,
+    );
+    // The broken "/releases/tag/" empty link must never appear.
+    expect(r.message).not.toContain("Release notes");
+    expect(r.message).not.toContain("<|");
+  });
+
+  it("angular scope uses the angular package npm URL", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmResult: "success",
+        npmVer: "2.0.0",
+        buildResult: "success",
+        scope: "angular",
+        packageCount: 1,
+        npmUrl: ANGULAR_NPM_URL,
+      }),
+    );
+    expect(r.message).toContain(`<${ANGULAR_NPM_URL}|npm>`);
+    expect(r.message).toContain("*CopilotKit angular v2.0.0*");
+    expect(r.message).toContain("(`latest`, 1 package)");
+  });
+
+  // ---- npm lane: failure (lane-level wording) -------------------------------
+  it("stable npm failure → lane-level red alert (NOT 'npm publish failed')", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmIntended: "true",
+        npmResult: "failure",
+        buildResult: "success",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *CopilotKit monorepo release failed* · <${RUN_URL}|View run>`,
+    );
+    // A post-publish step (tag/release) may have failed while publish itself
+    // succeeded — never claim "publish failed".
+    expect(r.message).not.toContain("publish failed");
+  });
+
+  it("stable npm publish step SUCCEEDED (version emitted) but JOB failed at a later step → FAILURE line, NOT success (if/else ordering)", () => {
+    // The central npm-lane design claim: a populated version does NOT force a
+    // success line. The publish step can succeed and emit a version while the
+    // JOB still ends in `failure` (e.g. a later tag/release step broke). The
+    // success arm requires npmResult === "success"; here npmResult is "failure",
+    // so the `else if (npmResult === "failure" ...)` branch wins → lane-level
+    // "release failed". This locks the if/else ORDERING: failure result beats a
+    // populated version. Wording stays lane-level ("release failed"), never
+    // "publish failed", precisely because publish itself may have succeeded.
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmIntended: "true",
+        npmResult: "failure",
+        npmVer: "1.2.3",
+        buildResult: "success",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *CopilotKit monorepo release failed* · <${RUN_URL}|View run>`,
+    );
+    // Must NOT render a success line despite the populated version.
+    expect(r.message).not.toContain("🚀");
+    expect(r.message).not.toContain("published to npm");
+    // Lane-level, never step-level.
+    expect(r.message).not.toContain("publish failed");
+  });
+
+  it("build failure (mode='', npm skipped) → lane-level npm/build red alert", () => {
+    // A failure in the build job before the publish job ran: npmResult is
+    // "skipped" and mode is empty, but buildResult is "failure".
+    const r = buildReleaseNotification(
+      base({
+        mode: "",
+        npmIntended: "true",
+        npmResult: "skipped",
+        buildResult: "failure",
+        scope: "monorepo",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *CopilotKit monorepo release failed* · <${RUN_URL}|View run>`,
+    );
+    expect(r.message).not.toContain("publish failed");
+  });
+
+  it("npm publish failure with empty mode (npmResult='failure') → lane-level red alert (no mode-coupling swallow)", () => {
+    // The npm FAILURE arm keys off npmIntended (the notify job's event-derived
+    // release intent) AND the job result — NOT on mode === "stable" (that would
+    // swallow a real stable publish failure whose mode output came back empty).
+    // An empty mode with a real publish failure on a genuine release attempt
+    // still pages.
+    const r = buildReleaseNotification(
+      base({
+        mode: "",
+        npmIntended: "true",
+        npmResult: "failure",
+        buildResult: "success",
+        scope: "monorepo",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *CopilotKit monorepo release failed* · <${RUN_URL}|View run>`,
+    );
+    expect(r.message).not.toContain("publish failed");
+  });
+
+  // ---- npm lane: EVENT-DERIVED intent gate ---------------------------------
+  it("npmIntended='true' + buildResult='failure' → npm red ALERT (intent gate open)", () => {
+    // The notify job determined an npm release was actually attempted
+    // (release/publish/* merge or a workflow_dispatch). A build-job failure on a
+    // genuine npm release must page — independent of needs.build outputs.
+    const r = buildReleaseNotification(
+      base({
+        mode: "",
+        npmIntended: "true",
+        npmResult: "skipped",
+        buildResult: "failure",
+        scope: "monorepo",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *CopilotKit monorepo release failed* · <${RUN_URL}|View run>`,
+    );
+  });
+
+  it("npmIntended='false' + buildResult='failure' → NEUTRAL (no npm release attempted)", () => {
+    // The notify job runs on EVERY merged PR. A routine non-release merge whose
+    // build job flakes (or a stray failure) carries no npm release intent
+    // (not a release/publish/* merge, not a dispatch), so the lane stays quiet.
+    const r = buildReleaseNotification(
+      base({
+        mode: "",
+        npmIntended: "false",
+        npmResult: "skipped",
+        buildResult: "failure",
+        scope: "monorepo",
+      }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  // ---- PyPI lane: independent of MODE --------------------------------------
+  it("PyPI success → only PyPI line", () => {
+    const r = buildReleaseNotification(
+      base({ pyPub: "true", pyResult: "success", pyVer: "0.9.0" }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      "🐍 *copilotkit (Python SDK) v0.9.0* published to PyPI · " +
+        `<${PY_URL}|PyPI>`,
+    );
+  });
+
+  it("PyPI failure → lane-level PyPI red alert", () => {
+    const r = buildReleaseNotification(
+      base({ pyIntended: "true", pyPub: "true", pyResult: "failure" }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *copilotkit (Python SDK) release failed* · <${RUN_URL}|View run>`,
+    );
+  });
+
+  it("build-python failure during a REAL Python release (pyPub='true', publish-python skipped) → PyPI red alert", () => {
+    // The previously-silent gap: on a genuine Python release where build-python
+    // FAILS, publish-python is skipped (its `if` requires
+    // build-python.result == 'success') → pyResult === 'skipped'. Keying the
+    // failure lane off pyBuildResult catches this so a real release that broke
+    // at build still pages, instead of posting nothing.
+    const r = buildReleaseNotification(
+      base({
+        pyIntended: "true",
+        pyPub: "true",
+        pyResult: "skipped",
+        pyBuildResult: "failure",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *copilotkit (Python SDK) release failed* · <${RUN_URL}|View run>`,
+    );
+  });
+
+  it("build-python CANCELLED during a real Python release → NEUTRAL (no false red on deliberate cancel)", () => {
+    // A cancelled build-python reports result 'cancelled' (NOT 'failure'), even
+    // when it hits timeout-minutes. The failure lane keys off
+    // pyBuildResult === 'failure', so a cancel stays neutral.
+    const r = buildReleaseNotification(
+      base({
+        pyIntended: "true",
+        pyPub: "true",
+        pyResult: "skipped",
+        pyBuildResult: "cancelled",
+      }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  it("build-python failure WITHOUT intent (pyIntended='false', pyBuildResult='failure') → NO post (routine PR flake)", () => {
+    // build-python runs on EVERY merged PR; a transient build-python failure on
+    // an unrelated PR (no release intent) must NOT page. The pyIntended === 'true'
+    // gate is what prevents this false-RED.
+    const r = buildReleaseNotification(
+      base({
+        pyIntended: "false",
+        pyPub: "",
+        pyResult: "skipped",
+        pyBuildResult: "failure",
+      }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  it("build-python without intent (pyIntended='false') → NO post (routine PR, no false red)", () => {
+    // build-python runs on EVERY merged PR; only its inner steps are
+    // pyproject-gated. A transient build-python failure on an unrelated
+    // (docs/npm-only) PR must NOT page a PyPI failure — the notify job's
+    // event-derived pyIntended is false (no Python release attempted).
+    const r = buildReleaseNotification(
+      base({ pyIntended: "false", pyPub: "", pyResult: "skipped" }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  // ---- PyPI lane: EARLY-INTENT failure gate (closes the should_publish gap) -
+  it("build-python failure AT/BEFORE detect on a genuine Python release (pyIntended='true', pyPub='' — detect never emitted) → PyPI red ALERT", () => {
+    // THE CLOSED GAP. should_publish (pyPub) is emitted at the END of the detect
+    // step. A build-python failure at/before detect (PyPI API outage,
+    // setup-python failure, malformed pyproject) on a genuine Python release
+    // never reaches the should_publish echo → pyPub="". Gating the failure arm
+    // on pyPub silently swallowed this. The notify job's event-derived
+    // pyIntended (computed independently of the build jobs) catches it.
+    const r = buildReleaseNotification(
+      base({
+        pyIntended: "true",
+        pyPub: "",
+        pyResult: "skipped",
+        pyBuildResult: "failure",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *copilotkit (Python SDK) release failed* · <${RUN_URL}|View run>`,
+    );
+  });
+
+  it("routine PR build-python flake (pyIntended='false', pyBuildResult='failure') → NEUTRAL (no false-RED)", () => {
+    // build-python runs on EVERY merged PR; an npm/docs-only PR's transient
+    // build-python failure carries no release intent (the notify job's
+    // pyIntended is false — the merged PR did not change sdk-python/pyproject.toml
+    // and this is not a python_publish dispatch), so the lane stays quiet.
+    const r = buildReleaseNotification(
+      base({
+        pyIntended: "false",
+        pyPub: "",
+        pyResult: "skipped",
+        pyBuildResult: "failure",
+      }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  it("python release intended (pyIntended='true', pyBuildResult='failure') → PyPI red ALERT", () => {
+    // An explicit Python release intent (a python_publish=true dispatch, or a
+    // merged PR that bumped sdk-python/pyproject.toml). A build failure before
+    // detect emits no should_publish, but the event-derived pyIntended signal
+    // still fires the alert.
+    const r = buildReleaseNotification(
+      base({
+        pyIntended: "true",
+        pyPub: "",
+        pyResult: "skipped",
+        pyBuildResult: "failure",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *copilotkit (Python SDK) release failed* · <${RUN_URL}|View run>`,
+    );
+  });
+
+  it("prerelease + BOTH lanes failing → ONLY the PyPI red line, npm fully suppressed (canary)", () => {
+    // A mode=prerelease dispatch where the npm lane fails AND the PyPI lane
+    // fails. The npm failure is canary noise → fully suppressed by
+    // mode === "prerelease". The PyPI lane is mode-independent, so its real
+    // failure (pyPub="true", pyResult="failure") still pages. Exactly one red
+    // line, the PyPI one.
+    const r = buildReleaseNotification(
+      base({
+        mode: "prerelease",
+        npmIntended: "true",
+        npmResult: "failure",
+        buildResult: "failure",
+        pyIntended: "true",
+        pyPub: "true",
+        pyResult: "failure",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    // No npm line: the npm failure marker "*CopilotKit" (the npm line's bold
+    // prefix) must be absent. NB: the RUN_URL contains "CopilotKit/CopilotKit",
+    // so assert on the line prefix, not the bare org name.
+    expect(r.message).not.toContain("*CopilotKit");
+    expect(r.message).toBe(
+      `🔴 *copilotkit (Python SDK) release failed* · <${RUN_URL}|View run>`,
+    );
+  });
+
+  it("prerelease + python_publish success → npm suppressed, PyPI line still posts", () => {
+    // A mode=prerelease dispatch that also runs the Python lane must still
+    // announce the real PyPI publish — the canary suppression is npm-only.
+    const r = buildReleaseNotification(
+      base({
+        mode: "prerelease",
+        npmResult: "success",
+        npmVer: "1.2.3-canary.1",
+        buildResult: "success",
+        pyPub: "true",
+        pyResult: "success",
+        pyVer: "0.9.0",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).not.toContain("🚀");
+    expect(r.message).not.toContain("canary");
+    expect(r.message).toBe(
+      "🐍 *copilotkit (Python SDK) v0.9.0* published to PyPI · " +
+        `<${PY_URL}|PyPI>`,
+    );
+  });
+
+  // ---- cancelled is NEUTRAL everywhere -------------------------------------
+  it("npm cancelled (mode=stable) → no line (neutral, no false red)", () => {
+    const r = buildReleaseNotification(
+      base({ mode: "stable", npmResult: "cancelled", buildResult: "success" }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  it("build cancelled → no line (neutral)", () => {
+    const r = buildReleaseNotification(
+      base({ mode: "", npmResult: "skipped", buildResult: "cancelled" }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  it("PyPI cancelled → no line (neutral)", () => {
+    const r = buildReleaseNotification(
+      base({ pyPub: "true", pyResult: "cancelled" }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  it("build-python succeeded but publish-python cancelled (should_publish=true) → no line (neutral)", () => {
+    // Distinct from the row above: here build-python passed (pyBuildResult
+    // 'success') and the publish job was cancelled. Neither a build failure nor
+    // a publish failure → neutral, no false red.
+    const r = buildReleaseNotification(
+      base({ pyPub: "true", pyResult: "cancelled", pyBuildResult: "success" }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  // ---- skipped lanes contribute nothing ------------------------------------
+  it("python-only run (npm lane skipped) → only PyPI line, NO false red", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "",
+        npmResult: "skipped",
+        buildResult: "skipped",
+        pyPub: "true",
+        pyResult: "success",
+        pyVer: "0.9.0",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).not.toContain("🔴");
+    expect(r.message).toBe(
+      "🐍 *copilotkit (Python SDK) v0.9.0* published to PyPI · " +
+        `<${PY_URL}|PyPI>`,
+    );
+  });
+
+  it("npm-only run (PyPI lane not acting) → only npm line", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmResult: "success",
+        npmVer: "1.2.3",
+        buildResult: "success",
+        pyPub: "false",
+        pyResult: "skipped",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toContain("🚀 *CopilotKit monorepo v1.2.3*");
+    expect(r.message).not.toContain("🐍");
+    expect(r.message).not.toContain("🔴");
+  });
+
+  // ---- both lanes ----------------------------------------------------------
+  it("both lanes succeed → one message with both lines", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmResult: "success",
+        npmVer: "1.2.3",
+        buildResult: "success",
+        pyPub: "true",
+        pyResult: "success",
+        pyVer: "0.9.0",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    const expected =
+      "🚀 *CopilotKit monorepo v1.2.3* published to npm (`latest`, 15 packages) · " +
+      `<${RELEASE_URL}|Release notes> · <${NPM_URL}|npm>\n` +
+      "🐍 *copilotkit (Python SDK) v0.9.0* published to PyPI · " +
+      `<${PY_URL}|PyPI>`;
+    expect(r.message).toBe(expected);
+  });
+
+  it("both lanes fail → one message with both lane-level red lines", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmIntended: "true",
+        npmResult: "failure",
+        buildResult: "success",
+        pyIntended: "true",
+        pyPub: "true",
+        pyResult: "failure",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *CopilotKit monorepo release failed* · <${RUN_URL}|View run>\n` +
+        `🔴 *copilotkit (Python SDK) release failed* · <${RUN_URL}|View run>`,
+    );
+  });
+
+  // ---- nothing acted -------------------------------------------------------
+  it("nothing acted (npm skipped, PyPI not publishing) → no post, empty message", () => {
+    const r = buildReleaseNotification(base());
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  // ---- no-false-success guards ---------------------------------------------
+  it("stable npm success with empty version → no npm success line (no false success)", () => {
+    // npmResult=success but no version is an anomalous state — do not claim
+    // success. With buildResult=success there is also no failure to report.
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmResult: "success",
+        npmVer: "",
+        buildResult: "success",
+      }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  it("PyPI success with empty version → no PyPI success line (no false success)", () => {
+    const r = buildReleaseNotification(
+      base({ pyPub: "true", pyResult: "success", pyVer: "" }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+
+  it("pluralization: monorepo scope with N packages → 'N packages'", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmResult: "success",
+        npmVer: "1.2.3",
+        buildResult: "success",
+        packageCount: 15,
+      }),
+    );
+    expect(r.message).toContain("(`latest`, 15 packages)");
+  });
+
+  it("packageCount=0 (unknown/degraded) → success line WITHOUT a packages count parenthetical", () => {
+    // A degraded/missing release.config.json resolves to 0 packages. The
+    // builder must NOT render the self-contradictory "(`latest`, 0 packages)";
+    // it omits the count parenthetical entirely → "published to npm (`latest`)".
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmResult: "success",
+        npmVer: "1.2.3",
+        buildResult: "success",
+        packageCount: 0,
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toContain("published to npm (`latest`)");
+    expect(r.message).not.toContain("packages");
+    expect(r.message).not.toContain("0 package");
+    expect(r.message).toBe(
+      "🚀 *CopilotKit monorepo v1.2.3* published to npm (`latest`) · " +
+        `<${RELEASE_URL}|Release notes> · <${NPM_URL}|npm>`,
+    );
+  });
+
+  // ---- empty-scope rendering (no doubled words / double spaces) -------------
+  it("empty scope on the FAILURE path → clean 'CopilotKit release failed' (no 'release release')", () => {
+    // A stable build failure where scope is empty must not render
+    // "CopilotKit release release failed".
+    const r = buildReleaseNotification(
+      base({
+        mode: "",
+        npmIntended: "true",
+        npmResult: "skipped",
+        buildResult: "failure",
+        scope: "",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).toBe(
+      `🔴 *CopilotKit release failed* · <${RUN_URL}|View run>`,
+    );
+    expect(r.message).not.toContain("release release");
+    expect(r.message).not.toContain("  ");
+  });
+
+  it("empty scope on the SUCCESS path → clean version line (no double space)", () => {
+    const r = buildReleaseNotification(
+      base({
+        mode: "stable",
+        npmResult: "success",
+        npmVer: "1.2.3",
+        buildResult: "success",
+        scope: "",
+      }),
+    );
+    expect(r.shouldPost).toBe(true);
+    expect(r.message).not.toContain("  ");
+    expect(r.message).toBe(
+      "🚀 *CopilotKit v1.2.3* published to npm (`latest`, 15 packages) · " +
+        `<${RELEASE_URL}|Release notes> · <${NPM_URL}|npm>`,
+    );
+  });
+
+  it("npm success but mode not stable (defensive) → no npm success line", () => {
+    // mode "" with a success result must not produce an npm success line.
+    // buildResult=success means no failure either → nothing posts.
+    const r = buildReleaseNotification(
+      base({
+        mode: "",
+        npmResult: "success",
+        npmVer: "1.2.3",
+        buildResult: "success",
+      }),
+    );
+    expect(r.shouldPost).toBe(false);
+    expect(r.message).toBe("");
+  });
+});

--- a/scripts/release/lib/build-release-notification.ts
+++ b/scripts/release/lib/build-release-notification.ts
@@ -1,5 +1,5 @@
 /**
- * Pure message-builder for the post-release #oss-alerts Slack notification.
+ * Pure message-builder for the post-release #engr Slack notification.
  *
  * This is the load-bearing truth table for what (if anything) gets posted to
  * Slack after the publish-release.yml workflow runs. It is deliberately a PURE
@@ -163,7 +163,7 @@ function pluralizePackages(count: number): string {
 }
 
 /**
- * Build the #oss-alerts Slack message for a release run. Pure function: same
+ * Build the #engr Slack message for a release run. Pure function: same
  * inputs always produce the same output.
  */
 export function buildReleaseNotification(

--- a/scripts/release/lib/build-release-notification.ts
+++ b/scripts/release/lib/build-release-notification.ts
@@ -1,0 +1,303 @@
+/**
+ * Pure message-builder for the post-release #oss-alerts Slack notification.
+ *
+ * This is the load-bearing truth table for what (if anything) gets posted to
+ * Slack after the publish-release.yml workflow runs. It is deliberately a PURE
+ * function of its inputs so the full truth table can be unit-tested without any
+ * GitHub Actions / network involvement. The thin CLI wrapper
+ * (scripts/release/build-release-notification.ts) parses env vars, resolves the
+ * package count from release.config.json, calls this function, and writes the
+ * result to GITHUB_OUTPUT.
+ *
+ * Failure model — TWO INDEPENDENT LANES (npm + PyPI):
+ *
+ *   - dry-run → no post (entirely suppressed).
+ *
+ *   - npm lane (canary npm fully suppressed — success AND failure — when
+ *     mode === "prerelease", because npm canaries are noise):
+ *       • SUCCESS line when mode==stable && npmResult==success && npmVer set.
+ *         The "<releaseUrl|Release notes>" link is included only when
+ *         releaseUrl is non-empty. This empty-releaseUrl guard is retained as
+ *         DEFENSE-IN-DEPTH: the empty-releaseUrl-on-SUCCESS state is NOT
+ *         currently reachable — the tag step is `if: success()`, so a tag-step
+ *         failure flips the publish JOB to `failure`, routing to the failure
+ *         arm (npmResult != "success") rather than rendering an empty link. The
+ *         guard exists so that a FUTURE change making the tag step
+ *         continue-on-error (publish success + empty tag output) cannot render a
+ *         broken empty "<|Release notes>" / "/releases/tag/" link. Do NOT
+ *         remove it. The "(`latest`, N packages)" count parenthetical is OMITTED
+ *         when the resolved packageCount is 0 (unknown/degraded config) — never
+ *         print the self-contradictory "0 packages".
+ *       • FAILURE alert (lane-level, NOT step-level) when
+ *         npmIntended && (npmResult==failure || buildResult==failure) &&
+ *         mode != "prerelease". Gated on the event-derived npmIntended (computed
+ *         in the notify job from the github.event payload — a workflow_dispatch
+ *         or a merged release/publish/* PR) and the job results, with the canary
+ *         suppression. NOT additionally gated on mode==stable (which would
+ *         swallow a real stable publish failure whose mode output came back
+ *         empty). See the inline LANE SYMMETRY note. The publish step may have
+ *         succeeded with a LATER tag/release step failing, so the wording is
+ *         "release failed", never "publish failed".
+ *
+ *   - PyPI lane (INDEPENDENT of MODE — PyPI has no canary concept, so a
+ *     mode=prerelease dispatch that also runs python_publish must still
+ *     announce the real PyPI publish. NB: this mode-independence only matters
+ *     when the python lane was actually dispatched; on a pure npm release the
+ *     lane is skipped and contributes nothing):
+ *       • SUCCESS line when pyPub=="true" && pyResult==success && pyVer set.
+ *         (Success legitimately requires detect to have run and emitted
+ *         should_publish, so pyPub is the correct success gate.)
+ *       • FAILURE alert when pyIntended &&
+ *         (pyResult==failure || pyBuildResult==failure), where pyIntended is the
+ *         notify job's event-derived Python-release intent (a python_publish
+ *         dispatch, OR a merged PR that changed sdk-python/pyproject.toml per
+ *         the GitHub PR changed-files API). Symmetric with the npm lane. The
+ *         pyBuildResult arm closes the gap where build-python FAILS during a
+ *         genuine release → publish-python is skipped (its `if` requires
+ *         build-python.result == 'success') → pyResult is "skipped", so a bare
+ *         pyResult check would post nothing. CRITICAL — gate on the
+ *         build-job-INDEPENDENT intent, not pyPub: should_publish (pyPub) is
+ *         emitted only at the END of the detect step, so a build-python failure
+ *         AT/BEFORE detect on a genuine release (PyPI API outage, setup-python
+ *         failure, malformed pyproject) never emits it → pyPub="" → a pyPub-gated
+ *         failure arm SILENTLY SWALLOWS the alert. pyIntended is computed in the
+ *         notify job itself from the github.event payload + the PR changed-files
+ *         API, so it does NOT depend on the build jobs running at all. pyIntended
+ *         also keeps routine non-Python PRs quiet: build-python runs on EVERY
+ *         merged PR, but a docs/npm-only PR neither changed pyproject.toml nor is
+ *         a python_publish dispatch, so a transient build flake stays neutral. A
+ *         CANCELLED build reports "cancelled" (NOT "failure") and stays neutral
+ *         — no false-RED on a deliberate cancel.
+ *
+ *   - cancelled is NEUTRAL everywhere — never a failure line. (GitHub has no
+ *     timeout-specific result; a job hitting timeout-minutes reports
+ *     "cancelled", which correctly stays neutral.) This matches the
+ *     showcase-notify convention and avoids false-red pages on deliberate
+ *     cancels (e.g. concurrency cancel-in-progress).
+ *
+ *   - a skipped lane contributes NOTHING (no false red).
+ *   - shouldPost is true iff ≥1 line (success OR failure) was emitted; an empty
+ *     message never posts.
+ *
+ * See build-release-notification.test.ts for the exhaustive truth table.
+ */
+
+export type ReleaseMode = "stable" | "prerelease" | "";
+
+/**
+ * GitHub Actions `result` values for a needed job. These are the ONLY values
+ * GitHub emits: success | failure | cancelled | skipped (plus "" when unset).
+ * There is no timeout-specific result — a job that hits timeout-minutes
+ * reports "cancelled". We only treat "success" and "failure" as actionable;
+ * "skipped"/"cancelled"/"" are neutral.
+ */
+export type JobResult = "success" | "failure" | "skipped" | "cancelled" | "";
+
+export interface BuildReleaseNotificationInput {
+  /** needs.build.outputs.mode — "stable" | "prerelease" | "" (empty when npm lane didn't run). */
+  mode: ReleaseMode;
+  /** needs.publish.result — the npm publish job result. */
+  npmResult: JobResult;
+  /** needs.publish.outputs.version — the published npm version (empty unless stable success). */
+  npmVer: string;
+  /** needs.build.result — the npm build job result (catches build-stage failures). */
+  buildResult: JobResult;
+  /**
+   * NPM_INTENDED — "true" when the notify job determined an npm release was
+   * actually attempted, computed in the notify job itself from the
+   * github.event payload (a workflow_dispatch, or a merged release/publish/*
+   * PR) — independent of whether/how the build jobs ran. The npm FAILURE arm
+   * gates on this so a build-job failure on a genuine npm release always pages,
+   * even if needs.build emitted no usable outputs.
+   */
+  npmIntended: string;
+  /** needs.build-python.outputs.should_publish — "true" when the PyPI lane acted. */
+  pyPub: string;
+  /**
+   * PY_INTENDED — "true" when the notify job determined a Python release was
+   * actually intended, computed in the notify job itself: a workflow_dispatch
+   * with python_publish=true, OR a merged PR that changed
+   * sdk-python/pyproject.toml (determined via the GitHub PR changed-files API,
+   * not the build job's outputs). This is the build-job-INDEPENDENT Python
+   * release-intent signal. should_publish (pyPub) is emitted only at the END of
+   * build-python's `detect` step, so a build-python failure at/before detect on
+   * a genuine release never emits should_publish — gating the failure arm on
+   * pyIntended (not pyPub) closes that silent-swallow gap.
+   */
+  pyIntended: string;
+  /** needs.publish-python.result — the PyPI publish job result. */
+  pyResult: JobResult;
+  /**
+   * needs.build-python.result — the PyPI build job result. Lets the failure
+   * lane catch a build-stage failure that skips publish-python (whose `if`
+   * requires build-python.result == 'success', so pyResult becomes "skipped").
+   */
+  pyBuildResult: JobResult;
+  /** needs.build-python.outputs.version — the published PyPI version. */
+  pyVer: string;
+  /** needs.build.outputs.scope — "monorepo" | "angular". */
+  scope: string;
+  /** inputs.dry-run — true on a dry-run dispatch. */
+  dryRun: boolean;
+  /** Number of packages in the npm scope (from release.config.json). */
+  packageCount: number;
+  /** URL to this workflow run (for failure "View run" links). */
+  runUrl: string;
+  /** URL to the GitHub Release for the npm release (for "Release notes" link). May be empty. */
+  releaseUrl: string;
+  /** URL to the npm package/org page (for the "npm" link). Scope-correct. */
+  npmUrl: string;
+  /** URL to the PyPI project page (for the "PyPI" link). */
+  pyUrl: string;
+}
+
+export interface BuildReleaseNotificationResult {
+  /** The combined Slack message (mrkdwn). Empty when shouldPost is false. */
+  message: string;
+  /** True iff there is ≥1 success line OR ≥1 failure line. */
+  shouldPost: boolean;
+}
+
+function pluralizePackages(count: number): string {
+  return count === 1 ? "1 package" : `${count} packages`;
+}
+
+/**
+ * Build the #oss-alerts Slack message for a release run. Pure function: same
+ * inputs always produce the same output.
+ */
+export function buildReleaseNotification(
+  input: BuildReleaseNotificationInput,
+): BuildReleaseNotificationResult {
+  const empty: BuildReleaseNotificationResult = {
+    message: "",
+    shouldPost: false,
+  };
+
+  // Dry-run never posts (no real publish happened on any lane).
+  if (input.dryRun) {
+    return empty;
+  }
+
+  // Both failure lanes gate on an event-derived intent signal computed in the
+  // notify job (NOT on the build jobs' outputs/results). npmIntended is "true"
+  // when an npm release was actually attempted; pyIntended is "true" when a
+  // Python release was actually intended. See the per-lane notes below.
+  const npmIntended = input.npmIntended === "true";
+  const pyIntended = input.pyIntended === "true";
+
+  const lines: string[] = [];
+  // Render the scope cleanly when empty: a bare " " or doubled "release"
+  // word must never appear. With scope present we get "CopilotKit <scope> …";
+  // with scope empty we collapse to "CopilotKit …" (no extra word/space).
+  const scopeSegment = input.scope ? `${input.scope} ` : "";
+
+  // --- npm lane -----------------------------------------------------------
+  // Canary (prerelease) npm runs are fully suppressed — success AND failure —
+  // because npm canaries are noise. The PyPI lane below is NOT gated on this.
+  if (input.mode !== "prerelease") {
+    if (
+      input.mode === "stable" &&
+      input.npmResult === "success" &&
+      input.npmVer
+    ) {
+      // Build the success line, including the "Release notes" link ONLY when
+      // releaseUrl is non-empty. This guard is retained as DEFENSE-IN-DEPTH (see
+      // header): the empty-releaseUrl-on-SUCCESS state is NOT currently
+      // reachable — the tag step is `if: success()`, so a tag-step failure flips
+      // the publish JOB to `failure` and routes to the failure arm rather than
+      // this success arm. The guard protects against a FUTURE change making the
+      // tag step continue-on-error (publish success + empty tag output), which
+      // would otherwise render a broken empty "<|Release notes>" /
+      // "/releases/tag/" link. Do NOT remove it.
+      const releaseNotes = input.releaseUrl
+        ? `<${input.releaseUrl}|Release notes> · `
+        : "";
+      // Omit the "(`latest`, N packages)" count parenthetical entirely when
+      // the package count is unknown/degraded (0) — never print "0 packages".
+      const countSuffix =
+        input.packageCount > 0
+          ? ` (\`latest\`, ${pluralizePackages(input.packageCount)})`
+          : " (`latest`)";
+      lines.push(
+        `🚀 *CopilotKit ${scopeSegment}v${input.npmVer}* published to npm` +
+          `${countSuffix} · ` +
+          `${releaseNotes}<${input.npmUrl}|npm>`,
+      );
+    } else if (
+      npmIntended &&
+      (input.npmResult === "failure" || input.buildResult === "failure")
+    ) {
+      // Lane-level wording: the publish step may have succeeded while a later
+      // tag/release step failed, so never say "npm publish failed".
+      //
+      // The npm FAILURE arm gates on npmIntended AND the job results, with the
+      // enclosing canary suppression (mode !== "prerelease"). It is NOT gated on
+      // mode === "stable" (that would swallow a real stable publish failure
+      // whose mode output came back empty).
+      //
+      // LANE SYMMETRY (now both lanes are intent-gated from the notify job's
+      // event-derived signals): npmIntended is computed in the notify job from
+      // the github.event payload (a workflow_dispatch, or a merged
+      // release/publish/* PR) — NOT inferred from the `build` job's
+      // branch-gating invariant. So a build-job failure that emits no usable
+      // outputs still pages on a genuine npm release, and a routine non-release
+      // merge's build flake stays quiet. The PyPI lane below is symmetric: it
+      // gates on pyIntended, likewise event-derived in the notify job.
+      lines.push(
+        `🔴 *CopilotKit ${scopeSegment}release failed* · <${input.runUrl}|View run>`,
+      );
+    }
+    // cancelled / skipped on the npm lane are NEUTRAL → no line.
+  }
+
+  // --- PyPI lane ----------------------------------------------------------
+  // INDEPENDENT of MODE — PyPI has no canary concept, so the prerelease path
+  // never suppresses a real PyPI publish.
+  // pyIntended is the notify job's event-derived Python-release intent signal,
+  // computed independently of the build jobs (a python_publish dispatch, or a
+  // merged PR that changed sdk-python/pyproject.toml per the GitHub PR
+  // changed-files API). The SUCCESS arm still requires pyPub (should_publish)
+  // because a legitimate success necessarily means detect ran and emitted it;
+  // only the FAILURE arm must gate on the build-job-independent intent so a
+  // build-python failure AT/BEFORE detect (which never reaches the
+  // should_publish echo) still pages.
+  if (input.pyPub === "true" && input.pyResult === "success" && input.pyVer) {
+    lines.push(
+      `🐍 *copilotkit (Python SDK) v${input.pyVer}* published to PyPI · ` +
+        `<${input.pyUrl}|PyPI>`,
+    );
+  } else if (
+    pyIntended &&
+    (input.pyResult === "failure" || input.pyBuildResult === "failure")
+  ) {
+    // Fire on a real Python release attempt when EITHER the publish job failed
+    // OR the build job failed. Keying off pyBuildResult catches the gap where
+    // build-python FAILS → publish-python is skipped (its `if` requires
+    // build-python.result == 'success') → pyResult is "skipped" and the bare
+    // pyResult check would post nothing.
+    //
+    // The gate is pyIntended (the notify job's event-derived Python-release
+    // intent), NOT pyPub: pyPub (should_publish) is emitted only at the END of
+    // the detect step, so a build-python failure AT/BEFORE detect on a genuine
+    // release (PyPI API outage, setup-python failure, malformed pyproject) never
+    // emits it → pyPub="" → the old pyPub gate silently swallowed the alert.
+    // pyIntended is computed in the notify job from the github.event payload +
+    // the PR changed-files API, so it is present regardless of how the build
+    // jobs ran. pyIntended also keeps routine non-Python PRs quiet: build-python
+    // runs on EVERY merged PR, but a docs/npm-only PR neither changed
+    // sdk-python/pyproject.toml nor is a python_publish dispatch, so a transient
+    // build flake there stays neutral. Use pyBuildResult === "failure" (NOT
+    // "skipped"): a CANCELLED build reports "cancelled" and stays NEUTRAL, so a
+    // deliberate cancel never false-REDs.
+    lines.push(
+      `🔴 *copilotkit (Python SDK) release failed* · <${input.runUrl}|View run>`,
+    );
+  }
+
+  if (lines.length === 0) {
+    return empty;
+  }
+
+  return { message: lines.join("\n"), shouldPost: true };
+}

--- a/scripts/release/lib/build-release-notification.wrapper.test.ts
+++ b/scripts/release/lib/build-release-notification.wrapper.test.ts
@@ -363,7 +363,7 @@ describe("wrapper CLI end-to-end message rendering (subprocess)", () => {
     // the build job is `skipped` on a non-release merge (no release/publish/*
     // ref) → MODE/SCOPE come back empty and no Python intent signal is set.
     // The notifier must stay completely silent — neither a success nor a
-    // failure line — so a routine docs/feature merge never pages #oss-alerts.
+    // failure line — so a routine docs/feature merge never pages #engr.
     const out = path.join(tmpDir, "gho.txt");
     fs.writeFileSync(out, "");
     const { code } = runWrapper({

--- a/scripts/release/lib/build-release-notification.wrapper.test.ts
+++ b/scripts/release/lib/build-release-notification.wrapper.test.ts
@@ -1,0 +1,413 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+import { execFileSync } from "child_process";
+import {
+  writeGithubOutput,
+  resolvePackageCountSafe,
+  resolveModeSafe,
+  resolveJobResultSafe,
+} from "../build-release-notification.js";
+import * as config from "./config.js";
+
+const WRAPPER = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../build-release-notification.ts",
+);
+
+// Resolve the local tsx binary so the subprocess never hits npx's network /
+// registry path (which is flaky in CI). Walk up from this file to the repo
+// root's node_modules/.bin/tsx.
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+const TSX_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "tsx");
+
+/**
+ * Run the wrapper CLI as a subprocess; returns { code, stdout, stderr }.
+ *
+ * Builds a CLEAN minimal env (only PATH + the caller's overrides) rather than
+ * spreading the runner's process.env. This matters because the suite itself may
+ * run under GitHub Actions with a real GITHUB_OUTPUT / GITHUB_ACTIONS set —
+ * spreading those in would pollute the fail-loud "GITHUB_OUTPUT unset" test and
+ * the DRY_RUN coercion cases.
+ */
+function runWrapper(env: Record<string, string | undefined>): {
+  code: number;
+  stdout: string;
+  stderr: string;
+} {
+  // Strip undefined values so an explicit `KEY: undefined` truly unsets it
+  // (rather than passing the string "undefined").
+  const cleanEnv: Record<string, string> = { PATH: process.env.PATH ?? "" };
+  for (const [k, v] of Object.entries(env)) {
+    if (v !== undefined) cleanEnv[k] = v;
+  }
+  try {
+    const stdout = execFileSync(TSX_BIN, [WRAPPER], {
+      env: cleanEnv,
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+    return { code: 0, stdout, stderr: "" };
+  } catch (e: unknown) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return {
+      code: err.status ?? 1,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+    };
+  }
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "release-notify-wrapper-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("writeGithubOutput", () => {
+  it("round-trips a multi-line message through the GITHUB_OUTPUT heredoc", () => {
+    const outputPath = path.join(tmpDir, "out.txt");
+    fs.writeFileSync(outputPath, "");
+    const message = "line one\nline two · <https://x|y>";
+
+    writeGithubOutput(outputPath, { message, shouldPost: true });
+
+    const raw = fs.readFileSync(outputPath, "utf8");
+
+    // Parse the heredoc the way GitHub Actions does: message<<DELIM ... DELIM.
+    const m = raw.match(/^message<<(\S+)\n([\s\S]*?)\n\1\n/m);
+    expect(m).not.toBeNull();
+    expect(m![2]).toBe(message);
+    expect(raw).toContain("should_post=true");
+  });
+
+  it("uses a per-write RANDOM delimiter (not a fixed sentinel)", () => {
+    const a = path.join(tmpDir, "a.txt");
+    const b = path.join(tmpDir, "b.txt");
+    fs.writeFileSync(a, "");
+    fs.writeFileSync(b, "");
+
+    writeGithubOutput(a, { message: "x", shouldPost: true });
+    writeGithubOutput(b, { message: "x", shouldPost: true });
+
+    const delimA = fs.readFileSync(a, "utf8").match(/^message<<(\S+)/m)?.[1];
+    const delimB = fs.readFileSync(b, "utf8").match(/^message<<(\S+)/m)?.[1];
+
+    expect(delimA).toBeTruthy();
+    expect(delimB).toBeTruthy();
+    // No fixed sentinel, and two separate writes must differ.
+    expect(delimA).not.toBe("__RELEASE_NOTIFY_EOF__");
+    expect(delimA).not.toBe(delimB);
+  });
+
+  it("does not corrupt output when the message itself contains a heredoc-like token", () => {
+    const outputPath = path.join(tmpDir, "out.txt");
+    fs.writeFileSync(outputPath, "");
+    // A pathological message containing the legacy fixed delimiter must not
+    // prematurely terminate the heredoc.
+    const message = "__RELEASE_NOTIFY_EOF__\nstill the message";
+
+    writeGithubOutput(outputPath, { message, shouldPost: true });
+
+    const raw = fs.readFileSync(outputPath, "utf8");
+    const m = raw.match(/^message<<(\S+)\n([\s\S]*?)\n\1\n/m);
+    expect(m).not.toBeNull();
+    expect(m![2]).toBe(message);
+  });
+});
+
+describe("resolvePackageCountSafe", () => {
+  it("returns 0 for an unknown scope (early return, no config lookup)", () => {
+    // An unknown scope is NOT a known npm scope, so it hits the early `return 0`
+    // BEFORE getScopeConfig is ever called — this exercises the not-a-known-scope
+    // branch, NOT the try/catch error-swallow path (see the throw test below).
+    expect(() => resolvePackageCountSafe("does-not-exist")).not.toThrow();
+    expect(resolvePackageCountSafe("does-not-exist")).toBe(0);
+  });
+
+  it("returns 0 for an empty scope (python-only run)", () => {
+    expect(resolvePackageCountSafe("")).toBe(0);
+  });
+
+  it("returns the real package count for a known scope (angular)", () => {
+    // angular has exactly one package in release.config.json.
+    expect(resolvePackageCountSafe("angular")).toBe(1);
+  });
+
+  it("returns the real package count for the monorepo scope (drift guard)", () => {
+    // Pins the actual count from release.config.json (15). If the package set
+    // drifts, this catches the staleness of the hardcoded "15 packages"
+    // assertions in build-release-notification.test.ts.
+    expect(resolvePackageCountSafe("monorepo")).toBe(15);
+  });
+
+  it("swallows a getScopeConfig throw on a KNOWN scope → returns 0 AND emits ::warning::", () => {
+    // Drive the catch branch (not the early return): stub getScopeConfig to
+    // throw for a KNOWN scope (monorepo), simulating a corrupt/missing
+    // release.config.json. The safe wrapper must degrade to 0 and surface the
+    // failure as a ::warning:: rather than crash the notifier.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const scopeSpy = vi
+      .spyOn(config, "getScopeConfig")
+      .mockImplementation(() => {
+        throw new Error("simulated corrupt release.config.json");
+      });
+
+    expect(() => resolvePackageCountSafe("monorepo")).not.toThrow();
+    expect(resolvePackageCountSafe("monorepo")).toBe(0);
+    expect(scopeSpy).toHaveBeenCalledWith("monorepo");
+    expect(warnSpy).toHaveBeenCalled();
+    expect(
+      warnSpy.mock.calls.some(([msg]) => String(msg).includes("::warning::")),
+    ).toBe(true);
+  });
+});
+
+describe("resolveModeSafe", () => {
+  it.each(["stable", "prerelease", ""] as const)(
+    'passes through the known mode "%s" unchanged',
+    (mode: string) => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      expect(resolveModeSafe(mode)).toBe(mode);
+      expect(warnSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it('coerces an unknown MODE (typo) to "" AND emits ::warning:: (degrade loud, no crash)', () => {
+    // A typo'd MODE must NOT be cast through unchecked. The safe resolver
+    // degrades to "" (neutral "npm lane did not run") and surfaces a
+    // ::warning:: so the degradation isn't silent. "" is the safe default: the
+    // npm-failure arm keys off job RESULTS (gated only by canary suppression),
+    // so a real failure still pages — only a stable SUCCESS would degrade, and
+    // that degradation is now visible in the run log.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(() => resolveModeSafe("stabel")).not.toThrow();
+    expect(resolveModeSafe("stabel")).toBe("");
+    expect(warnSpy).toHaveBeenCalled();
+    expect(
+      warnSpy.mock.calls.some(([msg]) => String(msg).includes("::warning::")),
+    ).toBe(true);
+  });
+});
+
+describe("resolveJobResultSafe", () => {
+  it.each(["success", "failure", "cancelled", "skipped", ""] as const)(
+    'passes through the known job result "%s" unchanged (no warning)',
+    (result: string) => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      expect(resolveJobResultSafe(result)).toBe(result);
+      expect(warnSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it('coerces an unknown job result to "failure" AND emits ::warning:: (page-on-uncertainty, no crash)', () => {
+    // A mis-wired needs.<job>.result (typo, renamed job, an Actions value we
+    // don't model) must NOT be cast through unchecked. RESULT values drive
+    // FAILURE-gating, so for a notifier whose thesis is "never swallow a real
+    // failure" an unknown result is anomalous and degrades toward "failure"
+    // (page-on-uncertainty), not silence. The intent gates (npmIntended/
+    // pyIntended) ensure this only pages on a real release. A ::warning:: makes
+    // the degradation visible in the run log.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(() => resolveJobResultSafe("succeeded")).not.toThrow();
+    expect(resolveJobResultSafe("succeeded")).toBe("failure");
+    expect(warnSpy).toHaveBeenCalled();
+    expect(
+      warnSpy.mock.calls.some(([msg]) => String(msg).includes("::warning::")),
+    ).toBe(true);
+  });
+});
+
+describe("wrapper CLI fail-loud (subprocess)", () => {
+  it("fails loud (non-zero + ::error::) when running under Actions with GITHUB_OUTPUT unset", () => {
+    // GITHUB_ACTIONS=true signals an Actions context; with no GITHUB_OUTPUT a
+    // status notifier that cannot write its output must fail visibly.
+    const { code, stderr } = runWrapper({
+      GITHUB_ACTIONS: "true",
+      GITHUB_OUTPUT: undefined,
+      MODE: "stable",
+      NPM_RESULT: "success",
+      NPM_VER: "1.2.3",
+      BUILD_RESULT: "success",
+    });
+    expect(code).not.toBe(0);
+    expect(stderr).toContain("::error::");
+  }, 30000);
+
+  it("writes output and exits 0 when GITHUB_OUTPUT is set", () => {
+    const out = path.join(tmpDir, "gho.txt");
+    fs.writeFileSync(out, "");
+    const { code } = runWrapper({
+      GITHUB_ACTIONS: "true",
+      GITHUB_OUTPUT: out,
+      MODE: "stable",
+      NPM_RESULT: "success",
+      NPM_VER: "1.2.3",
+      BUILD_RESULT: "success",
+      SCOPE: "monorepo",
+    });
+    expect(code).toBe(0);
+    const raw = fs.readFileSync(out, "utf8");
+    expect(raw).toContain("should_post=true");
+    expect(raw).toMatch(/^message<<\S+/m);
+  }, 30000);
+});
+
+describe("wrapper CLI DRY_RUN string coercion (subprocess)", () => {
+  // DRY_RUN is the inputs.dry-run boolean stringified by Actions. It gates EVERY
+  // production notification, yet the env→boolean coercion is only exercisable at
+  // this string layer. Only the exact string "true" suppresses the post.
+  function postFor(dryRun: string): { code: number; raw: string } {
+    const out = path.join(tmpDir, "gho.txt");
+    fs.writeFileSync(out, "");
+    const { code } = runWrapper({
+      GITHUB_ACTIONS: "true",
+      GITHUB_OUTPUT: out,
+      MODE: "stable",
+      NPM_RESULT: "success",
+      NPM_VER: "1.2.3",
+      BUILD_RESULT: "success",
+      SCOPE: "monorepo",
+      DRY_RUN: dryRun,
+    });
+    return { code, raw: fs.readFileSync(out, "utf8") };
+  }
+
+  it('DRY_RUN="true" → should_post=false (suppressed)', () => {
+    const { code, raw } = postFor("true");
+    expect(code).toBe(0);
+    expect(raw).toContain("should_post=false");
+  }, 30000);
+
+  it('DRY_RUN="false" → posts on an otherwise-successful stable run', () => {
+    const { code, raw } = postFor("false");
+    expect(code).toBe(0);
+    expect(raw).toContain("should_post=true");
+  }, 30000);
+
+  it('DRY_RUN="" (empty) → posts on an otherwise-successful stable run', () => {
+    const { code, raw } = postFor("");
+    expect(code).toBe(0);
+    expect(raw).toContain("should_post=true");
+  }, 30000);
+});
+
+describe("wrapper CLI end-to-end message rendering (subprocess)", () => {
+  it("mixed lane: npm success + PyPI failure → one 🚀 line and one 🔴 line in one message", () => {
+    const out = path.join(tmpDir, "gho.txt");
+    fs.writeFileSync(out, "");
+    const { code } = runWrapper({
+      GITHUB_ACTIONS: "true",
+      GITHUB_OUTPUT: out,
+      MODE: "stable",
+      NPM_RESULT: "success",
+      NPM_VER: "1.2.3",
+      BUILD_RESULT: "success",
+      NPM_INTENDED: "true",
+      SCOPE: "monorepo",
+      PY_INTENDED: "true",
+      PY_PUB: "true",
+      PY_RESULT: "failure",
+      RUN_URL: "https://github.com/CopilotKit/CopilotKit/actions/runs/123",
+    });
+    expect(code).toBe(0);
+    const m = fs
+      .readFileSync(out, "utf8")
+      .match(/^message<<(\S+)\n([\s\S]*?)\n\1\n/m);
+    expect(m).not.toBeNull();
+    const message = m![2];
+    expect(message).toContain("🚀");
+    expect(message).toContain("🔴");
+    expect(message).toContain("(Python SDK) release failed");
+    // Exactly two lines (one per lane).
+    expect(message.split("\n")).toHaveLength(2);
+  }, 30000);
+
+  it("PyPI build failure during a real release (PY_BUILD_RESULT=failure, publish skipped) → 🔴 PyPI alert", () => {
+    // End-to-end wiring of the PY_BUILD_RESULT env: build-python failed, so
+    // publish-python was skipped (PY_RESULT=skipped). The notifier must still
+    // emit the PyPI failure line via the pyBuildResult arm.
+    const out = path.join(tmpDir, "gho.txt");
+    fs.writeFileSync(out, "");
+    const { code } = runWrapper({
+      GITHUB_ACTIONS: "true",
+      GITHUB_OUTPUT: out,
+      PY_INTENDED: "true",
+      PY_PUB: "true",
+      PY_RESULT: "skipped",
+      PY_BUILD_RESULT: "failure",
+      RUN_URL: "https://github.com/CopilotKit/CopilotKit/actions/runs/123",
+    });
+    expect(code).toBe(0);
+    const raw = fs.readFileSync(out, "utf8");
+    expect(raw).toContain("should_post=true");
+    const m = raw.match(/^message<<(\S+)\n([\s\S]*?)\n\1\n/m);
+    expect(m).not.toBeNull();
+    const message = m![2];
+    expect(message).toContain("🔴");
+    expect(message).toContain("(Python SDK) release failed");
+  }, 30000);
+
+  it("build-skipped routine merge (BUILD_RESULT=skipped, MODE='', SCOPE='', NPM_INTENDED='false', PY_INTENDED='false') → should_post=false (no false red)", () => {
+    // The dominant real-world case: the notify job runs on EVERY merged PR, but
+    // the build job is `skipped` on a non-release merge (no release/publish/*
+    // ref) → MODE/SCOPE come back empty and no Python intent signal is set.
+    // The notifier must stay completely silent — neither a success nor a
+    // failure line — so a routine docs/feature merge never pages #oss-alerts.
+    const out = path.join(tmpDir, "gho.txt");
+    fs.writeFileSync(out, "");
+    const { code } = runWrapper({
+      GITHUB_ACTIONS: "true",
+      GITHUB_OUTPUT: out,
+      MODE: "",
+      SCOPE: "",
+      BUILD_RESULT: "skipped",
+      NPM_RESULT: "skipped",
+      NPM_INTENDED: "false",
+      PY_PUB: "",
+      PY_INTENDED: "false",
+      PY_RESULT: "skipped",
+      PY_BUILD_RESULT: "skipped",
+      RUN_URL: "https://github.com/CopilotKit/CopilotKit/actions/runs/123",
+    });
+    expect(code).toBe(0);
+    const raw = fs.readFileSync(out, "utf8");
+    expect(raw).toContain("should_post=false");
+  }, 30000);
+
+  it("packageCount=0 (unknown scope) → success line WITHOUT a packages count", () => {
+    // An empty/unknown SCOPE resolves to 0 packages; the rendered npm line must
+    // omit the count parenthetical, never print "0 packages".
+    const out = path.join(tmpDir, "gho.txt");
+    fs.writeFileSync(out, "");
+    const { code } = runWrapper({
+      GITHUB_ACTIONS: "true",
+      GITHUB_OUTPUT: out,
+      MODE: "stable",
+      NPM_RESULT: "success",
+      NPM_VER: "1.2.3",
+      BUILD_RESULT: "success",
+      SCOPE: "",
+      NPM_URL: "https://www.npmjs.com/org/copilotkit",
+    });
+    expect(code).toBe(0);
+    const m = fs
+      .readFileSync(out, "utf8")
+      .match(/^message<<(\S+)\n([\s\S]*?)\n\1\n/m);
+    expect(m).not.toBeNull();
+    const message = m![2];
+    expect(message).toContain("published to npm (`latest`)");
+    expect(message).not.toContain("packages");
+    expect(message).not.toContain("0 package");
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

Adds an automated, **concise** `#engr` Slack notification when a CopilotKit release publishes (or fails) — modeled on the internal-skills→#engr release pings, but **one message per release**, not one per package. The monorepo publishes ~15 npm packages + angular + the Python SDK; naive per-package posts would be spam, so a single post summarizes the whole release.

- **New `notify` job** in `publish-release.yml` — runs after both lanes (`always()`), gated to real release contexts (a `workflow_dispatch` or a *merged* PR). Posts exactly one message via the existing org-wide `SLACK_WEBHOOK_ENGR` secret, if-guarded so an unset webhook never breaks the step. Suppressed entirely for canaries (`mode=prerelease`) and dry-runs.
- **Release intent is computed in the notify job from the `github.event` payload** (dispatch inputs, merged `release/publish/*` head ref, and the PR changed-files API for the Python SDK) — *independent* of the build jobs. The build jobs emit their intent signals after failure-prone steps, so a build that dies early on a genuine release would otherwise leave the alert empty. Computing intent independently closes that silent-swallow class. Failure arms **page on uncertainty** (fail toward paging, never toward silence).
- **Pure, unit-tested message builder** (`scripts/release/lib/build-release-notification.ts`) with a CLI wrapper that serializes to `$GITHUB_OUTPUT` (random-delimiter heredoc, fail-loud when it can't emit). Exhaustive truth-table coverage: npm/PyPI success + failure arms, canary/dry-run suppression, cancelled-is-neutral, empty-version/empty-scope graceful rendering, package-count pluralization.
- **Self-watchdog:** if the notify job's own machinery fails, a best-effort Slack post fires so the failure isn't invisible. The intent step runs **first** (before checkout/install) so its outputs survive an infra failure and the watchdog can still fire.

Publish/PyPI logic (the build/publish/build-python/publish-python jobs) is untouched.

## Review

Converged through a 2-round, 7-agent unbiased code review (zero mandatory in-scope findings remaining; the one in-scope finding — the self-watchdog gating on a later step's output — was fixed by relocating the intent step). Pre-existing publish-lane issues surfaced by reviewers (prerelease canary verify-step, stable-tag retry idempotency, canary→PyPI gating) are **outside this diff** and documented separately.

## Test plan

- [x] `vitest run` on the builder + wrapper suites — **85 tests green** (builder 40, wrapper 27, versions 18)
- [x] `actionlint .github/workflows/publish-release.yml` — zero new findings (4 pre-existing style findings in untouched jobs)
- [x] Both secret-using Slack steps if-guarded on `env.SLACK_WEBHOOK != ''`
- [ ] CI green on the PR
- [ ] Observe a real `#engr` post on the next stable release