### PR TITLE
feat(showcase): starter dashboard row-group (harness probe + dashboard UI + CI image publish)

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -262,10 +262,23 @@ jobs:
           # done — a common "did my dispatch deploy?" footgun. The `all` and
           # empty (push-event) modes legitimately produce [] when there are
           # no changes and must still succeed.
-          if [ "$MATRIX" = "[]" ] && [ -n "$DISPATCH" ] && [ "$DISPATCH" != "all" ]; then
-            echo "::error::workflow_dispatch service='$DISPATCH' did not match any entry in ALL_SERVICES — check the dispatch_name spelling"
-            exit 1
-          fi
+          #
+          # The `starter-*` namespace is OWNED by the detect-starter-changes
+          # job (which scopes its OWN fail-loud to `starter-*`). A
+          # `service=starter-<slug>` dispatch legitimately yields [] here
+          # (no showcase service is named `starter-*`), so it must SKIP — an
+          # empty showcase matrix, NOT a fail-loud exit 1. Mirrors how the
+          # starter job scopes its fail-loud to the `starter-*` namespace.
+          case "$DISPATCH" in
+            starter-*) ;; # starter namespace → empty showcase matrix + skip
+            "" | "all") ;; # push / full-fleet → [] is legitimate
+            *)
+              if [ "$MATRIX" = "[]" ]; then
+                echo "::error::workflow_dispatch service='$DISPATCH' did not match any entry in ALL_SERVICES — check the dispatch_name spelling"
+                exit 1
+              fi
+              ;;
+          esac
 
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
           if [ "$MATRIX" = "[]" ]; then

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -15,6 +15,7 @@ on:
     branches: [main]
     paths:
       - "showcase/**"
+      - "examples/integrations/**"
       - ".github/workflows/showcase_build.yml"
       - ".github/workflows/showcase_build_check.yml"
   workflow_dispatch:
@@ -52,6 +53,22 @@ on:
           - showcase-harness
           - showcase-aimock
           - webhooks
+          # Per-starter image builds (model B, §b stage 1). These map to the
+          # build-starters job below, NOT the showcase `build` job. "all"
+          # builds the full showcase fleet AND all 12 starters; a specific
+          # starter slug narrows to that one starter via STARTER_DISPATCH.
+          - starter-langgraph-python
+          - starter-mastra
+          - starter-langgraph-js
+          - starter-crewai-crews
+          - starter-pydantic-ai
+          - starter-adk
+          - starter-agno
+          - starter-llamaindex
+          - starter-langgraph-fastapi
+          - starter-strands-python
+          - starter-ms-agent-framework-python
+          - starter-ms-agent-framework-dotnet
 
 # No top-level concurrency group. Every build run completes. This is the
 # whole point of the decoupling: rapid pushes to main no longer cancel
@@ -435,6 +452,180 @@ jobs:
           path: ${{ runner.temp }}/build-result/result.json
           if-no-files-found: error
           retention-days: 7
