### PR TITLE
fix(showcase/harness): add starter_smoke to DIMENSIONS so the probe loads (S5 phase 1)

### DIFF
--- a/showcase/harness/src/types/index.ts
+++ b/showcase/harness/src/types/index.ts
@@ -78,6 +78,16 @@ export const DIMENSIONS = [
   // `<level>` suffix (`starter:langgraph-python/agent`) — disjoint key
   // spaces because the dimension prefix differs. Informational only; like
   // d5/d6/qa it must NOT contribute to the feature-cell rollup.
+  //
+  // `starter_smoke` is the probe KIND literal (`kind: starter_smoke` in
+  // config/probes/starter_smoke.yml, and the `kind` the starterSmokeDriver
+  // registers under), distinct from the `starter` EMIT-prefix dimension
+  // above — the same kind/emit-prefix split as e2e_d6/d6, e2e_deep/d5, and
+  // e2e_demos/e2e. Without this closed-enum slot the probe-loader's Zod
+  // `kind` enum rejects starter_smoke.yml at parse time (union failure
+  // surfacing as "Unrecognized key(s): 'discovery'"), so the probe never
+  // loads and probe-loader.test.ts's shipped-config check fails.
+  "starter_smoke",
   "starter",
 ] as const;
 export type Dimension = (typeof DIMENSIONS)[number];


### PR DESCRIPTION
## Summary

Phase 1 of the S5 **starter container fleet** work: fix the blocking schema bug that prevented the `starter_smoke` probe from loading and that was the lone recurring `probe-loader.test.ts` failure.

This PR is **Phase 1 only**. Investigation revealed that the originally-planned **Phase 2 (register the 12 starters in the `railway-envs.ts` SSOT)** is architecturally wrong and would *reintroduce the exact build-skip regression* it was meant to avoid. Details below. Phase 3 (Railway provisioning) is documented for the orchestrator to execute after this merges; it needs **no SSOT changes**.

## Phase 1 — the schema fix (add `starter_smoke` to `DIMENSIONS`)

`config/probes/starter_smoke.yml` failed the probe-loader schema with `ZodError: Unrecognized key(s) in object: 'discovery'`.

**Root cause (add, not remove):** `discovery` is a *red herring*. The probe-config Zod `kind` enum is built from `DIMENSIONS` (`showcase/harness/src/types/index.ts`). `DIMENSIONS` listed the `starter` *emit-prefix* dimension but **not** the `starter_smoke` *probe kind*. The YAML declares `kind: starter_smoke` and the `starterSmokeDriver` registers under `kind: "starter_smoke"` (`orchestrator.ts:1055`), but the enum rejected it. Because `kind` is shared across all three union variants (`targets`/`discovery`/`target`), the union failure surfaced as the misleading "Unrecognized key(s): 'discovery'" message from the non-discovery variants.

`discovery` itself is a fully valid key — the `DiscoveryBlockSchema` already accepts `source`/`filter`/`key_template`, and the working `d6-all-pills-e2e.yml` uses the *identical* discovery shape (verified: it parses cleanly; the only delta between the two YAMLs is `kind`).

**Fix:** add `starter_smoke` alongside `starter`, mirroring every existing kind/emit pair (`e2e_d6`/`d6`, `e2e_deep`/`d5`, `e2e_demos`/`e2e`). Removing `discovery` from the YAML would have orphaned the registered driver and broken auto-discovery.

**Red→green:** before — `probe-loader.test.ts` 1 failed / 8 passed (shipped-config assertion). After — 9/9 passed, loader reports `count:12 errors:0` (all shipped probes incl. `starter_smoke` load). Full harness probe suite: **1175/1175 green**.

## Why Phase 2 (SSOT registration) is NOT in this PR — and must not be done

