### PR TITLE
fix(runtime): drop spurious "agents" license warning on agent run

### DIFF
--- a/packages/runtime/src/v2/runtime/handlers/handle-run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-run.ts
@@ -43,15 +43,6 @@ export async function handleRunAgent({
     configureAgentForRequest({ runtime, request, agentId, agent });
     await attachIntelligenceEnterpriseLearning({ runtime, request, agent });
 
-    if (
-      runtime.licenseChecker &&
-      !runtime.licenseChecker.checkFeature("agents")
-    ) {
-      console.warn(
-        '[CopilotKit Runtime] Warning: "agents" feature is not licensed. Visit copilotkit.ai/pricing',
-      );
-    }
-
     const input = await parseRunRequest(request);
     if (input instanceof Response) {
       return input;


### PR DESCRIPTION
The v2 `agent/run` handler (`packages/runtime/src/v2/runtime/handlers/handle-run.ts`) logged:

```
[CopilotKit Runtime] Warning: "agents" feature is not licensed. Visit copilotkit.ai/pricing
```

on **every** agent run whenever a `licenseChecker` was present.

## Why remove it

- **It can never pass.** `checkFeature("agents")` resolves against `@copilotkit/license-verifier`, whose license catalog defines no `"agents"` feature id. `isFeatureEnabled` returns `false` for any unknown feature before it ever consults the license, so the warning fires for every customer regardless of plan (free, dev, or enterprise).

## Scope

- Removes only the warning block.
- `runtime.licenseChecker` remains wired (`createLicenseChecker` in `core/runtime.ts`) and is still consumed by `get-runtime-info` for license status reporting — so this does not touch any actual licensing/status behavior.
- No tests asserted this warning.