### PR TITLE
fix(showcase/harness): prevent browser-pool PID-ceiling wedge — cap contexts + pids gauge + unrecoverable alarm

### DIFF
--- a/showcase/harness/Dockerfile
+++ b/showcase/harness/Dockerfile
@@ -151,35 +151,44 @@ EXPOSE 8080
 # serve" to its supervisor.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD node -e "require('http').get('http://127.0.0.1:8080/health',r=>process.exit(r.statusCode>=200&&r.statusCode<300?0:1)).on('error',()=>process.exit(1))" || exit 1
-# FIX #3 — raise the container PID/thread (nproc) soft ulimit before exec'ing
-# the orchestrator. THE OUTAGE: the harness runs a long-lived chromium pool —
-# at MAX_CONTEXTS=40 the legitimate workload spawns ~3.6GB / several hundred
-# OS threads (each headless chromium ~50+ PIDs, plus per-context renderer
-# threads). When kernel thread/PID demand approached the container's nproc
-# ceiling, `chromium.launch()` (and mid-life context opens) tripped
-# `pthread_create: Resource temporarily unavailable (errno 11)`, the browser
-# set drained, and the pool wedged. MAX_CONTEXTS stays 40 — verified safe on
-# the 24GB box at ~3.6GB RSS; the constraint was THREADS, not memory — so the
-# durable fix is to give the legitimate 40-context workload ample thread
-# headroom instead of running near the default ~1024 soft ceiling.
+# FIX #3 — raise the process nproc SOFT rlimit before exec'ing the orchestrator.
+# THE OUTAGE (PROVEN root cause): the harness runs a long-lived chromium pool;
+# under a d6 launch storm the cgroup PID/thread ceiling is exhausted —
+# `chromium.launch()` throws `pthread_create: Resource temporarily unavailable
+# (errno 11)` → "Target page, context or browser has been closed" → permanent
+# crash-loop, with `pids.current` pegged at the cgroup `pids.max` ceiling.
 #
-# We raise the SOFT nproc limit to the HARD limit ("ulimit -u $(ulimit -Hu)")
-# so the process gets the full headroom the kernel/cgroup already permits
-# without hard-coding a value the container may not be allowed to exceed. On
-# Railway the service additionally sets a generous pids cgroup limit (target:
-# 16384 — ~40x the steady-state thread count, leaving headroom for launch
-# bursts + recovery relaunches); the in-image `ulimit -u` ensures the soft
-# limit is lifted to that hard ceiling regardless of the inherited default.
+# CRUCIAL CORRECTION — this `ulimit -u` does NOT and CANNOT fix that ceiling:
+#   * `ulimit -u` only lifts THIS PROCESS's RLIMIT_NPROC (the per-process soft
+#     rlimit). It is unrelated to — and cannot raise — the cgroup `pids.max`,
+#     which is the actual control that wedges the pool.
+#   * The cgroup `pids.max` is set by the CONTAINER RUNTIME (e.g. Railway via
+#     `--pids-limit`), NOT from inside the image. On staging it is
+#     platform-fixed at `pids.max=1000` and is NOT raisable from this Dockerfile.
+#     (The earlier "16384 pids cgroup" claim was ASPIRATIONAL and never applied.)
+#   * cgroup counts THREADS, not just processes — and each chromium renderer
+#     carries ~15 threads, so PID/thread demand is the binding constraint.
+#
+# Because the ceiling is platform-fixed and demand-side, the REAL mitigation
+# lives in the application, not here:
+#   1. reduce thread demand — BROWSER_POOL_MAX_CONTEXTS default lowered 40 → 24
+#      (fewer concurrent contexts → fewer renderer threads → peak `pids.current`
+#      stays well under 1000), and
+#   2. resource-gauge early-warning logging (`pids.current`/`pids.max` + thread
+#      count on every launch / self-heal failure / probe tick) plus the
+#      circuit-breaker give-up + `pool-unrecoverable` alarm as the agnostic
+#      backstop that signals "redeploy required" when the ceiling does not relax.
+#
+# We KEEP the `ulimit -u $(ulimit -Hu)` line — it is HARMLESS (it lifts the soft
+# rlimit to the inherited hard rlimit) and removes the per-process rlimit as a
+# confound — but it must NOT be mistaken for a fix to the cgroup ceiling.
 # `exec` replaces the shell so node remains PID 1 (correct signal handling /
 # Railway shutdown). The fallback `|| true` keeps boot resilient if the runtime
-# forbids raising the soft limit (it is then governed solely by the cgroup
-# pids limit, which is still the dominant control).
+# forbids raising the soft limit.
 #
 # MUST run under bash, NOT the default `/bin/sh`. On this image (node:22-
 # bookworm-slim) `/bin/sh` is dash, whose builtin `ulimit` does NOT support the
 # `-u` (max-user-processes / nproc) flag — it errors `ulimit: Illegal option -u`,
-# which the `2>/dev/null || true` then SILENTLY swallows. The intended PID
-# protection therefore never applied. bash IS present (/usr/bin/bash) and its
-# `ulimit -u` works: verified under `--ulimit nproc=512:4096` the soft limit is
-# raised 512 → 4096 (the hard ceiling) under bash, while dash leaves it untouched.
+# which the `2>/dev/null || true` then SILENTLY swallows. bash IS present
+# (/usr/bin/bash) and its `ulimit -u` works.
 CMD ["/bin/bash", "-c", "ulimit -u $(ulimit -Hu) 2>/dev/null || true; exec node dist/orchestrator.js"]

--- a/showcase/harness/config/probes/d6-all-pills-e2e.yml
+++ b/showcase/harness/config/probes/d6-all-pills-e2e.yml
@@ -19,18 +19,20 @@
 # fan-out runs ~200s per service under CPU contention.
 #
 # -- timeout_ms: 1_200_000 (20 min) --
-# -- max_concurrency: 8 --
+# -- max_concurrency: 5 --
 #
 # Fleet sizing: discovery now enumerates ~18 showcase demo services (NOT the
 # legacy "8 services x 4 features" assumption this header carried before).
-# With max_concurrency: 8, the fan-out runs in ceil(18/8) = 3 serialized
-# rounds. Rounds 2 and 3 start late and execute under CPU contention, so each
+# With max_concurrency: 5, the fan-out runs in ceil(18/5) = 4 serialized
+# rounds. Later rounds start late and execute under CPU contention, so each
 # service's wall-clock stretches toward ~200s. The previous 600_000 (10 min)
 # outer cap was sized for a single round; under multiple rounds the late
 # rounds blew the per-service budget and ALL 18 services went red with
 # `driver timeout after 600000ms`. The corrected 1_200_000 (20 min) cap fits
 # 4 rounds x ~200s with comfortable headroom and matches the sibling
-# 18-service `e2e-demos` probe (same fleet, same 20-min budget).
+# 18-service `e2e-demos` probe (same fleet, same 20-min budget). The
+# concurrency itself (5, lowered from 8) is justified in the OVERLAP block
+# below — the round count here is just the budget-sizing consequence.
 #
 # -- Concurrency LOWERED 8 -> 5: cgroup pids.max=1000 ceiling, OVERLAP case --
 #

--- a/showcase/harness/config/probes/d6-all-pills-e2e.yml
+++ b/showcase/harness/config/probes/d6-all-pills-e2e.yml
@@ -26,23 +26,31 @@
 # With max_concurrency: 8, the fan-out runs in ceil(18/8) = 3 serialized
 # rounds. Rounds 2 and 3 start late and execute under CPU contention, so each
 # service's wall-clock stretches toward ~200s. The previous 600_000 (10 min)
-# outer cap was sized for a single 8-service round; under 3 rounds the late
+# outer cap was sized for a single round; under multiple rounds the late
 # rounds blew the per-service budget and ALL 18 services went red with
 # `driver timeout after 600000ms`. The corrected 1_200_000 (20 min) cap fits
-# 3 rounds x ~200s with comfortable headroom and matches the sibling
+# 4 rounds x ~200s with comfortable headroom and matches the sibling
 # 18-service `e2e-demos` probe (same fleet, same 20-min budget).
 #
-# Concurrency is deliberately held at 8, NOT raised: 8 services x 4 features =
-# 32 concurrent contexts, drawn from 3 chromium processes. The global context
-# cap is BROWSER_POOL_MAX_CONTEXTS=40 (D6 peak 32 + D5 peak 8); raising
-# max_concurrency would push past the 40-cap. Contexts (not processes) are the
-# scaling knob since the PID ceiling of 1000 is the binding constraint. This
-# is a timeout-only fix — peak contexts stay at 32.
+# -- Concurrency LOWERED 8 -> 5: cgroup pids.max=1000 ceiling, OVERLAP case --
+#
+# The PROVEN wedge is OS thread/PID exhaustion against the container cgroup
+# `pids.max=1000` ceiling: each concurrent feature-worker drives a chromium
+# renderer (~15 threads), and the live wedge peaked 998/1000 specifically
+# during a d6+d5 OVERLAP — the simultaneous renderers of BOTH probes summed
+# past the ceiling → pthread_create EAGAIN → "Target page ... has been closed"
+# → crash-loop. Fewer concurrent d6 feature-workers cut the simultaneous-
+# renderer thread peak, leaving headroom for a co-firing d5 (or a recovery
+# relaunch) without crossing 1000. This is the complementary lever to
+# BROWSER_POOL_MAX_CONTEXTS (already lowered 40 -> 24): max_concurrency caps
+# the d6 fan-out width (the overlap-peak driver), the context cap bounds the
+# global context/renderer count. 5 services x 4 features = 20 concurrent
+# contexts, comfortably under the 24-context global cap with overlap room.
 kind: e2e_d6
 id: d6-all-pills-e2e
 schedule: "40 * * * *"
 timeout_ms: 1200000
-max_concurrency: 8
+max_concurrency: 5
 discovery:
   source: railway-services
   filter:

--- a/showcase/harness/config/probes/e2e-deep.yml
+++ b/showcase/harness/config/probes/e2e-deep.yml
@@ -63,7 +63,10 @@
 # 4 services (max_concurrency) × FEATURE_CONCURRENCY(2) features per
 # service = up to 8 concurrent chromium contexts. Those contexts are drawn
 # from the 3 shared chromium processes (BROWSER_POOL_BROWSERS=3) under the
-# global BROWSER_POOL_MAX_CONTEXTS=40 cap (D6 peak 32 + this D5 peak 8).
+# global BROWSER_POOL_MAX_CONTEXTS=24 cap (D6 peak now 5×4=20 + this D5 peak
+# 8 = 28 > 24, so a d6+d5 OVERLAP serializes against the global cap — that
+# back-pressure is intended: it is the demand-side lever that keeps the
+# simultaneous-renderer count off the cgroup pids.max=1000 ceiling).
 # Each context resident-set is ~300MB; 8 parallel ≈ 2.4GB peak. Production
 # memory headroom on the orchestrator's Railway footprint has been measured
 # and can sustain this — the binding constraint is the PID ceiling of 1000,

--- a/showcase/harness/src/orchestrator-browser-pool-env.test.ts
+++ b/showcase/harness/src/orchestrator-browser-pool-env.test.ts
@@ -115,16 +115,18 @@ describe("orchestrator BrowserPool env construction (NaN footgun regression)", (
     await pool.shutdown();
   });
 
-  it("an unset BROWSER_POOL_MAX_CONTEXTS yields the default cap of 40", async () => {
+  it("an unset BROWSER_POOL_MAX_CONTEXTS yields the default cap of 24", async () => {
     delete process.env.BROWSER_POOL_MAX_CONTEXTS;
 
     const { launch } = makeCountingLauncher();
     const pool = new BrowserPool({ launchBrowser: launch, launchStaggerMs: 0 });
     await pool.init();
 
-    // `stats().size` exposes the resolved maxContexts. Default covers D6 peak
-    // 32 + D5 peak 8 so the two probe families never contend at the cap.
-    expect(pool.stats().size).toBe(40);
+    // `stats().size` exposes the resolved maxContexts. LOWERED from 40 to 24 to
+    // cap THREAD demand under the platform-fixed cgroup pids.max=1000 ceiling
+    // (the proven browser-pool wedge): fewer concurrent contexts → fewer
+    // chromium renderer threads → peak pids.current stays well under the ceiling.
+    expect(pool.stats().size).toBe(24);
     await pool.shutdown();
   });
 

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -1047,6 +1047,59 @@ describe("orchestrator.createBrowserPoolHealthSignals — writeUnrecoverable (te
     );
     expect(writes.some((w) => w.key === BROWSER_POOL_DEGRADED_KEY)).toBe(true);
   });
+
+  it("a HUNG Slack webhook is ABORTED at the timeout so the serialized health-signal chain is not stalled", async () => {
+    // A hung webhook fetch must not stall the SERIALIZED degraded↔healthy↔
+    // unrecoverable write chain indefinitely: the ping is aborted at
+    // BROWSER_POOL_SLACK_TIMEOUT_MS, logged best-effort, and the write resolves.
+    vi.useFakeTimers();
+    try {
+      const { writes, logs, writer, statusReader, testLogger } = makeHarness();
+      // fetch hangs until its AbortSignal fires, then rejects like a real abort.
+      const fetchImpl = vi.fn(
+        (_url: string, init: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () =>
+              reject(
+                Object.assign(new Error("The operation was aborted"), {
+                  name: "AbortError",
+                }),
+              ),
+            );
+          }),
+      );
+      const { writeUnrecoverable } = createBrowserPoolHealthSignals({
+        writer,
+        statusReader,
+        logger: testLogger,
+        env: { [BROWSER_POOL_ALERT_WEBHOOK_ENV]: "https://hooks.example/abc" },
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      const done = writeUnrecoverable(counters);
+      // Advance past the Slack timeout — the abort fires and the ping rejects.
+      await vi.advanceTimersByTimeAsync(5_000);
+      // The chain resolves (not stalled) within the bound.
+      await expect(done).resolves.toBeUndefined();
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      // The hung ping was aborted + logged best-effort.
+      expect(
+        logs.some(
+          (l) => l.msg === "boot.browser-pool-unrecoverable-slack-failed",
+        ),
+      ).toBe(true);
+      // The (unconditional) health-signal writes still landed.
+      expect(writes.some((w) => w.key === BROWSER_POOL_UNRECOVERABLE_KEY)).toBe(
+        true,
+      );
+      expect(writes.some((w) => w.key === BROWSER_POOL_DEGRADED_KEY)).toBe(
+        true,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 /**

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -9,6 +9,8 @@ import {
   createStatusReader,
   createBrowserPoolHealthSignals,
   BROWSER_POOL_DEGRADED_KEY,
+  BROWSER_POOL_UNRECOVERABLE_KEY,
+  BROWSER_POOL_ALERT_WEBHOOK_ENV,
   diffCronSchedules,
   envForCfg,
   createRailwayAdapter,
@@ -840,6 +842,146 @@ describe("orchestrator.createBrowserPoolHealthSignals (CR-FIX #6)", () => {
         (c) => c[0].key === BROWSER_POOL_DEGRADED_KEY,
       ),
     ).toBe(true);
+  });
+});
+
+/**
+ * Headline-fix coverage: `writeUnrecoverable` is the production wiring for the
+ * self-heal circuit-breaker's TERMINAL give-up. The breaker mechanism existed in
+ * the PR but the alarm was a production NO-OP (the pool's onUnrecoverable hook
+ * was never wired). These tests pin: (1) an UNCONDITIONAL distinct terminal
+ * health-signal write (+ escalation of the shared degraded key to
+ * critical/terminal) so a give-up is distinguishable from a transient degraded,
+ * and (2) a BEST-EFFORT, env-GUARDED Slack ping that is SKIPPED when the webhook
+ * URL is unset (alerting discipline) yet never blocks the health-signal write.
+ */
+describe("orchestrator.createBrowserPoolHealthSignals — writeUnrecoverable (terminal alarm)", () => {
+  interface KeyedWrite {
+    key: string;
+    state: State;
+    signal: Record<string, unknown>;
+    observedAt: string;
+  }
+  function makeHarness() {
+    const writes: KeyedWrite[] = [];
+    const logs: Array<{
+      level: string;
+      msg: string;
+      meta?: Record<string, unknown>;
+    }> = [];
+    const writer = {
+      write: vi.fn(async (result: KeyedWrite) => {
+        writes.push(result);
+        return {};
+      }),
+    };
+    const statusReader = {
+      getStateByKey: vi.fn(async (): Promise<State | null> => null),
+    };
+    const testLogger = {
+      warn: (msg: string, meta?: Record<string, unknown>) =>
+        logs.push({ level: "warn", msg, meta }),
+      error: (msg: string, meta?: Record<string, unknown>) =>
+        logs.push({ level: "error", msg, meta }),
+      info: (msg: string, meta?: Record<string, unknown>) =>
+        logs.push({ level: "info", msg, meta }),
+    };
+    return { writes, logs, writer, statusReader, testLogger };
+  }
+  const counters = { browserCount: 3, waiters: 7, maxHardRecoveries: 3 };
+
+  it("writes a DISTINCT terminal health signal AND escalates the degraded key to critical/terminal", async () => {
+    const { writes, logs, writer, statusReader, testLogger } = makeHarness();
+    const fetchImpl = vi.fn();
+    const { writeUnrecoverable } = createBrowserPoolHealthSignals({
+      writer,
+      statusReader,
+      logger: testLogger,
+      env: {}, // webhook UNSET
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await writeUnrecoverable(counters);
+
+    // (1a) The distinct terminal key was written, red + terminal + critical +
+    //      redeployRequired, carrying the breaker counters.
+    const terminal = writes.find(
+      (w) => w.key === BROWSER_POOL_UNRECOVERABLE_KEY,
+    );
+    expect(terminal).toBeDefined();
+    expect(terminal!.state).toBe("red");
+    expect(terminal!.signal.terminal).toBe(true);
+    expect(terminal!.signal.severity).toBe("critical");
+    expect(terminal!.signal.redeployRequired).toBe(true);
+    expect(terminal!.signal.browserCount).toBe(3);
+    expect(terminal!.signal.waiters).toBe(7);
+
+    // (1b) The shared degraded key was ALSO escalated so a consumer keying off
+    //      it alone still sees the critical/terminal state.
+    const degraded = writes.find((w) => w.key === BROWSER_POOL_DEGRADED_KEY);
+    expect(degraded).toBeDefined();
+    expect(degraded!.state).toBe("red");
+    expect(degraded!.signal.severity).toBe("critical");
+    expect(degraded!.signal.terminal).toBe(true);
+
+    // (2) Slack was SKIPPED (URL unset) — logged, not attempted.
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(
+      logs.some(
+        (l) => l.msg === "boot.browser-pool-unrecoverable-slack-skipped",
+      ),
+    ).toBe(true);
+  });
+
+  it("posts a best-effort Slack alert when the webhook URL IS set", async () => {
+    const { writes, writer, statusReader, testLogger } = makeHarness();
+    const fetchImpl = vi.fn(async (_url: string, _init: { body: string }) => ({
+      ok: true,
+      status: 200,
+    }));
+    const { writeUnrecoverable } = createBrowserPoolHealthSignals({
+      writer,
+      statusReader,
+      logger: testLogger,
+      env: { [BROWSER_POOL_ALERT_WEBHOOK_ENV]: "https://hooks.example/abc" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await writeUnrecoverable(counters);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe("https://hooks.example/abc");
+    const body = JSON.parse(init.body) as {
+      text: string;
+    };
+    expect(body.text).toContain("UNRECOVERABLE");
+    expect(body.text).toContain("REDEPLOY");
+    // The health-signal writes still happened (Slack is additive).
+    expect(writes.some((w) => w.key === BROWSER_POOL_UNRECOVERABLE_KEY)).toBe(
+      true,
+    );
+  });
+
+  it("a failing Slack post never prevents the (unconditional) health-signal write", async () => {
+    const { writes, writer, statusReader, testLogger } = makeHarness();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    const { writeUnrecoverable } = createBrowserPoolHealthSignals({
+      writer,
+      statusReader,
+      logger: testLogger,
+      env: { [BROWSER_POOL_ALERT_WEBHOOK_ENV]: "https://hooks.example/abc" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(writeUnrecoverable(counters)).resolves.toBeUndefined();
+    // The health signals landed despite the Slack failure.
+    expect(writes.some((w) => w.key === BROWSER_POOL_UNRECOVERABLE_KEY)).toBe(
+      true,
+    );
+    expect(writes.some((w) => w.key === BROWSER_POOL_DEGRADED_KEY)).toBe(true);
   });
 });
 

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -963,6 +963,70 @@ describe("orchestrator.createBrowserPoolHealthSignals — writeUnrecoverable (te
     );
   });
 
+  it("NAMES the cgroup pids signal in the Slack/alarm message when pids are present (>=0)", async () => {
+    // slot-6 F1: when the give-up snapshot measured the cgroup PID ceiling
+    // (cgroupPidsCurrent >= 0), the alarm must NAME it — pids.current/pids.max +
+    // threads — so the operator sees the PROVEN wedge cause, not just the
+    // abstract breaker counters. Off-Linux (-1 sentinel) the clause is omitted.
+    const { writes, writer, statusReader, testLogger } = makeHarness();
+    const fetchImpl = vi.fn(async (_url: string, _init: { body: string }) => ({
+      ok: true,
+      status: 200,
+    }));
+    const { writeUnrecoverable } = createBrowserPoolHealthSignals({
+      writer,
+      statusReader,
+      logger: testLogger,
+      env: { [BROWSER_POOL_ALERT_WEBHOOK_ENV]: "https://hooks.example/abc" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await writeUnrecoverable({
+      ...counters,
+      cgroupPidsCurrent: 998,
+      cgroupPidsMax: 1000,
+      treeThreadCount: 950,
+    });
+
+    const [, init] = fetchImpl.mock.calls[0]!;
+    const body = JSON.parse(init.body) as { text: string };
+    expect(body.text).toContain("pids.current=998/pids.max=1000");
+    expect(body.text).toContain("threads=950");
+    // The headline gauges are also persisted on the terminal health signal.
+    const terminal = writes.find(
+      (w) => w.key === BROWSER_POOL_UNRECOVERABLE_KEY,
+    );
+    expect(terminal!.signal.cgroupPidsCurrent).toBe(998);
+    expect(terminal!.signal.cgroupPidsMax).toBe(1000);
+    expect(terminal!.signal.treeThreadCount).toBe(950);
+  });
+
+  it("OMITS the pids clause when pids are unavailable (-1 sentinel, off-Linux)", async () => {
+    const { writer, statusReader, testLogger } = makeHarness();
+    const fetchImpl = vi.fn(async (_url: string, _init: { body: string }) => ({
+      ok: true,
+      status: 200,
+    }));
+    const { writeUnrecoverable } = createBrowserPoolHealthSignals({
+      writer,
+      statusReader,
+      logger: testLogger,
+      env: { [BROWSER_POOL_ALERT_WEBHOOK_ENV]: "https://hooks.example/abc" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await writeUnrecoverable({
+      ...counters,
+      cgroupPidsCurrent: -1,
+      cgroupPidsMax: -1,
+      treeThreadCount: -1,
+    });
+
+    const [, init] = fetchImpl.mock.calls[0]!;
+    const body = JSON.parse(init.body) as { text: string };
+    expect(body.text).not.toContain("pids.current");
+  });
+
   it("a failing Slack post never prevents the (unconditional) health-signal write", async () => {
     const { writes, writer, statusReader, testLogger } = makeHarness();
     const fetchImpl = vi.fn(async () => {

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -60,6 +60,7 @@ import {
   createPooledE2eFullLauncher,
 } from "./probes/drivers/d6-all-pills.js";
 import { BrowserPool } from "./probes/helpers/browser-pool.js";
+import { createResourceSnapshotWriter } from "./probes/helpers/resource-snapshot-writer.js";
 import { qaDriver } from "./probes/drivers/qa.js";
 import { starterSmokeDriver } from "./probes/drivers/starter-smoke.js";
 import { railwayServicesSource } from "./probes/discovery/railway-services.js";
@@ -319,8 +320,29 @@ export async function boot(opts: BootOptions = {}): Promise<{
     writeUnrecoverable: writeBrowserPoolUnrecoverable,
   } = createBrowserPoolHealthSignals({ writer, statusReader, logger });
 
+  // DURABLE forensic snapshot writer: persists the pool's OS resource gauges to
+  // the `resource_snapshots` PB collection so the history survives the
+  // container RESTART that ends every browser-pool wedge (Railway stdout rolls
+  // off; in-memory is cleared on restart — durable PB is the only
+  // post-wedge-retrievable trail). Reuses the SAME `pb` client the rest of the
+  // harness uses. Writes are best-effort (the writer swallows PB errors so a
+  // missing migration / PB hiccup never breaks the pool) with ring-style
+  // retention to bound growth.
+  const resourceSnapshotWriter = createResourceSnapshotWriter({ pb, logger });
+
   const browserPool = new BrowserPool({
     logger,
+    // DURABLE forensic logging: fire-and-forget the full gauge snapshot to PB on
+    // every meaningful pool condition + the periodic heartbeat. The hook is
+    // synchronous; the write is async + best-effort (never throws back here).
+    onSnapshot: (snapshot) => {
+      void resourceSnapshotWriter.write(
+        snapshot.event,
+        snapshot.gauges,
+        snapshot.stats,
+        snapshot.perBrowser,
+      );
+    },
     // FIX #2 — wire the pool's mid-life capacity-loss + recovery hooks to the
     // SAME degraded-signal write path. When the browser set empties mid-life the
     // pool fires `onDegraded` (red alarm) and self-heals; on a successful

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -316,6 +316,7 @@ export async function boot(opts: BootOptions = {}): Promise<{
   const {
     writeDegraded: writeBrowserPoolDegraded,
     writeHealthy: writeBrowserPoolHealthy,
+    writeUnrecoverable: writeBrowserPoolUnrecoverable,
   } = createBrowserPoolHealthSignals({ writer, statusReader, logger });
 
   const browserPool = new BrowserPool({
@@ -331,6 +332,18 @@ export async function boot(opts: BootOptions = {}): Promise<{
     },
     onRecovered: () => {
       void writeBrowserPoolHealthy();
+    },
+    // FIX (headline) — wire the TERMINAL alarm. When the self-heal
+    // circuit-breaker exhausts every hard recovery and gives up, write a DISTINCT
+    // `system:browser-pool-unrecoverable` health signal (and escalate the shared
+    // degraded key to critical/terminal) so a give-up is distinguishable from a
+    // transient self-heal-degraded, and best-effort ping Slack (guarded on the
+    // SLACK_WEBHOOK_BROWSER_POOL_UNRECOVERABLE env var — unset by default so the
+    // code deploys before the URL is wired). Without this, the breaker's give-up
+    // was a production NO-OP: the mechanism stopped spinning but NO operator was
+    // ever told a redeploy is required.
+    onUnrecoverable: (info) => {
+      void writeBrowserPoolUnrecoverable(info);
     },
   });
   let browserPoolReady = false;
@@ -1037,10 +1050,45 @@ export function registerAllProbeDrivers(
  */
 export const BROWSER_POOL_DEGRADED_KEY = "system:browser-pool-degraded";
 
+/**
+ * Distinct PB status key the TERMINAL (give-up) browser-pool signal is written
+ * under. Kept SEPARATE from `BROWSER_POOL_DEGRADED_KEY` so the dashboard /
+ * alerting can distinguish a TRANSIENT self-heal-degraded (red, expected to
+ * recover on its own) from an UNRECOVERABLE give-up (the breaker exhausted every
+ * hard recovery — a redeploy is genuinely required). The terminal signal also
+ * carries `severity: "critical"` + `terminal: true` so a consumer keying off the
+ * degraded key alone still sees the escalation.
+ */
+export const BROWSER_POOL_UNRECOVERABLE_KEY =
+  "system:browser-pool-unrecoverable";
+
+/**
+ * Env var holding the Slack incoming-webhook URL the TERMINAL browser-pool alarm
+ * posts to. Intentionally UNSET by default (alerting discipline: deploy the code
+ * first, wire the URL separately) — when unset the Slack post is skipped and
+ * only the (unconditional) PB health-signal write fires. A `system:`-prefixed
+ * health key drives the dashboard regardless; the Slack ping is a best-effort
+ * operator nudge on top.
+ */
+export const BROWSER_POOL_ALERT_WEBHOOK_ENV =
+  "SLACK_WEBHOOK_BROWSER_POOL_UNRECOVERABLE";
+
+/** Breaker counters surfaced in the terminal alarm so an operator sees how hard
+ *  the pool tried before giving up. */
+export interface BrowserPoolBreakerCounters {
+  browserCount: number;
+  waiters: number;
+  maxHardRecoveries: number;
+}
+
 interface BrowserPoolHealthSignalsDeps {
   writer: { write(result: ProbeResultLike): Promise<unknown> };
   statusReader: { getStateByKey(key: string): Promise<State | null> };
-  logger: Pick<Logger, "warn">;
+  logger: Pick<Logger, "warn"> & Partial<Pick<Logger, "error" | "info">>;
+  /** Env source (defaults to process.env) — injectable for tests. */
+  env?: Readonly<Record<string, string | undefined>>;
+  /** fetch impl (defaults to globalThis.fetch) — injectable for tests. */
+  fetchImpl?: typeof fetch;
 }
 
 interface ProbeResultLike {
@@ -1078,8 +1126,11 @@ export function createBrowserPoolHealthSignals(
 ): {
   writeDegraded: (reason: string) => Promise<void>;
   writeHealthy: () => Promise<void>;
+  writeUnrecoverable: (counters: BrowserPoolBreakerCounters) => Promise<void>;
 } {
   const { writer, statusReader, logger } = deps;
+  const env = deps.env ?? process.env;
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch;
   // Serialize writes so the persisted state reflects call ORDER under flapping.
   let writeChain: Promise<unknown> = Promise.resolve();
   // Monotonic observedAt: never emit a timestamp <= the previously-emitted one,
@@ -1152,7 +1203,106 @@ export function createBrowserPoolHealthSignals(
       }
     });
 
-  return { writeDegraded, writeHealthy };
+  /**
+   * TERMINAL alarm: the self-heal circuit-breaker exhausted every hard recovery
+   * and gave up. This is the headline operator signal the PR's breaker mechanism
+   * produces — distinct from a transient degraded.
+   *
+   * Two-part, with deliberately ASYMMETRIC guarantees:
+   *  1. The PB health-signal write is UNCONDITIONAL (best-effort, errors logged):
+   *     it writes a DISTINCT `system:browser-pool-unrecoverable` key (red) AND
+   *     escalates the shared degraded key with `severity: "critical"` +
+   *     `terminal: true`, so a give-up is distinguishable from a self-heal
+   *     degraded regardless of which key a consumer watches. Redeploy guidance
+   *     and the breaker counters are embedded so the operator knows what to do.
+   *  2. The Slack ping is BEST-EFFORT and GUARDED on
+   *     `SLACK_WEBHOOK_BROWSER_POOL_UNRECOVERABLE` being set (alerting discipline:
+   *     ship the code with the URL unset; wire the URL separately). When unset we
+   *     skip it loudly-in-logs but never fail the health-signal write.
+   */
+  const writeUnrecoverable = (
+    counters: BrowserPoolBreakerCounters,
+  ): Promise<void> =>
+    enqueue(async () => {
+      const message =
+        "browser pool UNRECOVERABLE — self-heal circuit-breaker gave up after " +
+        `${counters.maxHardRecoveries} hard recoveries; a REDEPLOY is required ` +
+        `(browserCount=${counters.browserCount}, waiters=${counters.waiters})`;
+      const observedAt = nextObservedAt();
+      // (1) UNCONDITIONAL health-signal writes — distinct terminal key + escalate
+      //     the shared degraded key to critical/terminal.
+      try {
+        await writer.write({
+          key: BROWSER_POOL_UNRECOVERABLE_KEY,
+          state: "red",
+          signal: {
+            terminal: true,
+            severity: "critical",
+            errorMessage: message,
+            redeployRequired: true,
+            browserCount: counters.browserCount,
+            waiters: counters.waiters,
+            maxHardRecoveries: counters.maxHardRecoveries,
+            unrecoverableSince: new Date().toISOString(),
+          },
+          observedAt,
+        });
+      } catch (writeErr) {
+        logger.warn("boot.browser-pool-status-write-failed", {
+          key: BROWSER_POOL_UNRECOVERABLE_KEY,
+          error:
+            writeErr instanceof Error ? writeErr.message : String(writeErr),
+        });
+      }
+      try {
+        await writer.write({
+          key: BROWSER_POOL_DEGRADED_KEY,
+          state: "red",
+          signal: {
+            errorMessage: message,
+            severity: "critical",
+            terminal: true,
+            redeployRequired: true,
+            degradedSince: new Date().toISOString(),
+          },
+          observedAt: nextObservedAt(),
+        });
+      } catch (writeErr) {
+        logger.warn("boot.browser-pool-status-write-failed", {
+          key: BROWSER_POOL_DEGRADED_KEY,
+          error:
+            writeErr instanceof Error ? writeErr.message : String(writeErr),
+        });
+      }
+      // (2) BEST-EFFORT, GUARDED Slack ping — only if the webhook URL is set.
+      const webhookUrl = env[BROWSER_POOL_ALERT_WEBHOOK_ENV];
+      if (!webhookUrl) {
+        logger.info?.("boot.browser-pool-unrecoverable-slack-skipped", {
+          reason: "webhook-env-unset",
+          envVar: BROWSER_POOL_ALERT_WEBHOOK_ENV,
+        });
+        return;
+      }
+      try {
+        const res = await fetchImpl(webhookUrl, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ text: `:rotating_light: ${message}` }),
+        });
+        if (!res.ok) {
+          logger.warn("boot.browser-pool-unrecoverable-slack-failed", {
+            status: res.status,
+          });
+        }
+      } catch (slackErr) {
+        logger.warn("boot.browser-pool-unrecoverable-slack-failed", {
+          error:
+            slackErr instanceof Error ? slackErr.message : String(slackErr),
+        });
+      }
+    });
+
+  return { writeDegraded, writeHealthy, writeUnrecoverable };
 }
 
 export function createStatusReader(pb: {

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -1151,6 +1151,14 @@ interface ProbeResultLike {
  * Exported for unit tests so the read-error + flap-ordering invariants can be
  * asserted without the full boot path.
  */
+/**
+ * Abort the best-effort Slack ping after this long. The health-signal writes
+ * are SERIALIZED (writeChain), so a hung webhook fetch would otherwise stall
+ * the whole degraded↔healthy↔unrecoverable write chain indefinitely. The ping
+ * is best-effort, so a timeout just logs and moves on.
+ */
+const BROWSER_POOL_SLACK_TIMEOUT_MS = 5_000;
+
 export function createBrowserPoolHealthSignals(
   deps: BrowserPoolHealthSignalsDeps,
 ): {
@@ -1324,11 +1332,19 @@ export function createBrowserPoolHealthSignals(
         });
         return;
       }
+      // Timeout the ping so a hung webhook can't stall the serialized
+      // health-signal write chain. Best-effort: an abort just logs + returns.
+      const slackAbort = new AbortController();
+      const slackTimer = setTimeout(
+        () => slackAbort.abort(),
+        BROWSER_POOL_SLACK_TIMEOUT_MS,
+      );
       try {
         const res = await fetchImpl(webhookUrl, {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ text: `:rotating_light: ${message}` }),
+          signal: slackAbort.signal,
         });
         if (!res.ok) {
           logger.warn("boot.browser-pool-unrecoverable-slack-failed", {
@@ -1340,6 +1356,8 @@ export function createBrowserPoolHealthSignals(
           error:
             slackErr instanceof Error ? slackErr.message : String(slackErr),
         });
+      } finally {
+        clearTimeout(slackTimer);
       }
     });
 

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -1073,12 +1073,20 @@ export const BROWSER_POOL_UNRECOVERABLE_KEY =
 export const BROWSER_POOL_ALERT_WEBHOOK_ENV =
   "SLACK_WEBHOOK_BROWSER_POOL_UNRECOVERABLE";
 
-/** Breaker counters surfaced in the terminal alarm so an operator sees how hard
- *  the pool tried before giving up. */
+/** Breaker counters + resource gauges surfaced in the terminal alarm so an
+ *  operator sees how hard the pool tried before giving up AND the PROVEN wedge
+ *  signal (the cgroup PID/thread ceiling) that caused it. */
 export interface BrowserPoolBreakerCounters {
   browserCount: number;
   waiters: number;
   maxHardRecoveries: number;
+  /** cgroup `pids.current` at give-up — the measured PID/thread count against
+   *  the ceiling. -1 off-Linux / when the cgroup PID controller is unreadable. */
+  cgroupPidsCurrent?: number;
+  /** cgroup `pids.max` ceiling at give-up (-1 = unbounded / unavailable). */
+  cgroupPidsMax?: number;
+  /** Process-tree thread count at give-up (demand against `pids.max`). */
+  treeThreadCount?: number;
 }
 
 interface BrowserPoolHealthSignalsDeps {
@@ -1224,10 +1232,18 @@ export function createBrowserPoolHealthSignals(
     counters: BrowserPoolBreakerCounters,
   ): Promise<void> =>
     enqueue(async () => {
+      // Name the PROVEN wedge signal (cgroup PID/thread-ceiling exhaustion) in
+      // the alert when it was measured, so the operator sees the real cause
+      // rather than just the abstract breaker counters.
+      const pidsClause =
+        counters.cgroupPidsCurrent !== undefined &&
+        counters.cgroupPidsCurrent >= 0
+          ? `, pids.current=${counters.cgroupPidsCurrent}/pids.max=${counters.cgroupPidsMax}, threads=${counters.treeThreadCount}`
+          : "";
       const message =
         "browser pool UNRECOVERABLE — self-heal circuit-breaker gave up after " +
         `${counters.maxHardRecoveries} hard recoveries; a REDEPLOY is required ` +
-        `(browserCount=${counters.browserCount}, waiters=${counters.waiters})`;
+        `(browserCount=${counters.browserCount}, waiters=${counters.waiters}${pidsClause})`;
       const observedAt = nextObservedAt();
       // (1) UNCONDITIONAL health-signal writes — distinct terminal key + escalate
       //     the shared degraded key to critical/terminal.
@@ -1243,6 +1259,9 @@ export function createBrowserPoolHealthSignals(
             browserCount: counters.browserCount,
             waiters: counters.waiters,
             maxHardRecoveries: counters.maxHardRecoveries,
+            cgroupPidsCurrent: counters.cgroupPidsCurrent,
+            cgroupPidsMax: counters.cgroupPidsMax,
+            treeThreadCount: counters.treeThreadCount,
             unrecoverableSince: new Date().toISOString(),
           },
           observedAt,

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Browser, BrowserContext } from "playwright";
-import { BrowserPool } from "./browser-pool.js";
+import {
+  BrowserPool,
+  defaultPurgeProfileDirs,
+  PURGE_MIN_AGE_MS,
+} from "./browser-pool.js";
 import type { LaunchBrowser } from "./browser-pool.js";
 
 /**
@@ -3335,5 +3342,96 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     );
     expect(openButNotClosed.length).toBe(0);
     expect(internals(pool).contextToBrowser.size).toBe(0);
+  });
+});
+
+// ── CR-FIX: defaultPurgeProfileDirs safety (symlink-safe + age-scoped) ────────
+//
+// The self-heal hard-recovery purge runs against the WORLD-WRITABLE OS temp dir.
+// The unfixed implementation did a blind `readdir` (no withFileTypes) + `rm(...,
+// {recursive:true,force:true})` on every `playwright_*` entry, so:
+//   (a) a planted `playwright_*` SYMLINK had its TARGET recursively deleted, and
+//   (b) a browser launching CONCURRENTLY with the purge had its FRESH profile dir
+//       nuked out from under it (re-wedging the very launch being revived).
+// The fix reads dirents, SKIPS symlinks + non-directories, and only removes dirs
+// older than `PURGE_MIN_AGE_MS`. These tests had ZERO coverage before (the pool
+// tests inject a no-op purge), so they pin the real implementation.
+describe("defaultPurgeProfileDirs — symlink-safe + age-scoped purge", () => {
+  let root: string;
+
+  async function makeAgedDir(name: string): Promise<string> {
+    const p = join(root, name);
+    await fs.mkdir(p, { recursive: true });
+    // Drop a file inside so we can prove a recursive delete removed contents.
+    await fs.writeFile(join(p, "sentinel"), "x");
+    // Backdate mtime well past the purge age threshold so it is eligible.
+    const old = new Date(Date.now() - (PURGE_MIN_AGE_MS + 60_000));
+    await fs.utimes(p, old, old);
+    return p;
+  }
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(join(tmpdir(), "purge-fixture-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it("removes OLD playwright_* and playwright-artifacts-* dirs, leaves non-matching dirs", async () => {
+    const pwOld = await makeAgedDir("playwright_abc123");
+    const artifactsOld = await makeAgedDir("playwright-artifacts-xyz");
+    const unrelated = await makeAgedDir("some-other-dir");
+
+    const removed = await defaultPurgeProfileDirs(root);
+
+    expect(removed).toBe(2);
+    await expect(fs.stat(pwOld)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(artifactsOld)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    // The non-matching dir is LEFT ALONE.
+    await expect(fs.stat(unrelated)).resolves.toBeDefined();
+  });
+
+  it("SKIPS a playwright_* SYMLINK and never deletes its target's contents", async () => {
+    // A real victim dir the symlink points at — must survive untouched.
+    const victim = join(root, "victim-target");
+    await fs.mkdir(victim, { recursive: true });
+    await fs.writeFile(join(victim, "precious"), "do-not-delete");
+    // Backdate the victim so it CANNOT be excused by the age guard.
+    const old = new Date(Date.now() - (PURGE_MIN_AGE_MS + 60_000));
+    await fs.utimes(victim, old, old);
+
+    // The planted symlink matches the prefix but is a SYMLINK, not a real dir.
+    const planted = join(root, "playwright_evil");
+    await fs.symlink(victim, planted);
+    await fs.lutimes?.(planted, old, old).catch(() => undefined);
+
+    const removed = await defaultPurgeProfileDirs(root);
+
+    // The symlink was skipped (not counted, target untouched).
+    expect(removed).toBe(0);
+    await expect(fs.stat(join(victim, "precious"))).resolves.toBeDefined();
+    // The symlink itself is left in place (we never followed/removed it).
+    await expect(fs.lstat(planted)).resolves.toBeDefined();
+  });
+
+  it("LEAVES too-fresh playwright_* dirs (a concurrently-launching browser's dir)", async () => {
+    const fresh = join(root, "playwright_fresh");
+    await fs.mkdir(fresh, { recursive: true });
+    // mtime = now → younger than PURGE_MIN_AGE_MS → must be skipped.
+
+    const removed = await defaultPurgeProfileDirs(root);
+
+    expect(removed).toBe(0);
+    await expect(fs.stat(fresh)).resolves.toBeDefined();
+  });
+
+  it("swallows a missing temp dir (ENOENT) and returns 0", async () => {
+    const removed = await defaultPurgeProfileDirs(
+      join(root, "does-not-exist-subdir"),
+    );
+    expect(removed).toBe(0);
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1885,8 +1885,13 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       selfHealMaxHardRecoveries: 3,
       // The purge models clearing stale /tmp/playwright_* profile dirs. Doing so
       // "unwedges" chromium — the proof that the hard recovery (not another
-      // identical relaunch) is what escapes the loop.
-      purgeProfileDirs: async () => {
+      // identical relaunch) is what escapes the loop. The SAME injected helper
+      // also serves the PROACTIVE sweep (init + every recycle), which passes the
+      // conservative `staleProfileDirTtlMs`; gate on the breaker's aggressive
+      // `PURGE_MIN_AGE_MS` so only the breaker's hard-recovery purge counts +
+      // heals (the proactive sweep must NOT prematurely unwedge the launcher).
+      purgeProfileDirs: async (minAgeMs) => {
+        if (minAgeMs !== PURGE_MIN_AGE_MS) return 0; // proactive sweep: no-op here
         purgeCalls++;
         launcher.setFailAfter(undefined);
         return 2;
@@ -1942,7 +1947,10 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       selfHealIntervalMs: 1,
       selfHealHardRecoveryThreshold: 3,
       selfHealMaxHardRecoveries: 5,
-      purgeProfileDirs: async () => {
+      // Count ONLY the breaker's hard-recovery purge (aggressive PURGE_MIN_AGE_MS),
+      // not the proactive sweep that shares this helper.
+      purgeProfileDirs: async (minAgeMs) => {
+        if (minAgeMs !== PURGE_MIN_AGE_MS) return 0; // proactive sweep: no-op here
         purgeCalls++;
         // Do NOT heal — keep the wedge so we can count failures BEFORE the first
         // purge fired.
@@ -1988,7 +1996,10 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       selfHealIntervalMs: 1,
       selfHealHardRecoveryThreshold: 2,
       selfHealMaxHardRecoveries: 2,
-      purgeProfileDirs: async () => {
+      // Count ONLY the breaker's hard-recovery purge (aggressive PURGE_MIN_AGE_MS),
+      // not the proactive sweep that shares this helper.
+      purgeProfileDirs: async (minAgeMs) => {
+        if (minAgeMs !== PURGE_MIN_AGE_MS) return 0; // proactive sweep: no-op here
         purgeCalls++;
         // Purge cannot fix it — the wedge survives even the profile-dir clear.
         return 0;
@@ -2071,7 +2082,11 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       selfHealIntervalMs: 1,
       selfHealHardRecoveryThreshold: 4,
       selfHealMaxHardRecoveries: 3,
-      purgeProfileDirs: async () => {
+      // Count ONLY the breaker's hard-recovery purge (aggressive PURGE_MIN_AGE_MS).
+      // The proactive sweep (init + recycle) shares this helper and would
+      // otherwise inflate purgeCalls past the `=== 0` assertion below.
+      purgeProfileDirs: async (minAgeMs) => {
+        if (minAgeMs !== PURGE_MIN_AGE_MS) return 0; // proactive sweep: no-op here
         purgeCalls++;
         return 0;
       },
@@ -2208,7 +2223,10 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       // The footgun: 0 would disable the `> 0` guards under the unfixed code.
       selfHealHardRecoveryThreshold: 0,
       selfHealMaxHardRecoveries: 0,
-      purgeProfileDirs: async () => {
+      // Count ONLY the breaker's hard-recovery purge (aggressive PURGE_MIN_AGE_MS),
+      // not the proactive sweep that shares this helper.
+      purgeProfileDirs: async (minAgeMs) => {
+        if (minAgeMs !== PURGE_MIN_AGE_MS) return 0; // proactive sweep: no-op here
         purgeCalls++;
         return 0;
       },
@@ -3383,7 +3401,7 @@ describe("defaultPurgeProfileDirs — symlink-safe + age-scoped purge", () => {
     const artifactsOld = await makeAgedDir("playwright-artifacts-xyz");
     const unrelated = await makeAgedDir("some-other-dir");
 
-    const removed = await defaultPurgeProfileDirs(root);
+    const removed = await defaultPurgeProfileDirs(PURGE_MIN_AGE_MS, root);
 
     expect(removed).toBe(2);
     await expect(fs.stat(pwOld)).rejects.toMatchObject({ code: "ENOENT" });
@@ -3408,7 +3426,7 @@ describe("defaultPurgeProfileDirs — symlink-safe + age-scoped purge", () => {
     await fs.symlink(victim, planted);
     await fs.lutimes?.(planted, old, old).catch(() => undefined);
 
-    const removed = await defaultPurgeProfileDirs(root);
+    const removed = await defaultPurgeProfileDirs(PURGE_MIN_AGE_MS, root);
 
     // The symlink was skipped (not counted, target untouched).
     expect(removed).toBe(0);
@@ -3422,7 +3440,7 @@ describe("defaultPurgeProfileDirs — symlink-safe + age-scoped purge", () => {
     await fs.mkdir(fresh, { recursive: true });
     // mtime = now → younger than PURGE_MIN_AGE_MS → must be skipped.
 
-    const removed = await defaultPurgeProfileDirs(root);
+    const removed = await defaultPurgeProfileDirs(PURGE_MIN_AGE_MS, root);
 
     expect(removed).toBe(0);
     await expect(fs.stat(fresh)).resolves.toBeDefined();
@@ -3430,8 +3448,250 @@ describe("defaultPurgeProfileDirs — symlink-safe + age-scoped purge", () => {
 
   it("swallows a missing temp dir (ENOENT) and returns 0", async () => {
     const removed = await defaultPurgeProfileDirs(
+      PURGE_MIN_AGE_MS,
       join(root, "does-not-exist-subdir"),
     );
     expect(removed).toBe(0);
+  });
+});
+
+describe("BrowserPool — PREVENTION: proactive stale-profile-dir sweep (durable root-cause fix)", () => {
+  // The RECURRING wedge: a long-lived harness container launches chromium
+  // repeatedly (init fill, hygiene recycles, crash-recovery relaunches); EVERY
+  // launch leaves a `/tmp/playwright_*` profile dir + `playwright-artifacts-*`
+  // dir whose Playwright close-time cleanup is BEST-EFFORT (logged-and-swallowed
+  // on failure). Over hours the orphans accumulate MONOTONICALLY until `/tmp`
+  // exhausts inodes/space — then every `chromium.launch()` throws "Target page,
+  // context or browser has been closed" and the pool wedges permanently (only a
+  // restart, which gives a fresh `/tmp`, clears it). The PREVENTION sweeps the
+  // age-gated stale dirs PROACTIVELY on a cadence (init + every recycle), keeping
+  // `/tmp` bounded so the exhaustion never happens. These tests assert the
+  // cadence fires (RED without the wiring) and that the real sweep — the SAME
+  // canonical `defaultPurgeProfileDirs` the breaker uses, just with the
+  // conservative `staleProfileDirTtlMs` age — is age-gated so it can never
+  // delete a dir still in use.
+
+  const poolInternals = (
+    pool: BrowserPool,
+  ): { browsers: Array<{ browser: { __crash(): void } }> } =>
+    pool as unknown as {
+      browsers: Array<{ browser: { __crash(): void } }>;
+    };
+
+  it("RED→GREEN: fires the stale-profile sweep once at init()", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    const sweepCalls: number[] = [];
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 8,
+      recycleAfter: 1000,
+      launchBrowser,
+      launchStaggerMs: 0,
+      staleProfileDirTtlMs: 60_000,
+      // Inject so we can assert the cadence WITHOUT touching the real FS. (An
+      // injected launcher would otherwise default the purge to a hermetic no-op.)
+      // The proactive sweep calls this with the conservative age threshold.
+      purgeProfileDirs: async (minAgeMs) => {
+        sweepCalls.push(minAgeMs);
+        return 0;
+      },
+    });
+    await pool.init();
+    await drainMicrotasks();
+
+    // Without the init() sweep wiring this is 0 (RED). With it, exactly one
+    // sweep fired, carrying the configured TTL as its age argument.
+    expect(sweepCalls.length).toBe(1);
+    expect(sweepCalls[0]).toBe(60_000);
+
+    await pool.shutdown();
+  });
+
+  it("RED→GREEN: fires the stale-profile sweep on EVERY recycle (crash + hygiene)", async () => {
+    // browser0 crashes → crash recycle; browser1 hits recycleAfter=1 → hygiene
+    // recycle. Each replacement must fire the sweep (the cadence that reclaims
+    // the orphans each chromium replacement would otherwise leave to accumulate).
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const sweepCalls: string[] = [];
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 8,
+      recycleAfter: 1, // first served context makes the entry hygiene-eligible
+      relaunchBackoffMs: 0,
+      launchBrowser,
+      launchStaggerMs: 0,
+      staleProfileDirTtlMs: 0,
+      purgeProfileDirs: async () => {
+        sweepCalls.push("sweep");
+        return 0;
+      },
+    });
+    await pool.init();
+    await drainMicrotasks();
+
+    const initSweeps = sweepCalls.length; // 1 (init)
+    expect(initSweeps).toBe(1);
+
+    // Crash browser0 → crash recycle → relaunch → sweep.
+    launched[0]!.__crash();
+    await waitFor(() => sweepCalls.length >= initSweeps + 1);
+
+    // Drive a hygiene recycle on a surviving/relaunched browser: acquire+release
+    // once (recycleAfter=1) so the next idle release fires a hygiene recycle.
+    const ctx = await pool.acquire();
+    await pool.release(ctx);
+    await waitFor(() => sweepCalls.length >= initSweeps + 2);
+
+    // Each recycle (crash AND hygiene) fired its own sweep on top of init's.
+    // Without the recycle-cadence wiring sweepCalls would stay at initSweeps (RED).
+    expect(sweepCalls.length).toBeGreaterThanOrEqual(initSweeps + 2);
+
+    await pool.shutdown();
+  });
+
+  it("BOUNDED ACCUMULATION: across N recycle cycles the sweep keeps the orphan dir count from growing without bound", async () => {
+    // Model the production accumulation: each launch "creates" 2 orphan dirs in a
+    // simulated `/tmp`; Playwright's close-time cleanup is modeled as FAILING
+    // (the swallowed-failure case that causes the real leak), so WITHOUT a sweep
+    // the count grows by 2 per recycle forever. The injected sweep removes the
+    // age-gated stale entries on the recycle cadence, so the simulated `/tmp`
+    // stays BOUNDED across many cycles instead of growing monotonically.
+    // Model the simulated container `/tmp` as a map of dirName → owning launch
+    // seq. Each launch adds 2 dirs (profile + artifacts) tagged with its seq. A
+    // LIVE browser's dir is "in use"; when a browser is replaced (recycle) the
+    // OLD seq's dirs become orphans Playwright's best-effort cleanup left behind
+    // (the swallowed-failure leak). The age-gated sweep reclaims dirs whose seq
+    // is no longer live — i.e. exactly the orphans, never an in-use dir.
+    const fakeTmp = new Map<string, number>(); // dirName -> launchSeq
+    let launchSeq = 0;
+    const liveSeqs = new Set<number>(); // seqs whose browser is currently live
+
+    const customLauncher: LaunchBrowser = async () => {
+      const seq = launchSeq++;
+      fakeTmp.set(`playwright_chromiumdev_profile-${seq}`, seq);
+      fakeTmp.set(`playwright-artifacts-${seq}`, seq);
+      liveSeqs.add(seq);
+      const b = makeFakeBrowser();
+      // When this browser is closed (recycle teardown calls browser.close()),
+      // its seq stops being live — its dirs become orphans (NOT cleaned, modeling
+      // the real leak). The age gate is modeled by "only non-live seqs are stale".
+      const origClose = b.close.bind(b);
+      b.close = async () => {
+        liveSeqs.delete(seq);
+        await origClose();
+      };
+      return b as unknown as Browser;
+    };
+
+    // Age-gated sweep: removes ONLY dirs whose owning seq is no longer live (the
+    // orphans). An in-use (live) browser's dir is never removed — the age gate's
+    // real-world analogue (a live browser touches its dir, mtime ~now < cutoff).
+    const sweep = async (): Promise<number> => {
+      let removed = 0;
+      for (const [name, seq] of [...fakeTmp]) {
+        if (!liveSeqs.has(seq)) {
+          fakeTmp.delete(name);
+          removed++;
+        }
+      }
+      return removed;
+    };
+
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 8,
+      recycleAfter: 1000,
+      relaunchBackoffMs: 0,
+      launchBrowser: customLauncher,
+      launchStaggerMs: 0,
+      staleProfileDirTtlMs: 0,
+      purgeProfileDirs: sweep,
+    });
+    await pool.init();
+    await drainMicrotasks();
+    // After init the 2 live browsers' dirs are present (4 entries); none are
+    // orphans yet, so the init sweep removed nothing.
+    expect(fakeTmp.size).toBe(4);
+
+    const poolBrowsers = poolInternals(pool).browsers as unknown as Array<{
+      browser: { __crash(): void };
+    }>;
+
+    // Drive MANY crash→recycle cycles. Each crash orphans the old browser's 2
+    // dirs and the relaunch adds 2 new live dirs; the recycle-cadence sweep
+    // reclaims the orphans. WITHOUT the sweep, fakeTmp would grow by 2 per cycle
+    // (unbounded → exhaustion → the production wedge). WITH it, it stays bounded
+    // at ~2 * browserCount (only the live browsers' dirs).
+    const CYCLES = 30;
+    for (let i = 0; i < CYCLES; i++) {
+      const launchSeqBefore = launchSeq;
+      poolBrowsers[0]!.browser.__crash();
+      await waitFor(
+        () =>
+          launchSeq > launchSeqBefore &&
+          poolInternals(pool).browsers.length === 2,
+      );
+    }
+    // The orphan-producing launch count grew linearly with CYCLES.
+    expect(launchSeq).toBeGreaterThanOrEqual(CYCLES + 2);
+    // Let the fire-and-forget cadence sweeps settle.
+    await waitFor(
+      () => liveSeqs.size === 2 && fakeTmp.size <= 2 * 2 + 2,
+      5_000,
+    );
+
+    // BOUNDED: `/tmp` holds only the live browsers' dirs (≤ 2*browsers) plus at
+    // most one in-flight cycle's slack — NOT 2 * (CYCLES + browsers). A no-sweep
+    // run would leave ~2 * (CYCLES + 2) = 64 entries here.
+    expect(fakeTmp.size).toBeLessThanOrEqual(2 * 2 + 2);
+
+    await pool.shutdown();
+  });
+
+  it("AGE GATE (real FS): defaultPurgeProfileDirs removes OLD orphans but NEVER a fresh in-use dir", async () => {
+    // The safety property the whole prevention rests on: the sweep must never
+    // delete a dir for a launch in flight / a live browser. Those are touched
+    // continuously (mtime ~now), so the age gate must skip them. Create a "fresh"
+    // dir (mtime now) and an "old" orphan (mtime far in the past) and assert the
+    // sweep removes ONLY the old one. Also assert a non-playwright dir is never
+    // touched (prefix gate). Uses the canonical helper with the conservative
+    // 5-min proactive TTL.
+    const tag = `${process.pid}-${Date.now()}`;
+    const freshDir = join(
+      tmpdir(),
+      `playwright_chromiumdev_profile-fresh-${tag}`,
+    );
+    const oldDir = join(tmpdir(), `playwright-artifacts-old-${tag}`);
+    const unrelatedDir = join(tmpdir(), `not-playwright-${tag}`);
+    await fs.mkdir(freshDir, { recursive: true });
+    await fs.mkdir(oldDir, { recursive: true });
+    await fs.mkdir(unrelatedDir, { recursive: true });
+    // Back-date the "old" orphan an hour so it is older than any sane TTL.
+    const oldTime = new Date(Date.now() - 3_600_000);
+    await fs.utimes(oldDir, oldTime, oldTime);
+
+    try {
+      // age = 5 min: the fresh dir (mtime now) is YOUNGER than the age gate and
+      // must be skipped; the hour-old orphan is OLDER and must be removed.
+      const removed = await defaultPurgeProfileDirs(5 * 60_000);
+      expect(removed).toBeGreaterThanOrEqual(1);
+
+      const exists = async (p: string): Promise<boolean> =>
+        fs
+          .stat(p)
+          .then(() => true)
+          .catch(() => false);
+
+      // The in-use (fresh) dir survives — the age gate protected it.
+      expect(await exists(freshDir)).toBe(true);
+      // The old orphan was reclaimed.
+      expect(await exists(oldDir)).toBe(false);
+      // A non-playwright dir is never touched (prefix gate).
+      expect(await exists(unrelatedDir)).toBe(true);
+    } finally {
+      await fs.rm(freshDir, { recursive: true, force: true });
+      await fs.rm(oldDir, { recursive: true, force: true });
+      await fs.rm(unrelatedDir, { recursive: true, force: true });
+    }
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1,13 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { promises as fs } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { describe, it, expect } from "vitest";
 import type { Browser, BrowserContext } from "playwright";
-import {
-  BrowserPool,
-  defaultPurgeProfileDirs,
-  PURGE_MIN_AGE_MS,
-} from "./browser-pool.js";
+import { BrowserPool } from "./browser-pool.js";
 import type { LaunchBrowser } from "./browser-pool.js";
 
 /**
@@ -1860,16 +1853,18 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
   // the breaker trips at the threshold, the HARD recovery PURGES the stale
   // profile dirs — modeled here by the purge "unwedging" the launcher — and the
   // pool cold-launches fresh, so acquire() succeeds again.
-  it("OUTAGE: circuit-breaker hard-recovers (purge + cold-launch) out of a chromium launch-crash-loop the plain self-heal could not escape", async () => {
+  it("OUTAGE: circuit-breaker hard-recovers (paced cold relaunch) out of a chromium launch-crash-loop the plain self-heal could not escape", async () => {
     // init launches 1 browser (call 1). Everything AFTER call 1 throws the
     // "...has been closed" launch-crash-loop error — modeling the wedged
-    // container. The PURGE is what breaks the wedge: when the breaker fires the
-    // hard recovery, the injected purge flips the launcher healthy so the
-    // subsequent COLD launch succeeds. Without the breaker the purge never runs,
-    // launches stay wedged, and the pool is dead forever.
+    // container. The PROVEN wedge (cgroup PID/thread-ceiling exhaustion) relaxes
+    // over time, so the hard recovery is a PACED cold relaunch: after the
+    // threshold of consecutive failures the breaker backs off, then flips the
+    // launcher healthy (the kernel relaxing) so the subsequent cold launch
+    // succeeds. Without the breaker's give-up backstop the loop would spin into
+    // the same wedge forever with no operator signal.
     const launcher = makeFakeLauncher({ failAfterCall: 1 });
     const { logger, events } = makeLeveledLogger();
-    let purgeCalls = 0;
+    let hardRecoveries = 0;
     let recovered = 0;
     const pool = new BrowserPool({
       browsers: 1,
@@ -1883,19 +1878,6 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       // Trip the hard recovery after 3 consecutive self-heal launch failures.
       selfHealHardRecoveryThreshold: 3,
       selfHealMaxHardRecoveries: 3,
-      // The purge models clearing stale /tmp/playwright_* profile dirs. Doing so
-      // "unwedges" chromium — the proof that the hard recovery (not another
-      // identical relaunch) is what escapes the loop. The SAME injected helper
-      // also serves the PROACTIVE sweep (init + every recycle), which passes the
-      // conservative `staleProfileDirTtlMs`; gate on the breaker's aggressive
-      // `PURGE_MIN_AGE_MS` so only the breaker's hard-recovery purge counts +
-      // heals (the proactive sweep must NOT prematurely unwedge the launcher).
-      purgeProfileDirs: async (minAgeMs) => {
-        if (minAgeMs !== PURGE_MIN_AGE_MS) return 0; // proactive sweep: no-op here
-        purgeCalls++;
-        launcher.setFailAfter(undefined);
-        return 2;
-      },
       onRecovered: () => {
         recovered++;
       },
@@ -1909,15 +1891,23 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     launcher.launched[0]!.__crash();
 
     // BREAKER PROOF: after the threshold of consecutive failures the hard
-    // recovery fires — the purge runs (clears the wedge) and the cold launch
-    // succeeds, reviving the pool to full strength and firing onRecovered.
+    // recovery fires (paced cold relaunch). The moment we observe it, flip the
+    // launcher healthy (modeling the PID/thread ceiling relaxing) so the NEXT
+    // cold relaunch succeeds and the pool revives to full strength + onRecovered.
+    await waitFor(
+      () =>
+        events.some((e) => e.event === "browser-pool.self-heal-hard-recovery"),
+      5_000,
+    );
+    hardRecoveries = events.filter(
+      (e) => e.event === "browser-pool.self-heal-hard-recovery",
+    ).length;
+    launcher.setFailAfter(undefined);
+
     await waitFor(() => recovered >= 1, 5_000);
-    expect(purgeCalls).toBeGreaterThanOrEqual(1);
+    expect(hardRecoveries).toBeGreaterThanOrEqual(1);
     expect(
       events.some((e) => e.event === "browser-pool.self-heal-hard-recovery"),
-    ).toBe(true);
-    expect(
-      events.some((e) => e.event === "browser-pool.self-heal-profile-purge"),
     ).toBe(true);
 
     // The pool is alive again: a fresh acquire succeeds (no timeout, no wedge).
@@ -1935,7 +1925,6 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
   it("circuit-breaker: fires the hard recovery only AFTER the consecutive-failure threshold is reached", async () => {
     const launcher = makeFakeLauncher({ failAfterCall: 1 });
     const { logger, events } = makeLeveledLogger();
-    let purgeCalls = 0;
     const pool = new BrowserPool({
       browsers: 1,
       maxContexts: 2,
@@ -1947,44 +1936,41 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       selfHealIntervalMs: 1,
       selfHealHardRecoveryThreshold: 3,
       selfHealMaxHardRecoveries: 5,
-      // Count ONLY the breaker's hard-recovery purge (aggressive PURGE_MIN_AGE_MS),
-      // not the proactive sweep that shares this helper.
-      purgeProfileDirs: async (minAgeMs) => {
-        if (minAgeMs !== PURGE_MIN_AGE_MS) return 0; // proactive sweep: no-op here
-        purgeCalls++;
-        // Do NOT heal — keep the wedge so we can count failures BEFORE the first
-        // purge fired.
-        return 0;
-      },
     });
     await pool.init();
     launcher.launched[0]!.__crash();
 
     // Wait until the first hard recovery has fired.
-    await waitFor(() => purgeCalls >= 1, 5_000);
+    await waitFor(
+      () =>
+        events.some((e) => e.event === "browser-pool.self-heal-hard-recovery"),
+      5_000,
+    );
 
-    // At the moment the FIRST purge fired, at least `threshold` consecutive
-    // self-heal launch failures must have been logged first (the breaker does
-    // not fire early).
-    const failuresBeforeFirstPurge = events.filter(
-      (e) => e.event === "browser-pool.self-heal-launch-failed",
-    ).length;
-    expect(failuresBeforeFirstPurge).toBeGreaterThanOrEqual(3);
+    // At the moment the FIRST hard recovery fired, at least `threshold`
+    // consecutive self-heal launch failures must have been logged first (the
+    // breaker does not fire early).
+    const firstHardRecoveryIdx = events.findIndex(
+      (e) => e.event === "browser-pool.self-heal-hard-recovery",
+    );
+    const failuresBeforeFirstHardRecovery = events
+      .slice(0, firstHardRecoveryIdx)
+      .filter((e) => e.event === "browser-pool.self-heal-launch-failed").length;
+    expect(failuresBeforeFirstHardRecovery).toBeGreaterThanOrEqual(3);
 
     await pool.shutdown();
   });
 
-  // RED (pre-breaker, silent spin) → GREEN: if even the HARD recovery cannot
-  // break the wedge (the purge does not help — e.g. a genuinely broken
-  // container), the breaker gives up LOUDLY after K hard recoveries with a
+  // RED (pre-breaker, silent spin) → GREEN: if even the HARD recovery (the paced
+  // cold relaunch) cannot break the wedge — e.g. the PID/thread ceiling never
+  // relaxes — the breaker gives up LOUDLY after K hard recoveries with a
   // `pool-unrecoverable` alarm and stops the heal loop, rather than spinning
   // self-heal-launch-failed forever with no operator signal.
   it("OUTAGE: circuit-breaker surfaces a loud pool-unrecoverable alarm (and stops) when even hard recovery cannot escape the wedge", async () => {
-    // Permanently wedged: launches throw forever and the purge never heals.
+    // Permanently wedged: launches throw forever (the ceiling never relaxes).
     const launcher = makeFakeLauncher({ failAfterCall: 1 });
     const { logger, events } = makeLeveledLogger();
     let unrecoverableCalls = 0;
-    let purgeCalls = 0;
     const pool = new BrowserPool({
       browsers: 1,
       maxContexts: 2,
@@ -1996,14 +1982,6 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       selfHealIntervalMs: 1,
       selfHealHardRecoveryThreshold: 2,
       selfHealMaxHardRecoveries: 2,
-      // Count ONLY the breaker's hard-recovery purge (aggressive PURGE_MIN_AGE_MS),
-      // not the proactive sweep that shares this helper.
-      purgeProfileDirs: async (minAgeMs) => {
-        if (minAgeMs !== PURGE_MIN_AGE_MS) return 0; // proactive sweep: no-op here
-        purgeCalls++;
-        // Purge cannot fix it — the wedge survives even the profile-dir clear.
-        return 0;
-      },
       onUnrecoverable: () => {
         unrecoverableCalls++;
       },
@@ -2015,7 +1993,10 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     // both fail, and then it gives up LOUDLY.
     await waitFor(() => unrecoverableCalls >= 1, 5_000);
     expect(unrecoverableCalls).toBe(1);
-    expect(purgeCalls).toBeGreaterThanOrEqual(2);
+    const hardRecoveries = events.filter(
+      (e) => e.event === "browser-pool.self-heal-hard-recovery",
+    ).length;
+    expect(hardRecoveries).toBeGreaterThanOrEqual(2);
     expect(
       events.some((e) => e.event === "browser-pool.pool-unrecoverable"),
     ).toBe(true);
@@ -2046,8 +2027,7 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     // Shape the launcher so the heal sequence is: fail, fail, fail (trip toward
     // threshold) … then SUCCEED once (partial revive — must reset the counter) …
     // then succeed again (full strength). If the counter did NOT reset on the
-    // partial success, a hard recovery (purge) would fire; we assert it does NOT.
-    let purgeCalls = 0;
+    // partial success, a hard recovery would fire; we assert it does NOT.
     let recovered = 0;
     const { logger, events } = makeLeveledLogger();
 
@@ -2082,14 +2062,6 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       selfHealIntervalMs: 1,
       selfHealHardRecoveryThreshold: 4,
       selfHealMaxHardRecoveries: 3,
-      // Count ONLY the breaker's hard-recovery purge (aggressive PURGE_MIN_AGE_MS).
-      // The proactive sweep (init + recycle) shares this helper and would
-      // otherwise inflate purgeCalls past the `=== 0` assertion below.
-      purgeProfileDirs: async (minAgeMs) => {
-        if (minAgeMs !== PURGE_MIN_AGE_MS) return 0; // proactive sweep: no-op here
-        purgeCalls++;
-        return 0;
-      },
       onRecovered: () => {
         recovered++;
       },
@@ -2108,7 +2080,6 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     // The breaker NEVER tripped a hard recovery: the 3-failure streak stayed
     // below the threshold of 4, and the partial revive reset the counter so the
     // second top-up launch could not push a stale counter over the line.
-    expect(purgeCalls).toBe(0);
     expect(
       events.some((e) => e.event === "browser-pool.self-heal-hard-recovery"),
     ).toBe(false);
@@ -2157,7 +2128,6 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       selfHealIntervalMs: 1,
       selfHealHardRecoveryThreshold: 2,
       selfHealMaxHardRecoveries: 2,
-      purgeProfileDirs: async () => 0, // never heals — forces a give-up
       onUnrecoverable: (info) => {
         unrecoverableCalls++;
         infos.push({
@@ -2210,7 +2180,6 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     const launcher = makeFakeLauncher({ failAfterCall: 1 });
     const { logger, events } = makeLeveledLogger();
     let unrecoverableCalls = 0;
-    let purgeCalls = 0;
     const pool = new BrowserPool({
       browsers: 1,
       maxContexts: 2,
@@ -2223,13 +2192,6 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
       // The footgun: 0 would disable the `> 0` guards under the unfixed code.
       selfHealHardRecoveryThreshold: 0,
       selfHealMaxHardRecoveries: 0,
-      // Count ONLY the breaker's hard-recovery purge (aggressive PURGE_MIN_AGE_MS),
-      // not the proactive sweep that shares this helper.
-      purgeProfileDirs: async (minAgeMs) => {
-        if (minAgeMs !== PURGE_MIN_AGE_MS) return 0; // proactive sweep: no-op here
-        purgeCalls++;
-        return 0;
-      },
       onUnrecoverable: () => {
         unrecoverableCalls++;
       },
@@ -2241,7 +2203,9 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     // spinning forever. Without the clamp, neither would fire (silent spin).
     await waitFor(() => unrecoverableCalls >= 1, 5_000);
     expect(unrecoverableCalls).toBe(1);
-    expect(purgeCalls).toBeGreaterThanOrEqual(1);
+    expect(
+      events.some((e) => e.event === "browser-pool.self-heal-hard-recovery"),
+    ).toBe(true);
     expect(
       events.some((e) => e.event === "browser-pool.pool-unrecoverable"),
     ).toBe(true);
@@ -3363,335 +3327,131 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
   });
 });
 
-// ── CR-FIX: defaultPurgeProfileDirs safety (symlink-safe + age-scoped) ────────
+// ── RESOURCE-GAUGE INSTRUMENTATION (early-warning logging) ───────────────────
 //
-// The self-heal hard-recovery purge runs against the WORLD-WRITABLE OS temp dir.
-// The unfixed implementation did a blind `readdir` (no withFileTypes) + `rm(...,
-// {recursive:true,force:true})` on every `playwright_*` entry, so:
-//   (a) a planted `playwright_*` SYMLINK had its TARGET recursively deleted, and
-//   (b) a browser launching CONCURRENTLY with the purge had its FRESH profile dir
-//       nuked out from under it (re-wedging the very launch being revived).
-// The fix reads dirents, SKIPS symlinks + non-directories, and only removes dirs
-// older than `PURGE_MIN_AGE_MS`. These tests had ZERO coverage before (the pool
-// tests inject a no-op purge), so they pin the real implementation.
-describe("defaultPurgeProfileDirs — symlink-safe + age-scoped purge", () => {
-  let root: string;
-
-  async function makeAgedDir(name: string): Promise<string> {
-    const p = join(root, name);
-    await fs.mkdir(p, { recursive: true });
-    // Drop a file inside so we can prove a recursive delete removed contents.
-    await fs.writeFile(join(p, "sentinel"), "x");
-    // Backdate mtime well past the purge age threshold so it is eligible.
-    const old = new Date(Date.now() - (PURGE_MIN_AGE_MS + 60_000));
-    await fs.utimes(p, old, old);
-    return p;
-  }
-
-  beforeEach(async () => {
-    root = await fs.mkdtemp(join(tmpdir(), "purge-fixture-"));
-  });
-
-  afterEach(async () => {
-    await fs.rm(root, { recursive: true, force: true }).catch(() => undefined);
-  });
-
-  it("removes OLD playwright_* and playwright-artifacts-* dirs, leaves non-matching dirs", async () => {
-    const pwOld = await makeAgedDir("playwright_abc123");
-    const artifactsOld = await makeAgedDir("playwright-artifacts-xyz");
-    const unrelated = await makeAgedDir("some-other-dir");
-
-    const removed = await defaultPurgeProfileDirs(PURGE_MIN_AGE_MS, root);
-
-    expect(removed).toBe(2);
-    await expect(fs.stat(pwOld)).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(fs.stat(artifactsOld)).rejects.toMatchObject({
-      code: "ENOENT",
+// The PROVEN browser-pool wedge is cgroup PID/thread-ceiling exhaustion: a d6
+// launch burst drives `pids.current` toward the platform-fixed `pids.max=1000`,
+// every `chromium.launch()` then throws pthread EAGAIN → "...has been closed" →
+// crash-loop. To make a burst approaching the ceiling OBSERVABLE — and let an
+// EAGAIN be correlated to a measured `pids.current` — the pool samples + logs
+// the OS resource gauges (`browser-pool.resource-gauges`, headline
+// pids.current/pids.max + thread count) on EVERY launch and on the
+// `self-heal-launch-failed` path. These tests pin that the gauge is sampled +
+// logged on those events (they FAIL before the gauge is wired). Off-Linux the
+// gauge fields degrade to -1; the test asserts the EVENT + label, not the
+// (host-specific) numeric values.
+describe("BrowserPool — resource-gauge instrumentation (PID-ceiling early warning)", () => {
+  it("RED→GREEN: logs the resource gauges on every launchBrowser() (label=launch)", async () => {
+    const launcher = makeFakeLauncher({});
+    const { logger, events } = makeLeveledLogger();
+    const pool = new BrowserPool({
+      browsers: 3,
+      maxContexts: 6,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
     });
-    // The non-matching dir is LEFT ALONE.
-    await expect(fs.stat(unrelated)).resolves.toBeDefined();
-  });
+    await pool.init();
 
-  it("SKIPS a playwright_* SYMLINK and never deletes its target's contents", async () => {
-    // A real victim dir the symlink points at — must survive untouched.
-    const victim = join(root, "victim-target");
-    await fs.mkdir(victim, { recursive: true });
-    await fs.writeFile(join(victim, "precious"), "do-not-delete");
-    // Backdate the victim so it CANNOT be excused by the age guard.
-    const old = new Date(Date.now() - (PURGE_MIN_AGE_MS + 60_000));
-    await fs.utimes(victim, old, old);
-
-    // The planted symlink matches the prefix but is a SYMLINK, not a real dir.
-    const planted = join(root, "playwright_evil");
-    await fs.symlink(victim, planted);
-    await fs.lutimes?.(planted, old, old).catch(() => undefined);
-
-    const removed = await defaultPurgeProfileDirs(PURGE_MIN_AGE_MS, root);
-
-    // The symlink was skipped (not counted, target untouched).
-    expect(removed).toBe(0);
-    await expect(fs.stat(join(victim, "precious"))).resolves.toBeDefined();
-    // The symlink itself is left in place (we never followed/removed it).
-    await expect(fs.lstat(planted)).resolves.toBeDefined();
-  });
-
-  it("LEAVES too-fresh playwright_* dirs (a concurrently-launching browser's dir)", async () => {
-    const fresh = join(root, "playwright_fresh");
-    await fs.mkdir(fresh, { recursive: true });
-    // mtime = now → younger than PURGE_MIN_AGE_MS → must be skipped.
-
-    const removed = await defaultPurgeProfileDirs(PURGE_MIN_AGE_MS, root);
-
-    expect(removed).toBe(0);
-    await expect(fs.stat(fresh)).resolves.toBeDefined();
-  });
-
-  it("swallows a missing temp dir (ENOENT) and returns 0", async () => {
-    const removed = await defaultPurgeProfileDirs(
-      PURGE_MIN_AGE_MS,
-      join(root, "does-not-exist-subdir"),
+    // init fills the fixed set with `browsers` launches — each must have logged a
+    // gauge sample labeled `launch` BEFORE forking the chromium process.
+    const launchGauges = events.filter(
+      (e) =>
+        e.event === "browser-pool.resource-gauges" &&
+        e.meta?.label === "launch",
     );
-    expect(removed).toBe(0);
-  });
-});
-
-describe("BrowserPool — PREVENTION: proactive stale-profile-dir sweep (durable root-cause fix)", () => {
-  // The RECURRING wedge: a long-lived harness container launches chromium
-  // repeatedly (init fill, hygiene recycles, crash-recovery relaunches); EVERY
-  // launch leaves a `/tmp/playwright_*` profile dir + `playwright-artifacts-*`
-  // dir whose Playwright close-time cleanup is BEST-EFFORT (logged-and-swallowed
-  // on failure). Over hours the orphans accumulate MONOTONICALLY until `/tmp`
-  // exhausts inodes/space — then every `chromium.launch()` throws "Target page,
-  // context or browser has been closed" and the pool wedges permanently (only a
-  // restart, which gives a fresh `/tmp`, clears it). The PREVENTION sweeps the
-  // age-gated stale dirs PROACTIVELY on a cadence (init + every recycle), keeping
-  // `/tmp` bounded so the exhaustion never happens. These tests assert the
-  // cadence fires (RED without the wiring) and that the real sweep — the SAME
-  // canonical `defaultPurgeProfileDirs` the breaker uses, just with the
-  // conservative `staleProfileDirTtlMs` age — is age-gated so it can never
-  // delete a dir still in use.
-
-  const poolInternals = (
-    pool: BrowserPool,
-  ): { browsers: Array<{ browser: { __crash(): void } }> } =>
-    pool as unknown as {
-      browsers: Array<{ browser: { __crash(): void } }>;
-    };
-
-  it("RED→GREEN: fires the stale-profile sweep once at init()", async () => {
-    const { launchBrowser } = makeFakeLauncher();
-    const sweepCalls: number[] = [];
-    const pool = new BrowserPool({
-      browsers: 2,
-      maxContexts: 8,
-      recycleAfter: 1000,
-      launchBrowser,
-      launchStaggerMs: 0,
-      staleProfileDirTtlMs: 60_000,
-      // Inject so we can assert the cadence WITHOUT touching the real FS. (An
-      // injected launcher would otherwise default the purge to a hermetic no-op.)
-      // The proactive sweep calls this with the conservative age threshold.
-      purgeProfileDirs: async (minAgeMs) => {
-        sweepCalls.push(minAgeMs);
-        return 0;
-      },
-    });
-    await pool.init();
-    await drainMicrotasks();
-
-    // Without the init() sweep wiring this is 0 (RED). With it, exactly one
-    // sweep fired, carrying the configured TTL as its age argument.
-    expect(sweepCalls.length).toBe(1);
-    expect(sweepCalls[0]).toBe(60_000);
+    expect(launchGauges.length).toBe(3);
+    // The headline cgroup PID fields are present in the structured payload (the
+    // signal the alert names); off-Linux they are -1, which is still a number.
+    const meta = launchGauges[0]!.meta!;
+    expect("cgroupPidsCurrent" in meta).toBe(true);
+    expect("cgroupPidsMax" in meta).toBe(true);
+    expect("treeThreadCount" in meta).toBe(true);
 
     await pool.shutdown();
   });
 
-  it("RED→GREEN: fires the stale-profile sweep on EVERY recycle (crash + hygiene)", async () => {
-    // browser0 crashes → crash recycle; browser1 hits recycleAfter=1 → hygiene
-    // recycle. Each replacement must fire the sweep (the cadence that reclaims
-    // the orphans each chromium replacement would otherwise leave to accumulate).
-    const { launchBrowser, launched } = makeFakeLauncher();
-    const sweepCalls: string[] = [];
+  it("RED→GREEN: logs the resource gauges on the self-heal-launch-failed path", async () => {
+    // init launches 1; everything after fails (persistent EAGAIN-style wedge).
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const { logger, events } = makeLeveledLogger();
     const pool = new BrowserPool({
-      browsers: 2,
-      maxContexts: 8,
-      recycleAfter: 1, // first served context makes the entry hygiene-eligible
-      relaunchBackoffMs: 0,
-      launchBrowser,
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser: launcher.launchBrowser,
       launchStaggerMs: 0,
-      staleProfileDirTtlMs: 0,
-      purgeProfileDirs: async () => {
-        sweepCalls.push("sweep");
-        return 0;
-      },
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 1,
+      // Give up after a couple hard recoveries so the loop terminates the test.
+      selfHealHardRecoveryThreshold: 2,
+      selfHealMaxHardRecoveries: 2,
     });
     await pool.init();
-    await drainMicrotasks();
+    // Crash the only browser → set empties → self-heal loop relaunches, every
+    // attempt fails → each failure logs a gauge sample labeled accordingly.
+    launcher.launched[0]!.__crash();
 
-    const initSweeps = sweepCalls.length; // 1 (init)
-    expect(initSweeps).toBe(1);
-
-    // Crash browser0 → crash recycle → relaunch → sweep.
-    launched[0]!.__crash();
-    await waitFor(() => sweepCalls.length >= initSweeps + 1);
-
-    // Drive a hygiene recycle on a surviving/relaunched browser: acquire+release
-    // once (recycleAfter=1) so the next idle release fires a hygiene recycle.
-    const ctx = await pool.acquire();
-    await pool.release(ctx);
-    await waitFor(() => sweepCalls.length >= initSweeps + 2);
-
-    // Each recycle (crash AND hygiene) fired its own sweep on top of init's.
-    // Without the recycle-cadence wiring sweepCalls would stay at initSweeps (RED).
-    expect(sweepCalls.length).toBeGreaterThanOrEqual(initSweeps + 2);
-
-    await pool.shutdown();
-  });
-
-  it("BOUNDED ACCUMULATION: across N recycle cycles the sweep keeps the orphan dir count from growing without bound", async () => {
-    // Model the production accumulation: each launch "creates" 2 orphan dirs in a
-    // simulated `/tmp`; Playwright's close-time cleanup is modeled as FAILING
-    // (the swallowed-failure case that causes the real leak), so WITHOUT a sweep
-    // the count grows by 2 per recycle forever. The injected sweep removes the
-    // age-gated stale entries on the recycle cadence, so the simulated `/tmp`
-    // stays BOUNDED across many cycles instead of growing monotonically.
-    // Model the simulated container `/tmp` as a map of dirName → owning launch
-    // seq. Each launch adds 2 dirs (profile + artifacts) tagged with its seq. A
-    // LIVE browser's dir is "in use"; when a browser is replaced (recycle) the
-    // OLD seq's dirs become orphans Playwright's best-effort cleanup left behind
-    // (the swallowed-failure leak). The age-gated sweep reclaims dirs whose seq
-    // is no longer live — i.e. exactly the orphans, never an in-use dir.
-    const fakeTmp = new Map<string, number>(); // dirName -> launchSeq
-    let launchSeq = 0;
-    const liveSeqs = new Set<number>(); // seqs whose browser is currently live
-
-    const customLauncher: LaunchBrowser = async () => {
-      const seq = launchSeq++;
-      fakeTmp.set(`playwright_chromiumdev_profile-${seq}`, seq);
-      fakeTmp.set(`playwright-artifacts-${seq}`, seq);
-      liveSeqs.add(seq);
-      const b = makeFakeBrowser();
-      // When this browser is closed (recycle teardown calls browser.close()),
-      // its seq stops being live — its dirs become orphans (NOT cleaned, modeling
-      // the real leak). The age gate is modeled by "only non-live seqs are stale".
-      const origClose = b.close.bind(b);
-      b.close = async () => {
-        liveSeqs.delete(seq);
-        await origClose();
-      };
-      return b as unknown as Browser;
-    };
-
-    // Age-gated sweep: removes ONLY dirs whose owning seq is no longer live (the
-    // orphans). An in-use (live) browser's dir is never removed — the age gate's
-    // real-world analogue (a live browser touches its dir, mtime ~now < cutoff).
-    const sweep = async (): Promise<number> => {
-      let removed = 0;
-      for (const [name, seq] of [...fakeTmp]) {
-        if (!liveSeqs.has(seq)) {
-          fakeTmp.delete(name);
-          removed++;
-        }
-      }
-      return removed;
-    };
-
-    const pool = new BrowserPool({
-      browsers: 2,
-      maxContexts: 8,
-      recycleAfter: 1000,
-      relaunchBackoffMs: 0,
-      launchBrowser: customLauncher,
-      launchStaggerMs: 0,
-      staleProfileDirTtlMs: 0,
-      purgeProfileDirs: sweep,
-    });
-    await pool.init();
-    await drainMicrotasks();
-    // After init the 2 live browsers' dirs are present (4 entries); none are
-    // orphans yet, so the init sweep removed nothing.
-    expect(fakeTmp.size).toBe(4);
-
-    const poolBrowsers = poolInternals(pool).browsers as unknown as Array<{
-      browser: { __crash(): void };
-    }>;
-
-    // Drive MANY crash→recycle cycles. Each crash orphans the old browser's 2
-    // dirs and the relaunch adds 2 new live dirs; the recycle-cadence sweep
-    // reclaims the orphans. WITHOUT the sweep, fakeTmp would grow by 2 per cycle
-    // (unbounded → exhaustion → the production wedge). WITH it, it stays bounded
-    // at ~2 * browserCount (only the live browsers' dirs).
-    const CYCLES = 30;
-    for (let i = 0; i < CYCLES; i++) {
-      const launchSeqBefore = launchSeq;
-      poolBrowsers[0]!.browser.__crash();
-      await waitFor(
-        () =>
-          launchSeq > launchSeqBefore &&
-          poolInternals(pool).browsers.length === 2,
-      );
-    }
-    // The orphan-producing launch count grew linearly with CYCLES.
-    expect(launchSeq).toBeGreaterThanOrEqual(CYCLES + 2);
-    // Let the fire-and-forget cadence sweeps settle.
     await waitFor(
-      () => liveSeqs.size === 2 && fakeTmp.size <= 2 * 2 + 2,
+      () =>
+        events.some(
+          (e) =>
+            e.event === "browser-pool.resource-gauges" &&
+            e.meta?.label === "self-heal-launch-failed",
+        ),
       5_000,
     );
-
-    // BOUNDED: `/tmp` holds only the live browsers' dirs (≤ 2*browsers) plus at
-    // most one in-flight cycle's slack — NOT 2 * (CYCLES + browsers). A no-sweep
-    // run would leave ~2 * (CYCLES + 2) = 64 entries here.
-    expect(fakeTmp.size).toBeLessThanOrEqual(2 * 2 + 2);
+    const healFailGauges = events.filter(
+      (e) =>
+        e.event === "browser-pool.resource-gauges" &&
+        e.meta?.label === "self-heal-launch-failed",
+    );
+    expect(healFailGauges.length).toBeGreaterThanOrEqual(1);
 
     await pool.shutdown();
   });
 
-  it("AGE GATE (real FS): defaultPurgeProfileDirs removes OLD orphans but NEVER a fresh in-use dir", async () => {
-    // The safety property the whole prevention rests on: the sweep must never
-    // delete a dir for a launch in flight / a live browser. Those are touched
-    // continuously (mtime ~now), so the age gate must skip them. Create a "fresh"
-    // dir (mtime now) and an "old" orphan (mtime far in the past) and assert the
-    // sweep removes ONLY the old one. Also assert a non-playwright dir is never
-    // touched (prefix gate). Uses the canonical helper with the conservative
-    // 5-min proactive TTL.
-    const tag = `${process.pid}-${Date.now()}`;
-    const freshDir = join(
-      tmpdir(),
-      `playwright_chromiumdev_profile-fresh-${tag}`,
-    );
-    const oldDir = join(tmpdir(), `playwright-artifacts-old-${tag}`);
-    const unrelatedDir = join(tmpdir(), `not-playwright-${tag}`);
-    await fs.mkdir(freshDir, { recursive: true });
-    await fs.mkdir(oldDir, { recursive: true });
-    await fs.mkdir(unrelatedDir, { recursive: true });
-    // Back-date the "old" orphan an hour so it is older than any sane TTL.
-    const oldTime = new Date(Date.now() - 3_600_000);
-    await fs.utimes(oldDir, oldTime, oldTime);
+  it("the pool-unrecoverable alarm payload carries the cgroup PID gauges (names the real signal)", async () => {
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const { logger } = makeLeveledLogger();
+    let captured:
+      | {
+          cgroupPidsCurrent: number;
+          cgroupPidsMax: number;
+          treeThreadCount: number;
+        }
+      | undefined;
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 1,
+      selfHealHardRecoveryThreshold: 2,
+      selfHealMaxHardRecoveries: 2,
+      onUnrecoverable: (info) => {
+        captured = {
+          cgroupPidsCurrent: info.cgroupPidsCurrent,
+          cgroupPidsMax: info.cgroupPidsMax,
+          treeThreadCount: info.treeThreadCount,
+        };
+      },
+    });
+    await pool.init();
+    launcher.launched[0]!.__crash();
 
-    try {
-      // age = 5 min: the fresh dir (mtime now) is YOUNGER than the age gate and
-      // must be skipped; the hour-old orphan is OLDER and must be removed.
-      const removed = await defaultPurgeProfileDirs(5 * 60_000);
-      expect(removed).toBeGreaterThanOrEqual(1);
+    await waitFor(() => captured !== undefined, 5_000);
+    // The give-up alarm names the PROVEN wedge signal (the measured PID counts +
+    // thread demand), not just the abstract breaker counters. Off-Linux these
+    // degrade to -1 — still a number, still present in the payload.
+    expect(typeof captured!.cgroupPidsCurrent).toBe("number");
+    expect(typeof captured!.cgroupPidsMax).toBe("number");
+    expect(typeof captured!.treeThreadCount).toBe("number");
 
-      const exists = async (p: string): Promise<boolean> =>
-        fs
-          .stat(p)
-          .then(() => true)
-          .catch(() => false);
-
-      // The in-use (fresh) dir survives — the age gate protected it.
-      expect(await exists(freshDir)).toBe(true);
-      // The old orphan was reclaimed.
-      expect(await exists(oldDir)).toBe(false);
-      // A non-playwright dir is never touched (prefix gate).
-      expect(await exists(unrelatedDir)).toBe(true);
-    } finally {
-      await fs.rm(freshDir, { recursive: true, force: true });
-      await fs.rm(oldDir, { recursive: true, force: true });
-      await fs.rm(unrelatedDir, { recursive: true, force: true });
-    }
+    await pool.shutdown();
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -3454,4 +3454,142 @@ describe("BrowserPool — resource-gauge instrumentation (PID-ceiling early warn
 
     await pool.shutdown();
   });
+
+  // ── DURABLE FORENSIC SNAPSHOTS: onSnapshot hook + heartbeat ─────────────────
+  //
+  // The wedge ends in a container restart that clears in-memory state, and the
+  // Railway stdout window rolls off — so the gauge history MUST be persisted
+  // durably (PB) to survive. The pool fires `onSnapshot` (full gauge sample +
+  // stats + per-browser breakdown) on every meaningful transition AND on a
+  // periodic heartbeat. These tests assert: (a) a snapshot fires on the
+  // degraded + unrecoverable transitions; (b) the heartbeat samples
+  // periodically; (c) BEST-EFFORT — a throwing onSnapshot never breaks the pool.
+
+  // RED (pre-wiring): no onSnapshot → no forensic capture at the degraded
+  // transition. GREEN: the moment the set empties, a `degraded` snapshot fires.
+  it("SNAPSHOT: fires a forensic snapshot on the degraded transition", async () => {
+    const launcher = makeFakeLauncher({ failAfterCall: 2 });
+    const snapshots: string[] = [];
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 4,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 5,
+      heartbeatMs: 0, // isolate the transition snapshot from the heartbeat
+      onSnapshot: (s) => {
+        snapshots.push(s.event);
+      },
+    });
+    await pool.init();
+    launcher.launched[0]!.__crash();
+    launcher.launched[1]!.__crash();
+
+    await waitFor(() => snapshots.includes("degraded"), 5_000);
+    expect(snapshots).toContain("degraded");
+    // The init snapshot also fired (baseline at boot).
+    expect(snapshots).toContain("init");
+
+    await pool.shutdown();
+  });
+
+  // GREEN: the TERMINAL give-up fires an `unrecoverable` snapshot — the single
+  // most important forensic row (pool dead, redeploy required).
+  it("SNAPSHOT: fires a forensic snapshot on the unrecoverable give-up", async () => {
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const snapshots: Array<{ event: string; pidsMax: number }> = [];
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 1,
+      selfHealHardRecoveryThreshold: 2,
+      selfHealMaxHardRecoveries: 2,
+      heartbeatMs: 0,
+      onSnapshot: (s) => {
+        snapshots.push({ event: s.event, pidsMax: s.gauges.cgroupPidsMax });
+      },
+    });
+    await pool.init();
+    launcher.launched[0]!.__crash();
+
+    await waitFor(
+      () => snapshots.some((s) => s.event === "unrecoverable"),
+      5_000,
+    );
+    expect(snapshots.some((s) => s.event === "unrecoverable")).toBe(true);
+    // The snapshot carried a real gauge sample (pidsMax is a number, -1 off-Linux).
+    const unrec = snapshots.find((s) => s.event === "unrecoverable")!;
+    expect(typeof unrec.pidsMax).toBe("number");
+
+    await pool.shutdown();
+  });
+
+  // GREEN: the periodic heartbeat fires baseline snapshots between events so a
+  // slow PID creep is visible even when no transition fires.
+  it("SNAPSHOT: heartbeat fires periodic baseline snapshots", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    let heartbeats = 0;
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      launchBrowser,
+      launchStaggerMs: 0,
+      heartbeatMs: 10, // tiny so the test observes several beats quickly
+      onSnapshot: (s) => {
+        if (s.event === "heartbeat") heartbeats++;
+      },
+    });
+    await pool.init();
+
+    await waitFor(() => heartbeats >= 2, 5_000);
+    expect(heartbeats).toBeGreaterThanOrEqual(2);
+
+    await pool.shutdown();
+
+    // After shutdown the heartbeat loop stops — no further beats accrue.
+    const afterShutdown = heartbeats;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(heartbeats).toBe(afterShutdown);
+  });
+
+  // BEST-EFFORT: a throwing onSnapshot hook is caught + logged and NEVER breaks
+  // the pool — acquire/release keep working. Mirrors the safeHook doctrine.
+  it("SNAPSHOT: a throwing onSnapshot hook does NOT break the pool (best-effort)", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    const { logger, events } = makeLeveledLogger();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser,
+      launchStaggerMs: 0,
+      heartbeatMs: 0,
+      onSnapshot: () => {
+        throw new Error("snapshot writer exploded");
+      },
+    });
+    // init() fires the "init" snapshot → the hook throws → must NOT reject init.
+    await expect(pool.init()).resolves.toBeUndefined();
+    // The throw was caught + logged, not propagated.
+    expect(
+      events.some(
+        (e) =>
+          e.event === "browser-pool.hook-failed" &&
+          e.meta?.hook === "onSnapshot",
+      ),
+    ).toBe(true);
+
+    // The pool is fully functional despite the throwing hook.
+    const ctx = await pool.acquire(undefined, 2_000);
+    expect(ctx).toBeDefined();
+    await pool.release(ctx);
+
+    await pool.shutdown();
+  });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1830,6 +1830,191 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     await pool.shutdown();
   });
 
+  // ── SELF-HEAL CIRCUIT-BREAKER (durable fix for the RECURRING wedge) ─────────
+  //
+  // The RECURRING staging BrowserPool collapse (#5185/#5221/#5225 each chipped
+  // at it but it kept recurring): after the long-lived harness container runs
+  // ~hours under sustained d6 cron load, chromium enters a LAUNCH crash-loop —
+  // every `chromium.launch()` throws `browserType.launch: Target page, context
+  // or browser has been closed`. The set empties, `startSelfHeal()` kicks in,
+  // and its loop just RELAUNCHES into the SAME wedged state forever
+  // (`self-heal-launch-failed` repeating) — backing off between identical
+  // attempts but NEVER escaping (the stale `/tmp/playwright_*` profile dirs /
+  // FD-shm pressure persist across every relaunch). acquire() therefore has no
+  // contexts forever → blocks to timeout fleet-wide. Only a container RESTART
+  // cleared it (reactive). The circuit-breaker makes the loop ESCAPE: after N
+  // consecutive launch failures it HARD-recovers (purge stale profile dirs +
+  // cold-launch); if even K hard recoveries fail it fires a LOUD
+  // pool-unrecoverable alarm instead of spinning silently.
+
+  // RED (pre-breaker) → GREEN (post-breaker): chromium is wedged (every launch
+  // throws "...has been closed"). PRE-breaker the self-heal loop relaunches
+  // identically forever and acquire() never gets a context (wedged). POST-breaker
+  // the breaker trips at the threshold, the HARD recovery PURGES the stale
+  // profile dirs — modeled here by the purge "unwedging" the launcher — and the
+  // pool cold-launches fresh, so acquire() succeeds again.
+  it("OUTAGE: circuit-breaker hard-recovers (purge + cold-launch) out of a chromium launch-crash-loop the plain self-heal could not escape", async () => {
+    // init launches 1 browser (call 1). Everything AFTER call 1 throws the
+    // "...has been closed" launch-crash-loop error — modeling the wedged
+    // container. The PURGE is what breaks the wedge: when the breaker fires the
+    // hard recovery, the injected purge flips the launcher healthy so the
+    // subsequent COLD launch succeeds. Without the breaker the purge never runs,
+    // launches stay wedged, and the pool is dead forever.
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const { logger, events } = makeLeveledLogger();
+    let purgeCalls = 0;
+    let recovered = 0;
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 1,
+      // Trip the hard recovery after 3 consecutive self-heal launch failures.
+      selfHealHardRecoveryThreshold: 3,
+      selfHealMaxHardRecoveries: 3,
+      // The purge models clearing stale /tmp/playwright_* profile dirs. Doing so
+      // "unwedges" chromium — the proof that the hard recovery (not another
+      // identical relaunch) is what escapes the loop.
+      purgeProfileDirs: async () => {
+        purgeCalls++;
+        launcher.setFailAfter(undefined);
+        return 2;
+      },
+      onRecovered: () => {
+        recovered++;
+      },
+    });
+    await pool.init();
+    expect(launcher.launched.length).toBe(1);
+
+    // Crash the only browser → crash recycle's relaunch throws (wedged) → set
+    // empties → self-heal begins, but every relaunch keeps throwing the
+    // "...has been closed" error. The plain self-heal would loop here forever.
+    launcher.launched[0]!.__crash();
+
+    // BREAKER PROOF: after the threshold of consecutive failures the hard
+    // recovery fires — the purge runs (clears the wedge) and the cold launch
+    // succeeds, reviving the pool to full strength and firing onRecovered.
+    await waitFor(() => recovered >= 1, 5_000);
+    expect(purgeCalls).toBeGreaterThanOrEqual(1);
+    expect(
+      events.some((e) => e.event === "browser-pool.self-heal-hard-recovery"),
+    ).toBe(true);
+    expect(
+      events.some((e) => e.event === "browser-pool.self-heal-profile-purge"),
+    ).toBe(true);
+
+    // The pool is alive again: a fresh acquire succeeds (no timeout, no wedge).
+    const ctx = await pool.acquire(undefined, 2_000);
+    expect(ctx).toBeDefined();
+    expect(pool.stats().inUse).toBe(1);
+
+    await pool.release(ctx);
+    await pool.shutdown();
+  });
+
+  // PROOF the breaker fires AT the threshold, not before. With threshold=3 the
+  // first 3 consecutive failures must NOT trigger a hard recovery; only the
+  // attempt past the threshold does.
+  it("circuit-breaker: fires the hard recovery only AFTER the consecutive-failure threshold is reached", async () => {
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const { logger, events } = makeLeveledLogger();
+    let purgeCalls = 0;
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 1,
+      selfHealHardRecoveryThreshold: 3,
+      selfHealMaxHardRecoveries: 5,
+      purgeProfileDirs: async () => {
+        purgeCalls++;
+        // Do NOT heal — keep the wedge so we can count failures BEFORE the first
+        // purge fired.
+        return 0;
+      },
+    });
+    await pool.init();
+    launcher.launched[0]!.__crash();
+
+    // Wait until the first hard recovery has fired.
+    await waitFor(() => purgeCalls >= 1, 5_000);
+
+    // At the moment the FIRST purge fired, at least `threshold` consecutive
+    // self-heal launch failures must have been logged first (the breaker does
+    // not fire early).
+    const failuresBeforeFirstPurge = events.filter(
+      (e) => e.event === "browser-pool.self-heal-launch-failed",
+    ).length;
+    expect(failuresBeforeFirstPurge).toBeGreaterThanOrEqual(3);
+
+    await pool.shutdown();
+  });
+
+  // RED (pre-breaker, silent spin) → GREEN: if even the HARD recovery cannot
+  // break the wedge (the purge does not help — e.g. a genuinely broken
+  // container), the breaker gives up LOUDLY after K hard recoveries with a
+  // `pool-unrecoverable` alarm and stops the heal loop, rather than spinning
+  // self-heal-launch-failed forever with no operator signal.
+  it("OUTAGE: circuit-breaker surfaces a loud pool-unrecoverable alarm (and stops) when even hard recovery cannot escape the wedge", async () => {
+    // Permanently wedged: launches throw forever and the purge never heals.
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const { logger, events } = makeLeveledLogger();
+    let unrecoverableCalls = 0;
+    let purgeCalls = 0;
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 1,
+      selfHealHardRecoveryThreshold: 2,
+      selfHealMaxHardRecoveries: 2,
+      purgeProfileDirs: async () => {
+        purgeCalls++;
+        // Purge cannot fix it — the wedge survives even the profile-dir clear.
+        return 0;
+      },
+      onUnrecoverable: () => {
+        unrecoverableCalls++;
+      },
+    });
+    await pool.init();
+    launcher.launched[0]!.__crash();
+
+    // The breaker hard-recovers twice (each preceded by `threshold` failures),
+    // both fail, and then it gives up LOUDLY.
+    await waitFor(() => unrecoverableCalls >= 1, 5_000);
+    expect(unrecoverableCalls).toBe(1);
+    expect(purgeCalls).toBeGreaterThanOrEqual(2);
+    expect(
+      events.some((e) => e.event === "browser-pool.pool-unrecoverable"),
+    ).toBe(true);
+
+    // The heal loop has STOPPED (not spinning) — the failure count stabilizes.
+    const failuresAtGiveUp = events.filter(
+      (e) => e.event === "browser-pool.self-heal-launch-failed",
+    ).length;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const failuresAfter = events.filter(
+      (e) => e.event === "browser-pool.self-heal-launch-failed",
+    ).length;
+    expect(failuresAfter).toBe(failuresAtGiveUp);
+
+    await pool.shutdown();
+  });
+
   // ── CR-FIX BUCKET A: crash-recovery / self-heal / accounting bugs ──────────
 
   // FIX #5 — pickLeastLoaded must rank by liveContexts.size + pendingOpens, not

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -2015,6 +2015,215 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     await pool.shutdown();
   });
 
+  // MULTI-BROWSER (shortfall > 1) breaker pacing. Every prior breaker test runs
+  // browsers:1, leaving the multi-browser pacing of consecutiveFailures /
+  // consecutiveHardRecoveries unverified. Here browsers:2: the set empties, the
+  // heal loop must top BOTH back up. We let it revive ONE browser (partial
+  // success) while the second relaunch in the SAME shortfall pass fails — the
+  // partial success must RESET the consecutive-failure counter so the breaker
+  // does NOT trip a premature hard recovery, then the loop tops up the second
+  // browser on a later iteration and recovers to full strength.
+  it("MULTI-BROWSER: a partial revive resets the breaker's consecutive-failure counter (no premature hard recovery)", async () => {
+    // init launches 2 (calls 1,2). Crash both → set empties → heal loop runs.
+    // Shape the launcher so the heal sequence is: fail, fail, fail (trip toward
+    // threshold) … then SUCCEED once (partial revive — must reset the counter) …
+    // then succeed again (full strength). If the counter did NOT reset on the
+    // partial success, a hard recovery (purge) would fire; we assert it does NOT.
+    let purgeCalls = 0;
+    let recovered = 0;
+    const { logger, events } = makeLeveledLogger();
+
+    // Custom launcher: init's 2 launches succeed; the next `failStreak` relaunch
+    // attempts fail; everything after succeeds. With threshold=4 and a 3-failure
+    // streak BEFORE the first success, the breaker must NOT trip (3 < 4), and the
+    // success resets the streak so the remaining top-up never trips it either.
+    let call = 0;
+    const failStreak = 3;
+    const initLaunches = 2;
+    const launched: FakeBrowser[] = [];
+    const launchBrowser: LaunchBrowser = async () => {
+      call++;
+      if (call > initLaunches && call <= initLaunches + failStreak) {
+        throw new Error(
+          "browserType.launch: Target page, context or browser has been closed",
+        );
+      }
+      const b = makeFakeBrowser({});
+      launched.push(b);
+      return b as unknown as Browser;
+    };
+
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 4,
+      logger,
+      launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 1,
+      selfHealHardRecoveryThreshold: 4,
+      selfHealMaxHardRecoveries: 3,
+      purgeProfileDirs: async () => {
+        purgeCalls++;
+        return 0;
+      },
+      onRecovered: () => {
+        recovered++;
+      },
+    });
+    await pool.init();
+    expect(launched.length).toBe(2);
+
+    // Crash both → both recycle relaunches fail (in the failStreak window) → set
+    // empties → heal loop begins, burns the rest of the streak, then revives.
+    launched[0]!.__crash();
+    launched[1]!.__crash();
+
+    // The pool comes back to FULL strength (2 browsers) and fires onRecovered.
+    await waitFor(() => recovered >= 1, 5_000);
+
+    // The breaker NEVER tripped a hard recovery: the 3-failure streak stayed
+    // below the threshold of 4, and the partial revive reset the counter so the
+    // second top-up launch could not push a stale counter over the line.
+    expect(purgeCalls).toBe(0);
+    expect(
+      events.some((e) => e.event === "browser-pool.self-heal-hard-recovery"),
+    ).toBe(false);
+    // Full strength restored.
+    expect(pool.stats().size).toBe(4); // maxContexts is the reported size
+    const live = launched.filter((b) => b.isConnected());
+    expect(live.length).toBe(2);
+
+    await pool.shutdown();
+  });
+
+  // LATCH SECOND-EPISODE (the silent-spin the breaker exists to kill). The give-up
+  // path must be able to fire its alarm on EACH distinct degraded episode. The
+  // unfixed code latched `this.unrecoverable` after the first give-up and cleared
+  // it ONLY on a successful launch, so a pool that gave up, briefly revived, then
+  // re-wedged into a SECOND give-up was silent on the second episode under any
+  // ordering where the latch outlived the episode boundary. The fix removes the
+  // instance latch (the loop-local consecutiveHardRecoveries guard already gives
+  // once-per-episode), so each fresh self-heal spawn can alarm.
+  //
+  // This drives TWO distinct degraded episodes on ONE permanently-wedged pool.
+  // Episode 1: the set empties and the breaker gives up (alarm #1), then the
+  // heal loop EXITS (by design — `pool-unrecoverable (and stops)` asserts this).
+  // Episode 2: the set is STILL wedged and empties AGAIN (the fresh degraded
+  // episode the comment on `onBrowserSetEmpty` describes: "set empties AGAIN
+  // while degraded is still true but NO heal loop is running"). That re-spawns a
+  // fresh heal loop which must be able to fire its OWN alarm (#2). The unfixed
+  // instance latch (`this.unrecoverable`, set on the first give-up and cleared
+  // ONLY by a successful launch — which never happens while wedged) made the
+  // second give-up SILENT. We trigger the second episode via the private
+  // empty-set entrypoint, the same call the recycle-eviction path makes.
+  it("LATCH: a second degraded episode ALSO fires onUnrecoverable (not silenced by a stale latch)", async () => {
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const { logger, events } = makeLeveledLogger();
+    let unrecoverableCalls = 0;
+    const infos: Array<{ browserCount: number; maxHardRecoveries: number }> =
+      [];
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 1,
+      selfHealHardRecoveryThreshold: 2,
+      selfHealMaxHardRecoveries: 2,
+      purgeProfileDirs: async () => 0, // never heals — forces a give-up
+      onUnrecoverable: (info) => {
+        unrecoverableCalls++;
+        infos.push({
+          browserCount: info.browserCount,
+          maxHardRecoveries: info.maxHardRecoveries,
+        });
+      },
+    });
+    await pool.init();
+
+    // Private hooks: the empty-set entrypoint + the selfHealing guard so we can
+    // wait for episode 1's loop to fully EXIT before triggering episode 2 (the
+    // recycle path itself calls onBrowserSetEmpty when browsers.length===0).
+    const priv = pool as unknown as {
+      onBrowserSetEmpty(): void;
+      selfHealing: boolean;
+    };
+
+    // EPISODE 1: crash the only browser → wedged → breaker gives up (#1) → loop
+    // exits (selfHealing flips back to false).
+    launcher.launched[0]!.__crash();
+    await waitFor(() => unrecoverableCalls >= 1, 5_000);
+    expect(unrecoverableCalls).toBe(1);
+    await waitFor(() => priv.selfHealing === false, 5_000);
+
+    // EPISODE 2: the container is STILL wedged and the set empties AGAIN. This is
+    // the fresh degraded episode — re-spawn the heal loop via the same empty-set
+    // entrypoint the recycle-eviction path uses. The breaker must be able to fire
+    // its alarm a SECOND time (the stale latch previously silenced it).
+    priv.onBrowserSetEmpty();
+    await waitFor(() => unrecoverableCalls >= 2, 8_000);
+    expect(unrecoverableCalls).toBe(2);
+    // The alarm carried the breaker counters both times.
+    expect(infos.every((i) => i.browserCount === 1)).toBe(true);
+    expect(
+      events.filter((e) => e.event === "browser-pool.pool-unrecoverable")
+        .length,
+    ).toBe(2);
+
+    await pool.shutdown();
+  });
+
+  // FOOTGUN CLAMP. The breaker guards are `> 0`, so a `selfHealHardRecovery
+  // Threshold` / `selfHealMaxHardRecoveries` of 0 (a config typo) would silently
+  // DISABLE both the hard recovery AND the give-up — reverting to the infinite
+  // silent spin this PR fixes. The fix CLAMPS resolved thresholds up to >= 1, so
+  // a 0 can't disable the safety net. With both passed as 0 (→ clamped to 1) a
+  // permanently-wedged pool MUST still hard-recover and then give up loudly.
+  it("FOOTGUN: a 0 breaker threshold is clamped to 1 (breaker stays armed, not silently disabled)", async () => {
+    const launcher = makeFakeLauncher({ failAfterCall: 1 });
+    const { logger, events } = makeLeveledLogger();
+    let unrecoverableCalls = 0;
+    let purgeCalls = 0;
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      logger,
+      launchBrowser: launcher.launchBrowser,
+      launchStaggerMs: 0,
+      relaunchMaxRetries: 0,
+      relaunchBackoffMs: 0,
+      selfHealIntervalMs: 1,
+      // The footgun: 0 would disable the `> 0` guards under the unfixed code.
+      selfHealHardRecoveryThreshold: 0,
+      selfHealMaxHardRecoveries: 0,
+      purgeProfileDirs: async () => {
+        purgeCalls++;
+        return 0;
+      },
+      onUnrecoverable: () => {
+        unrecoverableCalls++;
+      },
+    });
+    await pool.init();
+    launcher.launched[0]!.__crash();
+
+    // Clamped to 1: the breaker hard-recovers AND gives up loudly instead of
+    // spinning forever. Without the clamp, neither would fire (silent spin).
+    await waitFor(() => unrecoverableCalls >= 1, 5_000);
+    expect(unrecoverableCalls).toBe(1);
+    expect(purgeCalls).toBeGreaterThanOrEqual(1);
+    expect(
+      events.some((e) => e.event === "browser-pool.pool-unrecoverable"),
+    ).toBe(true);
+
+    await pool.shutdown();
+  });
+
   // ── CR-FIX BUCKET A: crash-recovery / self-heal / accounting bugs ──────────
 
   // FIX #5 — pickLeastLoaded must rank by liveContexts.size + pendingOpens, not

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1839,20 +1839,22 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
   // or browser has been closed`. The set empties, `startSelfHeal()` kicks in,
   // and its loop just RELAUNCHES into the SAME wedged state forever
   // (`self-heal-launch-failed` repeating) — backing off between identical
-  // attempts but NEVER escaping (the stale `/tmp/playwright_*` profile dirs /
-  // FD-shm pressure persist across every relaunch). acquire() therefore has no
+  // attempts but NEVER escaping (the wedge is the cgroup PID/thread ceiling, a
+  // platform-fixed demand-side ceiling an immediate relaunch only re-pins).
+  // acquire() therefore has no
   // contexts forever → blocks to timeout fleet-wide. Only a container RESTART
   // cleared it (reactive). The circuit-breaker makes the loop ESCAPE: after N
-  // consecutive launch failures it HARD-recovers (purge stale profile dirs +
-  // cold-launch); if even K hard recoveries fail it fires a LOUD
+  // consecutive launch failures it HARD-recovers (a PACED cold relaunch — gives
+  // the thread-exhausted kernel time to relax; NO /tmp purge); if even K hard
+  // recoveries fail it fires a LOUD
   // pool-unrecoverable alarm instead of spinning silently.
 
   // RED (pre-breaker) → GREEN (post-breaker): chromium is wedged (every launch
   // throws "...has been closed"). PRE-breaker the self-heal loop relaunches
   // identically forever and acquire() never gets a context (wedged). POST-breaker
-  // the breaker trips at the threshold, the HARD recovery PURGES the stale
-  // profile dirs — modeled here by the purge "unwedging" the launcher — and the
-  // pool cold-launches fresh, so acquire() succeeds again.
+  // the breaker trips at the threshold, the HARD recovery PACES a cold relaunch
+  // (gives the kernel time to relax — modeled here by the pacing "unwedging" the
+  // launcher) and the pool cold-launches fresh, so acquire() succeeds again.
   it("OUTAGE: circuit-breaker hard-recovers (paced cold relaunch) out of a chromium launch-crash-loop the plain self-heal could not escape", async () => {
     // init launches 1 browser (call 1). Everything AFTER call 1 throws the
     // "...has been closed" launch-crash-loop error — modeling the wedged

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -1,7 +1,5 @@
-import { promises as fs } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import type { Browser, BrowserContext } from "playwright";
+import { sampleResourceGauges } from "./resource-gauges";
 
 /**
  * Default delay the launch-serialization gate waits AFTER each chromium
@@ -98,127 +96,6 @@ const DEFAULT_SELF_HEAL_INTERVAL_MS = 2_000;
  */
 const DEFAULT_SELF_HEAL_HARD_RECOVERY_THRESHOLD = 4;
 const DEFAULT_SELF_HEAL_MAX_HARD_RECOVERIES = 3;
-
-/**
- * Glob-free prefix of the per-launch profile/temp dirs Playwright's chromium
- * leaves under the OS temp dir. The default chromium launcher does not pin a
- * `userDataDir`, so each launch creates an ephemeral `playwright_*` (and
- * related `playwright-artifacts-*`) directory; a crash-looping container
- * accumulates these and the FD/shm/inode pressure keeps every fresh launch
- * crashing. The hard-recovery purge removes them so a cold launch starts clean.
- */
-const PLAYWRIGHT_TMP_PREFIXES = ["playwright_", "playwright-artifacts-"];
-
-/**
- * Default minimum age (ms) a `playwright_*` dir must EXCEED before the
- * AGGRESSIVE breaker hard-recovery purge removes it. Bounds the blast radius: a
- * browser launching CONCURRENTLY with the purge (the cold-launch the hard
- * recovery is about to fire, or a sibling pool) has a fresh `playwright_*` dir;
- * recursively deleting it out from under an in-flight launch would re-wedge the
- * very launch we are trying to revive. Only dirs whose mtime is older than this
- * — i.e. left behind by the PRIOR wedged generation — are purged. 60s
- * comfortably exceeds a single launch/heal cycle. The hard-recovery path runs
- * only AFTER the fleet has already wedged, so it errs aggressive (reclaim fast).
- */
-export const PURGE_MIN_AGE_MS = 60_000;
-
-/**
- * Default minimum age (ms) a `playwright_*` dir must EXCEED before the PROACTIVE
- * stale-profile sweep removes it. The proactive sweep runs on a cadence (init +
- * every recycle) BEFORE any wedge, so it errs CONSERVATIVE: a 5-minute floor
- * leaves a wide margin so a dir belonging to a launch in flight or a live
- * browser (touched continuously, mtime ~now) is never even close to eligible.
- * The two ages feed the SAME `defaultPurgeProfileDirs` helper — the breaker
- * passes the aggressive `PURGE_MIN_AGE_MS`, the proactive sweep passes this.
- * Tunable on staging via env (BROWSER_POOL_STALE_PROFILE_DIR_TTL_MS) without a
- * code change.
- */
-export const DEFAULT_STALE_PROFILE_DIR_TTL_MS = 5 * 60_000;
-
-/**
- * The ONE canonical profile/temp-dir purge — shared by BOTH the durable
- * browser-pool defenses:
- *  - the PROACTIVE prevention sweep (run on a cadence at `init()` and on EVERY
- *    recycle relaunch, passing the conservative `staleProfileDirTtlMs`, 5 min)
- *    that keeps `/tmp` bounded so it never reaches the exhaustion that wedges
- *    every future `chromium.launch()`; and
- *  - the breaker's AGGRESSIVE hard-recovery purge (run only AFTER the fleet has
- *    already wedged, passing `PURGE_MIN_AGE_MS`, 60s) that reclaims the orphaned
- *    profile/FD/shm pressure so a cold launch starts clean.
- * Same hardened implementation, different `minAgeMs` argument — no duplicate
- * purge logic. Best-effort: removes the `${tmpdir()}/playwright_*` (and
- * `playwright-artifacts-*`) directories left behind whose mtime is older than
- * `minAgeMs`. Injectable via `BrowserPoolOptions.purgeProfileDirs` so tests can
- * drive both cadences without touching the real filesystem and assert it fired.
- *
- * SAFETY (the temp dir is world-writable `/tmp`, so an attacker — or a stray
- * tool — can plant entries there):
- *  - SYMLINKS are SKIPPED. `readdir(..., {withFileTypes:true})` lets us reject a
- *    `playwright_*` SYMLINK whose target is some other path; a blind
- *    `rm(recursive)` would follow it and recursively delete the target's
- *    contents. Only entries that are themselves real DIRECTORIES are eligible.
- *  - Entries younger than `minAgeMs` are LEFT ALONE so a concurrently launching
- *    browser's fresh dir (or a live browser's continuously-touched dir) is never
- *    nuked — the age gate the whole prevention safety rests on.
- *  - The realpath is verified to still resolve UNDER `tmpdir()` before removal,
- *    a belt-and-suspenders guard against a TOCTOU race / nested symlink.
- *
- * A failure to read the temp dir, stat an entry, or unlink it is swallowed (the
- * dir may not exist, be owned by another process, or vanish mid-purge) — the
- * purge is a hygiene best-effort, not a correctness dependency. The returned
- * count is LOG-ONLY (surfaced in `self-heal-profile-purge` /
- * `stale-profile-sweep`), not load-bearing.
- */
-export async function defaultPurgeProfileDirs(
-  minAgeMs: number,
-  dir: string = tmpdir(),
-): Promise<number> {
-  let removed = 0;
-  let entries: import("node:fs").Dirent[];
-  try {
-    entries = await fs.readdir(dir, { withFileTypes: true });
-  } catch {
-    return 0;
-  }
-  // Resolve the canonical (symlink-free) form of the scan dir ONCE so the
-  // per-entry containment check is robust to platform-level symlinks in the
-  // temp path itself (e.g. macOS `/var` → `/private/var`). A realpath failure
-  // falls back to the raw dir.
-  let realDir: string;
-  try {
-    realDir = await fs.realpath(dir);
-  } catch {
-    realDir = dir;
-  }
-  const now = Date.now();
-  for (const entry of entries) {
-    const name = entry.name;
-    if (!PLAYWRIGHT_TMP_PREFIXES.some((p) => name.startsWith(p))) continue;
-    // Skip symlinks (do NOT follow a planted `playwright_*` symlink) and any
-    // non-directory entry. Only real directories the wedged chromium left
-    // behind are purge candidates.
-    if (entry.isSymbolicLink() || !entry.isDirectory()) continue;
-    const full = join(dir, name);
-    try {
-      // lstat (no symlink follow) for the age check; a directory entry that
-      // isn't a symlink resolves to itself.
-      const stat = await fs.lstat(full);
-      if (stat.isSymbolicLink()) continue; // TOCTOU: became a symlink post-readdir.
-      if (now - stat.mtimeMs < minAgeMs) continue; // younger than the age gate — skip.
-      // Belt-and-suspenders: confirm the realpath stays under the scan dir
-      // before a recursive remove, so a nested-symlink trick can't escape it.
-      const real = await fs.realpath(full);
-      if (real !== join(realDir, name) && !real.startsWith(realDir + "/")) {
-        continue;
-      }
-      await fs.rm(full, { recursive: true, force: true });
-      removed++;
-    } catch {
-      // best-effort: another process may own it, or it vanished mid-purge.
-    }
-  }
-  return removed;
-}
 
 /**
  * Resolve a STRICTLY-POSITIVE numeric tunable with explicit-arg > env > default
@@ -329,18 +206,6 @@ interface PoolLogger {
 export type LaunchBrowser = () => Promise<Browser>;
 
 /**
- * Purges the stale per-launch profile/temp dirs Playwright's chromium leaves
- * behind whose mtime is older than `minAgeMs`, returning the count removed. The
- * default implementation removes `${tmpdir()}/playwright_*`. Invoked by BOTH the
- * proactive prevention sweep (init + every recycle, conservative
- * `staleProfileDirTtlMs`) AND the breaker's hard-recovery (aggressive
- * `PURGE_MIN_AGE_MS`) — same helper, different age. Tests inject a fake so both
- * cadences are exercisable without touching the real filesystem (and so the test
- * can assert the purge fired and with which age).
- */
-export type PurgeProfileDirs = (minAgeMs: number) => Promise<number>;
-
-/**
  * One long-lived browser PROCESS in the fixed set. Contexts are pooled over
  * this — the hot path (`acquire`/`release`) opens and closes CONTEXTS on an
  * already-running browser and never forks a process. A browser is only
@@ -392,9 +257,15 @@ export interface BrowserPoolOptions {
   /** Number of long-lived browser processes in the fixed set. Default 3
    *  (env BROWSER_POOL_BROWSERS, legacy fallback BROWSER_POOL_SIZE). */
   browsers?: number;
-  /** Global cap on concurrently-live contexts across all browsers. Default
-   *  40 (env BROWSER_POOL_MAX_CONTEXTS) — covers D6 peak 32 + D5 peak 8.
-   *  acquire() past this pends a waiter. */
+  /** Global cap on concurrently-live contexts across all browsers. Default 24
+   *  (env BROWSER_POOL_MAX_CONTEXTS). LOWERED from 40 to reduce THREAD demand
+   *  against the platform-fixed cgroup `pids.max=1000` ceiling — the PROVEN
+   *  wedge: each context backs a chromium renderer (~15 threads), so a d6 burst
+   *  at 40 contexts (~32 concurrent) drove `pids.current` to ~850-900 and a
+   *  concurrent recovery-relaunch pushed it over 1000 → pthread EAGAIN →
+   *  crash-loop. 24 keeps peak demand well under the ceiling while still
+   *  covering the d6 peak. Env-overridable. acquire() past this pends a
+   *  waiter. */
   maxContexts?: number;
   /** Per-browser served-context hygiene threshold: once a browser has served
    *  >= recycleAfter contexts AND has no live contexts, it is recycled (its
@@ -420,30 +291,15 @@ export interface BrowserPoolOptions {
    *  a small value. */
   selfHealIntervalMs?: number;
   /** Number of CONSECUTIVE self-heal launch failures after which the loop stops
-   *  retrying the identical relaunch and performs a HARD recovery (purge stale
-   *  profile/temp dirs, then cold-launch). Default 4 (env
-   *  BROWSER_POOL_SELF_HEAL_HARD_RECOVERY_THRESHOLD). Tests pass a small value to
-   *  trip the breaker deterministically. */
+   *  retrying the identical relaunch and performs a HARD recovery (a paced cold
+   *  relaunch). Default 4 (env BROWSER_POOL_SELF_HEAL_HARD_RECOVERY_THRESHOLD).
+   *  Tests pass a small value to trip the breaker deterministically. */
   selfHealHardRecoveryThreshold?: number;
   /** Number of CONSECUTIVE HARD recoveries that may fail to revive any browser
    *  before the pool gives up and fires the `pool-unrecoverable` alarm (instead
    *  of spinning forever). Default 3 (env
    *  BROWSER_POOL_SELF_HEAL_MAX_HARD_RECOVERIES). */
   selfHealMaxHardRecoveries?: number;
-  /** Injected profile/temp-dir purge (tests), given the age threshold. Defaults
-   *  to removing `${tmpdir()}/playwright_*` older than the passed age. Invoked by
-   *  BOTH the proactive prevention sweep (init + every recycle) AND the
-   *  self-heal hard-recovery path — same helper, different age argument. */
-  purgeProfileDirs?: PurgeProfileDirs;
-  /** Age (ms) a `${tmpdir()}/playwright_*` profile/artifact dir must EXCEED
-   *  before the PROACTIVE prevention sweep removes it. The age gate guarantees
-   *  the sweep never deletes a dir for a launch in flight or a live browser
-   *  (those are touched continuously, so their mtime is ~now). Conservative by
-   *  design (the sweep runs BEFORE any wedge). Default 300000 (5 min; env
-   *  BROWSER_POOL_STALE_PROFILE_DIR_TTL_MS). Tests pass 0 to sweep every matching
-   *  dir deterministically. Distinct from the breaker's aggressive
-   *  `PURGE_MIN_AGE_MS`, which the hard-recovery path passes instead. */
-  staleProfileDirTtlMs?: number;
   /**
    * Mid-life capacity-loss alarm hook. Invoked when the browser set EMPTIES
    * (every entry evicted) — the silent-outage gap the original code had, where
@@ -483,6 +339,15 @@ export interface BrowserPoolUnrecoverableInfo {
   waiters: number;
   /** Consecutive failed HARD recoveries that tripped the give-up. */
   maxHardRecoveries: number;
+  /** cgroup `pids.current` at give-up — the PROVEN wedge signal. Naming the
+   *  measured PID count (vs the `pids.max` ceiling) in the alarm payload tells
+   *  the operator the wedge was PID/thread-ceiling exhaustion, not a guess. -1
+   *  off-Linux / when the cgroup PID controller is unreadable. */
+  cgroupPidsCurrent: number;
+  /** cgroup `pids.max` ceiling at give-up (-1 = unbounded / unavailable). */
+  cgroupPidsMax: number;
+  /** Process-tree thread count at give-up (the demand against `pids.max`). */
+  treeThreadCount: number;
 }
 
 /**
@@ -521,19 +386,14 @@ export class BrowserPool {
   private readonly relaunchMaxRetries: number;
   private readonly relaunchBackoffMs: number;
   private readonly selfHealIntervalMs: number;
-  // Self-heal circuit-breaker (the durable fix for the RECURRING wedge): trip a
-  // HARD recovery (profile-dir purge + cold-launch) after this many consecutive
-  // self-heal launch failures, and give up (loud alarm) after this many
-  // consecutive failed HARD recoveries.
+  // Self-heal circuit-breaker (the root-cause-agnostic backstop for the
+  // RECURRING wedge): trip a HARD recovery (a paced cold relaunch) after this
+  // many consecutive self-heal launch failures, and give up (loud
+  // `onUnrecoverable` alarm) after this many consecutive failed HARD recoveries.
+  // This stops the infinite silent spin and signals "redeploy required" on ANY
+  // wedge — including the PROVEN cgroup PID/thread-ceiling exhaustion.
   private readonly selfHealHardRecoveryThreshold: number;
   private readonly selfHealMaxHardRecoveries: number;
-  private readonly purgeProfileDirs: PurgeProfileDirs;
-  // PREVENTION: conservative age gate for the PROACTIVE stale-profile sweep (run
-  // at init + every recycle). Distinct from the breaker's aggressive
-  // PURGE_MIN_AGE_MS — both feed the same `purgeProfileDirs` helper, just with a
-  // different age. Keeps `/tmp` from accumulating orphaned `playwright_*` dirs to
-  // the exhaustion that wedges every future launch (the confirmed root cause).
-  private readonly staleProfileDirTtlMs: number;
   private readonly onDegraded?: () => void;
   private readonly onRecovered?: () => void;
   private readonly onUnrecoverable?: (
@@ -588,11 +448,14 @@ export class BrowserPool {
     const envMax = process.env.BROWSER_POOL_MAX_CONTEXTS
       ? parseInt(process.env.BROWSER_POOL_MAX_CONTEXTS, 10)
       : undefined;
+    // Default 24 (lowered from 40) to cap THREAD demand under the platform-fixed
+    // cgroup pids.max=1000 ceiling — the proven wedge. Env-overridable via
+    // BROWSER_POOL_MAX_CONTEXTS.
     this.maxContexts =
       options.maxContexts ??
       (envMax !== undefined && !Number.isNaN(envMax) && envMax > 0
         ? envMax
-        : 40);
+        : 24);
 
     const envRecycle = process.env.BROWSER_POOL_RECYCLE_AFTER
       ? parseInt(process.env.BROWSER_POOL_RECYCLE_AFTER, 10)
@@ -658,62 +521,34 @@ export class BrowserPool {
       process.env.BROWSER_POOL_SELF_HEAL_MAX_HARD_RECOVERIES,
       DEFAULT_SELF_HEAL_MAX_HARD_RECOVERIES,
     );
-    // PREVENTION age gate (conservative). The proactive sweep passes this; the
-    // breaker's hard-recovery passes the aggressive PURGE_MIN_AGE_MS — both into
-    // the SAME purgeProfileDirs helper. resolveNonNegative (not resolvePositive):
-    // an explicit `0` is legitimate (tests sweep every matching dir).
-    this.staleProfileDirTtlMs = resolveNonNegative(
-      options.staleProfileDirTtlMs,
-      process.env.BROWSER_POOL_STALE_PROFILE_DIR_TTL_MS,
-      DEFAULT_STALE_PROFILE_DIR_TTL_MS,
-    );
-    // Purge resolution: an explicit injected purge wins. Otherwise, when a fake
-    // `launchBrowser` is injected (tests — the browsers are fakes, so there are
-    // NO real `/tmp/playwright_*` dirs to scan/remove), default to a hermetic
-    // no-op so NEITHER the proactive sweep NOR the breaker's hard-recovery path
-    // touches the real filesystem under test. Only the production path (real
-    // chromium launcher, no injected launcher) gets the real
-    // `${tmpdir()}/playwright_*` purge.
-    this.purgeProfileDirs =
-      options.purgeProfileDirs ??
-      (this.injectedLaunchBrowser
-        ? async (): Promise<number> => 0
-        : defaultPurgeProfileDirs);
     this.onDegraded = options.onDegraded;
     this.onRecovered = options.onRecovered;
     this.onUnrecoverable = options.onUnrecoverable;
   }
 
   /**
-   * PREVENTION: fire the PROACTIVE stale-profile-dir sweep without awaiting it
-   * (fire-and-forget — the sweep is hygiene, never on the critical path of a
-   * launch). Calls the SAME canonical `purgeProfileDirs` the breaker uses, but
-   * with the conservative `staleProfileDirTtlMs` age gate. Routes a removed-count
-   * to the structured log and any unexpected throw to the logger. Called once at
-   * init() and on every recycle relaunch so orphaned `/tmp/playwright_*` dirs are
-   * reclaimed on a cadence — keeping the container's `/tmp` from accumulating to
-   * the exhaustion that wedges every future `chromium.launch()` (the confirmed
-   * root cause). Orthogonal to the breaker, which purges UNCONDITIONALLY (its own
-   * aggressive age) only AFTER a wedge: the sweep PREVENTS the wedge, the breaker
-   * ESCAPES it if it ever still happens.
+   * EARLY-WARNING INSTRUMENTATION: sample + log the OS resource gauges so a
+   * burst approaching the cgroup `pids.max` ceiling (the PROVEN wedge cause) is
+   * observable, and an EAGAIN at `launchBrowser()` correlates to a measured
+   * `pids.current` near `pids.max`. Logged at `info` with the headline
+   * `pids.current`/`pids.max`/thread fields plus the refuted-candidate
+   * differential (FD/RSS/shm/tmp). Best-effort: a sampling failure is swallowed
+   * (degrades to -1 fields off-Linux), never on the critical path. `label`
+   * names the call site (`launch`, `self-heal-launch-failed`, probe ticks).
    */
-  private fireStaleProfileSweep(reason: "init" | "recycle"): void {
-    void this.purgeProfileDirs(this.staleProfileDirTtlMs)
-      .then((removed) => {
-        if (removed > 0) {
-          this.logger?.info("browser-pool.stale-profile-sweep", {
-            reason,
-            removed,
-            ttlMs: this.staleProfileDirTtlMs,
-          });
-        }
-      })
-      .catch((err: unknown) => {
-        this.logger?.warn?.("browser-pool.stale-profile-sweep-failed", {
-          reason,
-          error: err instanceof Error ? err.message : String(err),
-        });
+  private logGauges(label: string): void {
+    try {
+      const g = sampleResourceGauges();
+      this.logger?.info("browser-pool.resource-gauges", {
+        label,
+        ...g,
       });
+    } catch (err) {
+      this.logger?.warn?.("browser-pool.resource-gauges-failed", {
+        label,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   async init(): Promise<void> {
@@ -728,13 +563,6 @@ export class BrowserPool {
           args: ["--no-sandbox", "--disable-dev-shm-usage"],
         });
     }
-
-    // PREVENTION: sweep any stale `/tmp/playwright_*` orphans BEFORE the init
-    // fill. A long-lived container that was redeployed in place (or whose prior
-    // process left orphans) starts with a `/tmp` that may already carry dirs
-    // whose owning processes are long gone; reclaiming them up front keeps the
-    // baseline low. Fire-and-forget — never block the init fill on hygiene.
-    this.fireStaleProfileSweep("init");
 
     try {
       for (let i = 0; i < this.browserCount; i++) {
@@ -803,6 +631,12 @@ export class BrowserPool {
    * returned on the shutdown path — the throw means there is no browser to close.
    */
   private launchBrowser = (): Promise<Browser> => {
+    // EARLY WARNING: log the OS resource gauges on EVERY launch (init fill,
+    // crash recovery, hygiene recycle, self-heal). A launch is the moment PID
+    // demand spikes toward the cgroup `pids.max` ceiling — the proven wedge —
+    // so sampling here makes a burst approaching the ceiling observable and lets
+    // a `pthread_create` EAGAIN be correlated to a measured `pids.current`.
+    this.logGauges("launch");
     const gate = this.launchChain;
     const raw = gate.then(() => this.rawLaunchBrowser());
     // Gate the NEXT launch off the RAW result (pre-shutdown-handling) so the
@@ -1726,17 +1560,6 @@ export class BrowserPool {
 
       if (this.isShutdown) return;
 
-      // PREVENTION: sweep stale `/tmp/playwright_*` orphans on the recycle
-      // cadence. Each recycle (crash recovery OR hygiene) is a chromium
-      // replacement — exactly the point in the long-lived container's life where
-      // orphaned profile/artifact dirs accumulate. Sweeping the AGE-GATED stale
-      // dirs here (after the old browser has been closed, before the fresh one
-      // launches) reclaims the orphans Playwright's best-effort close-time
-      // cleanup left behind, keeping `/tmp` bounded across hours of cron load so
-      // a future launch never hits the exhaustion that wedges the whole pool.
-      // Fire-and-forget — the relaunch never waits on hygiene.
-      this.fireStaleProfileSweep("recycle");
-
       try {
         // FIX #1 — PID-ceiling backpressure: retry the relaunch with backoff
         // before giving up the entry. A `pthread_create: Resource temporarily
@@ -2022,6 +1845,11 @@ export class BrowserPool {
               hardRecoveryThreshold: this.selfHealHardRecoveryThreshold,
               error: err instanceof Error ? err.message : String(err),
             });
+            // EARLY WARNING: a self-heal launch just failed — capture the OS
+            // gauges so a `pthread_create` EAGAIN at this point correlates to a
+            // measured `pids.current` near `pids.max` (the proven wedge), making
+            // the thread-ceiling exhaustion visible in the logs as it happens.
+            this.logGauges("self-heal-launch-failed");
           }
         }
         if (this.browsers.length >= this.browserCount) {
@@ -2074,14 +1902,12 @@ export class BrowserPool {
   /**
    * CIRCUIT-BREAKER hard-recovery step. Invoked by the self-heal loop after
    * `selfHealHardRecoveryThreshold` consecutive launch failures — the signal
-   * that the loop is stuck relaunching into a wedged chromium (every
-   * `chromium.launch()` throwing `...has been closed`). Purges the stale
-   * `/tmp/playwright_*` profile/temp dirs the crash-looping processes left
-   * behind (the FD-shm/profile pressure that keeps every fresh launch crashing)
-   * so the next launch starts cold and clean. Best-effort: a purge failure is
-   * logged, not thrown — the cold-launch retry still proceeds. The
-   * `delayOrShutdown` after the purge paces the next attempt and stays promptly
-   * cancellable on shutdown.
+   * that the loop is stuck relaunching into a wedged chromium. The PROVEN wedge
+   * is cgroup PID/thread-ceiling exhaustion, which a `/tmp` purge does NOT fix
+   * (that ceiling is platform-fixed and demand-side), so the hard recovery is
+   * simply a PACED cold relaunch: it backs the loop off (`delayOrShutdown`) to
+   * give the thread-exhausted kernel time to relax before the next cold launch,
+   * rather than hammering it. Stays promptly cancellable on shutdown.
    */
   private async hardRecover(attempt: number): Promise<void> {
     if (this.isShutdown) return;
@@ -2090,21 +1916,6 @@ export class BrowserPool {
       maxHardRecoveries: this.selfHealMaxHardRecoveries,
       hardRecoveryThreshold: this.selfHealHardRecoveryThreshold,
     });
-    try {
-      // AGGRESSIVE age gate: the fleet has ALREADY wedged, so reclaim the prior
-      // generation's orphaned dirs fast (60s, vs the proactive sweep's
-      // conservative 5 min). Same canonical helper, different age argument.
-      const removed = await this.purgeProfileDirs(PURGE_MIN_AGE_MS);
-      this.logger?.info("browser-pool.self-heal-profile-purge", {
-        attempt,
-        removed,
-      });
-    } catch (err) {
-      this.logger?.warn?.("browser-pool.self-heal-profile-purge-failed", {
-        attempt,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
     // Pace the cold-launch retry into the (hopefully now-unwedged) kernel.
     if (!this.isShutdown && this.selfHealIntervalMs > 0) {
       await this.delayOrShutdown(this.selfHealIntervalMs);
@@ -2113,11 +1924,13 @@ export class BrowserPool {
 
   /**
    * CIRCUIT-BREAKER give-up step. Invoked when `selfHealMaxHardRecoveries`
-   * consecutive HARD recoveries (purge + cold-launch) have ALL failed to revive
-   * a single browser — the wedge survived even a profile-dir purge, so a
-   * redeploy is genuinely required. Emits the LOUD `pool-unrecoverable` alarm
-   * (the operator signal the old silent-spin path never sent) and lets the heal
-   * loop exit instead of spinning forever.
+   * consecutive HARD recoveries (paced cold relaunches) have ALL failed to
+   * revive a single browser — the wedge survived every relaunch, so a redeploy
+   * is genuinely required (the PROVEN cgroup PID/thread ceiling is not
+   * relaxing). Emits the LOUD `pool-unrecoverable` alarm (the operator signal
+   * the old silent-spin path never sent), carrying the measured cgroup
+   * `pids.current`/`pids.max` + thread count so the alert NAMES the real signal,
+   * and lets the heal loop exit instead of spinning forever.
    *
    * ONCE-PER-EPISODE is guaranteed STRUCTURALLY, not by an instance latch: each
    * distinct degraded episode spawns its OWN self-heal loop (`startSelfHeal` is
@@ -2131,10 +1944,28 @@ export class BrowserPool {
    * this breaker exists to kill. The latch was removed so each episode alarms.
    */
   private fireUnrecoverable(): void {
+    // Sample the OS gauges at the moment of give-up so the alarm NAMES the
+    // proven wedge signal (cgroup pids.current near pids.max + thread demand)
+    // rather than reporting only the abstract breaker counters. Best-effort: a
+    // sampling failure degrades the gauge fields to -1, never blocks the alarm.
+    let cgroupPidsCurrent = -1;
+    let cgroupPidsMax = -1;
+    let treeThreadCount = -1;
+    try {
+      const g = sampleResourceGauges();
+      cgroupPidsCurrent = g.cgroupPidsCurrent;
+      cgroupPidsMax = g.cgroupPidsMax;
+      treeThreadCount = g.treeThreadCount;
+    } catch {
+      // gauge sampling is best-effort; leave the -1 defaults.
+    }
     const info: BrowserPoolUnrecoverableInfo = {
       browserCount: this.browserCount,
       waiters: this.waiters.length,
       maxHardRecoveries: this.selfHealMaxHardRecoveries,
+      cgroupPidsCurrent,
+      cgroupPidsMax,
+      treeThreadCount,
     };
     this.logger?.error?.("browser-pool.pool-unrecoverable", { ...info });
     // Best-effort hook (mirrors safeHook) — passes the breaker counters so the

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -643,7 +643,8 @@ export class BrowserPool {
    * this on the meaningful transitions (degraded/unrecoverable/launch-fail/
    * crash/recycle/heartbeat/init/shutdown), NOT on the hot acquire/release path
    * — a full sample is a handful of /proc reads + two `df` execs, too costly per
-   * acquire. The hot path uses `logHotGauges` (a cheap cgroup-PID-only subset).
+   * acquire. The hot path uses `readHotGauges` (a cheap cgroup-PID-only subset
+   * folded into the existing acquire/release log line).
    *
    * Best-effort throughout: a gauge-sampling failure logs at warn and skips the
    * snapshot; a throwing `onSnapshot` hook is caught + logged. Neither ever
@@ -681,31 +682,23 @@ export class BrowserPool {
   }
 
   /**
-   * CHEAP gauge log for the HOT acquire/release path. Reads ONLY the cgroup PID
-   * counters (two small file reads — `pids.current`/`pids.max`) plus the pool's
-   * own in-memory context counts. Deliberately does NOT walk /proc or exec `df`
-   * (the costly part of a full sample) so logging on every acquire/release stays
-   * negligible. This gives a high-resolution view of the headline wedge signal
-   * (`pids.current` vs `pids.max`) on the busiest path without the full-sample
-   * cost, and does NOT fire the durable snapshot hook (the heartbeat + the
-   * transitions own durable persistence). Best-effort: a read failure degrades
-   * to -1 and is swallowed.
+   * CHEAP gauge read for the HOT acquire/release path. Reads ONLY the cgroup PID
+   * counters (two small file reads — `pids.current`/`pids.max`). Deliberately
+   * does NOT walk /proc or exec `df` (the costly part of a full sample) so
+   * sampling on every acquire/release stays negligible. The two counters are
+   * folded into the existing `browser-pool.acquire`/`browser-pool.release` log
+   * line (one line, not a duplicate second log) so the headline wedge signal
+   * (`pids.current` vs `pids.max`) is visible at acquire/release resolution
+   * without the full-sample cost; this does NOT fire the durable snapshot hook
+   * (the heartbeat + transitions own durable persistence). Best-effort: a read
+   * failure degrades to -1 and is swallowed.
    */
-  private logHotGauges(event: string): void {
+  private readHotGauges(): { pidsCurrent: number; pidsMax: number } {
     try {
       const pids = readCgroupPids();
-      this.logger?.info("browser-pool.hot-gauges", {
-        event,
-        pidsCurrent: pids.current,
-        pidsMax: pids.max,
-        inUse: this.liveContextCount,
-        available: this.maxContexts - this.liveContextCount,
-      });
-    } catch (err) {
-      this.logger?.warn?.("browser-pool.hot-gauges-failed", {
-        event,
-        error: err instanceof Error ? err.message : String(err),
-      });
+      return { pidsCurrent: pids.current, pidsMax: pids.max };
+    } catch {
+      return { pidsCurrent: -1, pidsMax: -1 };
     }
   }
 
@@ -1154,15 +1147,15 @@ export class BrowserPool {
 
     try {
       const context = await this.openContextOn(entry, options);
+      // HOT-PATH gauge: cheap cgroup-PID-only sample (no /proc walk, no df)
+      // folded INTO this acquire line so the headline wedge signal is visible at
+      // acquire resolution without the full-sample cost and without a duplicate
+      // log. Durable persistence is owned by the heartbeat + transitions.
       this.logger?.info("browser-pool.acquire", {
         available: this.maxContexts - this.liveContextCount,
         inUse: this.liveContextCount,
+        ...this.readHotGauges(),
       });
-      // HOT-PATH gauge: cheap cgroup-PID-only sample (no /proc walk, no df) so
-      // the headline wedge signal is visible at acquire resolution without the
-      // full-sample cost. Durable persistence is owned by the heartbeat +
-      // transitions, not this line.
-      this.logHotGauges("acquire");
       return context;
     } catch (err) {
       // SHUTDOWN STRADDLE: the pool shut down WHILE this open was in flight —
@@ -1493,14 +1486,14 @@ export class BrowserPool {
     entry.liveContexts.delete(context);
     this.releaseReservation();
 
+    // HOT-PATH gauge: cheap cgroup-PID-only subset (see acquire) folded INTO
+    // this release line — cheap enough to read on every release, one log line.
+    // Full samples are reserved for transitions + heartbeat.
     this.logger?.info("browser-pool.release", {
       available: this.maxContexts - this.liveContextCount,
       inUse: this.liveContextCount,
+      ...this.readHotGauges(),
     });
-    // HOT-PATH gauge: cheap cgroup-PID-only subset (see acquire). Cheap enough
-    // to fire on every release; full samples are reserved for transitions +
-    // heartbeat.
-    this.logHotGauges("release");
 
     // Hygiene-recycle intent, LATCHED synchronously: the instant this browser
     // has served >= recycleAfter contexts, mark `recyclePending`. This is a

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -110,22 +110,46 @@ const DEFAULT_SELF_HEAL_MAX_HARD_RECOVERIES = 3;
 const PLAYWRIGHT_TMP_PREFIXES = ["playwright_", "playwright-artifacts-"];
 
 /**
- * Minimum age (ms) a `playwright_*` dir must be before the purge removes it.
- * Bounds the blast radius: a browser launching CONCURRENTLY with the purge
- * (the cold-launch the hard recovery is about to fire, or a sibling pool) has a
- * fresh `playwright_*` dir; recursively deleting it out from under an in-flight
- * launch would re-wedge the very launch we are trying to revive. Only dirs whose
- * mtime is older than this — i.e. left behind by the PRIOR wedged generation —
- * are purged. 60s comfortably exceeds a single launch/heal cycle.
+ * Default minimum age (ms) a `playwright_*` dir must EXCEED before the
+ * AGGRESSIVE breaker hard-recovery purge removes it. Bounds the blast radius: a
+ * browser launching CONCURRENTLY with the purge (the cold-launch the hard
+ * recovery is about to fire, or a sibling pool) has a fresh `playwright_*` dir;
+ * recursively deleting it out from under an in-flight launch would re-wedge the
+ * very launch we are trying to revive. Only dirs whose mtime is older than this
+ * — i.e. left behind by the PRIOR wedged generation — are purged. 60s
+ * comfortably exceeds a single launch/heal cycle. The hard-recovery path runs
+ * only AFTER the fleet has already wedged, so it errs aggressive (reclaim fast).
  */
 export const PURGE_MIN_AGE_MS = 60_000;
 
 /**
- * Default profile/temp-dir purge used by the self-heal hard-recovery path.
- * Best-effort: removes the `${tmpdir()}/playwright_*` (and
- * `playwright-artifacts-*`) directories the wedged chromium processes left
- * behind. Injectable via `BrowserPoolOptions.purgeProfileDirs` so tests can
- * drive the breaker without touching the real filesystem and assert it fired.
+ * Default minimum age (ms) a `playwright_*` dir must EXCEED before the PROACTIVE
+ * stale-profile sweep removes it. The proactive sweep runs on a cadence (init +
+ * every recycle) BEFORE any wedge, so it errs CONSERVATIVE: a 5-minute floor
+ * leaves a wide margin so a dir belonging to a launch in flight or a live
+ * browser (touched continuously, mtime ~now) is never even close to eligible.
+ * The two ages feed the SAME `defaultPurgeProfileDirs` helper — the breaker
+ * passes the aggressive `PURGE_MIN_AGE_MS`, the proactive sweep passes this.
+ * Tunable on staging via env (BROWSER_POOL_STALE_PROFILE_DIR_TTL_MS) without a
+ * code change.
+ */
+export const DEFAULT_STALE_PROFILE_DIR_TTL_MS = 5 * 60_000;
+
+/**
+ * The ONE canonical profile/temp-dir purge — shared by BOTH the durable
+ * browser-pool defenses:
+ *  - the PROACTIVE prevention sweep (run on a cadence at `init()` and on EVERY
+ *    recycle relaunch, passing the conservative `staleProfileDirTtlMs`, 5 min)
+ *    that keeps `/tmp` bounded so it never reaches the exhaustion that wedges
+ *    every future `chromium.launch()`; and
+ *  - the breaker's AGGRESSIVE hard-recovery purge (run only AFTER the fleet has
+ *    already wedged, passing `PURGE_MIN_AGE_MS`, 60s) that reclaims the orphaned
+ *    profile/FD/shm pressure so a cold launch starts clean.
+ * Same hardened implementation, different `minAgeMs` argument — no duplicate
+ * purge logic. Best-effort: removes the `${tmpdir()}/playwright_*` (and
+ * `playwright-artifacts-*`) directories left behind whose mtime is older than
+ * `minAgeMs`. Injectable via `BrowserPoolOptions.purgeProfileDirs` so tests can
+ * drive both cadences without touching the real filesystem and assert it fired.
  *
  * SAFETY (the temp dir is world-writable `/tmp`, so an attacker — or a stray
  * tool — can plant entries there):
@@ -133,17 +157,20 @@ export const PURGE_MIN_AGE_MS = 60_000;
  *    `playwright_*` SYMLINK whose target is some other path; a blind
  *    `rm(recursive)` would follow it and recursively delete the target's
  *    contents. Only entries that are themselves real DIRECTORIES are eligible.
- *  - Entries younger than `PURGE_MIN_AGE_MS` are LEFT ALONE so a concurrently
- *    launching browser's fresh dir is never nuked (see `PURGE_MIN_AGE_MS`).
+ *  - Entries younger than `minAgeMs` are LEFT ALONE so a concurrently launching
+ *    browser's fresh dir (or a live browser's continuously-touched dir) is never
+ *    nuked — the age gate the whole prevention safety rests on.
  *  - The realpath is verified to still resolve UNDER `tmpdir()` before removal,
  *    a belt-and-suspenders guard against a TOCTOU race / nested symlink.
  *
  * A failure to read the temp dir, stat an entry, or unlink it is swallowed (the
  * dir may not exist, be owned by another process, or vanish mid-purge) — the
  * purge is a hygiene best-effort, not a correctness dependency. The returned
- * count is LOG-ONLY (surfaced in `self-heal-profile-purge`), not load-bearing.
+ * count is LOG-ONLY (surfaced in `self-heal-profile-purge` /
+ * `stale-profile-sweep`), not load-bearing.
  */
 export async function defaultPurgeProfileDirs(
+  minAgeMs: number,
   dir: string = tmpdir(),
 ): Promise<number> {
   let removed = 0;
@@ -177,7 +204,7 @@ export async function defaultPurgeProfileDirs(
       // isn't a symlink resolves to itself.
       const stat = await fs.lstat(full);
       if (stat.isSymbolicLink()) continue; // TOCTOU: became a symlink post-readdir.
-      if (now - stat.mtimeMs < PURGE_MIN_AGE_MS) continue; // too fresh — skip.
+      if (now - stat.mtimeMs < minAgeMs) continue; // younger than the age gate — skip.
       // Belt-and-suspenders: confirm the realpath stays under the scan dir
       // before a recursive remove, so a nested-symlink trick can't escape it.
       const real = await fs.realpath(full);
@@ -302,13 +329,16 @@ interface PoolLogger {
 export type LaunchBrowser = () => Promise<Browser>;
 
 /**
- * Purges the stale per-launch profile/temp dirs a crash-looping chromium leaves
- * behind, returning the count removed. The default implementation removes
- * `${tmpdir()}/playwright_*`. Tests inject a fake so the self-heal
- * circuit-breaker's hard-recovery path is exercisable without touching the real
- * filesystem (and so the test can assert the purge fired).
+ * Purges the stale per-launch profile/temp dirs Playwright's chromium leaves
+ * behind whose mtime is older than `minAgeMs`, returning the count removed. The
+ * default implementation removes `${tmpdir()}/playwright_*`. Invoked by BOTH the
+ * proactive prevention sweep (init + every recycle, conservative
+ * `staleProfileDirTtlMs`) AND the breaker's hard-recovery (aggressive
+ * `PURGE_MIN_AGE_MS`) — same helper, different age. Tests inject a fake so both
+ * cadences are exercisable without touching the real filesystem (and so the test
+ * can assert the purge fired and with which age).
  */
-export type PurgeProfileDirs = () => Promise<number>;
+export type PurgeProfileDirs = (minAgeMs: number) => Promise<number>;
 
 /**
  * One long-lived browser PROCESS in the fixed set. Contexts are pooled over
@@ -400,9 +430,20 @@ export interface BrowserPoolOptions {
    *  of spinning forever). Default 3 (env
    *  BROWSER_POOL_SELF_HEAL_MAX_HARD_RECOVERIES). */
   selfHealMaxHardRecoveries?: number;
-  /** Injected profile/temp-dir purge (tests). Defaults to removing
-   *  `${tmpdir()}/playwright_*`. Invoked by the self-heal hard-recovery path. */
+  /** Injected profile/temp-dir purge (tests), given the age threshold. Defaults
+   *  to removing `${tmpdir()}/playwright_*` older than the passed age. Invoked by
+   *  BOTH the proactive prevention sweep (init + every recycle) AND the
+   *  self-heal hard-recovery path — same helper, different age argument. */
   purgeProfileDirs?: PurgeProfileDirs;
+  /** Age (ms) a `${tmpdir()}/playwright_*` profile/artifact dir must EXCEED
+   *  before the PROACTIVE prevention sweep removes it. The age gate guarantees
+   *  the sweep never deletes a dir for a launch in flight or a live browser
+   *  (those are touched continuously, so their mtime is ~now). Conservative by
+   *  design (the sweep runs BEFORE any wedge). Default 300000 (5 min; env
+   *  BROWSER_POOL_STALE_PROFILE_DIR_TTL_MS). Tests pass 0 to sweep every matching
+   *  dir deterministically. Distinct from the breaker's aggressive
+   *  `PURGE_MIN_AGE_MS`, which the hard-recovery path passes instead. */
+  staleProfileDirTtlMs?: number;
   /**
    * Mid-life capacity-loss alarm hook. Invoked when the browser set EMPTIES
    * (every entry evicted) — the silent-outage gap the original code had, where
@@ -487,6 +528,12 @@ export class BrowserPool {
   private readonly selfHealHardRecoveryThreshold: number;
   private readonly selfHealMaxHardRecoveries: number;
   private readonly purgeProfileDirs: PurgeProfileDirs;
+  // PREVENTION: conservative age gate for the PROACTIVE stale-profile sweep (run
+  // at init + every recycle). Distinct from the breaker's aggressive
+  // PURGE_MIN_AGE_MS — both feed the same `purgeProfileDirs` helper, just with a
+  // different age. Keeps `/tmp` from accumulating orphaned `playwright_*` dirs to
+  // the exhaustion that wedges every future launch (the confirmed root cause).
+  private readonly staleProfileDirTtlMs: number;
   private readonly onDegraded?: () => void;
   private readonly onRecovered?: () => void;
   private readonly onUnrecoverable?: (
@@ -611,12 +658,22 @@ export class BrowserPool {
       process.env.BROWSER_POOL_SELF_HEAL_MAX_HARD_RECOVERIES,
       DEFAULT_SELF_HEAL_MAX_HARD_RECOVERIES,
     );
+    // PREVENTION age gate (conservative). The proactive sweep passes this; the
+    // breaker's hard-recovery passes the aggressive PURGE_MIN_AGE_MS — both into
+    // the SAME purgeProfileDirs helper. resolveNonNegative (not resolvePositive):
+    // an explicit `0` is legitimate (tests sweep every matching dir).
+    this.staleProfileDirTtlMs = resolveNonNegative(
+      options.staleProfileDirTtlMs,
+      process.env.BROWSER_POOL_STALE_PROFILE_DIR_TTL_MS,
+      DEFAULT_STALE_PROFILE_DIR_TTL_MS,
+    );
     // Purge resolution: an explicit injected purge wins. Otherwise, when a fake
     // `launchBrowser` is injected (tests — the browsers are fakes, so there are
     // NO real `/tmp/playwright_*` dirs to scan/remove), default to a hermetic
-    // no-op so the breaker's hard-recovery path never touches the real
-    // filesystem under test. Only the production path (real chromium launcher,
-    // no injected launcher) gets the real `${tmpdir()}/playwright_*` purge.
+    // no-op so NEITHER the proactive sweep NOR the breaker's hard-recovery path
+    // touches the real filesystem under test. Only the production path (real
+    // chromium launcher, no injected launcher) gets the real
+    // `${tmpdir()}/playwright_*` purge.
     this.purgeProfileDirs =
       options.purgeProfileDirs ??
       (this.injectedLaunchBrowser
@@ -625,6 +682,38 @@ export class BrowserPool {
     this.onDegraded = options.onDegraded;
     this.onRecovered = options.onRecovered;
     this.onUnrecoverable = options.onUnrecoverable;
+  }
+
+  /**
+   * PREVENTION: fire the PROACTIVE stale-profile-dir sweep without awaiting it
+   * (fire-and-forget — the sweep is hygiene, never on the critical path of a
+   * launch). Calls the SAME canonical `purgeProfileDirs` the breaker uses, but
+   * with the conservative `staleProfileDirTtlMs` age gate. Routes a removed-count
+   * to the structured log and any unexpected throw to the logger. Called once at
+   * init() and on every recycle relaunch so orphaned `/tmp/playwright_*` dirs are
+   * reclaimed on a cadence — keeping the container's `/tmp` from accumulating to
+   * the exhaustion that wedges every future `chromium.launch()` (the confirmed
+   * root cause). Orthogonal to the breaker, which purges UNCONDITIONALLY (its own
+   * aggressive age) only AFTER a wedge: the sweep PREVENTS the wedge, the breaker
+   * ESCAPES it if it ever still happens.
+   */
+  private fireStaleProfileSweep(reason: "init" | "recycle"): void {
+    void this.purgeProfileDirs(this.staleProfileDirTtlMs)
+      .then((removed) => {
+        if (removed > 0) {
+          this.logger?.info("browser-pool.stale-profile-sweep", {
+            reason,
+            removed,
+            ttlMs: this.staleProfileDirTtlMs,
+          });
+        }
+      })
+      .catch((err: unknown) => {
+        this.logger?.warn?.("browser-pool.stale-profile-sweep-failed", {
+          reason,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
   }
 
   async init(): Promise<void> {
@@ -639,6 +728,13 @@ export class BrowserPool {
           args: ["--no-sandbox", "--disable-dev-shm-usage"],
         });
     }
+
+    // PREVENTION: sweep any stale `/tmp/playwright_*` orphans BEFORE the init
+    // fill. A long-lived container that was redeployed in place (or whose prior
+    // process left orphans) starts with a `/tmp` that may already carry dirs
+    // whose owning processes are long gone; reclaiming them up front keeps the
+    // baseline low. Fire-and-forget — never block the init fill on hygiene.
+    this.fireStaleProfileSweep("init");
 
     try {
       for (let i = 0; i < this.browserCount; i++) {
@@ -1630,6 +1726,17 @@ export class BrowserPool {
 
       if (this.isShutdown) return;
 
+      // PREVENTION: sweep stale `/tmp/playwright_*` orphans on the recycle
+      // cadence. Each recycle (crash recovery OR hygiene) is a chromium
+      // replacement — exactly the point in the long-lived container's life where
+      // orphaned profile/artifact dirs accumulate. Sweeping the AGE-GATED stale
+      // dirs here (after the old browser has been closed, before the fresh one
+      // launches) reclaims the orphans Playwright's best-effort close-time
+      // cleanup left behind, keeping `/tmp` bounded across hours of cron load so
+      // a future launch never hits the exhaustion that wedges the whole pool.
+      // Fire-and-forget — the relaunch never waits on hygiene.
+      this.fireStaleProfileSweep("recycle");
+
       try {
         // FIX #1 — PID-ceiling backpressure: retry the relaunch with backoff
         // before giving up the entry. A `pthread_create: Resource temporarily
@@ -1984,7 +2091,10 @@ export class BrowserPool {
       hardRecoveryThreshold: this.selfHealHardRecoveryThreshold,
     });
     try {
-      const removed = await this.purgeProfileDirs();
+      // AGGRESSIVE age gate: the fleet has ALREADY wedged, so reclaim the prior
+      // generation's orphaned dirs fast (60s, vs the proactive sweep's
+      // conservative 5 min). Same canonical helper, different age argument.
+      const removed = await this.purgeProfileDirs(PURGE_MIN_AGE_MS);
       this.logger?.info("browser-pool.self-heal-profile-purge", {
         attempt,
         removed,

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -76,17 +76,18 @@ const DEFAULT_SELF_HEAL_INTERVAL_MS = 2_000;
  * loop just RELAUNCHES into the SAME wedged state over and over
  * (`self-heal-launch-failed` repeating, 28× in ~19s observed) — backing off
  * `selfHealIntervalMs` between identical attempts but NEVER doing anything
- * different to escape (stale `/tmp/playwright_*` profile dirs / accumulated
- * FD-shm pressure on the long-lived container persist across every relaunch).
+ * different to escape (the wedge is the cgroup PID/thread ceiling — a
+ * platform-fixed, demand-side ceiling that an immediate relaunch only re-pins).
  * `acquire()` therefore has no contexts forever → blocks to timeout fleet-wide.
  * Only a container RESTART cleared it — reactive, not durable.
  *
  * The breaker makes the self-heal loop ESCAPE: after
  * `selfHealHardRecoveryThreshold` CONSECUTIVE self-heal launch failures, instead
- * of looping another identical relaunch the pool performs a HARD recovery —
- * purges the stale `/tmp/playwright_*` profile/temp dirs the wedged chromium
- * processes left behind (the FD-shm/profile pressure that keeps every fresh
- * launch crashing) — then cold-launches fresh. Any successful launch resets the
+ * of looping another identical relaunch the pool performs a HARD recovery — a
+ * PACED cold relaunch that backs the loop off to give the thread-exhausted
+ * kernel time to relax before the next cold launch (NO `/tmp` purge — the wedge
+ * is the cgroup pids ceiling, mitigated demand-side, not a stale-profile-dir
+ * problem). Any successful launch resets the
  * consecutive counter. If `selfHealMaxHardRecoveries` consecutive HARD
  * recoveries ALSO fail to revive a single browser, the pool surfaces a LOUD
  * `browser-pool.pool-unrecoverable` alarm (via `onUnrecoverable`) and stops the
@@ -329,9 +330,9 @@ export interface BrowserPoolOptions {
   onRecovered?: () => void;
   /**
    * Unrecoverable-alarm hook. Invoked when the self-heal circuit-breaker has
-   * exhausted `selfHealMaxHardRecoveries` consecutive HARD recoveries (purge +
-   * cold-launch) WITHOUT reviving a single browser — i.e. the wedge survived
-   * even a profile-dir purge, so a redeploy is genuinely required. The
+   * exhausted `selfHealMaxHardRecoveries` consecutive HARD recoveries (paced
+   * cold relaunches) WITHOUT reviving a single browser — i.e. the wedge survived
+   * every paced relaunch, so a redeploy is genuinely required. The
    * orchestrator wires this to a LOUD operator alert (the signal the old
    * silent-spin path never sent). The breaker counters are passed so the alarm
    * can report how hard the pool tried before giving up. Best-effort: a throwing
@@ -1961,11 +1962,12 @@ export class BrowserPool {
    * CIRCUIT-BREAKER (the durable fix for the RECURRING wedge): the unfixed loop
    * just RELAUNCHED into the same wedged state forever — when chromium is in a
    * launch-crash-loop (`browserType.launch: ...has been closed`) every relaunch
-   * throws identically and the loop never escapes (the stale `/tmp/playwright_*`
-   * profile dirs / FD-shm pressure persist across every attempt). Now, after
+   * throws identically and the loop never escapes (the wedge is the cgroup
+   * PID/thread ceiling, which an immediate relaunch only re-pins). Now, after
    * `selfHealHardRecoveryThreshold` CONSECUTIVE launch failures, the loop stops
-   * looping identical relaunches and performs a HARD recovery — purges the stale
-   * profile/temp dirs — then cold-launches fresh. A single successful launch
+   * looping identical relaunches and performs a HARD recovery — a PACED cold
+   * relaunch (NO `/tmp` purge — see hardRecover) — then cold-launches fresh into
+   * a kernel given time to relax. A single successful launch
    * resets the failure counter. If `selfHealMaxHardRecoveries` consecutive HARD
    * recoveries ALSO revive nothing, it fires the LOUD `pool-unrecoverable` alarm
    * and stops (a redeploy is genuinely required) rather than spinning silently.
@@ -1995,7 +1997,8 @@ export class BrowserPool {
           // BREAKER: before attempting another identical relaunch, check whether
           // we have already failed `selfHealHardRecoveryThreshold` times in a
           // row. If so, escape the relaunch-into-the-same-wedge loop and HARD
-          // recover (purge stale profile/temp dirs) so the NEXT launch is cold.
+          // recover (paced cold relaunch — give the kernel time to relax; NO
+          // /tmp purge) so the NEXT launch is cold.
           if (
             this.selfHealHardRecoveryThreshold > 0 &&
             consecutiveFailures >= this.selfHealHardRecoveryThreshold
@@ -2004,8 +2007,8 @@ export class BrowserPool {
             consecutiveHardRecoveries++;
             await this.hardRecover(consecutiveHardRecoveries);
             if (this.isShutdown) break;
-            // Even the purge could not break the wedge after K tries — give up
-            // LOUDLY rather than spinning forever.
+            // Even the paced cold relaunch could not break the wedge after K
+            // tries — give up LOUDLY rather than spinning forever.
             if (
               this.selfHealMaxHardRecoveries > 0 &&
               consecutiveHardRecoveries >= this.selfHealMaxHardRecoveries

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -1,5 +1,6 @@
 import type { Browser, BrowserContext } from "playwright";
-import { sampleResourceGauges } from "./resource-gauges";
+import { sampleResourceGauges, readCgroupPids } from "./resource-gauges";
+import type { ResourceGauges } from "./resource-gauges";
 
 /**
  * Default delay the launch-serialization gate waits AFTER each chromium
@@ -96,6 +97,17 @@ const DEFAULT_SELF_HEAL_INTERVAL_MS = 2_000;
  */
 const DEFAULT_SELF_HEAL_HARD_RECOVERY_THRESHOLD = 4;
 const DEFAULT_SELF_HEAL_MAX_HARD_RECOVERIES = 3;
+
+/**
+ * Default heartbeat interval (ms) for the periodic baseline gauge snapshot. A
+ * ~45s cadence gives a baseline PID/thread trend BETWEEN lifecycle events — so
+ * a slow creep toward the cgroup `pids.max` ceiling (the proven wedge) is
+ * visible in the durable history even when no transition fired in the window.
+ * Cheap enough at this cadence (a handful of /proc reads + two short `df`
+ * execs); the hot acquire/release path uses only a cheap subset, never a full
+ * sample. Tunable on staging via BROWSER_POOL_HEARTBEAT_MS; 0 disables it.
+ */
+const DEFAULT_HEARTBEAT_MS = 45_000;
 
 /**
  * Resolve a STRICTLY-POSITIVE numeric tunable with explicit-arg > env > default
@@ -326,6 +338,51 @@ export interface BrowserPoolOptions {
    * hook is caught + logged, never crashes the pool.
    */
   onUnrecoverable?: (info: BrowserPoolUnrecoverableInfo) => void;
+  /**
+   * DURABLE forensic snapshot hook. Invoked with a FULL gauge sample + pool
+   * stats + per-browser breakdown on every MEANINGFUL pool condition
+   * (heartbeat + degraded/unrecoverable/launch-fail/crash transitions). The
+   * orchestrator wires this to the `resource_snapshots` PB writer so the gauge
+   * history survives the container RESTART that ends a wedge (Railway stdout
+   * rolls off; in-memory is cleared on restart — durable PB is the only
+   * post-wedge-retrievable trail). Best-effort: a throwing hook is caught +
+   * logged, never crashes the pool, and the snapshot writer itself swallows PB
+   * errors. Synchronous from the pool's perspective — the writer does its own
+   * fire-and-forget async persistence.
+   */
+  onSnapshot?: (snapshot: BrowserPoolSnapshot) => void;
+  /**
+   * Heartbeat interval (ms) for the periodic baseline gauge sample/snapshot.
+   * Default 45000 (env BROWSER_POOL_HEARTBEAT_MS). A heartbeat gives a baseline
+   * trend BETWEEN transition events so a slow PID-ceiling creep is visible even
+   * when no lifecycle event fires. 0 disables the heartbeat (tests). Driven by
+   * a self-rescheduling loop gated on the shutdown signal — NOT a raw
+   * setInterval (which would leak a timer past shutdown).
+   */
+  heartbeatMs?: number;
+}
+
+/**
+ * Full forensic snapshot handed to `onSnapshot`. Bundles the OS gauges, the
+ * pool's capacity stats, the per-browser breakdown, and the naming `event` so
+ * the durable writer can persist one row without re-sampling.
+ */
+export interface BrowserPoolSnapshot {
+  /** Pool condition that triggered the snapshot (`heartbeat`, `degraded`,
+   *  `unrecoverable`, `launch-fail`, `crash`, ...). */
+  event: string;
+  gauges: ResourceGauges;
+  stats: BrowserPoolStats;
+  perBrowser: BrowserPoolPerBrowserSnapshot[];
+}
+
+/** Per-browser breakdown entry in a {@link BrowserPoolSnapshot}. Pure counters
+ *  — no secrets — safe for the public-read PB collection. */
+export interface BrowserPoolPerBrowserSnapshot {
+  index: number;
+  liveContexts: number;
+  servedContexts: number;
+  recycling: boolean;
 }
 
 /**
@@ -399,6 +456,14 @@ export class BrowserPool {
   private readonly onUnrecoverable?: (
     info: BrowserPoolUnrecoverableInfo,
   ) => void;
+  // DURABLE forensic snapshot hook + heartbeat. The hook persists a full gauge
+  // sample to PocketBase (survives the wedge→restart); the heartbeat gives a
+  // baseline trend between transition events. The heartbeat is a
+  // self-rescheduling loop gated on `shutdownSignal` (NOT a raw setInterval) so
+  // it never leaks a timer past shutdown.
+  private readonly onSnapshot?: (snapshot: BrowserPoolSnapshot) => void;
+  private readonly heartbeatMs: number;
+  private heartbeatRunning = false;
   // True once the set has emptied and onDegraded fired; cleared when self-heal
   // succeeds. Guards against firing the degraded alarm / spawning a second
   // self-heal loop repeatedly.
@@ -524,6 +589,12 @@ export class BrowserPool {
     this.onDegraded = options.onDegraded;
     this.onRecovered = options.onRecovered;
     this.onUnrecoverable = options.onUnrecoverable;
+    this.onSnapshot = options.onSnapshot;
+    this.heartbeatMs = resolveNonNegative(
+      options.heartbeatMs,
+      process.env.BROWSER_POOL_HEARTBEAT_MS,
+      DEFAULT_HEARTBEAT_MS,
+    );
   }
 
   /**
@@ -549,6 +620,116 @@ export class BrowserPool {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+
+  /**
+   * Build the per-browser breakdown for a forensic snapshot. Pure counters
+   * (index / live-context count / served count / recycling flag) — no secrets —
+   * safe for the public-read `resource_snapshots` PB collection.
+   */
+  private perBrowserSnapshot(): BrowserPoolPerBrowserSnapshot[] {
+    return this.browsers.map((entry, index) => ({
+      index,
+      liveContexts: entry.liveContexts.size,
+      servedContexts: entry.servedContexts,
+      recycling: entry.recycling,
+    }));
+  }
+
+  /**
+   * FULL forensic snapshot of a MEANINGFUL pool condition: sample the OS gauges
+   * ONCE, log them with the event label, and fire the durable `onSnapshot` hook
+   * (which persists to PocketBase so the trail survives the wedge→restart). Use
+   * this on the meaningful transitions (degraded/unrecoverable/launch-fail/
+   * crash/recycle/heartbeat/init/shutdown), NOT on the hot acquire/release path
+   * — a full sample is a handful of /proc reads + two `df` execs, too costly per
+   * acquire. The hot path uses `logHotGauges` (a cheap cgroup-PID-only subset).
+   *
+   * Best-effort throughout: a gauge-sampling failure logs at warn and skips the
+   * snapshot; a throwing `onSnapshot` hook is caught + logged. Neither ever
+   * propagates into the pool's lifecycle paths.
+   */
+  private snapshot(event: string): void {
+    let gauges: ResourceGauges;
+    try {
+      gauges = sampleResourceGauges();
+    } catch (err) {
+      this.logger?.warn?.("browser-pool.resource-gauges-failed", {
+        label: event,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    this.logger?.info("browser-pool.resource-gauges", {
+      label: event,
+      ...gauges,
+    });
+    if (!this.onSnapshot) return;
+    try {
+      this.onSnapshot({
+        event,
+        gauges,
+        stats: this.stats(),
+        perBrowser: this.perBrowserSnapshot(),
+      });
+    } catch (err) {
+      this.logger?.error?.("browser-pool.hook-failed", {
+        hook: "onSnapshot",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * CHEAP gauge log for the HOT acquire/release path. Reads ONLY the cgroup PID
+   * counters (two small file reads — `pids.current`/`pids.max`) plus the pool's
+   * own in-memory context counts. Deliberately does NOT walk /proc or exec `df`
+   * (the costly part of a full sample) so logging on every acquire/release stays
+   * negligible. This gives a high-resolution view of the headline wedge signal
+   * (`pids.current` vs `pids.max`) on the busiest path without the full-sample
+   * cost, and does NOT fire the durable snapshot hook (the heartbeat + the
+   * transitions own durable persistence). Best-effort: a read failure degrades
+   * to -1 and is swallowed.
+   */
+  private logHotGauges(event: string): void {
+    try {
+      const pids = readCgroupPids();
+      this.logger?.info("browser-pool.hot-gauges", {
+        event,
+        pidsCurrent: pids.current,
+        pidsMax: pids.max,
+        inUse: this.liveContextCount,
+        available: this.maxContexts - this.liveContextCount,
+      });
+    } catch (err) {
+      this.logger?.warn?.("browser-pool.hot-gauges-failed", {
+        event,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Periodic baseline heartbeat: a self-rescheduling loop that fires a FULL
+   * forensic snapshot every `heartbeatMs`. Gated on `shutdownSignal` (the same
+   * proven mechanism the self-heal loop uses) so it aborts PROMPTLY on shutdown
+   * and never leaks a timer — a raw `setInterval` would keep firing after
+   * shutdown and pin a handle. Idempotent via `heartbeatRunning`. The heartbeat
+   * is what makes a slow PID-ceiling creep visible in the durable history even
+   * when no lifecycle event fires in the window.
+   */
+  private startHeartbeat(): void {
+    if (this.heartbeatMs <= 0) return;
+    if (this.heartbeatRunning) return;
+    this.heartbeatRunning = true;
+    void (async () => {
+      while (!this.isShutdown) {
+        await this.delayOrShutdown(this.heartbeatMs);
+        if (this.isShutdown) break;
+        this.snapshot("heartbeat");
+      }
+      this.heartbeatRunning = false;
+    })();
   }
 
   async init(): Promise<void> {
@@ -579,6 +760,10 @@ export class BrowserPool {
         this.browsers.push(entry);
         this.attachDisconnectHandler(entry, browser);
       }
+      // Baseline forensic snapshot the instant the fixed set is warm, then kick
+      // the periodic heartbeat so the durable history has a trend from boot.
+      this.snapshot("init");
+      this.startHeartbeat();
     } catch (err) {
       // A mid-fill launch failure (the PID-ceiling pthread_create EAGAIN /
       // "Zygote could not fork" this gate exists to survive) must not leak the
@@ -973,6 +1158,11 @@ export class BrowserPool {
         available: this.maxContexts - this.liveContextCount,
         inUse: this.liveContextCount,
       });
+      // HOT-PATH gauge: cheap cgroup-PID-only sample (no /proc walk, no df) so
+      // the headline wedge signal is visible at acquire resolution without the
+      // full-sample cost. Durable persistence is owned by the heartbeat +
+      // transitions, not this line.
+      this.logHotGauges("acquire");
       return context;
     } catch (err) {
       // SHUTDOWN STRADDLE: the pool shut down WHILE this open was in flight —
@@ -1307,6 +1497,10 @@ export class BrowserPool {
       available: this.maxContexts - this.liveContextCount,
       inUse: this.liveContextCount,
     });
+    // HOT-PATH gauge: cheap cgroup-PID-only subset (see acquire). Cheap enough
+    // to fire on every release; full samples are reserved for transitions +
+    // heartbeat.
+    this.logHotGauges("release");
 
     // Hygiene-recycle intent, LATCHED synchronously: the instant this browser
     // has served >= recycleAfter contexts, mark `recyclePending`. This is a
@@ -1387,6 +1581,11 @@ export class BrowserPool {
   }
 
   async shutdown(): Promise<void> {
+    // FULL durable snapshot before teardown — captures the final resource state
+    // while the browser set is still populated (the per-browser breakdown is
+    // meaningful only pre-teardown). Sampled BEFORE flipping isShutdown so the
+    // snapshot's `onSnapshot` write is not racing the post-shutdown drain.
+    this.snapshot("shutdown");
     this.isShutdown = true;
     // Wake any racing self-heal / backoff delay so it aborts promptly instead of
     // stalling shutdown for up to selfHealIntervalMs / relaunchBackoffMs.
@@ -1478,6 +1677,10 @@ export class BrowserPool {
       this.logger?.info("browser-pool.disconnected", {
         browserIndex: this.browsers.indexOf(entry),
       });
+      // A browser crashed/disconnected mid-life — capture a FULL durable
+      // snapshot so the resource state at the crash (esp. pids.current vs
+      // pids.max) is reconstructable post-restart.
+      this.snapshot("crash");
       this.recycleBrowser(entry);
     });
   }
@@ -1521,10 +1724,14 @@ export class BrowserPool {
     const browserIdx = this.browsers.indexOf(entry);
     this.logger?.info("browser-pool.recycle", {
       browserIndex: browserIdx,
+      reason,
       servedContexts: entry.servedContexts,
       recycleAfter: this.recycleAfter,
       totalRecycles: this.totalRecycles,
     });
+    // FULL durable snapshot at recycle start (crash OR hygiene): a recycle
+    // relaunches a chromium process — the PID-demand moment the wedge exploits.
+    this.snapshot(`recycle-${reason}`);
 
     // Drop the abandoned live contexts from the global lookup + count so a
     // later release() of a stale reference is a no-op and the cap accounting
@@ -1627,6 +1834,10 @@ export class BrowserPool {
           browserIndex: this.browsers.indexOf(entry),
           error: err instanceof Error ? err.message : String(err),
         });
+        // FULL durable snapshot: the relaunch retries are exhausted — a
+        // launch-fail transition. Capture the resource state so a `pthread_create`
+        // EAGAIN at the PID ceiling is correlatable post-restart.
+        this.snapshot("launch-fail");
         const idx = this.browsers.indexOf(entry);
         if (idx !== -1) this.browsers.splice(idx, 1);
         // FIX #2 — self-heal + alarm on empty browser set. The unfixed code
@@ -1733,6 +1944,11 @@ export class BrowserPool {
         waiters: this.waiters.length,
         browserCount: this.browserCount,
       });
+      // FULL durable snapshot at the degraded transition — the headline
+      // forensic moment. This MUST land in PB: the wedge ends in a restart that
+      // clears in-memory state, so the degraded-instant gauges are otherwise
+      // unretrievable.
+      this.snapshot("degraded");
       this.safeHook(this.onDegraded, "onDegraded");
     }
     this.startSelfHeal();
@@ -1845,11 +2061,13 @@ export class BrowserPool {
               hardRecoveryThreshold: this.selfHealHardRecoveryThreshold,
               error: err instanceof Error ? err.message : String(err),
             });
-            // EARLY WARNING: a self-heal launch just failed — capture the OS
-            // gauges so a `pthread_create` EAGAIN at this point correlates to a
-            // measured `pids.current` near `pids.max` (the proven wedge), making
-            // the thread-ceiling exhaustion visible in the logs as it happens.
-            this.logGauges("self-heal-launch-failed");
+            // EARLY WARNING: a self-heal launch just failed — capture a FULL
+            // DURABLE snapshot so a `pthread_create` EAGAIN at this point
+            // correlates to a measured `pids.current` near `pids.max` (the
+            // proven wedge) AND survives the wedge→restart in PB. This is the
+            // repeating signal (28× in ~19s observed) that is most often lost to
+            // the Railway stdout window — durable persistence is the point.
+            this.snapshot("self-heal-launch-failed");
           }
         }
         if (this.browsers.length >= this.browserCount) {
@@ -1880,6 +2098,10 @@ export class BrowserPool {
           browserCount: this.browserCount,
           waiters: this.waiters.length,
         });
+        // FULL durable snapshot at the recovered transition — bookends the
+        // degraded snapshot so the resource delta across the recovery window is
+        // reconstructable.
+        this.snapshot("recovered");
         this.safeHook(this.onRecovered, "onRecovered");
       }
       this.selfHealing = false;
@@ -1968,6 +2190,11 @@ export class BrowserPool {
       treeThreadCount,
     };
     this.logger?.error?.("browser-pool.pool-unrecoverable", { ...info });
+    // FULL durable snapshot at the TERMINAL give-up — the single most important
+    // forensic row. The pool is dead and a redeploy is required; this MUST be in
+    // PB because the redeploy clears everything in-memory and the stdout window
+    // will have long rolled off by the time an operator looks.
+    this.snapshot("unrecoverable");
     // Best-effort hook (mirrors safeHook) — passes the breaker counters so the
     // operator alarm can describe how hard the pool tried before giving up.
     if (this.onUnrecoverable) {

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -110,34 +110,108 @@ const DEFAULT_SELF_HEAL_MAX_HARD_RECOVERIES = 3;
 const PLAYWRIGHT_TMP_PREFIXES = ["playwright_", "playwright-artifacts-"];
 
 /**
- * Default profile/temp-dir purge used by the self-heal hard-recovery path.
- * Best-effort: removes every `${tmpdir()}/playwright_*` (and
- * `playwright-artifacts-*`) directory the wedged chromium processes left behind.
- * Injectable via `BrowserPoolOptions.purgeProfileDirs` so tests can drive the
- * breaker without touching the real filesystem and assert it fired. A failure to
- * read the temp dir or unlink an entry is swallowed (the dir may not exist, or
- * be owned by another process) — the purge is a hygiene best-effort, not a
- * correctness dependency.
+ * Minimum age (ms) a `playwright_*` dir must be before the purge removes it.
+ * Bounds the blast radius: a browser launching CONCURRENTLY with the purge
+ * (the cold-launch the hard recovery is about to fire, or a sibling pool) has a
+ * fresh `playwright_*` dir; recursively deleting it out from under an in-flight
+ * launch would re-wedge the very launch we are trying to revive. Only dirs whose
+ * mtime is older than this — i.e. left behind by the PRIOR wedged generation —
+ * are purged. 60s comfortably exceeds a single launch/heal cycle.
  */
-async function defaultPurgeProfileDirs(): Promise<number> {
-  const dir = tmpdir();
+export const PURGE_MIN_AGE_MS = 60_000;
+
+/**
+ * Default profile/temp-dir purge used by the self-heal hard-recovery path.
+ * Best-effort: removes the `${tmpdir()}/playwright_*` (and
+ * `playwright-artifacts-*`) directories the wedged chromium processes left
+ * behind. Injectable via `BrowserPoolOptions.purgeProfileDirs` so tests can
+ * drive the breaker without touching the real filesystem and assert it fired.
+ *
+ * SAFETY (the temp dir is world-writable `/tmp`, so an attacker — or a stray
+ * tool — can plant entries there):
+ *  - SYMLINKS are SKIPPED. `readdir(..., {withFileTypes:true})` lets us reject a
+ *    `playwright_*` SYMLINK whose target is some other path; a blind
+ *    `rm(recursive)` would follow it and recursively delete the target's
+ *    contents. Only entries that are themselves real DIRECTORIES are eligible.
+ *  - Entries younger than `PURGE_MIN_AGE_MS` are LEFT ALONE so a concurrently
+ *    launching browser's fresh dir is never nuked (see `PURGE_MIN_AGE_MS`).
+ *  - The realpath is verified to still resolve UNDER `tmpdir()` before removal,
+ *    a belt-and-suspenders guard against a TOCTOU race / nested symlink.
+ *
+ * A failure to read the temp dir, stat an entry, or unlink it is swallowed (the
+ * dir may not exist, be owned by another process, or vanish mid-purge) — the
+ * purge is a hygiene best-effort, not a correctness dependency. The returned
+ * count is LOG-ONLY (surfaced in `self-heal-profile-purge`), not load-bearing.
+ */
+export async function defaultPurgeProfileDirs(
+  dir: string = tmpdir(),
+): Promise<number> {
   let removed = 0;
-  let entries: string[];
+  let entries: import("node:fs").Dirent[];
   try {
-    entries = await fs.readdir(dir);
+    entries = await fs.readdir(dir, { withFileTypes: true });
   } catch {
     return 0;
   }
-  for (const name of entries) {
+  // Resolve the canonical (symlink-free) form of the scan dir ONCE so the
+  // per-entry containment check is robust to platform-level symlinks in the
+  // temp path itself (e.g. macOS `/var` → `/private/var`). A realpath failure
+  // falls back to the raw dir.
+  let realDir: string;
+  try {
+    realDir = await fs.realpath(dir);
+  } catch {
+    realDir = dir;
+  }
+  const now = Date.now();
+  for (const entry of entries) {
+    const name = entry.name;
     if (!PLAYWRIGHT_TMP_PREFIXES.some((p) => name.startsWith(p))) continue;
+    // Skip symlinks (do NOT follow a planted `playwright_*` symlink) and any
+    // non-directory entry. Only real directories the wedged chromium left
+    // behind are purge candidates.
+    if (entry.isSymbolicLink() || !entry.isDirectory()) continue;
+    const full = join(dir, name);
     try {
-      await fs.rm(join(dir, name), { recursive: true, force: true });
+      // lstat (no symlink follow) for the age check; a directory entry that
+      // isn't a symlink resolves to itself.
+      const stat = await fs.lstat(full);
+      if (stat.isSymbolicLink()) continue; // TOCTOU: became a symlink post-readdir.
+      if (now - stat.mtimeMs < PURGE_MIN_AGE_MS) continue; // too fresh — skip.
+      // Belt-and-suspenders: confirm the realpath stays under the scan dir
+      // before a recursive remove, so a nested-symlink trick can't escape it.
+      const real = await fs.realpath(full);
+      if (real !== join(realDir, name) && !real.startsWith(realDir + "/")) {
+        continue;
+      }
+      await fs.rm(full, { recursive: true, force: true });
       removed++;
     } catch {
       // best-effort: another process may own it, or it vanished mid-purge.
     }
   }
   return removed;
+}
+
+/**
+ * Resolve a STRICTLY-POSITIVE numeric tunable with explicit-arg > env > default
+ * precedence, then CLAMP the result to `>= 1`. Used for the circuit-breaker
+ * thresholds (`selfHealHardRecoveryThreshold` / `selfHealMaxHardRecoveries`)
+ * whose guards are `> 0`: a `0` (from either source, or a config typo) would
+ * silently DISABLE both the hard-recovery escape AND the give-up alarm, sending
+ * the loop right back to the infinite-silent-spin this breaker exists to kill.
+ * Unlike `resolveNonNegative` (where an explicit `0` legitimately disables
+ * retries/backoff), a `0` here is a footgun, so it is clamped up to the minimum
+ * safe value of 1 rather than honored. Mirrors `resolveNonNegative`'s
+ * precedence; differs only in the floor.
+ */
+function resolvePositive(
+  explicit: number | undefined,
+  envRaw: string | undefined,
+  fallback: number,
+): number {
+  const resolved = resolveNonNegative(explicit, envRaw, fallback);
+  return resolved < 1 ? 1 : resolved;
 }
 
 function delay(ms: number): Promise<void> {

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -1,6 +1,6 @@
 import type { Browser, BrowserContext } from "playwright";
-import { sampleResourceGauges, readCgroupPids } from "./resource-gauges";
-import type { ResourceGauges } from "./resource-gauges";
+import { sampleResourceGauges, readCgroupPids } from "./resource-gauges.js";
+import type { ResourceGauges } from "./resource-gauges.js";
 
 /**
  * Default delay the launch-serialization gate waits AFTER each chromium

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -1,3 +1,6 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Browser, BrowserContext } from "playwright";
 
 /**
@@ -63,6 +66,79 @@ const MAX_TRANSIENT_SERVE_RETRIES = 1;
  * waiters) or the pool shuts down.
  */
 const DEFAULT_SELF_HEAL_INTERVAL_MS = 2_000;
+
+/**
+ * Self-heal CIRCUIT-BREAKER policy. The OUTAGE this guards (verified from live
+ * staging logs — the RECURRING BrowserPool collapse #5185/#5221/#5225 each
+ * chipped at but never killed): after the long-lived harness container runs
+ * ~hours under sustained d6 cron load, chromium enters a LAUNCH crash-loop —
+ * every `chromium.launch()` throws `browserType.launch: Target page, context or
+ * browser has been closed`. The set empties, `startSelfHeal()` kicks in, and its
+ * loop just RELAUNCHES into the SAME wedged state over and over
+ * (`self-heal-launch-failed` repeating, 28× in ~19s observed) — backing off
+ * `selfHealIntervalMs` between identical attempts but NEVER doing anything
+ * different to escape (stale `/tmp/playwright_*` profile dirs / accumulated
+ * FD-shm pressure on the long-lived container persist across every relaunch).
+ * `acquire()` therefore has no contexts forever → blocks to timeout fleet-wide.
+ * Only a container RESTART cleared it — reactive, not durable.
+ *
+ * The breaker makes the self-heal loop ESCAPE: after
+ * `selfHealHardRecoveryThreshold` CONSECUTIVE self-heal launch failures, instead
+ * of looping another identical relaunch the pool performs a HARD recovery —
+ * purges the stale `/tmp/playwright_*` profile/temp dirs the wedged chromium
+ * processes left behind (the FD-shm/profile pressure that keeps every fresh
+ * launch crashing) — then cold-launches fresh. Any successful launch resets the
+ * consecutive counter. If `selfHealMaxHardRecoveries` consecutive HARD
+ * recoveries ALSO fail to revive a single browser, the pool surfaces a LOUD
+ * `browser-pool.pool-unrecoverable` alarm (via `onUnrecoverable`) and stops the
+ * heal loop rather than silently spinning forever — the operator signal that a
+ * redeploy is genuinely required.
+ *
+ * Tunable on staging via env (BROWSER_POOL_SELF_HEAL_* ) without a code change.
+ */
+const DEFAULT_SELF_HEAL_HARD_RECOVERY_THRESHOLD = 4;
+const DEFAULT_SELF_HEAL_MAX_HARD_RECOVERIES = 3;
+
+/**
+ * Glob-free prefix of the per-launch profile/temp dirs Playwright's chromium
+ * leaves under the OS temp dir. The default chromium launcher does not pin a
+ * `userDataDir`, so each launch creates an ephemeral `playwright_*` (and
+ * related `playwright-artifacts-*`) directory; a crash-looping container
+ * accumulates these and the FD/shm/inode pressure keeps every fresh launch
+ * crashing. The hard-recovery purge removes them so a cold launch starts clean.
+ */
+const PLAYWRIGHT_TMP_PREFIXES = ["playwright_", "playwright-artifacts-"];
+
+/**
+ * Default profile/temp-dir purge used by the self-heal hard-recovery path.
+ * Best-effort: removes every `${tmpdir()}/playwright_*` (and
+ * `playwright-artifacts-*`) directory the wedged chromium processes left behind.
+ * Injectable via `BrowserPoolOptions.purgeProfileDirs` so tests can drive the
+ * breaker without touching the real filesystem and assert it fired. A failure to
+ * read the temp dir or unlink an entry is swallowed (the dir may not exist, or
+ * be owned by another process) — the purge is a hygiene best-effort, not a
+ * correctness dependency.
+ */
+async function defaultPurgeProfileDirs(): Promise<number> {
+  const dir = tmpdir();
+  let removed = 0;
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return 0;
+  }
+  for (const name of entries) {
+    if (!PLAYWRIGHT_TMP_PREFIXES.some((p) => name.startsWith(p))) continue;
+    try {
+      await fs.rm(join(dir, name), { recursive: true, force: true });
+      removed++;
+    } catch {
+      // best-effort: another process may own it, or it vanished mid-purge.
+    }
+  }
+  return removed;
+}
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -152,6 +228,15 @@ interface PoolLogger {
 export type LaunchBrowser = () => Promise<Browser>;
 
 /**
+ * Purges the stale per-launch profile/temp dirs a crash-looping chromium leaves
+ * behind, returning the count removed. The default implementation removes
+ * `${tmpdir()}/playwright_*`. Tests inject a fake so the self-heal
+ * circuit-breaker's hard-recovery path is exercisable without touching the real
+ * filesystem (and so the test can assert the purge fired).
+ */
+export type PurgeProfileDirs = () => Promise<number>;
+
+/**
  * One long-lived browser PROCESS in the fixed set. Contexts are pooled over
  * this — the hot path (`acquire`/`release`) opens and closes CONTEXTS on an
  * already-running browser and never forks a process. A browser is only
@@ -230,6 +315,20 @@ export interface BrowserPoolOptions {
    *  emptied. Default 2000 (env BROWSER_POOL_SELF_HEAL_INTERVAL_MS). Tests pass
    *  a small value. */
   selfHealIntervalMs?: number;
+  /** Number of CONSECUTIVE self-heal launch failures after which the loop stops
+   *  retrying the identical relaunch and performs a HARD recovery (purge stale
+   *  profile/temp dirs, then cold-launch). Default 4 (env
+   *  BROWSER_POOL_SELF_HEAL_HARD_RECOVERY_THRESHOLD). Tests pass a small value to
+   *  trip the breaker deterministically. */
+  selfHealHardRecoveryThreshold?: number;
+  /** Number of CONSECUTIVE HARD recoveries that may fail to revive any browser
+   *  before the pool gives up and fires the `pool-unrecoverable` alarm (instead
+   *  of spinning forever). Default 3 (env
+   *  BROWSER_POOL_SELF_HEAL_MAX_HARD_RECOVERIES). */
+  selfHealMaxHardRecoveries?: number;
+  /** Injected profile/temp-dir purge (tests). Defaults to removing
+   *  `${tmpdir()}/playwright_*`. Invoked by the self-heal hard-recovery path. */
+  purgeProfileDirs?: PurgeProfileDirs;
   /**
    * Mid-life capacity-loss alarm hook. Invoked when the browser set EMPTIES
    * (every entry evicted) — the silent-outage gap the original code had, where
@@ -245,6 +344,16 @@ export interface BrowserPoolOptions {
    * clear the degraded signal back to green.
    */
   onRecovered?: () => void;
+  /**
+   * Unrecoverable-alarm hook. Invoked when the self-heal circuit-breaker has
+   * exhausted `selfHealMaxHardRecoveries` consecutive HARD recoveries (purge +
+   * cold-launch) WITHOUT reviving a single browser — i.e. the wedge survived
+   * even a profile-dir purge, so a redeploy is genuinely required. The
+   * orchestrator wires this to a LOUD operator alert (the signal the old
+   * silent-spin path never sent). Best-effort: a throwing hook is caught +
+   * logged, never crashes the pool.
+   */
+  onUnrecoverable?: () => void;
 }
 
 /**
@@ -283,8 +392,20 @@ export class BrowserPool {
   private readonly relaunchMaxRetries: number;
   private readonly relaunchBackoffMs: number;
   private readonly selfHealIntervalMs: number;
+  // Self-heal circuit-breaker (the durable fix for the RECURRING wedge): trip a
+  // HARD recovery (profile-dir purge + cold-launch) after this many consecutive
+  // self-heal launch failures, and give up (loud alarm) after this many
+  // consecutive failed HARD recoveries.
+  private readonly selfHealHardRecoveryThreshold: number;
+  private readonly selfHealMaxHardRecoveries: number;
+  private readonly purgeProfileDirs: PurgeProfileDirs;
   private readonly onDegraded?: () => void;
   private readonly onRecovered?: () => void;
+  private readonly onUnrecoverable?: () => void;
+  // Latched once the circuit-breaker has fired `onUnrecoverable` so the alarm is
+  // emitted exactly once per unrecoverable episode and the heal loop does not
+  // re-enter the give-up path. Cleared when a hard recovery later succeeds.
+  private unrecoverable = false;
   // True once the set has emptied and onDegraded fired; cleared when self-heal
   // succeeds. Guards against firing the degraded alarm / spawning a second
   // self-heal loop repeatedly.
@@ -390,8 +511,30 @@ export class BrowserPool {
       process.env.BROWSER_POOL_SELF_HEAL_INTERVAL_MS,
       DEFAULT_SELF_HEAL_INTERVAL_MS,
     );
+    this.selfHealHardRecoveryThreshold = resolveNonNegative(
+      options.selfHealHardRecoveryThreshold,
+      process.env.BROWSER_POOL_SELF_HEAL_HARD_RECOVERY_THRESHOLD,
+      DEFAULT_SELF_HEAL_HARD_RECOVERY_THRESHOLD,
+    );
+    this.selfHealMaxHardRecoveries = resolveNonNegative(
+      options.selfHealMaxHardRecoveries,
+      process.env.BROWSER_POOL_SELF_HEAL_MAX_HARD_RECOVERIES,
+      DEFAULT_SELF_HEAL_MAX_HARD_RECOVERIES,
+    );
+    // Purge resolution: an explicit injected purge wins. Otherwise, when a fake
+    // `launchBrowser` is injected (tests — the browsers are fakes, so there are
+    // NO real `/tmp/playwright_*` dirs to scan/remove), default to a hermetic
+    // no-op so the breaker's hard-recovery path never touches the real
+    // filesystem under test. Only the production path (real chromium launcher,
+    // no injected launcher) gets the real `${tmpdir()}/playwright_*` purge.
+    this.purgeProfileDirs =
+      options.purgeProfileDirs ??
+      (this.injectedLaunchBrowser
+        ? async (): Promise<number> => 0
+        : defaultPurgeProfileDirs);
     this.onDegraded = options.onDegraded;
     this.onRecovered = options.onRecovered;
+    this.onUnrecoverable = options.onUnrecoverable;
   }
 
   async init(): Promise<void> {
@@ -1585,11 +1728,29 @@ export class BrowserPool {
    * `selfHealIntervalMs` and retries, until success or shutdown. On recovery it
    * clears `degraded` and fires `onRecovered`. Guarded by `selfHealing` so only
    * one loop runs at a time.
+   *
+   * CIRCUIT-BREAKER (the durable fix for the RECURRING wedge): the unfixed loop
+   * just RELAUNCHED into the same wedged state forever — when chromium is in a
+   * launch-crash-loop (`browserType.launch: ...has been closed`) every relaunch
+   * throws identically and the loop never escapes (the stale `/tmp/playwright_*`
+   * profile dirs / FD-shm pressure persist across every attempt). Now, after
+   * `selfHealHardRecoveryThreshold` CONSECUTIVE launch failures, the loop stops
+   * looping identical relaunches and performs a HARD recovery — purges the stale
+   * profile/temp dirs — then cold-launches fresh. A single successful launch
+   * resets the failure counter. If `selfHealMaxHardRecoveries` consecutive HARD
+   * recoveries ALSO revive nothing, it fires the LOUD `pool-unrecoverable` alarm
+   * and stops (a redeploy is genuinely required) rather than spinning silently.
    */
   private startSelfHeal(): void {
     if (this.selfHealing) return;
     this.selfHealing = true;
     const loop = (async () => {
+      // Circuit-breaker counters, carried ACROSS iterations: consecutive launch
+      // failures (reset by ANY successful launch) trip the hard recovery;
+      // consecutive failed hard recoveries (reset by any successful launch) trip
+      // the unrecoverable alarm.
+      let consecutiveFailures = 0;
+      let consecutiveHardRecoveries = 0;
       // Keep iterating until the set is restored to FULL strength
       // (`browserCount`), not merely non-empty. The unfixed loop broke + fired
       // onRecovered the instant ONE browser revived, even though the pool target
@@ -1602,6 +1763,28 @@ export class BrowserPool {
         const shortfall = this.browserCount - this.browsers.length;
         for (let i = 0; i < shortfall; i++) {
           if (this.isShutdown) break;
+          // BREAKER: before attempting another identical relaunch, check whether
+          // we have already failed `selfHealHardRecoveryThreshold` times in a
+          // row. If so, escape the relaunch-into-the-same-wedge loop and HARD
+          // recover (purge stale profile/temp dirs) so the NEXT launch is cold.
+          if (
+            this.selfHealHardRecoveryThreshold > 0 &&
+            consecutiveFailures >= this.selfHealHardRecoveryThreshold
+          ) {
+            consecutiveFailures = 0;
+            consecutiveHardRecoveries++;
+            await this.hardRecover(consecutiveHardRecoveries);
+            if (this.isShutdown) break;
+            // Even the purge could not break the wedge after K tries — give up
+            // LOUDLY rather than spinning forever.
+            if (
+              this.selfHealMaxHardRecoveries > 0 &&
+              consecutiveHardRecoveries >= this.selfHealMaxHardRecoveries
+            ) {
+              this.fireUnrecoverable();
+              return;
+            }
+          }
           try {
             const fresh = await this.launchBrowser();
             if (this.isShutdown) {
@@ -1620,6 +1803,12 @@ export class BrowserPool {
             this.browsers.push(revived);
             this.attachDisconnectHandler(revived, fresh);
             launchedAny = true;
+            // A launch succeeded — the wedge (if any) is broken. Reset BOTH
+            // breaker counters and clear the unrecoverable latch so a future
+            // re-empty starts the breaker fresh.
+            consecutiveFailures = 0;
+            consecutiveHardRecoveries = 0;
+            this.unrecoverable = false;
             // Drain queued waiters onto the revived browser as capacity returns.
             while (
               this.waiters.length > 0 &&
@@ -1631,8 +1820,11 @@ export class BrowserPool {
               if (this.waiters.length >= before) break;
             }
           } catch (err) {
+            consecutiveFailures++;
             this.logger?.warn?.("browser-pool.self-heal-launch-failed", {
               attemptIndex: i,
+              consecutiveFailures,
+              hardRecoveryThreshold: this.selfHealHardRecoveryThreshold,
               error: err instanceof Error ? err.message : String(err),
             });
           }
@@ -1685,9 +1877,68 @@ export class BrowserPool {
   }
 
   /**
-   * Invoke a best-effort lifecycle hook (`onDegraded` / `onRecovered`) without
-   * letting a throwing hook crash the pool. A hook failure is logged, not
-   * propagated.
+   * CIRCUIT-BREAKER hard-recovery step. Invoked by the self-heal loop after
+   * `selfHealHardRecoveryThreshold` consecutive launch failures — the signal
+   * that the loop is stuck relaunching into a wedged chromium (every
+   * `chromium.launch()` throwing `...has been closed`). Purges the stale
+   * `/tmp/playwright_*` profile/temp dirs the crash-looping processes left
+   * behind (the FD-shm/profile pressure that keeps every fresh launch crashing)
+   * so the next launch starts cold and clean. Best-effort: a purge failure is
+   * logged, not thrown — the cold-launch retry still proceeds. The
+   * `delayOrShutdown` after the purge paces the next attempt and stays promptly
+   * cancellable on shutdown.
+   */
+  private async hardRecover(attempt: number): Promise<void> {
+    if (this.isShutdown) return;
+    this.logger?.error?.("browser-pool.self-heal-hard-recovery", {
+      attempt,
+      maxHardRecoveries: this.selfHealMaxHardRecoveries,
+      hardRecoveryThreshold: this.selfHealHardRecoveryThreshold,
+    });
+    try {
+      const removed = await this.purgeProfileDirs();
+      this.logger?.info("browser-pool.self-heal-profile-purge", {
+        attempt,
+        removed,
+      });
+    } catch (err) {
+      this.logger?.warn?.("browser-pool.self-heal-profile-purge-failed", {
+        attempt,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    // Pace the cold-launch retry into the (hopefully now-unwedged) kernel.
+    if (!this.isShutdown && this.selfHealIntervalMs > 0) {
+      await this.delayOrShutdown(this.selfHealIntervalMs);
+    }
+  }
+
+  /**
+   * CIRCUIT-BREAKER give-up step. Invoked when `selfHealMaxHardRecoveries`
+   * consecutive HARD recoveries (purge + cold-launch) have ALL failed to revive
+   * a single browser — the wedge survived even a profile-dir purge, so a
+   * redeploy is genuinely required. Emits the LOUD `pool-unrecoverable` alarm
+   * (the operator signal the old silent-spin path never sent) exactly once per
+   * episode (latched via `unrecoverable`) and lets the heal loop exit instead of
+   * spinning forever. A later set-empty event re-spawns the heal loop
+   * (`onBrowserSetEmpty` is unconditional); the latch is cleared by the first
+   * successful launch so a subsequent genuine recovery re-arms the breaker.
+   */
+  private fireUnrecoverable(): void {
+    if (this.unrecoverable) return;
+    this.unrecoverable = true;
+    this.logger?.error?.("browser-pool.pool-unrecoverable", {
+      browserCount: this.browserCount,
+      waiters: this.waiters.length,
+      maxHardRecoveries: this.selfHealMaxHardRecoveries,
+    });
+    this.safeHook(this.onUnrecoverable, "onUnrecoverable");
+  }
+
+  /**
+   * Invoke a best-effort lifecycle hook (`onDegraded` / `onRecovered` /
+   * `onUnrecoverable`) without letting a throwing hook crash the pool. A hook
+   * failure is logged, not propagated.
    */
   private safeHook(hook: (() => void) | undefined, name: string): void {
     if (!hook) return;

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -350,10 +350,24 @@ export interface BrowserPoolOptions {
    * cold-launch) WITHOUT reviving a single browser — i.e. the wedge survived
    * even a profile-dir purge, so a redeploy is genuinely required. The
    * orchestrator wires this to a LOUD operator alert (the signal the old
-   * silent-spin path never sent). Best-effort: a throwing hook is caught +
-   * logged, never crashes the pool.
+   * silent-spin path never sent). The breaker counters are passed so the alarm
+   * can report how hard the pool tried before giving up. Best-effort: a throwing
+   * hook is caught + logged, never crashes the pool.
    */
-  onUnrecoverable?: () => void;
+  onUnrecoverable?: (info: BrowserPoolUnrecoverableInfo) => void;
+}
+
+/**
+ * Breaker counters handed to the `onUnrecoverable` hook so the operator alarm
+ * can describe how hard the pool tried before giving up.
+ */
+export interface BrowserPoolUnrecoverableInfo {
+  /** Target browser-process count the pool could not revive a single one of. */
+  browserCount: number;
+  /** Acquire waiters still blocked at the moment of give-up. */
+  waiters: number;
+  /** Consecutive failed HARD recoveries that tripped the give-up. */
+  maxHardRecoveries: number;
 }
 
 /**
@@ -401,11 +415,9 @@ export class BrowserPool {
   private readonly purgeProfileDirs: PurgeProfileDirs;
   private readonly onDegraded?: () => void;
   private readonly onRecovered?: () => void;
-  private readonly onUnrecoverable?: () => void;
-  // Latched once the circuit-breaker has fired `onUnrecoverable` so the alarm is
-  // emitted exactly once per unrecoverable episode and the heal loop does not
-  // re-enter the give-up path. Cleared when a hard recovery later succeeds.
-  private unrecoverable = false;
+  private readonly onUnrecoverable?: (
+    info: BrowserPoolUnrecoverableInfo,
+  ) => void;
   // True once the set has emptied and onDegraded fired; cleared when self-heal
   // succeeds. Guards against firing the degraded alarm / spawning a second
   // self-heal loop repeatedly.
@@ -511,12 +523,16 @@ export class BrowserPool {
       process.env.BROWSER_POOL_SELF_HEAL_INTERVAL_MS,
       DEFAULT_SELF_HEAL_INTERVAL_MS,
     );
-    this.selfHealHardRecoveryThreshold = resolveNonNegative(
+    // Breaker thresholds are CLAMPED to >= 1 (not merely non-negative): a `0`
+    // would disable the `> 0` guards on the hard-recovery escape AND the give-up
+    // alarm, reverting to the infinite-silent-spin this breaker fixes. A config
+    // typo (or an explicit 0) can't silently disable the safety net.
+    this.selfHealHardRecoveryThreshold = resolvePositive(
       options.selfHealHardRecoveryThreshold,
       process.env.BROWSER_POOL_SELF_HEAL_HARD_RECOVERY_THRESHOLD,
       DEFAULT_SELF_HEAL_HARD_RECOVERY_THRESHOLD,
     );
-    this.selfHealMaxHardRecoveries = resolveNonNegative(
+    this.selfHealMaxHardRecoveries = resolvePositive(
       options.selfHealMaxHardRecoveries,
       process.env.BROWSER_POOL_SELF_HEAL_MAX_HARD_RECOVERIES,
       DEFAULT_SELF_HEAL_MAX_HARD_RECOVERIES,
@@ -1804,11 +1820,9 @@ export class BrowserPool {
             this.attachDisconnectHandler(revived, fresh);
             launchedAny = true;
             // A launch succeeded — the wedge (if any) is broken. Reset BOTH
-            // breaker counters and clear the unrecoverable latch so a future
-            // re-empty starts the breaker fresh.
+            // breaker counters so a future re-empty starts the breaker fresh.
             consecutiveFailures = 0;
             consecutiveHardRecoveries = 0;
-            this.unrecoverable = false;
             // Drain queued waiters onto the revived browser as capacity returns.
             while (
               this.waiters.length > 0 &&
@@ -1918,27 +1932,46 @@ export class BrowserPool {
    * consecutive HARD recoveries (purge + cold-launch) have ALL failed to revive
    * a single browser — the wedge survived even a profile-dir purge, so a
    * redeploy is genuinely required. Emits the LOUD `pool-unrecoverable` alarm
-   * (the operator signal the old silent-spin path never sent) exactly once per
-   * episode (latched via `unrecoverable`) and lets the heal loop exit instead of
-   * spinning forever. A later set-empty event re-spawns the heal loop
-   * (`onBrowserSetEmpty` is unconditional); the latch is cleared by the first
-   * successful launch so a subsequent genuine recovery re-arms the breaker.
+   * (the operator signal the old silent-spin path never sent) and lets the heal
+   * loop exit instead of spinning forever.
+   *
+   * ONCE-PER-EPISODE is guaranteed STRUCTURALLY, not by an instance latch: each
+   * distinct degraded episode spawns its OWN self-heal loop (`startSelfHeal` is
+   * gated only by `selfHealing`, which the prior loop clears on exit), the
+   * loop-local `consecutiveHardRecoveries` counter resets per spawn, and the
+   * loop `return`s the instant this fires — so it cannot double-fire within one
+   * loop, and a later set re-empty re-spawns a loop that can fire its OWN alarm.
+   * A prior buggy instance latch (`this.unrecoverable`, cleared ONLY on a
+   * successful launch) silenced every SUBSEQUENT episode of a permanently-wedged
+   * container that re-emptied after the first give-up — the exact silent-spin
+   * this breaker exists to kill. The latch was removed so each episode alarms.
    */
   private fireUnrecoverable(): void {
-    if (this.unrecoverable) return;
-    this.unrecoverable = true;
-    this.logger?.error?.("browser-pool.pool-unrecoverable", {
+    const info: BrowserPoolUnrecoverableInfo = {
       browserCount: this.browserCount,
       waiters: this.waiters.length,
       maxHardRecoveries: this.selfHealMaxHardRecoveries,
-    });
-    this.safeHook(this.onUnrecoverable, "onUnrecoverable");
+    };
+    this.logger?.error?.("browser-pool.pool-unrecoverable", { ...info });
+    // Best-effort hook (mirrors safeHook) — passes the breaker counters so the
+    // operator alarm can describe how hard the pool tried before giving up.
+    if (this.onUnrecoverable) {
+      try {
+        this.onUnrecoverable(info);
+      } catch (err) {
+        this.logger?.error?.("browser-pool.hook-failed", {
+          hook: "onUnrecoverable",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 
   /**
-   * Invoke a best-effort lifecycle hook (`onDegraded` / `onRecovered` /
-   * `onUnrecoverable`) without letting a throwing hook crash the pool. A hook
-   * failure is logged, not propagated.
+   * Invoke a best-effort lifecycle hook (`onDegraded` / `onRecovered`) without
+   * letting a throwing hook crash the pool. A hook failure is logged, not
+   * propagated. (`onUnrecoverable` is invoked inline in `fireUnrecoverable`
+   * because it takes a counters argument.)
    */
   private safeHook(hook: (() => void) | undefined, name: string): void {
     if (!hook) return;

--- a/showcase/harness/src/probes/helpers/resource-gauges.test.ts
+++ b/showcase/harness/src/probes/helpers/resource-gauges.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  sampleResourceGauges,
+  formatGauges,
+  readCgroupPids,
+} from "./resource-gauges";
+import type { ResourceGauges } from "./resource-gauges";
+
+describe("resource-gauges", () => {
+  describe("sampleResourceGauges", () => {
+    it("returns a fully-populated snapshot with all gauge fields", () => {
+      const g = sampleResourceGauges();
+      // Shape: every documented field is present and numeric (or ISO ts).
+      expect(typeof g.ts).toBe("string");
+      expect(Number.isNaN(Date.parse(g.ts))).toBe(false);
+      const numericFields: Array<keyof ResourceGauges> = [
+        "selfFdCount",
+        "treeThreadCount",
+        "treeProcCount",
+        "zombieCount",
+        "selfRssMb",
+        "treeRssMb",
+        "cgroupPidsCurrent",
+        "cgroupPidsMax",
+        "devShmUsedPct",
+        "tmpInodeUsedPct",
+        "tmpInodesUsed",
+        "tmpInodesFree",
+        "tmpSpaceUsedPct",
+        "tmpSpaceFreeMb",
+        "playwrightTmpDirs",
+      ];
+      for (const f of numericFields) {
+        expect(typeof g[f]).toBe("number");
+      }
+    });
+
+    it("degrades gracefully (no throw) regardless of host OS", () => {
+      // The sampler reads Linux-specific /proc + /sys/fs/cgroup; on a non-Linux
+      // host (e.g. CI/dev on macOS) every reader must fall back to -1 rather
+      // than throwing. The headline cgroup gauges degrade to -1 off-Linux.
+      expect(() => sampleResourceGauges()).not.toThrow();
+    });
+  });
+
+  describe("readCgroupPids", () => {
+    it("parses cgroup v2 pids.current / pids.max", () => {
+      const fake = (p: string): string => {
+        if (p === "/sys/fs/cgroup/pids.current") return "377\n";
+        if (p === "/sys/fs/cgroup/pids.max") return "1000\n";
+        throw new Error("ENOENT");
+      };
+      expect(readCgroupPids(fake)).toEqual({ current: 377, max: 1000 });
+    });
+
+    it("falls back to cgroup v1 paths when v2 is absent", () => {
+      const fake = (p: string): string => {
+        if (p === "/sys/fs/cgroup/pids/pids.current") return "500";
+        if (p === "/sys/fs/cgroup/pids/pids.max") return "1000";
+        throw new Error("ENOENT"); // v2 paths missing
+      };
+      expect(readCgroupPids(fake)).toEqual({ current: 500, max: 1000 });
+    });
+
+    it("reports unbounded pids.max ('max' sentinel) as -1", () => {
+      const fake = (p: string): string => {
+        if (p === "/sys/fs/cgroup/pids.current") return "120";
+        if (p === "/sys/fs/cgroup/pids.max") return "max";
+        throw new Error("ENOENT");
+      };
+      expect(readCgroupPids(fake)).toEqual({ current: 120, max: -1 });
+    });
+
+    it("returns -1/-1 when no cgroup PID controller is readable", () => {
+      const fake = (): string => {
+        throw new Error("ENOENT");
+      };
+      expect(readCgroupPids(fake)).toEqual({ current: -1, max: -1 });
+    });
+  });
+
+  describe("formatGauges", () => {
+    it("leads with the cgroup PID counters (the headline signal)", () => {
+      const g: ResourceGauges = {
+        ts: "2026-06-04T00:00:00.000Z",
+        selfFdCount: 12,
+        treeThreadCount: 850,
+        treeProcCount: 33,
+        zombieCount: 0,
+        selfRssMb: 200,
+        treeRssMb: 3600,
+        cgroupPidsCurrent: 950,
+        cgroupPidsMax: 1000,
+        devShmUsedPct: 0,
+        tmpInodeUsedPct: 1,
+        tmpInodesUsed: 100,
+        tmpInodesFree: 890,
+        tmpSpaceUsedPct: 5,
+        tmpSpaceFreeMb: 1000,
+        playwrightTmpDirs: 6,
+      };
+      const line = formatGauges(g, "launch");
+      expect(line).toContain("[launch]");
+      expect(line).toContain("pidsCurrent=950");
+      expect(line).toContain("pidsMax=1000");
+      expect(line).toContain("threads=850");
+      // The headline PID gauges precede the refuted-candidate differential.
+      expect(line.indexOf("pidsCurrent")).toBeLessThan(
+        line.indexOf("tmpInode"),
+      );
+    });
+
+    it("omits the label bracket when no label is given", () => {
+      const g = sampleResourceGauges();
+      const line = formatGauges(g);
+      expect(line.startsWith("[")).toBe(false);
+      expect(line).toContain("pidsCurrent=");
+    });
+  });
+});

--- a/showcase/harness/src/probes/helpers/resource-gauges.test.ts
+++ b/showcase/harness/src/probes/helpers/resource-gauges.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  sampleResourceGauges,
-  formatGauges,
-  readCgroupPids,
-} from "./resource-gauges.js";
+import { sampleResourceGauges, readCgroupPids } from "./resource-gauges.js";
 import type { ResourceGauges } from "./resource-gauges.js";
 
 describe("resource-gauges", () => {
@@ -76,45 +72,6 @@ describe("resource-gauges", () => {
         throw new Error("ENOENT");
       };
       expect(readCgroupPids(fake)).toEqual({ current: -1, max: -1 });
-    });
-  });
-
-  describe("formatGauges", () => {
-    it("leads with the cgroup PID counters (the headline signal)", () => {
-      const g: ResourceGauges = {
-        ts: "2026-06-04T00:00:00.000Z",
-        selfFdCount: 12,
-        treeThreadCount: 850,
-        treeProcCount: 33,
-        zombieCount: 0,
-        selfRssMb: 200,
-        treeRssMb: 3600,
-        cgroupPidsCurrent: 950,
-        cgroupPidsMax: 1000,
-        devShmUsedPct: 0,
-        tmpInodeUsedPct: 1,
-        tmpInodesUsed: 100,
-        tmpInodesFree: 890,
-        tmpSpaceUsedPct: 5,
-        tmpSpaceFreeMb: 1000,
-        playwrightTmpDirs: 6,
-      };
-      const line = formatGauges(g, "launch");
-      expect(line).toContain("[launch]");
-      expect(line).toContain("pidsCurrent=950");
-      expect(line).toContain("pidsMax=1000");
-      expect(line).toContain("threads=850");
-      // The headline PID gauges precede the refuted-candidate differential.
-      expect(line.indexOf("pidsCurrent")).toBeLessThan(
-        line.indexOf("tmpInode"),
-      );
-    });
-
-    it("omits the label bracket when no label is given", () => {
-      const g = sampleResourceGauges();
-      const line = formatGauges(g);
-      expect(line.startsWith("[")).toBe(false);
-      expect(line).toContain("pidsCurrent=");
     });
   });
 });

--- a/showcase/harness/src/probes/helpers/resource-gauges.test.ts
+++ b/showcase/harness/src/probes/helpers/resource-gauges.test.ts
@@ -3,8 +3,8 @@ import {
   sampleResourceGauges,
   formatGauges,
   readCgroupPids,
-} from "./resource-gauges";
-import type { ResourceGauges } from "./resource-gauges";
+} from "./resource-gauges.js";
+import type { ResourceGauges } from "./resource-gauges.js";
 
 describe("resource-gauges", () => {
   describe("sampleResourceGauges", () => {

--- a/showcase/harness/src/probes/helpers/resource-gauges.ts
+++ b/showcase/harness/src/probes/helpers/resource-gauges.ts
@@ -1,0 +1,325 @@
+/**
+ * resource-gauges.ts — point-in-time OS resource gauges for the harness's
+ * long-lived chromium pool, intended as PERMANENT instrumentation around
+ * `BrowserPool`'s acquire/release/recycle/relaunch cycle.
+ *
+ * WHY: the BrowserPool wedges under d6 launch storms — every `chromium.launch()`
+ * throws `pthread_create: Resource temporarily unavailable (errno 11)` →
+ * "Target page, context or browser has been closed" and the pool never recovers
+ * without a container restart. The PROVEN root cause is OS thread/PID exhaustion
+ * against the container cgroup `pids.max` ceiling (counts THREADS, not just
+ * processes): a d6 burst (max_concurrency:8 → ~32 contexts → ~32 renderers ×
+ * ~15 threads ≈ +480 on top of the ~377 idle baseline) peaks ~850-900, and a
+ * concurrent recovery-relaunch pushes it over the platform-fixed `pids.max=1000`
+ * ceiling. To make that observable — so a burst approaching `pids.max` is
+ * visible in the logs and an EAGAIN correlates to a measured `pids.current` near
+ * `pids.max` — we sample a cheap gauge snapshot on every pool launch / heal
+ * failure and at probe-tick boundaries.
+ *
+ * The HEADLINE gauges are the cgroup PID counters (`pids.current` / `pids.max`)
+ * and the process-tree thread count; the rest (FDs, RSS, /dev/shm, /tmp inodes,
+ * /tmp space) are kept so the differential that REFUTED every other candidate
+ * stays observable in production.
+ *
+ * All gauges are read from Linux `/proc` + `/sys/fs/cgroup` + `statvfs`-
+ * equivalents via `df`. They degrade gracefully (NaN / -1) on non-Linux hosts so
+ * the module is safe to import anywhere; the meaningful numbers come from inside
+ * the Linux container (which is where staging runs and where the wedge happens).
+ *
+ * Cost: a handful of readdir/statfs/readfile syscalls + two short `df` execs.
+ * Cheap enough to fire on every launch / heal failure.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+export interface ResourceGauges {
+  /** Wall-clock ISO timestamp of the sample. */
+  ts: string;
+  /** Open file descriptors held by THIS process (sockets, pipes, files). */
+  selfFdCount: number;
+  /** Total threads across the whole process tree rooted at this PID
+   *  (self + every descendant, incl. chromium renderers). */
+  treeThreadCount: number;
+  /** Total processes (PIDs) in the tree rooted at this PID. */
+  treeProcCount: number;
+  /** Count of zombie/defunct processes in the tree (state Z). */
+  zombieCount: number;
+  /** Resident set size of THIS process (MB). */
+  selfRssMb: number;
+  /** Summed RSS across the whole process tree (MB) — self + descendants. */
+  treeRssMb: number;
+  /** cgroup `pids.current` — live thread/process count charged against the
+   *  cgroup PID controller (THE headline signal; the ceiling that wedges). -1
+   *  if unavailable (non-Linux, no cgroup PID controller). */
+  cgroupPidsCurrent: number;
+  /** cgroup `pids.max` — the PID/thread ceiling the runtime fixed for this
+   *  container. `Infinity`-equivalent "max" is reported as -1 (unbounded);
+   *  -1 also signals unavailable. */
+  cgroupPidsMax: number;
+  /** /dev/shm usage percent (0..100); -1 if unavailable. */
+  devShmUsedPct: number;
+  /** /tmp inode usage percent (0..100); -1 if unavailable. */
+  tmpInodeUsedPct: number;
+  /** /tmp inodes used (absolute); -1 if unavailable. */
+  tmpInodesUsed: number;
+  /** /tmp inodes free (absolute); -1 if unavailable. */
+  tmpInodesFree: number;
+  /** /tmp disk-space usage percent (0..100); -1 if unavailable. */
+  tmpSpaceUsedPct: number;
+  /** /tmp disk-space free (MB); -1 if unavailable. */
+  tmpSpaceFreeMb: number;
+  /** Count of `playwright_*` + `playwright-artifacts-*` dirs under tmpdir(). */
+  playwrightTmpDirs: number;
+}
+
+/** Read this process's open-FD count via /proc/self/fd. */
+function readSelfFdCount(): number {
+  try {
+    return readdirSync("/proc/self/fd").length;
+  } catch {
+    return -1;
+  }
+}
+
+/**
+ * Read the cgroup PID controller's current/max counters. THE headline gauge:
+ * the wedge is exhaustion of this ceiling. Tries cgroup v2 first
+ * (`/sys/fs/cgroup/pids.{current,max}`), then falls back to cgroup v1
+ * (`/sys/fs/cgroup/pids/pids.{current,max}`). `pids.max` of the literal string
+ * "max" means unbounded → reported as -1. Any read failure → -1 (non-Linux, no
+ * PID controller mounted).
+ */
+export function readCgroupPids(
+  readFileImpl: (path: string) => string = (p) => readFileSync(p, "utf8"),
+): { current: number; max: number } {
+  const candidates: Array<{ current: string; max: string }> = [
+    // cgroup v2 (unified hierarchy)
+    { current: "/sys/fs/cgroup/pids.current", max: "/sys/fs/cgroup/pids.max" },
+    // cgroup v1 (legacy)
+    {
+      current: "/sys/fs/cgroup/pids/pids.current",
+      max: "/sys/fs/cgroup/pids/pids.max",
+    },
+  ];
+  for (const c of candidates) {
+    try {
+      const currentRaw = readFileImpl(c.current).trim();
+      const maxRaw = readFileImpl(c.max).trim();
+      const current = Number(currentRaw);
+      // "max" (cgroup's sentinel for unbounded) → -1.
+      const max = maxRaw === "max" ? -1 : Number(maxRaw);
+      if (Number.isFinite(current)) {
+        return { current, max: Number.isFinite(max) ? max : -1 };
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+  return { current: -1, max: -1 };
+}
+
+/**
+ * Walk /proc once, collecting every PID, summing per-pid thread counts and RSS,
+ * counting zombies, and restricting to the tree rooted at `rootPid` (self +
+ * transitive children). One pass over /proc — no `ps` fork per call.
+ */
+function readProcTree(rootPid: number): {
+  treeThreadCount: number;
+  treeProcCount: number;
+  zombieCount: number;
+  selfRssMb: number;
+  treeRssMb: number;
+} {
+  const pageSize = 4096; // statm fields are in pages; Linux default 4KiB.
+  type Stat = {
+    ppid: number;
+    threads: number;
+    state: string;
+    rssBytes: number;
+  };
+  const stats = new Map<number, Stat>();
+  let pids: string[];
+  try {
+    pids = readdirSync("/proc").filter((n) => /^\d+$/.test(n));
+  } catch {
+    return {
+      treeThreadCount: -1,
+      treeProcCount: -1,
+      zombieCount: -1,
+      selfRssMb: -1,
+      treeRssMb: -1,
+    };
+  }
+
+  for (const pidStr of pids) {
+    const pid = Number(pidStr);
+    try {
+      // /proc/<pid>/stat: comm may contain spaces/parens; split on the LAST
+      // ')' so fields after comm align regardless of comm content.
+      const raw = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const rparen = raw.lastIndexOf(")");
+      const after = raw.slice(rparen + 2).split(" ");
+      // After comm: state(0) ppid(1) ... num_threads is post-comm index 17.
+      const state = after[0];
+      const ppid = Number(after[1]);
+      const threads = Number(after[17]);
+      let rssBytes = 0;
+      try {
+        const statm = readFileSync(`/proc/${pid}/statm`, "utf8").split(" ");
+        rssBytes = Number(statm[1]) * pageSize; // field 2 = resident pages
+      } catch {
+        rssBytes = 0;
+      }
+      stats.set(pid, { ppid, threads, state, rssBytes });
+    } catch {
+      // Process vanished between readdir and read — skip.
+    }
+  }
+
+  // Build child adjacency and walk the tree from rootPid.
+  const childrenOf = new Map<number, number[]>();
+  for (const [pid, s] of stats) {
+    const arr = childrenOf.get(s.ppid) ?? [];
+    arr.push(pid);
+    childrenOf.set(s.ppid, arr);
+  }
+
+  let treeThreadCount = 0;
+  let treeProcCount = 0;
+  let zombieCount = 0;
+  let treeRssBytes = 0;
+  const stack = [rootPid];
+  const seen = new Set<number>();
+  while (stack.length > 0) {
+    const pid = stack.pop()!;
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    const s = stats.get(pid);
+    if (!s) continue;
+    treeProcCount += 1;
+    treeThreadCount += Number.isFinite(s.threads) ? s.threads : 0;
+    treeRssBytes += s.rssBytes;
+    if (s.state === "Z") zombieCount += 1;
+    for (const c of childrenOf.get(pid) ?? []) stack.push(c);
+  }
+
+  const selfStat = stats.get(rootPid);
+  const selfRssMb = selfStat ? selfStat.rssBytes / (1024 * 1024) : -1;
+
+  return {
+    treeThreadCount,
+    treeProcCount,
+    zombieCount,
+    selfRssMb: Math.round(selfRssMb),
+    treeRssMb: Math.round(treeRssBytes / (1024 * 1024)),
+  };
+}
+
+/** Parse `df` (1K blocks) for a mount: returns {usedPct, freeMb}. */
+function readDfSpace(path: string): { usedPct: number; freeMb: number } {
+  try {
+    const out = execFileSync("df", ["-kP", path], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const line = out.trim().split("\n").pop()!;
+    const cols = line.split(/\s+/);
+    // Filesystem 1024-blocks Used Available Capacity Mounted
+    const available = Number(cols[3]);
+    const capacity = Number(cols[4].replace("%", ""));
+    return { usedPct: capacity, freeMb: Math.round(available / 1024) };
+  } catch {
+    return { usedPct: -1, freeMb: -1 };
+  }
+}
+
+/** Parse `df -i` for a mount: returns {usedPct, used, free}. */
+function readDfInodes(path: string): {
+  usedPct: number;
+  used: number;
+  free: number;
+} {
+  try {
+    const out = execFileSync("df", ["-iP", path], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const line = out.trim().split("\n").pop()!;
+    const cols = line.split(/\s+/);
+    // Filesystem Inodes IUsed IFree IUse% Mounted
+    const used = Number(cols[2]);
+    const free = Number(cols[3]);
+    const usedPct = Number(cols[4].replace("%", ""));
+    return { usedPct, used, free };
+  } catch {
+    return { usedPct: -1, used: -1, free: -1 };
+  }
+}
+
+/** Count playwright_* + playwright-artifacts-* dirs under tmpdir(). */
+function countPlaywrightTmpDirs(): number {
+  try {
+    return readdirSync(tmpdir()).filter(
+      (n) =>
+        n.startsWith("playwright_") || n.startsWith("playwright-artifacts-"),
+    ).length;
+  } catch {
+    return -1;
+  }
+}
+
+/** Take one full gauge snapshot. */
+export function sampleResourceGauges(): ResourceGauges {
+  const tree = readProcTree(process.pid);
+  const cgroupPids = readCgroupPids();
+  const shm = readDfSpace("/dev/shm");
+  const tmpInodes = readDfInodes(tmpdir());
+  const tmpSpace = readDfSpace(tmpdir());
+  return {
+    ts: new Date().toISOString(),
+    selfFdCount: readSelfFdCount(),
+    treeThreadCount: tree.treeThreadCount,
+    treeProcCount: tree.treeProcCount,
+    zombieCount: tree.zombieCount,
+    selfRssMb: tree.selfRssMb,
+    treeRssMb: tree.treeRssMb,
+    cgroupPidsCurrent: cgroupPids.current,
+    cgroupPidsMax: cgroupPids.max,
+    devShmUsedPct: shm.usedPct,
+    tmpInodeUsedPct: tmpInodes.usedPct,
+    tmpInodesUsed: tmpInodes.used,
+    tmpInodesFree: tmpInodes.free,
+    tmpSpaceUsedPct: tmpSpace.usedPct,
+    tmpSpaceFreeMb: tmpSpace.freeMb,
+    playwrightTmpDirs: countPlaywrightTmpDirs(),
+  };
+}
+
+/**
+ * Format a gauge sample as a compact single-line key=val string for logs. The
+ * cgroup PID counters lead (the headline signal); the rest follow so the
+ * refuted-candidate differential stays in the log line.
+ */
+export function formatGauges(g: ResourceGauges, label?: string): string {
+  const parts = [
+    label ? `[${label}]` : undefined,
+    `pidsCurrent=${g.cgroupPidsCurrent}`,
+    `pidsMax=${g.cgroupPidsMax}`,
+    `threads=${g.treeThreadCount}`,
+    `procs=${g.treeProcCount}`,
+    `zombies=${g.zombieCount}`,
+    `fd=${g.selfFdCount}`,
+    `selfRssMb=${g.selfRssMb}`,
+    `treeRssMb=${g.treeRssMb}`,
+    `shmUsedPct=${g.devShmUsedPct}`,
+    `tmpInodePct=${g.tmpInodeUsedPct}`,
+    `tmpInodesUsed=${g.tmpInodesUsed}`,
+    `tmpInodesFree=${g.tmpInodesFree}`,
+    `tmpSpacePct=${g.tmpSpaceUsedPct}`,
+    `tmpFreeMb=${g.tmpSpaceFreeMb}`,
+    `pwTmpDirs=${g.playwrightTmpDirs}`,
+  ].filter(Boolean);
+  return parts.join(" ");
+}

--- a/showcase/harness/src/probes/helpers/resource-gauges.ts
+++ b/showcase/harness/src/probes/helpers/resource-gauges.ts
@@ -296,30 +296,3 @@ export function sampleResourceGauges(): ResourceGauges {
     playwrightTmpDirs: countPlaywrightTmpDirs(),
   };
 }
-
-/**
- * Format a gauge sample as a compact single-line key=val string for logs. The
- * cgroup PID counters lead (the headline signal); the rest follow so the
- * refuted-candidate differential stays in the log line.
- */
-export function formatGauges(g: ResourceGauges, label?: string): string {
-  const parts = [
-    label ? `[${label}]` : undefined,
-    `pidsCurrent=${g.cgroupPidsCurrent}`,
-    `pidsMax=${g.cgroupPidsMax}`,
-    `threads=${g.treeThreadCount}`,
-    `procs=${g.treeProcCount}`,
-    `zombies=${g.zombieCount}`,
-    `fd=${g.selfFdCount}`,
-    `selfRssMb=${g.selfRssMb}`,
-    `treeRssMb=${g.treeRssMb}`,
-    `shmUsedPct=${g.devShmUsedPct}`,
-    `tmpInodePct=${g.tmpInodeUsedPct}`,
-    `tmpInodesUsed=${g.tmpInodesUsed}`,
-    `tmpInodesFree=${g.tmpInodesFree}`,
-    `tmpSpacePct=${g.tmpSpaceUsedPct}`,
-    `tmpFreeMb=${g.tmpSpaceFreeMb}`,
-    `pwTmpDirs=${g.playwrightTmpDirs}`,
-  ].filter(Boolean);
-  return parts.join(" ");
-}

--- a/showcase/harness/src/probes/helpers/resource-snapshot-writer.test.ts
+++ b/showcase/harness/src/probes/helpers/resource-snapshot-writer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   createResourceSnapshotWriter,
   RESOURCE_SNAPSHOTS_COLLECTION,
@@ -379,6 +379,378 @@ describe("resource-snapshot-writer", () => {
     expect(row.threads).toBeNull();
     expect(row.fd_count).toBeNull();
     expect(row.procs).toBe(60);
+  });
+
+  it("IN-FLIGHT CAP: a write over the cap is DROPPED (emits dropped-over-inflight) and the in-flight counter does NOT leak", async () => {
+    // item #1 (drop seam): with maxInFlight=1 and a never-resolving create, a
+    // SECOND concurrent write must be dropped (warn), and once the hung write
+    // resolves/frees its slot a LATER write must be admitted — proving the
+    // in-flight counter didn't leak.
+    let releaseFirst: (() => void) | undefined;
+    const createCalls: string[] = [];
+    let resolveCount = 0;
+    const pb: SnapshotPbClient = {
+      async create(_collection, record) {
+        createCalls.push(String(record.event));
+        // First create hangs until released; subsequent creates resolve.
+        if (releaseFirst === undefined) {
+          await new Promise<void>((r) => {
+            releaseFirst = r;
+          });
+        }
+        resolveCount += 1;
+        return {} as never;
+      },
+      async list() {
+        return { totalItems: 0, items: [] };
+      },
+      async deleteByFilter() {
+        return 0;
+      },
+    };
+    const { logger, logs } = makeLogger();
+    const writer = createResourceSnapshotWriter({
+      pb,
+      logger,
+      maxInFlightWrites: 1,
+      // Disable the write timeout so the hang is what occupies the slot (not a
+      // timer firing); we free it manually.
+      writeTimeoutMs: 0,
+    });
+
+    // First write hangs (occupies the only in-flight slot).
+    const firstWrite = writer.write("hung", makeGauges(), STATS);
+    // Let the hung create register.
+    await Promise.resolve();
+    expect(createCalls).toEqual(["hung"]);
+
+    // Second concurrent write is DROPPED — the cap (1) is saturated.
+    await writer.write("dropped", makeGauges(), STATS);
+    const dropLog = logs.find(
+      (l) => l.event === "resource-snapshot.dropped-over-inflight",
+    );
+    expect(dropLog).toBeDefined();
+    expect(dropLog?.level).toBe("warn");
+    // The dropped write never reached create.
+    expect(createCalls).toEqual(["hung"]);
+
+    // Release the hung write — the slot frees.
+    releaseFirst?.();
+    await firstWrite;
+    expect(resolveCount).toBe(1);
+
+    // A LATER write is now ADMITTED (counter did not leak above the cap).
+    await writer.write("after", makeGauges(), STATS);
+    expect(createCalls).toEqual(["hung", "after"]);
+    expect(resolveCount).toBe(2);
+  });
+
+  it("DROP (healthy backpressure): a drop while a write SUCCEEDS does NOT escalate", async () => {
+    // item #2 (no false-positive): a single hung write that later succeeds is
+    // healthy backpressure, not a systematic outage. A concurrent drop while
+    // that write is in flight must NOT escalate once the write completes.
+    let release: (() => void) | undefined;
+    const pb: SnapshotPbClient = {
+      async create() {
+        if (release === undefined) {
+          await new Promise<void>((r) => {
+            release = r;
+          });
+        }
+        return {} as never;
+      },
+      async list() {
+        return { totalItems: 0, items: [] };
+      },
+      async deleteByFilter() {
+        return 0;
+      },
+    };
+    const { logger, logs } = makeLogger();
+    const writer = createResourceSnapshotWriter({
+      pb,
+      logger,
+      maxInFlightWrites: 1,
+      writeTimeoutMs: 0,
+      failureEscalationThreshold: 2,
+    });
+
+    const first = writer.write("slow", makeGauges(), STATS);
+    await Promise.resolve();
+    // A couple of drops occur while the first write is briefly in flight.
+    await writer.write("drop", makeGauges(), STATS);
+    await writer.write("drop", makeGauges(), STATS);
+    // The slow write SUCCEEDS — proving the cap wasn't hung.
+    release?.();
+    await first;
+
+    // No systematic-failure escalation (healthy backpressure, writes succeed).
+    expect(
+      logs.filter(
+        (l) => l.event === "resource-snapshot.write-failing-systematically",
+      ),
+    ).toHaveLength(0);
+  });
+
+  describe("with fake timers", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("WRITE-TIMEOUT → failure → escalation: a hung create times out, counts as a failure, and escalates after the threshold", async () => {
+      // item #1 (timeout seam) + #2: a hung pb.create must hit the write
+      // timeout, be counted as a FAILURE, and after the threshold escalate to
+      // the loud `write-failing-systematically` error.
+      vi.useFakeTimers();
+      const pb: SnapshotPbClient = {
+        async create() {
+          // Never resolves — only the write timeout frees the slot.
+          await new Promise<void>(() => {});
+          return {} as never;
+        },
+        async list() {
+          return { totalItems: 0, items: [] };
+        },
+        async deleteByFilter() {
+          return 0;
+        },
+      };
+      const { logger, logs } = makeLogger();
+      const writer = createResourceSnapshotWriter({
+        pb,
+        logger,
+        writeTimeoutMs: 1_000,
+        failureEscalationThreshold: 3,
+        maxInFlightWrites: 8,
+      });
+
+      // Fire 3 writes; each hangs, then its 1s timeout fires → 3 failures.
+      for (let i = 0; i < 3; i++) {
+        const p = writer.write("heartbeat", makeGauges(), STATS);
+        await vi.advanceTimersByTimeAsync(1_000);
+        await p;
+      }
+
+      // The timeout was counted as a write failure and escalated once.
+      const errs = logs.filter(
+        (l) =>
+          l.level === "error" &&
+          l.event === "resource-snapshot.write-failing-systematically",
+      );
+      expect(errs).toHaveLength(1);
+      // The failure record names the timeout (proves the timeout→failure seam).
+      const failLog = logs.find(
+        (l) => l.event === "resource-snapshot.write-failed",
+      );
+      expect(String(failLog?.meta?.error)).toContain("timed out");
+    });
+
+    it("DROP→ESCALATION: once writes are timing out, concurrent drops against the saturated cap CONTRIBUTE to the systematic-failure escalation", async () => {
+      // item #2: with PB hung the in-flight cap saturates with timing-out
+      // writes, so new snapshots increasingly hit the DROP path. A drop that
+      // co-occurs with writes already FAILING (the hung writes have begun
+      // timing out) must contribute to the failure signal so the loud
+      // `write-failing-systematically` error is not delayed/dodged by the DROP
+      // path. maxInFlightWrites:1 → after the first write hangs+times out
+      // (failure #1), each subsequent drop while the cap is held escalates the
+      // count, reaching the threshold via DROPS rather than only timeouts.
+      vi.useFakeTimers();
+      const pb: SnapshotPbClient = {
+        async create() {
+          await new Promise<void>(() => {}); // hung PB — only the timeout frees
+          return {} as never;
+        },
+        async list() {
+          return { totalItems: 0, items: [] };
+        },
+        async deleteByFilter() {
+          return 0;
+        },
+      };
+      const { logger, logs } = makeLogger();
+      const writer = createResourceSnapshotWriter({
+        pb,
+        logger,
+        maxInFlightWrites: 1,
+        writeTimeoutMs: 1_000,
+        failureEscalationThreshold: 4,
+      });
+
+      // Write A hangs and occupies the only slot; time it out → failure #1.
+      const a = writer.write("hung", makeGauges(), STATS);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await a;
+
+      // Write B now hangs and re-occupies the slot. With consecutiveFailures>0,
+      // concurrent DROPS contribute to escalation (not just future timeouts).
+      const b = writer.write("hung", makeGauges(), STATS);
+      await Promise.resolve();
+      // 3 drops while B holds the slot → failures 2,3,4 → escalation fires.
+      for (let i = 0; i < 3; i++) {
+        await writer.write("drop", makeGauges(), STATS);
+      }
+
+      const errs = logs.filter(
+        (l) =>
+          l.level === "error" &&
+          l.event === "resource-snapshot.write-failing-systematically",
+      );
+      expect(errs).toHaveLength(1);
+      // A drop carried the escalating failure (proves the drop→escalation seam).
+      const dropFail = logs.find(
+        (l) =>
+          l.event === "resource-snapshot.write-failed" &&
+          l.meta?.event === "drop",
+      );
+      expect(String(dropFail?.meta?.error)).toContain("cap saturated");
+
+      // Free B so no promise dangles past the test.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await b;
+    });
+  });
+
+  it("PRUNE no-progress backoff: a deleteByFilter that returns 0 while over cap does NOT sweep on every insert (gated by interval)", async () => {
+    // item #1b: when deletes structurally make no progress (PB delete-rule 403,
+    // filter 400, or 0 matched) while still over cap, the safety valve must NOT
+    // let knownOverCap re-arm a full list-probe + sweep on EVERY subsequent
+    // insert. The prune must back off to once-per-interval.
+    const created: Array<Record<string, unknown>> = [];
+    let seq = 0;
+    let listCalls = 0;
+    const pb: SnapshotPbClient = {
+      async create(_c, record) {
+        const row = { id: `row-${seq}`, __seq: seq, ...record };
+        seq += 1;
+        created.push(row);
+        return row as never;
+      },
+      async list(_c, opts) {
+        listCalls += 1;
+        const sorted = [...created];
+        const perPage = opts?.perPage ?? 30;
+        return {
+          totalItems: created.length,
+          items: sorted.slice(0, perPage) as never[],
+        };
+      },
+      // Delete ALWAYS fails to make progress (returns 0) — simulates a PB
+      // delete-rule 403 / filter that matches nothing while still over cap.
+      async deleteByFilter() {
+        return 0;
+      },
+    };
+    const { logger } = makeLogger();
+    let clock = 1_000_000;
+    const writer = createResourceSnapshotWriter({
+      pb,
+      logger,
+      maxRows: 3,
+      pruneIntervalMs: 60_000,
+      now: () => clock,
+    });
+
+    // Fill past the cap so prune engages and hits the no-progress backoff.
+    for (let i = 0; i < 6; i++) {
+      await writer.write("heartbeat", makeGauges({ ts: `t${i}` }), STATS);
+    }
+    const listsAfterFill = listCalls;
+
+    // Now insert MANY more within the SAME frozen instant (clock not advanced).
+    // If the backoff works, NONE of these re-probe (no list calls) — the prune
+    // is suppressed until the interval elapses, NOT re-armed per insert.
+    for (let i = 6; i < 30; i++) {
+      await writer.write("heartbeat", makeGauges({ ts: `t${i}` }), STATS);
+    }
+    expect(listCalls).toBe(listsAfterFill); // no per-insert re-probe
+
+    // After the interval elapses, the rate-limit gate opens and ONE retry sweep
+    // runs (head-probe + oldest-list), then backs off again. The point is the
+    // retry is gated to the interval — it did not fire on any of the 24
+    // intervening inserts.
+    clock += 60_001;
+    await writer.write("heartbeat", makeGauges({ ts: "t30" }), STATS);
+    const listsAfterRetry = listCalls;
+    expect(listsAfterRetry).toBeGreaterThan(listsAfterFill);
+
+    // And it backs off AGAIN: further same-instant inserts do not re-probe.
+    for (let i = 31; i < 40; i++) {
+      await writer.write("heartbeat", makeGauges({ ts: `t${i}` }), STATS);
+    }
+    expect(listCalls).toBe(listsAfterRetry);
+  });
+
+  it("PRUNE batch cap: a cold start far over cap deletes in BOUNDED batches (not a thousands-row list/filter)", async () => {
+    // item #1a: surplus can be thousands on a cold start over a large backlog;
+    // using it directly as perPage + a one-clause-per-row id filter builds a
+    // giant request URL that PB rejects (400/414). Each sweep must list/delete
+    // at most a bounded batch (200) and rely on knownOverCap to drain the rest.
+    const created: Array<Record<string, unknown>> = [];
+    let seq = 0;
+    const listPerPages: number[] = [];
+    const deleteClauseCounts: number[] = [];
+    // Seed 1500 rows directly (cold-start backlog) before the writer attaches.
+    for (let i = 0; i < 1500; i++) {
+      created.push({ id: `seed-${i}`, __seq: seq, observed_at: `s${i}` });
+      seq += 1;
+    }
+    const pb: SnapshotPbClient = {
+      async create(_c, record) {
+        const row = { id: `row-${seq}`, __seq: seq, ...record };
+        seq += 1;
+        created.push(row);
+        return row as never;
+      },
+      async list(_c, opts) {
+        if (opts?.perPage !== undefined && opts.sort === "observed_at") {
+          listPerPages.push(opts.perPage);
+        }
+        const perPage = opts?.perPage ?? 30;
+        const page = opts?.page ?? 1;
+        const start = (page - 1) * perPage;
+        return {
+          totalItems: created.length,
+          items: created.slice(start, start + perPage) as never[],
+        };
+      },
+      async deleteByFilter(_c, filter) {
+        const ids = new Set(
+          Array.from(filter.matchAll(/id = "([^"]+)"/g)).map((m) => m[1]),
+        );
+        deleteClauseCounts.push(ids.size);
+        const before = created.length;
+        for (let i = created.length - 1; i >= 0; i--) {
+          if (ids.has(String(created[i].id))) created.splice(i, 1);
+        }
+        return before - created.length;
+      },
+    };
+    const { logger } = makeLogger();
+    const writer = createResourceSnapshotWriter({
+      pb,
+      logger,
+      maxRows: 5,
+      pruneIntervalMs: 0,
+    });
+
+    // One insert triggers the first (bounded) sweep.
+    await writer.write("heartbeat", makeGauges({ ts: "x0" }), STATS);
+
+    // Every prune list used a BOUNDED perPage (<= 200), never the ~1495 surplus.
+    expect(listPerPages.length).toBeGreaterThan(0);
+    for (const pp of listPerPages) {
+      expect(pp).toBeLessThanOrEqual(200);
+    }
+    // Every delete filter had a BOUNDED clause count (<= 200).
+    for (const cc of deleteClauseCounts) {
+      expect(cc).toBeLessThanOrEqual(200);
+    }
+
+    // knownOverCap drains the rest across subsequent inserts; converges to cap.
+    for (let i = 1; i < 20; i++) {
+      await writer.write("heartbeat", makeGauges({ ts: `x${i}` }), STATS);
+    }
+    expect(created.length).toBeLessThanOrEqual(5);
   });
 
   it("uses the documented collection name", () => {

--- a/showcase/harness/src/probes/helpers/resource-snapshot-writer.test.ts
+++ b/showcase/harness/src/probes/helpers/resource-snapshot-writer.test.ts
@@ -62,36 +62,61 @@ function makeLogger(): {
 }
 
 /** In-memory PB fake recording creates + supporting list/deleteByFilter for the
- *  retention path. */
+ *  retention path. Each row gets a stable `id` (insertion order, with a stable
+ *  per-row sequence as a secondary sort key) so the writer's id-based,
+ *  tie-robust prune can address rows individually even when `observed_at`
+ *  collides at the same millisecond. */
 function makeFakePb(): {
   pb: SnapshotPbClient;
   created: Array<Record<string, unknown>>;
 } {
   const created: Array<Record<string, unknown>> = [];
+  let seq = 0;
+  // Sort newest-first by observed_at, tie-broken by insertion sequence DESC so
+  // ordering is stable across same-millisecond rows.
+  const newestFirst = (
+    a: Record<string, unknown>,
+    b: Record<string, unknown>,
+  ): number => {
+    const cmp = String(b.observed_at).localeCompare(String(a.observed_at));
+    if (cmp !== 0) return cmp;
+    return Number(b.__seq) - Number(a.__seq);
+  };
   const pb: SnapshotPbClient = {
     async create(_collection, record) {
-      created.push(record);
-      return record as never;
+      const row = { id: `row-${seq}`, __seq: seq, ...record };
+      seq += 1;
+      created.push(row);
+      return row as never;
     },
     async list(_collection, opts) {
-      // Sort newest-first by observed_at for the boundary lookup.
-      const sorted = [...created].sort((a, b) =>
-        String(b.observed_at).localeCompare(String(a.observed_at)),
-      );
+      const sort = opts?.sort ?? "-observed_at";
+      // "observed_at" => oldest first; "-observed_at" (or default) => newest.
+      const sorted = [...created].sort(newestFirst);
+      const ordered = sort.startsWith("-") ? sorted : sorted.reverse();
       const perPage = opts?.perPage ?? 30;
       const page = opts?.page ?? 1;
       const start = (page - 1) * perPage;
-      const items = sorted.slice(start, start + perPage);
+      const items = ordered.slice(start, start + perPage);
       return { totalItems: created.length, items: items as never[] };
     },
     async deleteByFilter(_collection, filter) {
-      // filter is `observed_at < "<cutoff>"`.
-      const m = filter.match(/observed_at < "(.+)"/);
-      if (!m) return 0;
-      const cutoff = m[1];
+      // The writer's tie-robust prune deletes by id: `id = "x" || id = "y"`.
+      const ids = new Set(
+        Array.from(filter.matchAll(/id = "([^"]+)"/g)).map((m) => m[1]),
+      );
+      // Back-compat: still honor a legacy `observed_at < "<cutoff>"` filter so a
+      // strict-cutoff prune can be exercised directly if needed.
+      const cutoffMatch = filter.match(/observed_at < "(.+)"/);
+      const cutoff = cutoffMatch?.[1];
       const before = created.length;
       for (let i = created.length - 1; i >= 0; i--) {
-        if (String(created[i].observed_at) < cutoff) created.splice(i, 1);
+        const row = created[i];
+        if (ids.has(String(row.id))) {
+          created.splice(i, 1);
+        } else if (cutoff !== undefined && String(row.observed_at) < cutoff) {
+          created.splice(i, 1);
+        }
       }
       return before - created.length;
     },
@@ -191,6 +216,169 @@ describe("resource-snapshot-writer", () => {
       await writer.write("heartbeat", makeGauges({ ts: `t${i}` }), STATS);
     }
     expect(created).toHaveLength(5);
+  });
+
+  it("RETENTION: converges to <= maxRows even when boundary timestamps are IDENTICAL (tie-robust)", async () => {
+    // fix #2: observed_at is ms-resolution and snapshots can fire in the SAME
+    // millisecond (degraded+heartbeat+crash). A bare `observed_at < cutoff`
+    // strict compare would strand the surplus rows that tie the boundary
+    // timestamp and spin forever (knownOverCap stays true, every insert re-runs
+    // a full no-op sweep → unbounded growth). The id-based prune converges.
+    const { pb, created } = makeFakePb();
+    const { logger } = makeLogger();
+    const writer = createResourceSnapshotWriter({
+      pb,
+      logger,
+      maxRows: 3,
+      pruneIntervalMs: 0,
+    });
+
+    // Write 6 snapshots that ALL share the exact same observed_at timestamp.
+    const tied = "2026-06-04T00:00:00.000Z";
+    for (let i = 0; i < 6; i++) {
+      await writer.write("heartbeat", makeGauges({ ts: tied }), STATS);
+    }
+
+    // Ring cap is 3 — despite every row tying the boundary timestamp, retention
+    // still converges to exactly maxRows.
+    expect(created).toHaveLength(3);
+  });
+
+  it("RETENTION: rate-limit keeps prune off the steady-state insert path, but knownOverCap catches up over cap", async () => {
+    // slot-6 F2: with pruneIntervalMs > 0 the rate-limit must keep the prune off
+    // the hot insert path once it has run for the interval (steady state, under
+    // cap), yet once over cap the knownOverCap flag must force a catch-up prune
+    // on the NEXT insert rather than waiting a full interval.
+    const { pb, created } = makeFakePb();
+    const { logger, logs } = makeLogger();
+    // Frozen clock: after the first insert's prove-probe, no further inserts in
+    // this test advance past the interval, so a prune can ONLY recur via the
+    // knownOverCap catch-up path (never via the rate-limit timer).
+    const nowMs = 10 * 60_000; // > pruneIntervalMs so the first insert probes.
+    const writer = createResourceSnapshotWriter({
+      pb,
+      logger,
+      maxRows: 3,
+      pruneIntervalMs: 60_000, // 1 min between rate-limited sweeps
+      now: () => nowMs,
+    });
+
+    // Probe a list-call counter so we can prove inserts past the first do NOT
+    // issue a list (the prune's first action) in steady state.
+    let listCalls = 0;
+    const origList = pb.list.bind(pb);
+    pb.list = ((collection, opts) => {
+      listCalls += 1;
+      return origList(collection, opts);
+    }) as typeof pb.list;
+
+    // STEADY STATE (under cap): first insert probes once (lastPruneAt=0 → over
+    // interval); subsequent inserts in the SAME frozen instant must NOT re-probe
+    // because the rate-limit window has not elapsed and we are under cap.
+    for (let i = 0; i < 3; i++) {
+      await writer.write("heartbeat", makeGauges({ ts: `t${i}` }), STATS);
+    }
+    expect(created).toHaveLength(3);
+    expect(listCalls).toBe(1); // only the first insert probed.
+
+    // Go OVER cap, all within the SAME frozen instant. The insert that crosses
+    // the cap trips knownOverCap; subsequent inserts must catch up and prune
+    // even though the rate-limit interval has not elapsed (clock frozen).
+    for (let i = 3; i < 7; i++) {
+      await writer.write("heartbeat", makeGauges({ ts: `t${i}` }), STATS);
+    }
+    // Converged back to cap via the knownOverCap catch-up (NOT a timer wait).
+    expect(created).toHaveLength(3);
+    const prunedLogs = logs.filter(
+      (l) => l.event === "resource-snapshot.pruned",
+    );
+    expect(prunedLogs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("ESCALATION: after N consecutive failures escalates to logger.error ONCE, resets on success", async () => {
+    // fix #3: systematic write failures (unrun migration / outage / schema
+    // drift) must not silently no-op forever. After the threshold the writer
+    // escalates ONCE to error (latched), the per-failure warn is throttled, and
+    // a subsequent success resets the latch.
+    let fail = true;
+    const flakyPb: SnapshotPbClient = {
+      async create() {
+        if (fail) throw new Error("pb create failed: 400 missing collection");
+        return {} as never;
+      },
+      async list() {
+        return { totalItems: 0, items: [] };
+      },
+      async deleteByFilter() {
+        return 0;
+      },
+    };
+    const { logger, logs } = makeLogger();
+    const writer = createResourceSnapshotWriter({
+      pb: flakyPb,
+      logger,
+      failureEscalationThreshold: 5,
+    });
+
+    // 5 consecutive failures → exactly ONE error escalation.
+    for (let i = 0; i < 5; i++) {
+      await writer.write("heartbeat", makeGauges(), STATS);
+    }
+    const errs = logs.filter(
+      (l) =>
+        l.level === "error" &&
+        l.event === "resource-snapshot.write-failing-systematically",
+    );
+    expect(errs).toHaveLength(1);
+
+    // More failures must NOT re-fire the latched error.
+    await writer.write("heartbeat", makeGauges(), STATS);
+    expect(
+      logs.filter(
+        (l) => l.event === "resource-snapshot.write-failing-systematically",
+      ),
+    ).toHaveLength(1);
+
+    // A success resets the latch; a subsequent failure burst can escalate again.
+    fail = false;
+    await writer.write("heartbeat", makeGauges(), STATS);
+    fail = true;
+    for (let i = 0; i < 5; i++) {
+      await writer.write("heartbeat", makeGauges(), STATS);
+    }
+    expect(
+      logs.filter(
+        (l) => l.event === "resource-snapshot.write-failing-systematically",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("NULL SENTINEL: a -1 gauge is written to PB as null, not -1", async () => {
+    // fix #4: the -1 "unavailable" sentinel (off-Linux / unreadable cgroup) must
+    // be stored as null so post-wedge queries separate measured-vs-unavailable.
+    const { pb, created } = makeFakePb();
+    const { logger } = makeLogger();
+    const writer = createResourceSnapshotWriter({ pb, logger });
+
+    await writer.write(
+      "heartbeat",
+      makeGauges({
+        cgroupPidsCurrent: -1,
+        cgroupPidsMax: -1,
+        treeThreadCount: -1,
+        selfFdCount: -1,
+        // A real (non-negative) reading must pass through unchanged.
+        treeProcCount: 60,
+      }),
+      STATS,
+    );
+
+    const row = created[0];
+    expect(row.pids_current).toBeNull();
+    expect(row.pids_max).toBeNull();
+    expect(row.threads).toBeNull();
+    expect(row.fd_count).toBeNull();
+    expect(row.procs).toBe(60);
   });
 
   it("uses the documented collection name", () => {

--- a/showcase/harness/src/probes/helpers/resource-snapshot-writer.test.ts
+++ b/showcase/harness/src/probes/helpers/resource-snapshot-writer.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  createResourceSnapshotWriter,
+  RESOURCE_SNAPSHOTS_COLLECTION,
+} from "./resource-snapshot-writer.js";
+import type { SnapshotPbClient } from "./resource-snapshot-writer.js";
+import type { ResourceGauges } from "./resource-gauges.js";
+import type { BrowserPoolStats } from "./browser-pool.js";
+
+function makeGauges(overrides?: Partial<ResourceGauges>): ResourceGauges {
+  return {
+    ts: "2026-06-04T00:00:00.000Z",
+    selfFdCount: 42,
+    treeThreadCount: 850,
+    treeProcCount: 60,
+    zombieCount: 0,
+    selfRssMb: 120,
+    treeRssMb: 900,
+    cgroupPidsCurrent: 850,
+    cgroupPidsMax: 1000,
+    devShmUsedPct: 12,
+    tmpInodeUsedPct: 3,
+    tmpInodesUsed: 100,
+    tmpInodesFree: 9000,
+    tmpSpaceUsedPct: 20,
+    tmpSpaceFreeMb: 5000,
+    playwrightTmpDirs: 2,
+    ...overrides,
+  };
+}
+
+const STATS: BrowserPoolStats = {
+  size: 24,
+  available: 20,
+  inUse: 4,
+  totalRecycles: 1,
+};
+
+interface LogEntry {
+  level: "info" | "warn" | "error";
+  event: string;
+  meta?: Record<string, unknown>;
+}
+
+function makeLogger(): {
+  logger: {
+    info: (e: string, m?: Record<string, unknown>) => void;
+    warn: (e: string, m?: Record<string, unknown>) => void;
+    error: (e: string, m?: Record<string, unknown>) => void;
+  };
+  logs: LogEntry[];
+} {
+  const logs: LogEntry[] = [];
+  return {
+    logger: {
+      info: (event, meta) => logs.push({ level: "info", event, meta }),
+      warn: (event, meta) => logs.push({ level: "warn", event, meta }),
+      error: (event, meta) => logs.push({ level: "error", event, meta }),
+    },
+    logs,
+  };
+}
+
+/** In-memory PB fake recording creates + supporting list/deleteByFilter for the
+ *  retention path. */
+function makeFakePb(): {
+  pb: SnapshotPbClient;
+  created: Array<Record<string, unknown>>;
+} {
+  const created: Array<Record<string, unknown>> = [];
+  const pb: SnapshotPbClient = {
+    async create(_collection, record) {
+      created.push(record);
+      return record as never;
+    },
+    async list(_collection, opts) {
+      // Sort newest-first by observed_at for the boundary lookup.
+      const sorted = [...created].sort((a, b) =>
+        String(b.observed_at).localeCompare(String(a.observed_at)),
+      );
+      const perPage = opts?.perPage ?? 30;
+      const page = opts?.page ?? 1;
+      const start = (page - 1) * perPage;
+      const items = sorted.slice(start, start + perPage);
+      return { totalItems: created.length, items: items as never[] };
+    },
+    async deleteByFilter(_collection, filter) {
+      // filter is `observed_at < "<cutoff>"`.
+      const m = filter.match(/observed_at < "(.+)"/);
+      if (!m) return 0;
+      const cutoff = m[1];
+      const before = created.length;
+      for (let i = created.length - 1; i >= 0; i--) {
+        if (String(created[i].observed_at) < cutoff) created.splice(i, 1);
+      }
+      return before - created.length;
+    },
+  };
+  return { pb, created };
+}
+
+describe("resource-snapshot-writer", () => {
+  it("persists a snapshot row with the gauge + stats fields", async () => {
+    const { pb, created } = makeFakePb();
+    const { logger } = makeLogger();
+    const writer = createResourceSnapshotWriter({ pb, logger });
+
+    await writer.write("degraded", makeGauges(), STATS, [
+      { index: 0, liveContexts: 2, servedContexts: 10, recycling: false },
+    ]);
+
+    expect(created).toHaveLength(1);
+    const row = created[0];
+    expect(row.event).toBe("degraded");
+    expect(row.observed_at).toBe("2026-06-04T00:00:00.000Z");
+    expect(row.pids_current).toBe(850);
+    expect(row.pids_max).toBe(1000);
+    expect(row.threads).toBe(850);
+    expect(row.contexts_in_use).toBe(4);
+    expect(row.contexts_available).toBe(20);
+    expect(row.browsers).toBe(1);
+    expect(Array.isArray(row.per_browser)).toBe(true);
+  });
+
+  it("BEST-EFFORT: a throwing PB create is swallowed (write resolves, does not reject) and logged", async () => {
+    const throwingPb: SnapshotPbClient = {
+      async create() {
+        throw new Error("pb create failed: 400 missing collection");
+      },
+      async list() {
+        return { totalItems: 0, items: [] };
+      },
+      async deleteByFilter() {
+        return 0;
+      },
+    };
+    const { logger, logs } = makeLogger();
+    const writer = createResourceSnapshotWriter({ pb: throwingPb, logger });
+
+    // MUST NOT reject — the pool's lifecycle paths call this and a throw would
+    // break the pool (the prior incident: an unrun-migration 400 broke the
+    // caller).
+    await expect(
+      writer.write("unrecoverable", makeGauges(), STATS),
+    ).resolves.toBeUndefined();
+
+    const failLog = logs.find(
+      (l) => l.event === "resource-snapshot.write-failed",
+    );
+    expect(failLog).toBeDefined();
+    expect(failLog?.level).toBe("warn");
+  });
+
+  it("RETENTION: prunes oldest rows beyond maxRows (ring-style)", async () => {
+    const { pb, created } = makeFakePb();
+    const { logger } = makeLogger();
+    // Tiny cap + pruneIntervalMs:0 so every write prunes deterministically.
+    const writer = createResourceSnapshotWriter({
+      pb,
+      logger,
+      maxRows: 3,
+      pruneIntervalMs: 0,
+    });
+
+    // Write 6 snapshots with strictly-increasing timestamps.
+    for (let i = 0; i < 6; i++) {
+      const ts = `2026-06-04T00:00:0${i}.000Z`;
+      await writer.write("heartbeat", makeGauges({ ts }), STATS);
+    }
+
+    // Ring cap is 3 — only the 3 newest survive.
+    expect(created).toHaveLength(3);
+    const tss = created.map((r) => r.observed_at).sort();
+    expect(tss).toEqual([
+      "2026-06-04T00:00:03.000Z",
+      "2026-06-04T00:00:04.000Z",
+      "2026-06-04T00:00:05.000Z",
+    ]);
+  });
+
+  it("RETENTION: does not prune when under cap", async () => {
+    const { pb, created } = makeFakePb();
+    const { logger } = makeLogger();
+    const writer = createResourceSnapshotWriter({
+      pb,
+      logger,
+      maxRows: 100,
+      pruneIntervalMs: 0,
+    });
+    for (let i = 0; i < 5; i++) {
+      await writer.write("heartbeat", makeGauges({ ts: `t${i}` }), STATS);
+    }
+    expect(created).toHaveLength(5);
+  });
+
+  it("uses the documented collection name", () => {
+    expect(RESOURCE_SNAPSHOTS_COLLECTION).toBe("resource_snapshots");
+  });
+});

--- a/showcase/harness/src/probes/helpers/resource-snapshot-writer.ts
+++ b/showcase/harness/src/probes/helpers/resource-snapshot-writer.ts
@@ -1,0 +1,222 @@
+/**
+ * resource-snapshot-writer.ts — DURABLE persistence of the BrowserPool's OS
+ * resource gauges to PocketBase, so the forensic history survives the
+ * container RESTART that ends every browser-pool wedge.
+ *
+ * WHY (the critical insight): the wedge (#5185/#5221/#5225) ends in a restart
+ * that clears anything in-memory, and Railway's stdout log window is capped and
+ * rolls off — a prior investigation lost the trail exactly that way. stdout /
+ * in-memory gauges alone are NOT retrievable post-wedge. Writing each
+ * meaningful gauge sample as a row in the `resource_snapshots` PB collection
+ * (see pb_migrations/1779989300_create_resource_snapshots.js) makes the
+ * PID/thread-ceiling exhaustion reconstructable AFTER the fact.
+ *
+ * BEST-EFFORT GUARANTEE: every write is wrapped so a missing migration, a PB
+ * hiccup, a 400 from an unrun migration, or any network error is SWALLOWED and
+ * logged — it can NEVER throw into the pool's lifecycle paths. This is a hard
+ * requirement learned from a prior incident where a state write that needed an
+ * unrun migration 400'd and broke the caller. The snapshot writer is pure
+ * instrumentation: it must degrade silently, never break the thing it observes.
+ *
+ * RETENTION: append-only under a ~30-60s heartbeat would grow unbounded
+ * (≈1k-2k rows/day). After each successful insert the writer prunes the oldest
+ * rows beyond `maxRows` (ring-style delete-oldest) keyed on the
+ * `observed_at DESC` index. Simpler than a TTL cron and bounds the volume
+ * deterministically. The prune is itself best-effort and rate-limited so a
+ * heartbeat burst doesn't issue a delete sweep on every single insert.
+ */
+
+import type { ResourceGauges } from "./resource-gauges.js";
+import type { BrowserPoolStats } from "./browser-pool.js";
+
+/** Collection name — mirrors the PB migration. */
+export const RESOURCE_SNAPSHOTS_COLLECTION = "resource_snapshots";
+
+/**
+ * Default ring cap on retained snapshot rows. ~5000 rows at a 30-60s heartbeat
+ * is ~1.5-3 days of baseline trend plus every transition in between — enough to
+ * look back across a wedge episode without growing unbounded. Env-overridable
+ * via RESOURCE_SNAPSHOT_MAX_ROWS.
+ */
+export const DEFAULT_RESOURCE_SNAPSHOT_MAX_ROWS = 5000;
+
+/**
+ * How often (at most) the ring prune actually runs. Pruning on EVERY insert
+ * would issue a list+delete sweep per heartbeat; instead we only prune once per
+ * this interval (and always once we're meaningfully over cap). Keeps the prune
+ * cost off the hot insert path.
+ */
+const DEFAULT_PRUNE_INTERVAL_MS = 5 * 60_000;
+
+/** Minimal PB surface the snapshot writer needs — a structural subset of the
+ *  harness `PbClient` so the real client satisfies it and tests can pass a
+ *  tiny fake. */
+export interface SnapshotPbClient {
+  create<T>(collection: string, record: Record<string, unknown>): Promise<T>;
+  list<T>(
+    collection: string,
+    opts?: {
+      filter?: string;
+      sort?: string;
+      page?: number;
+      perPage?: number;
+      skipTotal?: boolean;
+    },
+  ): Promise<{ totalItems: number; items: T[] }>;
+  deleteByFilter(collection: string, filter: string): Promise<number>;
+}
+
+/** Logger surface — matches the pool's optional-method idiom. */
+export interface SnapshotLogger {
+  info(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+  error?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/** Optional per-browser breakdown row (kept small + secret-free). */
+export interface PerBrowserSnapshot {
+  index: number;
+  liveContexts: number;
+  servedContexts: number;
+  recycling: boolean;
+}
+
+export interface ResourceSnapshotWriter {
+  /**
+   * Persist one snapshot row, best-effort. Resolves whether the write
+   * succeeded or was swallowed; NEVER rejects. The `event` names the pool
+   * condition (`heartbeat`, `degraded`, `unrecoverable`, `launch-fail`,
+   * `crash`, ...).
+   */
+  write(
+    event: string,
+    gauges: ResourceGauges,
+    stats: BrowserPoolStats,
+    perBrowser?: PerBrowserSnapshot[],
+  ): Promise<void>;
+}
+
+export interface ResourceSnapshotWriterOptions {
+  pb: SnapshotPbClient;
+  logger: SnapshotLogger;
+  /** Ring cap; defaults to env RESOURCE_SNAPSHOT_MAX_ROWS or 5000. */
+  maxRows?: number;
+  /** Minimum ms between prune sweeps. Defaults to 5min. Tests pass 0 to force
+   *  a prune on every write. */
+  pruneIntervalMs?: number;
+  /** Injectable clock for tests. */
+  now?: () => number;
+}
+
+function resolveMaxRows(explicit: number | undefined): number {
+  if (explicit !== undefined && Number.isFinite(explicit) && explicit > 0) {
+    return Math.floor(explicit);
+  }
+  const envRaw = process.env.RESOURCE_SNAPSHOT_MAX_ROWS;
+  const envParsed = envRaw ? parseInt(envRaw, 10) : NaN;
+  if (Number.isFinite(envParsed) && envParsed > 0) return envParsed;
+  return DEFAULT_RESOURCE_SNAPSHOT_MAX_ROWS;
+}
+
+/**
+ * Build the best-effort durable snapshot writer. The returned `write` swallows
+ * every error so it is safe to call from the pool's lifecycle paths.
+ */
+export function createResourceSnapshotWriter(
+  options: ResourceSnapshotWriterOptions,
+): ResourceSnapshotWriter {
+  const { pb, logger } = options;
+  const maxRows = resolveMaxRows(options.maxRows);
+  const pruneIntervalMs = options.pruneIntervalMs ?? DEFAULT_PRUNE_INTERVAL_MS;
+  const now = options.now ?? Date.now;
+  let lastPruneAt = 0;
+  // Once we've confirmed we're over cap, keep pruning every write until back
+  // under — otherwise a single rate-limited prune that can't clear the whole
+  // backlog in one sweep would leave us over cap until the next interval.
+  let knownOverCap = false;
+
+  async function prune(): Promise<void> {
+    try {
+      // Cheapest possible "are we over cap?" probe: ask PB for the total.
+      const head = await pb.list(RESOURCE_SNAPSHOTS_COLLECTION, {
+        perPage: 1,
+        skipTotal: false,
+      });
+      const total = head.totalItems;
+      if (total <= maxRows) {
+        knownOverCap = false;
+        return;
+      }
+      knownOverCap = true;
+      // Find the observed_at cutoff: the (maxRows)-th newest row's timestamp.
+      // Everything strictly older than that is surplus. Page directly to the
+      // boundary row rather than listing every surplus row client-side.
+      const boundary = await pb.list<{ observed_at: string }>(
+        RESOURCE_SNAPSHOTS_COLLECTION,
+        {
+          sort: "-observed_at",
+          page: maxRows,
+          perPage: 1,
+          skipTotal: true,
+        },
+      );
+      const cutoff = boundary.items[0]?.observed_at;
+      if (!cutoff) return;
+      const deleted = await pb.deleteByFilter(
+        RESOURCE_SNAPSHOTS_COLLECTION,
+        `observed_at < ${JSON.stringify(cutoff)}`,
+      );
+      if (deleted > 0) {
+        logger.info("resource-snapshot.pruned", { deleted, kept: maxRows });
+      }
+      knownOverCap = false;
+    } catch (err) {
+      // Prune is best-effort: a failed sweep just means we retry next time.
+      logger.warn?.("resource-snapshot.prune-failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return {
+    async write(event, gauges, stats, perBrowser): Promise<void> {
+      try {
+        await pb.create(RESOURCE_SNAPSHOTS_COLLECTION, {
+          observed_at: gauges.ts,
+          event,
+          pids_current: gauges.cgroupPidsCurrent,
+          pids_max: gauges.cgroupPidsMax,
+          threads: gauges.treeThreadCount,
+          procs: gauges.treeProcCount,
+          zombies: gauges.zombieCount,
+          fd_count: gauges.selfFdCount,
+          rss_mb: gauges.treeRssMb,
+          shm_pct: gauges.devShmUsedPct,
+          tmp_inode_pct: gauges.tmpInodeUsedPct,
+          browsers: perBrowser?.length ?? null,
+          contexts_in_use: stats.inUse,
+          contexts_available: stats.available,
+          per_browser: perBrowser ?? null,
+        });
+      } catch (err) {
+        // BEST-EFFORT: a missing migration (400), PB outage, or network error
+        // must NEVER break the pool. Swallow + log at warn so the gap is
+        // visible without crashing the caller. Learned from a prior incident
+        // where a state write that needed an unrun migration 400'd and broke
+        // the writer's caller.
+        logger.warn?.("resource-snapshot.write-failed", {
+          event,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+      // Ring retention: only sweep once per interval (or while known over cap)
+      // so a heartbeat burst doesn't issue a delete sweep on every insert.
+      const t = now();
+      if (knownOverCap || t - lastPruneAt >= pruneIntervalMs) {
+        lastPruneAt = t;
+        await prune();
+      }
+    },
+  };
+}

--- a/showcase/harness/src/probes/helpers/resource-snapshot-writer.ts
+++ b/showcase/harness/src/probes/helpers/resource-snapshot-writer.ts
@@ -18,12 +18,31 @@
  * unrun migration 400'd and broke the caller. The snapshot writer is pure
  * instrumentation: it must degrade silently, never break the thing it observes.
  *
- * RETENTION: append-only under a ~30-60s heartbeat would grow unbounded
- * (≈1k-2k rows/day). After each successful insert the writer prunes the oldest
- * rows beyond `maxRows` (ring-style delete-oldest) keyed on the
- * `observed_at DESC` index. Simpler than a TTL cron and bounds the volume
- * deterministically. The prune is itself best-effort and rate-limited so a
- * heartbeat burst doesn't issue a delete sweep on every single insert.
+ * FAILURE ESCALATION: "swallow + warn" alone is a trap — if PB SYSTEMATICALLY
+ * rejects writes (unrun migration, outage, schema drift) the durable log
+ * silently no-ops forever, defeating the whole point. So consecutive failures
+ * are counted: the per-failure warn is throttled (first few, then quiet), and
+ * after a threshold the writer escalates ONCE to a latched `logger.error` (reset
+ * on the first success) so a systematic outage is loud rather than invisible.
+ *
+ * RETENTION: append-only under the ~45s heartbeat (DEFAULT_HEARTBEAT_MS, plus a
+ * row per transition) would grow unbounded (≈2k rows/day at 45s). After each
+ * successful insert the writer prunes the oldest rows beyond `maxRows`
+ * (ring-style delete-oldest). The prune is robust to TIMESTAMP TIES: snapshots
+ * can fire in the same millisecond (degraded+heartbeat+crash all at once), and
+ * `observed_at` is ms-resolution, so a bare `observed_at < cutoff` strict
+ * compare could strand surplus rows that share the boundary timestamp and spin.
+ * Instead the prune deletes the oldest `surplus` rows by stable row IDENTITY
+ * (id), which converges regardless of ties. The prune is itself best-effort and
+ * rate-limited so a heartbeat burst doesn't issue a delete sweep on every
+ * single insert.
+ *
+ * SINGLE-WRITER ASSUMPTION: the rate-limit clock (`lastPruneAt`) and the
+ * `knownOverCap` ring state are PER-PROCESS in-memory. They are correct for the
+ * current single-writer harness. A future FLEET of writers against the SAME
+ * collection would each prune independently (extra delete sweeps, no shared
+ * rate-limit) — the planned multi-writer case needs an ELECTED pruner (or a
+ * server-side TTL) rather than inheriting this per-process state silently.
  */
 
 import type { ResourceGauges } from "./resource-gauges.js";
@@ -33,8 +52,8 @@ import type { BrowserPoolStats } from "./browser-pool.js";
 export const RESOURCE_SNAPSHOTS_COLLECTION = "resource_snapshots";
 
 /**
- * Default ring cap on retained snapshot rows. ~5000 rows at a 30-60s heartbeat
- * is ~1.5-3 days of baseline trend plus every transition in between — enough to
+ * Default ring cap on retained snapshot rows. ~5000 rows at the 45s heartbeat
+ * is ~2.5 days of baseline trend plus every transition in between — enough to
  * look back across a wedge episode without growing unbounded. Env-overridable
  * via RESOURCE_SNAPSHOT_MAX_ROWS.
  */
@@ -48,11 +67,43 @@ export const DEFAULT_RESOURCE_SNAPSHOT_MAX_ROWS = 5000;
  */
 const DEFAULT_PRUNE_INTERVAL_MS = 5 * 60_000;
 
+/**
+ * Consecutive snapshot-write failures before the writer escalates ONCE to
+ * `logger.error`. Below this, failures warn (throttled). The escalation is
+ * latched and resets on the first success.
+ */
+const DEFAULT_FAILURE_ESCALATION_THRESHOLD = 5;
+
+/**
+ * How many consecutive failures get a per-failure warn before the warn goes
+ * quiet (every Nth thereafter), so a sustained PB outage doesn't flood stdout.
+ */
+const FAILURE_WARN_THROTTLE_EVERY = 50;
+
+/**
+ * Cap on concurrent in-flight `pb.create` writes. During a launch-crash-loop
+ * burst the pool can fire many snapshots back-to-back; without a cap the
+ * unawaited (fire-and-forget) creates could pile up against a slow/hung PB.
+ * Beyond this we DROP the snapshot (best-effort instrumentation, not a queue).
+ */
+const DEFAULT_MAX_IN_FLIGHT_WRITES = 8;
+
+/**
+ * Abort a single `pb.create` after this long so a hung PB write can't sit in
+ * the in-flight set forever (and starve the cap). Best-effort: an aborted write
+ * is counted as a failure and swallowed.
+ */
+const DEFAULT_WRITE_TIMEOUT_MS = 10_000;
+
 /** Minimal PB surface the snapshot writer needs — a structural subset of the
  *  harness `PbClient` so the real client satisfies it and tests can pass a
  *  tiny fake. */
 export interface SnapshotPbClient {
-  create<T>(collection: string, record: Record<string, unknown>): Promise<T>;
+  create<T>(
+    collection: string,
+    record: Record<string, unknown>,
+    opts?: { signal?: AbortSignal },
+  ): Promise<T>;
   list<T>(
     collection: string,
     opts?: {
@@ -104,6 +155,12 @@ export interface ResourceSnapshotWriterOptions {
   /** Minimum ms between prune sweeps. Defaults to 5min. Tests pass 0 to force
    *  a prune on every write. */
   pruneIntervalMs?: number;
+  /** Consecutive failures before escalating once to error. Defaults to 5. */
+  failureEscalationThreshold?: number;
+  /** Max concurrent in-flight writes before dropping. Defaults to 8. */
+  maxInFlightWrites?: number;
+  /** Per-write abort timeout (ms). Defaults to 10s. 0 disables the timeout. */
+  writeTimeoutMs?: number;
   /** Injectable clock for tests. */
   now?: () => number;
 }
@@ -119,6 +176,18 @@ function resolveMaxRows(explicit: number | undefined): number {
 }
 
 /**
+ * Map a gauge value to the PB field value: the `-1` "unavailable" sentinel
+ * (off-Linux / unreadable cgroup / fd / df) becomes `null` so post-wedge
+ * queries cleanly separate a MEASURED reading from an UNAVAILABLE one — a real
+ * `-1` would be indistinguishable from a genuine count. The migration's number
+ * fields are nullable for exactly this. A real reading is never negative, so
+ * the only legitimate negative is the sentinel.
+ */
+function gaugeOrNull(value: number): number | null {
+  return value < 0 ? null : value;
+}
+
+/**
  * Build the best-effort durable snapshot writer. The returned `write` swallows
  * every error so it is safe to call from the pool's lifecycle paths.
  */
@@ -128,12 +197,100 @@ export function createResourceSnapshotWriter(
   const { pb, logger } = options;
   const maxRows = resolveMaxRows(options.maxRows);
   const pruneIntervalMs = options.pruneIntervalMs ?? DEFAULT_PRUNE_INTERVAL_MS;
+  const escalationThreshold =
+    options.failureEscalationThreshold ?? DEFAULT_FAILURE_ESCALATION_THRESHOLD;
+  const maxInFlight = options.maxInFlightWrites ?? DEFAULT_MAX_IN_FLIGHT_WRITES;
+  const writeTimeoutMs = options.writeTimeoutMs ?? DEFAULT_WRITE_TIMEOUT_MS;
   const now = options.now ?? Date.now;
   let lastPruneAt = 0;
   // Once we've confirmed we're over cap, keep pruning every write until back
   // under — otherwise a single rate-limited prune that can't clear the whole
   // backlog in one sweep would leave us over cap until the next interval.
   let knownOverCap = false;
+  // Local row-count estimate so the rate-limit can't STRAND us over cap until
+  // the next interval. Each successful insert bumps it; every prune resets it to
+  // the actual total. When the estimate crosses `maxRows` the next insert forces
+  // a catch-up prune immediately (knownOverCap) instead of waiting a full
+  // interval — the rate-limit only suppresses sweeps while we're UNDER cap.
+  // Starts at maxRows: until the first prune-probe establishes the real total we
+  // assume we MIGHT already be at the boundary, so a fresh process attaching to
+  // a full collection still prunes promptly.
+  let estimatedTotal = maxRows;
+  // Consecutive write failures (reset on any success). Drives the throttled
+  // warn + the latched error escalation.
+  let consecutiveFailures = 0;
+  // Latched once we've escalated to error, so a systematic outage screams ONCE
+  // rather than per-write. Reset on the first success.
+  let escalated = false;
+  // Best-effort in-flight cap so a fire-and-forget burst can't pile unawaited
+  // creates against a slow PB.
+  let inFlight = 0;
+
+  /**
+   * Run `pb.create` with a best-effort timeout so a hung write can't occupy an
+   * in-flight slot forever. Rejects on timeout (or any PB error); the caller
+   * swallows + counts it. Uses `Promise.race` rather than relying on the create
+   * honoring an AbortSignal — the real harness `PbClient.create` does NOT take a
+   * signal, so the race is what actually frees the in-flight slot on a hang. We
+   * still pass the signal best-effort for any client that DOES honor it.
+   */
+  async function createWithTimeout(
+    record: Record<string, unknown>,
+  ): Promise<void> {
+    if (writeTimeoutMs <= 0) {
+      await pb.create(RESOURCE_SNAPSHOTS_COLLECTION, record);
+      return;
+    }
+    const ac = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        ac.abort();
+        reject(new Error(`pb create timed out after ${writeTimeoutMs}ms`));
+      }, writeTimeoutMs);
+    });
+    try {
+      await Promise.race([
+        pb.create(RESOURCE_SNAPSHOTS_COLLECTION, record, { signal: ac.signal }),
+        timeout,
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  function onWriteSuccess(): void {
+    consecutiveFailures = 0;
+    escalated = false;
+  }
+
+  function onWriteFailure(event: string, err: unknown): void {
+    consecutiveFailures += 1;
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    // Latched error escalation: once we cross the threshold, scream ONCE so a
+    // systematic PB rejection (unrun migration, outage, schema drift) is loud.
+    if (consecutiveFailures >= escalationThreshold && !escalated) {
+      escalated = true;
+      logger.error?.("resource-snapshot.write-failing-systematically", {
+        consecutiveFailures,
+        threshold: escalationThreshold,
+        error: errorMsg,
+      });
+      return;
+    }
+    // Throttled per-failure warn: chatty for the first burst, then periodic so a
+    // sustained outage doesn't flood stdout.
+    if (
+      consecutiveFailures <= escalationThreshold ||
+      consecutiveFailures % FAILURE_WARN_THROTTLE_EVERY === 0
+    ) {
+      logger.warn?.("resource-snapshot.write-failed", {
+        event,
+        consecutiveFailures,
+        error: errorMsg,
+      });
+    }
+  }
 
   async function prune(): Promise<void> {
     try {
@@ -143,33 +300,59 @@ export function createResourceSnapshotWriter(
         skipTotal: false,
       });
       const total = head.totalItems;
+      // Re-anchor the local estimate to the authoritative count every sweep so a
+      // drifted estimate (dropped writes, external inserts) self-corrects.
+      estimatedTotal = total;
       if (total <= maxRows) {
         knownOverCap = false;
         return;
       }
       knownOverCap = true;
-      // Find the observed_at cutoff: the (maxRows)-th newest row's timestamp.
-      // Everything strictly older than that is surplus. Page directly to the
-      // boundary row rather than listing every surplus row client-side.
-      const boundary = await pb.list<{ observed_at: string }>(
+      // ROBUST-TO-TIES prune: delete the oldest `surplus` rows by stable row
+      // IDENTITY (id), NOT by a bare `observed_at < cutoff` strict compare.
+      // observed_at is ms-resolution and several snapshots can share the same
+      // millisecond (degraded+heartbeat+crash); a strict timestamp cutoff would
+      // strand the surplus rows that tie the boundary and spin forever. Listing
+      // the oldest rows directly and deleting them by id converges regardless.
+      const surplus = total - maxRows;
+      const oldest = await pb.list<{ id: string; observed_at: string }>(
         RESOURCE_SNAPSHOTS_COLLECTION,
         {
-          sort: "-observed_at",
-          page: maxRows,
-          perPage: 1,
+          sort: "observed_at", // oldest first
+          page: 1,
+          perPage: surplus,
           skipTotal: true,
         },
       );
-      const cutoff = boundary.items[0]?.observed_at;
-      if (!cutoff) return;
+      const ids = oldest.items
+        .map((r) => r.id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0);
+      if (ids.length === 0) {
+        // No usable ids (e.g. a fake/old PB without id) — stop here rather than
+        // spin; next interval retries. Don't leave knownOverCap latched on a
+        // structural inability to prune.
+        knownOverCap = false;
+        return;
+      }
+      const filter = ids.map((id) => `id = ${JSON.stringify(id)}`).join(" || ");
       const deleted = await pb.deleteByFilter(
         RESOURCE_SNAPSHOTS_COLLECTION,
-        `observed_at < ${JSON.stringify(cutoff)}`,
+        filter,
       );
       if (deleted > 0) {
         logger.info("resource-snapshot.pruned", { deleted, kept: maxRows });
       }
-      knownOverCap = false;
+      estimatedTotal = total - deleted;
+      if (deleted === 0) {
+        // Made no progress despite being over cap (e.g. nothing matched the id
+        // filter). Don't re-latch a sweep that can't converge; next interval
+        // retries. This is the safety valve that prevents a prune spin.
+        knownOverCap = false;
+        return;
+      }
+      // Keep catching up next insert if still over cap (a single sweep is capped
+      // at `surplus` deletes, which is exact here, but stay defensive).
+      knownOverCap = estimatedTotal > maxRows;
     } catch (err) {
       // Prune is best-effort: a failed sweep just means we retry next time.
       logger.warn?.("resource-snapshot.prune-failed", {
@@ -180,35 +363,51 @@ export function createResourceSnapshotWriter(
 
   return {
     async write(event, gauges, stats, perBrowser): Promise<void> {
+      // BEST-EFFORT in-flight cap: a fire-and-forget burst must not pile
+      // unawaited creates against a slow PB. Over the cap we DROP the snapshot
+      // (instrumentation, not a durable queue) and warn once-throttled.
+      if (inFlight >= maxInFlight) {
+        logger.warn?.("resource-snapshot.dropped-over-inflight", {
+          event,
+          inFlight,
+          maxInFlight,
+        });
+        return;
+      }
+      inFlight += 1;
       try {
-        await pb.create(RESOURCE_SNAPSHOTS_COLLECTION, {
+        await createWithTimeout({
           observed_at: gauges.ts,
           event,
-          pids_current: gauges.cgroupPidsCurrent,
-          pids_max: gauges.cgroupPidsMax,
-          threads: gauges.treeThreadCount,
-          procs: gauges.treeProcCount,
-          zombies: gauges.zombieCount,
-          fd_count: gauges.selfFdCount,
-          rss_mb: gauges.treeRssMb,
-          shm_pct: gauges.devShmUsedPct,
-          tmp_inode_pct: gauges.tmpInodeUsedPct,
+          pids_current: gaugeOrNull(gauges.cgroupPidsCurrent),
+          pids_max: gaugeOrNull(gauges.cgroupPidsMax),
+          threads: gaugeOrNull(gauges.treeThreadCount),
+          procs: gaugeOrNull(gauges.treeProcCount),
+          zombies: gaugeOrNull(gauges.zombieCount),
+          fd_count: gaugeOrNull(gauges.selfFdCount),
+          rss_mb: gaugeOrNull(gauges.treeRssMb),
+          shm_pct: gaugeOrNull(gauges.devShmUsedPct),
+          tmp_inode_pct: gaugeOrNull(gauges.tmpInodeUsedPct),
           browsers: perBrowser?.length ?? null,
           contexts_in_use: stats.inUse,
           contexts_available: stats.available,
           per_browser: perBrowser ?? null,
         });
+        onWriteSuccess();
+        // Local row-count estimate bumps per insert; once it crosses the cap the
+        // rate-limit must NOT strand us — force a catch-up prune on this insert.
+        estimatedTotal += 1;
+        if (estimatedTotal > maxRows) knownOverCap = true;
       } catch (err) {
         // BEST-EFFORT: a missing migration (400), PB outage, or network error
-        // must NEVER break the pool. Swallow + log at warn so the gap is
-        // visible without crashing the caller. Learned from a prior incident
-        // where a state write that needed an unrun migration 400'd and broke
-        // the writer's caller.
-        logger.warn?.("resource-snapshot.write-failed", {
-          event,
-          error: err instanceof Error ? err.message : String(err),
-        });
+        // must NEVER break the pool. Swallow + count (throttled warn, latched
+        // error after the threshold) so a systematic outage is loud without
+        // crashing the caller. Learned from a prior incident where a state
+        // write that needed an unrun migration 400'd and broke the caller.
+        onWriteFailure(event, err);
         return;
+      } finally {
+        inFlight -= 1;
       }
       // Ring retention: only sweep once per interval (or while known over cap)
       // so a heartbeat burst doesn't issue a delete sweep on every insert.

--- a/showcase/harness/src/probes/helpers/resource-snapshot-writer.ts
+++ b/showcase/harness/src/probes/helpers/resource-snapshot-writer.ts
@@ -68,6 +68,18 @@ export const DEFAULT_RESOURCE_SNAPSHOT_MAX_ROWS = 5000;
 const DEFAULT_PRUNE_INTERVAL_MS = 5 * 60_000;
 
 /**
+ * Max rows a SINGLE prune sweep lists + deletes. A cold start over a large
+ * backlog (or lowering RESOURCE_SNAPSHOT_MAX_ROWS on a full collection) makes
+ * `surplus = total - maxRows` thousands large; using that directly as
+ * `list({perPage})` and as a one-clause-per-row `id = ... || ...` delete filter
+ * builds a giant request + a thousands-clause filter URL that PB rejects
+ * (400/414) so the prune never converges. Instead each sweep drains at most this
+ * many oldest rows; `knownOverCap` keeps catching up across subsequent
+ * inserts/sweeps until back under cap.
+ */
+const PRUNE_BATCH_MAX = 200;
+
+/**
  * Consecutive snapshot-write failures before the writer escalates ONCE to
  * `logger.error`. Below this, failures warn (throttled). The escalation is
  * latched and resets on the first success.
@@ -207,6 +219,12 @@ export function createResourceSnapshotWriter(
   // under — otherwise a single rate-limited prune that can't clear the whole
   // backlog in one sweep would leave us over cap until the next interval.
   let knownOverCap = false;
+  // When a sweep makes NO structural progress while still over cap (PB
+  // delete-rule 403, filter 400, or a delete that matched 0 rows), we back the
+  // prune off until this timestamp so the retry is gated by the interval rather
+  // than firing on every insert via the knownOverCap re-arm. Until then BOTH the
+  // write-path re-arm and the prune gate honor the suppression.
+  let pruneSuppressedUntil = 0;
   // Local row-count estimate so the rate-limit can't STRAND us over cap until
   // the next interval. Each successful insert bumps it; every prune resets it to
   // the actual total. When the estimate crosses `maxRows` the next insert forces
@@ -249,11 +267,16 @@ export function createResourceSnapshotWriter(
         reject(new Error(`pb create timed out after ${writeTimeoutMs}ms`));
       }, writeTimeoutMs);
     });
+    // The orphaned create promise keeps running after a timeout wins the race.
+    // If a client that ignores the AbortSignal lets it REJECT later, the
+    // unhandled rejection would crash the process — swallow it. (The race
+    // result is what the caller acts on; this only neutralizes the loser.)
+    const create = pb.create(RESOURCE_SNAPSHOTS_COLLECTION, record, {
+      signal: ac.signal,
+    });
+    create.catch(() => {});
     try {
-      await Promise.race([
-        pb.create(RESOURCE_SNAPSHOTS_COLLECTION, record, { signal: ac.signal }),
-        timeout,
-      ]);
+      await Promise.race([create, timeout]);
     } finally {
       if (timer !== undefined) clearTimeout(timer);
     }
@@ -292,6 +315,23 @@ export function createResourceSnapshotWriter(
     }
   }
 
+  /**
+   * Back off the prune when a sweep makes no STRUCTURAL progress while still
+   * over cap (no usable ids, or `deleteByFilter` returned 0 — PB delete-rule
+   * 403, a filter 400, etc.). Clears `knownOverCap` AND opens a suppression
+   * window (`pruneSuppressedUntil`) for one `pruneIntervalMs`. Until that window
+   * elapses, the write-path re-arm leaves `knownOverCap` cleared and the prune
+   * gate stays shut — so the retry is genuinely gated to once-per-interval
+   * rather than re-running the failing list-probe + sweep on every insert
+   * (estimatedTotal is still over cap, which would otherwise re-arm immediately).
+   */
+  function suppressPruneUntilInterval(): void {
+    knownOverCap = false;
+    const t = now();
+    lastPruneAt = t;
+    pruneSuppressedUntil = t + pruneIntervalMs;
+  }
+
   async function prune(): Promise<void> {
     try {
       // Cheapest possible "are we over cap?" probe: ask PB for the total.
@@ -308,19 +348,26 @@ export function createResourceSnapshotWriter(
         return;
       }
       knownOverCap = true;
-      // ROBUST-TO-TIES prune: delete the oldest `surplus` rows by stable row
+      // BOUNDED sweep: a cold start over a large backlog makes `surplus`
+      // thousands large; listing/deleting all of it in one sweep builds a giant
+      // perPage + a thousands-clause `id = ... || ...` filter URL that PB
+      // rejects (400/414) so the prune never converges. Cap each sweep to
+      // `PRUNE_BATCH_MAX` oldest rows and let `knownOverCap` drain the rest
+      // across subsequent inserts/sweeps.
+      const surplus = total - maxRows;
+      const batch = Math.min(surplus, PRUNE_BATCH_MAX);
+      // ROBUST-TO-TIES prune: delete the oldest `batch` rows by stable row
       // IDENTITY (id), NOT by a bare `observed_at < cutoff` strict compare.
       // observed_at is ms-resolution and several snapshots can share the same
       // millisecond (degraded+heartbeat+crash); a strict timestamp cutoff would
       // strand the surplus rows that tie the boundary and spin forever. Listing
       // the oldest rows directly and deleting them by id converges regardless.
-      const surplus = total - maxRows;
       const oldest = await pb.list<{ id: string; observed_at: string }>(
         RESOURCE_SNAPSHOTS_COLLECTION,
         {
           sort: "observed_at", // oldest first
           page: 1,
-          perPage: surplus,
+          perPage: batch,
           skipTotal: true,
         },
       );
@@ -328,10 +375,10 @@ export function createResourceSnapshotWriter(
         .map((r) => r.id)
         .filter((id): id is string => typeof id === "string" && id.length > 0);
       if (ids.length === 0) {
-        // No usable ids (e.g. a fake/old PB without id) — stop here rather than
-        // spin; next interval retries. Don't leave knownOverCap latched on a
-        // structural inability to prune.
-        knownOverCap = false;
+        // No usable ids (e.g. a fake/old PB without id) — make no progress.
+        // Back off via the interval rate-limit (below) instead of re-arming
+        // knownOverCap, which would re-probe on EVERY subsequent insert.
+        suppressPruneUntilInterval();
         return;
       }
       const filter = ids.map((id) => `id = ${JSON.stringify(id)}`).join(" || ");
@@ -344,14 +391,19 @@ export function createResourceSnapshotWriter(
       }
       estimatedTotal = total - deleted;
       if (deleted === 0) {
-        // Made no progress despite being over cap (e.g. nothing matched the id
-        // filter). Don't re-latch a sweep that can't converge; next interval
-        // retries. This is the safety valve that prevents a prune spin.
-        knownOverCap = false;
+        // Made no STRUCTURAL progress despite being over cap (PB delete-rule
+        // 403, a filter 400, or the delete matched nothing). Re-arming
+        // knownOverCap here would re-run a full list-probe + sweep on EVERY
+        // subsequent insert, hammering a broken delete path once per heartbeat.
+        // Instead back off: clear knownOverCap AND advance lastPruneAt so the
+        // `pruneIntervalMs` rate-limit genuinely gates the retry (once per
+        // interval, not once per insert).
+        suppressPruneUntilInterval();
         return;
       }
-      // Keep catching up next insert if still over cap (a single sweep is capped
-      // at `surplus` deletes, which is exact here, but stay defensive).
+      // Keep catching up next insert while still over cap. A single sweep is
+      // bounded at `PRUNE_BATCH_MAX` deletes, so a large backlog drains over
+      // multiple inserts/sweeps rather than one oversized request.
       knownOverCap = estimatedTotal > maxRows;
     } catch (err) {
       // Prune is best-effort: a failed sweep just means we retry next time.
@@ -372,6 +424,25 @@ export function createResourceSnapshotWriter(
           inFlight,
           maxInFlight,
         });
+        // DROP→ESCALATION seam (item #2): if PB is 100% broken the in-flight
+        // slots stay occupied by hung/timing-out writes, so new snapshots keep
+        // hitting THIS drop path instead of the timeout→failure path — which
+        // would let the loud `write-failing-systematically` error be delayed or
+        // dodged entirely. So once writes are ALREADY failing
+        // (`consecutiveFailures > 0` — the hung writes have begun timing out, or
+        // PB is rejecting outright) a concurrent drop ALSO counts toward the
+        // systematic-failure signal, accelerating the loud error instead of
+        // masking it. A drop while writes are succeeding normally
+        // (`consecutiveFailures === 0`: healthy backpressure, the in-flight
+        // writes are pending-but-fine) does NOT escalate — no false positive.
+        if (consecutiveFailures > 0) {
+          onWriteFailure(
+            event,
+            new Error(
+              `in-flight cap saturated while writes are failing (inFlight=${inFlight}/${maxInFlight})`,
+            ),
+          );
+        }
         return;
       }
       inFlight += 1;
@@ -396,8 +467,13 @@ export function createResourceSnapshotWriter(
         onWriteSuccess();
         // Local row-count estimate bumps per insert; once it crosses the cap the
         // rate-limit must NOT strand us — force a catch-up prune on this insert.
+        // EXCEPTION: while a no-progress backoff window is open, do NOT re-arm;
+        // re-arming here is exactly the cascade that hammers a broken delete path
+        // once per insert. The interval gate below takes over after the window.
         estimatedTotal += 1;
-        if (estimatedTotal > maxRows) knownOverCap = true;
+        if (estimatedTotal > maxRows && now() >= pruneSuppressedUntil) {
+          knownOverCap = true;
+        }
       } catch (err) {
         // BEST-EFFORT: a missing migration (400), PB outage, or network error
         // must NEVER break the pool. Swallow + count (throttled warn, latched
@@ -410,9 +486,13 @@ export function createResourceSnapshotWriter(
         inFlight -= 1;
       }
       // Ring retention: only sweep once per interval (or while known over cap)
-      // so a heartbeat burst doesn't issue a delete sweep on every insert.
+      // so a heartbeat burst doesn't issue a delete sweep on every insert. While
+      // a no-progress backoff window is open, suppress the interval-driven sweep
+      // too — the retry is gated to once the window elapses.
       const t = now();
-      if (knownOverCap || t - lastPruneAt >= pruneIntervalMs) {
+      const intervalElapsed =
+        t - lastPruneAt >= pruneIntervalMs && t >= pruneSuppressedUntil;
+      if (knownOverCap || intervalElapsed) {
         lastPruneAt = t;
         await prune();
       }

--- a/showcase/harness/src/probes/loader/probe-invoker.ts
+++ b/showcase/harness/src/probes/loader/probe-invoker.ts
@@ -58,7 +58,7 @@ const SYNTHETIC_ERROR_MSG_BUDGET = 1200;
  * immediately drives a `pool.acquire()` that launches a Chromium
  * (~50 threads/procs each). With 5 simultaneous workers the kernel
  * sees ~250 thread spawns inside a few-ms window on top of an already-
- * warm 10-browser pool, and the container hits its PID/thread ceiling
+ * warm 3-browser pool, and the container hits its PID/thread ceiling
  * — fork/pthread_create returns EAGAIN, Chromium processes die, and
  * per-feature `browser.newContext()` fails with "Target page, context
  * or browser has been closed" so the whole run aborts at T+2s.

--- a/showcase/harness/src/probes/loader/probe-invoker.ts
+++ b/showcase/harness/src/probes/loader/probe-invoker.ts
@@ -10,10 +10,7 @@ import type { StatusWriter } from "../../writers/status-writer.js";
 import { truncateUtf8 } from "../../render/filters.js";
 import { ProbeRunTracker } from "../run-tracker.js";
 import type { ProbeRunWriter, ProbeRunSummary } from "../run-history.js";
-import {
-  sampleResourceGauges,
-  formatGauges,
-} from "../helpers/resource-gauges.js";
+import { sampleResourceGauges } from "../helpers/resource-gauges.js";
 
 /**
  * EARLY-WARNING INSTRUMENTATION: sample + log the OS resource gauges at a probe
@@ -21,9 +18,10 @@ import {
  * context-open burst, so sampling here (start + end) makes a burst approaching
  * the cgroup `pids.max` ceiling — the PROVEN browser-pool wedge — observable in
  * the per-tick logs. The headline `pids.current`/`pids.max`/thread fields lead
- * the structured payload and the compact `gauges` summary line. Best-effort: a
- * sampling failure (or non-Linux host, where the gauges degrade to -1) is
- * swallowed and never disrupts the tick.
+ * the structured payload (the full gauge set is spread in directly, so every
+ * field stays queryable rather than buried in a pre-formatted string).
+ * Best-effort: a sampling failure (or non-Linux host, where the gauges degrade
+ * to -1) is swallowed and never disrupts the tick.
  */
 function logTickGauges(
   logger: Logger,
@@ -35,7 +33,6 @@ function logTickGauges(
     logger.info("probe.resource-gauges", {
       probeId,
       boundary,
-      gauges: formatGauges(g, boundary),
       ...g,
     });
   } catch {

--- a/showcase/harness/src/probes/loader/probe-invoker.ts
+++ b/showcase/harness/src/probes/loader/probe-invoker.ts
@@ -10,6 +10,38 @@ import type { StatusWriter } from "../../writers/status-writer.js";
 import { truncateUtf8 } from "../../render/filters.js";
 import { ProbeRunTracker } from "../run-tracker.js";
 import type { ProbeRunWriter, ProbeRunSummary } from "../run-history.js";
+import {
+  sampleResourceGauges,
+  formatGauges,
+} from "../helpers/resource-gauges.js";
+
+/**
+ * EARLY-WARNING INSTRUMENTATION: sample + log the OS resource gauges at a probe
+ * tick boundary. A probe tick is exactly when the browser pool sees its launch /
+ * context-open burst, so sampling here (start + end) makes a burst approaching
+ * the cgroup `pids.max` ceiling — the PROVEN browser-pool wedge — observable in
+ * the per-tick logs. The headline `pids.current`/`pids.max`/thread fields lead
+ * the structured payload and the compact `gauges` summary line. Best-effort: a
+ * sampling failure (or non-Linux host, where the gauges degrade to -1) is
+ * swallowed and never disrupts the tick.
+ */
+function logTickGauges(
+  logger: Logger,
+  boundary: "tick-start" | "tick-complete",
+  probeId: string,
+): void {
+  try {
+    const g = sampleResourceGauges();
+    logger.info("probe.resource-gauges", {
+      probeId,
+      boundary,
+      gauges: formatGauges(g, boundary),
+      ...g,
+    });
+  } catch {
+    // gauge sampling is best-effort early-warning logging — never disrupt a tick.
+  }
+}
 
 /**
  * Bound the size of any string flowing into a synthetic-error ProbeResult.
@@ -339,6 +371,10 @@ export function buildProbeInvoker(
       discoveryOk: resolved.ok,
       triggered,
     });
+    // EARLY WARNING: snapshot the OS resource gauges at the tick boundary so a
+    // launch/context-open burst approaching the cgroup pids.max ceiling (the
+    // proven browser-pool wedge) is observable per tick.
+    logTickGauges(logger, "tick-start", cfg.id);
 
     // CR-A1.1: thread the trigger's slug filter end-to-end. Discover the
     // FULL roster (so logs/diagnostics still see what the source returned)
@@ -802,6 +838,10 @@ export function buildProbeInvoker(
         durationMs: Date.now() - tickStart,
         discoveryFailed: summary.discoveryFailed ?? false,
       });
+      // EARLY WARNING: snapshot the OS resource gauges at the tick-end boundary
+      // so post-burst PID/thread demand (and any failure to reclaim it) is
+      // observable alongside tick-start.
+      logTickGauges(logger, "tick-complete", cfg.id);
       // Structured per-service run summary — a single log line carrying
       // every target's outcome so Railway logs give a complete picture
       // without needing PocketBase.

--- a/showcase/harness/src/probes/loader/probe-invoker.ts
+++ b/showcase/harness/src/probes/loader/probe-invoker.ts
@@ -56,8 +56,8 @@ const SYNTHETIC_ERROR_MSG_BUDGET = 1200;
  * probe like d6-all-pills-e2e fans `max_concurrency` workers out across
  * its discovered services in the same JS tick, each worker
  * immediately drives a `pool.acquire()` that launches a Chromium
- * (~50 threads/procs each). With 8 simultaneous workers the kernel
- * sees ~400 thread spawns inside a 4ms window on top of an already-
+ * (~50 threads/procs each). With 5 simultaneous workers the kernel
+ * sees ~250 thread spawns inside a few-ms window on top of an already-
  * warm 10-browser pool, and the container hits its PID/thread ceiling
  * — fork/pthread_create returns EAGAIN, Chromium processes die, and
  * per-feature `browser.newContext()` fails with "Target page, context
@@ -73,8 +73,8 @@ const SYNTHETIC_ERROR_MSG_BUDGET = 1200;
  * Env-overridable: `SERVICE_STARTUP_STAGGER_MS` (parsed as int; non-finite
  * or negative values fall through to the default). Set to `0` to disable.
  *
- * Default chosen to spread 8 workers across ~2.1s — small relative to
- * the 10-minute D6 budget but large enough that each Chromium's
+ * Default chosen to spread 5 workers across ~1.2s — small relative to
+ * the 20-minute D6 budget but large enough that each Chromium's
  * thread-spawn burst (~150ms in practice) is done before the next
  * starts.
  */

--- a/showcase/pocketbase/pb_migrations/1779989300_create_resource_snapshots.js
+++ b/showcase/pocketbase/pb_migrations/1779989300_create_resource_snapshots.js
@@ -13,12 +13,21 @@
 // restart so the PID/thread-ceiling exhaustion (`pids.current` near
 // `pids.max`) is reconstructable AFTER the wedge.
 //
-// RETENTION: this collection is append-only and could grow unbounded under a
-// ~30-60s heartbeat (≈1k-2k rows/day). The writer enforces a RING-STYLE cap
-// (`RESOURCE_SNAPSHOT_MAX_ROWS`, default 5000) — after each insert it prunes
-// the oldest rows beyond the cap via `deleteByFilter` keyed on the
+// RETENTION: this collection is append-only and could grow unbounded under the
+// ~45s heartbeat (DEFAULT_HEARTBEAT_MS in browser-pool.ts) plus a row per
+// transition (≈2k rows/day at 45s). The writer enforces a RING-STYLE cap
+// (`RESOURCE_SNAPSHOT_MAX_ROWS`, default 5000 ≈ 2.5 days at 45s) — after each
+// insert it prunes the oldest rows beyond the cap by stable row id (robust to
+// same-millisecond `observed_at` ties), ordered via the
 // `idx_resource_snapshots_observed` index. Simpler than a TTL cron and bounds
 // the volume deterministically regardless of restart cadence.
+//
+// NULL-VS-UNAVAILABLE CONVENTION: every number field below is NULLABLE on
+// purpose. The gauges degrade to a `-1` "unavailable" sentinel off-Linux / on
+// an unreadable cgroup-pids / fd / df read; the writer maps that sentinel to
+// `null` here (never writes `-1`), so a post-wedge query can cleanly separate a
+// MEASURED reading from an UNAVAILABLE one — a stored `-1` would be
+// indistinguishable from a genuine count.
 //
 // PUBLIC-READ INVARIANT: mirrors `status` / `probe_runs` — listRule/viewRule =
 // "" (unauthenticated read) so the dashboard / a /debug endpoint can pull the

--- a/showcase/pocketbase/pb_migrations/1779989300_create_resource_snapshots.js
+++ b/showcase/pocketbase/pb_migrations/1779989300_create_resource_snapshots.js
@@ -1,0 +1,101 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// DURABLE forensic history of the harness's OS resource gauges around the
+// long-lived chromium BrowserPool. One row per snapshot, written best-effort
+// by `resource-snapshot-writer.ts` — periodically (heartbeat) and on every
+// significant pool transition (degraded, unrecoverable, launch-fail, crash).
+//
+// WHY this collection exists (and is NOT just stdout logging): the
+// browser-pool wedge (#5185/#5221/#5225) ENDS in a container restart that
+// clears anything in-memory, and Railway's stdout log window is capped and
+// rolls off — a prior investigation hit exactly that and lost the forensic
+// trail. Persisting the gauge history to PocketBase makes it survive the
+// restart so the PID/thread-ceiling exhaustion (`pids.current` near
+// `pids.max`) is reconstructable AFTER the wedge.
+//
+// RETENTION: this collection is append-only and could grow unbounded under a
+// ~30-60s heartbeat (≈1k-2k rows/day). The writer enforces a RING-STYLE cap
+// (`RESOURCE_SNAPSHOT_MAX_ROWS`, default 5000) — after each insert it prunes
+// the oldest rows beyond the cap via `deleteByFilter` keyed on the
+// `idx_resource_snapshots_observed` index. Simpler than a TTL cron and bounds
+// the volume deterministically regardless of restart cadence.
+//
+// PUBLIC-READ INVARIANT: mirrors `status` / `probe_runs` — listRule/viewRule =
+// "" (unauthenticated read) so the dashboard / a /debug endpoint can pull the
+// recent history without a session. The gauge fields are pure OS counters
+// (PID counts, thread/proc/zombie counts, FD/RSS/shm/tmp) and the
+// `per_browser` JSON is a derived breakdown — NEVER write secrets, env vars,
+// or auth tokens here. Writes stay superuser-only (createRule/deleteRule =
+// null) so only the harness can mint/prune rows.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    // Idempotency: re-running after a partial apply must be a no-op. PB JSVM
+    // exposes no typed error discrimination, so catch broadly and skip when
+    // the collection already exists (mirrors 1777165230_create_probe_runs).
+    try {
+      dao.findCollectionByNameOrId("resource_snapshots");
+      return;
+    } catch (e) {
+      // Not present — fall through to create.
+    }
+    const c = new Collection({
+      name: "resource_snapshots",
+      type: "base",
+      schema: [
+        // ISO timestamp of the sample. Indexed DESC for "last N snapshots"
+        // lookback and used as the retention prune key.
+        { name: "observed_at", type: "date", required: true },
+        // Pool lifecycle event that triggered the snapshot
+        // (`heartbeat`, `degraded`, `unrecoverable`, `launch-fail`,
+        // `crash`, ...). Free-text so the writer can add events without a
+        // schema migration; the headline transitions are documented in
+        // browser-pool.ts.
+        { name: "event", type: "text", required: true },
+        // --- Headline cgroup PID-ceiling gauges (the PROVEN wedge signal) ---
+        { name: "pids_current", type: "number" },
+        { name: "pids_max", type: "number" },
+        { name: "threads", type: "number" },
+        { name: "procs", type: "number" },
+        { name: "zombies", type: "number" },
+        // --- Refuted-candidate differential (kept observable) ---
+        { name: "fd_count", type: "number" },
+        { name: "rss_mb", type: "number" },
+        { name: "shm_pct", type: "number" },
+        { name: "tmp_inode_pct", type: "number" },
+        // --- Pool capacity at the moment of the sample ---
+        { name: "browsers", type: "number" },
+        { name: "contexts_in_use", type: "number" },
+        { name: "contexts_available", type: "number" },
+        // Optional per-browser breakdown (live contexts / served / state).
+        // 64KB ceiling — the realistic shape is a handful of small objects;
+        // keep the budget close to the max given the public listRule.
+        { name: "per_browser", type: "json", options: { maxSize: 65536 } },
+      ],
+      indexes: [
+        // Primary lookback + retention-prune key: newest-first by sample time.
+        "CREATE INDEX IF NOT EXISTS idx_resource_snapshots_observed ON resource_snapshots (observed_at DESC)",
+        // Event-scoped lookback ("show me every unrecoverable snapshot").
+        "CREATE INDEX IF NOT EXISTS idx_resource_snapshots_event ON resource_snapshots (event, observed_at DESC)",
+      ],
+      // Public read mirrors `status` / `probe_runs`; writes superuser-only.
+      listRule: "",
+      viewRule: "",
+      createRule: null,
+      updateRule: null,
+      deleteRule: null,
+    });
+    dao.saveCollection(c);
+  },
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("resource_snapshots");
+    } catch (e) {
+      // Already absent — nothing to do.
+      return;
+    }
+    dao.deleteCollection(c);
+  },
+);


### PR DESCRIPTION
## Root cause (PROVEN)

The recurring browser-pool wedge is **OS thread/PID exhaustion against the container cgroup `pids.max` ceiling**, not a `/tmp` leak.

Reproduced with the exact signature + differential: under a PID-limit constraint a reproduction produced `pthread_create: Resource temporarily unavailable (errno 11)` → `Target page, context or browser has been closed` → permanent crash-loop, with `pids.current` pegged at the ceiling.

Staging measurements:
- cgroup `pids.max = 1000` (platform-fixed by Railway via `--pids-limit`; NOT the aspirational 16384, and NOT raisable from the image).
- idle `pids.current ≈ 377` (3 browsers).
- a d6 burst (`max_concurrency:8` → ~32 contexts → ~32 renderers × ~15 threads ≈ +480) peaks ~850-900; the **live wedge peaked 998/1000 during a d6+d5 OVERLAP** when both probes' renderers summed past the ceiling → the ceiling. cgroup counts **THREADS**, not just processes.

Every other candidate was **refuted by measurement**: `/tmp` inode/space (2000 cycles, ≥890 inodes free, playwright dirs flat at 6 — graceful close reclaims them), `/dev/shm` (unused; `--disable-dev-shm-usage` works), file descriptors (clean at nofile=128), memory (OOM-kill is a different failure mode).

## Fix (re-scoped to the real cause)

- **Reduce thread pressure (the actual lever):** `BROWSER_POOL_MAX_CONTEXTS` default lowered **40 → 24** (aligns with the recommended deploy target). Fewer concurrent contexts → fewer chromium renderer threads → peak `pids.current` stays well under 1000. Still env-overridable.
- **Reduce the d6+d5 OVERLAP peak (complementary lever):** d6 `max_concurrency` lowered **8 → 5** in `d6-all-pills-e2e.yml`. The live wedge peaked 998/1000 specifically during a d6+d5 overlap — fewer concurrent d6 feature-workers cut the simultaneous-renderer thread peak, leaving headroom for a co-firing d5 (or a recovery relaunch) without crossing 1000. 5 services × 4 features = 20 concurrent contexts, comfortably under the 24-context cap.
- **Resource-gauge early-warning logging:** a reusable, unit-tested sampler reads the cgroup PID counters (`pids.current` / `pids.max`, v2 with v1 fallback) plus process-tree thread/proc counts, FDs, RSS, /dev/shm, /tmp inode/space. Off-Linux it degrades to -1.
- **Circuit-breaker give-up + `onUnrecoverable` alarm (root-cause-agnostic backstop):** retained from the prior scope. It stops the infinite silent spin and signals "redeploy required" on ANY wedge (including PID exhaustion). The alarm payload + the orchestrator's terminal alert message now carry the measured `pids.current`/`pids.max` + thread count, so the alert **names the real signal**. The footgun clamp is retained.

## Durable forensic logging (NEW)

The wedge ends in a container **restart** that clears all in-memory state, and Railway's stdout log window is capped and **rolls off** — so stdout/in-memory gauges are NOT retrievable post-wedge (a prior investigation hit exactly that). This adds copious, **durable** forensic history so a recurrence in staging has something to look back at AFTER the wedge→restart.

- **Gauge coverage expanded across the whole pool lifecycle** (was 3 sites): a full forensic snapshot (sample + structured log + durable persist) now fires on every meaningful transition — `init`, `recycle-crash` / `recycle-hygiene`, `crash`/disconnect, set-empty `degraded`, `self-heal-launch-failed`, `recovered`, `unrecoverable`, and `shutdown`.
- **Periodic heartbeat (~45s, `BROWSER_POOL_HEARTBEAT_MS`)** gives a baseline PID/thread trend between transition events. Driven by a shutdown-signal-gated self-rescheduling loop — **not a raw `setInterval` that leaks** past shutdown.
- **Hot-path cost control:** the busy `acquire`/`release` path logs only a **cheap cgroup-PID-only subset** (`pids.current`/`pids.max` + in-use/available — two small file reads, no `/proc` walk, no `df`) and does NOT durably persist. Full samples are reserved for transitions + heartbeat.
- **Durable persistence to PocketBase:** a new `resource_snapshots` PB collection (migration `1779989300_create_resource_snapshots.js`, idempotent create + public-read, mirroring `probe_runs`) stores each snapshot row: `observed_at`, `event`, `pids_current`/`pids_max`, threads/procs/zombies, FD/RSS/shm/tmp, context in-use/available, and an optional per-browser JSON breakdown.
- **Best-effort guarantee:** the snapshot writer **swallows + logs every PB error** (missing migration / 400 / hiccup / network) so it can never throw into the pool's lifecycle paths — learned from a prior incident where a state write needing an unrun migration 400'd and broke the caller. Reuses the shared `pb` client.
- **Retention:** ring-style — after each insert the writer prunes the oldest rows beyond a cap (`RESOURCE_SNAPSHOT_MAX_ROWS`, default 5000), rate-limited so a heartbeat burst doesn't sweep on every insert. Bounds the volume deterministically.

## Removed (targeted a PROVEN non-cause)

- Proactive stale-profile `/tmp` sweep (init + every recycle).
- `defaultPurgeProfileDirs` + the `PurgeProfileDirs` type + the `staleProfileDirTtlMs` / `PURGE_MIN_AGE_MS` options & env.
- The breaker's `/tmp` purge — the hard recovery is now simply the existing paced cold relaunch.
- The corresponding purge / init-sweep / recycle-sweep / bounded-accumulation tests.

## Dockerfile comment correction

The FIX #3 comment claimed the in-image `ulimit -u $(ulimit -Hu)` raised the cgroup `pids.max` (target 16384). It **cannot**: `ulimit -u` only lifts this process's `RLIMIT_NPROC`; the cgroup `pids.max` is set by the container runtime, is platform-fixed at 1000 on staging, and is not raisable from inside the image. The comment is rewritten to state this accurately and point at the demand-side mitigation. The harmless `ulimit -u` line itself is kept.

Note: **Railway cannot raise `pids.max` from the image**, so the only lever is demand-side (fewer concurrent contexts + lower d6 overlap concurrency) plus the gauge/alarm/durable observability.

## Deploy-safety note

The new `resource_snapshots` collection requires its PB migration to run on the harness PB before durable writes succeed. Because the writer is **best-effort**, deploying the harness code before the migration runs is safe — writes simply 404 and are logged at `warn`, never breaking the pool (verified: the orchestrator test suite exercises exactly this — writes 404 against a migration-less test PB and all tests still pass).

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] full browser-pool test file green (61 tests, incl. new snapshot/heartbeat + best-effort cases)
- [x] resource-snapshot-writer unit tests green (5 tests) — persists row, best-effort swallow on throwing PB, ring retention prune, no-prune-under-cap
- [x] resource-gauges unit tests green — cgroup v2/v1 parsing, "max" sentinel, graceful off-Linux degradation
- [x] env default test asserts MAX_CONTEXTS = 24; d6 config max_concurrency = 5
- [x] red-green proof: with snapshot/heartbeat wiring neutralized, 8 tests fail; all pass with the wiring
- [x] full harness suite green (1797 passed) except the known/unrelated `starter_smoke.yml "Unrecognized key: discovery"` config-loader failure
- [x] oxlint (0 errors) + oxfmt --check clean on touched files
- [x] PB migration syntax-valid (`node --check`)
