### PR TITLE
fix(react-core): stabilize v2 agent ref and connect effect to prevent stream re-subscription during HITL

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -216,6 +216,13 @@ export function CopilotChat({
   const isConnecting =
     hasExplicitThreadId && lastConnectedThreadId !== resolvedThreadId;
 
+  // Track the last agent+thread combination we called connect() on. Without
+  // this, connect() fires on every render where the `agent` reference changes
+  // — including unrelated context re-renders during streaming. This mirrors
+  // the v1 pattern in useCopilotChatInternal (lastConnectedAgentRef).
+  const lastConnectedAgentRef = useRef<AbstractAgent | null>(null);
+  const lastConnectedThreadRef = useRef<string | null>(null);
+
   useEffect(() => {
     // Non-explicit threads skip /connect, but the first runAgent still has to
     // ship the same SDK-generated threadId that the chat UI is rendering.
@@ -227,6 +234,17 @@ export function CopilotChat({
     // always 404 — skip the call. A real thread is only created once the
     // user runs the agent for the first time.
     if (!hasExplicitThreadId) return;
+
+    // Skip redundant connect calls when the agent reference changes due to
+    // context re-renders but the logical identity (agentId + threadId) hasn't
+    // changed. This prevents mid-stream re-subscription cascades that cause
+    // TOOL_CALL_ARGS double-processing and JSON parse errors.
+    if (
+      agent === lastConnectedAgentRef.current &&
+      resolvedThreadId === lastConnectedThreadRef.current
+    ) {
+      return;
+    }
 
     let detached = false;
 
@@ -269,11 +287,16 @@ export function CopilotChat({
         }
       }
     };
+    lastConnectedAgentRef.current = agent;
+    lastConnectedThreadRef.current = resolvedThreadId;
     connect(agent);
     return () => {
       // Abort the HTTP request and detach the active run.
       // This is critical for React StrictMode which unmounts+remounts in dev,
       // preventing duplicate /connect requests from reaching the server.
+      // Reset the refs so remounts always trigger a fresh connect.
+      lastConnectedAgentRef.current = null;
+      lastConnectedThreadRef.current = null;
       detached = true;
       connectAbortController.abort();
       // The .catch() is required to prevent a false-positive "Uncaught (in promise)

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -73,11 +73,27 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
     new Map(),
   );
 
+  // Cache resolved (real) agents by ID to maintain reference stability.
+  // Without this, the `agent` useMemo returns a new reference every time
+  // `copilotkit.agents` changes identity — even when the resolved agent for
+  // this agentId is the same object. That cascades into the subscription
+  // useEffect below, causing unsubscribe/resubscribe mid-stream and
+  // double-processing of TOOL_CALL_ARGS events (which corrupts tool arguments
+  // via duplicate concatenation, e.g. '{}' + '{}' = '{}{}').
+  const resolvedAgentCache = useRef<Map<string, AbstractAgent>>(new Map());
+
   const agent: AbstractAgent = useMemo(() => {
     const existing = copilotkit.getAgent(agentId);
     if (existing) {
-      // Real agent found — clear any cached provisional for this ID
+      // Real agent found — clear any cached provisional for this ID.
       provisionalAgentCache.current.delete(agentId);
+      // Return cached reference if the resolved agent is the same instance,
+      // keeping downstream useEffect deps stable during streaming.
+      const cached = resolvedAgentCache.current.get(agentId);
+      if (cached === existing) {
+        return cached;
+      }
+      resolvedAgentCache.current.set(agentId, existing);
       return existing;
     }
 


### PR DESCRIPTION
## Problem

The v2 `CopilotChat` component re-subscribes to the AG-UI stream mid-flight when CopilotKit context changes during streaming. This causes `TOOL_CALL_ARGS` events to be processed twice, corrupting tool arguments and breaking the chat permanently after a Human-in-the-Loop confirmation.

### Symptoms

1. Chat re-renders entire message history during streaming after HITL confirmation (view jumps)
2. Multiple HITL confirmation cards appear for a single tool call
3. Chat breaks permanently after HITL confirmation — next message causes `SyntaxError: JSON.parse("{}{}")`

### Root Cause

In `packages/react-core/src/v2/hooks/use-agent.tsx`, the `agent` useMemo depends on `copilotkit.agents`, which changes identity when the CopilotKit context re-renders during streaming. This produces a new `agent` reference that cascades into:

1. The subscription useEffect (line ~160) tears down and re-subscribes while the AG-UI SSE stream is still running.
2. The AG-UI client pipeline accumulates `TOOL_CALL_ARGS` deltas via `+=`. Re-subscription replays events, turning `'{}'` into `'{}{}'`.
3. `parseToolArguments()` in `packages/core/src/core/run-handler.ts:1052` calls `JSON.parse("{}{}")` → SyntaxError.

The v1 path avoids this with a `lastConnectedAgentRef` ref guard in `use-copilot-chat_internal.ts:349`.

## Fix

### 1. Stabilize `agent` reference in `useAgent()`

Added a `resolvedAgentCache` ref. When `copilotkit.agents` changes identity but `getAgent(agentId)` returns the same object, the cached reference is returned — keeping the subscription useEffect stable.

### 2. Add ref guard to v2 `CopilotChat` connect effect

Added `lastConnectedAgentRef` and `lastConnectedThreadRef` (mirroring the v1 pattern) to skip redundant `connectAgent()` calls when the agent reference changes due to context re-renders but the logical agent+thread identity hasn't changed. Refs are reset on cleanup so StrictMode remounts and real thread switches still trigger fresh connects.

## Workaround (for users on current release)

Use v1's `CopilotChat` from `@copilotkit/react-ui` instead of v2. Import `useHumanInTheLoop` directly from `@copilotkit/react-core/v2` (the v1 re-export wrapper crashes with "not iterable").

## Additional note

The v1 `useHumanInTheLoop` wrapper at `packages/react-core/src/hooks/use-human-in-the-loop.ts:70` calls `getZodParameters(parameters)` expecting a `Parameter[]` array. If a v2-style Zod schema is passed, it throws `TypeError: not iterable`. This is a separate bug that forces users to import the v2 hook directly.