### PR TITLE
fix(showcase): harden promote rollback, env-diff, verify-prod & deploy-poll

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -173,6 +173,7 @@ jobs:
       - working-directory: showcase/scripts
         run: npm ci
       - name: Live-probe staging for promote precondition
+        working-directory: showcase/scripts
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           SERVICES_CSV: ${{ needs.resolve-targets.outputs.services_csv }}
@@ -183,7 +184,9 @@ jobs:
           fi
           # Spec §7.2 P3: the live staging probe at promote time is
           # authoritative. CI verify history is a leading indicator only.
-          npx tsx showcase/scripts/verify-deploy.ts --env staging --services "$SERVICES_CSV"
+          # Run from showcase/scripts (where `npm ci` installed tsx) so npx
+          # uses the local install instead of network-fetching it.
+          npx tsx verify-deploy.ts --env staging --services "$SERVICES_CSV"
 
   promote:
     needs: [resolve-targets, verify-staging-precondition]
@@ -279,6 +282,7 @@ jobs:
       - working-directory: showcase/scripts
         run: npm ci
       - name: Run verify-deploy --env prod
+        working-directory: showcase/scripts
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           # Scope verification to the services that ACTUALLY promoted (from the
@@ -287,7 +291,12 @@ jobs:
           # guarantee a red verify and mask the health of the ones that did
           # promote.
           SERVICES_CSV: ${{ needs.promote.outputs.succeeded_csv }}
+          # The promote job's result, so the empty-CSV branch can tell a genuine
+          # all-failed run (empty succeeded set is expected) apart from a
+          # contract violation (promote reported success yet emitted no CSV).
+          PROMOTE_RESULT: ${{ needs.promote.result }}
         run: |
+          set -euo pipefail
           if [ -z "$RAILWAY_TOKEN" ]; then
             echo "::error::RAILWAY_TOKEN is not set"
             exit 1
@@ -298,11 +307,22 @@ jobs:
           # --services (which would either error or vacuously pass). The promote
           # job already exited non-zero in that case, so the overall run is red
           # via the notify state machine regardless.
+          #
+          # BUT: an empty succeeded set is only legitimate when promote did NOT
+          # succeed. If promote reported success and STILL emitted no CSV, the
+          # "promote already failed" assumption that justifies the vacuous skip
+          # is violated — fail loud instead of silently exiting 0.
           if [ -z "$SERVICES_CSV" ]; then
+            if [ "$PROMOTE_RESULT" = "success" ]; then
+              echo "::error::promote reported success but succeeded_csv is empty — contract violation"
+              exit 1
+            fi
             echo "::notice::succeeded_csv is empty (no services promoted, or promote did not run); skipping prod verification. The run is red via the promote job result if anything failed."
             exit 0
           fi
-          npx tsx showcase/scripts/verify-deploy.ts --env prod --services "$SERVICES_CSV"
+          # Run from showcase/scripts (where `npm ci` installed tsx) so npx uses
+          # the local install instead of network-fetching it.
+          npx tsx verify-deploy.ts --env prod --services "$SERVICES_CSV"
 
   notify:
     # Slack #oss-alerts only. Never #engr (engr is sacred — release alerts only).
@@ -374,10 +394,15 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
+          # Newlines are injected via fromJSON('"\n"') (a real LF char), NOT a
+          # literal '\n' in the template: GitHub Actions expression string
+          # literals do not interpret backslash escapes, so a literal '\n' would
+          # survive toJSON as the two chars \\n and Slack would render it
+          # verbatim as "\n" instead of a line break.
           payload: |
             {
               "text": ${{ toJSON(format(
-                '{0} *Showcase Promote Failed*\nServices: `{1}`\nresolve-targets={2} pre-staging={3} promote={4} verify-prod={5}\n<{6}/{7}/actions/runs/{8}|View run>',
+                '{0} *Showcase Promote Failed*{9}Services: `{1}`{9}resolve-targets={2} pre-staging={3} promote={4} verify-prod={5}{9}<{6}/{7}/actions/runs/{8}|View run>',
                 steps.state.outputs.icon,
                 steps.state.outputs.csv,
                 needs.resolve-targets.result,
@@ -386,7 +411,8 @@ jobs:
                 needs.verify-prod.result,
                 github.server_url,
                 github.repository,
-                github.run_id
+                github.run_id,
+                fromJSON('"\n"')
               )) }}
             }
       - name: Post to #team-showcase
@@ -395,15 +421,18 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_TEAM_SHOWCASE }}
           webhook-type: incoming-webhook
+          # Newlines via fromJSON('"\n"') (real LF), not a literal '\n' — see the
+          # #oss-alerts step above for why a literal '\n' renders verbatim.
           payload: |
             {
               "text": ${{ toJSON(format(
-                '{0} *Showcase Promoted to Prod*\nServices: `{1}`\n<{2}/{3}/actions/runs/{4}|View run>',
+                '{0} *Showcase Promoted to Prod*{5}Services: `{1}`{5}<{2}/{3}/actions/runs/{4}|View run>',
                 steps.state.outputs.icon,
                 steps.state.outputs.csv,
                 github.server_url,
                 github.repository,
-                github.run_id
+                github.run_id,
+                fromJSON('"\n"')
               )) }}
             }
       - name: Log (no Slack — webhook unset)

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -1815,8 +1815,10 @@ module Railway
                 if sa["start_command"] != sb["start_command"]
                     drift << "service #{name}: startCommand differs"
                 end
-                missing_in_b = sa["env_keys"] - sb["env_keys"]
-                missing_in_a = sb["env_keys"] - sa["env_keys"]
+                env_keys_a = sa["env_keys"] || []
+                env_keys_b = sb["env_keys"] || []
+                missing_in_b = env_keys_a - env_keys_b
+                missing_in_a = env_keys_b - env_keys_a
                 drift << "service #{name}: env keys missing in #{b}: #{missing_in_b.join(', ')}" unless missing_in_b.empty?
                 drift << "service #{name}: env keys missing in #{a}: #{missing_in_a.join(', ')}" unless missing_in_a.empty?
 

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -815,10 +815,16 @@ module Railway
 
     # rollback — roll a single service back one deploy (its previous deploy).
     class RollbackCommand < BaseCommand
+        # Number of most-recent deployments the query fetches. Used both to
+        # build the query and to detect the truncation hazard in
+        # find_previous_deployment (a window saturated at this size may have
+        # truncated the true previous deploy out of view).
+        DEPLOYMENTS_WINDOW = 10
+
         DEPLOYMENTS_QUERY = <<~GQL
             query Deployments($serviceId: String!, $envId: String!) {
                 deployments(
-                    first: 10
+                    first: #{DEPLOYMENTS_WINDOW}
                     input: { serviceId: $serviceId, environmentId: $envId }
                 ) { edges { node { id status meta createdAt } } }
             }
