### PR TITLE
fix(react-native): lazy-load optional expo attachment peers

### DIFF
--- a/.changeset/rn-optional-expo-attachments.md
+++ b/.changeset/rn-optional-expo-attachments.md
@@ -1,0 +1,24 @@
+---
+"@copilotkit/react-native": patch
+---
+
+fix(react-native): load expo attachment peers lazily so bare RN apps work without Expo
+
+`useAttachments` imported `expo-document-picker` and `expo-file-system` at the top
+level of the module, and `useAttachments` is re-exported from the package root and
+used internally by `CopilotChat`. Because those imports were static, importing
+_anything_ from `@copilotkit/react-native` (e.g. the documented quick-start
+`CopilotKitProvider` / `useAgent`) pulled both Expo modules into the consumer's
+bundle — even though they are declared as **optional** peer dependencies
+(`peerDependenciesMeta`). In a bare React Native app without Expo this broke two
+ways: Metro failed to resolve the modules at bundle time, and when they were
+present as JS-only it crashed at startup in `expo-modules-core`
+(`Cannot read property 'EventEmitter' of undefined`) since there is no native
+autolinking.
+
+The two modules are now imported lazily, inside the attachment callbacks that
+actually use them (`openPicker`, `processFiles`), via dynamic `import()` with a
+non-statically-analyzable specifier. Consumers that never use attachments — and
+bare RN apps without Expo — can now import the rest of the package without pulling
+in Expo or crashing. Attachment users are unaffected; the modules load on first
+use, matching the existing optional-peer contract.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -66,7 +66,8 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "test": "vitest run",
+    "test": "vitest run && pnpm run test:bundle",
+    "test:bundle": "node --test scripts/__tests__/*.test.mjs",
     "check-types": "tsc --noEmit",
     "publint": "publint .",
     "attw": "attw --pack . --profile node16 --ignore-rules internal-resolution-error",

