### PR TITLE
fix(showcase/harness): harden browser-pool shutdown races (post-shutdown context leak + acquire cap-overshoot)

### DIFF
--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -2877,7 +2877,8 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     launcher.__releaseParkedLaunches();
     await shutdownP;
     await waiterP;
-    // shutdown() awaited the orphan close: the straddled context is closed.
+    // The straddled orphan context was closed by the orphan guard's
+    // fire-and-forget close, and never landed in contextToBrowser.
     const openButNotClosed = launched[0]!.__contexts.filter(
       (c) => c.__closeCount === 0,
     );
@@ -2932,13 +2933,12 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     expect(internals(pool).waiters.length).toBe(0);
 
     await shutdownP;
-    // The straddled orphan context was closed and the pool is clean (item-2:
-    // shutdown awaited the tracked orphan close before resolving).
+    // The straddled orphan context was closed by the orphan guard's
+    // fire-and-forget close, and never landed in contextToBrowser.
     const openButNotClosed = launched[0]!.__contexts.filter(
       (c) => c.__closeCount === 0,
     );
     expect(openButNotClosed.length).toBe(0);
     expect(internals(pool).contextToBrowser.size).toBe(0);
-    expect(internals(pool).liveContextCount).toBe(0);
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -2563,4 +2563,231 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     expect(launched[0]!.__closeCount).toBeGreaterThanOrEqual(1);
     expect(launched[1]!.__closeCount).toBeGreaterThanOrEqual(1);
   });
