### PR TITLE
fix(showcase/harness): fix browser-pool close-during-launch teardown race

### DIFF
--- a/showcase/harness/Dockerfile
+++ b/showcase/harness/Dockerfile
@@ -174,4 +174,12 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
 # Railway shutdown). The fallback `|| true` keeps boot resilient if the runtime
 # forbids raising the soft limit (it is then governed solely by the cgroup
 # pids limit, which is still the dominant control).
-CMD ["/bin/sh", "-c", "ulimit -u $(ulimit -Hu) 2>/dev/null || true; exec node dist/orchestrator.js"]
+#
+# MUST run under bash, NOT the default `/bin/sh`. On this image (node:22-
+# bookworm-slim) `/bin/sh` is dash, whose builtin `ulimit` does NOT support the
+# `-u` (max-user-processes / nproc) flag — it errors `ulimit: Illegal option -u`,
+# which the `2>/dev/null || true` then SILENTLY swallows. The intended PID
+# protection therefore never applied. bash IS present (/usr/bin/bash) and its
+# `ulimit -u` works: verified under `--ulimit nproc=512:4096` the soft limit is
+# raised 512 → 4096 (the hard ceiling) under bash, while dash leaves it untouched.
+CMD ["/bin/bash", "-c", "ulimit -u $(ulimit -Hu) 2>/dev/null || true; exec node dist/orchestrator.js"]

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -183,6 +183,14 @@ interface FakeLauncher {
    *  undefined) to "heal" the simulated thread-exhausted kernel so subsequent
    *  relaunches succeed. */
   setFailAfter(threshold: number | undefined): void;
