### PR TITLE
fix(showcase/pocketbase): make probe_runs.triggered optional so scheduled run-history works

### DIFF
--- a/showcase/pocketbase/pb_migrations/1779989800_probe_runs_triggered_optional.js
+++ b/showcase/pocketbase/pb_migrations/1779989800_probe_runs_triggered_optional.js
@@ -1,0 +1,70 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// Make `probe_runs.triggered` OPTIONAL (not required).
+//
+// The S5 fleet aggregator (harness src/fleet/control-plane/result-aggregator.ts)
+// opens a run-history row for every fleet run with `triggered: false` — a
+// fleet run is driven by the producer's cron cadence, never an ad-hoc
+// Slack/webhook trigger. But `1777165230_create_probe_runs.js` shaped the
+// `triggered` column as `bool, required: true`, and PocketBase's `required`
+// validation rejects the boolean `false` (it is treated as "empty") with a
+// `validation_required` error. The result: the aggregator's run-history
+// `start()` fails on EVERY scheduled (non-triggered) run. Status cells still
+// land (run-history is best-effort), but run-history itself is broken for
+// scheduled runs — the dashboard's "last N runs" widget never records them.
+//
+// The legacy in-process probe-invoker writes `triggered: true` for ad-hoc
+// runs and `false` for scheduled ones too, so this also un-breaks scheduled
+// run-history on the existing deployed schema (the create migration above has
+// already run on staging/prod volumes — see the #5242-fixed chain — so we
+// ALTER the field on the live collection rather than recreating it).
+//
+// `triggered: false` is the correct semantic default: a run is "scheduled"
+// unless something explicitly marks it as ad-hoc-triggered.
+//
+// Additive + idempotent: a presence/already-optional check makes a re-run
+// after a partial apply a no-op (mirrors the field-presence gates in the
+// other fleet migrations). The down migration restores `required: true`.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_runs");
+    } catch (e) {
+      // The base collection isn't present yet — nothing to alter. The
+      // create migration (lower unix prefix) runs first; if it somehow
+      // hasn't, this is a no-op rather than a hard failure.
+      return;
+    }
+    const field = c.schema.getFieldByName("triggered");
+    if (!field) {
+      // Field gone (renamed/dropped by a future migration) — nothing to do.
+      return;
+    }
+    // Idempotency: already optional → no-op.
+    if (field.required === false) {
+      return;
+    }
+    field.required = false;
+    dao.saveCollection(c);
+  },
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_runs");
+    } catch (e) {
+      return;
+    }
+    const field = c.schema.getFieldByName("triggered");
+    if (!field) {
+      return;
+    }
+    if (field.required === true) {
+      return;
+    }
+    field.required = true;
+    dao.saveCollection(c);
+  },
+);


### PR DESCRIPTION
## Summary

Latent **current-production** bug fix. In the deployed PocketBase schema, `probe_runs.triggered` is `required: true`. PocketBase's `required` validation treats the boolean `false` as "empty" and rejects it with `validation_required`. The fleet aggregator (and the legacy in-process probe-invoker) open a run-history row with `triggered: false` for every **scheduled** (cron-driven, non-ad-hoc) run, so run-history `start()` fails on every scheduled run. Status cells still land (run-history is best-effort), so it has been failing silently — the dashboard's "last N runs" widget never records scheduled runs.

This is the **same fix that ships with the fleet branch** (`blitz/pool-fleet/integration`, commit `66e722532`), cherry-picked to a clean `main` PR so production gets it independently and sooner.

## The change

- Adds `showcase/pocketbase/pb_migrations/1779989800_probe_runs_triggered_optional.js` — a single, self-contained, **migration-only** change (no code deps).
- The migration finds the existing `probe_runs` collection, sets the `triggered` field `required = false`, and `saveCollection`s. The create migration already ran on staging/prod volumes, so this **ALTERs** the live field rather than recreating the collection.
- **Idempotent**: guards for collection-missing, field-missing, and already-optional (re-run after partial apply is a no-op).
- **Down migration**: find-then-restore `required = true`, with symmetric guards (collection-missing, field-missing, already-required).
- Rides cleanly on the #5242-fixed (idempotent + CI-built) PB migration chain; it is the highest unix-prefix migration so it runs last.

## Verification

- `node --check` on the migration: pass.
- **Full Docker boot test** (local `desktop-linux` builder):
  1. Built a seed image WITHOUT this migration, booted on a fresh named volume -> confirmed the live schema has `triggered required:true` (reproduces the broken prod state).
  2. Booted the WITH-fix image on the **same seeded volume** -> the migration flipped the live field to `triggered required:false` (proves the ALTER on an existing volume, not just a fresh create).
  3. Inserted a `triggered:false` record via the REST API -> **succeeds** (returns a record with `triggered:false`), confirming the exact write that previously failed with `validation_required` now works.
  4. Rebooted the fix image on the now-optional volume -> clean no-op, field stays `required:false` (idempotency confirmed).

## Scope confirmation

Migration-only: `1 file changed, 70 insertions(+)`. No unintended code carried over from the fleet branch.

## Test plan

- [ ] CI green
- [ ] Merge -> PB image rebuild -> on next deploy the migration ALTERs prod's `probe_runs.triggered` to optional; scheduled run-history `start()` writes stop failing