### PR TITLE
fix(showcase/pocketbase): make image bootable on existing staging volume + add CI build path

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -52,6 +52,7 @@ on:
           - shell-docs
           - showcase-harness
           - showcase-aimock
+          - showcase-pocketbase
           - webhooks
           # Per-starter image builds (model B, §b stage 1). These map to the
           # build-starters job below, NOT the showcase `build` job. "all"
@@ -175,6 +176,13 @@ jobs:
               - 'showcase/integrations/*/manifest.yaml'
             showcase_aimock:
               - 'showcase/aimock/**'
+            pocketbase:
+              # PB image is self-contained: PB binary + pb_migrations +
+              # pb_hooks + Dockerfile. No shared-module copy, so the slot
+              # is gated purely to its own subtree — it does NOT rebuild
+              # on every showcase push, only when migrations/hooks/Dockerfile
+              # change.
+              - 'showcase/pocketbase/**'
             webhooks:
               # Sentinel pattern that cannot match any in-tree path.
               # The webhooks GHCR image is built by the showcase-eval-webhook
@@ -228,6 +236,7 @@ jobs:
             {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"__GH_SHA__","build_args_branch":"__GH_REF_NAME__","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
             {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/harness/Dockerfile","health_path":"/health"},
             {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","timeout":5,"lfs":false,"build_args":"","dockerfile":"showcase/aimock/Dockerfile","health_path":"/health"},
+            {"dispatch_name":"showcase-pocketbase","filter_key":"pocketbase","context":"showcase/pocketbase","image":"showcase-pocketbase","railway_id":"ba11e854-d695-4738-9a45-2b0776788824","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/pocketbase/Dockerfile","health_path":"/api/health"},
             {"dispatch_name":"webhooks","filter_key":"webhooks","context":".","image":"showcase-eval-webhook","railway_id":"ba6acc13-7585-41fe-a5ee-585b34a58fcd","timeout":5,"lfs":false,"build_args":"","dockerfile":"","health_path":"/health","skip_build":true}
           ]'
 

--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -47,7 +47,6 @@ on:
           - ms-agent-dotnet
           - ms-agent-harness-dotnet
           - ms-agent-python
-          - pocketbase
           - pydantic-ai
           - shell
           - shell-dashboard
@@ -55,6 +54,7 @@ on:
           - shell-dojo
           - showcase-aimock
           - showcase-harness
+          - showcase-pocketbase
           - spring-ai
           - strands
           - webhooks

--- a/showcase/pocketbase/pb_hooks/main.pb.js
+++ b/showcase/pocketbase/pb_hooks/main.pb.js
@@ -24,66 +24,80 @@
 // additively. An operator can add staging / preview origins without a
 // code change; removing the prod default still requires editing this
 // file (env var cannot retire it).
+//
+// ─────────────────────────────────────────────────────────────────────
+// TWO PB-0.22 JSVM CONSTRAINTS THIS FILE OBEYS (both verified by booting
+// the built image against a real PB 0.22.21 binary — see the PR notes):
+//
+// 1. Registration hook. `onBeforeServe(...)` is NOT a global JSVM function
+//    in 0.22.x — only `$app.onBeforeServe()` exists (a Go method returning
+//    a Hook). Calling the bare `onBeforeServe(...)` identifier throws
+//    `ReferenceError: onBeforeServe is not defined` at hook load, which
+//    crash-loops the server (every request 502s). The documented global
+//    entry point for router middleware is `routerUse((next) => (c) => …)`
+//    (echo v5 middleware shape — outer fn takes the next handler, returns
+//    a `(c) => error` handler).
+//
+// 2. Self-contained closure. The per-request middleware closure runs in
+//    PocketBase's pooled goja runtime, where top-level helper functions
+//    and `const`s declared in this file are NOT in scope at request time.
+//    Referencing an out-of-closure helper throws a ReferenceError per
+//    request, which the router turns into an HTTP 400 on EVERY route
+//    (health, collection reads, everything). So ALL logic — the origin
+//    allowlist, the env-var augmentation, and the match — is inlined
+//    inside the returned `(c) => …` handler. Do not refactor the body out
+//    into module-level helpers; it will silently 400 every request.
+// ─────────────────────────────────────────────────────────────────────
+routerUse((next) => {
+  return (c) => {
+    // Built-in prod origin baked in so a fresh Railway volume is
+    // immediately reachable from the production dashboard without operator
+    // env-var configuration. If prod ever moves off
+    // dashboard.showcase.copilotkit.ai, change this default — the env var
+    // alone won't retire the stale origin. PB_CORS_ORIGINS (comma-
+    // separated) augments this list additively for staging / preview.
+    const allowlist = ["https://dashboard.showcase.copilotkit.ai"].concat(
+      ($os.getenv("PB_CORS_ORIGINS") || "")
+        .split(",")
+        .map(function (s) {
+          return s.trim();
+        })
+        .filter(function (s) {
+          return s.length > 0;
+        }),
+    );
 
-// Built-in prod origin baked in so a fresh Railway volume is immediately
-// reachable from the production dashboard without requiring operator
-// env-var configuration. If prod ever moves off
-// dashboard.showcase.copilotkit.ai, change this default — env var alone
-// won't retire the stale origin.
-const CORS_DEFAULT_ORIGINS = ["https://dashboard.showcase.copilotkit.ai"];
-
-function corsAllowedOrigins() {
-  const extra = ($os.getenv("PB_CORS_ORIGINS") || "")
-    .split(",")
-    .map(function (s) {
-      return s.trim();
-    })
-    .filter(function (s) {
-      return s.length > 0;
-    });
-  return CORS_DEFAULT_ORIGINS.concat(extra);
-}
-
-function originAllowed(origin, allowlist) {
-  if (!origin) return false;
-  for (let i = 0; i < allowlist.length; i++) {
-    if (allowlist[i] === origin) return true;
-  }
-  return false;
-}
-
-// Middleware registered at Pre so CORS runs before auth short-circuits
-// OPTIONS preflights. PB 0.22 exposes `e.router.use(...)` on the echo
-// router inside `onBeforeServe`; the callback receives the echo context
-// as its argument.
-onBeforeServe((e) => {
-  e.router.use((next) => {
-    return (c) => {
-      const origin = c.request().header.get("Origin");
-      const allowlist = corsAllowedOrigins();
-      if (originAllowed(origin, allowlist)) {
-        c.response().header().set("Access-Control-Allow-Origin", origin);
-        c.response().header().set("Vary", "Origin");
-        c.response()
-          .header()
-          .set(
-            "Access-Control-Allow-Methods",
-            "GET, POST, PATCH, DELETE, OPTIONS",
-          );
-        c.response()
-          .header()
-          .set(
-            "Access-Control-Allow-Headers",
-            "Content-Type, Authorization, X-Requested-With",
-          );
-        c.response().header().set("Access-Control-Max-Age", "600");
+    const origin = c.request().header.get("Origin");
+    let allowed = false;
+    if (origin) {
+      for (let i = 0; i < allowlist.length; i++) {
+        if (allowlist[i] === origin) {
+          allowed = true;
+          break;
+        }
       }
-      // Short-circuit preflight so downstream handlers (auth, routing)
-      // don't reject OPTIONS with 401/404.
-      if (c.request().method === "OPTIONS") {
-        return c.noContent(204);
-      }
-      return next(c);
-    };
-  });
+    }
+
+    if (allowed) {
+      c.response().header().set("Access-Control-Allow-Origin", origin);
+      c.response().header().set("Vary", "Origin");
+      c.response()
+        .header()
+        .set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS");
+      c.response()
+        .header()
+        .set(
+          "Access-Control-Allow-Headers",
+          "Content-Type, Authorization, X-Requested-With",
+        );
+      c.response().header().set("Access-Control-Max-Age", "600");
+    }
+
+    // Short-circuit preflight so downstream handlers (auth, routing)
+    // don't reject OPTIONS with 401/404.
+    if (c.request().method === "OPTIONS") {
+      return c.noContent(204);
+    }
+    return next(c);
+  };
 });

--- a/showcase/pocketbase/pb_hooks/main.pb.js
+++ b/showcase/pocketbase/pb_hooks/main.pb.js
@@ -83,7 +83,10 @@ routerUse((next) => {
       c.response().header().set("Vary", "Origin");
       c.response()
         .header()
-        .set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS");
+        .set(
+          "Access-Control-Allow-Methods",
+          "GET, POST, PATCH, DELETE, OPTIONS",
+        );
       c.response()
         .header()
         .set(

--- a/showcase/pocketbase/pb_migrations/1745193600_init_status.js
+++ b/showcase/pocketbase/pb_migrations/1745193600_init_status.js
@@ -8,6 +8,21 @@
 migrate(
   (db) => {
     const dao = new Dao(db);
+    // Idempotency: on an existing volume the `status` collection may
+    // already exist while this migration is NOT recorded in `_migrations`.
+    // A bare saveCollection(new Collection(...)) then throws
+    // `UNIQUE constraint failed: _collections.name`, aborting the entire
+    // migration chain. Mirror the proven probe_runs / resource_snapshots
+    // guard: find-or-skip. PB JSVM has no typed error discrimination, so
+    // catch broadly and treat a present collection as a clean no-op.
+    // (The later 1776789000/100 reconcile migrations own field-level
+    // schema corrections for an existing `status`.)
+    try {
+      dao.findCollectionByNameOrId("status");
+      return;
+    } catch (e) {
+      // Not present — fall through to create.
+    }
     const c = new Collection({
       name: "status",
       type: "base",
@@ -41,7 +56,13 @@ migrate(
   },
   (db) => {
     const dao = new Dao(db);
-    const c = dao.findCollectionByNameOrId("status");
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("status");
+    } catch (e) {
+      // Already absent — nothing to do.
+      return;
+    }
     dao.deleteCollection(c);
   },
 );

--- a/showcase/pocketbase/pb_migrations/1745193700_init_status_history.js
+++ b/showcase/pocketbase/pb_migrations/1745193700_init_status_history.js
@@ -8,6 +8,21 @@
 migrate(
   (db) => {
     const dao = new Dao(db);
+    // Idempotency: on an existing volume the `status_history` collection may
+    // already exist while this migration is NOT recorded in `_migrations`.
+    // A bare saveCollection(new Collection(...)) then throws
+    // `UNIQUE constraint failed: _collections.name`, aborting the entire
+    // migration chain. Mirror the proven probe_runs / resource_snapshots
+    // guard: find-or-skip. PB JSVM has no typed error discrimination, so
+    // catch broadly and treat a present collection as a clean no-op.
+    // (Later migrations own field-level corrections for an existing
+    // `status_history` — 1776789000/100 reconcile, 1776789200 field drop.)
+    try {
+      dao.findCollectionByNameOrId("status_history");
+      return;
+    } catch (e) {
+      // Not present — fall through to create.
+    }
     const c = new Collection({
       name: "status_history",
       type: "base",
@@ -54,7 +69,13 @@ migrate(
   },
   (db) => {
     const dao = new Dao(db);
-    const c = dao.findCollectionByNameOrId("status_history");
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("status_history");
+    } catch (e) {
+      // Already absent — nothing to do.
+      return;
+    }
     dao.deleteCollection(c);
   },
 );

--- a/showcase/pocketbase/pb_migrations/1745193800_init_alert_state.js
+++ b/showcase/pocketbase/pb_migrations/1745193800_init_alert_state.js
@@ -9,6 +9,21 @@
 migrate(
   (db) => {
     const dao = new Dao(db);
+    // Idempotency: on an existing volume the `alert_state` collection may
+    // already exist while this migration is NOT recorded in `_migrations`.
+    // A bare saveCollection(new Collection(...)) then throws
+    // `UNIQUE constraint failed: _collections.name`, aborting the entire
+    // migration chain. Mirror the proven probe_runs / resource_snapshots
+    // guard: find-or-skip. PB JSVM has no typed error discrimination, so
+    // catch broadly and treat a present collection as a clean no-op.
+    // (Later 1776789000/100 reconcile migrations own field-level schema
+    // corrections for an existing `alert_state`.)
+    try {
+      dao.findCollectionByNameOrId("alert_state");
+      return;
+    } catch (e) {
+      // Not present — fall through to create.
+    }
     const c = new Collection({
       name: "alert_state",
       type: "base",
@@ -32,7 +47,13 @@ migrate(
   },
   (db) => {
     const dao = new Dao(db);
-    const c = dao.findCollectionByNameOrId("alert_state");
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("alert_state");
+    } catch (e) {
+      // Already absent — nothing to do.
+      return;
+    }
     dao.deleteCollection(c);
   },
 );

--- a/showcase/pocketbase/pb_migrations/1777700000_create_baseline.js
+++ b/showcase/pocketbase/pb_migrations/1777700000_create_baseline.js
@@ -2,6 +2,21 @@
 migrate(
   (db) => {
     const dao = new Dao(db);
+    // Idempotency: on an existing volume the `baseline` collection may
+    // already exist while this migration is NOT recorded in `_migrations`
+    // (e.g. staging volumes pre-dating consistent migration tracking).
+    // A bare saveCollection(new Collection(...)) then throws
+    // `UNIQUE constraint failed: _collections.name`, which aborts the
+    // ENTIRE migration chain before later migrations can run. Mirror the
+    // proven probe_runs / resource_snapshots guard: find-or-skip. PB JSVM
+    // exposes no typed error discrimination, so catch broadly and treat a
+    // present collection as a clean no-op.
+    try {
+      dao.findCollectionByNameOrId("baseline");
+      return;
+    } catch (e) {
+      // Not present — fall through to create.
+    }
     const c = new Collection({
       name: "baseline",
       type: "base",
@@ -37,7 +52,13 @@ migrate(
   },
   (db) => {
     const dao = new Dao(db);
-    const c = dao.findCollectionByNameOrId("baseline");
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("baseline");
+    } catch (e) {
+      // Already absent — nothing to do.
+      return;
+    }
     dao.deleteCollection(c);
   },
 );

--- a/showcase/scripts/__tests__/sync-promote-service-options.test.ts
+++ b/showcase/scripts/__tests__/sync-promote-service-options.test.ts
@@ -333,7 +333,9 @@ describe("sync-promote-service-options", () => {
     expect(input.options[1]).toBe("all");
     expect(input.default).toBe("__select_a_service__");
     expect(input.options).toContain("ag2");
-    expect(input.options).toContain("pocketbase"); // no dispatchName → name fallback
+    // pocketbase now defines dispatchName "showcase-pocketbase", so the
+    // rendered token is the dispatchName, not the bare SSOT key.
+    expect(input.options).toContain("showcase-pocketbase");
     expect(input.options).not.toContain("bogus-stale-entry");
     // dispatchName tokens, not SSOT keys, for services that define one.
     expect(input.options).not.toContain("showcase-ag2");

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -120,8 +120,9 @@
       "serviceId": "ba11e854-d695-4738-9a45-2b0776788824",
       "prodInstanceId": "1ee376e2-13f2-4464-801e-d0aa0bf76532",
       "stagingInstanceId": "0bc7db7b-5a43-4b33-af46-d07fb53c8610",
-      "ciBuilt": false,
+      "ciBuilt": true,
       "gateValidated": true,
+      "dispatchName": "showcase-pocketbase",
       "repoNameOverride": {
         "prod": "showcase-pocketbase",
         "staging": "showcase-pocketbase"

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -121,9 +121,12 @@ describe("railway-envs SSOT", () => {
     );
   });
 
-  it("CI_BUILT_SERVICES contains exactly 25 services and excludes pocketbase/webhooks", () => {
-    expect(CI_BUILT_SERVICES.size).toBe(25);
-    expect(CI_BUILT_SERVICES.has("pocketbase")).toBe(false);
+  it("CI_BUILT_SERVICES contains exactly 26 services (incl. pocketbase) and excludes webhooks", () => {
+    expect(CI_BUILT_SERVICES.size).toBe(26);
+    // pocketbase is now CI-built (showcase_build.yml `pocketbase` slot,
+    // gated to showcase/pocketbase/** changes).
+    expect(CI_BUILT_SERVICES.has("pocketbase")).toBe(true);
+    // webhooks remains out-of-band (released by the showcase-eval-webhook repo).
     expect(CI_BUILT_SERVICES.has("webhooks")).toBe(false);
     // Sample positives.
     expect(CI_BUILT_SERVICES.has("showcase-mastra")).toBe(true);
@@ -142,9 +145,10 @@ describe("railway-envs SSOT", () => {
     });
   });
 
-  it("pocketbase and webhooks are marked ciBuilt=false but gateValidated=true", () => {
-    expect(SERVICES.pocketbase.ciBuilt).toBe(false);
+  it("pocketbase is ciBuilt=true with a dispatchName; webhooks stays ciBuilt=false; both gateValidated=true", () => {
+    expect(SERVICES.pocketbase.ciBuilt).toBe(true);
     expect(SERVICES.pocketbase.gateValidated).toBe(true);
+    expect(SERVICES.pocketbase.dispatchName).toBe("showcase-pocketbase");
     expect(SERVICES.webhooks.ciBuilt).toBe(false);
     expect(SERVICES.webhooks.gateValidated).toBe(true);
   });
@@ -237,9 +241,10 @@ describe("railway-envs SSOT", () => {
 
     // Reverse direction (scoped to CI-built): every CI-built SSOT entry's
     // dispatchName appears in the YAML matrix. Catches "added SSOT entry,
-    // forgot matrix slot." Non-CI-built services (pocketbase, webhooks)
-    // legitimately have no matrix entry — they're built by separate
-    // release workflows — so they are excluded from the reverse check.
+    // forgot matrix slot." pocketbase IS now CI-built (its
+    // "showcase-pocketbase" slot is gated to showcase/pocketbase/**) and
+    // so is included here; only webhooks remains non-CI-built (released by
+    // the showcase-eval-webhook repo) and thus excluded from this check.
     const yamlSet = new Set(dispatchNames);
     for (const name of CI_BUILT_SERVICES) {
       const entry = SERVICES[name];

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -281,11 +281,17 @@ export const SERVICES: Record<
     serviceId: "ba11e854-d695-4738-9a45-2b0776788824",
     prodInstanceId: "1ee376e2-13f2-4464-801e-d0aa0bf76532",
     stagingInstanceId: "0bc7db7b-5a43-4b33-af46-d07fb53c8610",
-    // pocketbase is a first-party ghcr.io/copilotkit/ image, but its
-    // GHCR repo name is `showcase-pocketbase` (NOT `pocketbase`), and
-    // it is built by a separate release workflow — not showcase_build.yml.
-    ciBuilt: false,
+    // pocketbase is a first-party ghcr.io/copilotkit/ image whose GHCR
+    // repo name is `showcase-pocketbase` (NOT `pocketbase`). It is now
+    // built+pushed by showcase_build.yml (the `pocketbase` matrix slot,
+    // gated to `showcase/pocketbase/**` changes) so PB hook + migration
+    // changes ship via CI instead of an ad-hoc manual build. ciBuilt:true
+    // also puts it in the default staging-redeploy scope, but the build's
+    // redeploy step only touches the matrix∩build-success intersection,
+    // so pocketbase only redeploys when its own files change.
+    ciBuilt: true,
     gateValidated: true,
+    dispatchName: "showcase-pocketbase",
     repoNameOverride: {
       prod: "showcase-pocketbase",
       staging: "showcase-pocketbase",
@@ -601,9 +607,10 @@ export function listServiceNames(): string[] {
 
 /**
  * The subset of SERVICES that `showcase_build.yml` actually builds and
- * pushes. Excludes `pocketbase` and `webhooks` (released by their own
- * repos). Default target set for `redeploy-env.ts <env>` when no
- * explicit `--services` list is provided.
+ * pushes. Excludes `webhooks` (released by its own repo's workflow).
+ * pocketbase IS CI-built (its matrix slot is gated to
+ * `showcase/pocketbase/**` changes). Default target set for
+ * `redeploy-env.ts <env>` when no explicit `--services` list is provided.
  */
 export const CI_BUILT_SERVICES: ReadonlySet<string> = new Set(
   Object.entries(SERVICES)

--- a/showcase/scripts/redeploy-env.test.ts
+++ b/showcase/scripts/redeploy-env.test.ts
@@ -29,7 +29,7 @@ describe("runRedeploy", () => {
     summary += s + "\n";
   };
 
-  it("default scope (no --services) targets the 25 CI-built services, NOT all 27", async () => {
+  it("default scope (no --services) targets the 26 CI-built services (incl. pocketbase), NOT all 27", async () => {
     const seenNames: string[] = [];
     const redeploy = vi.fn(async (serviceId: string) => {
       // Reverse-lookup the SSOT name from serviceId so the test can
@@ -49,24 +49,27 @@ describe("runRedeploy", () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.attempted).toBe(25);
-    expect(result.succeeded).toBe(25);
-    expect(redeploy).toHaveBeenCalledTimes(25);
-    expect(seenNames).not.toContain("pocketbase");
+    expect(result.attempted).toBe(26);
+    expect(result.succeeded).toBe(26);
+    expect(redeploy).toHaveBeenCalledTimes(26);
+    // pocketbase is now CI-built, so it IS in the default redeploy scope.
+    expect(seenNames).toContain("pocketbase");
+    // webhooks remains out-of-band.
     expect(seenNames).not.toContain("webhooks");
   });
 
-  it("default whole-env staging redeploy NEVER bounces pocketbase or webhooks", async () => {
-    // Explicit anti-regression test: this exact assertion exists
-    // because the v1 of this script iterated all 27 SERVICES.
+  it("default whole-env staging redeploy NEVER bounces webhooks (out-of-band)", async () => {
+    // Anti-regression: webhooks is released by its own repo's workflow
+    // and must stay out of the default redeploy scope. pocketbase, by
+    // contrast, is now CI-built and IS legitimately in the default scope.
     const seenIds = new Set<string>();
     const redeploy = vi.fn(async (serviceId: string) => {
       seenIds.add(serviceId);
       return { ok: true as const };
     });
     await runRedeploy({ env: "staging", redeploy, appendSummary });
-    expect(seenIds.has(SERVICES.pocketbase.serviceId)).toBe(false);
     expect(seenIds.has(SERVICES.webhooks.serviceId)).toBe(false);
+    expect(seenIds.has(SERVICES.pocketbase.serviceId)).toBe(true);
   });
 
   it("explicit --services list targets exactly that subset", async () => {
@@ -249,8 +252,10 @@ describe("resolveTargetServices", () => {
 
   it("returns the CI_BUILT_SERVICES set sorted when given undefined", () => {
     const resolved = resolveTargetServices(undefined);
-    expect(resolved.length).toBe(25);
-    expect(resolved).not.toContain("pocketbase");
+    expect(resolved.length).toBe(26);
+    // pocketbase is now CI-built and part of the default scope.
+    expect(resolved).toContain("pocketbase");
+    // webhooks remains out-of-band.
     expect(resolved).not.toContain("webhooks");
   });
 });


### PR DESCRIPTION
## Summary

A PocketBase image freshly built from `main` crash-loops staging PocketBase (502s). This was both a latent staging-down landmine and a hard prerequisite for the pool-fleet (which ships new `probe_jobs`/`workers` collections via the same migration path). Three fixes, all verified by **building the image and booting it against an existing volume** (the bug only surfaces on an existing volume, not a fresh one):

- **Hook crash (`fix` commit):** `pb_hooks/main.pb.js` registered CORS via the bare global `onBeforeServe(...)`, which is undefined in PB 0.22.x JSVM (only `$app.onBeforeServe()` exists) → `ReferenceError: onBeforeServe is not defined` at hook load → crash-loop. Switched to the documented global `routerUse((next) => (c) => …)`. Also fixed a second, subtler regression: PB's per-request middleware closure runs in a pooled goja runtime where top-level helpers/consts are out of scope, so calling them throws per request and the router returns **HTTP 400 on every route**. All allowlist/env/match logic is now inlined into the closure.
- **Migration non-idempotency (`fix` commit):** `1777700000_create_baseline.js` plus the three original `1745193*` creators (`status`, `status_history`, `alert_state`) called `saveCollection(new Collection(...))` unconditionally → `UNIQUE constraint failed: _collections.name` on an existing volume → aborts the **entire** chain before `resource_snapshots` / future fleet collections can run. Guarded each with the proven find-or-skip pattern (from `probe_runs` / `resource_snapshots`) and hardened their down-arms. The other 8 migrations were already idempotent and were left as-is.
- **No CI build path (`ci` commit):** added a `pocketbase` slot to `showcase_build.yml` (gated to `showcase/pocketbase/**`), flipped the SSOT to `ciBuilt: true` + `dispatchName: showcase-pocketbase`, regenerated `railway-envs.generated.json` + the `showcase_promote.yml` dropdown, and updated the SSOT/redeploy tests (`CI_BUILT_SERVICES` 25 → 26; `webhooks` is now the only non-CI-built service).

## Verification (build + boot the artifact, not a fresh-empty boot)

Built `showcase-pocketbase` (`linux/amd64`) locally, then:

1. **Fresh volume:** health 200, all 6 collections created (incl. `resource_snapshots`), all 12 JS migrations recorded, no errors.
2. **Existing-volume / staging simulation:** deleted the `_migrations` rows for `baseline`/`status`/`status_history`/`alert_state`/`resource_snapshots` while leaving the collections in place (the exact staging state — collections exist, migrations unrecorded), then rebooted the same image:
   - **health 200** (no 502 crash-loop)
   - logs clean — **no `UNIQUE constraint` abort, no `ReferenceError`**
   - the 5 migrations re-recorded cleanly; **no duplicate collections**
   - CORS hook live: allowlisted origin echoed on `Access-Control-Allow-Origin`, non-allowlisted not echoed, OPTIONS → 204
3. **Fleet path:** added a brand-new throwaway collection migration and confirmed it applies through the now-clean chain on the existing volume (health 200, collection created) — proves future `probe_jobs`/`workers` will ship cleanly.

Full `showcase/scripts` vitest suite green (48 files / 1719 tests); regenerated artifacts pass `--check`.

## Notes / honesty

- I could **not** inspect the actual staging volume contents; the simulation reproduces the documented staging state (collections present, migrations unrecorded, including a manually-created `resource_snapshots`) and the idempotent fix tolerates it.
- A broken image `ghcr.io/copilotkit/showcase-pocketbase:c46bd600` was pushed earlier and **should be deleted/ignored** — do not rely on it. The new CI path will produce a correct `:latest` + `:<sha>` from this branch once merged.
- PB version confirmed `0.22.21` (Dockerfile `PB_VERSION`, binary `--version`, and the embedded JSVM `types.d.ts`).

## Test plan

- [ ] CI green on the PR (build matrix incl. the new `pocketbase` slot; `showcase_validate` vitest).
- [ ] After merge: confirm `showcase_build.yml` builds+pushes `showcase-pocketbase:latest` + `:<sha>` and the staging redeploy brings PB up healthy (`/api/health` 200).
- [ ] Delete the stale broken `:c46bd600` GHCR image.