### PR TITLE
feat(showcase): committed starter-fleet Railway provisioner (staging)

### DIFF
--- a/showcase/scripts/__tests__/provision-starter-fleet.test.ts
+++ b/showcase/scripts/__tests__/provision-starter-fleet.test.ts
@@ -259,6 +259,69 @@ describe("fetchExistingServices", () => {
       fetchExistingServices(gql, PROJECT, STAGING_ENV_ID),
     ).rejects.toThrow(/returned null/);
   });
+
+  it("paginates the Relay ServiceConnection — services on page 2 are NOT truncated", async () => {
+    // Railway's `project.services` is a Relay connection that page-limits.
+    // With ~27 SSOT + 12 starter services in staging, a single un-paginated
+    // query returns a TRUNCATED first page — a starter that lives on page 2
+    // looks absent, the provisioner takes the CREATE path, and serviceCreate
+    // rejects with a non-transient "already exists" → the whole run ABORTS.
+    // fetchExistingServices must follow `pageInfo.hasNextPage`/`endCursor`
+    // until every page is drained, accumulating into one byName map.
+    let afterSeen: unknown;
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(
+        _query: string,
+        variables: Record<string, unknown> = {},
+      ): Promise<T> => {
+        const after = variables.after;
+        afterSeen = after;
+        const mkNode = (id: string, name: string) => ({
+          node: {
+            id,
+            name,
+            serviceInstances: {
+              edges: [
+                {
+                  node: {
+                    environmentId: STAGING_ENV_ID,
+                    domains: { serviceDomains: [] },
+                  },
+                },
+              ],
+            },
+          },
+        });
+        // Page 1: one service + hasNextPage. Page 2 (after cursor): the rest.
+        if (!after) {
+          return {
+            project: {
+              services: {
+                edges: [mkNode("svc-page1", "starter-mastra")],
+                pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+              },
+            },
+          } as T;
+        }
+        return {
+          project: {
+            services: {
+              edges: [mkNode("svc-page2", "starter-adk")],
+              pageInfo: { hasNextPage: false, endCursor: "cursor-2" },
+            },
+          },
+        } as T;
+      },
+    ) as RailwayGqlFn;
+
+    const map = await fetchExistingServices(gql, PROJECT, STAGING_ENV_ID);
+    // Both pages' services are present — page 2 was NOT truncated away.
+    expect(map.get("starter-mastra")?.id).toBe("svc-page1");
+    expect(map.get("starter-adk")?.id).toBe("svc-page2");
+    expect(map.size).toBe(2);
+    // The second query carried the first page's endCursor as `after`.
+    expect(afterSeen).toBe("cursor-1");
+  });
 });
 
 // ── provisionStarterFleet: create path ──────────────────────────────────
@@ -434,6 +497,56 @@ describe("provisionStarterFleet — create path", () => {
       sleepMs: NO_SLEEP,
     });
     expect(updateAttempts).toBe(2); // failed once, succeeded on retry
+    expect(summary.records[0].action).toBe("created");
+  });
+
+  it("retries Railway's INTERPOLATED 'Service <id> not found' (id in message)", async () => {
+    // Railway's real eventual-consistency message interpolates the service id:
+    // "Service abc-123 not found" — NOT the contiguous "Service not found".
+    // The transient regex must match the interpolated form so the post-create
+    // race is retried; otherwise the run aborts on a benign timing error.
+    let updateAttempts = 0;
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(
+        query: string,
+        variables: Record<string, unknown> = {},
+      ): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          const input = variables.input as { name: string };
+          return { serviceCreate: { id: "new-1", name: input.name } } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          updateAttempts += 1;
+          if (updateAttempts === 1) {
+            throw new Error(
+              "Railway GraphQL errors:\n  - Service abc-123-def not found",
+            );
+          }
+          return { serviceInstanceUpdate: true } as T;
+        }
+        if (query.includes("serviceInstanceRedeploy(")) {
+          return { serviceInstanceRedeploy: true } as T;
+        }
+        if (query.includes("serviceDomainCreate(")) {
+          return {
+            serviceDomainCreate: { domain: "new-1.up.railway.app" },
+          } as T;
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: [TWO_TARGETS[0]],
+      sleepMs: NO_SLEEP,
+    });
+    expect(updateAttempts).toBe(2); // failed once on interpolated msg, retried
     expect(summary.records[0].action).toBe("created");
   });
 
@@ -667,6 +780,86 @@ describe("provisionStarterFleet — redeploy", () => {
       calls.filter((c) => c.query.includes("serviceInstanceRedeploy(")),
     ).toHaveLength(0);
   });
+
+  it("THROWS when serviceInstanceRedeploy returns false (image would not run)", async () => {
+    // serviceInstanceRedeploy returns Boolean! (verified against
+    // redeploy-env.ts:117 + bin/railway RestoreCommand). A `false` return
+    // means Railway did not start a deployment — the image would never run,
+    // so the provisioner must fail loud rather than report success.
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(query: string): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          return {
+            serviceCreate: { id: "new-1", name: "starter-mastra" },
+          } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          return { serviceInstanceUpdate: true } as T;
+        }
+        if (query.includes("serviceInstanceRedeploy(")) {
+          return { serviceInstanceRedeploy: false } as T;
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    await expect(
+      provisionStarterFleet({
+        gql,
+        projectId: PROJECT,
+        stagingEnvId: STAGING_ENV_ID,
+        targets: [TWO_TARGETS[0]],
+        sleepMs: NO_SLEEP,
+      }),
+    ).rejects.toThrow(/image will not run/);
+  });
+
+  it("THROWS when serviceInstanceRedeploy returns null (no deployment started)", async () => {
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(query: string): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          return {
+            serviceCreate: { id: "new-1", name: "starter-mastra" },
+          } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          return { serviceInstanceUpdate: true } as T;
+        }
+        if (query.includes("serviceInstanceRedeploy(")) {
+          return { serviceInstanceRedeploy: null } as T;
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    await expect(
+      provisionStarterFleet({
+        gql,
+        projectId: PROJECT,
+        stagingEnvId: STAGING_ENV_ID,
+        targets: [TWO_TARGETS[0]],
+        sleepMs: NO_SLEEP,
+      }),
+    ).rejects.toThrow(/image will not run/);
+  });
+
+  it("SUCCEEDS when serviceInstanceRedeploy returns true (the verified Boolean! contract)", async () => {
+    const { gql } = makeMockGql();
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: [TWO_TARGETS[0]],
+      sleepMs: NO_SLEEP,
+    });
+    expect(summary.records[0].action).toBe("created");
+  });
 });
 
 // ── provisionStarterFleet: idempotent domain re-create (partial failure) ─
@@ -715,12 +908,14 @@ describe("provisionStarterFleet — domain already-exists is a benign no-op", ()
       },
     ) as RailwayGqlFn;
 
+    const logs: string[] = [];
     const summary = await provisionStarterFleet({
       gql,
       projectId: PROJECT,
       stagingEnvId: STAGING_ENV_ID,
       targets: TWO_TARGETS,
       sleepMs: NO_SLEEP,
+      log: (line) => logs.push(line),
     });
     // Both targets processed — the fleet did NOT abort.
     expect(summary.records).toHaveLength(2);
@@ -728,6 +923,11 @@ describe("provisionStarterFleet — domain already-exists is a benign no-op", ()
     expect(summary.records[0].domainAction).toBe("existing");
     // The second target's domain succeeded normally.
     expect(summary.records[1].domainAction).toBe("created");
+    // Forensic trail: the benign no-op log line includes the ACTUAL matched
+    // Railway error message, not just a generic "already exists" note.
+    expect(
+      logs.some((l) => l.includes("A domain already exists for this service")),
+    ).toBe(true);
   });
 
   it("still ABORTS on a genuine non-transient domain-create error", async () => {

--- a/showcase/scripts/__tests__/provision-starter-fleet.test.ts
+++ b/showcase/scripts/__tests__/provision-starter-fleet.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   deriveStarterTargets,
   fetchExistingServices,
+  parseArgs,
   provisionStarterFleet,
   resolveRegistryCredentials,
   STARTER_FLEET_PREFIX,
@@ -191,6 +192,10 @@ function makeMockGql(
 
       if (query.includes("serviceInstanceUpdate(")) {
         return { serviceInstanceUpdate: true } as T;
+      }
+
+      if (query.includes("serviceInstanceRedeploy(")) {
+        return { serviceInstanceRedeploy: true } as T;
       }
 
       if (query.includes("serviceDomainCreate(")) {
@@ -409,6 +414,9 @@ describe("provisionStarterFleet — create path", () => {
           }
           return { serviceInstanceUpdate: true } as T;
         }
+        if (query.includes("serviceInstanceRedeploy(")) {
+          return { serviceInstanceRedeploy: true } as T;
+        }
         if (query.includes("serviceDomainCreate(")) {
           return {
             serviceDomainCreate: { domain: "new-1.up.railway.app" },
@@ -558,6 +566,228 @@ describe("provisionStarterFleet — dry run", () => {
     expect(
       calls.filter((c) => c.query.includes("serviceInstanceUpdate(")),
     ).toHaveLength(0);
+    expect(
+      calls.filter((c) => c.query.includes("serviceInstanceRedeploy(")),
+    ).toHaveLength(0);
     expect(summary.records).toHaveLength(2);
+  });
+
+  it("reports a NEW service's domain as 'would-create' (faithful preview, not 'skipped')", async () => {
+    // A real run creates a domain for a new service, so dry-run must preview
+    // that as "would-create" rather than the misleading "skipped".
+    const { gql } = makeMockGql();
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+      dryRun: true,
+    });
+    expect(
+      summary.records.every((r) => r.domainAction === "would-create"),
+    ).toBe(true);
+  });
+
+  it("reports an EXISTING already-domained service as 'existing' in dry-run", async () => {
+    const { gql } = makeMockGql([
+      {
+        id: "existing-mastra",
+        name: "starter-mastra",
+        stagingDomain: "starter-mastra.up.railway.app",
+      },
+    ]);
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: [TWO_TARGETS[0]],
+      dryRun: true,
+    });
+    expect(summary.records[0].domainAction).toBe("existing");
+  });
+});
+
+// ── provisionStarterFleet: redeploy (image must actually run) ────────────
+
+describe("provisionStarterFleet — redeploy", () => {
+  it("triggers serviceInstanceRedeploy after configuring a NEW service so the image actually runs", async () => {
+    // serviceCreate + serviceInstanceUpdate(source.image) pins the image but
+    // does NOT start a deployment (auto-updates only fire on a NEW digest
+    // push; bin/railway documents update+redeploy as the canonical pattern).
+    // Without an explicit redeploy the service never runs and starter_smoke
+    // would never find it up.
+    const { gql, calls } = makeMockGql();
+    await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+    });
+    const redeploys = calls.filter((c) =>
+      c.query.includes("serviceInstanceRedeploy("),
+    );
+    expect(redeploys).toHaveLength(2);
+    for (const r of redeploys) {
+      expect(r.variables.environmentId).toBe(STAGING_ENV_ID);
+      expect(r.variables.environmentId).not.toBe(PRODUCTION_ENV_ID);
+    }
+  });
+
+  it("triggers serviceInstanceRedeploy on the update path (re-asserted image must run)", async () => {
+    const { gql, calls } = makeMockGql([
+      {
+        id: "existing-mastra",
+        name: "starter-mastra",
+        stagingDomain: "starter-mastra.up.railway.app",
+      },
+    ]);
+    await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: [TWO_TARGETS[0]],
+    });
+    const redeploys = calls.filter((c) =>
+      c.query.includes("serviceInstanceRedeploy("),
+    );
+    expect(redeploys).toHaveLength(1);
+    expect(redeploys[0].variables.serviceId).toBe("existing-mastra");
+  });
+
+  it("sends NO redeploy in dry-run mode", async () => {
+    const { gql, calls } = makeMockGql();
+    await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+      dryRun: true,
+    });
+    expect(
+      calls.filter((c) => c.query.includes("serviceInstanceRedeploy(")),
+    ).toHaveLength(0);
+  });
+});
+
+// ── provisionStarterFleet: idempotent domain re-create (partial failure) ─
+
+describe("provisionStarterFleet — domain already-exists is a benign no-op", () => {
+  it("treats a 'domain already exists' error as existing and CONTINUES the fleet (does not abort)", async () => {
+    // Partial-failure re-run: the start-of-run snapshot missed the domain
+    // (Railway eventual consistency / a run that died mid-fleet), so the
+    // provisioner re-issues serviceDomainCreate and Railway rejects it with a
+    // NON-transient "already exists" error. This must converge (mark existing,
+    // keep going), not abort the remaining fleet.
+    let domainAttempts = 0;
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(
+        query: string,
+        variables: Record<string, unknown> = {},
+      ): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          const input = variables.input as { name: string };
+          return {
+            serviceCreate: { id: `svc-${input.name}`, name: input.name },
+          } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          return { serviceInstanceUpdate: true } as T;
+        }
+        if (query.includes("serviceInstanceRedeploy(")) {
+          return { serviceInstanceRedeploy: true } as T;
+        }
+        if (query.includes("serviceDomainCreate(")) {
+          domainAttempts += 1;
+          // First target's domain create rejects as already-existing.
+          if (domainAttempts === 1) {
+            throw new Error(
+              "Railway GraphQL errors:\n  - A domain already exists for this service",
+            );
+          }
+          return {
+            serviceDomainCreate: { domain: "svc.up.railway.app" },
+          } as T;
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+      sleepMs: NO_SLEEP,
+    });
+    // Both targets processed — the fleet did NOT abort.
+    expect(summary.records).toHaveLength(2);
+    // The duplicate-domain target is marked existing (benign no-op).
+    expect(summary.records[0].domainAction).toBe("existing");
+    // The second target's domain succeeded normally.
+    expect(summary.records[1].domainAction).toBe("created");
+  });
+
+  it("still ABORTS on a genuine non-transient domain-create error", async () => {
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(query: string): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          return {
+            serviceCreate: { id: "svc-1", name: "starter-mastra" },
+          } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          return { serviceInstanceUpdate: true } as T;
+        }
+        if (query.includes("serviceInstanceRedeploy(")) {
+          return { serviceInstanceRedeploy: true } as T;
+        }
+        if (query.includes("serviceDomainCreate(")) {
+          throw new Error("Railway GraphQL errors:\n  - Unauthorized");
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    await expect(
+      provisionStarterFleet({
+        gql,
+        projectId: PROJECT,
+        stagingEnvId: STAGING_ENV_ID,
+        targets: [TWO_TARGETS[0]],
+        sleepMs: NO_SLEEP,
+      }),
+    ).rejects.toThrow(/Unauthorized/);
+  });
+});
+
+// ── parseArgs: argv validation ───────────────────────────────────────────
+
+describe("parseArgs", () => {
+  it("parses known flags", () => {
+    expect(parseArgs(["--dry-run"])).toEqual({
+      help: false,
+      list: false,
+      dryRun: true,
+    });
+    expect(parseArgs(["--list"])).toMatchObject({ list: true });
+    expect(parseArgs(["--help"])).toMatchObject({ help: true });
+    expect(parseArgs([])).toEqual({ help: false, list: false, dryRun: false });
+  });
+
+  it("REJECTS an unrecognized flag (mistyped --dry-rn must not silently run live)", () => {
+    expect(() => parseArgs(["--dry-rn"])).toThrow(/unknown|unrecognized/i);
+  });
+
+  it("rejects any unrecognized dash-prefixed argument", () => {
+    expect(() => parseArgs(["--list", "--bogus"])).toThrow(
+      /unknown|unrecognized/i,
+    );
+    expect(() => parseArgs(["-x"])).toThrow(/unknown|unrecognized/i);
   });
 });