+  /** Number of launchBrowser() calls currently PARKED mid-launch (the
+   *  `parkLaunchForCalls` set), awaiting __releaseParkedLaunches(). Models a real
+   *  chromium.launch() that has not yet resolved — its browser object exists but
+   *  is not yet registered in the pool's `this.browsers`. */
+  readonly __parkedLaunches: number;
+  /** Resolve ALL parked launches, returning the FakeBrowsers they resolve to (so
+   *  a test can assert on / crash them). */
+  __releaseParkedLaunches(): FakeBrowser[];
 }
 
 function makeFakeLauncher(opts?: {
@@ -200,10 +208,18 @@ function makeFakeLauncher(opts?: {
    *  recovery storm (init succeeds, all subsequent relaunches fail). Mutable
    *  via the returned `setFailAfter` so a test can "heal" the kernel mid-run. */
   failAfterCall?: number;
+  /** 1-based launch-call indices whose launchBrowser() PARKS — the FakeBrowser is
+   *  created but the launch promise does not resolve until
+   *  __releaseParkedLaunches() is called. Models a real chromium.launch() that is
+   *  mid-startup: the browser object exists (and can be closed!) but is not yet
+   *  registered in the pool's `this.browsers`. Drives the close-during-launch
+   *  teardown race. */
+  parkLaunchForCalls?: number[];
 }): FakeLauncher {
   const launched: FakeBrowser[] = [];
   let callCount = 0;
   let failAfter = opts?.failAfterCall;
+  const parkedReleases: Array<() => void> = [];
   const launchBrowser = async (): Promise<Browser> => {
     callCount++;
     if (opts?.failAtCalls?.includes(callCount)) {
@@ -219,6 +235,18 @@ function makeFakeLauncher(opts?: {
       deferNewContext: opts?.deferNewContextForCalls?.includes(callCount),
     });
     launched.push(b);
+    if (opts?.parkLaunchForCalls?.includes(callCount)) {
+      // The browser object exists but the launch is still "in flight": park the
+      // resolve so a concurrent teardown can run while the launch is mid-startup.
+      // A real chromium.launch() that has its target/browser closed underneath it
+      // rejects with "Target page, context or browser has been closed".
+      await new Promise<void>((resolve) => parkedReleases.push(resolve));
+      if (!b.isConnected()) {
+        throw new Error(
+          "browserType.launch: Target page, context or browser has been closed",
+        );
+      }
+    }
     return b as unknown as Browser;
   };
   return {
@@ -226,6 +254,14 @@ function makeFakeLauncher(opts?: {
     launched,
     setFailAfter(threshold) {
       failAfter = threshold;
+    },
+    get __parkedLaunches() {
+      return parkedReleases.length;
+    },
+    __releaseParkedLaunches() {
+      const toRelease = parkedReleases.splice(0, parkedReleases.length);
+      for (const r of toRelease) r();
+      return launched;
     },
   };
 }
@@ -2443,5 +2479,88 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
 
     await pool.release(served);
     await pool.shutdown();
+  });
+
+  // ===========================================================================
+  // FIX#13 — close-during-launch teardown race (the staging outage).
+  //
+  // A browser that is mid-`launch()` (the launch promise has not yet resolved,
+  // so it is NOT yet in `this.browsers` and has NOT yet had a disconnect handler
+  // attached) can be closed by a concurrent teardown path BEFORE the launch
+  // resolves. In production this manifested as the self-heal loop's
+  // `chromium.launch()` itself rejecting with
+  //   `browserType.launch: Target page, context or browser has been closed`
+  // (SIGTRAP — the browser was killed mid-startup). 336 such
+  // `self-heal-launch-failed` events in 4 min wedged the pool: every relaunch
+  // hit the same race, so the set never refilled.
+  //
+  // RED (pre-fix): `shutdown()` flips `isShutdown` and immediately closes every
+  // browser in `this.browsers`, but it has NO knowledge of a launch that is
+  // IN FLIGHT (created but not yet pushed). When the in-flight launch finally
+  // settles the pool either (a) hands the fresh browser out / leaves it leaked,
+  // or — modeled here — (b) the launch itself rejects because the browser was
+  // closed underneath it. The fix registers a "launching" marker BEFORE the
+  // await so shutdown awaits it instead of closing the browser mid-startup, and
+  // the launching path re-checks `isShutdown` AFTER the await to close cleanly
+  // ONLY then.
+  // GREEN: no `Target page, context or browser has been closed` rejection
+  // surfaces; the in-flight launch is either cleanly registered or cleanly
+  // closed exactly once after it settles.
+  // ===========================================================================
+  it("FIX#13: shutdown during an in-flight init launch waits for + cleanly closes the launching browser (no leak)", async () => {
+    // The init() fill loop launches the fixed set one browser at a time. A
+    // launch that is IN FLIGHT (the launch promise has not resolved) has its
+    // FakeBrowser created but is NOT yet in `this.browsers` and has NO disconnect
+    // handler. A concurrent shutdown() has no marker for this in-flight launch:
+    //   - shutdown's `inFlightRecycles` drain does NOT track init,
+    //   - shutdown closes only the browsers already in `this.browsers`.
+    // So pre-fix, shutdown returns while init's launch is still in flight; when
+    // the launch finally resolves it pushes a live browser that NOTHING ever
+    // closes — a permanently leaked chromium process (the steady-state form of
+    // the staging wedge: launches that escape teardown accounting).
+    //
+    // Drive it: browsers:2 so init does call 1 (resolves) then call 2 (PARKS).
+    const launcher = makeFakeLauncher({
+      parkLaunchForCalls: [2],
+    });
+    const { launchBrowser, launched } = launcher;
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 4,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+
+    const rejections: string[] = [];
+    const onRej = (e: unknown): void => {
+      rejections.push(e instanceof Error ? e.message : String(e));
+    };
+    process.on("unhandledRejection", onRej);
+
+    // Kick init() but do NOT await — its second launch (call 2) parks in flight.
+    const initP = pool.init();
+    await waitFor(() => launcher.__parkedLaunches > 0);
+    expect(launched.length).toBe(2);
+
+    // Concurrent teardown WHILE init's 2nd launch is in flight.
+    const shutdownP = pool.shutdown();
+    await drainMicrotasks();
+
+    // Release the parked launch so init can finish.
+    launcher.__releaseParkedLaunches();
+    await Promise.allSettled([initP, shutdownP]);
+    await drainMicrotasks(20);
+    await new Promise((r) => setTimeout(r, 20));
+    process.off("unhandledRejection", onRej);
+
+    // INVARIANT 1: no close-during-launch rejection escaped.
+    expect(
+      rejections.some((m) => m.includes("Target page, context or browser")),
+    ).toBe(false);
+    // INVARIANT 2: BOTH launched browsers were closed on shutdown — the
+    // in-flight one (launched[1]) is NOT leaked. Pre-fix shutdown returns before
+    // launched[1] registers, so it is never closed (__closeCount === 0).
+    expect(launched[0]!.__closeCount).toBeGreaterThanOrEqual(1);
+    expect(launched[1]!.__closeCount).toBeGreaterThanOrEqual(1);
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -299,6 +299,21 @@ export class BrowserPool {
   private readonly launchStaggerMs: number;
   private launchChain: Promise<unknown> = Promise.resolve();
 
+  // In-flight launches. Every `launchBrowser()` registers its launch promise
+  // here BEFORE awaiting `rawLaunchBrowser()` and removes it on settle. This is
+  // the atomicity fix for the close-during-launch teardown race: a browser that
+  // is mid-`launch()` is NOT yet in `this.browsers` and has NO disconnect
+  // handler, so it is invisible to every teardown path (shutdown's close pass,
+  // recycle, the disconnect handler). Under the self-heal/relaunch storm a
+  // teardown therefore raced an in-flight launch — closing the browser
+  // underneath it (`browserType.launch: Target page ... has been closed`,
+  // SIGTRAP) or leaking it entirely. shutdown() now DRAINS this set (so it waits
+  // for every in-flight launch to settle before its close pass), and
+  // `launchBrowser` re-checks `isShutdown` the instant a launch settles: if a
+  // shutdown intervened it closes the freshly-launched browser cleanly THEN,
+  // exactly once, instead of leaving it for a teardown that already ran.
+  private pendingLaunches = new Set<Promise<unknown>>();
+
   constructor(options: BrowserPoolOptions = {}) {
     this.logger = options.logger;
     this.injectedLaunchBrowser = options.launchBrowser;
@@ -446,15 +461,56 @@ export class BrowserPool {
    * receives the rejection via the returned `result`. The stagger applies
    * whether the launch resolved or threw — a failed launch is just as
    * PID-costly to retry.
+   *
+   * ATOMIC vs TEARDOWN: the launch promise is registered in `pendingLaunches`
+   * BEFORE it is awaited and removed when it settles, so `shutdown()` can DRAIN
+   * every in-flight launch before its close pass — a launch can no longer escape
+   * teardown accounting (the close-during-launch race). And the instant a launch
+   * settles, if a `shutdown()` raced in while it was in flight, this seam closes
+   * the freshly-launched browser cleanly THEN (exactly once) and re-throws a
+   * shutdown sentinel: the caller's launch then "fails" into its normal
+   * error/abort path rather than registering (and leaking) a browser into a pool
+   * that is going away. Callers must NOT separately close a browser this seam
+   * returned on the shutdown path — the throw means there is no browser to close.
    */
   private launchBrowser = (): Promise<Browser> => {
     const gate = this.launchChain;
-    const result = gate.then(() => this.rawLaunchBrowser());
-    this.launchChain = result
+    const raw = gate.then(() => this.rawLaunchBrowser());
+    // Gate the NEXT launch off the RAW result (pre-shutdown-handling) so the
+    // stagger/queue semantics are unchanged by the teardown guard below.
+    this.launchChain = raw
       .catch(() => undefined)
       .then(() =>
         this.launchStaggerMs > 0 ? delay(this.launchStaggerMs) : undefined,
       );
+
+    const result = raw.then((browser) => {
+      // The launch settled. If a shutdown raced in while it was in flight, this
+      // freshly-launched browser would otherwise be invisible to the close pass
+      // that already ran (it was never in `this.browsers`). Close it cleanly here
+      // — exactly once — and surface a shutdown sentinel so the caller does not
+      // register it into a pool that is tearing down.
+      if (this.isShutdown) {
+        // The launching browser is by definition not yet registered in
+        // `this.browsers`, so there is no meaningful index — log it as -1.
+        return this.closeBrowser(browser, -1).then((): Browser => {
+          throw new Error("BrowserPool shut down during launch");
+        });
+      }
+      return browser;
+    });
+
+    // Track the in-flight launch so shutdown() drains it before closing. Use a
+    // catch-swallowed handle so a rejected launch (failure OR the shutdown
+    // sentinel above) still settles the drain without surfacing an unhandled
+    // rejection on the tracking copy; the caller still receives the real
+    // rejection via `result`.
+    const tracked = result.catch(() => undefined);
+    this.pendingLaunches.add(tracked);
+    void tracked.finally(() => {
+      this.pendingLaunches.delete(tracked);
+    });
+
     return result;
   };
 
@@ -1127,17 +1183,27 @@ export class BrowserPool {
     }
     this.waiters = [];
 
-    // Drain in-flight recycles + self-heal loops in a LOOP, re-snapshotting each
-    // pass. A ONE-TIME snapshot is racy: a self-heal iteration (or an
-    // in-flight-recovery relaunch) can register a NEW promise in
+    // Drain in-flight recycles + self-heal loops AND in-flight launches in a
+    // LOOP, re-snapshotting each pass. A ONE-TIME snapshot is racy: a self-heal
+    // iteration (or an in-flight-recovery relaunch) can register a NEW promise in
     // `inFlightRecycles` AFTER the snapshot — and that late iteration may launch
     // a fresh chromium AFTER shutdown returned, leaking the process. Loop until
-    // the set is genuinely empty (each settled loop/recycle has dropped its
-    // handle), so we await every late-registered iteration too. The loops all
+    // BOTH sets are genuinely empty (each settled loop/recycle/launch has dropped
+    // its handle), so we await every late-registered iteration too.
+    //
+    // `pendingLaunches` is the close-during-launch fix: an init/recycle/self-heal
+    // launch that is mid-`launch()` is NOT yet in `this.browsers`, so the close
+    // pass below cannot see it. Draining it here makes shutdown WAIT for every
+    // in-flight launch to settle; the launch seam itself (`launchBrowser`) then
+    // observes `isShutdown` on settle and closes the freshly-launched browser
+    // cleanly — so it is neither closed mid-launch nor leaked. The loops all
     // check `isShutdown` and the delays abort via the shutdown signal, so this
     // converges promptly.
-    while (this.inFlightRecycles.size > 0) {
-      await Promise.allSettled(Array.from(this.inFlightRecycles));
+    while (this.inFlightRecycles.size > 0 || this.pendingLaunches.size > 0) {
+      await Promise.allSettled([
+        ...Array.from(this.inFlightRecycles),
+        ...Array.from(this.pendingLaunches),
+      ]);
     }
 
     // Close every live context, then every browser. Route through the close


### PR DESCRIPTION
## Summary

Fixes a live staging outage: the showcase-harness browser pool was wedged — every chromium launch was being closed microseconds after `launch()`, before the launch promise resolved (`browserType.launch: Target page, context or browser has been closed`, SIGTRAP). 336 `self-heal-launch-failed` events in 4 minutes; the self-heal loop relaunched forever, each relaunch hitting the same race.

### The race (concurrency logic bug)

A browser that is **mid-`launch()`** is not yet in `this.browsers` and has **no disconnect handler attached**, so it is invisible to every teardown path — `shutdown()`'s close pass closes only `this.browsers`, and `inFlightRecycles` tracks the recycle promise but nothing tracked the bare launch. Under the self-heal / relaunch storm introduced by the browser-pool hardening cluster (`098909992` / `dfc72f1a7` #5174 / `57ff0d332` / `6d2f5885d`, ~#5185), a concurrent teardown therefore raced an in-flight launch: the launch escaped teardown accounting entirely — leaked, or the browser was closed underneath the still-resolving `chromium.launch()`, which then rejected. The self-heal loop then relaunched forever.

### Atomic-launch fix

- `launchBrowser()` registers its launch promise in a new `pendingLaunches` set **before** awaiting `rawLaunchBrowser()`, and removes it on settle.
- `shutdown()` now drains `pendingLaunches` (alongside `inFlightRecycles`) **before** its close pass, so it **waits** for every in-flight launch to settle instead of closing a browser mid-launch.
- The launch seam re-checks `isShutdown` the instant the launch settles: if a shutdown intervened it closes the freshly-launched browser cleanly **then**, exactly once, and throws a shutdown sentinel so the caller (`init` / recycle relaunch / self-heal) does not register a browser into a pool that is going away.
- The launch-stagger gate still chains off the **raw** launch result, so serialization semantics are unchanged. All #5185 behaviors (backoff, self-heal, degraded/recovered alarms, waiter draining) are preserved.

Red-green test `FIX#13`: an in-flight launch racing a concurrent `shutdown()`. Pre-fix the launching browser escapes teardown (`closeCount === 0`, leaked); post-fix it is drained + closed cleanly exactly once, with no close-during-launch rejection.

### Secondary fix — the dash `ulimit -u` no-op

The runtime `CMD` raised the PID/nproc soft ulimit via `/bin/sh -c "ulimit -u $(ulimit -Hu) ..."`, but on `node:22-bookworm-slim` `/bin/sh` is **dash**, whose builtin `ulimit` does **not** support the `-u` flag — it errors `ulimit: Illegal option -u`, which `2>/dev/null || true` then silently swallows. So #5185's intended PID protection never applied. Switched the `CMD` to `/bin/bash` (present at `/usr/bin/bash`), whose `ulimit -u` works.

Verified against the exact base image under `--ulimit nproc=512:4096`:
- **bash**: soft limit raised 512 → 4096 (the hard ceiling).
- **dash** (old): `ulimit: Illegal option -u` — soft limit untouched.

## Test plan

- [x] Red-green for `FIX#13` race test (fails pre-fix: in-flight launch leaked / closeCount 0; passes post-fix)
- [x] Full harness vitest suite — 100 files, 1742 tests, all passing
- [x] `tsc --noEmit` clean
- [x] dash-vs-bash `ulimit -u` behavior verified directly against `node:22-bookworm-slim`
- [ ] CI green