### PR TITLE
fix(showcase/harness): --rebuild forces recreate + includes infra profile

### DIFF
--- a/showcase/harness/src/cli/lifecycle.test.ts
+++ b/showcase/harness/src/cli/lifecycle.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — vi.hoisted() runs before vi.mock factories so the spies
+// are available inside the factory closures. We capture every
+// `docker compose ...` invocation by recording execFileSync calls.
+// ---------------------------------------------------------------------------
+const { execFileSyncMock, execSyncMock, existsSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+  execSyncMock: vi.fn(),
+  existsSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+  execSync: (...args: unknown[]) => execSyncMock(...args),
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:fs", () => {
+  // stageSharedModules() short-circuits when INTEGRATIONS_DIR is absent.
+  const api = {
+    existsSync: (...args: unknown[]) => existsSyncMock(...args),
+    readdirSync: vi.fn(() => []),
+    readFileSync: vi.fn(() => "{}"),
+  };
+  return { default: api, ...api };
+});
+
+import { rebuild } from "./lifecycle.js";
+
+/** Pull out the compose argv (after the `-f <file>` prefix) for each call. */
+function composeCalls(): string[][] {
+  return execFileSyncMock.mock.calls
+    .filter((c) => c[0] === "docker")
+    .map((c) => c[1] as string[])
+    .filter((argv) => argv[0] === "compose")
+    .map((argv) => argv.slice(3)); // drop ["compose", "-f", "<file>"]
+}
+
+beforeEach(() => {
+  execFileSyncMock.mockReset();
+  execSyncMock.mockReset();
+  existsSyncMock.mockReset();
+  // No integrations dir → stageSharedModules() is a no-op.
+  existsSyncMock.mockReturnValue(false);
+  // Default: compose returns empty string.
+  execFileSyncMock.mockReturnValue("");
+});
+
+describe("rebuild() — targeted slugs", () => {
+  it("includes the infra profile in the build invocation so aimock resolves", async () => {
+    await rebuild(["langgraph-python"]);
+
+    const buildCall = composeCalls().find((argv) => argv.includes("build"));
+    expect(buildCall).toBeDefined();
+    // infra profile must be present alongside the slug profile
+    expect(buildCall).toContain("--profile");
+    expect(buildCall).toContain("infra");
+    expect(buildCall).toContain("langgraph-python");
+    // sanity: --profile infra appears before build
+    const infraIdx = buildCall!.indexOf("infra");
+    const buildIdx = buildCall!.indexOf("build");
+    expect(infraIdx).toBeLessThan(buildIdx);
+  });
+
+  it("force-recreates the targeted service so a stale container is replaced", async () => {
+    await rebuild(["langgraph-python"]);
+
+    const recreateCall = composeCalls().find(
+      (argv) => argv.includes("up") && argv.includes("--force-recreate"),
+    );
+    expect(recreateCall).toBeDefined();
+    expect(recreateCall).toContain("infra"); // infra profile included here too
+    expect(recreateCall).toContain("langgraph-python");
+    expect(recreateCall).toContain("-d");
+  });
+
+  it("recreates EVERY targeted slug regardless of prior running state", async () => {
+    // isRunning is no longer consulted for the targeted path — force-recreate
+    // is unconditional. Verify both slugs get rebuilt + recreated.
+    await rebuild(["a", "b"]);
+
+    const buildCall = composeCalls().find((argv) => argv.includes("build"));
+    expect(buildCall).toContain("a");
+    expect(buildCall).toContain("b");
+
+    const recreateCall = composeCalls().find((argv) =>
+      argv.includes("--force-recreate"),
+    );
+    expect(recreateCall).toContain("a");
+    expect(recreateCall).toContain("b");
+  });
+});

