### PR TITLE
fix(showcase/harness): prevent browser-pool /tmp profile-dir accumulation (durable root-cause fix for recurring wedge)

### DIFF
--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
+import { promises as fsp } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Browser, BrowserContext } from "playwright";
-import { BrowserPool } from "./browser-pool.js";
+import { BrowserPool, defaultSweepStaleProfileDirs } from "./browser-pool.js";
 import type { LaunchBrowser } from "./browser-pool.js";
 
 /**
@@ -2941,5 +2944,242 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
     );
     expect(openButNotClosed.length).toBe(0);
     expect(internals(pool).contextToBrowser.size).toBe(0);
+  });
+});
+
+describe("BrowserPool — PREVENTION: proactive stale-profile-dir sweep (durable root-cause fix)", () => {
+  // The RECURRING wedge: a long-lived harness container launches chromium
+  // repeatedly (init fill, hygiene recycles, crash-recovery relaunches); EVERY
+  // launch leaves a `/tmp/playwright_*` profile dir + `playwright-artifacts-*`
+  // dir whose Playwright close-time cleanup is BEST-EFFORT (logged-and-swallowed
+  // on failure). Over hours the orphans accumulate MONOTONICALLY until `/tmp`
+  // exhausts inodes/space — then every `chromium.launch()` throws "Target page,
+  // context or browser has been closed" and the pool wedges permanently (only a
+  // restart, which gives a fresh `/tmp`, clears it). The PREVENTION sweeps the
+  // age-gated stale dirs PROACTIVELY on a cadence (init + every recycle), keeping
+  // `/tmp` bounded so the exhaustion never happens. These tests assert the
+  // cadence fires (RED without the wiring) and that the real sweep is age-gated
+  // so it can never delete a dir still in use.
+
+  const poolInternals = (
+    pool: BrowserPool,
+  ): { browsers: Array<{ browser: { __crash(): void } }> } =>
+    pool as unknown as {
+      browsers: Array<{ browser: { __crash(): void } }>;
+    };
+
+  it("RED→GREEN: fires the stale-profile sweep once at init()", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    const sweepCalls: number[] = [];
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 8,
+      recycleAfter: 1000,
+      launchBrowser,
+      launchStaggerMs: 0,
+      staleProfileDirTtlMs: 60_000,
+      // Inject so we can assert the cadence WITHOUT touching the real FS. (An
+      // injected launcher would otherwise default the sweep to a hermetic no-op.)
+      sweepStaleProfileDirs: async (ttlMs) => {
+        sweepCalls.push(ttlMs);
+        return 0;
+      },
+    });
+    await pool.init();
+    await drainMicrotasks();
+
+    // Without the init() sweep wiring this is 0 (RED). With it, exactly one
+    // sweep fired, carrying the configured TTL.
+    expect(sweepCalls.length).toBe(1);
+    expect(sweepCalls[0]).toBe(60_000);
+
+    await pool.shutdown();
+  });
+
+  it("RED→GREEN: fires the stale-profile sweep on EVERY recycle (crash + hygiene)", async () => {
+    // browser0 crashes → crash recycle; browser1 hits recycleAfter=1 → hygiene
+    // recycle. Each replacement must fire the sweep (the cadence that reclaims
+    // the orphans each chromium replacement would otherwise leave to accumulate).
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const sweepCalls: string[] = [];
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 8,
+      recycleAfter: 1, // first served context makes the entry hygiene-eligible
+      relaunchBackoffMs: 0,
+      launchBrowser,
+      launchStaggerMs: 0,
+      staleProfileDirTtlMs: 0,
+      sweepStaleProfileDirs: async () => {
+        sweepCalls.push("sweep");
+        return 0;
+      },
+    });
+    await pool.init();
+    await drainMicrotasks();
+
+    const initSweeps = sweepCalls.length; // 1 (init)
+    expect(initSweeps).toBe(1);
+
+    // Crash browser0 → crash recycle → relaunch → sweep.
+    launched[0]!.__crash();
+    await waitFor(() => sweepCalls.length >= initSweeps + 1);
+
+    // Drive a hygiene recycle on a surviving/relaunched browser: acquire+release
+    // once (recycleAfter=1) so the next idle release fires a hygiene recycle.
+    const ctx = await pool.acquire();
+    await pool.release(ctx);
+    await waitFor(() => sweepCalls.length >= initSweeps + 2);
+
+    // Each recycle (crash AND hygiene) fired its own sweep on top of init's.
+    // Without the recycle-cadence wiring sweepCalls would stay at initSweeps (RED).
+    expect(sweepCalls.length).toBeGreaterThanOrEqual(initSweeps + 2);
+
+    await pool.shutdown();
+  });
+
+  it("BOUNDED ACCUMULATION: across N recycle cycles the sweep keeps the orphan dir count from growing without bound", async () => {
+    // Model the production accumulation: each launch "creates" 2 orphan dirs in a
+    // simulated `/tmp`; Playwright's close-time cleanup is modeled as FAILING
+    // (the swallowed-failure case that causes the real leak), so WITHOUT a sweep
+    // the count grows by 2 per recycle forever. The injected sweep removes the
+    // age-gated stale entries on the recycle cadence, so the simulated `/tmp`
+    // stays BOUNDED across many cycles instead of growing monotonically.
+    // Model the simulated container `/tmp` as a map of dirName → owning launch
+    // seq. Each launch adds 2 dirs (profile + artifacts) tagged with its seq. A
+    // LIVE browser's dir is "in use"; when a browser is replaced (recycle) the
+    // OLD seq's dirs become orphans Playwright's best-effort cleanup left behind
+    // (the swallowed-failure leak). The age-gated sweep reclaims dirs whose seq
+    // is no longer live — i.e. exactly the orphans, never an in-use dir.
+    const fakeTmp = new Map<string, number>(); // dirName -> launchSeq
+    let launchSeq = 0;
+    const liveSeqs = new Set<number>(); // seqs whose browser is currently live
+
+    const customLauncher: LaunchBrowser = async () => {
+      const seq = launchSeq++;
+      fakeTmp.set(`playwright_chromiumdev_profile-${seq}`, seq);
+      fakeTmp.set(`playwright-artifacts-${seq}`, seq);
+      liveSeqs.add(seq);
+      const b = makeFakeBrowser();
+      // When this browser is closed (recycle teardown calls browser.close()),
+      // its seq stops being live — its dirs become orphans (NOT cleaned, modeling
+      // the real leak). The age gate is modeled by "only non-live seqs are stale".
+      const origClose = b.close.bind(b);
+      b.close = async () => {
+        liveSeqs.delete(seq);
+        await origClose();
+      };
+      return b as unknown as Browser;
+    };
+
+    // Age-gated sweep: removes ONLY dirs whose owning seq is no longer live (the
+    // orphans). An in-use (live) browser's dir is never removed — the age gate's
+    // real-world analogue (a live browser touches its dir, mtime ~now < cutoff).
+    const sweep = async (): Promise<number> => {
+      let removed = 0;
+      for (const [name, seq] of [...fakeTmp]) {
+        if (!liveSeqs.has(seq)) {
+          fakeTmp.delete(name);
+          removed++;
+        }
+      }
+      return removed;
+    };
+
+    const pool = new BrowserPool({
+      browsers: 2,
+      maxContexts: 8,
+      recycleAfter: 1000,
+      relaunchBackoffMs: 0,
+      launchBrowser: customLauncher,
+      launchStaggerMs: 0,
+      staleProfileDirTtlMs: 0,
+      sweepStaleProfileDirs: sweep,
+    });
+    await pool.init();
+    await drainMicrotasks();
+    // After init the 2 live browsers' dirs are present (4 entries); none are
+    // orphans yet, so the init sweep removed nothing.
+    expect(fakeTmp.size).toBe(4);
+
+    const poolBrowsers = poolInternals(pool).browsers as unknown as Array<{
+      browser: { __crash(): void };
+    }>;
+
+    // Drive MANY crash→recycle cycles. Each crash orphans the old browser's 2
+    // dirs and the relaunch adds 2 new live dirs; the recycle-cadence sweep
+    // reclaims the orphans. WITHOUT the sweep, fakeTmp would grow by 2 per cycle
+    // (unbounded → exhaustion → the production wedge). WITH it, it stays bounded
+    // at ~2 * browserCount (only the live browsers' dirs).
+    const CYCLES = 30;
+    for (let i = 0; i < CYCLES; i++) {
+      const launchSeqBefore = launchSeq;
+      poolBrowsers[0]!.browser.__crash();
+      await waitFor(
+        () =>
+          launchSeq > launchSeqBefore &&
+          poolInternals(pool).browsers.length === 2,
+      );
+    }
+    // The orphan-producing launch count grew linearly with CYCLES.
+    expect(launchSeq).toBeGreaterThanOrEqual(CYCLES + 2);
+    // Let the fire-and-forget cadence sweeps settle.
+    await waitFor(
+      () => liveSeqs.size === 2 && fakeTmp.size <= 2 * 2 + 2,
+      5_000,
+    );
+
+    // BOUNDED: `/tmp` holds only the live browsers' dirs (≤ 2*browsers) plus at
+    // most one in-flight cycle's slack — NOT 2 * (CYCLES + browsers). A no-sweep
+    // run would leave ~2 * (CYCLES + 2) = 64 entries here.
+    expect(fakeTmp.size).toBeLessThanOrEqual(2 * 2 + 2);
+
+    await pool.shutdown();
+  });
+
+  it("AGE GATE (real FS): defaultSweepStaleProfileDirs removes OLD orphans but NEVER a fresh in-use dir", async () => {
+    // The safety property the whole prevention rests on: the sweep must never
+    // delete a dir for a launch in flight / a live browser. Those are touched
+    // continuously (mtime ~now), so the age gate must skip them. Create a "fresh"
+    // dir (mtime now) and an "old" orphan (mtime far in the past) and assert the
+    // sweep removes ONLY the old one. Also assert a non-playwright dir is never
+    // touched (prefix gate).
+    const tag = `${process.pid}-${Date.now()}`;
+    const freshDir = join(
+      tmpdir(),
+      `playwright_chromiumdev_profile-fresh-${tag}`,
+    );
+    const oldDir = join(tmpdir(), `playwright-artifacts-old-${tag}`);
+    const unrelatedDir = join(tmpdir(), `not-playwright-${tag}`);
+    await fsp.mkdir(freshDir, { recursive: true });
+    await fsp.mkdir(oldDir, { recursive: true });
+    await fsp.mkdir(unrelatedDir, { recursive: true });
+    // Back-date the "old" orphan an hour so it is older than any sane TTL.
+    const oldTime = new Date(Date.now() - 3_600_000);
+    await fsp.utimes(oldDir, oldTime, oldTime);
+
+    try {
+      // TTL = 5 min: the fresh dir (mtime now) is YOUNGER than the TTL and must
+      // be skipped; the hour-old orphan is OLDER and must be removed.
+      const removed = await defaultSweepStaleProfileDirs(5 * 60_000);
+      expect(removed).toBeGreaterThanOrEqual(1);
+
+      const exists = async (p: string): Promise<boolean> =>
+        fsp
+          .stat(p)
+          .then(() => true)
+          .catch(() => false);
+
+      // The in-use (fresh) dir survives — the age gate protected it.
+      expect(await exists(freshDir)).toBe(true);
+      // The old orphan was reclaimed.
+      expect(await exists(oldDir)).toBe(false);
+      // A non-playwright dir is never touched (prefix gate).
+      expect(await exists(unrelatedDir)).toBe(true);
+    } finally {
+      await fsp.rm(freshDir, { recursive: true, force: true });
+      await fsp.rm(oldDir, { recursive: true, force: true });
+      await fsp.rm(unrelatedDir, { recursive: true, force: true });
+    }
   });
 });

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -1,3 +1,6 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Browser, BrowserContext } from "playwright";
 
 /**
@@ -63,6 +66,97 @@ const MAX_TRANSIENT_SERVE_RETRIES = 1;
  * waiters) or the pool shuts down.
  */
 const DEFAULT_SELF_HEAL_INTERVAL_MS = 2_000;
