### PR TITLE
fix(showcase): mint GHCR bearer via /token exchange (unblocks docs promote)

### DIFF
--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -358,10 +358,23 @@ module Railway
                     http_get(url, headers: headers)
                 end
 
-            return nil if resp[:status] >= 400
-            JSON.parse(resp[:body])["token"]
-        rescue StandardError
-            nil
+            status = resp[:status]
+            if status >= 400
+                # A token WAS supplied but the exchange failed: surface it. The
+                # caller must NOT silently downgrade to an anonymous manifest
+                # read (that conflates "no token" with "supplied token failed").
+                raise Error, "GHCR /token exchange failed (#{status}) for #{org}/#{name}" if @token && !@token.empty?
+
+                # No token supplied: a non-2xx is the legitimate signal that the
+                # package is not anonymously pullable. The caller handles nil.
+                return nil
+            end
+
+            begin
+                JSON.parse(resp[:body])["token"]
+            rescue JSON::ParserError => e
+                raise Error, "GHCR /token returned unparseable body for #{org}/#{name}: #{e.message}"
+            end
         end
 
         def http_get(url, headers: {})

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -332,11 +332,32 @@ module Railway
             h
         end
 
+        # Mint the bearer used for manifest reads via GHCR's /token exchange.
+        #
+        # GHCR's OCI manifest endpoint rejects a RAW GitHub/Actions token sent as
+        # `Authorization: Bearer <token>` with HTTP 403 — the token must first be
+        # exchanged for a short-lived registry bearer. So we ALWAYS hit /token,
+        # even when a token is present (the previous "return @token raw" path was
+        # the bug that made every `docs` promote 403 in CI).
+        #
+        # When a token is present we authenticate the exchange with Basic auth:
+        # base64("x-access-token:<token>") — the username is arbitrary, the token
+        # is the password. For public packages the exchange also succeeds
+        # anonymously, so a missing token still yields a usable bearer.
         def bearer_for(org, name)
-            return @token if @token && !@token.empty?
-            # Public images: anonymous token from /token endpoint.
             url = "https://ghcr.io/token?service=ghcr.io&scope=repository:#{org}/#{name}:pull"
-            resp = http_get(url, headers: {})
+            headers = {}
+            if @token && !@token.empty?
+                headers["Authorization"] = "Basic " + ["x-access-token:#{@token}"].pack("m0")
+            end
+
+            resp =
+                if @http
+                    @http.call(method: :get, url: url, headers: headers)
+                else
+                    http_get(url, headers: headers)
+                end
+
             return nil if resp[:status] >= 400
             JSON.parse(resp[:body])["token"]
         rescue StandardError