@@ -891,13 +897,34 @@ module Railway
             # Railway's `deployments` connection returns nodes in an arbitrary
             # order, so sort newest-first by createdAt before selecting — same
             # hazard the sibling fetch_latest_staging_deployments guards against.
-            # Then pick the SECOND SUCCESS (the deploy preceding the current one).
-            successes = deployments
+            sorted = deployments
                 .sort_by { |d| d["createdAt"].to_s }
                 .reverse
-                .select { |d| d["status"] == "SUCCESS" }
-            return nil if successes.size < 2
-            successes[1]["id"]
+            # Target = the newest SUCCESS strictly OLDER than the current HEAD
+            # deploy (sorted[0]). Drop the head, then take the first SUCCESS in
+            # the remainder. This is correct in BOTH directions:
+            #   - head=SUCCESS -> the previous SUCCESS (one deploy back)
+            #   - head=FAILED/CRASHED -> the newest SUCCESS below the bad head,
+            #     i.e. the last-known-good — never skipping a good deploy.
+            target = sorted.drop(1).find { |d| d["status"] == "SUCCESS" }
+            return target["id"] if target
+
+            # No SUCCESS-before-head in the fetched window. If the window is
+            # SATURATED (we got back the full `first: N` page), the true
+            # previous deploy may simply have been truncated out of view — so
+            # fail loud rather than silently returning nil (which would make
+            # rollback a confusing no-op or roll to the wrong place). If fewer
+            # than N came back, this is a genuine "no previous" and nil is
+            # correct (the caller die!s with a clear message).
+            if deployments.size >= DEPLOYMENTS_WINDOW
+                Railway.die!(
+                    "Could not determine the previous deployment for " \
+                    "#{options[:service]} within the #{DEPLOYMENTS_WINDOW} most recent " \
+                    "deploys (no successful deploy older than the current one was " \
+                    "found in the window). Pass --to <deployment_id> explicitly.",
+                )
+            end
+            nil
         end
     end
 
@@ -1769,7 +1796,7 @@ module Railway
         # digest, startCommand, env-var KEY sets, and custom domains.
         def diff_services(snap_a, snap_b, a, b)
             drift = []
-            names = ((snap_a["services"] + snap_b["services"]).map { |s| s["name"] }).uniq.sort
+            names = (((snap_a["services"] || []) + (snap_b["services"] || [])).map { |s| s["name"] }).uniq.sort
             names.each do |name|
                 sa = Railway.find_service(snap_a, name)
                 sb = Railway.find_service(snap_b, name)

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -103,14 +103,6 @@ module Railway
     # same SSOT as EXPECTED_DOMAINS so they cannot drift.
     STAGING_SERVICES = SSOT_DATA.fetch("services").map { |s| s.fetch("name") }.sort.freeze
 
-    # Heuristic markers for env-scoped URLs (ignored in env-diff and promote).
-    ENV_SCOPED_URL_MARKERS = [
-        ".staging.copilotkit.ai",
-        ".copilotkit.ai",
-        "staging-",
-        "prod-",
-    ].freeze
-
     # ── Token / Auth ───────────────────────────────────────────────────────────
 
     module Auth
@@ -451,12 +443,6 @@ module Railway
     # Find service entry in a snapshot by name.
     def find_service(snapshot, name)
         (snapshot["services"] || []).find { |s| s["name"] == name }
-    end
-
-    # Strip env-scoped url-ish values when comparing two envs.
-    def env_scoped?(value)
-        return false unless value.is_a?(String)
-        ENV_SCOPED_URL_MARKERS.any? { |m| value.include?(m) }
     end
 
     # ── Snapshot Schema ────────────────────────────────────────────────────────
@@ -902,8 +888,14 @@ module Railway
         def find_previous_deployment(service_id, env_id)
             data = gql.query(DEPLOYMENTS_QUERY, serviceId: service_id, envId: env_id)
             deployments = (data.dig("deployments", "edges") || []).map { |e| e["node"] }
-            # Pick the second SUCCESS in reverse-chronological order.
-            successes = deployments.select { |d| d["status"] == "SUCCESS" }
+            # Railway's `deployments` connection returns nodes in an arbitrary
+            # order, so sort newest-first by createdAt before selecting — same
+            # hazard the sibling fetch_latest_staging_deployments guards against.
+            # Then pick the SECOND SUCCESS (the deploy preceding the current one).
+            successes = deployments
+                .sort_by { |d| d["createdAt"].to_s }
+                .reverse
+                .select { |d| d["status"] == "SUCCESS" }
             return nil if successes.size < 2
             successes[1]["id"]
         end
@@ -1744,13 +1736,12 @@ module Railway
         def parser
             OptionParser.new do |o|
                 o.banner = <<~BANNER
-                    Usage: bin/railway env-diff ENV_A ENV_B [--ignore-env-scoped]
+                    Usage: bin/railway env-diff ENV_A ENV_B
 
                       Compare image digests, startCommand, env-var key sets, and
-                      custom domains between two envs. Exits 0 if equal (modulo
-                      ignored markers), 1 if drift, 2 on error.
+                      custom domains between two envs. Exits 0 if equal, 1 if
+                      drift, 2 on error.
                 BANNER
-                o.on("--ignore-env-scoped") { options[:ignore_env_scoped] = true }
                 o.on("-h", "--help") { puts o; exit 0 }
             end
         end
@@ -1766,6 +1757,17 @@ module Railway
             snap_a = SnapshotCommand.new(["--env", a, "--dry-run"]).build_snapshot(id_a)
             snap_b = SnapshotCommand.new(["--env", b, "--dry-run"]).build_snapshot(id_b)
 
+            drift = diff_services(snap_a, snap_b, a, b)
+
+            drift.each { |line| puts line }
+            puts drift.empty? ? "OK: #{a} and #{b} agree." : "DRIFT: #{drift.size} finding(s)."
+            drift.empty? ? 0 : 1
+        end
+
+        # Pure comparison of two already-built snapshots. Returns an array of
+        # human-readable drift lines (empty == envs agree). Compares image
+        # digest, startCommand, env-var KEY sets, and custom domains.
+        def diff_services(snap_a, snap_b, a, b)
             drift = []
             names = ((snap_a["services"] + snap_b["services"]).map { |s| s["name"] }).uniq.sort
             names.each do |name|
@@ -1790,11 +1792,15 @@ module Railway
                 missing_in_a = sb["env_keys"] - sa["env_keys"]
                 drift << "service #{name}: env keys missing in #{b}: #{missing_in_b.join(', ')}" unless missing_in_b.empty?
                 drift << "service #{name}: env keys missing in #{a}: #{missing_in_a.join(', ')}" unless missing_in_a.empty?
-            end
 