+
+  // ── SHUTDOWN-RACE REGRESSIONS (pre-existing; surfaced by #5221's CR) ───────
+  // Two latent races distinct from #5221's close-during-launch fix:
+  //   (1) a serveNextWaiter()/openContextOn() that already shifted a waiter +
+  //       reserved BEFORE shutdown can settle its newContext() AFTER shutdown's
+  //       close-pass → the freshly-opened context lands in contextToBrowser /
+  //       liveContexts and is never closed (leaked context on a torn-down pool).
+  //   (2) the acquire() transient-retry → concurrent-recycle → orphan-guard
+  //       straddle must keep the reservation accounting balanced (no overshoot).
+
+  // Internal-state probe for the maps the public stats() surface does not
+  // expose: contextToBrowser size + total liveContexts across entries. Used to
+  // assert no context survives the shutdown close-pass.
+  const internals = (
+    pool: BrowserPool,
+  ): {
+    contextToBrowser: Map<unknown, unknown>;
+    liveContextCount: number;
+    browsers: Array<{ liveContexts: Set<unknown> }>;
+  } =>
+    pool as unknown as {
+      contextToBrowser: Map<unknown, unknown>;
+      liveContextCount: number;
+      browsers: Array<{ liveContexts: Set<unknown> }>;
+    };
+
+  // RACE 1 (post-shutdown context leak) — a serveNextWaiter() that shifted a
+  // waiter + reserved a slot BEFORE shutdown parks in openContextOn()'s
+  // newContext(). shutdown() flips isShutdown, drains inFlightRecycles +
+  // pendingLaunches (neither tracks the fire-and-forget serve), then runs its
+  // close-pass over contextToBrowser. AFTER that close-pass the parked
+  // newContext() resolves: pre-fix, openContextOn()'s orphan guard does NOT
+  // check isShutdown, so the just-opened context is added to liveContexts /
+  // contextToBrowser on a torn-down pool — a leaked context that is never
+  // closed. The fix treats shutdown like a recycle in the orphan guard (close
+  // the orphan, roll back the reservation, throw) AND bails serveNextWaiter
+  // before openContextOn when isShutdown.
+  it("RACE1: does NOT leak a context when a serve's open settles AFTER shutdown's close-pass", async () => {
+    // TWO browsers so we can hold shutdown()'s drain loop OPEN (a parked relaunch
+    // sits in inFlightRecycles + pendingLaunches) WHILE the serve's open on the
+    // OTHER, still-connected browser settles. That is the exact window the bug
+    // lives in: isShutdown is already true, but the serving browser has NOT been
+    // closed yet (shutdown's close-pass runs only AFTER the drain), so the
+    // pre-existing orphan guard's `!isConnected()` / recycle checks all pass and
+    // (pre-fix) the freshly-opened context is added to contextToBrowser/
+    // liveContexts on a tearing-down pool — a leak shutdown will never close.
+    //
+    //   call 1 → browser0 (serves the waiter; defers its newContext)
+    //   call 2 → browser1 (crashed below to trigger a recycle)
+    //   call 3 → browser1's relaunch, PARKED in flight → holds shutdown's drain
+    const launcher = makeFakeLauncher({
+      deferNewContextForCalls: [1], // browser0 defers every newContext
+      parkLaunchForCalls: [3], // browser1's relaunch parks → drain stays open
+    });
+    const { launchBrowser, launched } = launcher;
+    const { logger } = makeLeveledLogger();
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 1, // cap=1 so a single waiter queues behind c1
+      recycleAfter: 1000,
+      relaunchBackoffMs: 0,
+      logger,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(2);
+
+    // Fill the single cap slot with one context on browser0 (parked open →
+    // release the park). pickLeastLoaded picks browser0 (index 0, equal load).
+    const c1p = pool.acquire();
+    await drainMicrotasks();
+    await waitFor(() => launched[0]!.__pendingNewContexts > 0);
+    launched[0]!.__releaseNewContexts();
+    const c1 = await c1p;
+    expect(pool.stats().inUse).toBe(1);
+
+    // Enqueue a waiter past the cap. Bounded timeout so the test never hangs on
+    // the waiter's fate — the leak we assert is in the pool's internal maps.
+    let waiterSettled = false;
+    const waiterP = pool
+      .acquire(undefined, 5_000)
+      .then(() => (waiterSettled = true))
+      .catch(() => (waiterSettled = true));
+    await drainMicrotasks();
+
+    // CRASH browser1 → its recycle relaunch (call 3) PARKS in flight, keeping
+    // shutdown's drain loop (inFlightRecycles + pendingLaunches) open.
+    launched[1]!.__crash();
+    await waitFor(() => launcher.__parkedLaunches > 0);
+    expect(launched.length).toBe(3); // browser1's relaunch object exists, parked
+
+    // Release c1 → serveNextWaiter() shifts the waiter, RESERVES the freed slot,
+    // and parks its open in browser0's deferred newContext(). This serve is
+    // fire-and-forget — tracked by NEITHER inFlightRecycles NOR pendingLaunches.
+    await pool.release(c1);
+    await drainMicrotasks();
+    await waitFor(() => launched[0]!.__pendingNewContexts > 0);
+    expect(launched[0]!.__pendingNewContexts).toBe(1);
+
+    // Shutdown. isShutdown flips true synchronously; the drain loop then BLOCKS
+    // on the parked browser1 relaunch (call 3) — so shutdown's close-pass has
+    // NOT run yet and browser0 is still connected/open.
+    const shutdownP = pool.shutdown();
+    await drainMicrotasks();
+
+    // Resolve browser0's parked serve open NOW — isShutdown is true but browser0
+    // is still connected and un-recycled, so ONLY an isShutdown check in the
+    // orphan guard catches it. Pre-fix: the context lands in contextToBrowser/
+    // liveContexts on the tearing-down pool — a leak.
+    launched[0]!.__releaseNewContexts();
+    await drainMicrotasks(20);
+
+    // INVARIANT (asserted BEFORE the parked relaunch is released, so shutdown's
+    // close-pass has demonstrably not run): no serve context has leaked onto the
+    // tearing-down pool. Pre-fix: contextToBrowser.size === 1 / live === 1.
+    expect(internals(pool).contextToBrowser.size).toBe(0);
+    expect(internals(pool).liveContextCount).toBe(0);
+    // The orphaned serve context on browser0 must have been CLOSED, not lingering.
+    const openButNotClosed = launched[0]!.__contexts.filter(
+      (c) => c.__closeCount === 0,
+    );
+    expect(openButNotClosed.length).toBe(0);
+
+    // Release the parked relaunch so shutdown's drain loop completes + finishes.
+    launcher.__releaseParkedLaunches();
+    await shutdownP;
+    await waiterP;
+    expect(waiterSettled).toBe(true);
+    // Post-shutdown the pool is fully clean.
+    expect(internals(pool).contextToBrowser.size).toBe(0);
+    expect(internals(pool).liveContextCount).toBe(0);
+  });
+
+  // RACE 2 (acquire transient-retry cap-overshoot) — REGRESSION GUARD. acquire()'s
+  // transient retry path: a connected browser throws transiently, acquire()
+  // re-reserves and retries openContextOn(); the retry parks in newContext(); a
+  // CONCURRENT crash recycles the entry; the parked retry then hits
+  // openContextOn()'s orphan-by-recycle guard. The accounting invariant ("every
+  // reserveSlot matched by EXACTLY ONE trackOpenedContext OR releaseReservation")
+  // must hold across that straddle: the crash teardown rolls back the in-flight
+  // re-reservation against the OLD generation + bumps the generation, so the late
+  // settle's own `rollbackPendingOpen` is generation-guarded into a no-op — the
+  // reservation is rolled back EXACTLY ONCE (no overshoot, no double-rollback).
+  //
+  // This invariant is currently UPHELD by the generation guard (verified: the
+  // accounting is balanced — liveContextCount returns to 0 after the orphan).
+  // The test LOCKS it in so a future change to the transient-retry / orphan-guard
+  // interleaving that breaks the exactly-once rollback regresses loudly.
+  it("RACE2: transient-retry whose retry is orphaned by a concurrent recycle keeps accounting balanced (no overshoot)", async () => {
+    // browser0 (init) defers every newContext so the transient-retry's open can
+    // be parked across a concurrent crash.
+    const { launchBrowser, launched } = makeFakeLauncher({
+      deferNewContextForCalls: [1],
+    });
+    const { logger, events } = makeLeveledLogger();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      recycleAfter: 1000, // hygiene out of the picture; this is the crash path
+      relaunchBackoffMs: 0,
+      logger,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+    expect(launched.length).toBe(1);
+
+    // Arm ONE transient newContext() throw on browser0: the FIRST open in this
+    // acquire throws transiently (browser stays connected), driving acquire into
+    // its transient-retry branch (re-reserve + retry openContextOn).
+    launched[0]!.__armTransientThrow(1);
+
+    // Start an acquire. attempt 1 throws transiently → acquire re-reserves and
+    // retries; the retry parks in the deferred newContext() (pendingOpens=1, the
+    // re-reservation is held). Bounded timeout so the caller settles
+    // deterministically even though it ends up orphaned + re-enqueued.
+    let acquireSettled = false;
+    const acquireP = pool
+      .acquire(undefined, 200)
+      .then(() => (acquireSettled = true))
+      .catch(() => (acquireSettled = true));
+    await drainMicrotasks();
+    await waitFor(() => launched[0]!.__pendingNewContexts > 0);
+    // The transient retry's open is parked, holding exactly one reservation.
+    expect(pool.stats().inUse).toBe(1);
+    expect(entry0(pool).pendingOpens).toBe(1);
+
+    // CRASH browser0 WHILE the transient retry's open is in flight → recovery
+    // recycle rolls back the in-flight reservation against the OLD generation,
+    // bumps the generation, and reassigns entry.browser to a fresh process.
+    launched[0]!.__crash();
+    await waitFor(() => launched.length === 2);
+
+    // Resolve the parked retry's open on the ORIGINAL (now-replaced) browser →
+    // openContextOn's orphan-by-recycle guard closes it. Its own
+    // rollbackPendingOpen is generation-guarded → a NO-OP (the teardown already
+    // owned the rollback), so the reservation is rolled back EXACTLY ONCE.
+    launched[0]!.__releaseNewContexts();
+    await drainMicrotasks(30);
+
+    // The orphan guard fired (proves we hit the recycle-straddle path).
+    expect(
+      events.some((e) => e.event === "browser-pool.open-orphaned-by-recycle"),
+    ).toBe(true);
+
+    // ACCOUNTING INVARIANT (the load-bearing assertion): the straddle left the
+    // accounting BALANCED — no leaked reservation (would read inUse >= 1 with no
+    // live context) and no double-rollback (would drive the count negative,
+    // clamped to 0 but desyncing). liveContextCount + contextToBrowser are both
+    // back to ZERO, and pendingOpens on the fresh entry is clean.
+    expect(internals(pool).liveContextCount).toBe(0);
+    expect(internals(pool).contextToBrowser.size).toBe(0);
+    expect(pool.stats().inUse).toBe(0);
+    expect(pool.stats().available).toBe(2); // full cap reclaimed
+    expect(entry0(pool).pendingOpens).toBe(0);
+
+    // The orphan on the original (dead) browser was closed, never handed out.
+    const origOrphans = launched[0]!.__contexts.filter(
+      (c) => c.__closeCount === 0,
+    );
+    expect(origOrphans.length).toBe(0);
+
+    await acquireP;
+    expect(acquireSettled).toBe(true);
+    await pool.shutdown();
+  });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -2582,11 +2582,13 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     contextToBrowser: Map<unknown, unknown>;
     liveContextCount: number;
     browsers: Array<{ liveContexts: Set<unknown> }>;