--- a/showcase/scripts/__tests__/provision-starter-fleet.test.ts
+++ b/showcase/scripts/__tests__/provision-starter-fleet.test.ts
@@ -1,0 +1,563 @@
+/**
+ * Tests for the starter-fleet Railway provisioner
+ * (`provision-starter-fleet.ts`).
+ *
+ * Style note (mirrors redeploy-env / verify-railway-image-refs tests): the
+ * Railway GraphQL API is the only impure surface, and it is dependency-
+ * injected as a `RailwayGqlFn`. We exercise the pure derivation/credential
+ * helpers and the idempotent provisioning core against a recording mock —
+ * no live Railway calls, no `fetch` stubbing. Railway is an external
+ * boundary, so a plain recording mock is appropriate (aimock is only for
+ * LLM calls).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  deriveStarterTargets,
+  fetchExistingServices,
+  provisionStarterFleet,
+  resolveRegistryCredentials,
+  STARTER_FLEET_PREFIX,
+  STARTER_HEALTHCHECK_PATH,
+  STARTER_REGION,
+} from "../provision-starter-fleet";
+import type { RailwayGqlFn, StarterTarget } from "../provision-starter-fleet";
+import { STARTER_TO_COLUMN } from "../../harness/src/probes/helpers/starter-mapping";
+import { STAGING_ENV_ID, PRODUCTION_ENV_ID } from "../railway-envs";
+
+const PROJECT = "proj-test-id";
+
+// ── Target derivation ───────────────────────────────────────────────────
+
+describe("deriveStarterTargets", () => {
+  it("derives exactly the 12 starters from the STARTER_TO_COLUMN SSOT", () => {
+    const targets = deriveStarterTargets();
+    expect(targets).toHaveLength(12);
+    expect(targets.length).toBe(Object.keys(STARTER_TO_COLUMN).length);
+  });
+
+  it("uses the RAW starter slug for service name + image (NOT the remapped column slug)", () => {
+    const targets = deriveStarterTargets();
+    const byName = new Map(targets.map((t) => [t.serviceName, t]));
+
+    // adk -> column "google-adk", but the service/image use raw "adk".
+    const adk = byName.get("starter-adk");
+    expect(adk, "starter-adk must be present").toBeDefined();
+    expect(adk!.image).toBe("ghcr.io/copilotkit/starter-adk:latest");
+    // The remapped column slug must NOT leak into the service name.
+    expect(byName.has("starter-google-adk")).toBe(false);
+
+    // langgraph-js -> column "langgraph-typescript"; raw slug wins.
+    const lgjs = byName.get("starter-langgraph-js");
+    expect(lgjs, "starter-langgraph-js must be present").toBeDefined();
+    expect(lgjs!.image).toBe("ghcr.io/copilotkit/starter-langgraph-js:latest");
+    expect(byName.has("starter-langgraph-typescript")).toBe(false);
+  });
+
+  it("derives the full expected name + image set for all 12", () => {
+    const targets = deriveStarterTargets();
+    const names = targets.map((t) => t.serviceName).sort();
+    expect(names).toEqual(
+      [
+        "adk",
+        "agno",
+        "crewai-crews",
+        "langgraph-fastapi",
+        "langgraph-js",
+        "langgraph-python",
+        "llamaindex",
+        "mastra",
+        "ms-agent-framework-dotnet",
+        "ms-agent-framework-python",
+        "pydantic-ai",
+        "strands-python",
+      ]
+        .map((s) => `${STARTER_FLEET_PREFIX}${s}`)
+        .sort(),
+    );
+    for (const t of targets) {
+      expect(t.image).toBe(`ghcr.io/copilotkit/${t.serviceName}:latest`);
+    }
+  });
+
+  it("derives from an injected mapping (pure)", () => {
+    const targets = deriveStarterTargets({ foo: "bar", baz: "qux" });
+    expect(targets.map((t) => t.serviceName)).toEqual([
+      "starter-baz",
+      "starter-foo",
+    ]);
+  });
+});
+
+// ── Registry credentials ────────────────────────────────────────────────
+
+describe("resolveRegistryCredentials", () => {
+  it("returns undefined when GITHUB_TOKEN is unset", () => {
+    expect(resolveRegistryCredentials({})).toBeUndefined();
+  });
+
+  it("uses GHCR_USERNAME (preferred) as the username", () => {
+    expect(
+      resolveRegistryCredentials({
+        GITHUB_TOKEN: "ghp_x",
+        GHCR_USERNAME: "ck-bot",
+        GITHUB_ACTOR: "some-actor",
+      }),
+    ).toEqual({ username: "ck-bot", password: "ghp_x" });
+  });
+
+  it("falls back to GITHUB_ACTOR when GHCR_USERNAME is unset", () => {
+    expect(
+      resolveRegistryCredentials({
+        GITHUB_TOKEN: "ghp_x",
+        GITHUB_ACTOR: "ci-actor",
+      }),
+    ).toEqual({ username: "ci-actor", password: "ghp_x" });
+  });
+
+  it("throws (fail loud) when a token is present but no username is available", () => {
+    expect(() => resolveRegistryCredentials({ GITHUB_TOKEN: "ghp_x" })).toThrow(
+      /no GHCR username/i,
+    );
+  });
+});
+
+// ── Recording GraphQL mock ──────────────────────────────────────────────
+
+interface Call {
+  query: string;
+  variables: Record<string, unknown>;
+}
+
+/**
+ * Build a recording RailwayGqlFn. `projectServices` is the existing-services
+ * response (defaults to an empty project). serviceCreate returns a synthetic
+ * id derived from the requested name; serviceDomainCreate returns a synthetic
+ * domain. All calls are recorded for assertion.
+ */
+function makeMockGql(
+  projectServices: Array<{
+    id: string;
+    name: string;
+    stagingDomain?: string;
+  }> = [],
+): { gql: RailwayGqlFn; calls: Call[] } {
+  const calls: Call[] = [];
+  let createSeq = 0;
+
+  const gql: RailwayGqlFn = vi.fn(
+    async <T = unknown>(
+      query: string,
+      variables: Record<string, unknown> = {},
+    ): Promise<T> => {
+      calls.push({ query, variables });
+
+      if (query.includes("project(id:")) {
+        return {
+          project: {
+            services: {
+              edges: projectServices.map((s) => ({
+                node: {
+                  id: s.id,
+                  name: s.name,
+                  serviceInstances: {
+                    edges: [
+                      {
+                        node: {
+                          environmentId: STAGING_ENV_ID,
+                          domains: {
+                            serviceDomains: s.stagingDomain
+                              ? [{ domain: s.stagingDomain }]
+                              : [],
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              })),
+            },
+          },
+        } as T;
+      }
+
+      if (query.includes("serviceCreate(")) {
+        const input = variables.input as { name: string };
+        createSeq += 1;
+        return {
+          serviceCreate: { id: `new-svc-${createSeq}`, name: input.name },
+        } as T;
+      }
+
+      if (query.includes("serviceInstanceUpdate(")) {
+        return { serviceInstanceUpdate: true } as T;
+      }
+
+      if (query.includes("serviceDomainCreate(")) {
+        const input = variables.input as { serviceId: string };
+        return {
+          serviceDomainCreate: {
+            domain: `${input.serviceId}.up.railway.app`,
+          },
+        } as T;
+      }
+
+      throw new Error(`unexpected query in mock:\n${query}`);
+    },
+  ) as RailwayGqlFn;
+
+  return { gql, calls };
+}
+
+const TWO_TARGETS: StarterTarget[] = [
+  {
+    slug: "mastra",
+    serviceName: "starter-mastra",
+    image: "ghcr.io/copilotkit/starter-mastra:latest",
+  },
+  {
+    slug: "adk",
+    serviceName: "starter-adk",
+    image: "ghcr.io/copilotkit/starter-adk:latest",
+  },
+];
+
+/** No-op sleep so retry-bearing tests don't actually wait. */
+const NO_SLEEP = async (): Promise<void> => {};
+
+// ── fetchExistingServices ───────────────────────────────────────────────
+
+describe("fetchExistingServices", () => {
+  it("indexes services by name and detects staging domains", async () => {
+    const { gql } = makeMockGql([
+      {
+        id: "svc-a",
+        name: "starter-mastra",
+        stagingDomain: "m.up.railway.app",
+      },
+      { id: "svc-b", name: "starter-adk" },
+    ]);
+    const map = await fetchExistingServices(gql, PROJECT, STAGING_ENV_ID);
+    expect(map.get("starter-mastra")).toEqual({
+      id: "svc-a",
+      hasStagingDomain: true,
+    });
+    expect(map.get("starter-adk")).toEqual({
+      id: "svc-b",
+      hasStagingDomain: false,
+    });
+  });
+
+  it("throws when the project is null (bad id / no access)", async () => {
+    const gql: RailwayGqlFn = vi.fn(async () => ({ project: null })) as never;
+    await expect(
+      fetchExistingServices(gql, PROJECT, STAGING_ENV_ID),
+    ).rejects.toThrow(/returned null/);
+  });
+});
+
+// ── provisionStarterFleet: create path ──────────────────────────────────
+
+describe("provisionStarterFleet — create path", () => {
+  it("creates services with the correct GHCR image source", async () => {
+    const { gql, calls } = makeMockGql();
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+    });
+
+    expect(summary.records.map((r) => r.action)).toEqual([
+      "created",
+      "created",
+    ]);
+
+    const creates = calls.filter((c) => c.query.includes("serviceCreate("));
+    expect(creates).toHaveLength(2);
+    const createInputs = creates.map(
+      (c) =>
+        c.variables.input as {
+          name: string;
+          environmentId: string;
+          source: { image: string };
+        },
+    );
+    expect(createInputs[0]).toMatchObject({
+      projectId: PROJECT,
+      name: "starter-mastra",
+      source: { image: "ghcr.io/copilotkit/starter-mastra:latest" },
+    });
+    expect(createInputs[1]).toMatchObject({
+      name: "starter-adk",
+      source: { image: "ghcr.io/copilotkit/starter-adk:latest" },
+    });
+    // CRITICAL: serviceCreate MUST scope the new instance to the STAGING
+    // env — without environmentId Railway materializes the instance in the
+    // default (production) environment, leaking a prod instance per starter.
+    for (const ci of createInputs) {
+      expect(ci.environmentId).toBe(STAGING_ENV_ID);
+      expect(ci.environmentId).not.toBe(PRODUCTION_ENV_ID);
+    }
+  });
+
+  it("sets sleepApplication:true + healthcheck '/' + region us-west1 on the staging instance", async () => {
+    const { gql, calls } = makeMockGql();
+    await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+    });
+
+    const updates = calls.filter((c) =>
+      c.query.includes("serviceInstanceUpdate("),
+    );
+    expect(updates).toHaveLength(2);
+    for (const u of updates) {
+      // ALWAYS targets the staging env — never prod.
+      expect(u.variables.environmentId).toBe(STAGING_ENV_ID);
+      expect(u.variables.environmentId).not.toBe(PRODUCTION_ENV_ID);
+      const input = u.variables.input as Record<string, unknown>;
+      expect(input.sleepApplication).toBe(true);
+      expect(input.healthcheckPath).toBe(STARTER_HEALTHCHECK_PATH);
+      expect(input.healthcheckPath).toBe("/");
+      expect(input.region).toBe(STARTER_REGION);
+      expect(input.region).toBe("us-west1");
+    }
+  });
+
+  it("attaches registry credentials when provided", async () => {
+    const { gql, calls } = makeMockGql();
+    await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+      registryCredentials: { username: "ck-bot", password: "ghp_x" },
+    });
+    const update = calls.find((c) =>
+      c.query.includes("serviceInstanceUpdate("),
+    )!;
+    const input = update.variables.input as Record<string, unknown>;
+    expect(input.registryCredentials).toEqual({
+      username: "ck-bot",
+      password: "ghp_x",
+    });
+  });
+
+  it("omits registry credentials when none are provided", async () => {
+    const { gql, calls } = makeMockGql();
+    await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+    });
+    const update = calls.find((c) =>
+      c.query.includes("serviceInstanceUpdate("),
+    )!;
+    const input = update.variables.input as Record<string, unknown>;
+    expect(input.registryCredentials).toBeUndefined();
+  });
+
+  it("creates a staging-scoped domain per new service", async () => {
+    const { gql, calls } = makeMockGql();
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+    });
+    const domainCalls = calls.filter((c) =>
+      c.query.includes("serviceDomainCreate("),
+    );
+    expect(domainCalls).toHaveLength(2);
+    for (const d of domainCalls) {
+      const input = d.variables.input as { environmentId: string };
+      expect(input.environmentId).toBe(STAGING_ENV_ID);
+    }
+    expect(summary.records.every((r) => r.domainAction === "created")).toBe(
+      true,
+    );
+  });
+
+  it("retries the post-create instance update on transient 'ServiceInstance not found'", async () => {
+    // Railway materializes the env-scoped instance asynchronously after
+    // serviceCreate, so the first serviceInstanceUpdate can fail with
+    // "ServiceInstance not found". The provisioner must retry rather than
+    // abort the whole fleet.
+    let updateAttempts = 0;
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(
+        query: string,
+        variables: Record<string, unknown> = {},
+      ): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          const input = variables.input as { name: string };
+          return { serviceCreate: { id: "new-1", name: input.name } } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          updateAttempts += 1;
+          if (updateAttempts === 1) {
+            throw new Error(
+              "Railway GraphQL errors:\n  - ServiceInstance not found",
+            );
+          }
+          return { serviceInstanceUpdate: true } as T;
+        }
+        if (query.includes("serviceDomainCreate(")) {
+          return {
+            serviceDomainCreate: { domain: "new-1.up.railway.app" },
+          } as T;
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: [TWO_TARGETS[0]],
+      sleepMs: NO_SLEEP,
+    });
+    expect(updateAttempts).toBe(2); // failed once, succeeded on retry
+    expect(summary.records[0].action).toBe("created");
+  });
+
+  it("does NOT retry a non-transient error (fails loud)", async () => {
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(query: string): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          return {
+            serviceCreate: { id: "new-1", name: "starter-mastra" },
+          } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          throw new Error("Railway GraphQL errors:\n  - Unauthorized");
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    await expect(
+      provisionStarterFleet({
+        gql,
+        projectId: PROJECT,
+        stagingEnvId: STAGING_ENV_ID,
+        targets: [TWO_TARGETS[0]],
+        sleepMs: NO_SLEEP,
+      }),
+    ).rejects.toThrow(/Unauthorized/);
+  });
+});
+
+// ── provisionStarterFleet: idempotent update path ───────────────────────
+
+describe("provisionStarterFleet — idempotent update path", () => {
+  it("UPDATES (does not re-create) a starter service that already exists", async () => {
+    const { gql, calls } = makeMockGql([
+      {
+        id: "existing-mastra",
+        name: "starter-mastra",
+        stagingDomain: "starter-mastra.up.railway.app",
+      },
+    ]);
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+    });
+
+    const mastra = summary.records.find(
+      (r) => r.serviceName === "starter-mastra",
+    )!;
+    const adk = summary.records.find((r) => r.serviceName === "starter-adk")!;
+
+    // mastra already existed → updated, reuses its id, no create call for it.
+    expect(mastra.action).toBe("updated");
+    expect(mastra.serviceId).toBe("existing-mastra");
+    // adk did not exist → created.
+    expect(adk.action).toBe("created");
+
+    const creates = calls.filter((c) => c.query.includes("serviceCreate("));
+    expect(creates).toHaveLength(1);
+    expect((creates[0].variables.input as { name: string }).name).toBe(
+      "starter-adk",
+    );
+
+    // The existing service still gets its instance settings re-applied
+    // (converge sleep/healthcheck/region on re-run).
+    const updates = calls.filter((c) =>
+      c.query.includes("serviceInstanceUpdate("),
+    );
+    expect(updates).toHaveLength(2);
+  });
+
+  it("does NOT create a duplicate domain when the existing service already has one", async () => {
+    const { gql, calls } = makeMockGql([
+      {
+        id: "existing-mastra",
+        name: "starter-mastra",
+        stagingDomain: "starter-mastra.up.railway.app",
+      },
+    ]);
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      // only the already-domained service
+      targets: [TWO_TARGETS[0]],
+    });
+    const domainCalls = calls.filter((c) =>
+      c.query.includes("serviceDomainCreate("),
+    );
+    expect(domainCalls).toHaveLength(0);
+    expect(summary.records[0].domainAction).toBe("existing");
+  });
+
+  it("creates a domain for an existing service that lacks one", async () => {
+    const { gql, calls } = makeMockGql([
+      { id: "existing-mastra", name: "starter-mastra" }, // no domain
+    ]);
+    await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: [TWO_TARGETS[0]],
+    });
+    const domainCalls = calls.filter((c) =>
+      c.query.includes("serviceDomainCreate("),
+    );
+    expect(domainCalls).toHaveLength(1);
+  });
+});
+
+// ── provisionStarterFleet: dry run ──────────────────────────────────────
+
+describe("provisionStarterFleet — dry run", () => {
+  it("sends no mutations in dry-run mode (only the read query)", async () => {
+    const { gql, calls } = makeMockGql();
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: TWO_TARGETS,
+      dryRun: true,
+    });
+    expect(calls.every((c) => c.query.includes("project(id:"))).toBe(true);
+    expect(calls.filter((c) => c.query.includes("Create("))).toHaveLength(0);
+    expect(
+      calls.filter((c) => c.query.includes("serviceInstanceUpdate(")),
+    ).toHaveLength(0);
+    expect(summary.records).toHaveLength(2);
+  });
+});