--- a/showcase/harness/src/cli/lifecycle.ts
+++ b/showcase/harness/src/cli/lifecycle.ts
@@ -318,8 +318,15 @@ export async function down(
 /**
  * Rebuild Docker images, optionally for specific services.
  *
- * Stages shared modules first, builds images, then restarts any services
- * that were running before the rebuild.
+ * Stages shared modules first, builds images, then force-recreates the
+ * targeted services so a stale running container is always replaced with
+ * the freshly-built image (a rebuild that left the old container running
+ * was a silent no-op — see the 36h-stale-image false-positive).
+ *
+ * The `infra` profile is always included alongside the targeted slugs so
+ * compose can resolve infra `depends_on` deps (e.g. `aimock`). Without it,
+ * `docker compose --profile <slug> build <slug>` fails with
+ * "service <slug> depends on undefined service aimock".
  */
 export async function rebuild(
   slugs: string[],
@@ -327,36 +334,46 @@ export async function rebuild(
 ): Promise<void> {
   try {
     stageSharedModules();
-    // When no specific slugs, check ALL running services for restart
-    const servicesToCheck = slugs.length > 0 ? slugs : listRunningServices();
-    const runningBefore: string[] = [];
-    if (slugs.length > 0) {
-      for (const slug of servicesToCheck) {
-        if (await isRunning(slug)) {
-          runningBefore.push(slug);
-        }
-      }
-    } else {
-      runningBefore.push(...servicesToCheck);
-    }
 
     log.info("rebuilding images", {
       slugs: slugs.length ? slugs : ["all"],
     });
 
     if (slugs.length > 0) {
-      const profileArgs = slugs.flatMap((s) => ["--profile", s]);
+      // Always include the infra profile so infra `depends_on` deps
+      // (aimock, pocketbase, dashboard) are defined for the targeted slugs.
+      const profileArgs = ["--profile", "infra"];
+      for (const slug of slugs) {
+        profileArgs.push("--profile", slug);
+      }
       compose(...profileArgs, "build", ...slugs);
-    } else {
-      compose("--profile", "all", "build");
-    }
 
-    if (runningBefore.length > 0) {
-      log.info("restarting previously-running services", {
-        services: runningBefore,
+      // Force-recreate the targeted containers so the freshly-built image
+      // is actually adopted even if they were already running. `up -d`
+      // without --force-recreate would leave a stale container in place.
+      log.info("recreating services with freshly-built images", {
+        services: slugs,
       });
-      const restartProfiles = runningBefore.flatMap((s) => ["--profile", s]);
-      compose(...restartProfiles, "up", "-d", ...runningBefore);
+      compose(...profileArgs, "up", "-d", "--force-recreate", ...slugs);
+    } else {
+      // No specific slugs: rebuild everything, then recreate whatever was
+      // running before so we don't spin up services that were down.
+      const runningBefore = listRunningServices();
+      compose("--profile", "all", "build");
+
+      if (runningBefore.length > 0) {
+        log.info("recreating previously-running services", {
+          services: runningBefore,
+        });
+        const restartProfiles = runningBefore.flatMap((s) => ["--profile", s]);
+        compose(
+          ...restartProfiles,
+          "up",
+          "-d",
+          "--force-recreate",
+          ...runningBefore,
+        );
+      }
     }
   } finally {
     restoreSymlinks();

--- a/showcase/harness/src/cli/runner.ts
+++ b/showcase/harness/src/cli/runner.ts
@@ -28,7 +28,7 @@ import {
   buildFullInputs,
 } from "./targets.js";
 
-import { up, down, rebuild, isRunning } from "./lifecycle.js";
+import { up, down, rebuild, isRunning, healthCheck } from "./lifecycle.js";
 
 import {
   printResult,
@@ -177,16 +177,23 @@ export async function run(
   };
   process.on("SIGINT", onSigint);
 
-  // -- 4. Start missing services (with optional rebuild) --------------------
+  // -- 4. Rebuild targeted services if requested ----------------------------
+  // --rebuild must force a rebuild + recreate of EVERY targeted service,
+  // including ones that are already running — otherwise a stale container
+  // is silently reused (the 36h-stale-image false-positive). rebuild()
+  // builds the fresh image and force-recreates the container, and includes
+  // the infra profile so `aimock` (and friends) resolve.
+  if (options.rebuild && slugs.length > 0) {
+    console.log(`\n  \x1b[36mRebuilding services:\x1b[0m ${slugs.join(", ")}`);
+    logger.info("cli.runner.rebuilding", { slugs });
+    await rebuild(slugs);
+  }
+
+  // -- 5. Start missing services -------------------------------------------
   if (autoStarted.length > 0) {
     console.log(
       `\n  \x1b[36mStarting services:\x1b[0m ${autoStarted.join(", ")}`,
     );
-
-    if (options.rebuild) {
-      logger.info("cli.runner.rebuilding", { slugs: autoStarted });
-      await rebuild(autoStarted);
-    }
 
     await up(autoStarted);
 
@@ -194,7 +201,28 @@ export async function run(
     console.log("  \x1b[32mAll services healthy\x1b[0m\n");
   }
 
-  // -- 5. Build ProbeContext ------------------------------------------------
+  // -- 6. Health-check rebuilt-but-already-running services -----------------
+  // up() above only health-checks services it started. A service that was
+  // already running and got force-recreated by rebuild() is healthy-pending
+  // — verify it before probing so a broken rebuild fails loud here rather
+  // than mid-probe.
+  if (options.rebuild) {
+    const recreatedRunning = slugs.filter((s) => !autoStarted.includes(s));
+    if (recreatedRunning.length > 0) {
+      const results = await healthCheck(recreatedRunning);
+      const unhealthy = [...results.entries()]
+        .filter(([, ok]) => !ok)
+        .map(([name]) => name);
+      if (unhealthy.length > 0) {
+        throw new Error(
+          `Health check failed after rebuild for: ${unhealthy.join(", ")}. Check logs with: showcase logs <slug>`,
+        );
+      }
+      console.log("  \x1b[32mRebuilt services healthy\x1b[0m\n");
+    }
+  }
+
+  // -- 7. Build ProbeContext ------------------------------------------------
   const pbConfig = options.live ? resolvePbConfig(config) : null;
   const pbWriter = pbConfig ? createPbWriter(pbConfig, logger) : null;
 


### PR DESCRIPTION
## Summary

`bin/showcase test --rebuild` was broken in two ways depending on container state — it either silently did nothing or errored out. This cost multiple agents hours of manual workarounds.

### Root causes (both confirmed at file:line)

1. **Silent no-op when service already running** — `runner.run()` (showcase/harness/src/cli/runner.ts) only called `rebuild()` on services in `autoStarted` (those NOT already running). When the target was already up, `autoStarted` was empty and the whole rebuild block was skipped, so a stale running container was never replaced (the 36h-stale-image false-positive).
2. **"undefined service aimock" when service down** — `lifecycle.rebuild([slug])` (showcase/harness/src/cli/lifecycle.ts) ran `docker compose --profile <slug> build <slug>` WITHOUT `--profile infra`, so the infra `depends_on` dep `aimock` was undefined → `service <slug> depends on undefined service aimock: invalid compose project`.

### Fixes

- **runner.ts** — `--rebuild` now rebuilds **every targeted slug** regardless of running state, and health-checks rebuilt-but-already-running services before probing (down services are still health-checked by `up()`).
- **lifecycle.ts** — `rebuild()` includes `--profile infra` alongside the slug profiles (mirroring `up()`), and `up -d --force-recreate`s the targeted containers so the freshly-built image is actually adopted even if the container was already running.

The `rebuild` standalone CLI command benefits from the lifecycle fix too.

## Test plan

- [x] New red-green unit test `lifecycle.test.ts` — asserts the rebuild compose invocation includes `--profile infra` and `--force-recreate` (verified RED against original code: all 3 fail; GREEN with fix).
- [x] `tsc --noEmit` clean.
- [x] Full harness suite: 1768 passed; 1 pre-existing unrelated failure (`probe-loader.test.ts` `starter_smoke.yml`) — confirmed failing identically on clean origin/main with these files stashed.
- [ ] Real local Docker `bin/showcase test <slug> --d6 --rebuild` smoke NOT run (heavy multi-minute integration-image builds + live stack). Argument-assembly is the load-bearing logic and is unit-covered; the compose commands reuse the exact patterns already proven in `up()`/`recreate()`.