+    waiters: unknown[];
   } =>
     pool as unknown as {
       contextToBrowser: Map<unknown, unknown>;
       liveContextCount: number;
       browsers: Array<{ liveContexts: Set<unknown> }>;
+      waiters: unknown[];
     };
 
   // RACE 1 (post-shutdown context leak) — a serveNextWaiter() that shifted a
@@ -2697,22 +2699,25 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     expect(internals(pool).liveContextCount).toBe(0);
   });
 
-  // RACE 2 (acquire transient-retry cap-overshoot) — REGRESSION GUARD. acquire()'s
-  // transient retry path: a connected browser throws transiently, acquire()
-  // re-reserves and retries openContextOn(); the retry parks in newContext(); a
-  // CONCURRENT crash recycles the entry; the parked retry then hits
-  // openContextOn()'s orphan-by-recycle guard. The accounting invariant ("every
-  // reserveSlot matched by EXACTLY ONE trackOpenedContext OR releaseReservation")
-  // must hold across that straddle: the crash teardown rolls back the in-flight
-  // re-reservation against the OLD generation + bumps the generation, so the late
-  // settle's own `rollbackPendingOpen` is generation-guarded into a no-op — the
-  // reservation is rolled back EXACTLY ONCE (no overshoot, no double-rollback).
+  // RACE 2 (acquire transient-retry cap-overshoot) — REGRESSION LOCK FOR A
+  // PRE-EXISTING INVARIANT, NOT a shutdown-race proof. This test does NOT exercise
+  // any code added by the shutdown-leak fix and passes against main UNCHANGED; it
+  // is here purely to pin the generation-guarded exactly-once-rollback invariant
+  // that the transient-retry / orphan-by-recycle straddle already relied on, so a
+  // future edit to that interleaving regresses loudly.
   //
-  // This invariant is currently UPHELD by the generation guard (verified: the
-  // accounting is balanced — liveContextCount returns to 0 after the orphan).
-  // The test LOCKS it in so a future change to the transient-retry / orphan-guard
-  // interleaving that breaks the exactly-once rollback regresses loudly.
-  it("RACE2: transient-retry whose retry is orphaned by a concurrent recycle keeps accounting balanced (no overshoot)", async () => {
+  // The scenario: acquire()'s transient retry path — a connected browser throws
+  // transiently, acquire() re-reserves and retries openContextOn(); the retry
+  // parks in newContext(); a CONCURRENT crash recycles the entry; the parked retry
+  // then hits openContextOn()'s orphan-by-recycle guard. The accounting invariant
+  // ("every reserveSlot matched by EXACTLY ONE trackOpenedContext OR
+  // releaseReservation") must hold across that straddle: the crash teardown rolls
+  // back the in-flight re-reservation against the OLD generation + bumps the
+  // generation, so the late settle's own `rollbackPendingOpen` is
+  // generation-guarded into a no-op — the reservation is rolled back EXACTLY ONCE
+  // (no overshoot, no double-rollback). This invariant is UPHELD by the
+  // pre-existing generation guard; the shutdown fix neither created nor altered it.
+  it("RACE2 (pre-existing-invariant lock, NOT a shutdown-race proof): transient-retry orphaned by a concurrent recycle keeps accounting balanced (no overshoot)", async () => {
     // browser0 (init) defers every newContext so the transient-retry's open can
     // be parked across a concurrent crash.
     const { launchBrowser, launched } = makeFakeLauncher({
@@ -2789,5 +2794,151 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     await acquireP;
     expect(acquireSettled).toBe(true);
     await pool.shutdown();
+  });
+
+  // RACE 3 (shutdown-straddle caller settlement) — covers the two REACHABLE
+  // shutdown branches RACE1 does NOT: (3a) serveNextWaiter()'s post-open
+  // `if (this.isShutdown) waiter.reject(...)` leg, and (3b) acquire()'s OUTER-catch
+  // `if (this.isShutdown) throw` leg. In both, an open is in flight when
+  // shutdown() flips isShutdown and clears `this.waiters`; when the open then
+  // settles, openContextOn's orphan guard closes+rolls-back+throws, and the
+  // straddle branch must settle the CALLER with the shutdown sentinel — NOT
+  // re-enqueue onto the cleared `waiters` (where it would hang until its acquire
+  // timeout). Reverting either source guard makes the corresponding caller hang
+  // (RED); with the guard present the caller rejects promptly (GREEN).
+  it("RACE3a: a shifted waiter whose serve open straddles shutdown REJECTS (not enqueued, not hung)", async () => {
+    // Same two-browser drain-held setup as RACE1, but here we assert the WAITER's
+    // fate: it must reject with the shutdown sentinel, settled WELL BEFORE its
+    // (long) acquire timeout — proving serveNextWaiter's straddle reject ran and
+    // it was not stranded on the cleared queue.
+    const launcher = makeFakeLauncher({
+      deferNewContextForCalls: [1], // browser0 defers every newContext
+      parkLaunchForCalls: [3], // browser1's relaunch parks → drain stays open
+    });
+    const { launchBrowser, launched } = launcher;
+    const { logger } = makeLeveledLogger();
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 1, // cap=1 so a single waiter queues behind c1
+      recycleAfter: 1000,
+      relaunchBackoffMs: 0,
+      logger,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Fill the single cap slot on browser0.
+    const c1p = pool.acquire();
+    await drainMicrotasks();
+    await waitFor(() => launched[0]!.__pendingNewContexts > 0);
+    launched[0]!.__releaseNewContexts();
+    const c1 = await c1p;
+    expect(pool.stats().inUse).toBe(1);
+
+    // Enqueue a waiter past the cap with a LONG timeout — if the straddle reject
+    // does NOT fire, the only way this settles is the timeout, so a prompt
+    // rejection proves the reject branch ran.
+    let waiterErr: Error | undefined;
+    const waiterP = pool.acquire(undefined, 30_000).catch((e: Error) => {
+      waiterErr = e;
+    });
+    await drainMicrotasks();
+
+    // CRASH browser1 → its recycle relaunch (call 3) PARKS, holding shutdown's
+    // drain loop open.
+    launched[1]!.__crash();
+    await waitFor(() => launcher.__parkedLaunches > 0);
+
+    // Release c1 → serveNextWaiter() shifts the waiter, reserves, parks its open
+    // in browser0's deferred newContext(). The waiter is now OFF this.waiters.
+    await pool.release(c1);
+    await drainMicrotasks();
+    await waitFor(() => launched[0]!.__pendingNewContexts > 0);
+
+    // Shutdown — isShutdown flips synchronously, this.waiters (now empty, the
+    // waiter was shifted) is cleared; drain loop blocks on the parked relaunch.
+    const shutdownP = pool.shutdown();
+    await drainMicrotasks();
+
+    // Settle the parked serve open: openContextOn's orphan guard fires (isShutdown
+    // term), throws; serveNextWaiter's straddle branch must REJECT the shifted
+    // waiter.
+    launched[0]!.__releaseNewContexts();
+    await drainMicrotasks(20);
+
+    // The waiter settled by REJECTION (not hung, not enqueued).
+    expect(waiterErr).toBeDefined();
+    expect(waiterErr!.message).toBe("BrowserPool is shut down");
+    // It must NOT be sitting on the (cleared) waiters queue.
+    expect(internals(pool).waiters.length).toBe(0);
+
+    // Release the parked relaunch so shutdown completes.
+    launcher.__releaseParkedLaunches();
+    await shutdownP;
+    await waiterP;
+    // shutdown() awaited the orphan close: the straddled context is closed.
+    const openButNotClosed = launched[0]!.__contexts.filter(
+      (c) => c.__closeCount === 0,
+    );
+    expect(openButNotClosed.length).toBe(0);
+    expect(internals(pool).contextToBrowser.size).toBe(0);
+  });
+
+  it("RACE3b: an acquire whose open straddles shutdown REJECTS via the outer catch (not enqueued, not hung)", async () => {
+    // Single browser, cap large enough that the acquire opens directly (no waiter
+    // path). browser0 defers its newContext so we can park the acquire's open in
+    // flight, flip shutdown, then settle the open into the orphan guard. acquire()
+    // takes the OUTER catch's `if (this.isShutdown) throw` leg.
+    const { launchBrowser, launched } = makeFakeLauncher({
+      deferNewContextForCalls: [1],
+    });
+    const { logger } = makeLeveledLogger();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 4,
+      recycleAfter: 1000,
+      relaunchBackoffMs: 0,
+      logger,
+      launchBrowser,
+      launchStaggerMs: 0,
+    });
+    await pool.init();
+
+    // Start an acquire whose open parks in the deferred newContext().
+    let acquireErr: Error | undefined;
+    const acquireP = pool.acquire(undefined, 30_000).catch((e: Error) => {
+      acquireErr = e;
+    });
+    await drainMicrotasks();
+    await waitFor(() => launched[0]!.__pendingNewContexts > 0);
+    expect(pool.stats().inUse).toBe(1); // reservation held by the parked open
+
+    // Flip shutdown WHILE the open is parked. No parked relaunch here, so the
+    // drain loop is empty and shutdown proceeds to its close-pass — but it must
+    // still AWAIT the orphan close registered when the open settles into the
+    // guard. Kick shutdown without awaiting so we can settle the open first.
+    const shutdownP = pool.shutdown();
+    await drainMicrotasks();
+
+    // Settle the parked open: orphan guard (isShutdown term) closes+rolls-back+
+    // throws; acquire()'s outer catch `if (this.isShutdown) throw` must reject.
+    launched[0]!.__releaseNewContexts();
+
+    await acquireP;
+    expect(acquireErr).toBeDefined();
+    expect(acquireErr!.message).toBe("BrowserPool is shut down");
+    // No waiter was created (the acquire rejected, did not enqueue).
+    expect(internals(pool).waiters.length).toBe(0);
+
+    await shutdownP;
+    // The straddled orphan context was closed and the pool is clean (item-2:
+    // shutdown awaited the tracked orphan close before resolving).
+    const openButNotClosed = launched[0]!.__contexts.filter(
+      (c) => c.__closeCount === 0,
+    );
+    expect(openButNotClosed.length).toBe(0);
+    expect(internals(pool).contextToBrowser.size).toBe(0);
+    expect(internals(pool).liveContextCount).toBe(0);
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -2916,9 +2916,10 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     expect(pool.stats().inUse).toBe(1); // reservation held by the parked open
 
     // Flip shutdown WHILE the open is parked. No parked relaunch here, so the
-    // drain loop is empty and shutdown proceeds to its close-pass — but it must
-    // still AWAIT the orphan close registered when the open settles into the
-    // guard. Kick shutdown without awaiting so we can settle the open first.
+    // drain loop is empty and shutdown proceeds to its close-pass; the orphan
+    // opened-then-straddled here is closed by openContextOn's fire-and-forget
+    // orphan guard, not awaited by shutdown. Kick shutdown without awaiting so
+    // the straddled open settles into the guard first.
     const shutdownP = pool.shutdown();
     await drainMicrotasks();
 

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -726,16 +726,23 @@ export class BrowserPool {
       throw err;
     }
 
-    // BELT-AND-SUSPENDERS for the recycle-vs-open race: the entry may have been
-    // recycled (crash recovery or a hygiene recycle that fired before this
-    // counter was consulted) WHILE the newContext() above was in flight. If so
-    // the freshly-opened context is an orphan on a torn-down browser — closing
-    // or otherwise counting it would corrupt the cap and could hand a dead
-    // context to a holder. Detect that state, close the orphan, roll back the
-    // reservation + the in-flight marker (generation-guarded so a teardown that
-    // already rolled it back is not double-counted), and surface as a failure so
-    // the caller's retry/enqueue path handles it.
+    // BELT-AND-SUSPENDERS for the recycle-vs-open AND shutdown-vs-open races: the
+    // entry may have been recycled (crash recovery or a hygiene recycle that
+    // fired before this counter was consulted) OR the pool may have SHUT DOWN
+    // WHILE the newContext() above was in flight. If so the freshly-opened
+    // context is an orphan on a torn-down browser / a torn-down pool — closing or
+    // otherwise counting it would corrupt the cap, could hand a dead context to a
+    // holder, OR (the shutdown case) land in contextToBrowser/liveContexts AFTER
+    // shutdown()'s close-pass already ran, leaking a context that is never closed.
+    //
+    // The `isShutdown` term is the SHUTDOWN-LEAK fix: a serveNextWaiter()/acquire
+    // open that reserved before shutdown can settle AFTER shutdown's close-pass.
+    // shutdown() drains inFlightRecycles + pendingLaunches, but this open is
+    // fire-and-forget and tracked by NEITHER set, so the drain does not await it.
+    // Treating shutdown like a recycle here — close the just-opened orphan, roll
+    // back the reservation, and throw — keeps the post-shutdown pool clean.
     if (
+      this.isShutdown ||
       entry.generation !== genBefore ||
       entry.recycling ||
       entry.browser !== browserBefore ||
@@ -805,6 +812,16 @@ export class BrowserPool {
       });
       return context;
     } catch (err) {
+      // SHUTDOWN STRADDLE: the pool shut down WHILE this open was in flight —
+      // openContextOn's orphan guard closed the orphan, rolled the reservation
+      // back, and threw. Do NOT enter the transient-retry / recycle / enqueue
+      // path: shutdown() already cleared `this.waiters`, so enqueueWaiter would
+      // strand this acquire on a queue nothing drains (it would only settle on
+      // its own timeout). Reject promptly instead, mirroring the at-entry
+      // `isShutdown` guard. (openContextOn already rolled the reservation back.)
+      if (this.isShutdown) {
+        throw new Error("BrowserPool is shut down");
+      }
       // FIX #7 — a `newContext()` throw does NOT prove the browser died. The
       // unfixed code unconditionally recycled `entry`, so a TRANSIENT
       // newContext error on a still-`isConnected()` shared browser tore down a
@@ -829,6 +846,12 @@ export class BrowserPool {
         try {
           return await this.openContextOn(entry, options);
         } catch (transientRetryErr) {
+          // SHUTDOWN STRADDLE (retry leg): same as the outer catch — if the pool
+          // shut down during this retry's open, reject promptly rather than
+          // enqueueing onto a queue shutdown already cleared.
+          if (this.isShutdown) {
+            throw new Error("BrowserPool is shut down");
+          }
           this.logger?.warn?.("browser-pool.acquire-transient-retry-failed", {
             browserIndex: this.browsers.indexOf(entry),
             connected: entry.browser.isConnected(),
@@ -948,6 +971,15 @@ export class BrowserPool {
 
   private async serveNextWaiter(): Promise<void> {
     if (this.waiters.length === 0) return;
+    // SHUTDOWN GUARD: bail BEFORE shifting/reserving/opening once the pool is
+    // shutting down. shutdown() flips `isShutdown` and rejects every queued
+    // waiter synchronously; a serveNextWaiter scheduled just before that (or
+    // re-entering from a release/recycle handoff) must NOT shift a waiter and
+    // start an `openContextOn` whose context would settle AFTER shutdown's
+    // close-pass and leak into contextToBrowser/liveContexts. (The orphan guard
+    // in openContextOn is the belt; this is the suspenders — never start the open
+    // in the first place.)
+    if (this.isShutdown) return;
     const entry = this.pickLeastLoaded();
     if (!entry) return; // No live browser — waiter served by a later relaunch.
 
@@ -974,6 +1006,20 @@ export class BrowserPool {
     try {
       context = await this.openContextOn(entry, waiter.options);
     } catch (err) {
+      // SHUTDOWN STRADDLE: the pool may have shut down WHILE this open was in
+      // flight — openContextOn's orphan guard then closed the orphan, rolled the
+      // reservation back, and threw. shutdown() already rejected + cleared every
+      // queued waiter synchronously, so this shifted waiter is NOT on the queue
+      // anymore. Re-queueing it would strand it on a list nothing drains
+      // (shutdown's reject loop already ran) → a never-settling acquire. REJECT
+      // it here instead, mirroring shutdown's waiter-rejection, and do NOT touch
+      // the browser (everything is being torn down).
+      if (this.isShutdown) {
+        if (!waiter.settled) {
+          waiter.reject(new Error("BrowserPool is shutting down"));
+        }
+        return;
+      }
       // FIX #7 (propagated to serveNextWaiter) — a `newContext()` throw does NOT
       // prove the browser died. The unfixed code unconditionally recycled
       // `entry`, so a TRANSIENT newContext error on a still-`isConnected()`

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -569,6 +569,30 @@ export class BrowserPool {
   }
 
   /**
+   * Fire-and-forget orphan close that shutdown() still WAITS for. The orphan
+   * guard in openContextOn closes a just-opened context that straddled a recycle
+   * OR a shutdown; under shutdown that close is fire-and-forget and tracked by
+   * NEITHER drain set, so shutdown() could resolve while it is still in flight —
+   * violating the "shutdown resolved ⇒ everything closed" contract the
+   * pendingLaunches / inFlightRecycles drains uphold. Register the close promise
+   * in `inFlightRecycles` (the same set shutdown's drain loop re-snapshots until
+   * empty) so a close registered while shutdown is still draining is awaited too;
+   * self-remove on settle. Reuses the existing tracked-set mechanism — no new
+   * machinery. (Outside shutdown the add/delete is a harmless no-op: only
+   * shutdown's drain loop ever reads the set.)
+   */
+  private closeContextTracked(
+    context: BrowserContext,
+    browserIndex: number,
+  ): void {
+    const tracked = this.closeContext(context, browserIndex);
+    this.inFlightRecycles.add(tracked);
+    void tracked.finally(() => {
+      this.inFlightRecycles.delete(tracked);
+    });
+  }
+
+  /**
    * Pick the least-loaded live browser entry to open the next context on.
    * Skips entries that are recycling or whose browser has disconnected —
    * acquire() must never open a context on a dying browser. "Load" is measured
@@ -749,7 +773,11 @@ export class BrowserPool {
       !browserBefore.isConnected()
     ) {
       rollbackPendingOpen();
-      void this.closeContext(context, this.browsers.indexOf(entry));
+      // Track the orphan close so shutdown() awaits it (the shutdown-straddle
+      // case): a fire-and-forget close on a tearing-down pool would otherwise let
+      // shutdown() resolve with a context still closing. closeContextTracked
+      // registers it in inFlightRecycles, which shutdown's drain loop awaits.
+      this.closeContextTracked(context, this.browsers.indexOf(entry));
       this.logger?.warn?.("browser-pool.open-orphaned-by-recycle", {
         browserIndex: this.browsers.indexOf(entry),
       });
@@ -846,9 +874,13 @@ export class BrowserPool {
         try {
           return await this.openContextOn(entry, options);
         } catch (transientRetryErr) {
-          // SHUTDOWN STRADDLE (retry leg): same as the outer catch — if the pool
-          // shut down during this retry's open, reject promptly rather than
-          // enqueueing onto a queue shutdown already cleared.
+          // SHUTDOWN STRADDLE (retry leg): a DISTINCT, genuinely-reachable straddle
+          // window from the outer catch's guard — the outer guard already observed
+          // isShutdown===false, then we re-reserved and re-opened, and the pool can
+          // shut down WHILE THIS retry's open is in flight (its orphan guard then
+          // closed+rolled-back+threw, landing here). Reject promptly, mirroring the
+          // outer guard, rather than enqueueing onto a queue shutdown already
+          // cleared (which would strand this acquire until its timeout).
           if (this.isShutdown) {
             throw new Error("BrowserPool is shut down");
           }
@@ -1008,15 +1040,17 @@ export class BrowserPool {
     } catch (err) {
       // SHUTDOWN STRADDLE: the pool may have shut down WHILE this open was in
       // flight — openContextOn's orphan guard then closed the orphan, rolled the
-      // reservation back, and threw. shutdown() already rejected + cleared every
-      // queued waiter synchronously, so this shifted waiter is NOT on the queue
-      // anymore. Re-queueing it would strand it on a list nothing drains
-      // (shutdown's reject loop already ran) → a never-settling acquire. REJECT
-      // it here instead, mirroring shutdown's waiter-rejection, and do NOT touch
-      // the browser (everything is being torn down).
+      // reservation back, and threw. This waiter was `shift()`ed off `this.waiters`
+      // (line above) BEFORE shutdown could run; shutdown()'s reject-loop iterates
+      // ONLY what is still on `this.waiters`, so it never saw — and never rejected
+      // — this shifted waiter. Re-queueing it would strand it on a list nothing
+      // drains (shutdown's reject loop already ran) → a never-settling acquire.
+      // THIS branch is therefore the SOLE settler of a shifted-then-straddled
+      // waiter: REJECT it here, mirroring shutdown's waiter-rejection, and do NOT
+      // touch the browser (everything is being torn down).
       if (this.isShutdown) {
         if (!waiter.settled) {
-          waiter.reject(new Error("BrowserPool is shutting down"));
+          waiter.reject(new Error("BrowserPool is shut down"));
         }
         return;
       }

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -569,30 +569,6 @@ export class BrowserPool {
   }
 
   /**
-   * Fire-and-forget orphan close that shutdown() still WAITS for. The orphan
-   * guard in openContextOn closes a just-opened context that straddled a recycle
-   * OR a shutdown; under shutdown that close is fire-and-forget and tracked by
-   * NEITHER drain set, so shutdown() could resolve while it is still in flight —
-   * violating the "shutdown resolved ⇒ everything closed" contract the
-   * pendingLaunches / inFlightRecycles drains uphold. Register the close promise
-   * in `inFlightRecycles` (the same set shutdown's drain loop re-snapshots until
-   * empty) so a close registered while shutdown is still draining is awaited too;
-   * self-remove on settle. Reuses the existing tracked-set mechanism — no new
-   * machinery. (Outside shutdown the add/delete is a harmless no-op: only
-   * shutdown's drain loop ever reads the set.)
-   */
-  private closeContextTracked(
-    context: BrowserContext,
-    browserIndex: number,
-  ): void {
-    const tracked = this.closeContext(context, browserIndex);
-    this.inFlightRecycles.add(tracked);
-    void tracked.finally(() => {
-      this.inFlightRecycles.delete(tracked);
-    });
-  }
-
-  /**
    * Pick the least-loaded live browser entry to open the next context on.
    * Skips entries that are recycling or whose browser has disconnected —
    * acquire() must never open a context on a dying browser. "Load" is measured
@@ -773,11 +749,7 @@ export class BrowserPool {
       !browserBefore.isConnected()
     ) {
       rollbackPendingOpen();
-      // Track the orphan close so shutdown() awaits it (the shutdown-straddle
-      // case): a fire-and-forget close on a tearing-down pool would otherwise let
-      // shutdown() resolve with a context still closing. closeContextTracked
-      // registers it in inFlightRecycles, which shutdown's drain loop awaits.
-      this.closeContextTracked(context, this.browsers.indexOf(entry));
+      void this.closeContext(context, this.browsers.indexOf(entry));
       this.logger?.warn?.("browser-pool.open-orphaned-by-recycle", {
         browserIndex: this.browsers.indexOf(entry),
       });
@@ -1259,7 +1231,7 @@ export class BrowserPool {
 
     // Reject any queued waiters.
     for (const waiter of this.waiters) {
-      waiter.reject(new Error("BrowserPool is shutting down"));
+      waiter.reject(new Error("BrowserPool is shut down"));
     }
     this.waiters = [];
 


### PR DESCRIPTION
## Summary

Hardens two **pre-existing, latent** browser-pool shutdown races in `showcase/harness/src/probes/helpers/browser-pool.ts`. Both were *surfaced* by PR #5221's 7-agent CR but fell outside that PR's subject (the close-during-launch race), so they are addressed here as a follow-up. Neither was introduced by #5221.

### Race 1 — post-shutdown context leak (real bug, fixed)

`shutdown()`'s drain loop awaits `inFlightRecycles` + `pendingLaunches`, but `serveNextWaiter`/`openContextOn` opens are fire-and-forget (scheduled via `scheduleServeNextWaiter`) and tracked by **neither** set. A `serveNextWaiter` that already shifted a waiter + reserved a slot *before* shutdown could complete its `openContextOn` **after** the shutdown close-pass, adding the context to `contextToBrowser`/`liveContexts` on a torn-down pool — a leaked context that is never closed. `openContextOn`'s orphan guard checked `generation`/`recycling`/`isConnected` but **not** `isShutdown`.

**Fix:**
- Add an `isShutdown` term to `openContextOn`'s post-await orphan guard (treat shutdown like a recycle: close the just-opened context, roll back the reservation, throw).
- Bail `serveNextWaiter` *before* `openContextOn` when `isShutdown`.
- Reject (not re-queue) a shifted waiter / straddling `acquire()` when the open throws under shutdown, so it can't strand on the already-cleared waiter queue (which would otherwise only settle on its own timeout).

The orphan close under shutdown is **fire-and-forget** (`void this.closeContext(...)`), matching main's accepted behavior. `shutdown()` does **not** await the orphan close in the empty-drain case, and the PR makes no "shutdown resolved => everything closed" guarantee for that path.

### Race 2 — acquire transient-retry cap-overshoot (verified NOT a bug; regression-guarded)

The transient-retry → concurrent-recycle → orphan-guard straddle in `acquire()` was investigated for an unbalanced reservation rollback (overshoot). **Verified that the existing generation guard already holds the accounting invariant** (the crash teardown rolls back the in-flight re-reservation against the OLD generation + bumps the generation, so the late settle's own `rollbackPendingOpen` is a no-op — exactly-once rollback). `liveContextCount` returns to 0 after the orphan on **both** original and patched source. No source change was needed; a regression guard (RACE2) locks the invariant in.

### Race 3 — shutdown-straddle caller settlement (guards, red-green)

RACE3a (serveNextWaiter straddle-reject) and RACE3b (acquire outer-catch throw) cover the two reachable shutdown-straddle settlement branches: each guard, when reverted, makes the corresponding caller hang on the cleared waiter queue (RED); with the guard present the caller rejects promptly with the shutdown sentinel (GREEN).

The shutdown-condition error string is unified on **"BrowserPool is shut down"** across the at-entry guard, the straddle-reject legs, and `shutdown()`'s queued-waiter rejection (launch/relaunch-failure strings are a different condition and unchanged).

## Test plan

- [x] Red-green for Race 1 (RACE1): pre-fix `contextToBrowser.size === 1` (leak) → post-fix `=== 0`, orphan closed.
- [x] Regression guard for Race 2 (RACE2): balanced accounting across the straddle.
- [x] Red-green for Race 3 (RACE3a/RACE3b): each guard reverted makes the caller hang; present makes it reject with the sentinel.
- [x] Full harness suite: **1747 passed (100 files)**.
- [x] `tsc --noEmit`: clean (exit 0).
- [x] All #5185/#5221 behaviors preserved (relaunchWithBackoff, onBrowserSetEmpty self-heal, degraded/recovered alarms, pendingLaunches drain, atomic launch) — still green.