### PR TITLE
fix(examples/integrations): restore parity-check — sync instances to v2 north-star

### DIFF
--- a/examples/integrations/langgraph-fastapi/src/components/example-layout/index.tsx
+++ b/examples/integrations/langgraph-fastapi/src/components/example-layout/index.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { ModeToggle } from "./mode-toggle";
-import { useFrontendTool } from "@copilotkit/react-core";
+import { useFrontendTool } from "@copilotkit/react-core/v2";
 
 interface ExampleLayoutProps {
   chatContent: ReactNode;

--- a/examples/integrations/langgraph-js/docker-route-override.ts
+++ b/examples/integrations/langgraph-js/docker-route-override.ts
@@ -6,11 +6,11 @@
  */
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  InMemoryAgentRunner,
+  createCopilotEndpoint,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
-import type { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
 const agentUrl = process.env.AGENT_URL || "http://localhost:8123";
 
@@ -18,14 +18,15 @@ const defaultAgent = new HttpAgent({
   url: `${agentUrl}/`,
 });
 
-export const POST = async (req: NextRequest) => {
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    endpoint: "/api/copilotkit",
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    runtime: new CopilotRuntime({
-      agents: { default: defaultAgent },
-    }),
-  });
+const runtime = new CopilotRuntime({
+  agents: { default: defaultAgent },
+  runner: new InMemoryAgentRunner(),
+});
 
-  return handleRequest(req);
-};
+const app = createCopilotEndpoint({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);

--- a/examples/integrations/langgraph-js/src/components/example-layout/index.tsx
+++ b/examples/integrations/langgraph-js/src/components/example-layout/index.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { ModeToggle } from "./mode-toggle";
-import { useFrontendTool } from "@copilotkit/react-core";
+import { useFrontendTool } from "@copilotkit/react-core/v2";
 
 interface ExampleLayoutProps {
   chatContent: ReactNode;

--- a/examples/integrations/strands-python/docker-route-override.ts
+++ b/examples/integrations/strands-python/docker-route-override.ts
@@ -6,11 +6,11 @@
  */
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  InMemoryAgentRunner,
+  createCopilotEndpoint,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
-import type { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
 const agentUrl = process.env.AGENT_URL || "http://localhost:8123";
 
@@ -18,14 +18,15 @@ const defaultAgent = new HttpAgent({
   url: `${agentUrl}/`,
 });
 
-export const POST = async (req: NextRequest) => {
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    endpoint: "/api/copilotkit",
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    runtime: new CopilotRuntime({
-      agents: { default: defaultAgent },
-    }),
-  });
+const runtime = new CopilotRuntime({
+  agents: { default: defaultAgent },
+  runner: new InMemoryAgentRunner(),
+});
 
-  return handleRequest(req);
-};
+const app = createCopilotEndpoint({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);

--- a/examples/integrations/strands-python/src/components/example-layout/index.tsx
+++ b/examples/integrations/strands-python/src/components/example-layout/index.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { ModeToggle } from "./mode-toggle";
-import { useFrontendTool } from "@copilotkit/react-core";
+import { useFrontendTool } from "@copilotkit/react-core/v2";
 
 interface ExampleLayoutProps {
   chatContent: ReactNode;


### PR DESCRIPTION
## Summary

The `parity-check` CI job (`pnpm parity:check` → `examples/integrations/_parity/verify.ts`) was **red on `main`**. Three instances diverged from the `langgraph-python` north-star on two tracked verbatim files:

- `src/components/example-layout/index.tsx` — instances on `@copilotkit/react-core` (v1), north-star on `@copilotkit/react-core/v2`
- `docker-route-override.ts` — `langgraph-js` + `strands-python` on `@copilotkit/runtime` (v1) + `copilotRuntimeNextJSAppRouterEndpoint`, north-star on `@copilotkit/runtime/v2` + `createCopilotEndpoint`/`InMemoryAgentRunner`

Failing instances: `langgraph-js` (2 errors), `strands-python` (2 errors), `langgraph-fastapi` (1 error).

## Root cause (corrected)

This was **not** introduced by #5222 (that PR only deleted a stale top-level `app/api/copilotkit` route in langgraph-js — it never touched these two files), and it is **not** langgraph-js-specific.

The real cause is the partial revert in `3721e7b36` (Revert of #5151). The v2 API migration `23af69041` had moved the north-star **and** the instances to the v2 surface. The revert rolled the **instances'** `example-layout/index.tsx` and `docker-route-override.ts` back to the v1 API while leaving the **north-star on v2**. That left every demo internally inconsistent: each instance's real `src/app/api/copilotkit` route already imports `@copilotkit/runtime/v2` on copilotkit `1.59.3`, but its Docker route override and example layout were stranded on v1.

## Fix

Re-baseline the instances **forward** to the v2 north-star via `pnpm parity:sync --all`. This is a genuine reconciliation (v2 is the correct, floated state — confirmed by the real api route + 1.59.3 pins), not a masking re-baseline.

- Only the **5 drifting verbatim files** change (`+33 / -31`).
- **0** package.json keys move (all instances already pin `1.59.3`).
- No agent-surface, prompt, or allowed-divergence files touched.
- Synced files now byte-match the north-star (sha256 equals the verifier's `expected:` hashes).

## Verification

`pnpm parity:check` (verify.ts) is **green locally** — `0 errors` across all instances (the single remaining `next-env.d.ts` warning is pre-existing and non-fatal — generated file, not in north-star).

```
langgraph-js       — 83 ok, 1 warn, 0 error
langgraph-fastapi  — 86 ok, 1 warn, 0 error
strands-python     — 84 ok, 1 warn, 0 error
exit 0
```

## Related

Open PR #5223 (starter-demo polish) is also red on parity-check only because it branches off this red `main`. Once this merges, #5223 will go green on rebase. This PR does not touch #5223.

## Test plan

- [x] Reproduce red parity-check locally off fresh `origin/main`
- [x] `pnpm parity:sync --all` (dry-run then apply) — 5 files, 0 pkg keys
- [x] `pnpm parity:check` green (exit 0), synced files byte-match north-star
- [ ] CI `parity-check` green on this PR