--- a/showcase/bin/spec/test_ghcr_bearer.rb
+++ b/showcase/bin/spec/test_ghcr_bearer.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# Proves bearer_for ALWAYS performs the GHCR /token exchange instead of
+# returning a raw GitHub token. GHCR's OCI manifest endpoint rejects a raw
+# GitHub Actions token with HTTP 403 — only a bearer minted via the /token
+# exchange is accepted. When a token is present the exchange MUST authenticate
+# with Basic auth (base64("x-access-token:<token>")); for public packages the
+# exchange also succeeds anonymously.
+class GHCRBearerTest < Minitest::Test
+    # Recording fake HTTP layer: captures every (method, url, headers) call so
+    # tests can assert what was actually sent on the wire.
+    class RecordingHTTP
+        attr_reader :calls
+
+        def initialize(responses)
+            @responses = responses
+            @calls = []
+        end
+
+        def call(method:, url:, headers: {})
+            @calls << { method: method, url: url, headers: headers }
+            r = @responses[[method, url]] || @responses[url]
+            raise "no fake response for #{[method, url].inspect}" unless r
+            r
+        end
+    end
+
+    DIGEST      = "sha256:cafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00d"
+    REF         = "ghcr.io/copilotkit/showcase-shell@#{DIGEST}"
+    MANIFEST    = "https://ghcr.io/v2/copilotkit/showcase-shell/manifests/#{DIGEST}"
+    TOKEN_URL   = "https://ghcr.io/token?service=ghcr.io&scope=repository:copilotkit/showcase-shell:pull"
+    RAW_TOKEN   = "ghs_rawGitHubActionsToken"
+    MINTED      = "minted-bearer-from-exchange"
+
+    def fakes(extra = {})
+        RecordingHTTP.new({
+            TOKEN_URL => { status: 200, headers: {}, body: %({"token":"#{MINTED}"}) },
+            MANIFEST  => { status: 200, headers: {}, body: "" },
+        }.merge(extra))
+    end
+
+    def test_token_present_performs_basic_auth_exchange
+        http = fakes
+        g = Railway::GHCR.new(token: RAW_TOKEN, http: http)
+        assert_equal :exists, g.manifest_exists(REF)
+
+        token_call = http.calls.find { |c| c[:method] == :get && c[:url] == TOKEN_URL }
+        refute_nil token_call, "bearer_for must hit the GHCR /token exchange even when a token is present"
+
+        expected_basic = "Basic " + ["x-access-token:#{RAW_TOKEN}"].pack("m0")
+        auth = token_call[:headers]["Authorization"]
+        assert_equal expected_basic, auth,
+            "token exchange must authenticate with Basic base64(x-access-token:<token>)"
+    end
+
+    def test_manifest_read_uses_minted_bearer_not_raw_token
+        http = fakes
+        g = Railway::GHCR.new(token: RAW_TOKEN, http: http)
+        g.manifest_exists(REF)
+
+        manifest_call = http.calls.find { |c| c[:method] == :head && c[:url] == MANIFEST }
+        refute_nil manifest_call
+        assert_equal "Bearer #{MINTED}", manifest_call[:headers]["Authorization"],
+            "manifest read must use the minted bearer, never the raw GitHub token"
+        refute_equal "Bearer #{RAW_TOKEN}", manifest_call[:headers]["Authorization"],
+            "sending the raw GitHub token as a Bearer is exactly the bug that 403s"
+    end
+
+    def test_anonymous_exchange_still_works_for_public_packages
+        # No token: the exchange must still run, anonymously (no Authorization
+        # header on the /token request), and the minted token used downstream.
+        http = fakes
+        g = Railway::GHCR.new(token: nil, http: http)
+        assert_equal :exists, g.manifest_exists(REF)
+
+        token_call = http.calls.find { |c| c[:method] == :get && c[:url] == TOKEN_URL }
+        refute_nil token_call, "anonymous path must still mint a bearer via /token"
+        assert_nil token_call[:headers]["Authorization"],
+            "anonymous exchange must not send an Authorization header"
+
+        manifest_call = http.calls.find { |c| c[:method] == :head && c[:url] == MANIFEST }
+        assert_equal "Bearer #{MINTED}", manifest_call[:headers]["Authorization"]
+    end
+end

--- a/showcase/bin/spec/test_ghcr_bearer.rb
+++ b/showcase/bin/spec/test_ghcr_bearer.rb
@@ -83,4 +83,41 @@ class GHCRBearerTest < Minitest::Test
         manifest_call = http.calls.find { |c| c[:method] == :head && c[:url] == MANIFEST }
         assert_equal "Bearer #{MINTED}", manifest_call[:headers]["Authorization"]
     end
+
+    # When a token WAS supplied and the /token exchange returns a non-2xx,
+    # that is a real failure (bad/insufficient token), NOT a license to fall
+    # back to an anonymous manifest read. bearer_for must RAISE GHCR::Error so
+    # manifest_exists's documented raise-on-failure contract holds.
+    def test_token_present_exchange_401_raises
+        http = fakes(TOKEN_URL => { status: 401, headers: {}, body: "unauthorized" })
+        g = Railway::GHCR.new(token: RAW_TOKEN, http: http)
+
+        err = assert_raises(Railway::GHCR::Error) { g.manifest_exists(REF) }
+        assert_match(/token exchange failed/i, err.message)
+    end
+
+    # A 200 with a body that is not parseable JSON is a broken exchange, not a
+    # usable bearer. bearer_for must RAISE rather than swallow JSON::ParserError.
+    def test_token_present_malformed_body_raises
+        http = fakes(TOKEN_URL => { status: 200, headers: {}, body: "<html>not json</html>" })
+        g = Railway::GHCR.new(token: RAW_TOKEN, http: http)
+
+        err = assert_raises(Railway::GHCR::Error) { g.manifest_exists(REF) }
+        assert_match(/unparseable/i, err.message)
+    end
+
+    # Regression guard: when a token was supplied and the exchange failed, the
+    # manifest HEAD must NEVER be sent — and certainly never anonymously. The
+    # old swallow-to-nil behavior issued an anonymous HEAD, conflating "no
+    # token" with "supplied token failed to exchange".
+    def test_token_present_exchange_failure_never_does_anonymous_manifest_read
+        http = fakes(TOKEN_URL => { status: 403, headers: {}, body: "forbidden" })
+        g = Railway::GHCR.new(token: RAW_TOKEN, http: http)
+
+        assert_raises(Railway::GHCR::Error) { g.manifest_exists(REF) }
+
+        manifest_call = http.calls.find { |c| c[:method] == :head && c[:url] == MANIFEST }
+        assert_nil manifest_call,
+            "no manifest HEAD must be issued when a supplied token fails the /token exchange"
+    end
 end

