### PR TITLE
ci(showcase): notify #team-showcase on successful prod promotion

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -17,6 +17,7 @@ name: "Showcase: Promote (staging → prod)"
 #                                     target service(s). Feature-level probes,
 #                                     not naked 200.
 #   4. notify                       → Slack #oss-alerts on any red. Never #engr.
+#                                     success → #team-showcase.
 
 on:
   workflow_dispatch:
@@ -314,6 +315,7 @@ jobs:
       actions: read
     env:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+      SLACK_WEBHOOK_TS: ${{ secrets.SLACK_WEBHOOK_TEAM_SHOWCASE }}
     steps:
       # Best-effort promote invariant (do NOT reintroduce a PRE gate below):
       #   resolve-targets              = HARD precondition (must succeed).
@@ -382,6 +384,23 @@ jobs:
                 needs.verify-staging-precondition.result,
                 needs.promote.result,
                 needs.verify-prod.result,
+                github.server_url,
+                github.repository,
+                github.run_id
+              )) }}
+            }
+      - name: Post to #team-showcase
+        if: steps.state.outputs.state == 'success' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK_TS != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_TEAM_SHOWCASE }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ${{ toJSON(format(
+                '{0} *Showcase Promoted to Prod*\nServices: `{1}`\n<{2}/{3}/actions/runs/{4}|View run>',
+                steps.state.outputs.icon,
+                steps.state.outputs.csv,
                 github.server_url,
                 github.repository,
                 github.run_id

--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -412,3 +412,10 @@ jobs:
           CSV: ${{ steps.state.outputs.csv }}
         run: |
           echo "::warning::Showcase promote failed for '$CSV' but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."
+      - name: Log (no Slack — team-showcase webhook unset)
+        if: steps.state.outputs.state == 'success' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK_TS == ''
+        env:
+          CSV: ${{ steps.state.outputs.csv }}
+          ICON: ${{ steps.state.outputs.icon }}
+        run: |
+          echo "::notice::$ICON Showcase promoted to prod for '$CSV' but SLACK_WEBHOOK_TEAM_SHOWCASE is not set; no #team-showcase notification sent."


### PR DESCRIPTION
## Summary

Adds a Slack notification to **#team-showcase** whenever a showcase staging→prod promotion **succeeds**, matching our existing routing convention (releases → #engr, PRs/promote-failures → #oss-alerts). Today the promote workflow only posts to #oss-alerts on failure; the `success` state was computed but unused.

## Changes (all in the `notify` job of `showcase_promote.yml`)

- New **success-only** "Post to #team-showcase" step, gated on `state == 'success'`, mirroring the existing #oss-alerts step exactly (same pinned `slackapi/slack-github-action@b0fa283 # v2.1.0`, `incoming-webhook`, `toJSON(format(...))` payload).
- Job-level `SLACK_WEBHOOK_TS: ${{ secrets.SLACK_WEBHOOK_TEAM_SHOWCASE }}` so the step `if:` can gate on `env.SLACK_WEBHOOK_TS != ''` (step `if:` can't read `secrets.*` directly — same pattern as the existing `SLACK_WEBHOOK`).
- Symmetric "Log (no Slack — team-showcase webhook unset)" `::notice::` fallback, so a successful promote with the webhook unset still leaves a trace (mirrors the failure path's fallback).
- Failures still route **only** to #oss-alerts — unchanged.

## Activation (required before notifications fire)

The new step **no-ops until** an org secret `SLACK_WEBHOOK_TEAM_SHOWCASE` exists, so this is safe to merge now. To activate: create the `#team-showcase` Slack incoming webhook, then set it as a CopilotKit **org** secret (visibility=all), matching the convention for `SLACK_WEBHOOK_OSS_ALERTS` / `SLACK_WEBHOOK_ENGR`.

## Test plan

- [x] `actionlint` exit 0
- [x] YAML parses
- [x] Step is mutually exclusive with the webhook-unset log fallback (one fires per successful run)
- [ ] CI green
- [ ] After the org secret is set: a real promote posts to #team-showcase

## Out of scope (separate follow-up)

Review surfaced several pre-existing `notify`/`verify-prod` robustness items not touched here (verify-prod empty-CSV vacuous-green hardening, `npx tsx` working-dir in the verify jobs, env-vs-secrets webhook-reference fragility, literal `\n` rendering shared with the existing #oss-alerts step). To be addressed in a separate showcase-promote hardening PR.