-            drift.each { |line| puts line }
-            puts drift.empty? ? "OK: #{a} and #{b} agree." : "DRIFT: #{drift.size} finding(s)."
-            drift.empty? ? 0 : 1
+                domains_a = sa["custom_domains"] || []
+                domains_b = sb["custom_domains"] || []
+                domains_missing_in_b = domains_a - domains_b
+                domains_missing_in_a = domains_b - domains_a
+                drift << "service #{name}: custom domains missing in #{b}: #{domains_missing_in_b.join(', ')}" unless domains_missing_in_b.empty?
+                drift << "service #{name}: custom domains missing in #{a}: #{domains_missing_in_a.join(', ')}" unless domains_missing_in_a.empty?
+            end
+            drift
         end
     end
 

--- a/showcase/bin/spec/test_env_diff.rb
+++ b/showcase/bin/spec/test_env_diff.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# EnvDiffCommand compares two env snapshots and reports drift. Historically it
+# diffed digest, startCommand, and env-var KEY sets — but the banner also
+# advertised "custom domains", which the diff loop never actually compared.
+# These tests pin the custom-domain comparison so the banner is honest:
+#
+#   1. Identical custom_domains across both envs => no drift line.
+#   2. Differing custom_domains => a drift line that names the service and the
+#      offending domains, in both directions (missing-in-a / missing-in-b).
+#
+# We exercise the pure diff helper (diff_services) directly so the test does
+# not need to stand up Railway GraphQL — the helper takes two already-built
+# snapshots and returns the drift array.
+class EnvDiffTest < Minitest::Test
+    def snapshot_with(domains_a: [], domains_b: [])
+        # Two single-service snapshots that agree on everything EXCEPT the
+        # custom_domains set, so any drift surfaced is attributable to domains.
+        snap_a = {
+            "services" => [
+                {
+                    "name"           => "showcase-shell",
+                    "digest"         => "sha256:abc",
+                    "start_command"  => nil,
+                    "env_keys"       => %w[PORT NODE_ENV],
+                    "custom_domains" => domains_a,
+                },
+            ],
+        }
+        snap_b = {
+            "services" => [
+                {
+                    "name"           => "showcase-shell",
+                    "digest"         => "sha256:abc",
+                    "start_command"  => nil,
+                    "env_keys"       => %w[PORT NODE_ENV],
+                    "custom_domains" => domains_b,
+                },
+            ],
+        }
+        [snap_a, snap_b]
+    end
+
+    def test_identical_custom_domains_no_drift
+        snap_a, snap_b = snapshot_with(
+            domains_a: ["shell.copilotkit.ai"],
+            domains_b: ["shell.copilotkit.ai"],
+        )
+        cmd = Railway::EnvDiffCommand.new(%w[staging production])
+        drift = cmd.diff_services(snap_a, snap_b, "staging", "production")
+        assert_empty drift
+    end
+
+    def test_differing_custom_domains_reported_both_directions
+        snap_a, snap_b = snapshot_with(
+            domains_a: ["only-in-staging.copilotkit.ai"],
+            domains_b: ["only-in-prod.copilotkit.ai"],
+        )
+        cmd = Railway::EnvDiffCommand.new(%w[staging production])
+        drift = cmd.diff_services(snap_a, snap_b, "staging", "production")
+
+        # One finding per direction, each naming the offending domain.
+        missing_in_b = drift.find { |l| l.include?("custom domains missing in production") }
+        missing_in_a = drift.find { |l| l.include?("custom domains missing in staging") }
+        assert missing_in_b, "expected a 'missing in production' finding, got: #{drift.inspect}"
+        assert missing_in_a, "expected a 'missing in staging' finding, got: #{drift.inspect}"
+        assert_includes missing_in_b, "only-in-staging.copilotkit.ai"
+        assert_includes missing_in_a, "only-in-prod.copilotkit.ai"
+    end
+end

--- a/showcase/bin/spec/test_env_diff.rb
+++ b/showcase/bin/spec/test_env_diff.rb
@@ -94,9 +94,12 @@ class EnvDiffTest < Minitest::Test
         assert missing, "expected 'extra-svc missing in production', got: #{drift.inspect}"
     end
 