+
+/**
+ * PREVENTION (the durable root-cause fix for the RECURRING wedge — distinct from
+ * the after-the-fact circuit-breaker ESCAPE). The OUTAGE this PREVENTS, verified
+ * from the recurring staging collapse: the long-lived harness container runs a
+ * single Node process that launches chromium repeatedly under sustained d6 cron
+ * load (init fill, hygiene recycles, crash-recovery relaunches). EVERY
+ * `chromium.launch()` Playwright performs creates TWO ephemeral directories
+ * under the OS temp dir — a `playwright_chromium*dev_profile-*` userDataDir AND a
+ * `playwright-artifacts-*` dir. With `--disable-dev-shm-usage` (passed by the
+ * harness AND a Playwright default) chromium ALSO routes its shared-memory /
+ * cache I/O into that profile dir under `/tmp` instead of `/dev/shm`.
+ *
+ * Playwright removes those dirs in the child process's `close` handler, but the
+ * removal is BEST-EFFORT — `processLauncher` logs-and-swallows any `removeFolders`
+ * failure (ENOSPC, EBUSY, a hung close on a wedged chromium, or the Node process
+ * itself being signalled). Over HOURS the orphaned `playwright_*` dirs accumulate
+ * MONOTONICALLY in the container's `/tmp` until the filesystem exhausts
+ * inodes/space — at which point chromium can no longer create its profile dir
+ * and dies INSTANTLY on startup, so EVERY launch throws `browserType.launch:
+ * Target page, context or browser has been closed`. The set empties, self-heal
+ * relaunches into the SAME exhausted `/tmp`, and the pool wedges PERMANENTLY —
+ * only a container restart (which gives a fresh `/tmp`) clears it.
+ *
+ * The PREVENTION sweeps stale `${tmpdir()}/playwright_*` (and
+ * `playwright-artifacts-*`) dirs PROACTIVELY on a cadence — once at `init()` and
+ * on EVERY recycle relaunch — so `/tmp` never reaches exhaustion in the first
+ * place. The sweep is AGE-GATED (only dirs whose mtime is older than
+ * `staleProfileDirTtlMs`): a dir belonging to a launch in flight or a live
+ * browser is touched continuously and is far younger than the TTL, so the sweep
+ * can NEVER delete a dir still in use. This is orthogonal to the circuit-breaker
+ * (which purges UNCONDITIONALLY only AFTER the wedge has already taken the fleet
+ * down): the sweep stops the accumulation, the breaker escapes it if it ever
+ * still happens.
+ *
+ * Tunable on staging via env (BROWSER_POOL_STALE_PROFILE_DIR_TTL_MS) without a
+ * code change.
+ */
+const DEFAULT_STALE_PROFILE_DIR_TTL_MS = 5 * 60_000;
+
+/**
+ * Glob-free prefixes of the per-launch profile/artifact dirs Playwright's
+ * chromium leaves under the OS temp dir. The default chromium launcher pins no
+ * `userDataDir`, so every launch mkdtemp's a `playwright_*` profile dir and a
+ * `playwright-artifacts-*` dir; a long-lived container accumulates the orphans
+ * that escaped Playwright's best-effort close-time cleanup.
+ */
+const PLAYWRIGHT_TMP_PREFIXES = ["playwright_", "playwright-artifacts-"];
+
+/**
+ * Default proactive stale-profile-dir sweep used by the prevention path.
+ * Best-effort: removes every `${tmpdir()}/playwright_*` (and
+ * `playwright-artifacts-*`) directory whose mtime is older than `ttlMs` — i.e.
+ * dirs that no live browser / in-flight launch is still touching, so they are
+ * orphans from launches whose Playwright close-time cleanup failed. Returns the
+ * count removed. Injectable via `BrowserPoolOptions.sweepStaleProfileDirs` so
+ * tests drive the cadence without touching the real filesystem. A failure to
+ * read the temp dir, stat an entry, or unlink one is swallowed (the dir may not
+ * exist, be owned by another process, or vanish mid-sweep) — the sweep is
+ * hygiene, never a correctness dependency.
+ */
+export async function defaultSweepStaleProfileDirs(
+  ttlMs: number,
+): Promise<number> {
+  const dir = tmpdir();
+  const cutoff = Date.now() - ttlMs;
+  let removed = 0;
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return 0;
+  }
+  for (const name of entries) {
+    if (!PLAYWRIGHT_TMP_PREFIXES.some((p) => name.startsWith(p))) continue;
+    const full = join(dir, name);
+    try {
+      // AGE GATE: only sweep dirs older than the TTL. A dir for a launch in
+      // flight or a live browser is touched continuously (mtime ~now), so it is
+      // never older than the TTL and is never swept. Stat failure → skip (it may
+      // have vanished mid-sweep).
+      const stat = await fs.stat(full);
+      if (stat.mtimeMs > cutoff) continue;
+      await fs.rm(full, { recursive: true, force: true });
+      removed++;
+    } catch {
+      // best-effort: another process may own it, or it vanished mid-sweep.
+    }
+  }
+  return removed;
+}
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -152,6 +246,17 @@ interface PoolLogger {
 export type LaunchBrowser = () => Promise<Browser>;
 
 /**
+ * Proactively sweeps stale per-launch profile/artifact dirs Playwright's
+ * chromium leaves under the OS temp dir, returning the count removed. Given the
+ * age TTL so it removes ONLY dirs older than `ttlMs` (orphans no live browser /
+ * in-flight launch is still touching). The default removes
+ * `${tmpdir()}/playwright_*` older than the TTL. Tests inject a fake so the
+ * prevention cadence (init + each recycle relaunch) is exercisable without
+ * touching the real filesystem (and so the test can assert the sweep fired).
+ */
+export type SweepStaleProfileDirs = (ttlMs: number) => Promise<number>;
+
+/**
  * One long-lived browser PROCESS in the fixed set. Contexts are pooled over
  * this — the hot path (`acquire`/`release`) opens and closes CONTEXTS on an
  * already-running browser and never forks a process. A browser is only
@@ -230,6 +335,18 @@ export interface BrowserPoolOptions {
    *  emptied. Default 2000 (env BROWSER_POOL_SELF_HEAL_INTERVAL_MS). Tests pass
    *  a small value. */
   selfHealIntervalMs?: number;
+  /** Age (ms) a `${tmpdir()}/playwright_*` profile/artifact dir must EXCEED
+   *  before the proactive sweep removes it. The age gate guarantees the sweep
+   *  never deletes a dir for a launch in flight or a live browser (those are
+   *  touched continuously, so their mtime is ~now). Default 300000 (5 min; env
+   *  BROWSER_POOL_STALE_PROFILE_DIR_TTL_MS). Tests pass 0 to sweep every
+   *  matching dir deterministically. */
+  staleProfileDirTtlMs?: number;
+  /** Injected proactive stale-profile-dir sweep (tests). Defaults to removing
+   *  `${tmpdir()}/playwright_*` older than `staleProfileDirTtlMs`. Invoked once
+   *  at init() and on every recycle relaunch — the PREVENTION cadence that keeps
+   *  `/tmp` from accumulating to exhaustion. */
+  sweepStaleProfileDirs?: SweepStaleProfileDirs;
   /**
    * Mid-life capacity-loss alarm hook. Invoked when the browser set EMPTIES
    * (every entry evicted) — the silent-outage gap the original code had, where
@@ -283,6 +400,11 @@ export class BrowserPool {
   private readonly relaunchMaxRetries: number;
   private readonly relaunchBackoffMs: number;
   private readonly selfHealIntervalMs: number;
+  // PREVENTION: proactive stale-profile-dir sweep policy. The age TTL gates the
+  // sweep so it never removes a dir still in use; the sweep itself runs at init
+  // and on every recycle relaunch to keep `/tmp` from accumulating to exhaustion.
+  private readonly staleProfileDirTtlMs: number;
+  private readonly sweepStaleProfileDirs: SweepStaleProfileDirs;
   private readonly onDegraded?: () => void;
   private readonly onRecovered?: () => void;
   // True once the set has emptied and onDegraded fired; cleared when self-heal
@@ -390,8 +512,52 @@ export class BrowserPool {
       process.env.BROWSER_POOL_SELF_HEAL_INTERVAL_MS,
       DEFAULT_SELF_HEAL_INTERVAL_MS,
     );
+    this.staleProfileDirTtlMs = resolveNonNegative(
+      options.staleProfileDirTtlMs,
+      process.env.BROWSER_POOL_STALE_PROFILE_DIR_TTL_MS,
+      DEFAULT_STALE_PROFILE_DIR_TTL_MS,
+    );
+    // Sweep resolution mirrors the launcher resolution: an explicit injected
+    // sweep wins. Otherwise, when a fake `launchBrowser` is injected (tests — the
+    // browsers are fakes, so there are NO real `/tmp/playwright_*` dirs to
+    // scan/remove), default to a hermetic no-op so the prevention cadence never
+    // touches the real filesystem under test. Only the production path (real
+    // chromium launcher, no injected launcher) gets the real sweep.
+    this.sweepStaleProfileDirs =
+      options.sweepStaleProfileDirs ??
+      (this.injectedLaunchBrowser
+        ? async (): Promise<number> => 0
+        : defaultSweepStaleProfileDirs);
     this.onDegraded = options.onDegraded;
     this.onRecovered = options.onRecovered;
+  }
+
+  /**
+   * PREVENTION: fire the proactive stale-profile-dir sweep without awaiting it
+   * (fire-and-forget — the sweep is hygiene, never on the critical path of a
+   * launch). Routes a removed-count to the structured log and any unexpected
+   * throw to the logger. Called once at init() and on every recycle relaunch so
+   * orphaned `/tmp/playwright_*` dirs are reclaimed on a cadence — keeping the
+   * container's `/tmp` from accumulating to the exhaustion that wedges every
+   * future `chromium.launch()`.
+   */
+  private fireStaleProfileSweep(reason: "init" | "recycle"): void {
+    void this.sweepStaleProfileDirs(this.staleProfileDirTtlMs)
+      .then((removed) => {
+        if (removed > 0) {
+          this.logger?.info("browser-pool.stale-profile-sweep", {
+            reason,
+            removed,
+            ttlMs: this.staleProfileDirTtlMs,
+          });
+        }
+      })
+      .catch((err: unknown) => {
+        this.logger?.warn?.("browser-pool.stale-profile-sweep-failed", {
+          reason,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
   }
 
   async init(): Promise<void> {
@@ -406,6 +572,13 @@ export class BrowserPool {
           args: ["--no-sandbox", "--disable-dev-shm-usage"],
         });
     }
+
+    // PREVENTION: sweep any stale `/tmp/playwright_*` orphans BEFORE the init
+    // fill. A long-lived container that was redeployed in place (or whose prior
+    // process left orphans) starts with a `/tmp` that may already carry dirs
+    // whose owning processes are long gone; reclaiming them up front keeps the
+    // baseline low. Fire-and-forget — never block the init fill on hygiene.
+    this.fireStaleProfileSweep("init");
 
     try {
       for (let i = 0; i < this.browserCount; i++) {
@@ -1396,6 +1569,17 @@ export class BrowserPool {
       await this.closeBrowser(oldBrowser, browserIdx);
 
       if (this.isShutdown) return;
+
+      // PREVENTION: sweep stale `/tmp/playwright_*` orphans on the recycle
+      // cadence. Each recycle (crash recovery OR hygiene) is a chromium
+      // replacement — exactly the point in the long-lived container's life where
+      // orphaned profile/artifact dirs accumulate. Sweeping the AGE-GATED stale
+      // dirs here (after the old browser has been closed, before the fresh one
+      // launches) reclaims the orphans Playwright's best-effort close-time
+      // cleanup left behind, keeping `/tmp` bounded across hours of cron load so
+      // a future launch never hits the exhaustion that wedges the whole pool.
+      // Fire-and-forget — the relaunch never waits on hygiene.
+      this.fireStaleProfileSweep("recycle");
 
       try {
         // FIX #1 — PID-ceiling backpressure: retry the relaunch with backoff


### PR DESCRIPTION
## Root cause (the recurring BrowserPool wedge, ~4th occurrence)

The long-lived harness container runs a **single Node process** that launches chromium repeatedly under sustained d6 cron load — init fill, hygiene recycles, and crash-recovery relaunches. Every `chromium.launch()` Playwright performs `mkdtemp`s **two** ephemeral dirs under the OS temp dir:

- a `playwright_chromium*dev_profile-*` **userDataDir**, and
- a `playwright-artifacts-*` dir.

Because the harness passes `--disable-dev-shm-usage` (which is **also** a Playwright default), chromium routes its shared-memory / cache I/O into that profile dir under `/tmp` instead of `/dev/shm` — concentrating all per-browser pressure on `/tmp`.

Playwright removes those dirs in the child process's `close` handler, but the removal is **best-effort**: `processLauncher`'s `cleanup()` calls `removeFolders()` and **logs-and-swallows** any failure (ENOSPC, EBUSY, a hung close on a wedged chromium, or the Node process being signalled). Over **hours**, the orphaned `playwright_*` dirs accumulate **monotonically** in the container's `/tmp` until the filesystem exhausts inodes/space. At that point chromium can no longer create its profile dir and dies **instantly on startup**, so **every** `chromium.launch()` throws:

```
browserType.launch: Target page, context or browser has been closed
```

The browser set empties, `startSelfHeal()` relaunches into the **same exhausted `/tmp`**, and the pool wedges **permanently** — only a container restart (which gives a fresh `/tmp`) clears it. This matches the recurring staging signature exactly (every launch throws "Target page … has been closed"; `self-heal-launch-failed` repeating; only a restart recovers).

### Why this is the mechanism (evidence)

- **Code**: the production launcher pins no `userDataDir`, so Playwright `mkdtemp`s a fresh profile + artifacts dir **per launch**; cleanup is tied to the child `close` handler and `removeFolders` failures are swallowed.
- **Empirical**: confirmed locally that each `chromium.launch({args:["--no-sandbox","--disable-dev-shm-usage"]})` creates **2** `playwright*` temp dirs and that graceful `browser.close()` removes them — while a failed/swallowed cleanup leaves them orphaned.
- The other candidate mechanisms are already mitigated and have **different** error signatures: PID/thread exhaustion (`pthread_create: Resource temporarily unavailable`) is handled by the Dockerfile `ulimit -u` raise + launch-stagger + relaunch backoff; `/dev/shm` exhaustion is redirected by `--disable-dev-shm-usage`. Neither produces "Target page … has been closed" on every launch.

## Prevention (this PR — distinct from the circuit-breaker)

PR #5234 adds a circuit-breaker that **escapes** the wedge after the fact (purges `/tmp/playwright_*` only **after** N consecutive self-heal failures, once the fleet is already 0/N). This PR **stops the accumulation** so the wedge never happens:

- Proactively **sweep** stale `${tmpdir()}/playwright_*` (and `playwright-artifacts-*`) dirs on a **cadence** — once at `init()` and on **every recycle relaunch** (crash recovery **and** hygiene). Each recycle is a chromium replacement, exactly where orphans are produced.
- The sweep is **age-gated** (`staleProfileDirTtlMs`, default **5 min**): a dir for a launch in flight or a live browser is touched continuously (mtime ~now), so it is never older than the TTL and is **never** swept. The sweep therefore cannot delete a dir still in use.
- Fire-and-forget (never on a launch's critical path) and best-effort (failures logged, never fatal). Tunable via `BROWSER_POOL_STALE_PROFILE_DIR_TTL_MS` and an injectable `sweepStaleProfileDirs`.

Net effect: `/tmp` stays bounded at ~`2 * browserCount` live dirs instead of growing `2`-per-launch toward exhaustion.

## Red-green tests

- Sweep fires **once at init()** (carries the configured TTL).
- Sweep fires on **every recycle** (crash + hygiene).
- **Bounded accumulation**: across 30 recycle cycles `/tmp` stays bounded at ~`2 * browserCount` instead of growing `2`-per-cycle (a no-sweep run would leave ~64 entries).
- **Age gate (real FS)**: `defaultSweepStaleProfileDirs` removes an hour-old orphan but **never** a fresh (in-use) dir, and **never** a non-`playwright` dir.

All four **fail without the wiring** (proven by stashing the source change), pass with it.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `vitest run browser-pool.test.ts` — 52 passed (48 existing + 4 new)
- [x] Full harness suite — 1772 passed; the **only** failure is the known/unrelated `starter_smoke.yml "Unrecognized key: discovery"` in `probe-loader.test.ts` (not touched by this PR)
- [x] `prettier --check` — clean
- [ ] CI green

Does **not** touch PR #5234's files/branch; the two are complementary (prevention + escape).