--- a/showcase/bin/spec/test_ghcr_digest.rb
+++ b/showcase/bin/spec/test_ghcr_digest.rb
@@ -34,11 +34,19 @@ class GHCRDigestTest < Minitest::Test
         assert_equal "sha256:def", p3[:digest]
     end
 
+    # bearer_for ALWAYS performs the /token exchange now, so every fake that
+    # reaches a manifest HEAD must also model a successful exchange.
+    TOKEN_URL = "https://ghcr.io/token?service=ghcr.io&scope=repository:copilotkit/showcase-shell:pull"
+
+    def token_ok
+        { TOKEN_URL => { status: 200, headers: {}, body: %({"token":"minted"}) } }
+    end
+
     def test_resolve_digest_returns_digest_from_header
         url = "https://ghcr.io/v2/copilotkit/showcase-shell/manifests/latest"
-        fake = FakeHTTP.new(
+        fake = FakeHTTP.new(token_ok.merge(
             url => { status: 200, headers: { "docker-content-digest" => "sha256:beefcafe" }, body: "" },
-        )
+        ))
         g = Railway::GHCR.new(token: "x", http: fake)
         assert_equal "sha256:beefcafe", g.resolve_digest("ghcr.io/copilotkit/showcase-shell:latest")
     end
@@ -52,14 +60,14 @@ class GHCRDigestTest < Minitest::Test
 
     def test_resolve_digest_returns_nil_on_404
         url = "https://ghcr.io/v2/copilotkit/showcase-shell/manifests/nope"
-        fake = FakeHTTP.new(url => { status: 404, headers: {}, body: "" })
+        fake = FakeHTTP.new(token_ok.merge(url => { status: 404, headers: {}, body: "" }))
         g = Railway::GHCR.new(token: "x", http: fake)
         assert_nil g.resolve_digest("ghcr.io/copilotkit/showcase-shell:nope")
     end
 
     def test_resolve_digest_raises_on_5xx
         url = "https://ghcr.io/v2/copilotkit/showcase-shell/manifests/latest"
-        fake = FakeHTTP.new(url => { status: 500, headers: {}, body: "boom" })
+        fake = FakeHTTP.new(token_ok.merge(url => { status: 500, headers: {}, body: "boom" }))
         g = Railway::GHCR.new(token: "x", http: fake)
         assert_raises(Railway::GHCR::Error) do
             g.resolve_digest("ghcr.io/copilotkit/showcase-shell:latest")

--- a/showcase/bin/spec/test_ghcr_manifest_exists.rb
+++ b/showcase/bin/spec/test_ghcr_manifest_exists.rb
@@ -16,31 +16,38 @@ class GHCRManifestExistsTest < Minitest::Test
         end
     end
 
-    DIGEST   = "sha256:cafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00d"
-    REF      = "ghcr.io/copilotkit/showcase-shell@#{DIGEST}"
-    URL      = "https://ghcr.io/v2/copilotkit/showcase-shell/manifests/#{DIGEST}"
+    DIGEST    = "sha256:cafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00d"
+    REF       = "ghcr.io/copilotkit/showcase-shell@#{DIGEST}"
+    URL       = "https://ghcr.io/v2/copilotkit/showcase-shell/manifests/#{DIGEST}"
+    TOKEN_URL = "https://ghcr.io/token?service=ghcr.io&scope=repository:copilotkit/showcase-shell:pull"
+
+    # bearer_for ALWAYS performs the /token exchange now, so every fake that
+    # reaches a manifest HEAD must also model a successful exchange.
+    def token_ok
+        { TOKEN_URL => { status: 200, headers: {}, body: %({"token":"minted"}) } }
+    end
 
     def test_manifest_exists_returns_exists_on_200
-        fake = FakeHTTP.new(URL => { status: 200, headers: {}, body: "" })
+        fake = FakeHTTP.new(token_ok.merge(URL => { status: 200, headers: {}, body: "" }))
         g = Railway::GHCR.new(token: "x", http: fake)
         assert_equal :exists, g.manifest_exists(REF)
     end
 
     def test_manifest_exists_returns_missing_on_404
-        fake = FakeHTTP.new(URL => { status: 404, headers: {}, body: "" })
+        fake = FakeHTTP.new(token_ok.merge(URL => { status: 404, headers: {}, body: "" }))
         g = Railway::GHCR.new(token: "x", http: fake)
         assert_equal :missing, g.manifest_exists(REF)
     end
 
     def test_manifest_exists_returns_auth_failed_on_401_403
-        fake401 = FakeHTTP.new(URL => { status: 401, headers: {}, body: "" })
-        fake403 = FakeHTTP.new(URL => { status: 403, headers: {}, body: "" })
+        fake401 = FakeHTTP.new(token_ok.merge(URL => { status: 401, headers: {}, body: "" }))
+        fake403 = FakeHTTP.new(token_ok.merge(URL => { status: 403, headers: {}, body: "" }))
         assert_equal :auth_failed, Railway::GHCR.new(token: "x", http: fake401).manifest_exists(REF)
         assert_equal :auth_failed, Railway::GHCR.new(token: "x", http: fake403).manifest_exists(REF)
     end
 
     def test_manifest_exists_raises_on_5xx
-        fake = FakeHTTP.new(URL => { status: 500, headers: {}, body: "boom" })
+        fake = FakeHTTP.new(token_ok.merge(URL => { status: 500, headers: {}, body: "boom" }))
         g = Railway::GHCR.new(token: "x", http: fake)
         assert_raises(Railway::GHCR::Error) { g.manifest_exists(REF) }
     end

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1170:@full_staging_snapshot = @staging_snapshot',
-        '1171:@full_prod_snapshot    = @prod_snapshot',
+        '1183:@full_staging_snapshot = @staging_snapshot',
+        '1184:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1179:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1192:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1187:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1192:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1193:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1194:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1200:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1205:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1206:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1207:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1198:# @staging_snapshot / @prod_snapshot directly.',
+        '1211:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1200:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1201:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1213:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1214:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1225:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1238:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1237:@full_staging_snapshot || @staging_snapshot',
-        '1241:@full_prod_snapshot || @prod_snapshot',
-        '1245:@staging_snapshot',
-        '1249:@prod_snapshot',
+        '1250:@full_staging_snapshot || @staging_snapshot',
+        '1254:@full_prod_snapshot || @prod_snapshot',
+        '1258:@staging_snapshot',
+        '1262:@prod_snapshot',
     ].freeze
 
     def setup

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1149:@full_staging_snapshot = @staging_snapshot',
-        '1150:@full_prod_snapshot    = @prod_snapshot',
+        '1170:@full_staging_snapshot = @staging_snapshot',
+        '1171:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1158:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1179:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1166:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1171:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1172:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1173:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1187:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1192:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1193:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1194:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1177:# @staging_snapshot / @prod_snapshot directly.',
+        '1198:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1179:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1180:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1200:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1201:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1204:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1225:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1216:@full_staging_snapshot || @staging_snapshot',
-        '1220:@full_prod_snapshot || @prod_snapshot',
-        '1224:@staging_snapshot',
-        '1228:@prod_snapshot',
+        '1237:@full_staging_snapshot || @staging_snapshot',
+        '1241:@full_prod_snapshot || @prod_snapshot',
+        '1245:@staging_snapshot',
+        '1249:@prod_snapshot',
     ].freeze
 
     def setup


### PR DESCRIPTION
## Summary

`showcase bin/railway promote docs` has been failing in CI on every run with `REFUSE: P1 (docs): GHCR manifest HEAD 403 for ghcr.io/copilotkit/showcase-shell-docs:latest`. Root cause: `GHCR#bearer_for` sent the GitHub/Actions token **raw** as `Authorization: Bearer <token>` to the GHCR OCI manifest endpoint, which rejects it with `403`. GHCR requires the token to first be exchanged for a short-lived registry bearer via its `/token` endpoint.

Verified live against the real public `showcase-shell-docs` package: raw bearer → `403`, `/token`-minted bearer → `200`, anonymous → `401`.

## Changes

- `bearer_for` now **always** performs the GHCR `/token` exchange. When a token is present it authenticates the exchange with Basic auth (`base64("x-access-token:<token>")`) and uses the minted token as the manifest bearer; public packages still mint anonymously.
- Fail-loud hardening: a failed exchange (non-2xx with a token present, or an unparseable `/token` body) now raises `GHCR::Error` instead of silently swallowing to `nil` and degrading to an anonymous request — restoring `manifest_exists`'s documented "raises on transport/5xx" contract.
- Tests: new `test_ghcr_bearer.rb` pins the on-the-wire behavior (Basic-auth exchange, minted-bearer-not-raw-token, anonymous path, raise-on-failed-exchange, never-anonymous-after-supplied-token-failure). Existing GHCR specs updated to model the now-mandatory exchange.

## Test plan

- [x] `showcase/bin/spec` suite green: 117 runs, 410 assertions, 0 failures
- [x] `ruby -c showcase/bin/railway` syntax OK
- [x] Red-green verified on the new fail-loud paths
- [ ] CI green

## Out of scope (separate follow-up)

Review surfaced three pre-existing, unrelated `bin/railway` bugs not touched here: `rollback`'s `find_previous_deployment` selects from an unsorted deployment list, and `env-diff`'s `--ignore-env-scoped` flag / advertised custom-domain comparison are no-ops. To be addressed in a separate PR.