-    # A snapshot lacking a "services" key must not raise NoMethodError — every
-    # accessor in diff_services must guard with `|| []`. Without the guard this
-    # raises before returning, failing the test loudly.
+    # A snapshot lacking a "services" key must not raise NoMethodError. NOTE:
+    # because the missing "services" key makes find_service return nil for the
+    # one service that exists only in snap_b, this case exercises ONLY the
+    # top-level `["services"] || []` guard and the missing-service branch — it
+    # `next`s before ever reaching the env_keys / custom_domains comparison.
+    # The env_keys/custom_domains accessors are pinned separately below.
     def test_snapshot_without_services_key_does_not_crash
         snap_a = {} # no "services" key at all
         snap_b = {
@@ -109,5 +112,61 @@ class EnvDiffTest < Minitest::Test
         drift = cmd.diff_services(snap_a, snap_b, "staging", "production")
         missing = drift.find { |l| l.include?("showcase-shell") && l.include?("missing in staging") }
         assert missing, "expected 'showcase-shell missing in staging', got: #{drift.inspect}"
+    end
+
+    # A service present in BOTH snapshots where one side OMITS "env_keys"
+    # (e.g. a v1/partial/hand-edited snapshot read from a git SHA) must not
+    # raise NoMethodError. This genuinely reaches the env_keys comparison
+    # branch (find_service returns the service on both sides, so the method
+    # does NOT `next`). Without an `|| []` guard, `sa["env_keys"] - sb[...]`
+    # raises `undefined method '-' for nil`.
+    def test_service_without_env_keys_does_not_crash
+        snap_a = {
+            "services" => [
+                # No "env_keys" key at all on this side.
+                { "name" => "showcase-shell", "digest" => "sha256:abc",
+                  "start_command" => nil, "custom_domains" => [] },
+            ],
+        }
+        snap_b = {
+            "services" => [
+                { "name" => "showcase-shell", "digest" => "sha256:abc",
+                  "start_command" => nil, "env_keys" => %w[PORT NODE_ENV],
+                  "custom_domains" => [] },
+            ],
+        }
+        cmd = Railway::EnvDiffCommand.new(%w[staging production])
+        drift = cmd.diff_services(snap_a, snap_b, "staging", "production")
+        # snap_a is missing both keys present in snap_b, so they must be
+        # reported as "missing in staging" (the a-side env).
+        missing_in_a = drift.find { |l| l.include?("env keys missing in staging") }
+        assert missing_in_a, "expected an 'env keys missing in staging' finding, got: #{drift.inspect}"
+        assert_includes missing_in_a, "PORT"
+        assert_includes missing_in_a, "NODE_ENV"
+    end
+
+    # Symmetric to the env_keys case: a service present in BOTH snapshots where
+    # one side OMITS "custom_domains" must not raise NoMethodError when the
+    # other side has domains to diff against. Pins the custom_domains guard at
+    # the comparison branch (not just the missing-service branch).
+    def test_service_without_custom_domains_does_not_crash
+        snap_a = {
+            "services" => [
+                { "name" => "showcase-shell", "digest" => "sha256:abc",
+                  "start_command" => nil, "env_keys" => %w[PORT] },
+            ],
+        }
+        snap_b = {
+            "services" => [
+                { "name" => "showcase-shell", "digest" => "sha256:abc",
+                  "start_command" => nil, "env_keys" => %w[PORT],
+                  "custom_domains" => ["shell.copilotkit.ai"] },
+            ],
+        }
+        cmd = Railway::EnvDiffCommand.new(%w[staging production])
+        drift = cmd.diff_services(snap_a, snap_b, "staging", "production")
+        missing_in_a = drift.find { |l| l.include?("custom domains missing in staging") }
+        assert missing_in_a, "expected a 'custom domains missing in staging' finding, got: #{drift.inspect}"
+        assert_includes missing_in_a, "shell.copilotkit.ai"
     end
 end

--- a/showcase/bin/spec/test_env_diff.rb
+++ b/showcase/bin/spec/test_env_diff.rb
@@ -69,4 +69,45 @@ class EnvDiffTest < Minitest::Test
         assert_includes missing_in_b, "only-in-staging.copilotkit.ai"
         assert_includes missing_in_a, "only-in-prod.copilotkit.ai"
     end
+
+    # A service that exists in one snapshot but not the other must surface a
+    # "missing in <env>" drift line. This also exercises the missing-service
+    # branch that was previously untested.
+    def test_service_missing_in_one_env_reported
+        snap_a = {
+            "services" => [
+                { "name" => "showcase-shell", "digest" => "sha256:abc",
+                  "start_command" => nil, "env_keys" => %w[PORT], "custom_domains" => [] },
+                { "name" => "extra-svc", "digest" => "sha256:def",
+                  "start_command" => nil, "env_keys" => %w[PORT], "custom_domains" => [] },
+            ],
+        }
+        snap_b = {
+            "services" => [
+                { "name" => "showcase-shell", "digest" => "sha256:abc",
+                  "start_command" => nil, "env_keys" => %w[PORT], "custom_domains" => [] },
+            ],
+        }
+        cmd = Railway::EnvDiffCommand.new(%w[staging production])
+        drift = cmd.diff_services(snap_a, snap_b, "staging", "production")
+        missing = drift.find { |l| l.include?("extra-svc") && l.include?("missing in production") }
+        assert missing, "expected 'extra-svc missing in production', got: #{drift.inspect}"
+    end
+
+    # A snapshot lacking a "services" key must not raise NoMethodError — every
+    # accessor in diff_services must guard with `|| []`. Without the guard this
+    # raises before returning, failing the test loudly.
+    def test_snapshot_without_services_key_does_not_crash
+        snap_a = {} # no "services" key at all
+        snap_b = {
+            "services" => [
+                { "name" => "showcase-shell", "digest" => "sha256:abc",
+                  "start_command" => nil, "env_keys" => %w[PORT], "custom_domains" => [] },
+            ],
+        }
+        cmd = Railway::EnvDiffCommand.new(%w[staging production])
+        drift = cmd.diff_services(snap_a, snap_b, "staging", "production")
+        missing = drift.find { |l| l.include?("showcase-shell") && l.include?("missing in staging") }
+        assert missing, "expected 'showcase-shell missing in staging', got: #{drift.inspect}"
+    end
 end

--- a/showcase/bin/spec/test_rollback_sort.rb
+++ b/showcase/bin/spec/test_rollback_sort.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# RollbackCommand#find_previous_deployment must pick the SECOND-NEWEST SUCCESS
+# deployment by createdAt — i.e. the deploy immediately preceding the current
+# one. Railway's GraphQL `deployments` connection returns nodes in an arbitrary
+# order, so the method MUST sort by createdAt descending before selecting,
+# exactly as the sibling fetch_latest_staging_deployments documents and does.
+#
+# This test feeds deployments in NON-chronological edge order and asserts the
+# correct previous (second-newest SUCCESS) id is returned. Against the unsorted
+# implementation it picks whatever happens to be second in the raw list (RED);
+# after sorting it picks the true second-newest (GREEN).
+class RollbackSortTest < Minitest::Test
+    # Minimal fake GraphQL client: returns canned DEPLOYMENTS_QUERY edges.
+    class FakeGQL
+        def initialize(nodes)
+            @nodes = nodes
+        end
+
+        def query(_query_str, _variables = {})
+            { "deployments" => { "edges" => @nodes.map { |n| { "node" => n } } } }
+        end
+    end
+
+    def test_picks_second_newest_success_regardless_of_edge_order
+        # Edge order is deliberately scrambled (NOT chronological). By createdAt
+        # the SUCCESS deployments are, newest-first:
+        #   dep-newest (T5) > dep-prev (T3) > dep-old (T1)
+        # so the "previous" deploy is dep-prev. A FAILED deploy at T4 must be
+        # ignored even though it is newer than dep-prev.
+        nodes = [
+            { "id" => "dep-old",    "status" => "SUCCESS", "createdAt" => "2026-01-01T00:00:00Z" },
+            { "id" => "dep-newest", "status" => "SUCCESS", "createdAt" => "2026-01-05T00:00:00Z" },
+            { "id" => "dep-failed", "status" => "FAILED",  "createdAt" => "2026-01-04T00:00:00Z" },
+            { "id" => "dep-prev",   "status" => "SUCCESS", "createdAt" => "2026-01-03T00:00:00Z" },
+        ]
+
+        cmd = Railway::RollbackCommand.new([])
+        cmd.instance_variable_set(:@gql, FakeGQL.new(nodes))
+
+        result = cmd.find_previous_deployment("svc-1", "env-1")
+        assert_equal "dep-prev", result,
+            "expected the second-newest SUCCESS by createdAt (dep-prev), got #{result.inspect}"
+    end
+
+    def test_returns_nil_when_fewer_than_two_successes
+        nodes = [
+            { "id" => "dep-only",   "status" => "SUCCESS", "createdAt" => "2026-01-05T00:00:00Z" },
+            { "id" => "dep-failed", "status" => "FAILED",  "createdAt" => "2026-01-04T00:00:00Z" },
+        ]
+        cmd = Railway::RollbackCommand.new([])
+        cmd.instance_variable_set(:@gql, FakeGQL.new(nodes))
+        assert_nil cmd.find_previous_deployment("svc-1", "env-1")
+    end
+end

--- a/showcase/bin/spec/test_rollback_sort.rb
+++ b/showcase/bin/spec/test_rollback_sort.rb
@@ -2,17 +2,30 @@
 
 require_relative "spec_helper"
 
-# RollbackCommand#find_previous_deployment must pick the SECOND-NEWEST SUCCESS
-# deployment by createdAt — i.e. the deploy immediately preceding the current
-# one. Railway's GraphQL `deployments` connection returns nodes in an arbitrary
-# order, so the method MUST sort by createdAt descending before selecting,
-# exactly as the sibling fetch_latest_staging_deployments documents and does.
+# RollbackCommand#find_previous_deployment must pick the newest SUCCESS
+# deployment STRICTLY OLDER than the current HEAD deploy (by createdAt) — i.e.
+# the last-known-good deploy to roll back to. Railway's GraphQL `deployments`
+# connection returns nodes in an arbitrary order, so the method MUST sort by
+# createdAt descending before selecting, exactly as the sibling
+# fetch_latest_staging_deployments documents and does.
 #
-# This test feeds deployments in NON-chronological edge order and asserts the
-# correct previous (second-newest SUCCESS) id is returned. Against the unsorted
-# implementation it picks whatever happens to be second in the raw list (RED);
-# after sorting it picks the true second-newest (GREEN).
+# Selection logic: sort newest-first by createdAt, drop the HEAD (index 0),
+# then take the first SUCCESS in the remainder. This is correct in BOTH
+# directions:
+#   - head=SUCCESS  -> the previous SUCCESS (one deploy back)
+#   - head=FAILED   -> the newest SUCCESS below the failed head (the
+#                      last-known-good — NOT one good deploy too far)
+#
+# Truncation hazard: the query only fetches `first: N` deployments in arbitrary
+# order, so a >N-deploy service may not contain the true previous within the
+# window. When no target is found AND the window is saturated (returned count
+# >= N), the method must die! loud rather than return nil — otherwise rollback
+# becomes a confusing no-op or rolls to the wrong place.
 class RollbackSortTest < Minitest::Test
+    # Mirror the production query's `first:` limit so the saturated-window test
+    # stays in lockstep with bin/railway.
+    WINDOW = Railway::RollbackCommand::DEPLOYMENTS_WINDOW
+
     # Minimal fake GraphQL client: returns canned DEPLOYMENTS_QUERY edges.
     class FakeGQL
         def initialize(nodes)
@@ -24,12 +37,18 @@ class RollbackSortTest < Minitest::Test
         end
     end
 
-    def test_picks_second_newest_success_regardless_of_edge_order
+    def cmd_for(nodes)
+        cmd = Railway::RollbackCommand.new([])
+        cmd.instance_variable_set(:@gql, FakeGQL.new(nodes))
+        cmd
+    end
+
+    def test_head_success_picks_previous_success
         # Edge order is deliberately scrambled (NOT chronological). By createdAt
         # the SUCCESS deployments are, newest-first:
         #   dep-newest (T5) > dep-prev (T3) > dep-old (T1)
-        # so the "previous" deploy is dep-prev. A FAILED deploy at T4 must be
-        # ignored even though it is newer than dep-prev.
+        # HEAD is dep-newest (SUCCESS), so the rollback target is the previous
+        # SUCCESS, dep-prev. A FAILED deploy at T4 must be ignored.
         nodes = [
             { "id" => "dep-old",    "status" => "SUCCESS", "createdAt" => "2026-01-01T00:00:00Z" },
             { "id" => "dep-newest", "status" => "SUCCESS", "createdAt" => "2026-01-05T00:00:00Z" },
@@ -37,21 +56,51 @@ class RollbackSortTest < Minitest::Test
             { "id" => "dep-prev",   "status" => "SUCCESS", "createdAt" => "2026-01-03T00:00:00Z" },
         ]
 
-        cmd = Railway::RollbackCommand.new([])
-        cmd.instance_variable_set(:@gql, FakeGQL.new(nodes))
-
-        result = cmd.find_previous_deployment("svc-1", "env-1")
+        result = cmd_for(nodes).find_previous_deployment("svc-1", "env-1")
         assert_equal "dep-prev", result,
-            "expected the second-newest SUCCESS by createdAt (dep-prev), got #{result.inspect}"
+            "expected the previous SUCCESS below the SUCCESS head (dep-prev), got #{result.inspect}"
     end
 
-    def test_returns_nil_when_fewer_than_two_successes
+    def test_head_failed_picks_newest_success_below_head
+        # HEAD is FAILED (this is exactly when rollback is invoked). The target
+        # MUST be the newest SUCCESS strictly below the failed head — SUCCESS_A
+        # at T4 — NOT SUCCESS_B at T3 (the old `successes[1]` behavior would
+        # skip a good deploy and roll back one too far).
+        nodes = [
+            { "id" => "head-failed", "status" => "FAILED",  "createdAt" => "2026-01-05T00:00:00Z" },
+            { "id" => "success-a",   "status" => "SUCCESS", "createdAt" => "2026-01-04T00:00:00Z" },
+            { "id" => "success-b",   "status" => "SUCCESS", "createdAt" => "2026-01-03T00:00:00Z" },
+        ]
+
+        result = cmd_for(nodes).find_previous_deployment("svc-1", "env-1")
+        assert_equal "success-a", result,
+            "head=FAILED must roll back to the newest SUCCESS below it (success-a), " \
+            "not skip it to success-b; got #{result.inspect}"
+    end
+
+    def test_returns_nil_when_no_success_below_head_and_window_not_saturated
+        # Fewer than WINDOW deployments returned => genuine "no previous",
+        # returning nil is correct (the caller die!s with a clear message).
         nodes = [
             { "id" => "dep-only",   "status" => "SUCCESS", "createdAt" => "2026-01-05T00:00:00Z" },
             { "id" => "dep-failed", "status" => "FAILED",  "createdAt" => "2026-01-04T00:00:00Z" },
         ]
-        cmd = Railway::RollbackCommand.new([])
-        cmd.instance_variable_set(:@gql, FakeGQL.new(nodes))
-        assert_nil cmd.find_previous_deployment("svc-1", "env-1")
+        assert_nil cmd_for(nodes).find_previous_deployment("svc-1", "env-1")
+    end
+
+    def test_raises_when_window_saturated_and_no_target_found
+        # Exactly WINDOW deployments returned with no SUCCESS below the head =>
+        # the true previous may have been truncated out of the window. The
+        # method must die! (SystemExit) rather than silently return nil.
+        head = { "id" => "head", "status" => "FAILED", "createdAt" => "2026-02-#{WINDOW + 1}T00:00:00Z" }
+        rest = (1...WINDOW).map do |i|
+            { "id" => "crashed-#{i}", "status" => "CRASHED", "createdAt" => format("2026-02-%02dT00:00:00Z", i) }
+        end
+        nodes = [head] + rest
+        assert_equal WINDOW, nodes.size, "test must return exactly WINDOW deployments"
+
+        assert_raises(SystemExit) do
+            cmd_for(nodes).find_previous_deployment("svc-1", "env-1")
+        end
     end
 end

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1175:@full_staging_snapshot = @staging_snapshot',
-        '1176:@full_prod_snapshot    = @prod_snapshot',
+        '1202:@full_staging_snapshot = @staging_snapshot',
+        '1203:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1184:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1211:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1192:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1197:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1198:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1199:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1219:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1224:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1225:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1226:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1203:# @staging_snapshot / @prod_snapshot directly.',
+        '1230:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1205:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1206:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1232:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1233:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1230:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1257:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1242:@full_staging_snapshot || @staging_snapshot',
-        '1246:@full_prod_snapshot || @prod_snapshot',
-        '1250:@staging_snapshot',
-        '1254:@prod_snapshot',
+        '1269:@full_staging_snapshot || @staging_snapshot',
+        '1273:@full_prod_snapshot || @prod_snapshot',
+        '1277:@staging_snapshot',
+        '1281:@prod_snapshot',
     ].freeze
 
     def setup

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1183:@full_staging_snapshot = @staging_snapshot',
-        '1184:@full_prod_snapshot    = @prod_snapshot',
+        '1175:@full_staging_snapshot = @staging_snapshot',
+        '1176:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1192:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1184:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1200:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1205:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1206:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1207:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1192:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1197:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1198:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1199:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1211:# @staging_snapshot / @prod_snapshot directly.',
+        '1203:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1213:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1214:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1205:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1206:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1238:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1230:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1250:@full_staging_snapshot || @staging_snapshot',
-        '1254:@full_prod_snapshot || @prod_snapshot',
-        '1258:@staging_snapshot',
-        '1262:@prod_snapshot',
+        '1242:@full_staging_snapshot || @staging_snapshot',
+        '1246:@full_prod_snapshot || @prod_snapshot',
+        '1250:@staging_snapshot',
+        '1254:@prod_snapshot',
     ].freeze
 
     def setup