The task assumed the 12 starters must be registered in `showcase/scripts/railway-envs.ts` (like PR #5242 did for pocketbase) for the dashboard's Starter row to probe them. **The architecture shows otherwise**, and doing it would re-break the build:

1. **The starter fleet is fully decoupled from the SSOT.** The 27-service `railway-envs.ts` SSOT and its `verify-railway-image-refs` gate manage only the `showcase-*` / infra fleet. The 12 `starter-*` services live in a separate namespace that the gate does not own. (Generated JSON has 0 starter entries; 27 services.)

2. **The dashboard does not read the SSOT for starters.** The Starter row is fed by `starter:<col>/<level>` PocketBase rows emitted by the `starter_smoke` probe, keyed via `starter-mapping.ts` (`STARTER_TO_COLUMN`). The SSOT is not in that data path.

3. **The probe auto-discovers `starter-*` Railway services at runtime.** The `railway-services` discovery source issues its OWN Railway GraphQL query (`RAILWAY_PROJECT_ID`/`RAILWAY_ENVIRONMENT_ID`) and filters on `namePrefix: "starter-"`. It never reads `railway-envs.ts`. The YAML comment says it explicitly: "When S5 lands the services, no YAML edit is needed."

4. **Registering them in the SSOT now would RE-TRIGGER the regression.** `verify-railway-image-refs.ts` is a *bidirectional live-Railway drift gate* and is a hard `needs:` of the `build` job. Adding 12 `gateValidated: true` SSOT entries for services that **don't exist on Railway yet** makes `findMissingServices()` return them → gate fails → `build` job SKIPPED → no images pushed → dashboard can't update. That is the *same* class of failure as the deleted canary (which failed the OTHER direction, `findUntrackedServices`), just from the SSOT side. The SSOT and live Railway must stay in lockstep; you cannot lead with fabricated UUIDs (the SSOT tests also assert real UUID-shaped `serviceId`/`prodInstanceId`/`stagingInstanceId`).

   PR #5242 was safe because **pocketbase already existed on Railway** — it only needed a CI build path. The starters do **not** exist on Railway yet, so the situations are not analogous.

**Net:** the per-starter GHCR images already build (the decoupled `build-starters` job; 12 slugs in `ALL_STARTERS`, all 12 Dockerfiles present). All that remains is provisioning the 12 Railway `starter-*` services — and the probe picks them up automatically with zero SSOT/YAML changes.

## Phase 3 — Railway provisioning plan (PREP ONLY, do NOT fire without confirmation)

Goal: create 12 sleepable/scale-to-zero `starter-*` services in the Showcase Railway project (`6f8c6bff-a80d-4f8f-b78d-50b32bcf4479`, staging env `8edfef02-ea09-4a20-8689-261f21cc2849`), each sourced from `ghcr.io/copilotkit/starter-<image>:latest`, **without** touching the SSOT.

Service name → GHCR image (the 12, from `ALL_STARTERS`):
`starter-langgraph-python`, `starter-mastra`, `starter-langgraph-js`, `starter-crewai-crews`, `starter-pydantic-ai`, `starter-adk`, `starter-agno`, `starter-llamaindex`, `starter-langgraph-fastapi`, `starter-strands-python`, `starter-ms-agent-framework-python`, `starter-ms-agent-framework-dotnet` (image repo == service name).

Per service (Railway GraphQL, via the project's existing token):
- `serviceCreate({ projectId, name: "starter-<slug>", source: { image: "ghcr.io/copilotkit/starter-<slug>:latest" } })`.
- Set the service instance region/env to the staging environment; enable **scale-to-zero / sleep** on the instance (`serviceInstanceUpdate` with the sleep flag) so idle cost ~$0.
- Set required runtime env vars to point chat at aimock (zero LLM cost): the same aimock base-URL wiring the showcase integrations use (`OPENAI_BASE_URL`/equivalent → the aimock service). Confirm each starter's `entrypoint.sh` expects these before firing.
- Generate a Railway public domain for each (`serviceDomainCreate`) so the probe's HTTP checks have a base URL.

Verification after provisioning (the orchestrator runs this, all live):
- `verify-railway-image-refs.ts` MUST still pass — confirm it does NOT flag the new `starter-*` services as `untracked`. **This needs checking:** `findUntrackedServices` fails on *any* Railway service absent from the SSOT. The 12 starters will be absent (by design). So before/with provisioning, the gate must be made starter-aware — the clean options are: (a) scope the gate's Railway query/`findUntrackedServices` to exclude the `starter-` prefix (preferred — symmetrical with the harness discovery filter and the smoke.yml exclusions), or (b) less ideally, add `gateIgnore: true` SSOT stubs. **Option (a) is a small code change that should land in THIS PR's follow-up or be confirmed before provisioning, or the first push to main after provisioning will skip the build.** This is the single remaining sharp edge and the orchestrator must resolve it before firing Phase 3.
- Each service RUNNING then sleeping; `GET https://<domain>/api/health` 200 on wake.
- Next `starter_smoke` tick (hourly :40) auto-discovers all 12 and emits `starter:<col>/<level>` rows; dashboard Starter row goes live. No redeploy/YAML/SSOT change needed.

## Test plan

- [x] `probe-loader.test.ts` red→green (1 fail → 9 pass)
- [x] Full harness probe suite green (1175/1175)
- [x] SSOT untouched: `emit-railway-envs-json.ts --check` up to date; `railway-envs.test.ts` + `redeploy-env.test.ts` + promote-options test green (84/84)
- [ ] CI green on this PR