### PR TITLE
fix(showcase/aimock): reorder gen-ui-interrupt d6 fixture legs (ag2)

### DIFF
--- a/showcase/aimock/d6/ag2/gen-ui-interrupt.json
+++ b/showcase/aimock/d6/ag2/gen-ui-interrupt.json
@@ -6,29 +6,7 @@
   },
   "fixtures": [
     {
-      "_comment": "gen-ui-interrupt sales-call pill — second leg: confirmation after user picks a slot and resolve fires. Keyed by toolCallId so it only matches when the prior tool result is being fed back. Placed BEFORE first-leg so toolCallId matching takes precedence over toolName matching.",
-      "match": {
-        "userMessage": "intro call with the sales team",
-        "toolCallId": "call_d5_schedule_sales_001",
-        "context": "ag2"
-      },
-      "response": {
-        "content": "Booked: Sales intro call confirmed for the slot you picked."
-      }
-    },
-    {
-      "_comment": "gen-ui-interrupt alice-1on1 pill — second leg: confirmation after user picks a slot. Placed BEFORE first-leg so toolCallId matching takes precedence.",
-      "match": {
-        "userMessage": "1:1 with Alice",
-        "toolCallId": "call_d5_schedule_alice_001",
-        "context": "ag2"
-      },
-      "response": {
-        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
-      }
-    },
-    {
-      "_comment": "gen-ui-interrupt sales-call pill — first leg: schedule_meeting tool call triggers Python agent's interrupt(...). The toolName gate ensures this matches only when schedule_meeting is in the tool list (the agent must declare it).",
+      "_comment": "gen-ui-interrupt sales-call pill — first leg: schedule_meeting tool call triggers Python agent's interrupt(...). The toolName gate ensures this matches only when schedule_meeting is in the tool list (the agent must declare it). Placed BEFORE the toolCallId resume-leg so the duplicate-userMessage dedup does not shadow the tool-emitting leg — mirrors the passing mastra/pydantic-ai ordering.",
       "match": {
         "userMessage": "intro call with the sales team",
         "toolName": "schedule_meeting",
@@ -53,7 +31,18 @@
       }
     },
     {
-      "_comment": "gen-ui-interrupt alice-1on1 pill — first leg: schedule_meeting tool call.",
+      "_comment": "gen-ui-interrupt sales-call pill — second leg: confirmation after user picks a slot and resolve fires. Keyed by toolCallId so it only matches when the prior tool result is being fed back (last message is the tool result for this call).",
+      "match": {
+        "userMessage": "intro call with the sales team",
+        "toolCallId": "call_d5_schedule_sales_001",
+        "context": "ag2"
+      },
+      "response": {
+        "content": "Booked: Sales intro call confirmed for the slot you picked."
+      }
+    },
+    {
+      "_comment": "gen-ui-interrupt alice-1on1 pill — first leg: schedule_meeting tool call. Placed BEFORE the toolCallId resume-leg so the tool-emitting leg is not shadowed.",
       "match": {
         "userMessage": "1:1 with Alice",
         "toolName": "schedule_meeting",
@@ -75,6 +64,17 @@
             }
           }
         ]
+      }
+    },
+    {
+      "_comment": "gen-ui-interrupt alice-1on1 pill — second leg: confirmation after user picks a slot. Keyed by toolCallId so it only matches when the prior tool result is being fed back.",
+      "match": {
+        "userMessage": "1:1 with Alice",
+        "toolCallId": "call_d5_schedule_alice_001",
+        "context": "ag2"
+      },
+      "response": {
+        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
       }
     }
   ]


### PR DESCRIPTION
## Summary

Audit follow-up to #5232, which fixed the `gen-ui-interrupt` d6 fixture leg mis-order for `langgraph-python` + `langgraph-typescript`. This PR audits the rest of the fleet and fixes the one remaining mis-ordered fixture.

**The bug (proven in #5232):** in `showcase/aimock/d6/<integration>/gen-ui-interrupt.json`, aimock's `matchFixture` is first-match-wins in array order, and the loader dedups on `userMessage`. If a pill's `toolCallId` resume-leg is placed BEFORE its `toolName:schedule_meeting` first-leg, the text-only resume-leg shadows the tool-emitting leg on turn-2 — no tool call, the interrupt never fires, and `time-picker-card` never mounts (cell goes red).

**Fix:** reorder each pill so the `toolName` first-leg precedes its `toolCallId` resume-leg, mirroring the proven-correct mastra / pydantic-ai / langgraph pattern. Reorder only — response payloads and match keys are byte-identical (verified against HEAD).

## Per-integration audit

Enumerated all 16 `showcase/aimock/d6/*/gen-ui-interrupt.json`:

| Integration | Ordering | Supports gen-ui-interrupt? | Action |
|---|---|---|---|
| **ag2** | **BUGGY** (toolCallId before toolName) | NSF in manifest | **Reordered** |
| langgraph-python / langgraph-typescript | buggy | yes | already fixed in #5232 |
| built-in-agent, langroid | plain legs (no guards) | yes | correct, untouched |
| claude-sdk-python/typescript, langgraph-fastapi, ms-agent-dotnet/python, pydantic-ai, spring-ai, strands | toolName-before-toolCallId | yes | correct, untouched |
| agno, crewai-crews, google-adk, llamaindex, mastra, ms-agent-harness-dotnet | (various) | NSF | n/a |

**ag2 was the only remaining mis-ordered fixture.**

## Verification (honest)

- **ag2 (the change): verified-by-structure.** ag2 cannot be run-verified because its manifest lists `gen-ui-interrupt` under `not_supported_features`, so the cell is skipped (never executed) by both the d5 and d6 drivers. Its fixture is now byte-pattern-identical to #5232's proven fix and to mastra/pydantic-ai. No d6 cell will flip on this change (ag2's cell stays NSF/skipped).
- **Mechanism: verified-by-run on a representative live cell.** Ran `pydantic-ai --d6` locally (real e2e driver + built container + aimock d6 mount, isolated compose project): `gen-ui-interrupt` cell passed (`pass:true`) with the correct ordering. The 8 unrelated failures (tool-rendering, agent-config 404, byoc, multimodal) are pre-existing local-env issues, not gen-ui-interrupt.

## D6 cell impact

**0 cells.** The only mis-ordered fixture (ag2) marks gen-ui-interrupt as not-supported, so no live cell greens from this change. The fix is a correctness/consistency change that prevents the latent shadowing bug from biting if ag2 ever enables the feature, and brings the whole fleet to a uniform, proven-correct ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)