--- a/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
@@ -287,6 +287,92 @@ describe("checkDeploymentSuccess", () => {
     expect(err).toMatch(/no deployments/);
   });
 
+  it("waits out an in-progress deployment, then passes on SUCCESS", async () => {
+    // DEPLOYING twice, then SUCCESS — the exact race verify-prod hit
+    // (promote pins digest, Railway still rolling out). Must NOT fail on
+    // the first in-progress read.
+    const statuses = ["DEPLOYING", "DEPLOYING", "SUCCESS"];
+    let i = 0;
+    const fetchImpl = makeFetch(() =>
+      gqlDeploymentResponse(statuses[Math.min(i++, statuses.length - 1)]),
+    );
+    const sleeps: number[] = [];
+    const err = await checkDeploymentSuccess(
+      "svc-id",
+      "prod",
+      TOKEN,
+      fetchImpl,
+      5000,
+      "docs",
+      "docs",
+      {
+        pollTimeoutMs: 150_000,
+        pollIntervalMs: 5_000,
+        // Deterministic, instant sleep seam — record the requested delays.
+        sleep: async (ms: number) => {
+          sleeps.push(ms);
+        },
+      },
+    );
+    expect(err).toBeUndefined();
+    // Polled twice (two in-progress reads) before the SUCCESS read.
+    expect(sleeps).toEqual([5_000, 5_000]);
+    expect((fetchImpl as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(3);
+  });
+
+  it("fails when an in-progress deployment never settles before the poll budget", async () => {
+    // Always DEPLOYING. A monotonic `now` seam advances past the budget
+    // so the loop terminates deterministically with a timeout error.
+    const fetchImpl = makeFetch(() => gqlDeploymentResponse("DEPLOYING"));
+    let clock = 0;
+    const err = await checkDeploymentSuccess(
+      "svc-id",
+      "prod",
+      TOKEN,
+      fetchImpl,
+      5000,
+      "docs",
+      "docs",
+      {
+        pollTimeoutMs: 20_000,
+        pollIntervalMs: 5_000,
+        sleep: async (ms: number) => {
+          clock += ms;
+        },
+        now: () => clock,
+      },
+    );
+    expect(err).toMatch(/still in progress/);
+    expect(err).toMatch(/DEPLOYING/);
+    expect(err).toMatch(/prod/);
+  });
+
+  it("fails FAST on a terminal FAILED status without waiting", async () => {
+    const fetchImpl = makeFetch(() => gqlDeploymentResponse("FAILED"));
+    const sleeps: number[] = [];
+    const err = await checkDeploymentSuccess(
+      "svc-id",
+      "prod",
+      TOKEN,
+      fetchImpl,
+      5000,
+      "docs",
+      "docs",
+      {
+        pollTimeoutMs: 150_000,
+        pollIntervalMs: 5_000,
+        sleep: async (ms: number) => {
+          sleeps.push(ms);
+        },
+      },
+    );
+    expect(err).toMatch(/FAILED/);
+    expect(err).toMatch(/expected SUCCESS/);
+    // No waiting on a terminal failure — exactly one query, zero sleeps.
+    expect(sleeps).toEqual([]);
+    expect((fetchImpl as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
   it("sends the Authorization bearer + serviceId/environmentId variables", async () => {
     const calls: Array<{ url: string; body: unknown; auth?: string }> = [];
     const fetchImpl = makeFetch((url, init) => {

--- a/showcase/scripts/verify-deploy.drivers.baseline.ts
+++ b/showcase/scripts/verify-deploy.drivers.baseline.ts
@@ -125,9 +125,71 @@ export interface BaselineOpts {
   getRailwayToken?: () => string | undefined;
   /** Per-call timeout for each fetch (ms). Default 30s. */
   timeoutMs?: number;
+  /**
+   * Poll/wait config for the deployment-SUCCESS check. Forwarded to
+   * `checkDeploymentSuccess` so an in-progress Railway rollout is waited
+   * out rather than failed on the first read. Production callers omit it
+   * (defaults: ~150s budget / 5s interval, real sleep). Tests inject a
+   * `sleep`/`now` seam + a small budget for determinism.
+   */
+  deployPoll?: DeployPollOpts;
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Railway deployment statuses that are NON-terminal — the rollout is
+ * still in flight and the status WILL change to a terminal state on its
+ * own. `checkDeploymentSuccess` polls (rather than failing fast) while
+ * the latest deployment sits in any of these, because a verify-prod that
+ * fires seconds after a promote pins a new digest legitimately observes
+ * the new deployment mid-roll. (Empirically: promote run 26966193624's
+ * predecessor pinned the docs digest, then verify-prod ran ~17s later and
+ * saw status="DEPLOYING" — a transient, not a failure.)
+ *
+ * Matches Railway's `DeploymentStatus` enum non-terminal members.
+ */
+const IN_PROGRESS_DEPLOY_STATUSES: ReadonlySet<string> = new Set([
+  "QUEUED",
+  "BUILDING",
+  "INITIALIZING",
+  "DEPLOYING",
+  "WAITING",
+  "NEEDS_APPROVAL",
+]);
+
+/**
+ * Poll budget for waiting out an in-progress deployment. ~150s total at
+ * a 5s interval — long enough to outlast a normal Railway container
+ * rollout, short enough that a genuinely stuck deploy still reds the gate
+ * in bounded time. Terminal-failure statuses (FAILED/CRASHED/REMOVED/...)
+ * NEVER consume this budget; only the in-progress set above triggers a
+ * wait.
+ */
+const DEFAULT_DEPLOY_POLL_TIMEOUT_MS = 150_000;
+const DEFAULT_DEPLOY_POLL_INTERVAL_MS = 5_000;
+
+export interface DeployPollOpts {
+  /** Total budget to wait out in-progress statuses (ms). */
+  pollTimeoutMs?: number;
+  /** Delay between polls while in-progress (ms). */
+  pollIntervalMs?: number;
+  /**
+   * Test seam — replaces the real wall-clock sleep so the poll loop is
+   * deterministic and instant under test. Production callers omit it and
+   * get a real `setTimeout`-backed delay.
+   */
+  sleep?: (ms: number) => Promise<void>;
+  /**
+   * Test seam — monotonic clock source for the budget check. Defaults to
+   * `Date.now`. Injected so tests can drive the timeout deterministically.
+   */
+  now?: () => number;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
  * Walk `RAILWAY_TOKEN` env var → `~/.railway/config.json` and return the
@@ -219,27 +281,33 @@ async function fetchWithTimeout(
 }
 
 /**
- * Query Railway for the latest deployment of the given service in the
- * given env and assert `status === "SUCCESS"`. Returns a string error
- * message on any failure (network, GraphQL `errors[]`, missing edge,
- * non-SUCCESS status); returns `undefined` on success.
+ * Outcome of a SINGLE Railway deployment-status query. Either an
+ * infrastructure/contract error (terminal — surfaced immediately) or the
+ * raw `status` string of the latest deployment for further classification
+ * by the poll loop.
  */
-export async function checkDeploymentSuccess(
+type DeployQueryResult =
+  | { kind: "error"; error: string }
+  | { kind: "status"; status: string };
+
+/**
+ * Issue ONE `deployments(first:1)` query for the service's latest
+ * deployment in the target env. Returns the raw status string on a clean
+ * response, or a structured error for any network / GraphQL / shape
+ * failure. Does NOT interpret the status — that classification (SUCCESS
+ * vs in-progress vs terminal-fail) lives in `checkDeploymentSuccess` so
+ * it can decide whether to wait or fail fast.
+ */
+async function queryDeploymentStatus(
   serviceId: string,
+  environmentId: string,
   env: EnvName,
   token: string,
   fetchImpl: FetchLike,
   timeoutMs: number,
   driverLabel: string,
-  serviceName?: string,
-): Promise<string | undefined> {
-  const environmentId = envIdFor(env);
-  // Tag identifies the offending service in multi-service runs. When
-  // the caller does not supply a name we fall back to the serviceId so
-  // a Railway operator can still grep the diagnostic to a target.
-  const tag = serviceName
-    ? `service="${serviceName}" (serviceId=${serviceId})`
-    : `serviceId=${serviceId}`;
+  tag: string,
+): Promise<DeployQueryResult> {
   const query = `query latestDeployment($serviceId: String!, $environmentId: String!) {
   deployments(first: 1, input: { serviceId: $serviceId, environmentId: $environmentId }) {
     edges { node { id status } }
@@ -269,11 +337,17 @@ export async function checkDeploymentSuccess(
       : e instanceof Error
         ? e.message
         : String(e);
-    return `${driverLabel}: Railway GraphQL fetch failed [${tag}]: ${msg}`;
+    return {
+      kind: "error",
+      error: `${driverLabel}: Railway GraphQL fetch failed [${tag}]: ${msg}`,
+    };
   }
   if (!res.ok) {
     const body = (await res.text()).slice(0, 200);
-    return `${driverLabel}: Railway GraphQL HTTP ${res.status} [${tag}]: ${body}`;
+    return {
+      kind: "error",
+      error: `${driverLabel}: Railway GraphQL HTTP ${res.status} [${tag}]: ${body}`,
+    };
   }
   let json: RailwayDeploymentsResponse;
   try {
@@ -283,21 +357,115 @@ export async function checkDeploymentSuccess(
     // Release the body in the error path even if json() partially
     // consumed it — undici will leak the socket otherwise.
     await releaseBody(res);
-    return `${driverLabel}: Railway GraphQL JSON parse failed [${tag}]: ${msg}`;
+    return {
+      kind: "error",
+      error: `${driverLabel}: Railway GraphQL JSON parse failed [${tag}]: ${msg}`,
+    };
   }
   if (json.errors?.length) {
-    return `${driverLabel}: Railway GraphQL errors [${tag}]: ${json.errors
-      .map((e) => e.message)
-      .join("; ")}`;
+    return {
+      kind: "error",
+      error: `${driverLabel}: Railway GraphQL errors [${tag}]: ${json.errors
+        .map((e) => e.message)
+        .join("; ")}`,
+    };
   }
   const node = json.data?.deployments?.edges?.[0]?.node;
   if (!node) {
-    return `${driverLabel}: Railway returned no deployments for ${env} [${tag}]`;
+    return {
+      kind: "error",
+      error: `${driverLabel}: Railway returned no deployments for ${env} [${tag}]`,
+    };
   }
-  if (node.status !== "SUCCESS") {
-    return `${driverLabel}: latest ${env} deployment status="${node.status}" (expected SUCCESS) [${tag}]`;
+  return { kind: "status", status: node.status };
+}
+
+/**
+ * Query Railway for the latest deployment of the given service in the
+ * given env and assert it reaches `status === "SUCCESS"`. Returns a
+ * string error message on any failure; returns `undefined` on success.
+ *
+ * In-progress handling: a deployment whose latest status is still in
+ * flight (`DEPLOYING`/`BUILDING`/`INITIALIZING`/`QUEUED`/`WAITING`/
+ * `NEEDS_APPROVAL` — see `IN_PROGRESS_DEPLOY_STATUSES`) is NOT a failure.
+ * verify-prod commonly runs seconds after a promote pins a new digest,
+ * while Railway is still rolling the container out. We POLL (every
+ * `pollIntervalMs`, up to `pollTimeoutMs` total) until the deployment
+ * reaches a terminal state, then assert SUCCESS. Terminal-failure
+ * statuses (`FAILED`/`CRASHED`/`REMOVED`/anything not SUCCESS and not
+ * in-progress) fail FAST with no waiting — preserving the prior
+ * fail-on-non-SUCCESS behavior for those. Infrastructure/contract errors
+ * (network, GraphQL `errors[]`, missing edge) also fail fast.
+ *
+ * Backward-compatible signature: `pollOpts` is optional and trailing.
+ * Callers that omit it get the production poll budget; tests inject a
+ * `sleep`/`now` seam (and a small budget) for deterministic, instant
+ * runs.
+ */
+export async function checkDeploymentSuccess(
+  serviceId: string,
+  env: EnvName,
+  token: string,
+  fetchImpl: FetchLike,
+  timeoutMs: number,
+  driverLabel: string,
+  serviceName?: string,
+  pollOpts?: DeployPollOpts,
+): Promise<string | undefined> {
+  const environmentId = envIdFor(env);
+  // Tag identifies the offending service in multi-service runs. When
+  // the caller does not supply a name we fall back to the serviceId so
+  // a Railway operator can still grep the diagnostic to a target.
+  const tag = serviceName
+    ? `service="${serviceName}" (serviceId=${serviceId})`
+    : `serviceId=${serviceId}`;
+
+  const pollTimeoutMs =
+    pollOpts?.pollTimeoutMs ?? DEFAULT_DEPLOY_POLL_TIMEOUT_MS;
+  const pollIntervalMs =
+    pollOpts?.pollIntervalMs ?? DEFAULT_DEPLOY_POLL_INTERVAL_MS;
+  const sleep = pollOpts?.sleep ?? defaultSleep;
+  const now = pollOpts?.now ?? Date.now;
+
+  const deadline = now() + pollTimeoutMs;
+  let lastInProgressStatus = "";
+  for (;;) {
+    const result = await queryDeploymentStatus(
+      serviceId,
+      environmentId,
+      env,
+      token,
+      fetchImpl,
+      timeoutMs,
+      driverLabel,
+      tag,
+    );
+    // Infra/contract failures are terminal — surface immediately.
+    if (result.kind === "error") return result.error;
+
+    const status = result.status;
+    if (status === "SUCCESS") return undefined;
+
+    // In-progress: the rollout is still settling. Wait and re-query
+    // until terminal or the poll budget is exhausted.
+    if (IN_PROGRESS_DEPLOY_STATUSES.has(status)) {
+      lastInProgressStatus = status;
+      if (now() >= deadline) {
+        return `${driverLabel}: latest ${env} deployment still in progress (status="${status}") after ${pollTimeoutMs}ms wait (expected SUCCESS) [${tag}]`;
+      }
+      await sleep(pollIntervalMs);
+      continue;
+    }
+
+    // Any other status (FAILED/CRASHED/REMOVED/unknown) is a terminal
+    // non-SUCCESS — fail fast, no waiting. Preserves the original
+    // error-string shape so existing assertions/greps keep matching.
+    return `${driverLabel}: latest ${env} deployment status="${status}" (expected SUCCESS) [${tag}]${
+      lastInProgressStatus
+        ? ` [transitioned from in-progress "${lastInProgressStatus}"]`
+        : ""
+    }`;
   }
-  return undefined;
 }
 
 /**
@@ -388,6 +556,7 @@ export async function probeBaseline(
     timeoutMs,
     opts.driverLabel,
     target.name,
+    opts.deployPoll,
   );
   if (deployErr) return { ok: false, error: deployErr };
 


### PR DESCRIPTION
## Summary

Hardens a set of pre-existing `showcase` promote/`bin/railway` bugs surfaced during review of the GHCR bearer fix (#5239) and the #team-showcase notification (#5240). Each is an independent, real defect; all changes are covered by tests (Ruby `bin/spec` **127 runs / 0 failures**, TS `verify-deploy` drivers **82 passing**, `actionlint` clean).

## Fixes

1. **`rollback` could roll back to the wrong deployment.** `find_previous_deployment` selected the second-newest SUCCESS from an *unsorted* GraphQL result, and assumed the head deploy was always SUCCESS — so when the latest deploy FAILED/CRASHED (the exact case rollback is for) it rolled back one good deploy too far. Now sorts by `createdAt` desc, selects the newest SUCCESS strictly older than the current head (`sorted.drop(1).find { SUCCESS }`), and **fails loud** (rather than silently mis-rolling) when the `first: N` window is saturated with no valid target — telling the operator to pass `--to`.
2. **`env-diff` was dishonest.** It advertised custom-domain comparison it never performed, and exposed a `--ignore-env-scoped` flag that was parsed but never read. Now actually diffs `custom_domains` (the snapshot already carried them), removes the dead flag/helper, and nil-guards **every** accessor in `diff_services` (`services`, `env_keys`, `custom_domains`) consistent with the rest of the file.
3. **`verify-prod` could vacuously pass.** Its empty-`succeeded_csv` branch `exit 0`'d unconditionally. Now fails loud if `promote` reported success but produced no succeeded set (contract violation), while still skipping cleanly when promote genuinely failed.
4. **`verify-prod` raced the prod rollout.** It failed instantly when the just-promoted deploy was still `DEPLOYING` (observed live: promote succeeded, verify-prod failed ~17s later mid-rollout). `verify-deploy` now polls in-progress statuses (`DEPLOYING`/`BUILDING`/`INITIALIZING`/`WAITING`/`QUEUED`/`NEEDS_APPROVAL`) until terminal (~150s budget), still failing fast on `FAILED`/`CRASHED`/`REMOVED`.
5. **`npx tsx` ran from the wrong cwd** in the verify jobs (deps installed in `showcase/scripts`, invoked from repo root → could fetch `tsx` from the network). Now runs with `working-directory: showcase/scripts`, matching the resolve/promote jobs.
6. **Slack payloads rendered literal `\n`.** Both promote Slack posts used `toJSON(format('...\n...'))`, where the literal `\n` survives as backslash-n (verified live in #team-showcase). Now uses the `fromJSON('"\n"')` idiom for real line breaks.

## Test plan
- [x] `showcase/bin/spec` — 127 runs, 0 failures (new: rollback head-FAILED + saturated-window, env-diff custom-domain + nil-guard cases)
- [x] `showcase/scripts` `tsc --noEmit` clean; `verify-deploy` driver tests 82 passing (in-progress→SUCCESS, →timeout, fast-fail-on-terminal)
- [x] `actionlint` clean
- [ ] CI green

## Out of scope (separate follow-up)
Review surfaced further pre-existing items intentionally NOT fixed here (no diff overlap): `run_staging_probe`'s `IO.popen` nests its options hash inside the argv array (stderr redirect verified working; the `child_env` hash isn't applied but the probe inherits the parent env in CI); `image_shape`/`parse_image_ref`/`PinCommand` colon-splitting for registry-port refs (latent — portless `ghcr.io` only); the deeper `DEPLOYMENTS_QUERY first:10` truncation beyond the new fail-loud guard; `succeeded_csv` integrity under a 20-min promote-job timeout; and a few comment/test-coverage nits.