+
+  # ────────────────────────────────────────────────────────────────────
+  # Per-starter image publish (model B, §b stage 1 / Phase 1).
+  #
+  # Fully decoupled from the showcase `build`→`aggregate`→`redeploy` chain
+  # above: starters are self-contained npm projects (no monorepo-source
+  # build, no shared-module copy) and build from their own root Dockerfile
+  # at examples/integrations/<slug>/Dockerfile (the single-image deployable:
+  # Next.js frontend + agent, EXPOSE 3000, CMD entrypoint.sh — distinct from
+  # the docker/Dockerfile.app + docker/Dockerfile.agent split stack used by
+  # docker-compose.test.yml). Published to ghcr.io/copilotkit/starter-<slug>
+  # (the `starter-` prefix is disjoint from `showcase-*`; S2's harness
+  # discovery filters on namePrefix "starter-"). Railway deploy is the
+  # gated S5 — NOT done here.
+  #
+  # The 12 starter slugs are the matrix source of truth (the smoke matrix in
+  # test_smoke-starter.yml and STARTER_TO_COLUMN in
+  # showcase/harness/src/probes/helpers/starter-mapping.ts). The dashboard
+  # column remap lives in the harness (§a), so this layer uses raw starter
+  # slugs.
+  detect-starter-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.starter-matrix.outputs.matrix }}
+      has_changes: ${{ steps.starter-matrix.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Detect changed starter paths
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            workflow_config:
+              - '.github/workflows/showcase_build.yml'
+            langgraph_python:
+              - 'examples/integrations/langgraph-python/**'
+            mastra:
+              - 'examples/integrations/mastra/**'
+            langgraph_js:
+              - 'examples/integrations/langgraph-js/**'
+            crewai_crews:
+              - 'examples/integrations/crewai-crews/**'
+            pydantic_ai:
+              - 'examples/integrations/pydantic-ai/**'
+            adk:
+              - 'examples/integrations/adk/**'
+            agno:
+              - 'examples/integrations/agno/**'
+            llamaindex:
+              - 'examples/integrations/llamaindex/**'
+            langgraph_fastapi:
+              - 'examples/integrations/langgraph-fastapi/**'
+            strands_python:
+              - 'examples/integrations/strands-python/**'
+            ms_agent_framework_python:
+              - 'examples/integrations/ms-agent-framework-python/**'
+            ms_agent_framework_dotnet:
+              - 'examples/integrations/ms-agent-framework-dotnet/**'
+
+      - name: Build starter matrix
+        id: starter-matrix
+        env:
+          DISPATCH_SERVICE: ${{ github.event.inputs.service }}
+          FILTER_CHANGES: ${{ steps.filter.outputs.changes }}
+        run: |
+          set -euo pipefail
+          # One slot per starter. `slug` is the examples/integrations/<slug>
+          # directory name; `image` is the published GHCR repo (starter-<slug>);
+          # `filter_key` matches the paths-filter key above.
+          ALL_STARTERS='[
+            {"slug":"langgraph-python","image":"starter-langgraph-python","filter_key":"langgraph_python"},
+            {"slug":"mastra","image":"starter-mastra","filter_key":"mastra"},
+            {"slug":"langgraph-js","image":"starter-langgraph-js","filter_key":"langgraph_js"},
+            {"slug":"crewai-crews","image":"starter-crewai-crews","filter_key":"crewai_crews"},
+            {"slug":"pydantic-ai","image":"starter-pydantic-ai","filter_key":"pydantic_ai"},
+            {"slug":"adk","image":"starter-adk","filter_key":"adk"},
+            {"slug":"agno","image":"starter-agno","filter_key":"agno"},
+            {"slug":"llamaindex","image":"starter-llamaindex","filter_key":"llamaindex"},
+            {"slug":"langgraph-fastapi","image":"starter-langgraph-fastapi","filter_key":"langgraph_fastapi"},
+            {"slug":"strands-python","image":"starter-strands-python","filter_key":"strands_python"},
+            {"slug":"ms-agent-framework-python","image":"starter-ms-agent-framework-python","filter_key":"ms_agent_framework_python"},
+            {"slug":"ms-agent-framework-dotnet","image":"starter-ms-agent-framework-dotnet","filter_key":"ms_agent_framework_dotnet"}
+          ]'
+
+          # Dispatch modes (mirror the showcase detect-changes job):
+          #   "all"                     → every starter (full-fleet rebuild).
+          #   "starter-<slug>"          → that one starter (strip "starter-" prefix to match .image).
+          #   "<showcase service slug>" → no starters (this is a showcase-only dispatch).
+          #   "" (push event)           → starters whose filter_key appears in CHANGES
+          #                               (or workflow_config touched → rebuild all).
+          DISPATCH="${DISPATCH_SERVICE:-}"
+          CHANGES="${FILTER_CHANGES:-[]}"
+
+          # `.image` is exactly "starter-<slug>", which is also the
+          # workflow_dispatch choice value, so a specific-starter dispatch
+          # matches `$dispatch == .image` directly.
+          MATRIX=$(echo "$ALL_STARTERS" | jq -c --arg dispatch "$DISPATCH" --argjson changes "$CHANGES" '
+            [.[] |
+              (.filter_key as $fk | select(
+              $dispatch == "all" or
+              ($dispatch != "" and $dispatch != "all" and $dispatch == .image) or
+              ($dispatch == "" and (($changes | index("workflow_config") != null) or ($changes | index($fk) != null)))
+            ))]
+          ')
+
+          # Fail loudly on a typo'd starter dispatch (mirrors showcase job).
+          # Only applies to the starter-* dispatch namespace; a showcase
+          # service slug or "all" legitimately yields [] here.
+          case "$DISPATCH" in
+            starter-*)
+              if [ "$MATRIX" = "[]" ]; then
+                echo "::error::workflow_dispatch service='$DISPATCH' did not match any starter — check the slug"
+                exit 1
+              fi
+              ;;
+          esac
+
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          if [ "$MATRIX" = "[]" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-starters:
+    needs: [detect-starter-changes]
+    if: needs.detect-starter-changes.outputs.has_changes == 'true'
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 20
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        starter: ${{ fromJSON(needs.detect-starter-changes.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Depot
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push starter image
+        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
+        with:
+          project: m2kw2wmmcp
+          context: examples/integrations/${{ matrix.starter.slug }}
+          file: examples/integrations/${{ matrix.starter.slug }}/Dockerfile
+          # Pin amd64: Railway and GHCR serve x86 hosts. Depot defaults to
+          # the runner's native arch, so an arm64-only image would crash on
+          # pull with "does not have a linux/amd64 variant available".
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/copilotkit/${{ matrix.starter.image }}:latest
+            ghcr.io/copilotkit/${{ matrix.starter.image }}:${{ github.sha }}
 
   aggregate-build-results:
     name: Aggregate build results

--- a/.github/workflows/test_smoke-starter.yml
+++ b/.github/workflows/test_smoke-starter.yml
@@ -1,17 +1,27 @@
 name: test / smoke / starter
 
-# Reduced to a PR build-sanity gate (model B, §e / Phase 5). The 6h
-# `schedule` cron was DROPPED: the live dashboard signal for starter health
-# now comes from the harness HTTP-probing the deployed (sleepable) Railway
-# starter services, and the harness alert path (alerts/alert-engine.ts →
-# #oss-alerts) carries the scheduled-failure Slack signal that used to fire
-# from this cron. What remains is the fast pre-merge build-sanity gate: the
-# `pull_request` trigger on examples/integrations/** still builds + smoke-
+# PR build-sanity gate (model B, §e / Phase 5) PLUS the post-merge 6h
+# floating-dependency breakage detector. The eventual live dashboard signal
+# for starter health comes from the harness HTTP-probing the deployed
+# (sleepable) Railway starter services — but those S5 Railway services do
+# NOT exist yet, so this `schedule` cron remains the ONLY post-merge
+# detector that catches a starter broken by a floating transitive dependency
+# or an upstream CopilotKit release. We KEEP the 6h cron (and the harness
+# alert path, alerts/alert-engine.ts → #oss-alerts, carries the
+# scheduled-failure Slack signal too) until S5 starter-service probing is
+# confirmed live, at which point the cron can be retired in favour of the
+# harness signal. The fast pre-merge build-sanity gate is the
+# `pull_request` trigger on examples/integrations/**: it builds + smoke-
 # tests each starter offline against aimock on every starter change. The
 # post-merge GHCR `:latest` publish that feeds the Railway services lives in
 # showcase_build.yml's build-starters job (push:main, §b stage 1), so it is
 # intentionally NOT duplicated here.
 on:
+  schedule:
+    # Every 6h — post-merge floating-dependency / upstream-release breakage
+    # detector. Stays until S5 harness probing of live Railway starter
+    # services is confirmed, then retire in favour of the harness signal.
+    - cron: "0 */6 * * *"
   workflow_run:
     workflows: ["publish / release"]
     types: [completed]

--- a/.github/workflows/test_smoke-starter.yml
+++ b/.github/workflows/test_smoke-starter.yml
@@ -1,9 +1,17 @@
 name: test / smoke / starter
 
+# Reduced to a PR build-sanity gate (model B, §e / Phase 5). The 6h
+# `schedule` cron was DROPPED: the live dashboard signal for starter health
+# now comes from the harness HTTP-probing the deployed (sleepable) Railway
+# starter services, and the harness alert path (alerts/alert-engine.ts →
+# #oss-alerts) carries the scheduled-failure Slack signal that used to fire
+# from this cron. What remains is the fast pre-merge build-sanity gate: the
+# `pull_request` trigger on examples/integrations/** still builds + smoke-
+# tests each starter offline against aimock on every starter change. The
+# post-merge GHCR `:latest` publish that feeds the Railway services lives in
+# showcase_build.yml's build-starters job (push:main, §b stage 1), so it is
+# intentionally NOT duplicated here.
 on:
-  schedule:
-    # Every 6 hours — catches floating dep breakage
-    - cron: "0 */6 * * *"
   workflow_run:
     workflows: ["publish / release"]
     types: [completed]

--- a/showcase/harness/config/probes/starter_smoke.yml
+++ b/showcase/harness/config/probes/starter_smoke.yml
@@ -1,0 +1,108 @@
+# Probe: starter_smoke
+#
+# Per-starter smoke health over HTTP — the harness twin of the GitHub
+# Actions `smoke-starter` matrix (`showcase/tests/e2e/starter-smoke.spec.ts`).
+# Instead of building each starter image and driving Playwright in CI, this
+# probe HTTP-probes each starter's own deployed (scale-to-zero) Railway
+# service on the harness cadence — the SAME probe model `smoke.yml` runs
+# against the 19 deployed showcase services, no new harness capability.
+#
+# Discovery-driven: the `railway-services` source enumerates every
+# `starter-*` service in the orchestrator's project (paralleling smoke's
+# `showcase-*` filter), and the driver fans out one invocation per service.
+#
+# Each driver invocation issues FOUR HTTP checks against the deployed base
+# URL and side-emits one row per smoke level plus an aggregate primary
+# (see drivers/starter-smoke.ts):
+#   - health      GET  `${base}/api/health`        → 200 + JSON body
+#   - agent       POST `${base}/api/copilotkit/`    → any non-404 response
+#   - chat        POST `${base}/api/copilotkit/`    → non-empty body (aimock)
+#   - interaction GET  `${base}/`                   → 200 (app shell serves)
+#
+# Rows emitted per invocation:
+#   - Primary `starter:<column-slug>`           aggregate { total, passed,
+#                                               failed[], errorClass }.
+#                                               Green iff all four levels
+#                                               passed; red if ANY flipped.
+#   - Side    `starter:<column-slug>/<level>`   one per level ∈
+#                                               {health,agent,chat,
+#                                               interaction}; green/red with
+#                                               a keyed `errorClass`
+#                                               (transport-error |
+#                                               smoke-failed | aborted) and a
+#                                               Slack-safe `errorDesc`.
+#
+# Slug remap: the driver strips the `starter-` prefix from the Railway
+# service name to get the smoke-matrix slug, then remaps that to the
+# dashboard COLUMN slug via probes/helpers/starter-mapping.ts (S1's source
+# of truth) BEFORE any emit, so the dashboard only ever sees column slugs.
+#
+# Transport-failure classification: a scale-to-zero starter must WAKE on the
+# probe's first request, and that cold-start can legitimately exceed a
+# per-check timeout. Such a fetch-level failure is classified
+# `transport-error` (distinct from a real `smoke-failed` HTTP regression)
+# so a single slow wake reads soft, not as a hard red — the dashboard's
+# two-miss staleness rule absorbs it.
+#
+# ── Cadence ────────────────────────────────────────────────────────────
+#
+# Hourly at :40 (offset from smoke :*/5, e2e-demos :10, D5/D6 to avoid
+# contention). Starters are aimock-backed (zero LLM cost per tick) and the
+# four checks are cheap HTTP round-trips, but each tick WAKES sleeping
+# scale-to-zero services, so we keep the cadence well above the 15-min smoke
+# rhythm to keep wake frequency (and idle cost) low. The dashboard's
+# `STARTER_STALE_AFTER_MS` (UI slot) is derived from THIS schedule at
+# strictly > 2 probe periods, so a single missed/slow-wake tick stays green
+# and only two consecutive misses flip amber. Keep this cron and that
+# staleness window in lockstep.
+kind: starter_smoke
+id: starter_smoke
+schedule: "40 * * * *"
+#
+# ── timeout_ms ─────────────────────────────────────────────────────────
+#
+# Outer driver-invocation cap. GENEROUS, DELIBERATELY PROVISIONAL: the
+# Railway scale-to-zero wake latency is the primary open unknown (spec
+# §c / Risks) and is measured by a SEPARATE, GATED slot (S5 — the Railway
+# starter-services + wake-latency spike). Until that spike lands and gives
+# us a worst-case wake number, this cap is set high enough that a cold-start
+# wake plus four sequential HTTP checks cannot trip the outer race and read
+# a spurious red on the first tick of a sleeping service. TUNE THIS DOWN to
+# (observed worst-case wake latency + check budget) once the S5 spike
+# reports its number — that is the explicit follow-up, not a value to trust
+# blindly here. The driver also re-applies a per-check timeout internally
+# (STARTER_SMOKE_TIMEOUT_MS / 30s default) so one hung endpoint can't steal
+# the whole budget from its sibling checks.
+timeout_ms: 120000
+#
+# ── max_concurrency ────────────────────────────────────────────────────
+#
+# Caps simultaneous per-tick driver invocations. ≤12 starter services, four
+# HTTP checks each; at concurrency 6 the tick clears in ≤2 pool-cycles and
+# stays well under any Railway edge rate limit. Per-tick socket bound:
+# max_concurrency × 4 checks = 24 inflight. Mirrors smoke.yml's bound.
+max_concurrency: 6
+discovery:
+  source: railway-services
+  filter:
+    # Matches all `starter-*` Railway services (the per-starter sleepable
+    # services stood up by the gated S5 slot). The driver strips the
+    # `starter-` prefix internally to derive the smoke-matrix slug, then
+    # remaps to the dashboard column slug. Paralleling smoke's
+    # `showcase-*` filter.
+    #
+    # NOTE: the historical `showcase-starter-*` services (decommissioned in
+    # PR #4390, excluded in smoke.yml) are NOT matched here — those used the
+    # `showcase-` prefix. The new model deploys clean `starter-<slug>`
+    # services (one image, one app, one signal; spec §b). When S5 lands the
+    # services, no YAML edit is needed — auto-discovery picks up each new
+    # `starter-*` service on the next tick.
+    namePrefix: "starter-"
+  # `key_template` lives at the `discovery:` level (sibling of `source` /
+  # `filter`), per loader/schema.ts:DiscoveryBlockSchema. The driver derives
+  # the primary key as `starter:<column-slug>` itself (after the
+  # starter→column remap), so this template value is only the discovery
+  # dedupe key carrying the full Railway service name — the driver rewrites
+  # to the column-slug key before returning, matching how liveness.ts
+  # rewrites `smoke:showcase-<name>` → `smoke:<slug>`.
+  key_template: "starter_smoke:${name}"

--- a/showcase/harness/config/probes/starter_smoke.yml
+++ b/showcase/harness/config/probes/starter_smoke.yml
@@ -51,10 +51,11 @@
 # four checks are cheap HTTP round-trips, but each tick WAKES sleeping
 # scale-to-zero services, so we keep the cadence well above the 15-min smoke
 # rhythm to keep wake frequency (and idle cost) low. The dashboard's
-# `STARTER_STALE_AFTER_MS` (UI slot) is derived from THIS schedule at
-# strictly > 2 probe periods, so a single missed/slow-wake tick stays green
-# and only two consecutive misses flip amber. Keep this cron and that
-# staleness window in lockstep.
+# `STARTER_STALE_AFTER_MS` (UI slot) is derived from THIS hourly schedule
+# (1h probe period) at strictly > 2 probe periods — it is set to 2.5h, so a
+# single missed/slow-wake tick (last row ~2h old) stays green and only two
+# consecutive misses (last row ~3h old) flip amber. Keep this cron and that
+# 2.5h staleness window in lockstep.
 kind: starter_smoke
 id: starter_smoke
 schedule: "40 * * * *"

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -1968,6 +1968,7 @@ describe("orchestrator.registerAllProbeDrivers (post-#4292 hotfix guard)", () =>
         "qa",
         "redirect_decommission",
         "smoke",
+        "starter_smoke",
         "version_drift",
       ].sort(),
     );

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -61,6 +61,7 @@ import {
 } from "./probes/drivers/d6-all-pills.js";
 import { BrowserPool } from "./probes/helpers/browser-pool.js";
 import { qaDriver } from "./probes/drivers/qa.js";
+import { starterSmokeDriver } from "./probes/drivers/starter-smoke.js";
 import { railwayServicesSource } from "./probes/discovery/railway-services.js";
 import { pnpmPackagesDiscoverySource } from "./probes/discovery/pnpm-packages.js";
 import { withCache } from "./probes/discovery/caching-source.js";
@@ -1016,6 +1017,7 @@ export function registerAllProbeDrivers(
   }
 
   probeRegistry.register(qaDriver);
+  probeRegistry.register(starterSmokeDriver);
 }
 
 /**

--- a/showcase/harness/src/probes/drivers/starter-smoke.test.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect } from "vitest";
+import {
+  createStarterSmokeDriver,
+  starterSmokeDriver,
+  type StarterSmokeAggregateSignal,
+  type StarterSmokeLevelSignal,
+} from "./starter-smoke.js";
+import { logger } from "../../logger.js";
+import type {
+  ProbeContext,
+  ProbeResult,
+  ProbeResultWriter,
+} from "../../types/index.js";
+
+// Driver-level tests for the starter_smoke ProbeDriver. The Railway starter
+// services don't exist yet (a separate gated slot stands them up), so every
+// test injects a fake `fetchImpl` — no real network. Coverage:
+//   - schema accepts the discovery shape, rejects malformed input
+//   - the FOUR checks (health/agent/chat/interaction) map to the right
+//     `starter:<col>/<level>` side-emit keys
+//   - the starter→column slug remap is applied before emit
+//   - pass → green, fail → red (smoke-failed), transport-fail → classified
+//   - the aggregate primary is emitted under `starter:<col>`
+
+function mkWriter(): {
+  writer: ProbeResultWriter;
+  writes: ProbeResult<unknown>[];
+} {
+  const writes: ProbeResult<unknown>[] = [];
+  const writer: ProbeResultWriter = {
+    async write(result) {
+      writes.push(result);
+      return undefined;
+    },
+  };
+  return { writer, writes };
+}
+
+/**
+ * Fake fetch that answers each level per the supplied opts. agent and chat
+ * share the `/api/copilotkit/` URL but differ by HTTP method body, so we
+ * branch on the request body to tell them apart (chat carries `messages`).
+ */
+function fakeFetch(opts: {
+  healthStatus?: number;
+  healthBody?: string;
+  agentStatus?: number;
+  chatStatus?: number;
+  chatBody?: string;
+  interactionStatus?: number;
+  // When set for a level, that fetch rejects (transport failure).
+  throwOn?: Partial<Record<"health" | "agent" | "chat" | "interaction", Error>>;
+}): typeof fetch {
+  return (async (url: string | URL, init?: RequestInit) => {
+    const href = typeof url === "string" ? url : url.toString();
+    let level: "health" | "agent" | "chat" | "interaction";
+    if (/\/api\/health/.test(href)) {
+      level = "health";
+    } else if (/\/api\/copilotkit/.test(href)) {
+      const body = typeof init?.body === "string" ? init.body : "";
+      level = body.includes("messages") ? "chat" : "agent";
+    } else {
+      level = "interaction";
+    }
+
+    const toThrow = opts.throwOn?.[level];
+    if (toThrow) throw toThrow;
+
+    let status: number;
+    let body: string;
+    if (level === "health") {
+      status = opts.healthStatus ?? 200;
+      body = opts.healthBody ?? '{"status":"ok"}';
+    } else if (level === "agent") {
+      status = opts.agentStatus ?? 200;
+      body = '{"ok":true}';
+    } else if (level === "chat") {
+      status = opts.chatStatus ?? 200;
+      body = opts.chatBody ?? '{"reply":"hello back"}';
+    } else {
+      status = opts.interactionStatus ?? 200;
+      body = "<html><body>app shell</body></html>";
+    }
+    return new Response(body, { status, statusText: `HTTP ${status}` });
+  }) as unknown as typeof fetch;
+}
+
+function mkCtx(
+  fetchImpl: typeof fetch,
+  writer?: ProbeResultWriter,
+): ProbeContext {
+  return {
+    now: () => new Date("2026-06-03T00:00:00Z"),
+    logger,
+    env: {},
+    writer,
+    fetchImpl,
+  };
+}
+
+function sideRows(
+  writes: ProbeResult<unknown>[],
+): ProbeResult<StarterSmokeLevelSignal>[] {
+  return writes as ProbeResult<StarterSmokeLevelSignal>[];
+}
+
+describe("starterSmokeDriver", () => {
+  it("exposes kind === 'starter_smoke'", () => {
+    expect(starterSmokeDriver.kind).toBe("starter_smoke");
+  });
+
+  it("inputSchema accepts the discovery shape { key, name, publicUrl }", () => {
+    const parsed = starterSmokeDriver.inputSchema.safeParse({
+      key: "starter_smoke:starter-mastra",
+      name: "starter-mastra",
+      publicUrl: "https://starter-mastra.up.railway.app",
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("inputSchema rejects missing publicUrl", () => {
+    const parsed = starterSmokeDriver.inputSchema.safeParse({
+      key: "starter_smoke:starter-mastra",
+      name: "starter-mastra",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("inputSchema rejects a non-url publicUrl", () => {
+    const parsed = starterSmokeDriver.inputSchema.safeParse({
+      key: "k",
+      name: "starter-mastra",
+      publicUrl: "not-a-url",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("happy path: all 4 checks green → aggregate green + 4 green side rows keyed starter:<col>/<level>", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    // mastra is a DIRECT mapping (starter slug === column slug).
+    const r = (await driver.run(mkCtx(fakeFetch({}), writer), {
+      key: "starter_smoke:starter-mastra",
+      name: "starter-mastra",
+      publicUrl: "https://starter-mastra.up.railway.app",
+    })) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("green");
+    expect(r.key).toBe("starter:mastra");
+    expect(r.signal.columnSlug).toBe("mastra");
+    expect(r.signal.starterSlug).toBe("mastra");
+    expect(r.signal.passed).toBe(4);
+    expect(r.signal.failed).toEqual([]);
+
+    const rows = sideRows(writes);
+    expect(rows).toHaveLength(4);
+    expect(rows.map((w) => w.key)).toEqual([
+      "starter:mastra/health",
+      "starter:mastra/agent",
+      "starter:mastra/chat",
+      "starter:mastra/interaction",
+    ]);
+    expect(rows.every((w) => w.state === "green")).toBe(true);
+  });
+
+  it("applies the starter→column slug remap (drift case: langgraph-js → langgraph-typescript)", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(mkCtx(fakeFetch({}), writer), {
+      key: "starter_smoke:starter-langgraph-js",
+      name: "starter-langgraph-js",
+      publicUrl: "https://starter-langgraph-js.up.railway.app",
+    })) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    // Primary + every side row must be keyed to the COLUMN slug, not the
+    // starter slug.
+    expect(r.key).toBe("starter:langgraph-typescript");
+    expect(r.signal.columnSlug).toBe("langgraph-typescript");
+    expect(r.signal.starterSlug).toBe("langgraph-js");
+    expect(sideRows(writes).map((w) => w.key)).toEqual([
+      "starter:langgraph-typescript/health",
+      "starter:langgraph-typescript/agent",
+      "starter:langgraph-typescript/chat",
+      "starter:langgraph-typescript/interaction",
+    ]);
+  });
+
+  it("agent 404 → that level red (smoke-failed) and aggregate red", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ agentStatus: 404 }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["agent"]);
+    expect(r.signal.errorClass).toBe("smoke-failed");
+
+    const agentRow = sideRows(writes).find((w) => w.key === "starter:agno/agent")!;
+    expect(agentRow.state).toBe("red");
+    expect(agentRow.signal.errorClass).toBe("smoke-failed");
+    expect(agentRow.signal.errorDesc).toContain("404");
+  });
+
+  it("chat with empty body → chat red (smoke-failed)", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ chatBody: "   " }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["chat"]);
+    const chatRow = sideRows(writes).find((w) => w.key === "starter:agno/chat")!;
+    expect(chatRow.state).toBe("red");
+    expect(chatRow.signal.errorDesc).toContain("empty response");
+  });
+
+  it("health malformed (200 but non-JSON) → health red", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ healthBody: "<html>not json</html>" }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["health"]);
+    const healthRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/health",
+    )!;
+    expect(healthRow.signal.errorDesc).toContain("malformed body");
+  });
+
+  it("transport failure (cold-start wake) → classified transport-error, NOT smoke-failed", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const connErr = new Error("connect ECONNREFUSED");
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ throwOn: { health: connErr } }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["health"]);
+    // A cold-start / transport hiccup must be classified distinctly so it
+    // doesn't read as a hard red.
+    expect(r.signal.errorClass).toBe("transport-error");
+    const healthRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/health",
+    )!;
+    expect(healthRow.signal.errorClass).toBe("transport-error");
+  });
+
+  it("aggregate errorClass prefers smoke-failed over transport-error when both occur", async () => {
+    const { writer } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const connErr = new Error("ETIMEDOUT");
+    const r = (await driver.run(
+      mkCtx(
+        fakeFetch({ throwOn: { interaction: connErr }, agentStatus: 404 }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed.sort()).toEqual(["agent", "interaction"]);
+    // smoke-failed (agent 404) is more actionable than the transport
+    // hiccup on interaction, so it wins the aggregate class.
+    expect(r.signal.errorClass).toBe("smoke-failed");
+  });
+
+  it("unmapped starter (no column) → red aggregate with smoke-failed class, no per-level rows", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(mkCtx(fakeFetch({}), writer), {
+      key: "starter_smoke:starter-nonexistent",
+      name: "starter-nonexistent",
+      publicUrl: "https://starter-nonexistent.up.railway.app",
+    })) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.key).toBe("starter:nonexistent");
+    expect(r.signal.errorClass).toBe("smoke-failed");
+    // No per-level side rows when we can't resolve a column slug.
+    expect(writes).toHaveLength(0);
+  });
+
+  it("emits side rows even without a writer wired (no throw)", async () => {
+    const driver = createStarterSmokeDriver();
+    // No writer on the ctx — driver must not throw, primary still returns.
+    const r = (await driver.run(mkCtx(fakeFetch({})), {
+      key: "starter_smoke:starter-mastra",
+      name: "starter-mastra",
+      publicUrl: "https://starter-mastra.up.railway.app",
+    })) as ProbeResult<StarterSmokeAggregateSignal>;
+    expect(r.state).toBe("green");
+    expect(r.key).toBe("starter:mastra");
+  });
+});