--- a/packages/react-native/scripts/__tests__/attachments-optional-expo.test.mjs
+++ b/packages/react-native/scripts/__tests__/attachments-optional-expo.test.mjs
@@ -1,0 +1,89 @@
+// Standalone Node test (not vitest) — it drives real tsdown builds, which
+// don't work inside the package-wide jsdom vitest environment. Same approach
+// as react-core's scripts/__tests__/measure-copilotchat.test.mjs.
+//
+// The expo attachment modules are optional peers: if they appear as static
+// imports in the published build, Metro resolves them at bundle time and
+// bare RN apps (no Expo installed) fail to build or crash at startup. They
+// may only be reached through a runtime import opaque to static analysis.
+//
+// Invoked from package.json `test:bundle` and the chained `test` command.
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "tsdown";
+
+const pkgRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+const EXPO_MODULES = ["expo-document-picker", "expo-file-system"];
+
+// Static references Metro would try to resolve at bundle time:
+//   import ... from "expo-document-picker"   (ESM)
+//   require("expo-document-picker")          (CJS)
+//   import("expo-document-picker")           (literal dynamic import,
+//   including a constant-folded template literal)
+const staticReferencePattern = (moduleName) =>
+  new RegExp(
+    `(from\\s*|require\\(\\s*|import\\(\\s*)["'\`]${moduleName}["'\`]`,
+  );
+
+const tempDirs = [];
+after(async () => {
+  await Promise.all(
+    tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+/** Bundle a src entry with the package's real build config and return the
+ * concatenated output per format. */
+async function bundleEntry(entry) {
+  const outDir = await mkdtemp(path.join(pkgRoot, ".bundle-test-"));
+  tempDirs.push(outDir);
+  await build({
+    config: path.join(pkgRoot, "tsdown.config.ts"),
+    entry: [path.join(pkgRoot, entry)],
+    format: ["esm", "cjs"],
+    dts: false,
+    sourcemap: false,
+    outDir,
+    silent: true,
+  });
+  const files = (await readdir(outDir)).filter(
+    (f) => f.endsWith(".mjs") || f.endsWith(".cjs"),
+  );
+  assert.ok(files.length > 0, `expected emitted output for ${entry}`);
+  let combined = "";
+  for (const file of files) {
+    combined += await readFile(path.join(outDir, file), "utf8");
+  }
+  return combined;
+}
+
+describe("expo attachment modules stay out of static analysis", () => {
+  it("main entry has no static expo import", async () => {
+    const combined = await bundleEntry("src/index.ts");
+    for (const moduleName of EXPO_MODULES) {
+      assert.ok(
+        !staticReferencePattern(moduleName).test(combined),
+        `${moduleName} is statically imported in the build — Metro will ` +
+          `try to resolve it at bundle time and bare RN apps will break`,
+      );
+    }
+  });
+
+  it("main entry still wires the lazy runtime loaders", async () => {
+    const combined = await bundleEntry("src/index.ts");
+    for (const moduleName of EXPO_MODULES) {
+      assert.ok(
+        new RegExp(`["'\`]${moduleName}["'\`]`).test(combined),
+        `${moduleName} is no longer referenced at all — the lazy ` +
+          `attachment loaders appear to be gone`,
+      );
+    }
+  });
+});

--- a/packages/react-native/src/__tests__/use-attachments-missing-expo.test.ts
+++ b/packages/react-native/src/__tests__/use-attachments-missing-expo.test.ts
@@ -1,0 +1,130 @@
+// packages/react-native/src/__tests__/use-attachments-missing-expo.test.ts
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// Simulate a bare RN app where the optional expo modules are NOT installed:
+// loading them fails the way Metro would. The hoisted counters record
+// whether a load was ever attempted.
+const expoLoads = vi.hoisted(() => ({ documentPicker: 0, fileSystem: 0 }));
+
+vi.mock("expo-document-picker", () => {
+  expoLoads.documentPicker += 1;
+  throw new Error("Unable to resolve module 'expo-document-picker'");
+});
+
+vi.mock("expo-file-system", () => {
+  expoLoads.fileSystem += 1;
+  throw new Error("Unable to resolve module 'expo-file-system'");
+});
+
+// Mock @copilotkit/shared -- only the utils we use
+vi.mock("@copilotkit/shared", () => ({
+  getModalityFromMimeType: () => "document",
+  formatFileSize: (bytes: number) => `${bytes} B`,
+  randomUUID: () => "test-uuid-" + Math.random().toString(36).slice(2, 8),
+}));
+
+// Import AFTER mocks -- this import itself fails if expo is pulled in statically
+import { useAttachments } from "../hooks/use-attachments";
+import type { NativeFileInput } from "../hooks/use-attachments";
+
+const testFile: NativeFileInput = {
+  uri: "file:///tmp/report.pdf",
+  name: "report.pdf",
+  size: 1024,
+  mimeType: "application/pdf",
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("useAttachments without expo modules installed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    expoLoads.documentPicker = 0;
+    expoLoads.fileSystem = 0;
+  });
+
+  it("imports and mounts without ever loading the expo modules", () => {
+    const { result } = renderHook(() =>
+      useAttachments({ config: { enabled: true } }),
+    );
+
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.attachments).toEqual([]);
+    expect(expoLoads.documentPicker).toBe(0);
+    expect(expoLoads.fileSystem).toBe(0);
+  });
+
+  it("openPicker fails gracefully when expo-document-picker is missing", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useAttachments({ config: { enabled: true } }),
+    );
+
+    await act(async () => {
+      await expect(result.current.openPicker()).resolves.toBeUndefined();
+    });
+
+    expect(expoLoads.documentPicker).toBeGreaterThan(0);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[CopilotKit] Document picker error:",
+      expect.any(Error),
+    );
+    expect(result.current.attachments).toEqual([]);
+
+    consoleError.mockRestore();
+  });
+
+  it("processFiles reports upload-failed when expo-file-system is missing", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const onUploadFailed = vi.fn();
+    const { result } = renderHook(() =>
+      useAttachments({
+        // No onUpload, so the default expo-file-system reader path is used.
+        config: { enabled: true, onUploadFailed },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.processFiles([testFile]);
+    });
+
+    expect(expoLoads.fileSystem).toBeGreaterThan(0);
+    expect(onUploadFailed).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "upload-failed", file: testFile }),
+    );
+    expect(result.current.attachments).toEqual([]);
+
+    consoleError.mockRestore();
+  });
+
+  it("custom onUpload keeps attachments working without any expo module", async () => {
+    const { result } = renderHook(() =>
+      useAttachments({
+        config: {
+          enabled: true,
+          onUpload: async () => ({
+            type: "data" as const,
+            value: "Zm9vYmFy",
+            mimeType: "application/pdf",
+          }),
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.processFiles([testFile]);
+    });
+
+    expect(result.current.attachments).toHaveLength(1);
+    expect(result.current.attachments[0].status).toBe("ready");
+    expect(expoLoads.fileSystem).toBe(0);
+    expect(expoLoads.documentPicker).toBe(0);
+  });
+});

--- a/packages/react-native/src/hooks/use-attachments.ts
+++ b/packages/react-native/src/hooks/use-attachments.ts
@@ -10,8 +10,26 @@ import type {
   AttachmentUploadResult,
   AttachmentUploadErrorReason,
 } from "@copilotkit/shared";
