### PR TITLE
fix(showcase): tolerate starter-* services in railway image-ref drift gate

### DIFF
--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -77,7 +77,9 @@ describe("findUntrackedServices (Railway -> SSOT direction)", () => {
       "starter-mastra", // starter fleet — tolerated
       "showcase-rogue-untracked", // real drift — must be flagged
     ]);
-    expect(findUntrackedServices(railway)).toEqual(["showcase-rogue-untracked"]);
+    expect(findUntrackedServices(railway)).toEqual([
+      "showcase-rogue-untracked",
+    ]);
   });
 
   it("does NOT flag a service that the SSOT marks gateIgnore: true", () => {

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from "vitest";
 import {
   findMissingServices,
   findUntrackedServices,
+  isStarterFleetService,
   summarizeFailures,
   validateImage,
 } from "../verify-railway-image-refs";
@@ -53,6 +54,32 @@ describe("findUntrackedServices (Railway -> SSOT direction)", () => {
     expect(findUntrackedServices(railway)).toEqual(["alpha-svc", "zeta-svc"]);
   });
 
+  it("does NOT flag a `starter-*` live service that is absent from the SSOT", () => {
+    // The starter container fleet (starter-<slug>) is auto-discovered by
+    // the starter_smoke probe (railway-services source, namePrefix
+    // "starter-") and is intentionally DECOUPLED from this 27-service
+    // SSOT. Provisioning a starter-* service must NOT trip the
+    // Railway->SSOT drift gate (which previously SKIPPED the build).
+    const railway = new Set<string>([
+      "showcase-mastra", // tracked
+      "starter-langgraph-python", // starter fleet, decoupled — tolerated
+      "starter-mastra", // starter fleet, decoupled — tolerated
+    ]);
+    expect(findUntrackedServices(railway)).toEqual([]);
+  });
+
+  it("STILL flags a real (non-starter) untracked Railway service", () => {
+    // Drift detection for the tracked fleet must be preserved: a genuine
+    // out-of-band service (here a rogue `showcase-*`) is still a hard fail
+    // even when a tolerated starter-* service is present alongside it.
+    const railway = new Set<string>([
+      "showcase-mastra", // tracked
+      "starter-mastra", // starter fleet — tolerated
+      "showcase-rogue-untracked", // real drift — must be flagged
+    ]);
+    expect(findUntrackedServices(railway)).toEqual(["showcase-rogue-untracked"]);
+  });
+
   it("does NOT flag a service that the SSOT marks gateIgnore: true", () => {
     // Inject a transient entry into SERVICES for this test, then remove.
     const sentinel = "transient-third-party-relay";
@@ -75,6 +102,38 @@ describe("findUntrackedServices (Railway -> SSOT direction)", () => {
     } finally {
       delete (SERVICES as Record<string, ServiceEntry>)[sentinel];
     }
+  });
+});
+
+describe("isStarterFleetService predicate", () => {
+  it("matches names that start with the `starter-` prefix", () => {
+    expect(isStarterFleetService("starter-mastra")).toBe(true);
+    expect(isStarterFleetService("starter-langgraph-python")).toBe(true);
+    expect(isStarterFleetService("starter-")).toBe(true);
+  });
+
+  it("does NOT match tracked showcase / infra service names", () => {
+    expect(isStarterFleetService("showcase-mastra")).toBe(false);
+    expect(isStarterFleetService("dashboard")).toBe(false);
+    expect(isStarterFleetService("pocketbase")).toBe(false);
+    // The decommissioned `showcase-starter-*` services use the
+    // `showcase-` prefix, NOT `starter-`, so they are NOT starter-fleet.
+    expect(isStarterFleetService("showcase-starter-ag2")).toBe(false);
+  });
+});
+
+describe("findMissingServices — starter fleet is never required", () => {
+  it("does not require any `starter-*` service (none are in the SSOT)", () => {
+    // Starter services are decoupled from the SSOT, so they are never
+    // gateValidated SSOT entries and findMissingServices never demands
+    // them. A present-set containing only a starter service must still
+    // report the real gateValidated services as missing — and never the
+    // starter itself.
+    const present = new Set<string>(["starter-mastra"]);
+    const missing = findMissingServices("prod", present);
+    expect(missing).not.toContain("starter-mastra");
+    // Sanity: the tracked fleet is still required when absent.
+    expect(missing).toContain("showcase-mastra");
   });
 });
 

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -49,6 +49,36 @@ import { RailwayTokenError, resolveRailwayToken } from "./lib/railway-token";
 
 const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
 
+/**
+ * Railway service-name prefix for the starter container fleet. Mirrors the
+ * `namePrefix: "starter-"` discovery filter in
+ * `showcase/harness/config/probes/starter_smoke.yml` (and the
+ * `deriveStarterSlug` strip in `drivers/starter-smoke.ts`).
+ */
+const STARTER_FLEET_PREFIX = "starter-";
+
+/**
+ * True iff `name` is a starter-container-fleet Railway service
+ * (`starter-<slug>`).
+ *
+ * The starter fleet is DECOUPLED from this 27-service SSOT: each
+ * `starter-*` service is AUTO-DISCOVERED at runtime by the `starter_smoke`
+ * probe via the `railway-services` discovery source filtered on
+ * `namePrefix: "starter-"` — it is never read from `railway-envs.ts`.
+ * Therefore the SSOT⨉Railway drift checks below MUST exclude these
+ * services: a provisioned `starter-*` service is neither required-in-SSOT
+ * (findMissingServices) nor flagged-as-untracked (findUntrackedServices).
+ * Without this carve-out, provisioning a starter service trips the
+ * Railway→SSOT drift gate and SKIPS the showcase build.
+ *
+ * NOTE: this matches the `starter-` prefix only — the decommissioned
+ * `showcase-starter-*` services use the `showcase-` prefix and are NOT
+ * starter-fleet (they are excluded by smoke.yml's nameExcludes instead).
+ */
+export function isStarterFleetService(name: string): boolean {
+  return name.startsWith(STARTER_FLEET_PREFIX);
+}
+
 // Canonical shapes per env.
 //   Staging :latest pattern — exact-match against `<repo>:latest`.
 //   Prod    @sha256:<hex>  — exact-match against `<repo>@sha256:<64 hex>`.
@@ -196,6 +226,11 @@ export function findMissingServices(
 ): string[] {
   const missing: string[] = [];
   for (const [name, entry] of Object.entries(SERVICES)) {
+    // Starter-fleet services are SSOT-decoupled (see
+    // isStarterFleetService) — never require them in the SSOT→Railway
+    // direction. Defense-in-depth: SERVICES never contains a starter-*
+    // key today, so this is a guard against a future stray entry.
+    if (isStarterFleetService(name)) continue;
     if (!entry.gateValidated) continue;
     if (!presentServiceNames.has(name)) missing.push(name);
   }
@@ -221,6 +256,13 @@ export function findUntrackedServices(
 ): string[] {
   const untracked: string[] = [];
   for (const name of railwayServiceNames) {
+    // Starter-fleet services (starter-<slug>) are SSOT-decoupled and
+    // auto-discovered by the starter_smoke probe (see
+    // isStarterFleetService) — a provisioned starter-* service is NOT
+    // drift, so never flag it as untracked. This is the carve-out that
+    // lets the 12 starter services be provisioned without skipping the
+    // showcase build.
+    if (isStarterFleetService(name)) continue;
     const entry = SERVICES[name];
     // Any SSOT entry — gateIgnored or not — is known/accounted-for in
     // the Railway->SSOT direction. Only absence from the SSOT counts.


### PR DESCRIPTION
## Summary

Makes `showcase/scripts/verify-railway-image-refs.ts` tolerate `starter-*` Railway services so the 12 starter-container-fleet services can be provisioned **without** being in the `railway-envs.ts` SSOT and **without** skipping the showcase build.

### Background

The starter fleet is **decoupled** from the 27-service SSOT. The dashboard's Starter row reads probe-emitted `starter:<col>/<level>` PocketBase rows; the `starter_smoke` probe **auto-discovers** `starter-*` Railway services at runtime via a `railway-services` discovery source filtered on `namePrefix: "starter-"` — it never reads the SSOT.

But `verify-railway-image-refs.ts` is a hard `needs:` of the `build` job and runs a **bidirectional** live-Railway drift check:
- `findUntrackedServices()` fails on any live Railway service absent from the SSOT.
- `findMissingServices()` fails on any SSOT entry absent from Railway.

So provisioning a `starter-*` service → untracked in SSOT → `findUntrackedServices` fails → **build SKIPPED** (the canary regression observed earlier). And the wrong fix (SSOT stubs for not-yet-existing services) breaks `findMissingServices` instead.

## Changes

- Added a single, well-named predicate `isStarterFleetService(name) => name.startsWith("starter-")` (constant `STARTER_FLEET_PREFIX = "starter-"`), with a docstring explaining the starter fleet is auto-discovered + SSOT-decoupled. Mirrors the `namePrefix: "starter-"` convention in `starter_smoke.yml` and the `deriveStarterSlug` strip in `drivers/starter-smoke.ts`.
- Scoped **both** drift checks to exclude starter-fleet services:
  - `findUntrackedServices` — a provisioned `starter-*` service is no longer flagged as untracked (the carve-out that unblocks provisioning).
  - `findMissingServices` — defense-in-depth guard (no `starter-*` key exists in SERVICES today, but a future stray entry would never be demanded).
- **No behavior change** for real `showcase-*`/infra services — they are drift-checked exactly as before.

Result: provisioned `starter-*` services are neither required-in-SSOT nor flagged-as-untracked, so provisioning the 12 starter services will **not** skip the build.

### Note: ordering

This is the prerequisite code change before any starter service is provisioned. **Phase-3 starter provisioning must happen AFTER this PR merges.**

## Test plan

Red-green TDD (added to `showcase/scripts/__tests__/verify-railway-image-refs.test.ts`):

- [x] `starter-*` live service present-but-not-in-SSOT does **not** fail the gate (`findUntrackedServices` returns `[]`).
- [x] A real `showcase-*` untracked service **still** fails the gate (drift detection preserved for the tracked fleet).
- [x] `isStarterFleetService` predicate matches `starter-*` and rejects `showcase-*`/infra (incl. the decommissioned `showcase-starter-*`, which uses the `showcase-` prefix).
- [x] `findMissingServices` never requires a `starter-*` service while still requiring the tracked fleet.
- [x] `pnpm exec tsc --noEmit` clean in `showcase/scripts`.
- [x] SSOT/verify/redeploy/promote suites green (221 tests across 10 files).
- [x] `emit-railway-envs-json.ts --check` reports no drift.