--- a/showcase/harness/src/probes/drivers/starter-smoke.test.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.test.ts
@@ -201,7 +201,9 @@ describe("starterSmokeDriver", () => {
     expect(r.signal.failed).toEqual(["agent"]);
     expect(r.signal.errorClass).toBe("smoke-failed");
 
-    const agentRow = sideRows(writes).find((w) => w.key === "starter:agno/agent")!;
+    const agentRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/agent",
+    )!;
     expect(agentRow.state).toBe("red");
     expect(agentRow.signal.errorClass).toBe("smoke-failed");
     expect(agentRow.signal.errorDesc).toContain("404");
@@ -210,18 +212,17 @@ describe("starterSmokeDriver", () => {
   it("chat with empty body → chat red (smoke-failed)", async () => {
     const { writer, writes } = mkWriter();
     const driver = createStarterSmokeDriver();
-    const r = (await driver.run(
-      mkCtx(fakeFetch({ chatBody: "   " }), writer),
-      {
-        key: "starter_smoke:starter-agno",
-        name: "starter-agno",
-        publicUrl: "https://starter-agno.up.railway.app",
-      },
-    )) as ProbeResult<StarterSmokeAggregateSignal>;
+    const r = (await driver.run(mkCtx(fakeFetch({ chatBody: "   " }), writer), {
+      key: "starter_smoke:starter-agno",
+      name: "starter-agno",
+      publicUrl: "https://starter-agno.up.railway.app",
+    })) as ProbeResult<StarterSmokeAggregateSignal>;
 
     expect(r.state).toBe("red");
     expect(r.signal.failed).toEqual(["chat"]);
-    const chatRow = sideRows(writes).find((w) => w.key === "starter:agno/chat")!;
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
     expect(chatRow.state).toBe("red");
     expect(chatRow.signal.errorDesc).toContain("empty response");
   });

--- a/showcase/harness/src/probes/drivers/starter-smoke.test.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.test.ts
@@ -5,6 +5,7 @@ import {
   type StarterSmokeAggregateSignal,
   type StarterSmokeLevelSignal,
 } from "./starter-smoke.js";
+import { STARTER_LEVELS } from "../helpers/starter-mapping.js";
 import { logger } from "../../logger.js";
 import type {
   ProbeContext,
@@ -320,5 +321,80 @@ describe("starterSmokeDriver", () => {
     })) as ProbeResult<StarterSmokeAggregateSignal>;
     expect(r.state).toBe("green");
     expect(r.key).toBe("starter:mastra");
+  });
+
+  it("external abort (already-aborted ctx.abortSignal) → levels classified 'aborted'", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    // A fetch that rejects with an AbortError, paired with an
+    // already-aborted external signal: the per-check catch must classify the
+    // failure as `aborted` (the outer tick was abandoned), distinct from a
+    // per-endpoint `transport-error` slow wake.
+    const abortErr = new Error("The operation was aborted");
+    abortErr.name = "AbortError";
+    const ctx: ProbeContext = {
+      now: () => new Date("2026-06-03T00:00:00Z"),
+      logger,
+      env: {},
+      writer,
+      fetchImpl: fakeFetch({
+        throwOn: {
+          health: abortErr,
+          agent: abortErr,
+          chat: abortErr,
+          interaction: abortErr,
+        },
+      }),
+      abortSignal: AbortSignal.abort(),
+    };
+    const r = (await driver.run(ctx, {
+      key: "starter_smoke:starter-agno",
+      name: "starter-agno",
+      publicUrl: "https://starter-agno.up.railway.app",
+    })) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed.sort()).toEqual([
+      "agent",
+      "chat",
+      "health",
+      "interaction",
+    ]);
+    // All levels aborted → aggregate worst class is `aborted`.
+    expect(r.signal.errorClass).toBe("aborted");
+    const rows = sideRows(writes);
+    for (const row of rows) {
+      expect(row.signal.errorClass).toBe("aborted");
+    }
+  });
+
+  it("a writer whose write() rejects must not fail the aggregate tick (swallowed + still green)", async () => {
+    // makeSideEmit must swallow a side-emit writer throw at error-level so a
+    // per-row write hiccup never takes the aggregate tick down with it.
+    const writeErrors: unknown[] = [];
+    const throwingWriter: ProbeResultWriter = {
+      async write() {
+        throw new Error("simulated writer failure");
+      },
+    };
+    const driver = createStarterSmokeDriver();
+    const ctx = mkCtx(fakeFetch({}), throwingWriter);
+    const r = (await driver
+      .run(ctx, {
+        key: "starter_smoke:starter-mastra",
+        name: "starter-mastra",
+        publicUrl: "https://starter-mastra.up.railway.app",
+      })
+      .catch((e) => {
+        writeErrors.push(e);
+        throw e;
+      })) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    // The writer threw on every side-emit, yet the aggregate tick completed
+    // and stayed green — the throw was swallowed, not propagated.
+    expect(writeErrors).toHaveLength(0);
+    expect(r.state).toBe("green");
+    expect(r.key).toBe("starter:mastra");
+    expect(r.signal.passed).toBe(STARTER_LEVELS.length);
   });
 });