-import * as DocumentPicker from "expo-document-picker";
-import * as FileSystem from "expo-file-system";
+
+// `expo-document-picker` and `expo-file-system` are *optional* peer dependencies
+// (see package.json `peerDependenciesMeta`). They are imported lazily, inside the
+// callbacks that actually need them, so that consumers who never use attachments
+// -- including bare React Native apps without Expo installed -- can import the
+// rest of the package (CopilotKitProvider, useAgent, CopilotChat, ...) without
+// pulling Expo into their bundle or crashing at startup on the missing native
+// `expo-modules-core`.
+//
+// The specifiers are kept out of static analysis (built via a template literal)
+// so that Metro does not try to resolve the modules at bundle time when they are
+// not installed; resolution happens only when an attachment API is actually used.
+const DOCUMENT_PICKER_MODULE = "expo-document-picker";
+const FILE_SYSTEM_MODULE = "expo-file-system";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const loadDocumentPicker = (): Promise<any> =>
+  import(`${DOCUMENT_PICKER_MODULE}`);
+const loadFileSystem = (): Promise<any> => import(`${FILE_SYSTEM_MODULE}`);
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 // ---------------------------------------------------------------------------
 // Types
@@ -181,7 +199,8 @@ export function useAttachments({
             source = uploadSource;
             uploadMetadata = meta;
           } else {
-            // Default: read file as base64 via expo-file-system
+            // Default: read file as base64 via expo-file-system (loaded lazily)
+            const FileSystem = await loadFileSystem();
             const base64 = await FileSystem.readAsStringAsync(file.uri, {
               encoding: FileSystem.EncodingType.Base64,
             });
@@ -231,6 +250,9 @@ export function useAttachments({
       .filter(Boolean);
 
     try {
+      // expo-document-picker is loaded lazily so the module is only required
+      // when the picker is actually opened.
+      const DocumentPicker = await loadDocumentPicker();
       const result = await DocumentPicker.getDocumentAsync({
         type: typeArray.length > 0 ? typeArray : ["*/*"],
         copyToCacheDirectory: true,
@@ -239,12 +261,19 @@ export function useAttachments({
 
       if (result.canceled || !result.assets?.length) return;
 
-      const nativeFiles: NativeFileInput[] = result.assets.map((asset) => ({
-        uri: asset.uri,
-        name: asset.name ?? "unknown",
-        size: asset.size ?? 0,
-        mimeType: asset.mimeType ?? "application/octet-stream",
-      }));
+      const nativeFiles: NativeFileInput[] = result.assets.map(
+        (asset: {
+          uri: string;
+          name?: string | null;
+          size?: number | null;
+          mimeType?: string | null;
+        }) => ({
+          uri: asset.uri,
+          name: asset.name ?? "unknown",
+          size: asset.size ?? 0,
+          mimeType: asset.mimeType ?? "application/octet-stream",
+        }),
+      );
 
       await processFiles(nativeFiles);
     } catch (error) {


### PR DESCRIPTION
## What does this PR do?

Makes the optional Expo attachment peers truly optional in `@copilotkit/react-native`, so bare React Native apps (without Expo) can use the package.

**Root cause.** `useAttachments` statically imported `expo-document-picker` and `expo-file-system` at module top level. The hook is re-exported from the package root and used internally by `CopilotChat`, so every consumer of the package loaded those imports — even consumers that never use attachments. Although both packages are declared as optional peers (`peerDependenciesMeta`), the static import made them effectively mandatory, breaking bare RN apps two ways:

1. **Bundle time** — Metro could not resolve `expo-document-picker` / `expo-file-system` when they weren't installed.
2. **Runtime** — even when JS resolved, the Expo modules need native autolinking; without it the app crashed at startup in `expo-modules-core` (`Cannot read property 'EventEmitter' of undefined`).

**Fix.** Load the modules lazily via dynamic `import()` inside the attachment callbacks (`openPicker`, `processFiles`), so non-attachment consumers and bare RN apps no longer pull in Expo. The specifiers are built from variables to keep them out of Metro's static analysis, so resolution happens only when an attachment API is actually used. Attachment behavior is unchanged; modules load on first use.

**Verification.**
- Built `dist` contains no static top-level Expo import; the dynamic `import()` calls are preserved.
- Full RN test suite passes (245 tests).
- Verified on a physical device (Samsung Galaxy S21 Ultra, Android 14, bare React Native with no Expo installed): the app bundles and boots with no `Unable to resolve expo-document-picker` / `expo-file-system` error.

A changeset is included (`patch`).

## Related PRs and Issues

- (none)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked
