### PR TITLE
fix(showcase/aimock): reorder gen-ui-interrupt d6 fixture legs to unshadow the tool-emitting leg

### DIFF
--- a/showcase/aimock/d6/langgraph-python/gen-ui-interrupt.json
+++ b/showcase/aimock/d6/langgraph-python/gen-ui-interrupt.json
@@ -6,29 +6,7 @@
   },
   "fixtures": [
     {
-      "_comment": "gen-ui-interrupt sales-call pill — second leg: confirmation after user picks a slot and resolve fires. Keyed by toolCallId so it only matches when the prior tool result is being fed back. Placed BEFORE first-leg so toolCallId matching takes precedence over toolName matching.",
-      "match": {
-        "userMessage": "intro call with the sales team",
-        "toolCallId": "call_d5_schedule_sales_001",
-        "context": "langgraph-python"
-      },
-      "response": {
-        "content": "Booked: Sales intro call confirmed for the slot you picked."
-      }
-    },
-    {
-      "_comment": "gen-ui-interrupt alice-1on1 pill — second leg: confirmation after user picks a slot. Placed BEFORE first-leg so toolCallId matching takes precedence.",
-      "match": {
-        "userMessage": "1:1 with Alice",
-        "toolCallId": "call_d5_schedule_alice_001",
-        "context": "langgraph-python"
-      },
-      "response": {
-        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
-      }
-    },
-    {
-      "_comment": "gen-ui-interrupt sales-call pill — first leg: schedule_meeting tool call triggers Python agent's interrupt(...). The toolName gate ensures this matches only when schedule_meeting is in the tool list (the agent must declare it).",
+      "_comment": "gen-ui-interrupt sales-call pill — first leg: schedule_meeting tool call triggers Python agent's interrupt(...). The toolName gate ensures this matches only when schedule_meeting is in the tool list (the agent must declare it). Placed BEFORE the toolCallId resume-leg so the duplicate-userMessage dedup does not shadow the tool-emitting leg — mirrors the passing mastra/pydantic-ai ordering.",
       "match": {
         "userMessage": "intro call with the sales team",
         "toolName": "schedule_meeting",
@@ -53,7 +31,18 @@
       }
     },
     {
-      "_comment": "gen-ui-interrupt alice-1on1 pill — first leg: schedule_meeting tool call.",
+      "_comment": "gen-ui-interrupt sales-call pill — second leg: confirmation after user picks a slot and resolve fires. Keyed by toolCallId so it only matches when the prior tool result is being fed back (last message is the tool result for this call).",
+      "match": {
+        "userMessage": "intro call with the sales team",
+        "toolCallId": "call_d5_schedule_sales_001",
+        "context": "langgraph-python"
+      },
+      "response": {
+        "content": "Booked: Sales intro call confirmed for the slot you picked."
+      }
+    },
+    {
+      "_comment": "gen-ui-interrupt alice-1on1 pill — first leg: schedule_meeting tool call. Placed BEFORE the toolCallId resume-leg so the tool-emitting leg is not shadowed.",
       "match": {
         "userMessage": "1:1 with Alice",
         "toolName": "schedule_meeting",
@@ -75,6 +64,17 @@
             }
           }
         ]
+      }
+    },
+    {
+      "_comment": "gen-ui-interrupt alice-1on1 pill — second leg: confirmation after user picks a slot. Keyed by toolCallId so it only matches when the prior tool result is being fed back.",
+      "match": {
+        "userMessage": "1:1 with Alice",
+        "toolCallId": "call_d5_schedule_alice_001",
+        "context": "langgraph-python"
+      },
+      "response": {
+        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
       }
     }
   ]

--- a/showcase/aimock/d6/langgraph-typescript/gen-ui-interrupt.json
+++ b/showcase/aimock/d6/langgraph-typescript/gen-ui-interrupt.json
@@ -7,36 +7,14 @@
   },
   "fixtures": [
     {
-      "_comment": "gen-ui-interrupt sales-call pill \u2014 second leg: confirmation after user picks a slot and resolve fires. Keyed by toolCallId so it only matches when the prior tool result is being fed back. Placed BEFORE first-leg so toolCallId matching takes precedence over toolName matching.",
-      "match": {
-        "userMessage": "intro call with the sales team",
-        "toolCallId": "call_d5_schedule_sales_001",
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "Booked: Sales intro call confirmed for the slot you picked."
-      }
-    },
-    {
-      "_comment": "gen-ui-interrupt alice-1on1 pill \u2014 second leg: confirmation after user picks a slot. Placed BEFORE first-leg so toolCallId matching takes precedence.",
-      "match": {
-        "userMessage": "1:1 with Alice",
-        "toolCallId": "call_d5_schedule_alice_001",
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
-      }
-    },
-    {
-      "_comment": "gen-ui-interrupt sales-call pill \u2014 first leg: schedule_meeting tool call triggers Python agent's interrupt(...). The toolName gate ensures this matches only when schedule_meeting is in the tool list (the agent must declare it).",
+      "_comment": "gen-ui-interrupt sales-call pill — first leg: schedule_meeting tool call triggers the agent's interrupt(...). The toolName gate ensures this matches only when schedule_meeting is in the tool list (the agent must declare it). Placed BEFORE the toolCallId resume-leg so the duplicate-userMessage dedup does not shadow the tool-emitting leg — mirrors the passing mastra/pydantic-ai ordering.",
       "match": {
         "userMessage": "intro call with the sales team",
         "toolName": "schedule_meeting",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Sure \u2014 let me check available times.",
+        "content": "Sure — let me check available times.",
         "toolCalls": [
           {
             "id": "call_d5_schedule_sales_001",
@@ -60,20 +38,31 @@
       }
     },
     {
-      "_comment": "gen-ui-interrupt alice-1on1 pill \u2014 first leg: schedule_meeting tool call.",
+      "_comment": "gen-ui-interrupt sales-call pill — second leg: confirmation after user picks a slot and resolve fires. Keyed by toolCallId so it only matches when the prior tool result is being fed back (last message is the tool result for this call).",
+      "match": {
+        "userMessage": "intro call with the sales team",
+        "toolCallId": "call_d5_schedule_sales_001",
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "content": "Booked: Sales intro call confirmed for the slot you picked."
+      }
+    },
+    {
+      "_comment": "gen-ui-interrupt alice-1on1 pill — first leg: schedule_meeting tool call. Placed BEFORE the toolCallId resume-leg so the tool-emitting leg is not shadowed.",
       "match": {
         "userMessage": "1:1 with Alice",
         "toolName": "schedule_meeting",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Got it \u2014 pulling up next-week slots.",
+        "content": "Got it — pulling up next-week slots.",
         "toolCalls": [
           {
             "id": "call_d5_schedule_alice_001",
             "name": "schedule_meeting",
             "arguments": {
-              "topic": "1:1 with Alice \u2014 Q2 goals",
+              "topic": "1:1 with Alice — Q2 goals",
               "attendee": "Alice",
               "slots": [
                 {
@@ -88,6 +77,17 @@
             }
           }
         ]
+      }
+    },
+    {
+      "_comment": "gen-ui-interrupt alice-1on1 pill — second leg: confirmation after user picks a slot. Keyed by toolCallId so it only matches when the prior tool result is being fed back.",
+      "match": {
+        "userMessage": "1:1 with Alice",
+        "toolCallId": "call_d5_schedule_alice_001",
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
       }
     }
   ]


### PR DESCRIPTION
## Summary

Fixes the lone remaining LGP D6 red — `gen-ui-interrupt` — at its real root cause: a d6 aimock fixture ordering bug (NOT an `@copilotkit` version issue; a prior investigation confirmed 1.59.3 does not fix it).

The `gen-ui-interrupt` d6 probe drives two interrupt turns in one thread (sales-call, then alice-1on1). Each turn is a 2-leg interrupt→resume cycle. In the **langgraph-python** and **langgraph-typescript** d6 fixtures, each pill's `toolCallId` resume-leg was placed BEFORE its `toolName:schedule_meeting` first-leg.

aimock's fixture loader dedups on `userMessage` (first-match-wins on duplicate `userMessage` — `matchFixture` in `router.js` returns the first matching fixture by array order). With the resume-leg first, the text-only resume-leg **shadowed** the tool-emitting first-leg on turn-2 (`duplicate userMessage … shadows fixture`). The agent then emitted a plain text reply with no `schedule_meeting` tool call, the interrupt never fired, and the `time-picker-card` never mounted → turn-2 timed out.

The passing integrations (mastra, pydantic-ai) order the `toolName` first-leg FIRST. This PR mirrors that ordering for langgraph-python and langgraph-typescript. The resume-leg still only matches when the last message is its tool result (the `toolCallId` guard requires `last.role === "tool"`), so the booked/scheduled confirmation continues to work.

No other integrations' fixtures touched. No `@copilotkit` version changes.

## Local red→green proof (apples-to-apples)

Verified against a locally-built `showcase-langgraph-python` container + real `e2e_d6` driver, with the fixture served via the aimock d6 volume mount (isolated compose stack):

- **BUGGY ordering (toolCallId-leg first):** `feature-complete {"featureType":"gen-ui-interrupt","pass":false,"errorDesc":"gen-ui-interrupt-alice-1on1: expected [data-testid=\"time-picker-card\"] to mount within 60000ms"}` — turn-1 (sales-call) passes, turn-2 (alice-1on1) fails. Failed on retry too (not a flake).
- **FIXED ordering (toolName-leg first):** `feature-complete {"featureType":"gen-ui-interrupt","pass":true,"durationMs":25464}` — both turns mount the time-picker-card and resume.

## Test plan

- [x] gen-ui-interrupt d6 pill passes locally with the fixed fixture (turn-2 mounts time-picker-card)
- [x] Confirmed RED with the original ordering on the same stack (causal proof)
- [x] Both fixtures valid JSON; langgraph-typescript mirrors langgraph-python
- [ ] CI green