--- a/showcase/harness/src/probes/drivers/starter-smoke.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.ts
@@ -1,0 +1,534 @@
+import { z } from "zod";
+import { sanitizeErrorDesc } from "./sanitize.js";
+import {
+  STARTER_LEVELS,
+  starterToColumnSlug,
+  type StarterLevel,
+} from "../helpers/starter-mapping.js";
+import type { ProbeDriver } from "../types.js";
+import type { ProbeContext, ProbeResult } from "../../types/index.js";
+
+/**
+ * starter_smoke driver — per-starter L1–L4 smoke health over HTTP.
+ *
+ * This is the harness twin of the GitHub-Actions `smoke-starter` matrix
+ * (`showcase/tests/e2e/starter-smoke.spec.ts`): instead of building each
+ * starter image and running Playwright in CI, it HTTP-probes each starter's
+ * own deployed (scale-to-zero) Railway service on the harness cadence. The
+ * model is the *same* probe machinery the `smoke` dimension (`liveness.ts`)
+ * already runs against the 19 deployed showcase services — no new harness
+ * capability, no Docker-on-harness, no browser.
+ *
+ * One invocation = one starter service. Per starter the driver issues FOUR
+ * HTTP checks against the deployed base URL and side-emits one row per
+ * level plus an aggregate primary:
+ *
+ *   - **health**      GET  `${base}/api/health` → 200 + JSON-parseable body.
+ *                     Mirrors the `@health` tag (health endpoint responds).
+ *   - **agent**       POST `${base}/api/copilotkit/` with `{}` → any non-404
+ *                     response. Reuses the exact `checkAgentEndpoint`
+ *                     contract `liveness.ts`'s smoke agent check uses: a
+ *                     non-404 proves the CopilotKit runtime is mounted; a
+ *                     404 means the route isn't wired.
+ *   - **chat**        POST `${base}/api/copilotkit/` with a minimal chat
+ *                     round-trip payload (aimock answers it) → a non-empty
+ *                     response body. Mirrors the `@chat` tag (chat
+ *                     round-trip via aimock returns a response) but over a
+ *                     single HTTP turn rather than a browser.
+ *   - **interaction** GET `${base}/` → 200 (the app shell serves). Mirrors
+ *                     the `@interaction` tag, which branches on `hasAppMode`
+ *                     (`starter-smoke.spec.ts:123`). We keep this check
+ *                     GENERIC — both the App-mode and CopilotSidebar
+ *                     starters serve the same root shell, so an HTTP-level
+ *                     "root page renders" signal stays valid for every
+ *                     starter without encoding per-starter UI branching the
+ *                     way the Playwright spec does. `hasAppMode` is accepted
+ *                     in the input (so the row/tooltip can stay generic and
+ *                     a future browser-based interaction probe can branch)
+ *                     but does NOT change the HTTP behaviour here.
+ *
+ * Side-emit + slug remap (mirrors `e2e-readiness.ts` / `d4-chat-roundtrip.ts`):
+ * the starter slug from discovery (`starter-<slug>` Railway service name) is
+ * remapped to the dashboard COLUMN slug via `starterToColumnSlug` (S1's
+ * single source of truth) BEFORE any emit, so the dashboard only ever sees
+ * column slugs. Per starter the driver writes four side rows
+ * `starter:<column-slug>/<level>` via `makeSideEmit`, plus an aggregate
+ * `starter:<column-slug>` primary (the `run()` return value, picked up by
+ * the invoker's `writer.write()` like every other driver).
+ *
+ * Transport-failure classification (mirrors `e2e-readiness.ts`'s keyed
+ * `errorClass`): a scale-to-zero starter must WAKE on the probe's first
+ * request, and that cold-start can legitimately exceed the per-check
+ * timeout. We do NOT let a wake/transport hiccup read as a hard red. A
+ * fetch-level failure (timeout, connection refused, DNS, abort) is emitted
+ * with `errorClass: "transport-error"` so the dashboard / alert rules can
+ * branch on a stable discriminator and let the two-miss staleness rule
+ * absorb a single slow wake — distinct from `errorClass: "smoke-failed"` (a
+ * real HTTP-level regression: 404 agent route, 500 health, empty chat).
+ *
+ * Live-wiring against real Railway starter services is gated on a separate
+ * slot (the services don't exist yet); this driver is unit-tested with a
+ * stubbed `fetchImpl` and ships ready for that slot to point it at the
+ * deployed base URLs.
+ */
+
+/**
+ * Per-target input. Discovery (`railway-services`) populates `name`
+ * (`starter-<slug>`) + `publicUrl`; `hasAppMode` is optional advisory
+ * metadata (see the interaction-check note above). `.passthrough()` so a
+ * full discovery record can spread in without pre-filtering, matching the
+ * smoke / e2e drivers.
+ */
+const inputSchema = z
+  .object({
+    key: z.string().min(1),
+    /** Railway service name (`starter-<slug>`). */
+    name: z.string().min(1),
+    /** `https://<domain>` base URL of the deployed starter service. */
+    publicUrl: z.string().url(),
+    /**
+     * Whether the starter exposes the Chat/App mode toggle
+     * (`starter-smoke.spec.ts`). Advisory only — the HTTP interaction check
+     * stays generic regardless. Defaults to false when absent.
+     */
+    hasAppMode: z.boolean().optional(),
+  })
+  .passthrough();
+
+type StarterSmokeDriverInput = z.infer<typeof inputSchema>;
+
+/**
+ * Aggregate signal on the primary `starter:<column-slug>` result.
+ * `failed` lists the levels that flipped red; `errorClass` is the worst
+ * keyed failure class across the four checks (`transport-error` is treated
+ * as softer than `smoke-failed` for dashboard branching).
+ */
+export interface StarterSmokeAggregateSignal {
+  starterSlug: string;
+  columnSlug: string;
+  publicUrl: string;
+  total: number;
+  passed: number;
+  failed: StarterLevel[];
+  /** Worst keyed failure class across levels, when the aggregate is red. */
+  errorClass?: StarterFailureClass;
+}
+
+/** Per-level side-emit signal on each `starter:<column-slug>/<level>` row. */
+export interface StarterSmokeLevelSignal {
+  starterSlug: string;
+  columnSlug: string;
+  level: StarterLevel;
+  /** The URL actually probed for this level. */
+  url: string;
+  /** Numeric HTTP status; absent on transport failure / timeout. */
+  status?: number;
+  /** Slack-safe human-readable failure reason (red rows only). */
+  errorDesc?: string;
+  /** Keyed failure class (red rows only). */
+  errorClass?: StarterFailureClass;
+  latencyMs: number;
+}
+
+/**
+ * Keyed failure taxonomy. `transport-error` (timeout / cold-start wake /
+ * connection failure) is deliberately distinct from `smoke-failed` (a real
+ * HTTP-level regression) so a scale-to-zero wake hiccup never masquerades
+ * as a hard red. `aborted` is the external-abort / outer-timeout case.
+ */
+export type StarterFailureClass =
+  | "transport-error"
+  | "smoke-failed"
+  | "aborted";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const TIMEOUT_ENV_VAR = "STARTER_SMOKE_TIMEOUT_MS";
+
+/**
+ * Minimal chat round-trip payload posted to the CopilotKit runtime. The
+ * runtime answers this with a streamed/structured response that aimock
+ * fulfils; we only assert the response is non-empty (the `@chat` contract:
+ * "chat round-trip via aimock returns a response"). Kept intentionally
+ * minimal — a full GraphQL `generateCopilotResponse` body would couple the
+ * probe to the runtime's request schema, which drifts; a non-empty body
+ * from a non-404 POST is sufficient proof-of-life for the chat path.
+ */
+const CHAT_PROBE_BODY = JSON.stringify({
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+export function createStarterSmokeDriver(
+  deps: { timeoutMs?: number } = {},
+): ProbeDriver<StarterSmokeDriverInput, StarterSmokeAggregateSignal> {
+  const depTimeoutMs = deps.timeoutMs;
+  return {
+    kind: "starter_smoke",
+    inputSchema,
+    async run(
+      ctx: ProbeContext,
+      input: StarterSmokeDriverInput,
+    ): Promise<ProbeResult<StarterSmokeAggregateSignal>> {
+      const observedAt = ctx.now().toISOString();
+      const fetchImpl = ctx.fetchImpl ?? globalThis.fetch.bind(globalThis);
+      const timeoutMs = resolveTimeoutMs(ctx, depTimeoutMs);
+      const starterSlug = deriveStarterSlug(input.name);
+      const base = input.publicUrl.replace(/\/$/, "");
+
+      // Remap starter slug → dashboard column slug (S1's source of truth)
+      // BEFORE any emit so the dashboard only ever sees column slugs.
+      const columnSlug = starterToColumnSlug(starterSlug);
+      if (!columnSlug) {
+        // An unmapped starter service is a config/mapping drift (a new
+        // starter deployed before its remap entry landed). Surface it as a
+        // red aggregate with a keyed class so the slug-drift lint test and
+        // operators see it, rather than a silent fan-out hole. No column
+        // slug means we cannot key per-level rows, so only the primary is
+        // emitted (under the un-remapped starter key as a last resort).
+        ctx.logger.warn("probe.starter-smoke.unmapped-starter", {
+          starterSlug,
+          name: input.name,
+        });
+        return {
+          key: `starter:${starterSlug}`,
+          state: "red",
+          signal: {
+            starterSlug,
+            columnSlug: starterSlug,
+            publicUrl: base,
+            total: 0,
+            passed: 0,
+            failed: [...STARTER_LEVELS],
+            errorClass: "smoke-failed",
+          },
+          observedAt,
+        };
+      }
+
+      const sideEmit = makeSideEmit(ctx);
+
+      // Per-level URL + probe method. Each level owns its own HTTP call and
+      // success criterion so a single hung endpoint can't blind its
+      // siblings (the same paired-probe isolation `liveness.ts` keeps).
+      const levelUrls: Record<StarterLevel, string> = {
+        health: `${base}/api/health`,
+        agent: `${base}/api/copilotkit/`,
+        chat: `${base}/api/copilotkit/`,
+        interaction: `${base}/`,
+      };
+
+      const failed: StarterLevel[] = [];
+      let passed = 0;
+      let worstClass: StarterFailureClass | undefined;
+
+      for (const level of STARTER_LEVELS) {
+        const url = levelUrls[level];
+        const result = await probeLevel({
+          fetchImpl,
+          level,
+          url,
+          timeoutMs,
+          now: ctx.now,
+          abortSignal: ctx.abortSignal,
+        });
+
+        const state = result.ok ? "green" : "red";
+        if (result.ok) {
+          passed++;
+        } else {
+          failed.push(level);
+          worstClass = worsen(worstClass, result.errorClass);
+        }
+
+        await sideEmit({
+          key: `starter:${columnSlug}/${level}`,
+          state,
+          signal: {
+            starterSlug,
+            columnSlug,
+            level,
+            url,
+            status: result.status,
+            errorDesc: result.errorDesc,
+            errorClass: result.ok ? undefined : result.errorClass,
+            latencyMs: result.latencyMs,
+          },
+          observedAt: ctx.now().toISOString(),
+        });
+      }
+
+      const aggregateGreen = failed.length === 0;
+      return {
+        key: `starter:${columnSlug}`,
+        state: aggregateGreen ? "green" : "red",
+        signal: {
+          starterSlug,
+          columnSlug,
+          publicUrl: base,
+          total: STARTER_LEVELS.length,
+          passed,
+          failed,
+          errorClass: aggregateGreen ? undefined : worstClass,
+        },
+        observedAt,
+      };
+    },
+  };
+}
+
+interface LevelOutcome {
+  ok: boolean;
+  status?: number;
+  errorDesc?: string;
+  errorClass?: StarterFailureClass;
+  latencyMs: number;
+}
+
+/**
+ * Issue one HTTP check for a level and classify the outcome.
+ *
+ *   - health/interaction: GET, success = 2xx (interaction tolerates any
+ *     2xx HTML shell; health additionally requires a JSON-parseable body).
+ *   - agent: POST `{}`, success = any non-404 response (proof the runtime
+ *     is mounted), 404 = `smoke-failed`.
+ *   - chat: POST a minimal chat payload, success = a non-404 response with
+ *     a non-empty body (aimock answered).
+ *
+ * Transport failures (timeout / cold-start wake / connection / DNS / abort)
+ * are classified `transport-error` (or `aborted` on external abort) so a
+ * scale-to-zero wake hiccup is softer than a real HTTP regression
+ * (`smoke-failed`).
+ */
+async function probeLevel(opts: {
+  fetchImpl: typeof fetch;
+  level: StarterLevel;
+  url: string;
+  timeoutMs: number;
+  now: () => Date;
+  abortSignal?: AbortSignal;
+}): Promise<LevelOutcome> {
+  const { fetchImpl, level, url, timeoutMs, now, abortSignal } = opts;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  // Chain the invoker's external abort into this check so an outer timeout
+  // releases the socket promptly.
+  const onExternalAbort = (): void => controller.abort();
+  if (abortSignal) {
+    if (abortSignal.aborted) controller.abort();
+    else abortSignal.addEventListener("abort", onExternalAbort, { once: true });
+  }
+  const started = now().getTime();
+  try {
+    const isPost = level === "agent" || level === "chat";
+    const res = await fetchImpl(url, {
+      method: isPost ? "POST" : "GET",
+      headers: isPost ? { "Content-Type": "application/json" } : undefined,
+      body: level === "chat" ? CHAT_PROBE_BODY : isPost ? "{}" : undefined,
+      signal: controller.signal,
+      // Follow trailing-slash 308s so we judge the FINAL response (an
+      // unmounted route that redirects to a 404 must read red), matching
+      // the smoke agent check.
+      redirect: "follow",
+    });
+    const latencyMs = now().getTime() - started;
+
+    // agent / chat: a 404 is a real regression (route not mounted).
+    if ((level === "agent" || level === "chat") && res.status === 404) {
+      const body = await safeReadBody(res);
+      return {
+        ok: false,
+        status: 404,
+        errorClass: "smoke-failed",
+        errorDesc: sanitizeErrorDesc(
+          body.length > 0
+            ? `${level} endpoint 404: ${body}`
+            : `${level} endpoint 404 — route not mounted`,
+        ),
+        latencyMs,
+      };
+    }
+
+    // chat: a non-404 response must carry a non-empty body (aimock answered).
+    if (level === "chat") {
+      const body = await safeReadBody(res);
+      if (!res.ok) {
+        return {
+          ok: false,
+          status: res.status,
+          errorClass: "smoke-failed",
+          errorDesc: sanitizeErrorDesc(`chat http ${res.status}: ${body}`),
+          latencyMs,
+        };
+      }
+      if (body.trim().length === 0) {
+        return {
+          ok: false,
+          status: res.status,
+          errorClass: "smoke-failed",
+          errorDesc: sanitizeErrorDesc("chat returned empty response body"),
+          latencyMs,
+        };
+      }
+      return { ok: true, status: res.status, latencyMs };
+    }
+
+    // agent: any non-404 response is proof-of-life.
+    if (level === "agent") {
+      return { ok: true, status: res.status, latencyMs };
+    }
+
+    // health / interaction: require a 2xx.
+    if (!res.ok) {
+      const body = await safeReadBody(res);
+      return {
+        ok: false,
+        status: res.status,
+        errorClass: "smoke-failed",
+        errorDesc: sanitizeErrorDesc(
+          body.length > 0
+            ? `${level} http ${res.status}: ${body}`
+            : `${level} http ${res.status}`,
+        ),
+        latencyMs,
+      };
+    }
+
+    // health additionally requires a JSON-parseable body — a 200 that
+    // serves an HTML error page (misrouted edge) must NOT pass.
+    if (level === "health") {
+      const parseErr = await verifyJsonBody(res);
+      if (parseErr) {
+        return {
+          ok: false,
+          status: res.status,
+          errorClass: "smoke-failed",
+          errorDesc: sanitizeErrorDesc(`health malformed body: ${parseErr}`),
+          latencyMs,
+        };
+      }
+    }
+
+    return { ok: true, status: res.status, latencyMs };
+  } catch (err) {
+    const latencyMs = now().getTime() - started;
+    const isAbortError =
+      err instanceof Error &&
+      (err.name === "AbortError" || err.name === "TimeoutError");
+    // Distinguish an EXTERNAL abort (invoker outer-timeout) from this
+    // check's own timeout. Either way it's a transport-class failure, but
+    // the keyed class lets dashboards tell "the whole tick was abandoned"
+    // from "this one endpoint was slow to wake".
+    const externallyAborted = abortSignal?.aborted ?? false;
+    const errorClass: StarterFailureClass = externallyAborted
+      ? "aborted"
+      : "transport-error";
+    const errorDesc = sanitizeErrorDesc(
+      isAbortError
+        ? externallyAborted
+          ? "aborted"
+          : `timeout after ${timeoutMs}ms (cold-start wake or hung endpoint)`
+        : err instanceof Error
+          ? err.message
+          : String(err),
+    );
+    return { ok: false, errorClass, errorDesc, latencyMs };
+  } finally {
+    clearTimeout(timer);
+    if (abortSignal) abortSignal.removeEventListener("abort", onExternalAbort);
+  }
+}
+
+/**
+ * Order the failure classes worst-first so the aggregate carries the most
+ * actionable class: a real `smoke-failed` regression dominates a soft
+ * `transport-error` wake hiccup, which dominates a tick-level `aborted`.
+ */
+const CLASS_RANK: Record<StarterFailureClass, number> = {
+  "smoke-failed": 3,
+  "transport-error": 2,
+  aborted: 1,
+};
+
+function worsen(
+  current: StarterFailureClass | undefined,
+  next: StarterFailureClass | undefined,
+): StarterFailureClass | undefined {
+  if (!next) return current;
+  if (!current) return next;
+  return CLASS_RANK[next] > CLASS_RANK[current] ? next : current;
+}
+
+/**
+ * Build a per-`run()` side-emit function. Captures a `warnedNoWriter` flag
+ * so the writer-missing warn fires AT MOST ONCE per invocation instead of
+ * per-row. Writer throws stay swallowed at error-level — a side-emit hiccup
+ * must not take the aggregate tick down with it. Mirrors
+ * `e2e-readiness.ts`'s `makeSideEmit`.
+ */
+type SideEmit = (result: ProbeResult<StarterSmokeLevelSignal>) => Promise<void>;
+
+function makeSideEmit(ctx: ProbeContext): SideEmit {
+  let warnedNoWriter = false;
+  return async (result) => {
+    if (!ctx.writer) {
+      if (!warnedNoWriter) {
+        warnedNoWriter = true;
+        ctx.logger.warn("probe.starter-smoke.writer-missing", {
+          key: result.key,
+        });
+      }
+      return;
+    }
+    try {
+      await ctx.writer.write(result);
+    } catch (err) {
+      ctx.logger.error("probe.starter-smoke.side-emit-writer-failed", {
+        key: result.key,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+}
+
+/**
+ * Derive the starter slug from the Railway service name by stripping the
+ * `starter-` prefix (`starter-langgraph-js` → `langgraph-js`). The slug is
+ * the smoke-matrix slug (NOT the column slug) — `starterToColumnSlug`
+ * performs the remap. Falls back to the whole name when the prefix is
+ * absent so a hand-wired target still produces a distinct slug.
+ */
+function deriveStarterSlug(name: string): string {
+  return name.startsWith("starter-") ? name.slice("starter-".length) : name;
+}
+
+function resolveTimeoutMs(ctx: ProbeContext, depTimeoutMs?: number): number {
+  const raw = ctx.env[TIMEOUT_ENV_VAR];
+  if (typeof raw === "string" && /^\d+$/.test(raw.trim())) {
+    const n = Number.parseInt(raw.trim(), 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return depTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+}
+
+/** Best-effort bounded body read; empty string when unreadable. */
+async function safeReadBody(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return "";
+  }
+}
+
+/** Returns null when the body is empty or JSON-parseable, else a reason. */
+async function verifyJsonBody(res: Response): Promise<string | null> {
+  const text = await safeReadBody(res);
+  if (!text) return null;
+  try {
+    JSON.parse(text);
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+/** Default driver instance — registered by the orchestrator at boot. */
+export const starterSmokeDriver = createStarterSmokeDriver();

--- a/showcase/harness/src/probes/drivers/starter-smoke.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.ts
@@ -195,7 +195,7 @@ export function createStarterSmokeDriver(
             starterSlug,
             columnSlug: starterSlug,
             publicUrl: base,
-            total: 0,
+            total: STARTER_LEVELS.length,
             passed: 0,
             failed: [...STARTER_LEVELS],
             errorClass: "smoke-failed",

--- a/showcase/harness/src/probes/helpers/starter-mapping-drift.test.ts
+++ b/showcase/harness/src/probes/helpers/starter-mapping-drift.test.ts
@@ -45,7 +45,9 @@ const EXCLUDED_STARTERS: ReadonlySet<string> = new Set<string>();
 /** Parse the `slug:` values out of the `STARTERS` array in the smoke spec. */
 function parseSmokeMatrixSlugs(): string[] {
   const src = readFileSync(STARTER_SPEC_FILE, "utf8");
-  const block = src.match(/const STARTERS:\s*Starter\[\]\s*=\s*\[([\s\S]+?)\n\];/);
+  const block = src.match(
+    /const STARTERS:\s*Starter\[\]\s*=\s*\[([\s\S]+?)\n\];/,
+  );
   if (!block || !block[1]) {
     throw new Error(
       "drift parser: could not locate `STARTERS` array in starter-smoke.spec.ts — " +
@@ -104,8 +106,9 @@ describe("starter-mapping-drift", () => {
     const both = Object.keys(STARTER_TO_COLUMN).filter((s) =>
       EXCLUDED_STARTERS.has(s),
     );
-    expect(both, `starters both mapped and excluded: ${JSON.stringify(both)}`).toEqual(
-      [],
-    );
+    expect(
+      both,
+      `starters both mapped and excluded: ${JSON.stringify(both)}`,
+    ).toEqual([]);
   });
 });

--- a/showcase/harness/src/probes/helpers/starter-mapping-drift.test.ts
+++ b/showcase/harness/src/probes/helpers/starter-mapping-drift.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Drift test — `STARTER_TO_COLUMN` vs the smoke matrix and the dashboard
+ * columns.
+ *
+ * The harness `starter_smoke` probe family remaps each starter slug to a
+ * dashboard COLUMN slug via `STARTER_TO_COLUMN` before emitting
+ * `starter:<column-slug>/<level>` rows. Two ways that mapping silently rots:
+ *
+ *   1. A starter is added/renamed in the smoke matrix
+ *      (`STARTERS` in `showcase/tests/e2e/starter-smoke.spec.ts`) but the
+ *      remap is not updated ⇒ the new starter is probed but its rows are
+ *      dropped (no column to write to) — the bug the spec's §a lint guards.
+ *   2. A column slug in the remap no longer matches a real
+ *      `showcase/integrations/<slug>/manifest.yaml` directory (a column was
+ *      renamed/removed) ⇒ the harness writes rows the dashboard can never
+ *      read; the cell stays "not yet run" forever.
+ *
+ * This test catches both. It mirrors `d5-mapping-drift.test.ts`: the smoke
+ * matrix lives in a Playwright spec outside this pnpm workspace and the
+ * column list is the on-disk integration directory set, so both are parsed
+ * via `fs` rather than imported. The set of starters with NO column
+ * (`EXCLUDED_STARTERS`) is empty by design (all 12 map), but is kept
+ * explicit so a future no-column starter can be excluded deliberately
+ * instead of silently failing coverage.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { STARTER_TO_COLUMN } from "./starter-mapping.js";
+
+const STARTER_SPEC_FILE = resolve(
+  __dirname,
+  "../../../../tests/e2e/starter-smoke.spec.ts",
+);
+
+const INTEGRATIONS_DIR = resolve(__dirname, "../../../../integrations");
+
+/**
+ * Starters intentionally probed but with no dashboard column. Empty by
+ * design (§a: 12 mapped, 0 excluded), but kept explicit so a deliberate
+ * future exclusion is distinguishable from an accidental dropped mapping.
+ */
+const EXCLUDED_STARTERS: ReadonlySet<string> = new Set<string>();
+
+/** Parse the `slug:` values out of the `STARTERS` array in the smoke spec. */
+function parseSmokeMatrixSlugs(): string[] {
+  const src = readFileSync(STARTER_SPEC_FILE, "utf8");
+  const block = src.match(/const STARTERS:\s*Starter\[\]\s*=\s*\[([\s\S]+?)\n\];/);
+  if (!block || !block[1]) {
+    throw new Error(
+      "drift parser: could not locate `STARTERS` array in starter-smoke.spec.ts — " +
+        "if the spec's shape changed, update the regex in this test.",
+    );
+  }
+  const slugs = Array.from(
+    block[1].matchAll(/slug:\s*"([^"]+)"/g),
+    (m) => m[1] as string,
+  );
+  if (slugs.length === 0) {
+    throw new Error(
+      "drift parser: matched the STARTERS block but found no `slug:` entries.",
+    );
+  }
+  return slugs;
+}
+
+/** The on-disk dashboard column slugs = integration manifest directories. */
+function readColumnSlugs(): Set<string> {
+  return new Set(
+    readdirSync(INTEGRATIONS_DIR, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name),
+  );
+}
+
+describe("starter-mapping-drift", () => {
+  it("every smoke-matrix starter is either mapped or explicitly excluded", () => {
+    const matrixSlugs = parseSmokeMatrixSlugs();
+    const unaccounted = matrixSlugs.filter(
+      (slug) => !(slug in STARTER_TO_COLUMN) && !EXCLUDED_STARTERS.has(slug),
+    );
+    expect(
+      unaccounted,
+      `starters in the smoke matrix with no mapping AND no explicit exclusion: ` +
+        `${JSON.stringify(unaccounted)} — add them to STARTER_TO_COLUMN ` +
+        `(starter-mapping.ts) or to EXCLUDED_STARTERS in this test.`,
+    ).toEqual([]);
+  });
+
+  it("every mapped column slug exists as a real dashboard column (manifest dir)", () => {
+    const columns = readColumnSlugs();
+    const orphans = Object.entries(STARTER_TO_COLUMN)
+      .filter(([, columnSlug]) => !columns.has(columnSlug))
+      .map(([starterSlug, columnSlug]) => `${starterSlug}→${columnSlug}`);
+    expect(
+      orphans,
+      `mapped column slugs with no matching showcase/integrations/<slug> ` +
+        `manifest directory: ${JSON.stringify(orphans)} — a column was ` +
+        `renamed/removed, or the mapping has a typo.`,
+    ).toEqual([]);
+  });
+
+  it("no mapped starter is also excluded (mutually exclusive sets)", () => {
+    const both = Object.keys(STARTER_TO_COLUMN).filter((s) =>
+      EXCLUDED_STARTERS.has(s),
+    );
+    expect(both, `starters both mapped and excluded: ${JSON.stringify(both)}`).toEqual(
+      [],
+    );
+  });
+});

--- a/showcase/harness/src/probes/helpers/starter-mapping.ts
+++ b/showcase/harness/src/probes/helpers/starter-mapping.ts
@@ -1,0 +1,79 @@
+/**
+ * Starter → dashboard-column-slug mapping.
+ *
+ * The starter-smoke matrix (`STARTERS` in
+ * `showcase/tests/e2e/starter-smoke.spec.ts`) names each starter template by
+ * its own slug. The dashboard, however, has exactly 19 columns — one per
+ * `showcase/integrations/<slug>/manifest.yaml` — and the `starter` probe
+ * family must write `starter:<dashboard-column-slug>/<level>` rows so the
+ * dashboard only ever sees column slugs (mirroring how `CATALOG_TO_D5_KEY`
+ * bridges the harness↔dashboard namespaces in `live-status.ts`).
+ *
+ * This module is the single source of truth for that remap. There are 12
+ * starters: 5 whose slug drifts from the column slug, and 7 that map
+ * one-to-one (the slug is identical on both sides). The other 7 dashboard
+ * columns (ag2, claude-sdk-python, claude-sdk-typescript, langroid,
+ * spring-ai, built-in-agent, ms-agent-harness-dotnet) have NO smoke starter
+ * — they are intentionally absent from this map, and the UI renders them in
+ * the dashboard's existing grey "not supported" ✗ state. 12 mapped + 7
+ * unmapped = 19 columns.
+ *
+ * Slug-drift is guarded by `starter-mapping-drift.test.ts`, which asserts
+ * every starter in the smoke matrix is mapped (or explicitly excluded) and
+ * every mapped column slug exists as a real manifest directory.
+ *
+ * Keying note: the `starter` dimension keys per-level sub-rows as
+ * `starter:<column-slug>/<level>` where level ∈ {health,agent,chat,
+ * interaction}. This does NOT collide with the existing `agent`/`chat`/
+ * `tools` depth dimensions: those are *separate dimensions* keyed
+ * `<dim>:<slug>` (e.g. `agent:langgraph-python`), whereas the starter
+ * smoke levels live UNDER the `starter` dimension as the `<level>` suffix
+ * (`starter:langgraph-python/agent`). The dimension prefix differs, so the
+ * key spaces are disjoint.
+ */
+
+/**
+ * Starter slug (as it appears in the smoke matrix) → dashboard column slug
+ * (the `showcase/integrations/<slug>` directory name).
+ *
+ * The 5 drift entries come first (slug differs across the two surfaces);
+ * the 7 direct entries follow (slug identical on both sides, listed
+ * explicitly so the map is exhaustive over the 12-starter matrix and the
+ * drift test can assert full coverage rather than inferring identity).
+ */
+export const STARTER_TO_COLUMN: Readonly<Record<string, string>> = {
+  // ── 5 drift mappings (starter slug ≠ dashboard column slug) ──
+  adk: "google-adk",
+  "langgraph-js": "langgraph-typescript",
+  "strands-python": "strands",
+  "ms-agent-framework-dotnet": "ms-agent-dotnet",
+  "ms-agent-framework-python": "ms-agent-python",
+  // ── 7 direct mappings (starter slug === dashboard column slug) ──
+  "crewai-crews": "crewai-crews",
+  "langgraph-fastapi": "langgraph-fastapi",
+  "langgraph-python": "langgraph-python",
+  agno: "agno",
+  llamaindex: "llamaindex",
+  mastra: "mastra",
+  "pydantic-ai": "pydantic-ai",
+};
+
+/** The four smoke levels probed per starter, in dashboard sub-row order. */
+export const STARTER_LEVELS = [
+  "health",
+  "agent",
+  "chat",
+  "interaction",
+] as const;
+
+export type StarterLevel = (typeof STARTER_LEVELS)[number];
+
+/**
+ * Resolve a starter slug to its dashboard column slug, or `undefined` if the
+ * starter has no mapped column. A starter probe MUST remap via this resolver
+ * before emitting `starter:<column-slug>/<level>` rows so the dashboard only
+ * ever sees column slugs.
+ */
+export function starterToColumnSlug(starterSlug: string): string | undefined {
+  return STARTER_TO_COLUMN[starterSlug];
+}

--- a/showcase/harness/src/probes/loader/probe-config-parity.test.ts
+++ b/showcase/harness/src/probes/loader/probe-config-parity.test.ts
@@ -69,6 +69,12 @@ const RAILWAY_PROBES_EXEMPT_FROM_EXCLUDES_FLOOR: Record<string, string> = {
   // no infra leakage to exclude.
   "qa.yml":
     "qa is scoped to one service via precise namePrefix; no infra leakage",
+  // starter_smoke enumerates `starter-*` services — a namespace fully
+  // DISJOINT from the `showcase-*` infra services the floor protects, so
+  // no infra service can ever leak into its enumeration and the floor
+  // doesn't apply.
+  "starter_smoke.yml":
+    "starter_smoke uses a starter- namePrefix disjoint from showcase-* infra; no infra leakage",
 };
 
 describe("probe-config nameExcludes parity", () => {
@@ -208,10 +214,21 @@ describe("probe-config nameExcludes parity", () => {
           typeof prefix === "string" &&
           prefix.startsWith("showcase-") &&
           prefix.length > "showcase-".length;
+        // A prefix fully DISJOINT from `showcase-` (e.g. `starter-`) is
+        // even safer than a narrow `showcase-X` sub-prefix: no infra
+        // service (all `showcase-*`) can match it, so none can ever leak
+        // into this probe's enumeration. Treat a non-empty, non-showcase-
+        // prefix as satisfying the floor-exemption guard for the same
+        // reason `hasNarrowPrefix` does — the infra-leak risk is nil.
+        const hasDisjointPrefix =
+          typeof prefix === "string" &&
+          prefix.length > 0 &&
+          !"showcase-".startsWith(prefix) &&
+          !prefix.startsWith("showcase-");
         const rationaleSpansEverything = /all services/i.test(rationale ?? "");
         expect(
-          hasNarrowPrefix || rationaleSpansEverything,
-          `${file}: exempt probe must EITHER have a namePrefix narrower than "showcase-" (got ${JSON.stringify(prefix)}) OR carry an "all services" phrase in its RAILWAY_PROBES_EXEMPT_FROM_EXCLUDES_FLOOR rationale. Without one, broadening this probe later would silently flap infra services red.`,
+          hasNarrowPrefix || hasDisjointPrefix || rationaleSpansEverything,
+          `${file}: exempt probe must EITHER have a namePrefix narrower than "showcase-", OR a namePrefix disjoint from "showcase-" (got ${JSON.stringify(prefix)}), OR carry an "all services" phrase in its RAILWAY_PROBES_EXEMPT_FROM_EXCLUDES_FLOOR rationale. Without one, broadening this probe later would silently flap infra services red.`,
         ).toBe(true);
         continue;
       }

--- a/showcase/harness/src/types/index.ts
+++ b/showcase/harness/src/types/index.ts
@@ -65,6 +65,20 @@ export const DIMENSIONS = [
   // level signals (e.g. discovery auth status) that are not tied to any
   // specific probe driver but need closed-enum validation in rule YAMLs.
   "system",
+  // Starter-smoke dimension. The `starter_smoke` probe family fans out
+  // across the deployed per-starter Railway services and side-emits one
+  // row per smoke level: `starter:<column-slug>/<level>` where level ∈
+  // {health,agent,chat,interaction}, plus an aggregate `starter:<col>`
+  // primary. The starter slug is remapped to the dashboard COLUMN slug
+  // (see probes/helpers/starter-mapping.ts) before emit so the dashboard
+  // only ever sees column slugs. The per-level sub-key does NOT collide
+  // with the `agent`/`chat`/`tools` depth dimensions above: those are
+  // separate dimensions keyed `<dim>:<slug>` (e.g. `agent:langgraph-python`),
+  // whereas the starter levels live UNDER the `starter` dimension as the
+  // `<level>` suffix (`starter:langgraph-python/agent`) — disjoint key
+  // spaces because the dimension prefix differs. Informational only; like
+  // d5/d6/qa it must NOT contribute to the feature-cell rollup.
+  "starter",
 ] as const;
 export type Dimension = (typeof DIMENSIONS)[number];
 

--- a/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
@@ -8,7 +8,7 @@ import { CellMatrix } from "../cell-matrix";
 import type { CatalogCell } from "../depth-utils";
 import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
 import type { FeatureCategory } from "@/lib/registry";
-import { E2E_STALE_AFTER_MS } from "@/lib/staleness";
+import { E2E_STALE_AFTER_MS, STARTER_STALE_AFTER_MS } from "@/lib/staleness";
 
 // Mock localStorage
 const storageMap = new Map<string, string>();
@@ -710,5 +710,90 @@ describe("CellMatrix", () => {
     } finally {
       nowSpy.mockRestore();
     }
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Starter row-group (spec §d)                                         */
+/* ------------------------------------------------------------------ */
+
+describe("CellMatrix — Starter row-group", () => {
+  // agno is a MAPPED starter column; ag2 is one of the 7 NOT-supported columns.
+  const starterIntegrations: IntegrationInfo[] = [
+    { slug: "agno", name: "Agno", tier: "at_parity" },
+    { slug: "ag2", name: "AG2", tier: "partial" },
+  ];
+
+  const renderMatrix = (live: LiveStatusMap) =>
+    render(
+      <CellMatrix
+        cells={[]}
+        categories={[]}
+        features={[]}
+        integrations={starterIntegrations}
+        liveStatus={live}
+        defaultOpenCategories={new Set()}
+        filter="all"
+        referenceSlug="agno"
+      />,
+    );
+
+  it("renders the Starter header and four fixed sub-rows", () => {
+    const { getByText, getByTestId } = renderMatrix(new Map());
+    expect(getByText("Starter")).toBeDefined();
+    for (const level of ["health", "agent", "chat", "interaction"]) {
+      expect(getByTestId(`starter-row-${level}`)).toBeDefined();
+    }
+  });
+
+  it("✓ green for a passing mapped starter cell", () => {
+    const live = mapOf([row("starter:agno/health", "starter", "green")]);
+    const { getByTestId } = renderMatrix(live);
+    const cell = getByTestId("starter-cell-agno-health");
+    expect(cell.textContent).toContain("✓");
+  });
+
+  it("red ✗ for a failed mapped starter cell", () => {
+    const live = mapOf([row("starter:agno/chat", "starter", "red")]);
+    const { getByTestId } = renderMatrix(live);
+    const cell = getByTestId("starter-cell-agno-chat");
+    expect(cell.textContent).toContain("✗");
+  });
+
+  it("gray ? for a mapped column with no row yet (not-yet-run)", () => {
+    const { getByTestId } = renderMatrix(new Map());
+    const cell = getByTestId("starter-cell-agno-agent");
+    expect(cell.textContent).toContain("?");
+  });
+
+  it("not-supported ✗ for an unmapped column, tooltip 'no starter for this integration'", () => {
+    const { getByTestId } = renderMatrix(new Map());
+    const cell = getByTestId("starter-cell-ag2-health");
+    // grey/hollow ✗ — the chip carries the tooltip title.
+    expect(cell.textContent).toContain("✗");
+    const chip = cell.querySelector("[title]");
+    expect(chip?.getAttribute("title")).toBe("no starter for this integration");
+  });
+
+  it("~ stale: a frozen-green starter row downgrades to amber ~", () => {
+    const staleAt = new Date(
+      Date.now() - STARTER_STALE_AFTER_MS - 1,
+    ).toISOString();
+    const live = mapOf([
+      {
+        id: "id-stale",
+        key: "starter:agno/interaction",
+        dimension: "starter",
+        state: "green" as const,
+        signal: {},
+        observed_at: staleAt,
+        transitioned_at: staleAt,
+        fail_count: 0,
+        first_failure_at: null,
+      },
+    ]);
+    const { getByTestId } = renderMatrix(live);
+    const cell = getByTestId("starter-cell-agno-interaction");
+    expect(cell.textContent).toContain("~");
   });
 });

--- a/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-matrix.test.tsx
@@ -769,7 +769,7 @@ describe("CellMatrix — Starter row-group", () => {
   it("not-supported ✗ for an unmapped column, tooltip 'no starter for this integration'", () => {
     const { getByTestId } = renderMatrix(new Map());
     const cell = getByTestId("starter-cell-ag2-health");
-    // grey/hollow ✗ — the chip carries the tooltip title.
+    // grey ✗ — the chip carries the tooltip title.
     expect(cell.textContent).toContain("✗");
     const chip = cell.querySelector("[title]");
     expect(chip?.getAttribute("title")).toBe("no starter for this integration");

--- a/showcase/shell-dashboard/src/components/cell-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/cell-matrix.tsx
@@ -15,12 +15,23 @@ import { DepthChip } from "./depth-chip";
 import { CellDrilldown } from "./cell-drilldown";
 import { IntegrationHeader } from "./integration-header";
 import { useCollapsible, CategoryHeaderRow } from "./collapsible-category";
+import { ToneChip } from "./badges";
 import { buildCellModel } from "@/lib/cell-model";
 import type { CatalogCell } from "./depth-utils";
 import type { ParityTier } from "./parity-badge";
 import type { FilterMode } from "./filter-chips";
-import { resolveCell } from "@/lib/live-status";
-import type { LiveStatusMap, ConnectionStatus } from "@/lib/live-status";
+import {
+  resolveCell,
+  resolveStarterRow,
+  buildStarterBadge,
+  starterIsSupported,
+  STARTER_LEVELS,
+} from "@/lib/live-status";
+import type {
+  LiveStatusMap,
+  ConnectionStatus,
+  StarterLevel,
+} from "@/lib/live-status";
 import type { FeatureCategory } from "@/lib/registry";
 
 /** Identifies a selected cell for drilldown. */
@@ -218,6 +229,105 @@ function CategorySection({
 }
 
 /* ------------------------------------------------------------------ */
+/*  StarterSection — the "Starter" pseudo-category row-group (spec §d)  */
+/* ------------------------------------------------------------------ */
+
+/** Human-readable label per starter sub-row, in STARTER_LEVELS order. */
+const STARTER_LEVEL_LABEL: Record<StarterLevel, string> = {
+  health: "Health",
+  agent: "Agent",
+  chat: "Chat",
+  interaction: "Interaction",
+};
+
+interface StarterSectionProps {
+  visibleIntegrations: IntegrationInfo[];
+  liveStatus: LiveStatusMap;
+  defaultOpen: boolean;
+  connection: ConnectionStatus;
+  now: number;
+}
+
+/**
+ * The "Starter" row-group: four fixed sub-rows (health/agent/chat/interaction)
+ * keyed to the integration columns. Rendered like a `CategorySection`, but the
+ * cells resolve via `resolveStarterRow` + `buildStarterBadge` (the full 5-state
+ * §d vocabulary) instead of the depth model.
+ *
+ * INFORMATIONAL ONLY: this group never calls `resolveCell`, so starter rows
+ * cannot contribute to the feature-cell `rollup` (spec §d) — the exclusion is
+ * structural, not a filter.
+ */
+function StarterSection({
+  visibleIntegrations,
+  liveStatus,
+  defaultOpen,
+  connection,
+  now,
+}: StarterSectionProps) {
+  const { isOpen, toggle } = useCollapsible({
+    name: "Starter",
+    defaultOpen,
+  });
+
+  const supportedCount = visibleIntegrations.filter((int) =>
+    starterIsSupported(int.slug),
+  ).length;
+
+  return (
+    <>
+      <CategoryHeaderRow
+        name="Starter"
+        count={`${supportedCount}/${visibleIntegrations.length}`}
+        colSpan={visibleIntegrations.length + 1}
+        isOpen={isOpen}
+        onToggle={toggle}
+      />
+      {isOpen &&
+        STARTER_LEVELS.map((level) => (
+          <tr
+            key={level}
+            data-testid={`starter-row-${level}`}
+            className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
+          >
+            <td className="sticky left-0 z-10 bg-[var(--bg-surface)] px-4 py-1.5 border-r border-[var(--border)] align-middle min-w-[200px]">
+              <span className="text-xs text-[var(--text)]">
+                {STARTER_LEVEL_LABEL[level]}
+              </span>
+            </td>
+            {visibleIntegrations.map((int) => {
+              const isSupported = starterIsSupported(int.slug);
+              const row = isSupported
+                ? resolveStarterRow(liveStatus, int.slug, level)
+                : null;
+              const badge = buildStarterBadge(
+                level,
+                isSupported,
+                row,
+                now,
+                connection,
+              );
+              return (
+                <td
+                  key={int.slug}
+                  data-testid={`starter-cell-${int.slug}-${level}`}
+                  className="border-l border-[var(--border)] px-3 py-1.5 align-middle text-center"
+                >
+                  <ToneChip
+                    tone={badge.tone}
+                    label={badge.label}
+                    title={badge.tooltip}
+                  />
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  CellMatrix                                                         */
 /* ------------------------------------------------------------------ */
 
@@ -405,6 +515,20 @@ export function CellMatrix({
               />
             );
           })}
+          {/*
+           * "Starter" pseudo-category row-group (spec §d). Informational
+           * smoke-health for the deployed starter services — rendered after
+           * the feature categories, never contributing to any feature cell's
+           * rollup (it does not call resolveCell). Shown across all filter
+           * modes since it is a health surface, not a feature-coverage row.
+           */}
+          <StarterSection
+            visibleIntegrations={visibleIntegrations}
+            liveStatus={liveStatus}
+            defaultOpen
+            connection={connection}
+            now={now}
+          />
         </tbody>
       </table>
     </div>

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -956,6 +956,36 @@ describe("buildStarterBadge — 5-state cell vocabulary (§d)", () => {
     expect(b.label).toBe("✓");
   });
 
+  // Hourly-cadence derivation (starter_smoke.yml `schedule: "40 * * * *"`,
+  // 1h probe period; STARTER_STALE_AFTER_MS = 2.5h). These pin the window to
+  // the hourly basis: a single missed tick (last row ~2h old) MUST stay green;
+  // two consecutive misses (last row ~3h old) MUST flip amber.
+  const ONE_HOUR_MS = 60 * 60 * 1000;
+
+  it("window is strictly > 2 hourly probe periods and < 3 (derived 2.5h)", () => {
+    expect(STARTER_STALE_AFTER_MS).toBeGreaterThan(2 * ONE_HOUR_MS);
+    expect(STARTER_STALE_AFTER_MS).toBeLessThan(3 * ONE_HOUR_MS);
+  });
+
+  it("single missed hourly tick (~2h old) stays green", () => {
+    const oneMiss = row("starter:agno/agent", "starter", "green", {
+      observed_at: new Date(NOW - 2 * ONE_HOUR_MS).toISOString(),
+    });
+    const b = buildStarterBadge("agent", true, oneMiss, NOW, "live");
+    expect(b.tone).toBe("green");
+    expect(b.label).toBe("✓");
+  });
+
+  it("two consecutive missed hourly ticks (~3h old) flip amber ~", () => {
+    const twoMisses = row("starter:agno/agent", "starter", "green", {
+      observed_at: new Date(NOW - 3 * ONE_HOUR_MS).toISOString(),
+    });
+    const b = buildStarterBadge("agent", true, twoMisses, NOW, "live");
+    expect(b.tone).toBe("amber");
+    expect(b.label).toBe("~");
+    expect(b.row?.state).toBe("degraded");
+  });
+
   it("gray ?: supported column, no row yet → gray ? (not-yet-run)", () => {
     const b = buildStarterBadge("interaction", true, null, NOW, "live");
     expect(b.tone).toBe("gray");

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -1,14 +1,23 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   CATALOG_TO_D5_KEY,
+  STARTER_COLUMNS,
+  STARTER_LEVELS,
+  buildStarterBadge,
   keyFor,
   mergeRowsToMap,
   resolveCell,
+  resolveStarterRow,
+  starterIsSupported,
   upsertByKey,
 } from "./live-status";
-import type { LiveStatusMap, StatusRow } from "./live-status";
+import type { LiveStatusMap, StatusRow, StarterLevel } from "./live-status";
 import { formatTs } from "./format-ts";
-import { E2E_STALE_AFTER_MS, LIVENESS_STALE_AFTER_MS } from "./staleness";
+import {
+  E2E_STALE_AFTER_MS,
+  LIVENESS_STALE_AFTER_MS,
+  STARTER_STALE_AFTER_MS,
+} from "./staleness";
 
 // A recent timestamp so green rows are not treated as stale by the
 // staleness downgrade in resolveCell (which compares against Date.now()).
@@ -834,5 +843,186 @@ describe("formatTooltip behaviour (via resolveCell)", () => {
   it("connection=error + null row: plain offline tooltip", () => {
     const c = resolveCell(mapOf([]), "a", "b", { connection: "error" });
     expect(c.e2e.tooltip).toBe("dashboard offline (§5.3)");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Starter row-group (spec §d / §a)                                    */
+/* ------------------------------------------------------------------ */
+
+const NOW = Date.now();
+
+describe("STARTER_COLUMNS (§a 12-mapped / 7-not-supported split)", () => {
+  it("contains exactly the 12 mapped columns", () => {
+    // 12 mapped + 7 not-supported = 19 columns. Guards the dashboard's copy
+    // of the harness STARTER_TO_COLUMN value set against silent rot.
+    expect(STARTER_COLUMNS.size).toBe(12);
+  });
+
+  it("includes the 5 drift columns and 7 direct columns", () => {
+    for (const col of [
+      "google-adk",
+      "langgraph-typescript",
+      "strands",
+      "ms-agent-dotnet",
+      "ms-agent-python",
+      "crewai-crews",
+      "langgraph-fastapi",
+      "langgraph-python",
+      "agno",
+      "llamaindex",
+      "mastra",
+      "pydantic-ai",
+    ]) {
+      expect(starterIsSupported(col)).toBe(true);
+    }
+  });
+
+  it("treats the 7 unmapped columns as not supported", () => {
+    for (const col of [
+      "ag2",
+      "claude-sdk-python",
+      "claude-sdk-typescript",
+      "langroid",
+      "spring-ai",
+      "built-in-agent",
+      "ms-agent-harness-dotnet",
+    ]) {
+      expect(starterIsSupported(col)).toBe(false);
+    }
+  });
+});
+
+describe("resolveStarterRow", () => {
+  it("looks up the flat starter:<col>/<level> key", () => {
+    const r = row("starter:agno/health", "starter", "green");
+    const live = mapOf([r]);
+    expect(resolveStarterRow(live, "agno", "health")).toBe(r);
+  });
+
+  it("returns null for a column/level with no row (not-yet-run)", () => {
+    expect(resolveStarterRow(mapOf([]), "agno", "chat")).toBeNull();
+  });
+
+  it("does not cross-contaminate levels", () => {
+    const live = mapOf([row("starter:agno/agent", "starter", "red")]);
+    expect(resolveStarterRow(live, "agno", "agent")?.state).toBe("red");
+    expect(resolveStarterRow(live, "agno", "health")).toBeNull();
+  });
+});
+
+describe("buildStarterBadge — 5-state cell vocabulary (§d)", () => {
+  it("✓ healthy: green row → green ✓", () => {
+    const b = buildStarterBadge(
+      "health",
+      true,
+      row("starter:agno/health", "starter", "green"),
+      NOW,
+      "live",
+    );
+    expect(b.tone).toBe("green");
+    expect(b.label).toBe("✓");
+  });
+
+  it("red ✗ smoke-failed: red row → red ✗", () => {
+    const b = buildStarterBadge(
+      "chat",
+      true,
+      row("starter:agno/chat", "starter", "red"),
+      NOW,
+      "live",
+    );
+    expect(b.tone).toBe("red");
+    expect(b.label).toBe("✗");
+  });
+
+  it("~ stale: green row older than STARTER_STALE_AFTER_MS downgrades to amber ~", () => {
+    const stale = row("starter:agno/agent", "starter", "green", {
+      observed_at: new Date(NOW - STARTER_STALE_AFTER_MS - 1).toISOString(),
+    });
+    const b = buildStarterBadge("agent", true, stale, NOW, "live");
+    expect(b.tone).toBe("amber");
+    expect(b.label).toBe("~");
+    // The downgraded effective row's state agrees with the tone.
+    expect(b.row?.state).toBe("degraded");
+  });
+
+  it("~ stale boundary: green row EXACTLY at the window is NOT stale (strict >)", () => {
+    const atBoundary = row("starter:agno/agent", "starter", "green", {
+      observed_at: new Date(NOW - STARTER_STALE_AFTER_MS).toISOString(),
+    });
+    const b = buildStarterBadge("agent", true, atBoundary, NOW, "live");
+    expect(b.tone).toBe("green");
+    expect(b.label).toBe("✓");
+  });
+
+  it("gray ?: supported column, no row yet → gray ? (not-yet-run)", () => {
+    const b = buildStarterBadge("interaction", true, null, NOW, "live");
+    expect(b.tone).toBe("gray");
+    expect(b.label).toBe("?");
+  });
+
+  it("not-supported ✗: unmapped column → gray ✗, mapping-derived (not data-derived)", () => {
+    // Keyed off isSupported=false, NOT off a missing row — so it is visually
+    // distinct from the gray `?` not-yet-run state (same tone, different glyph)
+    // AND from the red smoke-failed ✗ (different tone).
+    const b = buildStarterBadge("health", false, null, NOW, "live");
+    expect(b.tone).toBe("gray");
+    expect(b.label).toBe("✗");
+    expect(b.tooltip).toBe("no starter for this integration");
+    expect(b.row).toBeNull();
+  });
+
+  it("not-supported ✗ is independent of any row data (mapping wins)", () => {
+    // Even if a stray row existed, an unmapped column must still render the
+    // not-supported state — the caller passes row=null for unmapped columns,
+    // but assert buildStarterBadge ignores row entirely when !isSupported.
+    const b = buildStarterBadge(
+      "health",
+      false,
+      row("starter:ag2/health", "starter", "green"),
+      NOW,
+      "live",
+    );
+    expect(b.label).toBe("✗");
+    expect(b.tone).toBe("gray");
+  });
+
+  it("tooltip carries the per-level descriptor for data-bearing states", () => {
+    const expected: Record<StarterLevel, string> = {
+      health: "health endpoint responded",
+      agent: "agent endpoint reachable (non-404)",
+      chat: "chat round-trip via aimock returned a response",
+      interaction: "UI interactions work, no console errors",
+    };
+    for (const level of STARTER_LEVELS) {
+      const b = buildStarterBadge(
+        level,
+        true,
+        row(`starter:agno/${level}`, "starter", "green"),
+        NOW,
+        "live",
+      );
+      expect(b.tooltip).toContain(expected[level]);
+    }
+  });
+});
+
+describe("starter rows are informational — excluded from resolveCell rollup", () => {
+  it("a red starter row does NOT make the feature-cell rollup red", () => {
+    // resolveCell only reads health + e2e (+ informational badges). A starter
+    // row sharing the slug must never leak into the rollup.
+    const live = mapOf([
+      row("health:agno", "health", "green"),
+      row("e2e:agno/agentic-chat", "e2e", "green"),
+      // A red starter row for the same integration:
+      row("starter:agno/health", "starter", "red"),
+      row("starter:agno/chat", "starter", "red"),
+    ]);
+    const cell = resolveCell(live, "agno", "agentic-chat", { now: NOW });
+    // Rollup stays green (or whatever health+e2e dictate) — NOT red.
+    expect(cell.rollup).not.toBe("red");
+    // And the CellState shape exposes no starter contributor.
+    expect(Object.keys(cell)).not.toContain("starter");
   });
 });

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -430,7 +430,7 @@ const STARTER_LEVEL_DESCRIPTION: Readonly<Record<StarterLevel, string>> = {
  * Build a `BadgeRender` for one starter sub-cell, applying the FULL 5-state
  * cell vocabulary (§d):
  *
- *   - not-supported  → grey/hollow "✗", mapping-derived (`!isSupported`),
+ *   - not-supported  → grey "✗", mapping-derived (`!isSupported`),
  *                      tooltip "no starter for this integration". Distinct
  *                      from the red smoke-failed ✗. Resolved FIRST so it can
  *                      never collide with the gray `?` initial state.
@@ -453,7 +453,7 @@ export function buildStarterBadge(
   connection: ConnectionStatus,
 ): BadgeRender {
   if (!isSupported) {
-    // Mapping-derived: this column has no starter (§a). Grey/hollow ✗,
+    // Mapping-derived: this column has no starter (§a). Grey ✗,
     // visually distinct from a red smoke-failed ✗. NOT data-derived, so it
     // renders identically before and after the first probe tick.
     return {

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -18,6 +18,7 @@ import { formatTs } from "./format-ts";
 import {
   E2E_STALE_AFTER_MS,
   LIVENESS_STALE_AFTER_MS,
+  STARTER_STALE_AFTER_MS,
   isStale,
 } from "./staleness";
 
@@ -342,6 +343,145 @@ function resolveD6Row(
   return worst;
 }
 
+/* ------------------------------------------------------------------ */
+/*  Starter row-group (spec §d / §a)                                    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * The four smoke levels probed per starter, in dashboard sub-row order.
+ * Mirrors `STARTER_LEVELS` in
+ * `showcase/harness/src/probes/helpers/starter-mapping.ts` — the harness owns
+ * the producer-side list, the dashboard carries its own copy because the two
+ * packages do not share a module boundary (the dashboard imports only `@/*`).
+ */
+export const STARTER_LEVELS = [
+  "health",
+  "agent",
+  "chat",
+  "interaction",
+] as const;
+
+export type StarterLevel = (typeof STARTER_LEVELS)[number];
+
+/**
+ * The dashboard column slugs that HAVE a smoke starter (the 12 mapped columns,
+ * §a). This is the dashboard's own copy of the *value set* of `STARTER_TO_COLUMN`
+ * in `showcase/harness/src/probes/helpers/starter-mapping.ts` — the harness owns
+ * the producer-side remap and the dashboard cannot import across the package
+ * boundary, so the column list is mirrored here. The
+ * `starter-mapping-drift.test.ts` lint test guards the harness side against slug
+ * drift; `live-status.test.ts` asserts THIS set has exactly 12 entries so the
+ * 12-mapped / 7-not-supported split (12 + 7 = 19) can never silently rot.
+ *
+ * A column ABSENT from this set has NO starter and renders the dashboard's
+ * existing grey "not supported" ✗ state (§d) — keyed off the MAPPING, never off
+ * a missing row, so it never collides with the gray `?` not-yet-run state.
+ */
+export const STARTER_COLUMNS: ReadonlySet<string> = new Set([
+  // 5 drift columns (starter slug ≠ column slug on the producer side)
+  "google-adk",
+  "langgraph-typescript",
+  "strands",
+  "ms-agent-dotnet",
+  "ms-agent-python",
+  // 7 direct columns (starter slug === column slug)
+  "crewai-crews",
+  "langgraph-fastapi",
+  "langgraph-python",
+  "agno",
+  "llamaindex",
+  "mastra",
+  "pydantic-ai",
+]);
+
+/** `true` when `columnSlug` has a mapped smoke starter (§a). */
+export function starterIsSupported(columnSlug: string): boolean {
+  return STARTER_COLUMNS.has(columnSlug);
+}
+
+/**
+ * Resolve the `starter:<columnSlug>/<level>` row for one starter sub-cell.
+ *
+ * Sibling to `resolveD5Row`/`resolveD6Row`, but the starter keyspace is flat:
+ * one row per (column, level) — there is no multi-key fan-out to fold, so this
+ * is a direct lookup, not a worst-state reduction. The 5-state cell vocabulary
+ * (§d) is produced by `buildStarterBadge`; this helper only returns the raw
+ * row (or `null` for not-yet-run). The not-supported state is mapping-derived
+ * and handled by the caller via `starterIsSupported`, NOT inferred here from a
+ * missing row.
+ */
+export function resolveStarterRow(
+  live: LiveStatusMap,
+  columnSlug: string,
+  level: StarterLevel,
+): StatusRow | null {
+  return live.get(keyFor("starter", columnSlug, level)) ?? null;
+}
+
+/** Per-level tooltip copy (§d). `interaction` stays generic. */
+const STARTER_LEVEL_DESCRIPTION: Readonly<Record<StarterLevel, string>> = {
+  health: "health endpoint responded",
+  agent: "agent endpoint reachable (non-404)",
+  chat: "chat round-trip via aimock returned a response",
+  interaction: "UI interactions work, no console errors",
+};
+
+/**
+ * Build a `BadgeRender` for one starter sub-cell, applying the FULL 5-state
+ * cell vocabulary (§d):
+ *
+ *   - not-supported  → grey/hollow "✗", mapping-derived (`!isSupported`),
+ *                      tooltip "no starter for this integration". Distinct
+ *                      from the red smoke-failed ✗. Resolved FIRST so it can
+ *                      never collide with the gray `?` initial state.
+ *   - gray `?`       → no row yet (not-yet-run / initial).
+ *   - ✓ green        → last probe passed.
+ *   - red ✗          → last probe failed (actionable regression).
+ *   - `~` amber      → stale: a green row older than STARTER_STALE_AFTER_MS is
+ *                      downgraded to degraded (delegated to `buildBadge`).
+ *
+ * The data-bearing states (green/red/stale/gray) are delegated to the shared
+ * `buildBadge` path under the `health` dimension label so the level glyphs/copy
+ * reuse the same staleness downgrade + tooltip machinery as every other badge;
+ * the per-level descriptor is appended to the tooltip.
+ */
+export function buildStarterBadge(
+  level: StarterLevel,
+  isSupported: boolean,
+  row: StatusRow | null,
+  now: number,
+  connection: ConnectionStatus,
+): BadgeRender {
+  if (!isSupported) {
+    // Mapping-derived: this column has no starter (§a). Grey/hollow ✗,
+    // visually distinct from a red smoke-failed ✗. NOT data-derived, so it
+    // renders identically before and after the first probe tick.
+    return {
+      tone: "gray",
+      label: "✗",
+      tooltip: "no starter for this integration",
+      row: null,
+    };
+  }
+  const base = buildBadge(
+    "starter",
+    row,
+    now,
+    STARTER_STALE_AFTER_MS,
+    connection,
+  );
+  const descriptor = STARTER_LEVEL_DESCRIPTION[level];
+  // Suffix the level descriptor onto the resolved-state tooltip (state +
+  // observed_at come from the shared path). For not-yet-run there is no row,
+  // so keep buildBadge's "probe pending" copy but still name what would be
+  // checked.
+  return {
+    ...base,
+    tooltip:
+      connection === "error" ? base.tooltip : `${descriptor} — ${base.tooltip}`,
+  };
+}
+
 function rowTone(row: StatusRow | null): BadgeTone {
   if (!row) return "gray";
   switch (row.state) {
@@ -373,7 +513,8 @@ export type LiveDimension =
   | "chat"
   | "tools"
   | "d5"
-  | "d6";
+  | "d6"
+  | "starter";
 
 function formatLabel(dim: LiveDimension, row: StatusRow | null): string {
   if (!row) return "?";

--- a/showcase/shell-dashboard/src/lib/staleness.ts
+++ b/showcase/shell-dashboard/src/lib/staleness.ts
@@ -46,6 +46,20 @@ export const D4_STALE_AFTER_MS = 60 * 60 * 1000;
 export const LIVENESS_STALE_AFTER_MS = 45 * 60 * 1000;
 
 /**
+ * Staleness window for the `starter` dimension (`starter:<column>/<level>`
+ * rows written by the harness `starter_smoke` probe family). Per spec §d, the
+ * window is derived from the probe cadence and MUST be strictly greater than
+ * two probe periods, so a single late/missed/slow-wake tick stays green and
+ * only two consecutive misses flip amber. The probe ships on a 6h cadence
+ * (mirroring the retired `test_smoke-starter.yml` cron the live signal
+ * replaces); 13h is > 2×6h with headroom to absorb the scale-to-zero
+ * cold-start latency (§c) folded into a single tick. Keep this in lockstep
+ * with S2's `starter_smoke.yml` `schedule` — if the cadence changes, this
+ * window must be re-derived (> 2× the new period). Not env-tunable.
+ */
+export const STARTER_STALE_AFTER_MS = 13 * 60 * 60 * 1000;
+
+/**
  * Determine whether a row's `observed_at` is older than `maxAgeMs` relative
  * to `now`. An unparseable/missing timestamp is treated as NOT stale —
  * staleness must be a positive signal, never inferred from bad data.

--- a/showcase/shell-dashboard/src/lib/staleness.ts
+++ b/showcase/shell-dashboard/src/lib/staleness.ts
@@ -50,14 +50,18 @@ export const LIVENESS_STALE_AFTER_MS = 45 * 60 * 1000;
  * rows written by the harness `starter_smoke` probe family). Per spec §d, the
  * window is derived from the probe cadence and MUST be strictly greater than
  * two probe periods, so a single late/missed/slow-wake tick stays green and
- * only two consecutive misses flip amber. The probe ships on a 6h cadence
- * (mirroring the retired `test_smoke-starter.yml` cron the live signal
- * replaces); 13h is > 2×6h with headroom to absorb the scale-to-zero
- * cold-start latency (§c) folded into a single tick. Keep this in lockstep
- * with S2's `starter_smoke.yml` `schedule` — if the cadence changes, this
- * window must be re-derived (> 2× the new period). Not env-tunable.
+ * only two consecutive misses flip amber. The probe ships on an HOURLY cadence
+ * (`schedule: "40 * * * *"`, see harness/config/probes/starter_smoke.yml), so
+ * the probe period is 1h. We set the window to 2.5h: > 2×1h (so two consecutive
+ * missed hourly ticks, which age the last row to ~2h, then ~3h, flip amber on
+ * the SECOND miss) yet < 3h (so a single missed/slow-wake tick — last row ~2h
+ * old — stays green, absorbing a scale-to-zero cold-start wake folded into one
+ * tick, §c). 2.5h is the tightest window satisfying ">2 periods" that still
+ * trips on the second miss. Keep this in lockstep with S2's `starter_smoke.yml`
+ * `schedule` — if the cadence changes, this window must be re-derived
+ * (> 2× the new period). Not env-tunable.
  */
-export const STARTER_STALE_AFTER_MS = 13 * 60 * 60 * 1000;
+export const STARTER_STALE_AFTER_MS = 2.5 * 60 * 60 * 1000;
 
 /**
  * Determine whether a row's `observed_at` is older than `maxAgeMs` relative

--- a/showcase/shell-dashboard/src/lib/starter-column-equality.test.ts
+++ b/showcase/shell-dashboard/src/lib/starter-column-equality.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Cross-package value-equality drift test — dashboard `STARTER_COLUMNS` vs the
+ * harness `STARTER_TO_COLUMN` column-slug VALUES.
+ *
+ * The harness `starter_smoke` probe family remaps each starter slug to a
+ * dashboard COLUMN slug via `STARTER_TO_COLUMN`
+ * (`showcase/harness/src/probes/helpers/starter-mapping.ts`) and emits
+ * `starter:<column-slug>/<level>` rows. The dashboard keeps its OWN copy of
+ * that mapping's VALUE SET — `STARTER_COLUMNS` in `live-status.ts` — to decide
+ * which columns render a starter cell vs the grey "not supported" ✗.
+ *
+ * The existing guards only check COUNTS (each side asserts 12). That lets a
+ * future slug RENAME on one side (e.g. harness `strands` → `strands-x` without
+ * the dashboard following) keep both counts at 12 while silently flipping a
+ * column to the grey "not-supported" state — a green starter would render as if
+ * it had no starter at all. This test closes that gap by asserting SET-EQUALITY
+ * between the harness column-slug values and the dashboard `STARTER_COLUMNS`.
+ *
+ * The harness mapping lives in a SEPARATE pnpm workspace
+ * (`showcase/harness`), so the dashboard cannot import across the package
+ * boundary. We parse the harness source via `fs` (mirroring the harness-side
+ * `starter-mapping-drift.test.ts` which `fs`-reads the Playwright spec and the
+ * integrations dir), reading the authoritative `STARTER_TO_COLUMN` values
+ * directly so a rename on the harness side reds this test.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { STARTER_COLUMNS } from "./live-status";
+
+const HARNESS_MAPPING_FILE = resolve(
+  __dirname,
+  "../../../harness/src/probes/helpers/starter-mapping.ts",
+);
+
+/**
+ * Parse the VALUE side of every `key: "value"` (or `key: value` direct) entry
+ * in the `STARTER_TO_COLUMN` object literal of the harness source. Throws if
+ * the block can't be located so a shape change is loud, not a silent pass.
+ */
+function parseHarnessColumnSlugs(): string[] {
+  const src = readFileSync(HARNESS_MAPPING_FILE, "utf8");
+  const block = src.match(
+    /STARTER_TO_COLUMN[^=]*=\s*\{([\s\S]+?)\n\};/,
+  );
+  if (!block || !block[1]) {
+    throw new Error(
+      "equality parser: could not locate `STARTER_TO_COLUMN` object literal in " +
+        "starter-mapping.ts — if the source shape changed, update this regex.",
+    );
+  }
+  // Match the value side of each `<key>: "<column-slug>"` entry, skipping
+  // comment lines (`// ...`). Values are always double-quoted column slugs.
+  const values = Array.from(
+    block[1].matchAll(/^\s*(?:"[^"]+"|[\w-]+)\s*:\s*"([^"]+)"/gm),
+    (m) => m[1] as string,
+  );
+  if (values.length === 0) {
+    throw new Error(
+      "equality parser: parsed zero column-slug values from STARTER_TO_COLUMN — " +
+        "regex likely drifted from the source shape.",
+    );
+  }
+  return values;
+}
+
+describe("starter column-slug cross-package equality", () => {
+  it("dashboard STARTER_COLUMNS exactly equals the harness STARTER_TO_COLUMN value set", () => {
+    const harnessValues = new Set(parseHarnessColumnSlugs());
+    const dashboardColumns = STARTER_COLUMNS;
+
+    // Every harness-emitted column slug must be a renderable dashboard column.
+    for (const slug of harnessValues) {
+      expect(
+        dashboardColumns.has(slug),
+        `harness emits starter:${slug}/* but the dashboard has no STARTER_COLUMNS entry for "${slug}" — it would render grey "not supported"`,
+      ).toBe(true);
+    }
+    // Every dashboard starter column must be produced by the harness mapping.
+    for (const slug of dashboardColumns) {
+      expect(
+        harnessValues.has(slug),
+        `dashboard STARTER_COLUMNS has "${slug}" but no harness STARTER_TO_COLUMN entry maps to it — that column can never receive a starter row`,
+      ).toBe(true);
+    }
+
+    expect(harnessValues.size).toBe(dashboardColumns.size);
+  });
+});

--- a/showcase/shell-dashboard/src/lib/starter-column-equality.test.ts
+++ b/showcase/shell-dashboard/src/lib/starter-column-equality.test.ts
@@ -40,9 +40,7 @@ const HARNESS_MAPPING_FILE = resolve(
  */
 function parseHarnessColumnSlugs(): string[] {
   const src = readFileSync(HARNESS_MAPPING_FILE, "utf8");
-  const block = src.match(
-    /STARTER_TO_COLUMN[^=]*=\s*\{([\s\S]+?)\n\};/,
-  );
+  const block = src.match(/STARTER_TO_COLUMN[^=]*=\s*\{([\s\S]+?)\n\};/);
   if (!block || !block[1]) {
     throw new Error(
       "equality parser: could not locate `STARTER_TO_COLUMN` object literal in " +


### PR DESCRIPTION
## Summary

Integrates the four completed "Starter dashboard row-group" spec slots (model B) into one feature branch. Adds an end-to-end path for per-starter live smoke-health on the showcase dashboard:

**CI builds per-starter images → sleepable Railway services (gated S5, NOT in this PR) → harness HTTP-probes → dashboard row-group.**

## The four areas

- **(a) harness — starter dimension + mapping (S1):** new `starter` probe dimension in harness types + `showcase/harness/src/probes/helpers/starter-mapping.ts` (single source of truth: `STARTER_TO_COLUMN`, `starterToColumnSlug`, `STARTER_LEVELS`; 12 mapped starters / 7 unmapped columns = 19) + a drift-lint test guarding slug drift against real manifest directories.
- **(b) harness — `starter_smoke` probe (S2):** `starter-smoke` driver + `config/probes/starter_smoke.yml` fanning out per-starter health/agent/chat/interaction levels, orchestrator registration, probe-config-parity exemption, and 13 driver unit tests.
- **(c) dashboard — Starter row-group (S3):** `resolveStarterRow` (flat `starter:<col>/<level>` lookup) + `buildStarterBadge` 5-state cell vocabulary (green ✓ / red ✗ smoke-failed / amber ~ stale / gray ? not-yet-run / grey ✗ not-supported), the `StarterSection` row-group, rollup-exclusion, and a 2.5h staleness window derived from the hourly probe cadence (> 2 probe periods, so two consecutive missed hourly ticks flip amber while a single missed/slow-wake tick stays green).
- **(d) ci — image publish + PR gate (S4):** `showcase_build.yml` gains `detect-starter-changes` + `build-starters` Depot→GHCR matrix publishing `ghcr.io/copilotkit/starter-<slug>:latest|<sha>` for the 12 starters (`--platform linux/amd64`); `test_smoke-starter.yml` retains both its PR build-sanity gate AND the 6h `schedule` cron — the cron stays until S5 starter-service probing is confirmed live, as it is the only post-merge floating-dependency breakage detector until then.

## Scope

**S5 (Railway provisioning of the sleepable starter services + live probe wiring) is intentionally OUT of scope**, gated on cost approval. This PR lands the framework; no Railway services are created or probed live by it.

## Verified vs assumed

- VERIFIED locally: integration cleanliness (zero cherry-pick conflicts), both typechecks, both full test suites, YAML parse.
- NOT verified (out of scope = S5, cannot run here): Depot builds, GHCR pushes, and live Railway HTTP probes.

## CR-round fixes (applied)

- **Staleness window:** corrected `STARTER_STALE_AFTER_MS` from 13h (which had a stale "6h cadence" comment) to **2.5h**, re-derived from the actual hourly probe cadence (`schedule: "40 * * * *"`). Reconciled both the `staleness.ts` and `starter_smoke.yml` comments to the same hourly basis + 2.5h window; extended the staleness tests with explicit hourly-tick boundaries (1 miss → green, 2 misses → amber).
- **workflow_dispatch collision:** scoped `showcase_build.yml`'s `detect-changes` fail-loud `exit 1` to non-`starter-*` inputs (case statement), so `service=starter-<slug>` resolves to an empty showcase matrix and SKIPS instead of reddening the run; typo'd showcase names still fail loud. (jq-simulated all three cases.)
- **Cross-package equality test:** added a dashboard-side test asserting `STARTER_COLUMNS` set-equals the harness `STARTER_TO_COLUMN` column-slug values (not just counts), closing the silent-rename gap.
- **6h smoke cron restored:** kept until S5 live probing (see (d) above).
- **Harness:** fixed the unmapped-aggregate `total` count invariant (`0` → `STARTER_LEVELS.length`); added the missing `aborted` errorClass and writer-throw-swallow unit tests.
- **Comments:** dropped the inaccurate "hollow" from the not-supported ✗ comments (no hollow render variant; renders as grey ✗).

## Local green proof

- `tsc --noEmit`: clean on **both** `showcase/harness` and `showcase/shell-dashboard` (the only standalone-tsc errors are pre-existing generated `@/data/*.json` modules produced by the `pretest`/`prebuild` hooks; the full `next build` resolves them and passes).
- Harness vitest: **1761 passed** (102 files).
- Dashboard vitest: **815 passed, 1 skipped** (51 files); `next build` green.
- All `.github/workflows/*.yml` parse + actionlint clean for the changed regions.

Spec: starter-row-group (Notion, model B).

DO NOT MERGE — review only.
