### PR TITLE
fix(showcase/harness): size d6-all-pills probe budget for the 18-service fleet

### DIFF
--- a/showcase/harness/config/probes/d6-all-pills-e2e.yml
+++ b/showcase/harness/config/probes/d6-all-pills-e2e.yml
@@ -15,19 +15,33 @@
 # :40 is offset off every other Playwright probe so none co-fire for the
 # shared browser pool: e2e-smoke (`*/15` = :00/:15/:30/:45), e2e-demos (:10),
 # and e2e-deep/D5 (:05/:20/:35/:50). With BROWSER_POOL_BROWSERS=3
-# chromium processes and FEATURE_CONCURRENCY=4, estimated runtime ~7-10 min.
+# chromium processes and FEATURE_CONCURRENCY=4, the slowest round of the
+# fan-out runs ~200s per service under CPU contention.
 #
-# -- timeout_ms: 600_000 (10 min) --
+# -- timeout_ms: 1_200_000 (20 min) --
 # -- max_concurrency: 8 --
 #
-# 8 services x 4 features = 32 concurrent contexts, drawn from 3 chromium
-# processes. The global context cap is BROWSER_POOL_MAX_CONTEXTS=40 (D6 peak
-# 32 + D5 peak 8); contexts (not processes) are the scaling knob since the
-# PID ceiling of 1000 is the binding constraint.
+# Fleet sizing: discovery now enumerates ~18 showcase demo services (NOT the
+# legacy "8 services x 4 features" assumption this header carried before).
+# With max_concurrency: 8, the fan-out runs in ceil(18/8) = 3 serialized
+# rounds. Rounds 2 and 3 start late and execute under CPU contention, so each
+# service's wall-clock stretches toward ~200s. The previous 600_000 (10 min)
+# outer cap was sized for a single 8-service round; under 3 rounds the late
+# rounds blew the per-service budget and ALL 18 services went red with
+# `driver timeout after 600000ms`. The corrected 1_200_000 (20 min) cap fits
+# 3 rounds x ~200s with comfortable headroom and matches the sibling
+# 18-service `e2e-demos` probe (same fleet, same 20-min budget).
+#
+# Concurrency is deliberately held at 8, NOT raised: 8 services x 4 features =
+# 32 concurrent contexts, drawn from 3 chromium processes. The global context
+# cap is BROWSER_POOL_MAX_CONTEXTS=40 (D6 peak 32 + D5 peak 8); raising
+# max_concurrency would push past the 40-cap. Contexts (not processes) are the
+# scaling knob since the PID ceiling of 1000 is the binding constraint. This
+# is a timeout-only fix — peak contexts stay at 32.
 kind: e2e_d6
 id: d6-all-pills-e2e
 schedule: "40 * * * *"
-timeout_ms: 600000
+timeout_ms: 1200000
 max_concurrency: 8
 discovery:
   source: railway-services


### PR DESCRIPTION
## Problem

The `d6-all-pills-e2e` probe (`showcase/harness/config/probes/d6-all-pills-e2e.yml`) was sized for a stale fleet. Its header said "8 services × 4 features" and it shipped `timeout_ms: 600000` (10 min) with `max_concurrency: 8`.

Discovery now enumerates ~18 showcase demo services. The fan-out math:

- `ceil(18 / 8)` = **3 serialized rounds**
- Rounds 2 and 3 start late and run under CPU contention, stretching each service's wall-clock toward ~200s
- The 10-min outer cap was sized for a single 8-service round, so the late rounds blow the per-service budget → **all 18 services go red** with the `driver timeout after 600000ms` cluster

The browser pool is NOT the bottleneck — peak is 32 contexts (8 services × 4 features), well under `BROWSER_POOL_MAX_CONTEXTS=40`. The sibling 18-service `e2e-demos` probe already runs at a 20-min budget for the same fleet.

## Fix

- `timeout_ms: 600000` → `1200000` (20 min), matching the sibling `e2e-demos` probe (same fleet, same budget). 3 rounds × ~200s fits comfortably.
- **`max_concurrency` stays at 8** — raising it would push D6 peak past the 40-context cap. This is a timeout-only change; peak contexts stay at 32.
- Header comment rewritten to document the real ~18-service fleet and the fan-out-math rationale.

## Blast radius (timeout-only, not concurrency)

- D6 peak stays at **32 contexts** (`BROWSER_POOL_MAX_CONTEXTS=40`, leaving 8 for D5).
- D5 schedule is offset (`:05/:20/:35/:50`) vs D6 (`:40`) — no co-fire.
- The separate hourly `starter_smoke` / S5 family (`max_concurrency: 6`) coexists unchanged.
- Schema (`loader/schema.ts`) caps `timeout_ms` at 1_800_000 (30 min); 1_200_000 is within bounds and equals the documented slowest user (`e2e-demos`).

## Expected effect

The 17 non-defect d6 cells go green. Only `gen-ui-interrupt` stays red (a real defect, fixed separately).

## Validation

- YAML parses; Zod schema + probe-loader parity tests pass.
- `probe-config-parity.test.ts` (16) + `schema.test.ts` pass.
- `d6-all-pills.test.ts` + `e2e-readiness.test.ts` + `orchestrator.test.ts` — 110/110 pass.
- `tsc --noEmit` on harness: clean.
- (A pre-existing `starter_smoke.yml` probe-loader failure reproduces identically on clean `origin/main` and is unrelated to this change.)