--- a/showcase/scripts/__tests__/provision-starter-fleet.test.ts
+++ b/showcase/scripts/__tests__/provision-starter-fleet.test.ts
@@ -260,6 +260,79 @@ describe("fetchExistingServices", () => {
     ).rejects.toThrow(/returned null/);
   });
 
+  it("tolerates a service node with null serviceInstances (transitional service)", async () => {
+    // A service in a transitional state can return a null serviceInstances
+    // connection (or null .edges). An unguarded `.edges.find(...)` throws a
+    // TypeError that aborts the ENTIRE fetch — before any starter is touched.
+    // The fetch must coalesce and treat such a node as having no staging
+    // instance / no domain rather than crash.
+    const gql: RailwayGqlFn = vi.fn(async () => ({
+      project: {
+        services: {
+          edges: [
+            {
+              node: {
+                id: "svc-null-instances",
+                name: "starter-mastra",
+                serviceInstances: null,
+              },
+            },
+            {
+              node: {
+                id: "svc-null-edges",
+                name: "starter-adk",
+                serviceInstances: { edges: null },
+              },
+            },
+          ],
+        },
+      },
+    })) as never;
+
+    const map = await fetchExistingServices(gql, PROJECT, STAGING_ENV_ID);
+    expect(map.get("starter-mastra")).toEqual({
+      id: "svc-null-instances",
+      hasStagingDomain: false,
+    });
+    expect(map.get("starter-adk")).toEqual({
+      id: "svc-null-edges",
+      hasStagingDomain: false,
+    });
+  });
+
+  it("FAILS LOUD when the page-drain loop is truncated (hasNextPage still true at the bound)", async () => {
+    // If the defensive page bound is reached while pageInfo.hasNextPage is
+    // STILL true, the byName map is a TRUNCATED snapshot. Returning it
+    // silently would feed erroneous create-vs-update decisions (a service on
+    // an undrained page looks absent → CREATE → "already exists"). Refuse to
+    // provision against a truncated snapshot.
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(): Promise<T> =>
+        ({
+          project: {
+            services: {
+              edges: [
+                {
+                  node: {
+                    id: "svc-loop",
+                    name: "starter-loop",
+                    serviceInstances: { edges: [] },
+                  },
+                },
+              ],
+              // Always more pages, never a usable cursor advance → the loop
+              // exhausts its bound with hasNextPage still true.
+              pageInfo: { hasNextPage: true, endCursor: "stuck-cursor" },
+            },
+          },
+        }) as T,
+    ) as RailwayGqlFn;
+
+    await expect(
+      fetchExistingServices(gql, PROJECT, STAGING_ENV_ID),
+    ).rejects.toThrow(/truncated/i);
+  });
+
   it("paginates the Relay ServiceConnection — services on page 2 are NOT truncated", async () => {
     // Railway's `project.services` is a Relay connection that page-limits.
     // With ~27 SSOT + 12 starter services in staging, a single un-paginated
@@ -550,6 +623,206 @@ describe("provisionStarterFleet — create path", () => {
     expect(summary.records[0].action).toBe("created");
   });
 
+  it("THROWS when serviceCreate returns no id (silent-success guard)", async () => {
+    // serviceCreate must yield a non-empty service id. A null/empty id means
+    // the create silently failed — every downstream mutation would target an
+    // invalid service. Fail loud, naming the service.
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(query: string): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          return { serviceCreate: { id: "", name: "starter-mastra" } } as T;
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    await expect(
+      provisionStarterFleet({
+        gql,
+        projectId: PROJECT,
+        stagingEnvId: STAGING_ENV_ID,
+        targets: [TWO_TARGETS[0]],
+        sleepMs: NO_SLEEP,
+      }),
+    ).rejects.toThrow(/serviceCreate.*starter-mastra/i);
+  });
+
+  it("THROWS when serviceInstanceUpdate returns false (settings NOT applied)", async () => {
+    // serviceInstanceUpdate returns Boolean! — a `false` return means
+    // sleepApplication/healthcheck/image/creds were NOT applied. Reporting
+    // success here would run the service WITHOUT sleep. Fail loud.
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(query: string): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          return {
+            serviceCreate: { id: "new-1", name: "starter-mastra" },
+          } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          return { serviceInstanceUpdate: false } as T;
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    await expect(
+      provisionStarterFleet({
+        gql,
+        projectId: PROJECT,
+        stagingEnvId: STAGING_ENV_ID,
+        targets: [TWO_TARGETS[0]],
+        sleepMs: NO_SLEEP,
+      }),
+    ).rejects.toThrow(/serviceInstanceUpdate.*starter-mastra/i);
+  });
+
+  it("does NOT log 'configured ...' before the update result is verified", async () => {
+    // The "configured ..." log line must come AFTER the update result is
+    // verified — a false return must throw without ever claiming the settings
+    // were configured.
+    const logs: string[] = [];
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(query: string): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          return {
+            serviceCreate: { id: "new-1", name: "starter-mastra" },
+          } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          return { serviceInstanceUpdate: false } as T;
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    await expect(
+      provisionStarterFleet({
+        gql,
+        projectId: PROJECT,
+        stagingEnvId: STAGING_ENV_ID,
+        targets: [TWO_TARGETS[0]],
+        sleepMs: NO_SLEEP,
+        log: (line) => logs.push(line),
+      }),
+    ).rejects.toThrow();
+    expect(logs.some((l) => l.includes("configured"))).toBe(false);
+  });
+
+  it("THROWS when serviceDomainCreate returns no domain on the create path", async () => {
+    // serviceDomainCreate must yield a domain on the create path. A
+    // null/empty domain means the create silently failed.
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(query: string): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          return {
+            serviceCreate: { id: "new-1", name: "starter-mastra" },
+          } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          return { serviceInstanceUpdate: true } as T;
+        }
+        if (query.includes("serviceInstanceRedeploy(")) {
+          return { serviceInstanceRedeploy: true } as T;
+        }
+        if (query.includes("serviceDomainCreate(")) {
+          return { serviceDomainCreate: { domain: "" } } as T;
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    await expect(
+      provisionStarterFleet({
+        gql,
+        projectId: PROJECT,
+        stagingEnvId: STAGING_ENV_ID,
+        targets: [TWO_TARGETS[0]],
+        sleepMs: NO_SLEEP,
+      }),
+    ).rejects.toThrow(/serviceDomainCreate.*starter-mastra/i);
+  });
+
+  it("absorbs a serviceCreate 'already exists' rejection → falls to update, fleet continues", async () => {
+    // A snapshot-miss (Railway eventual consistency) makes a service look
+    // absent → CREATE path. If serviceCreate then rejects with a non-transient
+    // "already exists", the script must NOT abort: it re-fetches the service
+    // id by name and falls through to the UPDATE path so the fleet converges.
+    let createAttempts = 0;
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(
+        query: string,
+        variables: Record<string, unknown> = {},
+      ): Promise<T> => {
+        if (query.includes("project(id:")) {
+          // First snapshot is empty (miss). A re-fetch by name must surface
+          // the now-visible service so the update path can use its id.
+          if (createAttempts === 0) {
+            return { project: { services: { edges: [] } } } as T;
+          }
+          return {
+            project: {
+              services: {
+                edges: [
+                  {
+                    node: {
+                      id: "found-mastra",
+                      name: "starter-mastra",
+                      serviceInstances: { edges: [] },
+                    },
+                  },
+                ],
+              },
+            },
+          } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          createAttempts += 1;
+          const input = variables.input as { name: string };
+          throw new Error(
+            `Railway GraphQL errors:\n  - Service ${input.name} already exists`,
+          );
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          return { serviceInstanceUpdate: true } as T;
+        }
+        if (query.includes("serviceInstanceRedeploy(")) {
+          return { serviceInstanceRedeploy: true } as T;
+        }
+        if (query.includes("serviceDomainCreate(")) {
+          return {
+            serviceDomainCreate: { domain: "found-mastra.up.railway.app" },
+          } as T;
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    const summary = await provisionStarterFleet({
+      gql,
+      projectId: PROJECT,
+      stagingEnvId: STAGING_ENV_ID,
+      targets: [TWO_TARGETS[0]],
+      sleepMs: NO_SLEEP,
+    });
+    // Did not abort: the target was processed via the update path with the
+    // re-fetched id.
+    expect(summary.records).toHaveLength(1);
+    expect(summary.records[0].action).toBe("updated");
+    expect(summary.records[0].serviceId).toBe("found-mastra");
+  });
+
   it("does NOT retry a non-transient error (fails loud)", async () => {
     const gql: RailwayGqlFn = vi.fn(
       async <T = unknown>(query: string): Promise<T> => {
@@ -577,6 +850,92 @@ describe("provisionStarterFleet — create path", () => {
         sleepMs: NO_SLEEP,
       }),
     ).rejects.toThrow(/Unauthorized/);
+  });
+
+  it("does NOT treat a newline-joined multi-error blob as transient (no cross-line bridge)", async () => {
+    // The transient regex must not bridge "Service" on one error line to
+    // "not found" on a DIFFERENT line of a newline-joined GraphQL error blob.
+    // Railway interpolates the id on a SINGLE line ("Service <id> not found"),
+    // which never contains a newline. A blob that pairs an unrelated "Service
+    // ..." line with a "... not found" line is NOT the eventual-consistency
+    // signal and must fail loud immediately (no wasted retries).
+    let updateAttempts = 0;
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(query: string): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          return {
+            serviceCreate: { id: "new-1", name: "starter-mastra" },
+          } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          updateAttempts += 1;
+          throw new Error(
+            "Railway GraphQL errors:\n  - Service config invalid\n  - Volume not found",
+          );
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    await expect(
+      provisionStarterFleet({
+        gql,
+        projectId: PROJECT,
+        stagingEnvId: STAGING_ENV_ID,
+        targets: [TWO_TARGETS[0]],
+        sleepMs: NO_SLEEP,
+      }),
+    ).rejects.toThrow(/config invalid/);
+    // Failed loud on the first attempt — not retried as transient.
+    expect(updateAttempts).toBe(1);
+  });
+
+  it("wraps the rethrow with retry-exhaustion context when the schedule is exhausted", async () => {
+    // When every transient retry is exhausted, the final rethrow must carry
+    // context (how many retries, that the error was transient) with the
+    // original error as `cause`.
+    const gql: RailwayGqlFn = vi.fn(
+      async <T = unknown>(query: string): Promise<T> => {
+        if (query.includes("project(id:")) {
+          return { project: { services: { edges: [] } } } as T;
+        }
+        if (query.includes("serviceCreate(")) {
+          return {
+            serviceCreate: { id: "new-1", name: "starter-mastra" },
+          } as T;
+        }
+        if (query.includes("serviceInstanceUpdate(")) {
+          // Always transient → exhausts the schedule.
+          throw new Error(
+            "Railway GraphQL errors:\n  - ServiceInstance not found",
+          );
+        }
+        throw new Error(`unexpected query:\n${query}`);
+      },
+    ) as RailwayGqlFn;
+
+    let caught: unknown;
+    try {
+      await provisionStarterFleet({
+        gql,
+        projectId: PROJECT,
+        stagingEnvId: STAGING_ENV_ID,
+        targets: [TWO_TARGETS[0]],
+        sleepMs: NO_SLEEP,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/exhausted.*retries.*transient/i);
+    // The original transient error is preserved as the cause.
+    expect((caught as Error).cause).toBeInstanceOf(Error);
+    expect(((caught as Error).cause as Error).message).toMatch(
+      /ServiceInstance not found/,
+    );
   });
 });
 

--- a/showcase/scripts/provision-starter-fleet.ts
+++ b/showcase/scripts/provision-starter-fleet.ts
@@ -40,8 +40,11 @@
  * does NOT trip the CI image-ref gate / skip the showcase build.
  *
  * IDEMPOTENT: a starter-* service that already exists in staging is UPDATED
- * (instance settings re-applied; a domain created only if none exists) rather
- * than duplicated or errored.
+ * (instance settings re-applied; a domain created only if none exists, and an
+ * "already exists" rejection on re-create is absorbed as a no-op) rather than
+ * duplicated or errored. The pinned image is always (re)deployed via
+ * serviceInstanceRedeploy so it actually runs — serviceInstanceUpdate alone
+ * only pins the image ref.
  *
  * Usage:
  *   npx tsx showcase/scripts/provision-starter-fleet.ts            # provision all 12
@@ -172,6 +175,10 @@ interface ServiceDomainResult {
   serviceDomainCreate: { domain: string };
 }
 
+interface ServiceInstanceRedeployResult {
+  serviceInstanceRedeploy: boolean;
+}
+
 /** Existing-service lookup result: id + whether it already has a staging domain. */
 export interface ExistingService {
   id: string;
@@ -251,14 +258,29 @@ export interface ProvisionOptions {
 const RETRY_DELAYS_MS = [1000, 2000, 4000, 8000];
 
 /**
- * Retry a Railway mutation that can transiently fail with "ServiceInstance
- * not found" while the env-scoped instance is still materializing after
- * serviceCreate. Re-throws non-transient errors immediately and re-throws
- * the last transient error once the schedule is exhausted.
+ * The Railway eventual-consistency error classes that warrant a retry: the
+ * env-scoped serviceInstance is materialized asynchronously after
+ * serviceCreate, so both serviceInstanceUpdate AND serviceDomainCreate /
+ * serviceInstanceRedeploy issued too eagerly can race it. The instance is
+ * surfaced either as "ServiceInstance not found" or (for the domain create)
+ * as a generic "Service ... not found" while the instance is still settling.
+ * NOTE: an "already exists" domain error is NON-transient and is handled
+ * separately (caught as a benign no-op) — it must NOT match here.
+ */
+const TRANSIENT_ERROR_RE = /(ServiceInstance not found|Service not found)/i;
+
+/**
+ * Retry a Railway mutation that can transiently fail while the env-scoped
+ * instance is still materializing after serviceCreate. Re-throws
+ * non-transient errors immediately and re-throws the last transient error
+ * once the schedule is exhausted. The transient predicate is overridable
+ * per-call so callers with a different eventual-consistency signature can
+ * supply their own.
  */
 async function withRetry<T>(
   fn: () => Promise<T>,
   sleep: (ms: number) => Promise<void>,
+  isTransient: (msg: string) => boolean = (msg) => TRANSIENT_ERROR_RE.test(msg),
 ): Promise<T> {
   let lastErr: unknown;
   for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
@@ -267,14 +289,24 @@ async function withRetry<T>(
     } catch (e) {
       lastErr = e;
       const msg = e instanceof Error ? e.message : String(e);
-      // Only retry the known eventual-consistency error.
-      if (!/ServiceInstance not found/i.test(msg)) throw e;
+      // Only retry the known eventual-consistency errors.
+      if (!isTransient(msg)) throw e;
       if (attempt === RETRY_DELAYS_MS.length) break;
       await sleep(RETRY_DELAYS_MS[attempt]);
     }
   }
   throw lastErr;
 }
+
+/**
+ * A serviceDomainCreate that rejects because a domain ALREADY exists is a
+ * benign no-op on a partial-failure re-run (the start-of-run snapshot missed
+ * the domain due to Railway eventual consistency, or a prior run died
+ * mid-fleet). We converge by treating it as "existing" rather than aborting
+ * the remaining fleet. This is NOT a transient/retryable error — matching it
+ * here would waste the retry schedule on a permanent condition.
+ */
+const DOMAIN_ALREADY_EXISTS_RE = /(already\s+exists|duplicate)/i;
 
 export interface ProvisionRecord {
   slug: string;
@@ -283,7 +315,7 @@ export interface ProvisionRecord {
   serviceId: string;
   action: "created" | "updated";
   domain?: string;
-  domainAction: "created" | "existing" | "skipped";
+  domainAction: "created" | "existing" | "skipped" | "would-create";
 }
 
 export interface ProvisionSummary {
@@ -298,8 +330,23 @@ export interface ProvisionSummary {
  *     sleepApplication: true + healthcheckPath + region + (optional) GHCR
  *     registryCredentials — applied on BOTH the create and update paths so a
  *     re-run converges drifted settings;
+ *   - serviceInstanceRedeploy so the pinned image ACTUALLY RUNS. A
+ *     serviceCreate + serviceInstanceUpdate(source.image) only pins the image
+ *     ref; it does NOT start a deployment. Railway's image auto-updates fire
+ *     only when a NEW digest is pushed to the tag, so a freshly-provisioned
+ *     service whose :latest digest already exists would sit with no running
+ *     deployment (and the starter_smoke probe would never find it up) without
+ *     this explicit redeploy. This mirrors the documented update+redeploy
+ *     pattern in bin/railway (RestoreCommand / pin_and_verify) and the
+ *     explicit serviceInstanceRedeploy that showcase_deploy.yml issues after
+ *     every GHCR push (see showcase/RAILWAY.md). The update path re-asserts
+ *     source.image too, so it also redeploys to run the (re-)pinned image.
  *   - serviceDomainCreate for the staging env, but ONLY when the service has
- *     no staging domain yet (so re-runs don't pile up domains).
+ *     no staging domain yet (so re-runs don't pile up domains). A
+ *     serviceDomainCreate that rejects with an "already exists" error (the
+ *     snapshot missed the domain due to eventual consistency, or a prior run
+ *     died mid-fleet) is caught as a benign no-op so the re-run converges
+ *     instead of aborting the remaining fleet.
  *
  * Pure w.r.t. I/O: every Railway interaction goes through the injected `gql`.
  */
@@ -399,32 +446,74 @@ export async function provisionStarterFleet(
           registryCredentials ? ", registry creds" : ""
         }`,
       );
+
+      // Redeploy so the pinned image ACTUALLY RUNS. serviceInstanceUpdate
+      // only pins source.image; without this the service has no running
+      // deployment and starter_smoke would never find it up. Wrapped in
+      // withRetry for the same instance-materialization race as the update.
+      const redeployed = await withRetry(
+        () =>
+          gql<ServiceInstanceRedeployResult>(
+            `mutation serviceInstanceRedeploy($serviceId: String!, $environmentId: String!) {
+              serviceInstanceRedeploy(serviceId: $serviceId, environmentId: $environmentId)
+            }`,
+            { serviceId, environmentId: stagingEnvId },
+          ),
+        sleepMs,
+      );
+      if (redeployed.serviceInstanceRedeploy !== true) {
+        throw new Error(
+          `serviceInstanceRedeploy returned ${JSON.stringify(
+            redeployed.serviceInstanceRedeploy,
+          )} for ${target.serviceName} (${serviceId}) — image will not run.`,
+        );
+      }
+      log(`  redeployed — image now running`);
     }
 
     // Domain: create only when none exists yet (idempotent).
     let domain: string | undefined;
-    let domainAction: "created" | "existing" | "skipped";
+    let domainAction: "created" | "existing" | "skipped" | "would-create";
     if (prior?.hasStagingDomain) {
       domainAction = "existing";
       log(`  staging domain already present — skipping create`);
     } else if (dryRun) {
-      domainAction = "skipped";
+      // Faithful preview: a real run WOULD create a domain here (the service
+      // has none yet), so report "would-create" rather than the misleading
+      // "skipped".
+      domainAction = "would-create";
+      log(`  domain: would create (none present)`);
     } else {
-      const domainResult = await withRetry(
-        () =>
-          gql<ServiceDomainResult>(
-            `mutation serviceDomainCreate($input: ServiceDomainCreateInput!) {
-              serviceDomainCreate(input: $input) { domain }
-            }`,
-            {
-              input: { serviceId, environmentId: stagingEnvId },
-            },
-          ),
-        sleepMs,
-      );
-      domain = domainResult.serviceDomainCreate.domain;
-      domainAction = "created";
-      log(`  domain: https://${domain}`);
+      try {
+        const domainResult = await withRetry(
+          () =>
+            gql<ServiceDomainResult>(
+              `mutation serviceDomainCreate($input: ServiceDomainCreateInput!) {
+                serviceDomainCreate(input: $input) { domain }
+              }`,
+              {
+                input: { serviceId, environmentId: stagingEnvId },
+              },
+            ),
+          sleepMs,
+        );
+        domain = domainResult.serviceDomainCreate.domain;
+        domainAction = "created";
+        log(`  domain: https://${domain}`);
+      } catch (e) {
+        // Idempotent convergence on a partial-failure re-run: if the domain
+        // already exists (the start-of-run snapshot missed it, or a prior run
+        // died mid-fleet), Railway rejects the create with a non-transient
+        // "already exists" error. That is benign — treat it as existing and
+        // KEEP GOING rather than aborting the remaining fleet. Any other
+        // error still aborts (fail loud).
+        const msg = e instanceof Error ? e.message : String(e);
+        if (!DOMAIN_ALREADY_EXISTS_RE.test(msg)) throw e;
+        domainAction = "existing";
+        log(
+          `  staging domain already exists (per Railway) — treating as no-op`,
+        );
+      }
     }
 
     records.push({
@@ -443,27 +532,30 @@ export async function provisionStarterFleet(
 
 // ── Live GraphQL caller ─────────────────────────────────────────────────
 
-let cachedToken: string | undefined;
-function getToken(): string {
-  if (cachedToken) return cachedToken;
+/**
+ * Resolve the Railway token, normalizing the typed RailwayTokenError into a
+ * plain Error so main().catch owns the process exit (rather than a deep
+ * process.exit(1) inside the GraphQL boundary). main() validates this UP
+ * FRONT — before any provisioning — so a missing token fails fast instead of
+ * mid-mutation.
+ */
+function resolveTokenOrThrow(): string {
   try {
-    cachedToken = resolveRailwayToken().token;
-    return cachedToken;
+    return resolveRailwayToken().token;
   } catch (e) {
     if (e instanceof RailwayTokenError) {
-      console.error(e.message);
-      process.exit(1);
+      throw new Error(e.message, { cause: e });
     }
     throw e;
   }
 }
 
-function makeLiveGql(): RailwayGqlFn {
+/** Build a live GraphQL caller bound to a single, already-resolved token. */
+function makeLiveGql(token: string): RailwayGqlFn {
   return async function railwayGql<T = unknown>(
     query: string,
     variables: Record<string, unknown> = {},
   ): Promise<T> {
-    const token = getToken();
     const res = await fetch(RAILWAY_API, {
       method: "POST",
       headers: {
@@ -508,35 +600,70 @@ async function listStarterServices(gql: RailwayGqlFn): Promise<void> {
   }
 }
 
-async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-
-  if (args.includes("--help")) {
-    console.log(`Usage:
+const USAGE = `Usage:
   npx tsx showcase/scripts/provision-starter-fleet.ts            Provision all 12 starter-* services in staging
   npx tsx showcase/scripts/provision-starter-fleet.ts --list     List starter-* services in staging
   npx tsx showcase/scripts/provision-starter-fleet.ts --dry-run  Plan only (no mutations)
-`);
-    process.exit(0);
+`;
+
+export interface ParsedArgs {
+  help: boolean;
+  list: boolean;
+  dryRun: boolean;
+}
+
+/** The flags this script recognizes. */
+const KNOWN_FLAGS = new Set(["--help", "--list", "--dry-run"]);
+
+/**
+ * Parse argv into the recognized flags, REJECTING any unrecognized argument.
+ * Without this, a mistyped flag (e.g. `--dry-rn`) is silently ignored and —
+ * because dryRun stays false — the script proceeds to REAL live provisioning,
+ * the exact opposite of the operator's intent. Throws on any unknown arg so
+ * main().catch aborts before any mutation.
+ *
+ * Exported pure for unit testing.
+ */
+export function parseArgs(args: string[]): ParsedArgs {
+  for (const arg of args) {
+    if (!KNOWN_FLAGS.has(arg)) {
+      throw new Error(`Unknown argument: ${arg}\n${USAGE}`);
+    }
+  }
+  return {
+    help: args.includes("--help"),
+    list: args.includes("--list"),
+    dryRun: args.includes("--dry-run"),
+  };
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs(process.argv.slice(2));
+
+  if (parsed.help) {
+    console.log(USAGE);
+    return;
   }
 
-  const gql = makeLiveGql();
+  // Validate the Railway token UP FRONT — before any provisioning — so a
+  // missing/unreadable token fails fast (and main().catch owns the exit)
+  // rather than blowing up mid-mutation on the first GraphQL call.
+  const token = resolveTokenOrThrow();
+  const gql = makeLiveGql(token);
 
-  if (args.includes("--list")) {
+  if (parsed.list) {
     await listStarterServices(gql);
     return;
   }
 
-  const dryRun = args.includes("--dry-run");
+  const dryRun = parsed.dryRun;
   const targets = deriveStarterTargets();
 
-  let registryCredentials: RegistryCredentials | undefined;
-  try {
-    registryCredentials = resolveRegistryCredentials();
-  } catch (e) {
-    console.error((e as Error).message);
-    process.exit(1);
-  }
+  // Validate registry credentials UP FRONT too (mirrors the existing
+  // resolveRegistryCredentials validation) so a token-without-username
+  // misconfig fails before any mutation. The throw propagates to
+  // main().catch — no deep process.exit here.
+  const registryCredentials = resolveRegistryCredentials();
   if (!registryCredentials) {
     console.warn(
       "\n  WARNING: GITHUB_TOKEN not set. Registry credentials will NOT be configured — Railway cannot pull the private GHCR starter images until creds are added.\n",

--- a/showcase/scripts/provision-starter-fleet.ts
+++ b/showcase/scripts/provision-starter-fleet.ts
@@ -151,16 +151,20 @@ interface ProjectServicesResult {
         node: {
           id: string;
           name: string;
-          serviceInstances: {
-            edges: Array<{
+          // A transitional service can return a null serviceInstances
+          // connection (or null .edges) — both fields are optional/nullable
+          // so the drain loop can coalesce instead of throwing a TypeError
+          // that would abort the entire fetch.
+          serviceInstances?: {
+            edges?: Array<{
               node: {
                 environmentId: string;
                 domains?: {
                   serviceDomains?: Array<{ domain: string }>;
                 } | null;
               };
-            }>;
-          };
+            }> | null;
+          } | null;
         };
       }>;
       pageInfo?: {
@@ -192,6 +196,46 @@ interface ServiceDomainResult {
  */
 interface ServiceInstanceRedeployResult {
   serviceInstanceRedeploy: boolean | null;
+}
+
+/**
+ * `serviceInstanceUpdate` returns a Boolean! in Railway's schema — `true`
+ * once the instance config (sleepApplication / healthcheck / image / region /
+ * registryCredentials) is applied. Same precedent as serviceInstanceRedeploy
+ * (redeploy-env.ts / bin/railway treat the scalar as a bare boolean). A
+ * `false`/`null` return means the config was NOT applied — e.g. the service
+ * would run WITHOUT sleep — so it must be asserted, never discarded.
+ */
+interface ServiceInstanceUpdateResult {
+  serviceInstanceUpdate: boolean | null;
+}
+
+/**
+ * Uniform Railway-mutation-result guard: a single chokepoint so no mutation's
+ * result can be silently discarded (the "mutation result not validated" defect
+ * class). `ok` extracts the meaningful field from the result; when it is
+ * falsy (empty string, false, null, undefined) we throw, naming the mutation
+ * and service so the failure is forensic rather than a silent success.
+ *
+ * Returns the (now-verified) result for fluent use at the call site.
+ */
+function assertMutationOk<T>(
+  result: T,
+  ok: (r: T) => unknown,
+  mutation: string,
+  serviceName: string,
+  serviceId: string,
+  note = "mutation did not take effect; refusing to report success.",
+): T {
+  const value = ok(result);
+  if (!value) {
+    throw new Error(
+      `${mutation} returned ${JSON.stringify(
+        value,
+      )} for ${serviceName} (${serviceId}) — ${note}`,
+    );
+  }
+  return result;
 }
 
 /** Existing-service lookup result: id + whether it already has a staging domain. */
@@ -255,7 +299,10 @@ export async function fetchExistingServices(
 
     for (const edge of data.project.services.edges) {
       const svc = edge.node;
-      const stagingInstance = svc.serviceInstances.edges.find(
+      // A transitional service can surface a null serviceInstances connection
+      // (or null .edges); coalesce so an unguarded `.find` can't throw a
+      // TypeError that aborts the entire fetch before any starter is touched.
+      const stagingInstance = (svc.serviceInstances?.edges ?? []).find(
         (e) => e.node.environmentId === stagingEnvId,
       );
       const hasStagingDomain =
@@ -264,10 +311,19 @@ export async function fetchExistingServices(
     }
 
     const pageInfo = data.project.services.pageInfo;
-    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) {
+      return byName;
+    }
     after = pageInfo.endCursor;
   }
-  return byName;
+  // Reaching the defensive page bound while pageInfo.hasNextPage is STILL true
+  // means the snapshot is TRUNCATED — services on undrained pages look absent,
+  // which would feed erroneous CREATE decisions (and a non-transient "already
+  // exists" abort). Refuse to provision against a partial snapshot: fail loud
+  // rather than return the truncated map.
+  throw new Error(
+    `fetchExistingServices drained ${byName.size} services across the page bound but Railway still reports more pages (hasNextPage) — refusing to provision against a truncated service snapshot.`,
+  );
 }
 
 export interface ProvisionOptions {
@@ -304,12 +360,14 @@ const RETRY_DELAYS_MS = [1000, 2000, 4000, 8000];
  * Railway INTERPOLATES the service id into the second form — the real message
  * is "Service <id> not found" (e.g. "Service abc-123 not found"), NOT the
  * contiguous "Service not found". So the pattern matches "Service" followed by
- * "not found" with anything (the id) in between; the `(Instance)?` alternation
- * still covers the literal "ServiceInstance not found" form. `[\s\S]*?` is a
- * non-greedy any-char (incl. newline) bridge so the id between the two anchors
- * never blocks the match.
+ * "not found" with the id in between; the `(Instance)?` alternation still
+ * covers the literal "ServiceInstance not found" form. The bridge is `[^\n]*?`
+ * (NOT `[\s\S]*?`) — the interpolated id never contains a newline, so keeping
+ * the match SINGLE-LINE prevents a multi-error newline-joined GraphQL blob
+ * from bridging an unrelated "Service ..." line to a "... not found" line and
+ * mis-classifying a non-transient failure as the eventual-consistency signal.
  */
-const TRANSIENT_ERROR_RE = /Service(Instance)?\b[\s\S]*?not found/i;
+const TRANSIENT_ERROR_RE = /Service(Instance)?\b[^\n]*?not found/i;
 
 /**
  * Retry a Railway mutation that can transiently fail while the env-scoped
@@ -337,18 +395,28 @@ async function withRetry<T>(
       await sleep(RETRY_DELAYS_MS[attempt]);
     }
   }
-  throw lastErr;
+  // Schedule exhausted on a transient error: wrap the rethrow with context
+  // (how many retries, that it was transient) so the operator sees WHY the
+  // run failed, preserving the original error as `cause`.
+  const lastMsg = lastErr instanceof Error ? lastErr.message : String(lastErr);
+  throw new Error(
+    `Exhausted ${RETRY_DELAYS_MS.length} retries for transient Railway error: ${lastMsg}`,
+    { cause: lastErr },
+  );
 }
 
 /**
- * A serviceDomainCreate that rejects because a domain ALREADY exists is a
- * benign no-op on a partial-failure re-run (the start-of-run snapshot missed
- * the domain due to Railway eventual consistency, or a prior run died
- * mid-fleet). We converge by treating it as "existing" rather than aborting
- * the remaining fleet. This is NOT a transient/retryable error — matching it
- * here would waste the retry schedule on a permanent condition.
+ * An "already exists"-class rejection. Two call sites converge on it rather
+ * than abort, on a partial-failure re-run (the start-of-run snapshot missed
+ * the resource due to Railway eventual consistency, or a prior run died
+ * mid-fleet):
+ *   - serviceDomainCreate: treat as the domain already existing (benign no-op);
+ *   - serviceCreate: re-fetch the now-visible service by name and fall through
+ *     to the UPDATE path instead of aborting the whole fleet.
+ * This is NOT a transient/retryable error — matching it in the retry predicate
+ * would waste the retry schedule on a permanent condition.
  */
-const DOMAIN_ALREADY_EXISTS_RE = /(already\s+exists|duplicate)/i;
+const ALREADY_EXISTS_RE = /(already\s+exists|duplicate)/i;
 
 export interface ProvisionRecord {
   slug: string;
@@ -439,15 +507,51 @@ export async function provisionStarterFleet(
       if (registryCredentials) {
         createInput.registryCredentials = registryCredentials;
       }
-      const created = await gql<ServiceCreateResult>(
-        `mutation serviceCreate($input: ServiceCreateInput!) {
-          serviceCreate(input: $input) { id name }
-        }`,
-        { input: createInput },
-      );
-      serviceId = created.serviceCreate.id;
-      action = "created";
-      log(`+ ${target.serviceName} created (${serviceId})`);
+      try {
+        const created = await gql<ServiceCreateResult>(
+          `mutation serviceCreate($input: ServiceCreateInput!) {
+            serviceCreate(input: $input) { id name }
+          }`,
+          { input: createInput },
+        );
+        assertMutationOk(
+          created,
+          (r) => r.serviceCreate?.id,
+          "serviceCreate",
+          target.serviceName,
+          "<creating>",
+        );
+        serviceId = created.serviceCreate.id;
+        action = "created";
+        log(`+ ${target.serviceName} created (${serviceId})`);
+      } catch (e) {
+        // A snapshot-miss (Railway eventual consistency) can make a service
+        // look absent → CREATE path → a non-transient "already exists"
+        // rejection. That must NOT abort the whole fleet: re-fetch the now-
+        // visible service id by name and fall through to the UPDATE path so
+        // the run converges. Any other error still fails loud.
+        const msg = e instanceof Error ? e.message : String(e);
+        if (!ALREADY_EXISTS_RE.test(msg)) throw e;
+        const refetched = await fetchExistingServices(
+          gql,
+          projectId,
+          stagingEnvId,
+        );
+        const found = refetched.get(target.serviceName);
+        if (!found) {
+          // The create said "already exists" but a re-fetch can't find it —
+          // genuinely inconsistent; fail loud rather than guess.
+          throw new Error(
+            `serviceCreate for ${target.serviceName} rejected as already-existing, but a re-fetch could not find it by name — refusing to proceed against an inconsistent snapshot.`,
+            { cause: e },
+          );
+        }
+        serviceId = found.id;
+        action = "updated";
+        log(
+          `↻ ${target.serviceName} already exists (re-fetched ${serviceId}) — updating: ${msg}`,
+        );
+      }
     }
 
     // Apply sleep + healthcheck + region (+ creds) against staging on BOTH
@@ -469,9 +573,9 @@ export async function provisionStarterFleet(
       // race it ("ServiceInstance not found"). Retry briefly so a fresh
       // create converges. Existing services (update path) hit this on the
       // first try.
-      await withRetry(
+      const updated = await withRetry(
         () =>
-          gql(
+          gql<ServiceInstanceUpdateResult>(
             `mutation serviceInstanceUpdate($serviceId: String!, $environmentId: String!, $input: ServiceInstanceUpdateInput!) {
               serviceInstanceUpdate(serviceId: $serviceId, environmentId: $environmentId, input: $input)
             }`,
@@ -482,6 +586,17 @@ export async function provisionStarterFleet(
             },
           ),
         sleepMs,
+      );
+      // serviceInstanceUpdate returns Boolean! — a `false`/`null` return means
+      // sleepApplication/healthcheck/image/creds were NOT applied (the service
+      // would run WITHOUT sleep) while the script reports success. Assert the
+      // result and only log "configured ..." AFTER it is verified.
+      assertMutationOk(
+        updated,
+        (r) => r.serviceInstanceUpdate,
+        "serviceInstanceUpdate",
+        target.serviceName,
+        serviceId,
       );
       log(
         `  configured sleep=true, healthcheck=${STARTER_HEALTHCHECK_PATH}, region=${STARTER_REGION}${
@@ -506,15 +621,17 @@ export async function provisionStarterFleet(
       // serviceInstanceRedeploy returns Boolean! (see the result-type comment
       // for the verified contract + sources). A `false`/`null` return means
       // Railway did NOT enqueue a deployment, so the image would never run —
-      // fail loud rather than report success. Accept any truthy value
-      // defensively in case the contract ever widens to a richer result.
-      if (!redeployed.serviceInstanceRedeploy) {
-        throw new Error(
-          `serviceInstanceRedeploy returned ${JSON.stringify(
-            redeployed.serviceInstanceRedeploy,
-          )} for ${target.serviceName} (${serviceId}) — image will not run.`,
-        );
-      }
+      // fail loud rather than report success. Routed through the same uniform
+      // mutation-result guard as serviceCreate / serviceInstanceUpdate; any
+      // truthy value is accepted defensively in case the contract ever widens.
+      assertMutationOk(
+        redeployed,
+        (r) => r.serviceInstanceRedeploy,
+        "serviceInstanceRedeploy",
+        target.serviceName,
+        serviceId,
+        "image will not run.",
+      );
       log(`  redeployed — image now running`);
     }
 
@@ -544,6 +661,15 @@ export async function provisionStarterFleet(
             ),
           sleepMs,
         );
+        // Assert the create actually yielded a domain — a null/empty domain
+        // is a silent-success the script must not report as created.
+        assertMutationOk(
+          domainResult,
+          (r) => r.serviceDomainCreate?.domain,
+          "serviceDomainCreate",
+          target.serviceName,
+          serviceId,
+        );
         domain = domainResult.serviceDomainCreate.domain;
         domainAction = "created";
         log(`  domain: https://${domain}`);
@@ -555,7 +681,7 @@ export async function provisionStarterFleet(
         // KEEP GOING rather than aborting the remaining fleet. Any other
         // error still aborts (fail loud).
         const msg = e instanceof Error ? e.message : String(e);
-        if (!DOMAIN_ALREADY_EXISTS_RE.test(msg)) throw e;
+        if (!ALREADY_EXISTS_RE.test(msg)) throw e;
         domainAction = "existing";
         // Include the ACTUAL matched Railway message for a forensic trail —
         // so a re-run log shows exactly which "already exists" wording was

--- a/showcase/scripts/provision-starter-fleet.ts
+++ b/showcase/scripts/provision-starter-fleet.ts
@@ -163,6 +163,10 @@ interface ProjectServicesResult {
           };
         };
       }>;
+      pageInfo?: {
+        hasNextPage: boolean;
+        endCursor?: string | null;
+      } | null;
     };
   } | null;
 }
@@ -175,8 +179,19 @@ interface ServiceDomainResult {
   serviceDomainCreate: { domain: string };
 }
 
+/**
+ * `serviceInstanceRedeploy` returns a Boolean! in Railway's schema — `true`
+ * once the redeploy is enqueued. VERIFIED against the two in-repo consumers
+ * that read this mutation's result:
+ *   - showcase/scripts/redeploy-env.ts types it `serviceInstanceRedeploy?:
+ *     boolean` and gates on `!== true`;
+ *   - showcase/bin/railway (RestoreCommand P5) requires
+ *     `redeployed["serviceInstanceRedeploy"]` truthy.
+ * Both treat it as a bare boolean, and bin/railway's REDEPLOY_MUTATION selects
+ * NO subfields on the result (confirming a scalar, not an object/deployment).
+ */
 interface ServiceInstanceRedeployResult {
-  serviceInstanceRedeploy: boolean;
+  serviceInstanceRedeploy: boolean | null;
 }
 
 /** Existing-service lookup result: id + whether it already has a staging domain. */
@@ -197,41 +212,60 @@ export async function fetchExistingServices(
   projectId: string,
   stagingEnvId: string,
 ): Promise<Map<string, ExistingService>> {
-  const data = await gql<ProjectServicesResult>(
-    `query project($id: String!) {
-      project(id: $id) {
-        services {
-          edges { node {
-            id
-            name
-            serviceInstances {
-              edges { node {
-                environmentId
-                domains { serviceDomains { domain } }
-              } }
-            }
-          } }
-        }
-      }
-    }`,
-    { id: projectId },
-  );
-
-  if (!data.project) {
-    throw new Error(
-      `Railway project ${projectId} returned null — check PROJECT_ID and that the Railway token has access to this project.`,
-    );
-  }
-
   const byName = new Map<string, ExistingService>();
-  for (const edge of data.project.services.edges) {
-    const svc = edge.node;
-    const stagingInstance = svc.serviceInstances.edges.find(
-      (e) => e.node.environmentId === stagingEnvId,
+  // `project.services` is a Relay ServiceConnection that PAGE-LIMITS. The
+  // showcase project holds ~27 SSOT + 12 starter services, comfortably more
+  // than one page. A single un-paginated query returns a TRUNCATED snapshot —
+  // a starter that lands on a later page then looks ABSENT, the provisioner
+  // takes the CREATE path, and serviceCreate rejects with a non-transient
+  // "already exists" (NOT retried) which ABORTS the whole run. So drain every
+  // page via `pageInfo.hasNextPage`/`endCursor` (standard Relay cursor loop —
+  // bin/railway's SERVICES_LIST_QUERY predates this hazard and is unpaginated,
+  // so there is no in-repo precedent to mirror), accumulating into byName.
+  let after: string | null = null;
+  // Defensive upper bound so a malformed `pageInfo` (always hasNextPage with a
+  // stuck cursor) can't spin forever — far above any realistic project size.
+  for (let page = 0; page < 1000; page++) {
+    const data: ProjectServicesResult = await gql<ProjectServicesResult>(
+      `query project($id: String!, $after: String) {
+        project(id: $id) {
+          services(first: 100, after: $after) {
+            edges { node {
+              id
+              name
+              serviceInstances {
+                edges { node {
+                  environmentId
+                  domains { serviceDomains { domain } }
+                } }
+              }
+            } }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }`,
+      { id: projectId, after },
     );
-    const hasStagingDomain =
-      (stagingInstance?.node.domains?.serviceDomains?.length ?? 0) > 0;
-    byName.set(svc.name, { id: svc.id, hasStagingDomain });
+
+    if (!data.project) {
+      throw new Error(
+        `Railway project ${projectId} returned null — check PROJECT_ID and that the Railway token has access to this project.`,
+      );
+    }
+
+    for (const edge of data.project.services.edges) {
+      const svc = edge.node;
+      const stagingInstance = svc.serviceInstances.edges.find(
+        (e) => e.node.environmentId === stagingEnvId,
+      );
+      const hasStagingDomain =
+        (stagingInstance?.node.domains?.serviceDomains?.length ?? 0) > 0;
+      byName.set(svc.name, { id: svc.id, hasStagingDomain });
+    }
+
+    const pageInfo = data.project.services.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+    after = pageInfo.endCursor;
   }
   return byName;
 }
@@ -266,8 +300,16 @@ const RETRY_DELAYS_MS = [1000, 2000, 4000, 8000];
  * as a generic "Service ... not found" while the instance is still settling.
  * NOTE: an "already exists" domain error is NON-transient and is handled
  * separately (caught as a benign no-op) — it must NOT match here.
+ *
+ * Railway INTERPOLATES the service id into the second form — the real message
+ * is "Service <id> not found" (e.g. "Service abc-123 not found"), NOT the
+ * contiguous "Service not found". So the pattern matches "Service" followed by
+ * "not found" with anything (the id) in between; the `(Instance)?` alternation
+ * still covers the literal "ServiceInstance not found" form. `[\s\S]*?` is a
+ * non-greedy any-char (incl. newline) bridge so the id between the two anchors
+ * never blocks the match.
  */
-const TRANSIENT_ERROR_RE = /(ServiceInstance not found|Service not found)/i;
+const TRANSIENT_ERROR_RE = /Service(Instance)?\b[\s\S]*?not found/i;
 
 /**
  * Retry a Railway mutation that can transiently fail while the env-scoped
@@ -461,7 +503,12 @@ export async function provisionStarterFleet(
           ),
         sleepMs,
       );
-      if (redeployed.serviceInstanceRedeploy !== true) {
+      // serviceInstanceRedeploy returns Boolean! (see the result-type comment
+      // for the verified contract + sources). A `false`/`null` return means
+      // Railway did NOT enqueue a deployment, so the image would never run —
+      // fail loud rather than report success. Accept any truthy value
+      // defensively in case the contract ever widens to a richer result.
+      if (!redeployed.serviceInstanceRedeploy) {
         throw new Error(
           `serviceInstanceRedeploy returned ${JSON.stringify(
             redeployed.serviceInstanceRedeploy,
@@ -510,8 +557,11 @@ export async function provisionStarterFleet(
         const msg = e instanceof Error ? e.message : String(e);
         if (!DOMAIN_ALREADY_EXISTS_RE.test(msg)) throw e;
         domainAction = "existing";
+        // Include the ACTUAL matched Railway message for a forensic trail —
+        // so a re-run log shows exactly which "already exists" wording was
+        // absorbed, not just a generic note.
         log(
-          `  staging domain already exists (per Railway) — treating as no-op`,
+          `  staging domain already exists (per Railway) — treating as no-op: ${msg}`,
         );
       }
     }
@@ -665,9 +715,20 @@ async function main(): Promise<void> {
   // main().catch — no deep process.exit here.
   const registryCredentials = resolveRegistryCredentials();
   if (!registryCredentials) {
-    console.warn(
-      "\n  WARNING: GITHUB_TOKEN not set. Registry credentials will NOT be configured — Railway cannot pull the private GHCR starter images until creds are added.\n",
-    );
+    if (dryRun) {
+      console.warn(
+        "\n  WARNING: GITHUB_TOKEN not set. Registry credentials will NOT be configured — Railway cannot pull the private GHCR starter images until creds are added.\n",
+      );
+    } else {
+      // ABORT on the LIVE path: creating services that point at a PRIVATE
+      // GHCR image with no pull credentials yields a perpetual
+      // image-pull-backoff while the script reports "success". That is worse
+      // than failing — fail loud up front. warn-and-continue is only
+      // tolerable under --dry-run, where no service is actually created.
+      throw new Error(
+        "GITHUB_TOKEN is not set. The starter images are PRIVATE GHCR images; provisioning live services without registry credentials would leave every service in image-pull-backoff while reporting success. Set GITHUB_TOKEN (+ GHCR_USERNAME / GITHUB_ACTOR) and re-run, or use --dry-run to plan without mutations.",
+      );
+    }
   }
 
   console.log(

--- a/showcase/scripts/provision-starter-fleet.ts
+++ b/showcase/scripts/provision-starter-fleet.ts
@@ -1,0 +1,577 @@
+#!/usr/bin/env npx tsx
+/**
+ * provision-starter-fleet.ts — Committed, reproducible Railway provisioner
+ * for the SSOT-decoupled "starter container fleet" in the showcase STAGING
+ * environment.
+ *
+ * Creates (or idempotently updates) one sleepable Railway service per
+ * starter template, pulling the per-starter image from GHCR:
+ *
+ *   service name : starter-<slug>          (RAW starter slug, e.g.
+ *                                            starter-langgraph-js, NOT the
+ *                                            remapped dashboard column slug)
+ *   image        : ghcr.io/copilotkit/starter-<slug>:latest
+ *   env          : STAGING ONLY (railway-envs STAGING_ENV_ID)
+ *   sleep        : sleepApplication = true (the whole point — sleepable)
+ *   healthcheck  : "/"  (the starters' single deployable image EXPOSEs 3000
+ *                  running the Next.js frontend; the frontend serves "/" and
+ *                  "/api/copilotkit" but has NO "/api/health" route — that
+ *                  path 404s and would wedge Railway healthchecks forever.
+ *                  The agent's "/health" lives on the internal agent port
+ *                  8123, which Railway does not expose. So "/" is the only
+ *                  correct, reachable healthcheck for the exposed surface.)
+ *   region       : us-west1 (matches every existing showcase service)
+ *   GHCR creds   : registryCredentials from GITHUB_TOKEN + GHCR username
+ *                  (same mechanism deploy-to-railway.ts uses)
+ *   domain       : a generated Railway domain per service (serviceDomainCreate)
+ *
+ * The 12 starter slugs are the keys of STARTER_TO_COLUMN in
+ * showcase/harness/src/probes/helpers/starter-mapping.ts — the single source
+ * of truth shared with the smoke matrix (showcase/tests/e2e/starter-smoke.spec.ts)
+ * and the CI build matrix (.github/workflows/showcase_build.yml). This script
+ * derives its target list from that SSOT so the fleet can never drift from the
+ * matrix.
+ *
+ * The fleet is intentionally DECOUPLED from the 27-service railway-envs SSOT:
+ * starter-* services are auto-discovered at runtime by the starter_smoke probe
+ * (railway-services source, namePrefix "starter-") and are NOT added to
+ * SERVICES. PR #5254 already made verify-railway-image-refs.ts tolerate
+ * starter-* names in BOTH drift directions, so provisioning these services
+ * does NOT trip the CI image-ref gate / skip the showcase build.
+ *
+ * IDEMPOTENT: a starter-* service that already exists in staging is UPDATED
+ * (instance settings re-applied; a domain created only if none exists) rather
+ * than duplicated or errored.
+ *
+ * Usage:
+ *   npx tsx showcase/scripts/provision-starter-fleet.ts            # provision all 12
+ *   npx tsx showcase/scripts/provision-starter-fleet.ts --list     # list starter-* services in staging
+ *   npx tsx showcase/scripts/provision-starter-fleet.ts --dry-run  # plan only, no mutations
+ *
+ * Requires: RAILWAY_TOKEN env var or ~/.railway/config.json, plus GITHUB_TOKEN
+ * (+ GHCR_USERNAME or GITHUB_ACTOR) so the private GHCR images can be pulled.
+ */
+
+import { fileURLToPath } from "url";
+import { STARTER_TO_COLUMN } from "../harness/src/probes/helpers/starter-mapping";
+import { PROJECT_ID, STAGING_ENV_ID } from "./railway-envs";
+import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
+import { RailwayTokenError, resolveRailwayToken } from "./lib/railway-token";
+
+const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
+
+/** Railway service-name prefix for the starter fleet (RAW starter slug). */
+export const STARTER_FLEET_PREFIX = "starter-";
+
+/**
+ * The healthcheck path Railway probes against the exposed container port.
+ * "/" — see the file header for why this is NOT "/api/health".
+ */
+export const STARTER_HEALTHCHECK_PATH = "/";
+
+/** Region every existing showcase service runs in; match it. */
+export const STARTER_REGION = "us-west1";
+
+// ── Target derivation (from the starter-mapping SSOT) ───────────────────
+
+export interface StarterTarget {
+  /** RAW starter slug, e.g. "langgraph-js", "adk". */
+  slug: string;
+  /** Railway service name, e.g. "starter-langgraph-js". */
+  serviceName: string;
+  /** GHCR image ref, e.g. "ghcr.io/copilotkit/starter-langgraph-js:latest". */
+  image: string;
+}
+
+/**
+ * Derive the 12 provisioning targets from STARTER_TO_COLUMN (the SSOT). The
+ * service name and image both use the RAW starter slug (the map KEY), never
+ * the remapped dashboard column slug (the map VALUE). Sorted for stable,
+ * reproducible output.
+ *
+ * Exported pure for unit testing.
+ */
+export function deriveStarterTargets(
+  mapping: Readonly<Record<string, string>> = STARTER_TO_COLUMN,
+): StarterTarget[] {
+  return Object.keys(mapping)
+    .sort()
+    .map((slug) => ({
+      slug,
+      serviceName: `${STARTER_FLEET_PREFIX}${slug}`,
+      image: `ghcr.io/copilotkit/${STARTER_FLEET_PREFIX}${slug}:latest`,
+    }));
+}
+
+// ── GHCR registry credentials ───────────────────────────────────────────
+
+export interface RegistryCredentials {
+  username: string;
+  password: string;
+}
+
+/**
+ * Resolve GHCR registry credentials the same way deploy-to-railway.ts does:
+ * GITHUB_TOKEN as the password, and GHCR_USERNAME (preferred) or GITHUB_ACTOR
+ * (CI) as the username. Returns undefined when GITHUB_TOKEN is unset (caller
+ * warns and proceeds without creds). THROWS when a token is present but no
+ * username is available — fail loud rather than baking a personal handle in.
+ *
+ * Exported pure for unit testing.
+ */
+export function resolveRegistryCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+): RegistryCredentials | undefined {
+  const githubToken = env.GITHUB_TOKEN;
+  if (!githubToken) return undefined;
+  const ghcrUser = (env.GHCR_USERNAME || env.GITHUB_ACTOR || "").trim();
+  if (!ghcrUser) {
+    throw new Error(
+      "GITHUB_TOKEN is set but no GHCR username is available. Set GHCR_USERNAME (or GITHUB_ACTOR in CI) to the username the token is issued to.",
+    );
+  }
+  return { username: ghcrUser, password: githubToken };
+}
+
+// ── Injectable Railway GraphQL boundary ─────────────────────────────────
+
+/** Minimal GraphQL caller signature — injected so the core is unit-testable. */
+export type RailwayGqlFn = <T = unknown>(
+  query: string,
+  variables?: Record<string, unknown>,
+) => Promise<T>;
+
+interface ProjectServicesResult {
+  project: {
+    services: {
+      edges: Array<{
+        node: {
+          id: string;
+          name: string;
+          serviceInstances: {
+            edges: Array<{
+              node: {
+                environmentId: string;
+                domains?: {
+                  serviceDomains?: Array<{ domain: string }>;
+                } | null;
+              };
+            }>;
+          };
+        };
+      }>;
+    };
+  } | null;
+}
+
+interface ServiceCreateResult {
+  serviceCreate: { id: string; name: string };
+}
+
+interface ServiceDomainResult {
+  serviceDomainCreate: { domain: string };
+}
+
+/** Existing-service lookup result: id + whether it already has a staging domain. */
+export interface ExistingService {
+  id: string;
+  hasStagingDomain: boolean;
+}
+
+/**
+ * Fetch the project's services (with their staging-env domains) and index
+ * them by name. Returns a map of serviceName -> ExistingService so the
+ * provisioner can decide create-vs-update and skip redundant domain creation.
+ *
+ * Exported for unit testing against an injected RailwayGqlFn.
+ */
+export async function fetchExistingServices(
+  gql: RailwayGqlFn,
+  projectId: string,
+  stagingEnvId: string,
+): Promise<Map<string, ExistingService>> {
+  const data = await gql<ProjectServicesResult>(
+    `query project($id: String!) {
+      project(id: $id) {
+        services {
+          edges { node {
+            id
+            name
+            serviceInstances {
+              edges { node {
+                environmentId
+                domains { serviceDomains { domain } }
+              } }
+            }
+          } }
+        }
+      }
+    }`,
+    { id: projectId },
+  );
+
+  if (!data.project) {
+    throw new Error(
+      `Railway project ${projectId} returned null — check PROJECT_ID and that the Railway token has access to this project.`,
+    );
+  }
+
+  const byName = new Map<string, ExistingService>();
+  for (const edge of data.project.services.edges) {
+    const svc = edge.node;
+    const stagingInstance = svc.serviceInstances.edges.find(
+      (e) => e.node.environmentId === stagingEnvId,
+    );
+    const hasStagingDomain =
+      (stagingInstance?.node.domains?.serviceDomains?.length ?? 0) > 0;
+    byName.set(svc.name, { id: svc.id, hasStagingDomain });
+  }
+  return byName;
+}
+
+export interface ProvisionOptions {
+  gql: RailwayGqlFn;
+  projectId: string;
+  stagingEnvId: string;
+  targets: StarterTarget[];
+  registryCredentials?: RegistryCredentials;
+  /** When true, no mutations are sent — plan only. */
+  dryRun?: boolean;
+  log?: (line: string) => void;
+  /**
+   * Sleep implementation between retries of the post-create
+   * serviceInstanceUpdate / serviceDomainCreate (Railway materializes the
+   * env-scoped instance asynchronously). Injected so tests don't actually
+   * wait. Defaults to a real setTimeout-backed delay.
+   */
+  sleepMs?: (ms: number) => Promise<void>;
+}
+
+/** Default inter-retry delay schedule (ms). */
+const RETRY_DELAYS_MS = [1000, 2000, 4000, 8000];
+
+/**
+ * Retry a Railway mutation that can transiently fail with "ServiceInstance
+ * not found" while the env-scoped instance is still materializing after
+ * serviceCreate. Re-throws non-transient errors immediately and re-throws
+ * the last transient error once the schedule is exhausted.
+ */
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  sleep: (ms: number) => Promise<void>,
+): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastErr = e;
+      const msg = e instanceof Error ? e.message : String(e);
+      // Only retry the known eventual-consistency error.
+      if (!/ServiceInstance not found/i.test(msg)) throw e;
+      if (attempt === RETRY_DELAYS_MS.length) break;
+      await sleep(RETRY_DELAYS_MS[attempt]);
+    }
+  }
+  throw lastErr;
+}
+
+export interface ProvisionRecord {
+  slug: string;
+  serviceName: string;
+  image: string;
+  serviceId: string;
+  action: "created" | "updated";
+  domain?: string;
+  domainAction: "created" | "existing" | "skipped";
+}
+
+export interface ProvisionSummary {
+  records: ProvisionRecord[];
+}
+
+/**
+ * The idempotent provisioning core. For each target:
+ *   - create the service (source.image = GHCR ref) if it does not exist,
+ *     otherwise reuse the existing service id (UPDATE path);
+ *   - serviceInstanceUpdate against the STAGING env with
+ *     sleepApplication: true + healthcheckPath + region + (optional) GHCR
+ *     registryCredentials — applied on BOTH the create and update paths so a
+ *     re-run converges drifted settings;
+ *   - serviceDomainCreate for the staging env, but ONLY when the service has
+ *     no staging domain yet (so re-runs don't pile up domains).
+ *
+ * Pure w.r.t. I/O: every Railway interaction goes through the injected `gql`.
+ */
+export async function provisionStarterFleet(
+  opts: ProvisionOptions,
+): Promise<ProvisionSummary> {
+  const {
+    gql,
+    projectId,
+    stagingEnvId,
+    targets,
+    registryCredentials,
+    dryRun = false,
+    log = () => {},
+    sleepMs = (ms: number) => new Promise((r) => setTimeout(r, ms)),
+  } = opts;
+
+  const existing = await fetchExistingServices(gql, projectId, stagingEnvId);
+  const records: ProvisionRecord[] = [];
+
+  for (const target of targets) {
+    const prior = existing.get(target.serviceName);
+    let serviceId: string;
+    let action: "created" | "updated";
+
+    if (prior) {
+      serviceId = prior.id;
+      action = "updated";
+      log(`↻ ${target.serviceName} exists (${serviceId}) — updating`);
+    } else if (dryRun) {
+      serviceId = "<dry-run>";
+      action = "created";
+      log(`+ ${target.serviceName} would be created (${target.image})`);
+    } else {
+      // CRITICAL: pass `environmentId` so the new service instance is
+      // scoped to STAGING only. Without it, Railway materializes the
+      // instance in the project's DEFAULT (production) environment — which
+      // would leak a prod instance for every starter. `registryCredentials`
+      // is also supplied here so the staging instance can pull the private
+      // GHCR image from birth (before the serviceInstanceUpdate below
+      // re-asserts the rest of the config).
+      const createInput: Record<string, unknown> = {
+        projectId,
+        environmentId: stagingEnvId,
+        name: target.serviceName,
+        source: { image: target.image },
+      };
+      if (registryCredentials) {
+        createInput.registryCredentials = registryCredentials;
+      }
+      const created = await gql<ServiceCreateResult>(
+        `mutation serviceCreate($input: ServiceCreateInput!) {
+          serviceCreate(input: $input) { id name }
+        }`,
+        { input: createInput },
+      );
+      serviceId = created.serviceCreate.id;
+      action = "created";
+      log(`+ ${target.serviceName} created (${serviceId})`);
+    }
+
+    // Apply sleep + healthcheck + region (+ creds) against staging on BOTH
+    // paths. The image source is also re-asserted on the update path so a
+    // drifted existing service converges back to the canonical GHCR ref.
+    const instanceInput: Record<string, unknown> = {
+      source: { image: target.image },
+      sleepApplication: true,
+      healthcheckPath: STARTER_HEALTHCHECK_PATH,
+      region: STARTER_REGION,
+    };
+    if (registryCredentials) {
+      instanceInput.registryCredentials = registryCredentials;
+    }
+
+    if (!dryRun && serviceId !== "<dry-run>") {
+      // Railway materializes the env-scoped serviceInstance asynchronously
+      // after serviceCreate; a serviceInstanceUpdate issued too eagerly can
+      // race it ("ServiceInstance not found"). Retry briefly so a fresh
+      // create converges. Existing services (update path) hit this on the
+      // first try.
+      await withRetry(
+        () =>
+          gql(
+            `mutation serviceInstanceUpdate($serviceId: String!, $environmentId: String!, $input: ServiceInstanceUpdateInput!) {
+              serviceInstanceUpdate(serviceId: $serviceId, environmentId: $environmentId, input: $input)
+            }`,
+            {
+              serviceId,
+              environmentId: stagingEnvId,
+              input: instanceInput,
+            },
+          ),
+        sleepMs,
+      );
+      log(
+        `  configured sleep=true, healthcheck=${STARTER_HEALTHCHECK_PATH}, region=${STARTER_REGION}${
+          registryCredentials ? ", registry creds" : ""
+        }`,
+      );
+    }
+
+    // Domain: create only when none exists yet (idempotent).
+    let domain: string | undefined;
+    let domainAction: "created" | "existing" | "skipped";
+    if (prior?.hasStagingDomain) {
+      domainAction = "existing";
+      log(`  staging domain already present — skipping create`);
+    } else if (dryRun) {
+      domainAction = "skipped";
+    } else {
+      const domainResult = await withRetry(
+        () =>
+          gql<ServiceDomainResult>(
+            `mutation serviceDomainCreate($input: ServiceDomainCreateInput!) {
+              serviceDomainCreate(input: $input) { domain }
+            }`,
+            {
+              input: { serviceId, environmentId: stagingEnvId },
+            },
+          ),
+        sleepMs,
+      );
+      domain = domainResult.serviceDomainCreate.domain;
+      domainAction = "created";
+      log(`  domain: https://${domain}`);
+    }
+
+    records.push({
+      slug: target.slug,
+      serviceName: target.serviceName,
+      image: target.image,
+      serviceId,
+      action,
+      domain,
+      domainAction,
+    });
+  }
+
+  return { records };
+}
+
+// ── Live GraphQL caller ─────────────────────────────────────────────────
+
+let cachedToken: string | undefined;
+function getToken(): string {
+  if (cachedToken) return cachedToken;
+  try {
+    cachedToken = resolveRailwayToken().token;
+    return cachedToken;
+  } catch (e) {
+    if (e instanceof RailwayTokenError) {
+      console.error(e.message);
+      process.exit(1);
+    }
+    throw e;
+  }
+}
+
+function makeLiveGql(): RailwayGqlFn {
+  return async function railwayGql<T = unknown>(
+    query: string,
+    variables: Record<string, unknown> = {},
+  ): Promise<T> {
+    const token = getToken();
+    const res = await fetch(RAILWAY_API, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Railway API error: ${res.status} ${text}`);
+    }
+    const json = (await res.json()) as {
+      data?: T;
+      errors?: Array<{ message: string }>;
+    };
+    if (json.errors?.length) {
+      throw new Error(
+        `Railway GraphQL errors:\n${json.errors
+          .map((e) => `  - ${e.message}`)
+          .join("\n")}`,
+      );
+    }
+    return json.data as T;
+  };
+}
+
+// ── Subcommands ─────────────────────────────────────────────────────────
+
+async function listStarterServices(gql: RailwayGqlFn): Promise<void> {
+  const existing = await fetchExistingServices(gql, PROJECT_ID, STAGING_ENV_ID);
+  const starters = [...existing.entries()]
+    .filter(([name]) => name.startsWith(STARTER_FLEET_PREFIX))
+    .sort(([a], [b]) => a.localeCompare(b));
+  console.log(`Starter-fleet services in staging (${starters.length}):\n`);
+  for (const [name, svc] of starters) {
+    console.log(
+      `  ${name.padEnd(40)} ${svc.id}  ${
+        svc.hasStagingDomain ? "[domain]" : "[no domain]"
+      }`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help")) {
+    console.log(`Usage:
+  npx tsx showcase/scripts/provision-starter-fleet.ts            Provision all 12 starter-* services in staging
+  npx tsx showcase/scripts/provision-starter-fleet.ts --list     List starter-* services in staging
+  npx tsx showcase/scripts/provision-starter-fleet.ts --dry-run  Plan only (no mutations)
+`);
+    process.exit(0);
+  }
+
+  const gql = makeLiveGql();
+
+  if (args.includes("--list")) {
+    await listStarterServices(gql);
+    return;
+  }
+
+  const dryRun = args.includes("--dry-run");
+  const targets = deriveStarterTargets();
+
+  let registryCredentials: RegistryCredentials | undefined;
+  try {
+    registryCredentials = resolveRegistryCredentials();
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(1);
+  }
+  if (!registryCredentials) {
+    console.warn(
+      "\n  WARNING: GITHUB_TOKEN not set. Registry credentials will NOT be configured — Railway cannot pull the private GHCR starter images until creds are added.\n",
+    );
+  }
+
+  console.log(
+    `Provisioning ${targets.length} sleepable starter-* services in STAGING (env ${STAGING_ENV_ID})${
+      dryRun ? " [DRY RUN]" : ""
+    }\n`,
+  );
+
+  const summary = await provisionStarterFleet({
+    gql,
+    projectId: PROJECT_ID,
+    stagingEnvId: STAGING_ENV_ID,
+    targets,
+    registryCredentials,
+    dryRun,
+    log: (line) => console.log(line),
+  });
+
+  console.log(`\nDone. ${summary.records.length} services processed:\n`);
+  for (const r of summary.records) {
+    console.log(
+      `  ${r.serviceName.padEnd(40)} ${r.serviceId}  (${r.action}${
+        r.domain ? `, https://${r.domain}` : `, domain:${r.domainAction}`
+      })`,
+    );
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Adds `showcase/scripts/provision-starter-fleet.ts` — a committed, reproducible, **idempotent** provisioner for the SSOT-decoupled **starter container fleet**, and uses it to provision the 12 sleepable `starter-*` services in the showcase **STAGING** environment.

- Derives the **12 targets** from `STARTER_TO_COLUMN` (the smoke-matrix SSOT in `showcase/harness/src/probes/helpers/starter-mapping.ts`) so the fleet can never drift from the CI build matrix. Service name + image both use the **RAW starter slug** (e.g. `starter-langgraph-js`, `starter-adk`), never the remapped dashboard column slug.
- Per service: `serviceCreate` **scoped to the staging env** (`environmentId` on `ServiceCreateInput`, so **no production instance is ever materialized**) with `source.image=ghcr.io/copilotkit/starter-<slug>:latest` + GHCR `registryCredentials`; then `serviceInstanceUpdate` (staging) with `sleepApplication: true` + `healthcheckPath="/"` + `region=us-west1`; then `serviceDomainCreate` for a generated staging domain. A bounded retry absorbs Railway's eventual-consistency `ServiceInstance not found` right after create.
- **Healthcheck is `/`, not `/api/health`**: the starters' single deployable image `EXPOSE`s 3000 running the Next.js frontend, which serves `/` and `/api/copilotkit` but has **no `/api/health` route**; the agent's `/health` lives on the internal 8123 port Railway does not expose. (`region` reads back `null` on the serviceInstance for **all** existing showcase services too — normal Railway behavior, so the fleet matches the existing fleet.)

This fleet is intentionally **decoupled** from the 27-service `railway-envs.ts` SSOT — `starter-*` services are auto-discovered at runtime by the `starter_smoke` probe (`railway-services` source, `namePrefix: "starter-"`). **#5254** already made `verify-railway-image-refs.ts` tolerate `starter-*` names in both drift directions, so provisioning these services does **not** trip the CI image-ref gate / skip the showcase build.

## Provisioned (staging env `8edfef02-…`, all sleepApplication=true)

| service | id | domain |
| --- | --- | --- |
| starter-adk | 37691009-c0b2-4af7-8960-9f0b3f0a6be3 | starter-adk-staging.up.railway.app |
| starter-agno | 5ab3c37e-18a5-44e5-8329-26243dd98da8 | starter-agno-staging.up.railway.app |
| starter-crewai-crews | 2a9a4230-e6cd-4c1d-92a5-36e5c624371a | starter-crewai-crews-staging.up.railway.app |
| starter-langgraph-fastapi | 6ae57213-52ea-4fea-b4a0-7bc304cbc80e | starter-langgraph-fastapi-staging.up.railway.app |
| starter-langgraph-js | d044c3e5-bb27-4d5e-a2bf-e3b382981372 | starter-langgraph-js-staging.up.railway.app |
| starter-langgraph-python | 10dca514-7c8f-4a32-9708-9f29a944da36 | starter-langgraph-python-staging.up.railway.app |
| starter-llamaindex | 3255b27f-ea84-44b7-b587-b1687b409363 | starter-llamaindex-staging.up.railway.app |
| starter-mastra | 6548403e-3fee-4443-9d59-d8b041a3d43a | starter-mastra-staging.up.railway.app |
| starter-ms-agent-framework-dotnet | 1b4c5296-97f6-463d-90af-6e04d7919957 | starter-ms-agent-framework-dotnet-staging.up.railway.app |
| starter-ms-agent-framework-python | 225d0a06-d1cd-4b82-ae9c-2d1e8ecbaf86 | starter-ms-agent-framework-python-staging.up.railway.app |
| starter-pydantic-ai | c01d0d24-af88-4631-8a9a-23cffef2b36a | starter-pydantic-ai-staging.up.railway.app |
| starter-strands-python | 321735ab-c14d-4e45-a1c2-e47f2b29d774 | starter-strands-python-staging.up.railway.app |

Read-back via Railway GraphQL confirms all 12 are **staging-only** (no prod/other-env instance), `sleepApplication=true`, correct `:latest` GHCR image, `healthcheckPath="/"`, and a domain.

## Test plan

Red-green TDD against an injected Railway GraphQL mock (Railway is an external boundary — plain recording mock, not aimock):

- [x] target derivation: exactly 12, RAW slug (adk→`starter-adk` not `starter-google-adk`; langgraph-js→`starter-langgraph-js` not `…-typescript`)
- [x] GHCR credential resolution (GHCR_USERNAME preferred, GITHUB_ACTOR fallback, fail-loud when token present but no username)
- [x] `sleepApplication: true`, `healthcheckPath="/"`, `region=us-west1` on the staging instance
- [x] `serviceCreate` scopes to the **staging** env on BOTH create and update (never prod)
- [x] idempotent update-vs-create + domain de-duplication
- [x] transient `ServiceInstance not found` retry; non-transient errors fail loud
- [x] `pnpm exec tsc --noEmit` clean; `oxlint` + `oxfmt --check` clean; full showcase/scripts suite green (49 files / 1748 tests)

Do not merge yet — pending CR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)