### PR TITLE
perf(showcase-dashboard): order-safe concurrent paged initial status fetch + loading state

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
@@ -91,7 +91,77 @@ describe("computeColumnTallyDetail", () => {
       amber: [],
       red: [],
       unknown: true,
+      loading: false,
     });
+  });
+
+  // A4 regression: the connecting+empty initial-load branch in
+  // `computeColumnTallyDetail` (mirroring `computeColumnTally`). While the
+  // first PocketBase fetch is in flight the live-status map is empty AND the
+  // connection is "connecting". Returning authoritative empty buckets in that
+  // window reads as "every cell is at depth 0" — a lie. The detail must surface
+  // `loading: true` (a subset of `unknown`) instead, never authoritative
+  // emptiness, until the first rows land.
+  it("returns loading: true (unknown, not authoritative empty) while connecting with no rows", () => {
+    const integration = makeIntegration("test-int", ["feat-1"]);
+    const features = [makeFeature("feat-1", "Feature 1")];
+    const liveStatus: LiveStatusMap = new Map();
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "connecting",
+    );
+
+    expect(result).toEqual({
+      green: [],
+      amber: [],
+      red: [],
+      unknown: true,
+      loading: true,
+    });
+  });
+
+  it("does NOT treat connecting-with-rows as loading (data already arrived)", () => {
+    const integration = makeIntegration("test-int", ["feat-a"]);
+    const features = [makeFeature("feat-a", "Feature A")];
+    // A delta arrived during a transient reconnect: rows are present, so the
+    // detail is authoritative even though the connection is mid-reconnect.
+    const liveStatus: LiveStatusMap = new Map([
+      ["e2e:test-int/feat-a", makeRow("e2e:test-int/feat-a", "e2e", "red")],
+    ]);
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "connecting",
+    );
+
+    expect(result.loading).toBe(false);
+    expect(result.unknown).toBe(false);
+    expect(result.red).toEqual([
+      { label: "Feature A", dimension: "e2e", featureId: "feat-a" },
+    ]);
+  });
+
+  it("live with no rows is NOT loading — authoritative empty result", () => {
+    const integration = makeIntegration("test-int", ["feat-1"]);
+    const features = [makeFeature("feat-1", "Feature 1")];
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      new Map(),
+      "live",
+    );
+
+    expect(result.loading).toBe(false);
+    expect(result.unknown).toBe(false);
+    expect(result.green).toEqual([]);
+    expect(result.amber).toEqual([]);
+    expect(result.red).toEqual([]);
   });
 
   it("green D6 cells land in green bucket", () => {

--- a/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
@@ -803,7 +803,13 @@ describe("(6) edges + rollup precedence", () => {
       // subagents → no rows → gray (excluded)
     ]);
     const tally = computeColumnTally(integration, features, live, "live");
-    expect(tally).toEqual({ green: 1, amber: 0, red: 1, unknown: false });
+    expect(tally).toEqual({
+      green: 1,
+      amber: 0,
+      red: 1,
+      unknown: false,
+      loading: false,
+    });
   });
 
   it("column tally returns unknown=true when connection is error", () => {
@@ -818,7 +824,13 @@ describe("(6) edges + rollup precedence", () => {
       mapOf([]),
       "error",
     );
-    expect(tally).toEqual({ green: 0, amber: 0, red: 0, unknown: true });
+    expect(tally).toEqual({
+      green: 0,
+      amber: 0,
+      red: 0,
+      unknown: true,
+      loading: false,
+    });
   });
 });
 

--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -10,6 +10,8 @@ import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import { LiveIndicator, computeColumnTally, FeatureGrid } from "./feature-grid";
 import type { CellContext, CellRenderer } from "./feature-grid";
+import { OverlayColumnHeader } from "./overlay-column-header";
+import type { Overlay } from "@/lib/overlay-types";
 import { urlsFor } from "./cell-pieces";
 import { getIntegrations } from "@/lib/registry";
 import { starterIsSupported, STARTER_LEVELS } from "@/lib/live-status";
@@ -145,7 +147,13 @@ describe("computeColumnTally", () => {
     live.set("e2e:i1/f2", row("e2e:i1/f2", "e2e", "green"));
     const t = computeColumnTally(integration, features, live);
     // D6-ceiling: D3-only green with no D5/D6 → gray → not counted
-    expect(t).toEqual({ green: 0, amber: 0, red: 0, unknown: false });
+    expect(t).toEqual({
+      green: 0,
+      amber: 0,
+      red: 0,
+      unknown: false,
+      loading: false,
+    });
   });
 
   it("red D3 → red chip, green D3 without D5/D6 → gray", () => {
@@ -156,7 +164,13 @@ describe("computeColumnTally", () => {
     live.set("e2e:i1/f2", row("e2e:i1/f2", "e2e", "green"));
     const t = computeColumnTally(integration, features, live);
     // f1 red (gate fail), f2 gray (no D5/D6)
-    expect(t).toEqual({ green: 0, amber: 0, red: 1, unknown: false });
+    expect(t).toEqual({
+      green: 0,
+      amber: 0,
+      red: 1,
+      unknown: false,
+      loading: false,
+    });
   });
 
   it("health row alone does not contribute to tally", () => {
@@ -164,7 +178,13 @@ describe("computeColumnTally", () => {
     live.set("health:i1", row("health:i1", "health", "red"));
     const t = computeColumnTally(integration, features, live);
     // No D3 rows → all cells gray → nothing counted
-    expect(t).toEqual({ green: 0, amber: 0, red: 0, unknown: false });
+    expect(t).toEqual({
+      green: 0,
+      amber: 0,
+      red: 0,
+      unknown: false,
+      loading: false,
+    });
   });
 
   it("features without demos are gray (unwired), not counted", () => {
@@ -178,7 +198,13 @@ describe("computeColumnTally", () => {
     };
     const t = computeColumnTally(partialInt, features, live);
     // f1: wired + D3=green but no D5/D6 → gray; f2: unwired → gray
-    expect(t).toEqual({ green: 0, amber: 0, red: 0, unknown: false });
+    expect(t).toEqual({
+      green: 0,
+      amber: 0,
+      red: 0,
+      unknown: false,
+      loading: false,
+    });
   });
 
   it("not_supported_features are gray, not counted", () => {
@@ -191,7 +217,13 @@ describe("computeColumnTally", () => {
     };
     const t = computeColumnTally(unsupportedInt, features, live);
     // f1: D3=green but no D5/D6 → gray; f2: unsupported → gray
-    expect(t).toEqual({ green: 0, amber: 0, red: 0, unknown: false });
+    expect(t).toEqual({
+      green: 0,
+      amber: 0,
+      red: 0,
+      unknown: false,
+      loading: false,
+    });
   });
 
   it("returns unknown=true when connection is error", () => {
@@ -205,7 +237,49 @@ describe("computeColumnTally", () => {
 
   it("returns zeros with unknown=false when no rows", () => {
     const t = computeColumnTally(integration, features, new Map());
-    expect(t).toEqual({ green: 0, amber: 0, red: 0, unknown: false });
+    expect(t).toEqual({
+      green: 0,
+      amber: 0,
+      red: 0,
+      unknown: false,
+      loading: false,
+    });
+  });
+
+  // Regression: while the initial PocketBase fetch is still in flight the
+  // live-status map is empty AND the connection is "connecting". Returning
+  // authoritative ✓0 ~0 ✗0 in that window reads as "everything is at depth 0",
+  // which is a lie — the data simply hasn't arrived yet. The header must show a
+  // loading/unknown state instead, NEVER zeros, until the first rows land.
+  it("returns loading=true (unknown, not authoritative zeros) while connecting with no rows", () => {
+    const t = computeColumnTally(
+      integration,
+      features,
+      new Map(),
+      "connecting",
+    );
+    expect(t.loading).toBe(true);
+    expect(t.unknown).toBe(true);
+    expect(t.green).toBe(0);
+    expect(t.amber).toBe(0);
+    expect(t.red).toBe(0);
+  });
+
+  it("does NOT treat connecting-with-rows as loading (data already arrived)", () => {
+    const live: LiveStatusMap = new Map();
+    live.set("e2e:i1/f1", row("e2e:i1/f1", "e2e", "red"));
+    // A delta arrived during a transient reconnect: rows are present, so the
+    // tally is authoritative even though the connection is mid-reconnect.
+    const t = computeColumnTally(integration, features, live, "connecting");
+    expect(t.loading).toBe(false);
+    expect(t.unknown).toBe(false);
+    expect(t.red).toBe(1);
+  });
+
+  it("live with no rows is NOT loading — it is an authoritative empty result", () => {
+    const t = computeColumnTally(integration, features, new Map(), "live");
+    expect(t.loading).toBe(false);
+    expect(t.unknown).toBe(false);
   });
 
   it("amber chip when D5=green but D6 absent", () => {
@@ -236,7 +310,13 @@ describe("computeColumnTally", () => {
     );
     const t = computeColumnTally(mappedInt, mappedFeatures, mappedLive);
     // D3=green, D4=green, D5=green → amber (D6 not yet green)
-    expect(t).toEqual({ green: 0, amber: 1, red: 0, unknown: false });
+    expect(t).toEqual({
+      green: 0,
+      amber: 1,
+      red: 0,
+      unknown: false,
+      loading: false,
+    });
   });
 });
 
@@ -338,5 +418,77 @@ describe("FeatureGrid — Starter row-group", () => {
     const { getByTestId } = renderGrid(live);
     const cell = getByTestId(`starter-cell-${mapped!.slug}-interaction`);
     expect(cell.textContent).toContain("~");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  OverlayColumnHeader — loading / offline rendering (spec §5.3, A5)   */
+/*                                                                      */
+/*  The core §5.3 guarantee: during the initial-load window the header   */
+/*  must NOT render authoritative ✓0 ~0 ✗0 (which reads as "every cell   */
+/*  at depth 0" — a lie). It shows a "… loading" affordance while the    */
+/*  first signal is in flight, and "? offline" when the stream is down.  */
+/* ------------------------------------------------------------------ */
+
+describe("OverlayColumnHeader — loading / offline rendering (§5.3)", () => {
+  const integration: Integration = {
+    slug: "i1",
+    name: "Integration One",
+    category: "c",
+    language: "ts",
+    description: "",
+    repo: "",
+    backend_url: "https://x",
+    deployed: true,
+    features: ["f1"],
+    demos: [{ id: "f1", name: "f1", description: "", tags: [] }],
+  };
+
+  const HEALTH: Set<Overlay> = new Set<Overlay>(["health"]);
+
+  it("loading tally → '… loading' affordance, NOT authoritative zero counts", () => {
+    const { getByText, queryByText } = render(
+      <OverlayColumnHeader
+        integration={integration}
+        tally={{ green: 0, amber: 0, red: 0, unknown: true, loading: true }}
+        overlays={HEALTH}
+      />,
+    );
+    // The loading affordance renders.
+    expect(getByText(/loading/)).toBeDefined();
+    // The authoritative zero glyphs must NOT render during loading.
+    expect(queryByText(/✓\s*0/)).toBeNull(); // ✓ 0
+    expect(queryByText(/✗\s*0/)).toBeNull(); // ✗ 0
+    expect(queryByText(/^~\s*0$/)).toBeNull(); // ~ 0
+  });
+
+  it("unknown (offline) tally → '? offline' affordance, NOT authoritative zero counts", () => {
+    const { getByText, queryByText } = render(
+      <OverlayColumnHeader
+        integration={integration}
+        tally={{ green: 0, amber: 0, red: 0, unknown: true, loading: false }}
+        overlays={HEALTH}
+      />,
+    );
+    // The offline affordance renders.
+    expect(getByText(/offline/)).toBeDefined();
+    // The authoritative zero glyphs must NOT render while offline.
+    expect(queryByText(/✓\s*0/)).toBeNull(); // ✓ 0
+    expect(queryByText(/✗\s*0/)).toBeNull(); // ✗ 0
+    expect(queryByText(/^~\s*0$/)).toBeNull(); // ~ 0
+  });
+
+  it("authoritative (not loading, not unknown) tally → renders the count glyphs", () => {
+    const { getByText, queryByText } = render(
+      <OverlayColumnHeader
+        integration={integration}
+        tally={{ green: 2, amber: 1, red: 3, unknown: false, loading: false }}
+        overlays={HEALTH}
+      />,
+    );
+    // Counts render; neither loading nor offline affordance is shown.
+    expect(getByText(/✓/)).toBeDefined(); // ✓
+    expect(queryByText(/loading/)).toBeNull();
+    expect(queryByText(/offline/)).toBeNull();
   });
 });

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -67,6 +67,14 @@ export type CellRenderer = (ctx: CellContext) => React.ReactNode;
  * When the SSE stream is down (`connection === "error"`) we return all-zero —
  * the column header falls back to an "unknown" rendering so stale counts
  * don't read as authoritative while the dashboard is offline.
+ *
+ * Likewise during the INITIAL load — `connection === "connecting"` with an
+ * empty `liveStatus` map (the first PocketBase fetch hasn't resolved yet) — we
+ * return `loading: true` (also `unknown: true`). Without this guard the header
+ * renders authoritative `✓0 ~0 ✗0` while data is merely in flight, which reads
+ * as "every cell is at depth 0" — a lie. `loading` lets the header show a
+ * loading affordance instead of fake zeros. Once any rows arrive (even mid
+ * reconnect) the tally is authoritative again.
  */
 export function computeColumnTally(
   integration: Integration,
@@ -74,9 +82,21 @@ export function computeColumnTally(
   liveStatus: LiveStatusMap,
   connection: ConnectionStatus = "live",
   now: number = Date.now(),
-): { green: number; amber: number; red: number; unknown: boolean } {
+): {
+  green: number;
+  amber: number;
+  red: number;
+  unknown: boolean;
+  loading: boolean;
+} {
   if (connection === "error") {
-    return { green: 0, amber: 0, red: 0, unknown: true };
+    return { green: 0, amber: 0, red: 0, unknown: true, loading: false };
+  }
+
+  // Initial-load window: connecting AND no rows yet. Surface a loading state
+  // (which the header treats as unknown) instead of authoritative zeros.
+  if (connection === "connecting" && liveStatus.size === 0) {
+    return { green: 0, amber: 0, red: 0, unknown: true, loading: true };
   }
 
   let green = 0;
@@ -106,7 +126,7 @@ export function computeColumnTally(
     // gray → skip (no data / unsupported / unwired)
   }
 
-  return { green, amber, red, unknown: false };
+  return { green, amber, red, unknown: false, loading: false };
 }
 
 /**
@@ -120,11 +140,16 @@ export function computeColumnTallyDetail(
   integration: Integration,
   features: Feature[],
   liveStatus: LiveStatusMap,
-  connection: ConnectionStatus,
+  connection: ConnectionStatus = "live",
   now: number = Date.now(),
 ): TallyDetail {
   if (connection === "error") {
-    return { green: [], amber: [], red: [], unknown: true };
+    return { green: [], amber: [], red: [], unknown: true, loading: false };
+  }
+
+  // Initial-load window: connecting AND no rows yet — mirror computeColumnTally.
+  if (connection === "connecting" && liveStatus.size === 0) {
+    return { green: [], amber: [], red: [], unknown: true, loading: true };
   }
 
   const green: TallyItem[] = [];
@@ -181,7 +206,7 @@ export function computeColumnTallyDetail(
     else if (model.chipColor === "red") red.push(item);
   }
 
-  return { green, amber, red, unknown: false };
+  return { green, amber, red, unknown: false, loading: false };
 }
 
 /**
@@ -763,11 +788,16 @@ export function FeatureGrid({
               </th>
               {showRefDepth && <RefDepthHeader />}
               {integrations.map((integration) => {
+                // Fail-safe default: a missing tally must render the
+                // loading/offline affordance, NEVER authoritative ✓0 ~0 ✗0
+                // (the "fake-zero lie" §5.3 guards against). Default toward
+                // "we don't know" (unknown+loading), not "everything is zero".
                 const tally = tallies.get(integration.slug) ?? {
                   green: 0,
                   amber: 0,
                   red: 0,
-                  unknown: false,
+                  unknown: true,
+                  loading: true,
                 };
 
                 // Overlay-aware header when overlays prop is provided
@@ -787,11 +817,13 @@ export function FeatureGrid({
 
                 // Legacy header rendering (backwards compat when overlays not provided)
                 const total = tally.green + tally.amber + tally.red;
-                const tallyTitle = tally.unknown
-                  ? "dashboard offline — live signal unavailable (§5.3)"
-                  : total
-                    ? `${tally.green} green · ${tally.amber} amber · ${tally.red} red of ${total} countable signals (D4 per feature; Health counted once per integration)`
-                    : "no countable signals for this column";
+                const tallyTitle = tally.loading
+                  ? "loading — waiting for the first live signal"
+                  : tally.unknown
+                    ? "dashboard offline — live signal unavailable (§5.3)"
+                    : total
+                      ? `${tally.green} green · ${tally.amber} amber · ${tally.red} red of ${total} countable signals (D4 per feature; Health counted once per integration)`
+                      : "no countable signals for this column";
                 return (
                   <th
                     key={integration.slug}
@@ -814,7 +846,11 @@ export function FeatureGrid({
                       className="mt-1 text-[10px] tabular-nums text-[var(--text-muted)]"
                       title={tallyTitle}
                     >
-                      {tally.unknown ? (
+                      {tally.loading ? (
+                        <span className="text-[var(--text-muted)] animate-pulse">
+                          … loading
+                        </span>
+                      ) : tally.unknown ? (
                         <span className="text-[var(--text-muted)]">
                           ? offline
                         </span>

--- a/showcase/shell-dashboard/src/components/overlay-column-header.tsx
+++ b/showcase/shell-dashboard/src/components/overlay-column-header.tsx
@@ -18,7 +18,20 @@ import type { Overlay } from "@/lib/overlay-types";
 
 export interface OverlayColumnHeaderProps {
   integration: Integration;
-  tally?: { green: number; amber: number; red: number; unknown: boolean };
+  tally?: {
+    green: number;
+    amber: number;
+    red: number;
+    unknown: boolean;
+    // REQUIRED (not optional): the producers — `computeColumnTally` /
+    // `computeColumnTallyDetail` — ALWAYS return a concrete `loading` boolean,
+    // and `FeatureGrid` always passes it. Keeping it optional was a latent gap:
+    // a future caller omitting `loading` would render authoritative ✓0/~0/✗0
+    // during an error/loading window (the exact "stale-green lie" this header
+    // prevents). The `tally` object itself stays optional; `loading` within it
+    // is mandatory once a tally is supplied.
+    loading: boolean;
+  };
   tallyDetail?: TallyDetail;
   overlays: Set<Overlay>;
   parityTier?: ParityTier;
@@ -38,11 +51,13 @@ export function OverlayColumnHeader({
   const showParity = overlays.has("parity");
 
   const total = tally ? tally.green + tally.amber + tally.red : 0;
-  const tallyTitle = tally?.unknown
-    ? "dashboard offline -- live signal unavailable"
-    : total
-      ? `${tally?.green ?? 0} green \u00b7 ${tally?.amber ?? 0} amber \u00b7 ${tally?.red ?? 0} red of ${total} signals`
-      : "no countable signals for this column";
+  const tallyTitle = tally?.loading
+    ? "loading -- waiting for the first live signal"
+    : tally?.unknown
+      ? "dashboard offline -- live signal unavailable"
+      : total
+        ? `${tally?.green ?? 0} green \u00b7 ${tally?.amber ?? 0} amber \u00b7 ${tally?.red ?? 0} red of ${total} signals`
+        : "no countable signals for this column";
 
   return (
     <th
@@ -72,7 +87,11 @@ export function OverlayColumnHeader({
           className="mt-1 text-[9px] tabular-nums text-[var(--text-muted)]"
           title={tallyTitle}
         >
-          {tally.unknown ? (
+          {tally.loading ? (
+            <span className="text-[var(--text-muted)] animate-pulse">
+              {"…"} loading
+            </span>
+          ) : tally.unknown ? (
             <span className="text-[var(--text-muted)]">? offline</span>
           ) : (
             <>

--- a/showcase/shell-dashboard/src/components/tally-types.ts
+++ b/showcase/shell-dashboard/src/components/tally-types.ts
@@ -9,4 +9,10 @@ export interface TallyDetail {
   amber: TallyItem[];
   red: TallyItem[];
   unknown: boolean;
+  /**
+   * True only during the initial-load window (connecting + no rows yet). A
+   * subset of `unknown` — distinguishes "data still loading" from "dashboard
+   * offline" so the header can show a loading affordance instead of zeros.
+   */
+  loading: boolean;
 }

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.autocancel.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.autocancel.test.tsx
@@ -122,31 +122,46 @@ afterAll(() => {
   server.close();
 });
 
+// Snapshot of `window.__SHOWCASE_CONFIG__` so beforeEach's injection is
+// reverted in afterEach — otherwise the fake-server URL leaks into any later
+// test in the same worker that reads runtime config.
+let prevShowcaseConfig: unknown;
+let hadShowcaseConfig = false;
+
 beforeEach(() => {
   // jsdom has neither EventSource (PB realtime/SSE) nor a usable localStorage
   // for the SDK's auth store. Stub both so constructing/driving the real
   // PocketBase client doesn't blow up — we never exercise the SSE subscribe
   // path here (the bug under test is in the initial paged fetch).
-  (globalThis as unknown as { EventSource: unknown }).EventSource = class {
-    close(): void {}
-    addEventListener(): void {}
-    removeEventListener(): void {}
-  };
-  const store = new Map<string, string>();
-  Object.defineProperty(globalThis, "localStorage", {
-    configurable: true,
-    value: {
-      getItem: (k: string) => store.get(k) ?? null,
-      setItem: (k: string, v: string) => store.set(k, v),
-      removeItem: (k: string) => store.delete(k),
-      clear: () => store.clear(),
+  //
+  // Use vi.stubGlobal so vi.unstubAllGlobals() in afterEach fully restores the
+  // originals: the previous Object.defineProperty / raw-assignment approach
+  // overwrote globalThis.EventSource and globalThis.localStorage and never put
+  // them back, contaminating any sibling test that touched those globals.
+  vi.stubGlobal(
+    "EventSource",
+    class {
+      close(): void {}
+      addEventListener(): void {}
+      removeEventListener(): void {}
     },
+  );
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
   });
   // Point the production runtime-config reader at our fake server, then reset
-  // the pb module so getPb() rebuilds its singleton against this URL.
-  (
-    globalThis as unknown as { window: Window & typeof globalThis }
-  ).window.__SHOWCASE_CONFIG__ = {
+  // the pb module so getPb() rebuilds its singleton against this URL. Snapshot
+  // the prior value so afterEach can restore it (window is shared jsdom state,
+  // not a global vi.stubGlobal can track).
+  const win = (globalThis as unknown as { window: Window & typeof globalThis })
+    .window as unknown as { __SHOWCASE_CONFIG__?: unknown };
+  hadShowcaseConfig = "__SHOWCASE_CONFIG__" in win;
+  prevShowcaseConfig = win.__SHOWCASE_CONFIG__;
+  win.__SHOWCASE_CONFIG__ = {
     pocketbaseUrl: baseUrl,
     shellUrl: baseUrl,
     opsBaseUrl: baseUrl,
@@ -155,6 +170,16 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Restore every global we stubbed (EventSource, localStorage) and the
+  // window config we injected, so nothing leaks into sibling tests.
+  vi.unstubAllGlobals();
+  const win = (globalThis as unknown as { window: Window & typeof globalThis })
+    .window as unknown as { __SHOWCASE_CONFIG__?: unknown };
+  if (hadShowcaseConfig) {
+    win.__SHOWCASE_CONFIG__ = prevShowcaseConfig;
+  } else {
+    delete win.__SHOWCASE_CONFIG__;
+  }
   vi.resetModules();
 });
 
@@ -163,16 +188,27 @@ describe("useLiveStatus (real PocketBase SDK — auto-cancellation regression)",
     // Import AFTER resetModules + config injection so the hook closes over a
     // freshly-constructed pb singleton pointed at our fake server.
     const { useLiveStatus } = await import("./useLiveStatus");
-    const { result } = renderHook(() => useLiveStatus("smoke"));
+    const { result, unmount } = renderHook(() => useLiveStatus("smoke"));
 
-    // Without `requestKey: null`, pages 2 & 3 share the page-1 auto request
-    // key, get auto-cancelled, Promise.all rejects, and the hook lands in
-    // "error" (or never reaches "live") instead. The fix lets every page
-    // complete → all 1300 rows → "live".
-    await waitFor(() => expect(result.current.status).toBe("live"), {
-      timeout: 5000,
-    });
-    expect(result.current.rows).toHaveLength(TOTAL_ROWS);
-    expect(result.current.error).toBeNull();
+    try {
+      // Without `requestKey: null`, pages 2 & 3 share the page-1 auto request
+      // key, get auto-cancelled, Promise.all rejects, and the hook lands in
+      // "error" (or never reaches "live") instead. The fix lets every page
+      // complete → all 1300 rows → "live".
+      await waitFor(() => expect(result.current.status).toBe("live"), {
+        timeout: 5000,
+      });
+      expect(result.current.rows).toHaveLength(TOTAL_ROWS);
+      expect(result.current.error).toBeNull();
+    } finally {
+      // Reaching "live" starts a 30s setInterval heartbeat that pings the
+      // about-to-close in-process server via the pb singleton. Without an
+      // explicit unmount the effect cleanup never runs, so the interval (and
+      // its pb client) leak past the test and a post-teardown tick fires
+      // against a dead socket. Unmounting runs the effect's cleanup
+      // (clearHeartbeat + teardownSubscription) before afterAll closes the
+      // server.
+      unmount();
+    }
   }, 10000);
 });

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.autocancel.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.autocancel.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * REAL-SDK regression test for the PocketBase auto-cancellation bug.
+ *
+ * The sibling `useLiveStatus.test.tsx` mocks `../lib/pb`, so it never
+ * exercises the real PocketBase JS SDK and therefore MISSED this bug: the
+ * SDK derives a request key from `method + path` and AUTO-CANCELS any
+ * in-flight request that shares it. `fetchInitial` fans pages 2..N out
+ * CONCURRENTLY at the SAME path (`/api/collections/status/records`), so
+ * every page after the first would cancel its predecessor — the cancelled
+ * promises reject, `Promise.all` rejects, and the hook drops to OFFLINE.
+ *
+ * This test stands up a real in-process Node http server that serves the
+ * status records endpoint paged with a per-page delay (so multiple fan-out
+ * pages are genuinely in flight at once), points the PRODUCTION `getPb()`
+ * client at it, drives the REAL hook, and asserts it reaches "live" with
+ * ALL pages' rows. It is RED if `requestKey: null` is removed from the list
+ * options and GREEN with it.
+ *
+ * NOTE: this file deliberately does NOT mock `../lib/pb` — it uses the real
+ * SDK against a real socket. EventSource + localStorage are stubbed because
+ * jsdom lacks the realtime/SSE plumbing the subscribe() path needs; we only
+ * assert the initial paged fetch here (the bug lives in fetchInitial, not in
+ * the SSE subscribe path).
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+// Total rows the fake server serves, spread across PB's 500-row page clamp.
+// 1300 rows → 3 pages (500 + 500 + 300): page 1 reports totalPages, then the
+// hook fans out pages 2 & 3 concurrently — exactly the scenario the SDK's
+// auto-cancellation breaks.
+const TOTAL_ROWS = 1300;
+const PER_PAGE_CLAMP = 500;
+// Per-page artificial latency. Long enough that pages 2 & 3 are GENUINELY
+// in flight simultaneously, so the SDK's same-path auto-cancel actually
+// fires (a zero-delay server might resolve page 2 before page 3 is even
+// dispatched, masking the bug).
+const PAGE_DELAY_MS = 40;
+
+function makeRow(i: number): Record<string, unknown> {
+  const id = `r${String(i).padStart(4, "0")}`;
+  return {
+    id,
+    key: `smoke:int/f${id}`,
+    dimension: "smoke",
+    state: "green",
+    signal: {},
+    observed_at: "2026-04-20T00:00:00Z",
+    transitioned_at: "2026-04-20T00:00:00Z",
+    fail_count: 0,
+    first_failure_at: null,
+  };
+}
+
+const ALL_ROWS = Array.from({ length: TOTAL_ROWS }, (_, i) => makeRow(i));
+
+/**
+ * Minimal PocketBase-compatible list endpoint. Honours `?page=`/`?perPage=`
+ * (clamped to 500, like real PB) and delays each response by PAGE_DELAY_MS so
+ * concurrent fan-out pages overlap on the wire.
+ */
+function startPbServer(): Promise<{ server: Server; url: string }> {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (!url.pathname.startsWith("/api/collections/status/records")) {
+      res.statusCode = 404;
+      res.end(JSON.stringify({ message: "not found" }));
+      return;
+    }
+    const page = Number(url.searchParams.get("page") ?? "1");
+    const perPage = Math.min(
+      Number(url.searchParams.get("perPage") ?? String(PER_PAGE_CLAMP)),
+      PER_PAGE_CLAMP,
+    );
+    const start = (page - 1) * perPage;
+    const items = ALL_ROWS.slice(start, start + perPage);
+    const body = JSON.stringify({
+      page,
+      perPage,
+      totalItems: TOTAL_ROWS,
+      totalPages: Math.max(1, Math.ceil(TOTAL_ROWS / perPage)),
+      items,
+    });
+    // Delay so concurrent fan-out pages are genuinely in flight together.
+    setTimeout(() => {
+      res.setHeader("content-type", "application/json");
+      res.end(body);
+    }, PAGE_DELAY_MS);
+  });
+  return new Promise((resolve) => {
+    // Bind to 127.0.0.1 (not localhost) — the PB SDK warns localhost can
+    // mis-resolve to ::1 and refuse the connection in Node.
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const started = await startPbServer();
+  server = started.server;
+  baseUrl = started.url;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+beforeEach(() => {
+  // jsdom has neither EventSource (PB realtime/SSE) nor a usable localStorage
+  // for the SDK's auth store. Stub both so constructing/driving the real
+  // PocketBase client doesn't blow up — we never exercise the SSE subscribe
+  // path here (the bug under test is in the initial paged fetch).
+  (globalThis as unknown as { EventSource: unknown }).EventSource = class {
+    close(): void {}
+    addEventListener(): void {}
+    removeEventListener(): void {}
+  };
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+    },
+  });
+  // Point the production runtime-config reader at our fake server, then reset
+  // the pb module so getPb() rebuilds its singleton against this URL.
+  (
+    globalThis as unknown as { window: Window & typeof globalThis }
+  ).window.__SHOWCASE_CONFIG__ = {
+    pocketbaseUrl: baseUrl,
+    shellUrl: baseUrl,
+    opsBaseUrl: baseUrl,
+  };
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("useLiveStatus (real PocketBase SDK — auto-cancellation regression)", () => {
+  it("reaches live with ALL pages despite concurrent same-path fan-out", async () => {
+    // Import AFTER resetModules + config injection so the hook closes over a
+    // freshly-constructed pb singleton pointed at our fake server.
+    const { useLiveStatus } = await import("./useLiveStatus");
+    const { result } = renderHook(() => useLiveStatus("smoke"));
+
+    // Without `requestKey: null`, pages 2 & 3 share the page-1 auto request
+    // key, get auto-cancelled, Promise.all rejects, and the hook lands in
+    // "error" (or never reaches "live") instead. The fix lets every page
+    // complete → all 1300 rows → "live".
+    await waitFor(() => expect(result.current.status).toBe("live"), {
+      timeout: 5000,
+    });
+    expect(result.current.rows).toHaveLength(TOTAL_ROWS);
+    expect(result.current.error).toBeNull();
+  }, 10000);
+});

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.test.tsx
@@ -5,6 +5,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 
+// Track calls to React.startTransition without losing its real behavior. The
+// hook wraps the heavy initial `setRows(initial)` commit in startTransition so
+// React 19 can yield to user input mid-walk instead of blocking on the
+// full-matrix re-render. We can't `vi.spyOn` a frozen ESM namespace export, so
+// we partial-mock `react` and wrap the real implementation.
+const startTransitionCalls = { count: 0 };
+vi.mock("react", async (importActual) => {
+  const actual = await importActual<typeof import("react")>();
+  return {
+    ...actual,
+    startTransition: (cb: () => void) => {
+      startTransitionCalls.count += 1;
+      return actual.startTransition(cb);
+    },
+  };
+});
+
 // Mock PB client used by the hook. Drives initial + subscribe events.
 type Action = "create" | "update" | "delete";
 type Listener = (e: {
@@ -12,12 +29,15 @@ type Listener = (e: {
   record: Record<string, unknown>;
 }) => void;
 
+// PocketBase clamps perPage to 500, so the paged initial fetch uses 500.
+const PB_PAGE_SIZE = 500;
+
 const mockState = {
   initial: [] as Record<string, unknown>[],
   listener: null as Listener | null,
   failRemaining: 0,
-  // Capture the options passed to getFullList / subscribe so tests can
-  // assert server-side filter is forwarded (not client-side only).
+  // Capture the options passed to the initial getList(1, …) call / subscribe so
+  // tests can assert server-side filter is forwarded (not client-side only).
   lastInitialGetListOpts: undefined as unknown,
   lastSubscribeOpts: undefined as unknown,
   // Make getList (heartbeat) fail on demand to drive reconnection.
@@ -29,7 +49,56 @@ const mockState = {
   // Track how many times the unsubscribe function returned by subscribe
   // was actually invoked — for teardown / dimension-change tests.
   unsubscribeCalls: 0,
+  // Per-page resolution-delay map (page number → ms) so a test can make a
+  // LATER page resolve BEFORE an earlier one, proving the merge is ordered by
+  // request index, not by resolution order. Empty = all resolve immediately.
+  pageResolveDelayMs: {} as Record<number, number>,
+  // Records the order in which the initial getList page requests were ISSUED
+  // (before any await), so tests can assert pages 2..N are dispatched
+  // concurrently rather than awaited serially.
+  initialPageRequestOrder: [] as number[],
+  // Per-page options captured for EVERY initial getList page request (not just
+  // the last), so a test can assert the hook forwards a stable `sort` to ALL
+  // pages — offset pagination over a live-mutating collection drops/duplicates
+  // rows without one.
+  initialPageOpts: [] as { filter?: string; sort?: string }[],
 };
+
+// Build a PocketBase-style paged getList response over `mockState.initial`,
+// honouring the 500-row perPage clamp PB enforces server-side. When a `sort`
+// key is supplied, the rows are ordered by that field BEFORE slicing — exactly
+// as PocketBase applies `?sort=` server-side. This makes the stable-sort
+// assertion BEHAVIORAL: if the hook ever stopped forwarding `sort` to a page,
+// that page would slice an unsorted view and the merged result would differ.
+function pageResponse(
+  page: number,
+  perPage: number,
+  sort?: string,
+): {
+  items: Record<string, unknown>[];
+  page: number;
+  perPage: number;
+  totalItems: number;
+  totalPages: number;
+} {
+  const effPerPage = Math.min(perPage, PB_PAGE_SIZE);
+  const ordered = sort
+    ? [...mockState.initial].sort((a, b) => {
+        const av = String(a[sort] ?? "");
+        const bv = String(b[sort] ?? "");
+        return av < bv ? -1 : av > bv ? 1 : 0;
+      })
+    : mockState.initial;
+  const total = ordered.length;
+  const start = (page - 1) * effPerPage;
+  return {
+    items: ordered.slice(start, start + effPerPage),
+    page,
+    perPage: effPerPage,
+    totalItems: total,
+    totalPages: Math.max(1, Math.ceil(total / effPerPage)),
+  };
+}
 
 vi.mock("../lib/pb", () => {
   const pb = {
@@ -43,33 +112,45 @@ vi.mock("../lib/pb", () => {
       return out;
     },
     collection: (_name: string) => ({
-      // getFullList is used by the initial fetch (replaces paginated getList).
-      // Returns a plain array, respecting the `batch` option as a cap.
-      getFullList: vi.fn(async (opts?: { batch?: number; filter?: string }) => {
-        mockState.getListCalls += 1;
-        mockState.lastInitialGetListOpts = opts;
-        if (mockState.failRemaining > 0) {
-          mockState.failRemaining -= 1;
-          throw new Error("pb-unreachable");
-        }
-        const cap = opts?.batch ?? Infinity;
-        return mockState.initial.slice(0, cap);
-      }),
-      // getList is still used for heartbeat pings (getList(1, 1)).
+      // getList serves two callers, distinguished by `perPage`:
+      //   - heartbeat ping  → getList(1, 1, …)
+      //   - initial fetch   → getList(page, PB_PAGE_SIZE, …) for each page
+      // The initial fetch issues page 1 first (to read totalPages), then fans
+      // out pages 2..N concurrently. To prove the merge is order-safe, a test
+      // can set `pageResolveDelayMs` so a LATER page resolves BEFORE an earlier
+      // one — the hook must still return rows in page order.
       getList: vi.fn(
-        async (_page: number, _perPage: number, _opts?: unknown) => {
-          mockState.getListCalls += 1;
-          if (mockState.heartbeatFailRemaining > 0) {
-            mockState.heartbeatFailRemaining -= 1;
-            throw new Error("heartbeat-fail");
+        async (
+          page: number,
+          perPage: number,
+          opts?: { filter?: string; sort?: string },
+        ) => {
+          // Heartbeat ping: perPage 1. Keep its 1-row contract + fail hook.
+          if (perPage === 1) {
+            mockState.getListCalls += 1;
+            if (mockState.heartbeatFailRemaining > 0) {
+              mockState.heartbeatFailRemaining -= 1;
+              throw new Error("heartbeat-fail");
+            }
+            return pageResponse(1, 1);
           }
-          return {
-            items: mockState.initial.slice(0, 1),
-            page: 1,
-            perPage: 1,
-            totalItems: mockState.initial.length,
-            totalPages: 1,
-          };
+          // Initial paged fetch.
+          mockState.getListCalls += 1;
+          mockState.initialPageRequestOrder.push(page);
+          mockState.lastInitialGetListOpts = opts;
+          mockState.initialPageOpts.push(opts ?? {});
+          if (mockState.failRemaining > 0) {
+            mockState.failRemaining -= 1;
+            throw new Error("pb-unreachable");
+          }
+          const delay = mockState.pageResolveDelayMs[page] ?? 0;
+          if (delay > 0) {
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          }
+          // Apply the requested `sort` server-side (see pageResponse) so the
+          // forwarded-sort contract is exercised behaviorally, not just by
+          // inspecting the captured option string.
+          return pageResponse(page, perPage, opts?.sort);
         },
       ),
       subscribe: vi.fn(async (_topic: string, cb: Listener, opts?: unknown) => {
@@ -106,6 +187,12 @@ describe("useLiveStatus", () => {
     mockState.getListCalls = 0;
     mockState.subscribeCalls = 0;
     mockState.unsubscribeCalls = 0;
+    mockState.pageResolveDelayMs = {};
+    mockState.initialPageRequestOrder = [];
+    mockState.initialPageOpts = [];
+    // Reset the startTransition counter so the transition assertion can't pass
+    // on stale state leaked from a prior test (A3).
+    startTransitionCalls.count = 0;
   });
 
   it("transitions connecting → live and exposes initial rows", async () => {
@@ -126,6 +213,36 @@ describe("useLiveStatus", () => {
     expect(result.current.status).toBe("connecting");
     await waitFor(() => expect(result.current.status).toBe("live"));
     expect(result.current.rows).toHaveLength(1);
+  });
+
+  it("applies the initial full-matrix rows inside a React transition (non-blocking first paint)", async () => {
+    // The first commit with real data invalidates per-key memo checks on EVERY
+    // cell (empty map → populated map), a hundreds-of-cells synchronous render.
+    // Wrapping `setRows(initial)` in startTransition lets React 19 yield to user
+    // input mid-walk instead of freezing the main thread for the load. The
+    // "connecting → live" status flip must stay urgent so the indicator updates
+    // immediately. React.startTransition is wrapped (see the top-of-file mock):
+    // it MUST be invoked when the initial rows land. The counter is reset in
+    // beforeEach (A3) so this assertion can't pass on state leaked by a prior
+    // test rather than this one's own initial-rows commit.
+    mockState.initial = [
+      {
+        id: "1",
+        key: "smoke:a/b",
+        dimension: "smoke",
+        state: "green",
+        signal: {},
+        observed_at: "2026-04-20T00:00:00Z",
+        transitioned_at: "2026-04-20T00:00:00Z",
+        fail_count: 0,
+        first_failure_at: null,
+      },
+    ];
+    const { result } = renderHook(() => useLiveStatus("smoke"));
+    await waitFor(() => expect(result.current.status).toBe("live"));
+    expect(result.current.rows).toHaveLength(1);
+    // The initial-rows commit must have gone through a transition.
+    expect(startTransitionCalls.count).toBeGreaterThan(0);
   });
 
   it("passes server-side filter to the initial getList and subscribe", async () => {
@@ -393,8 +510,10 @@ describe("useLiveStatus", () => {
     }
   });
 
-  it("INITIAL_CAP: stops at 500 rows even when more are available (C5 F20)", async () => {
-    // 350 rows: well below cap. Verify pagination pulls all 350.
+  it("single page: fetches all rows when the collection fits in one page", async () => {
+    // 350 rows: below the 500/page clamp. getList(1, 500) reads page 1 and its
+    // reported totalPages=1, so there is no fan-out and NO extra request — the
+    // initial fetch is a single best-effort snapshot reconciled by SSE.
     mockState.initial = Array.from({ length: 350 }, (_, i) => ({
       id: `r${i}`,
       key: `smoke:int/f${i}`,
@@ -409,10 +528,15 @@ describe("useLiveStatus", () => {
     const { result } = renderHook(() => useLiveStatus("smoke"));
     await waitFor(() => expect(result.current.status).toBe("live"));
     expect(result.current.rows).toHaveLength(350);
+    // Only page 1 is requested — totalPages=1 means no fan-out and no probe.
+    expect(mockState.initialPageRequestOrder).toEqual([1]);
   });
 
-  it("INITIAL_CAP: truncates to 2000 when collection is larger (C5 F20)", async () => {
-    // 2100 rows: exceeds cap. We expect exactly 2000.
+  it("paged fetch: collects ALL pages (no INITIAL_CAP truncation)", async () => {
+    // 2100 rows across 5 pages (500/page, last page 100). The previous
+    // single-getFullList impl capped at INITIAL_CAP=2000, silently dropping
+    // 100 late-created rows (e2e per-cell → D2-instead-of-D4 bug). The paged
+    // fetch collects every page — all 2100 rows — with no length-based break.
     mockState.initial = Array.from({ length: 2100 }, (_, i) => ({
       id: `r${i}`,
       key: `smoke:int/f${i}`,
@@ -426,7 +550,118 @@ describe("useLiveStatus", () => {
     }));
     const { result } = renderHook(() => useLiveStatus("smoke"));
     await waitFor(() => expect(result.current.status).toBe("live"));
-    expect(result.current.rows).toHaveLength(2000);
+    expect(result.current.rows).toHaveLength(2100);
+    // 5 data pages requested (page 1 + concurrent fan-out 2..5). No probe.
+    expect(mockState.initialPageRequestOrder.sort((a, b) => a - b)).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+  });
+
+  it("paged fetch is order-safe under out-of-order page resolution AND concurrent (perf regression fix)", async () => {
+    // The reverted #4504 parallel fix pushed Promise.all page results into an
+    // array IN RESOLUTION ORDER and had an early `break` on
+    // `collected.length >= total` — a non-deterministic merge that could also
+    // truncate before late pages landed. This asserts the order-safe contract:
+    //
+    //   (a) ALL pages present (no truncation), and
+    //   (b) rows in deterministic PAGE order regardless of which page's HTTP
+    //       response lands first, and
+    //   (c) pages 2..N are dispatched CONCURRENTLY (page 2 issued before page 1
+    //       has resolved), not awaited serially.
+    //
+    // We force page 1 to resolve LAST: page 1 is delayed 60ms while pages 2+
+    // resolve immediately. A resolution-order merge would interleave/scramble;
+    // an index-ordered `Promise.all` merge yields rows in strict page order.
+    const TOTAL = 1300; // 3 pages: 500 + 500 + 300
+    // Zero-pad `id` so that the page response's `sort: "id"` ordering (applied
+    // server-side by the mock, mirroring PocketBase) matches the source array
+    // index order — this isolates the assertion to page-MERGE order under
+    // out-of-order HTTP resolution, not the sort itself.
+    mockState.initial = Array.from({ length: TOTAL }, (_, i) => ({
+      id: `r${String(i).padStart(4, "0")}`,
+      key: `smoke:int/f${String(i).padStart(4, "0")}`,
+      dimension: "smoke",
+      state: "green",
+      signal: {},
+      observed_at: "2026-04-20T00:00:00Z",
+      transitioned_at: "2026-04-20T00:00:00Z",
+      fail_count: 0,
+      first_failure_at: null,
+    }));
+    // Make the EARLIEST page resolve LAST: page 1 slow, later pages fast.
+    mockState.pageResolveDelayMs = { 1: 60, 2: 10, 3: 0 };
+
+    const { result } = renderHook(() => useLiveStatus("smoke"));
+    await waitFor(() => expect(result.current.status).toBe("live"), {
+      timeout: 5000,
+    });
+
+    // (a) Completeness: every page present, no truncation.
+    expect(result.current.rows).toHaveLength(TOTAL);
+
+    // (b) Determinism: rows in strict page order — identical to the source
+    // order — even though page 1's response landed AFTER pages 2 & 3.
+    const expectedKeys = mockState.initial.map((r) => r.key as string);
+    expect(result.current.rows.map((r) => r.key)).toEqual(expectedKeys);
+
+    // (c) Concurrency: data pages 1..3 were ISSUED (pushed to the request
+    // order). Pages 2 and 3 are fanned out concurrently (not awaited serially).
+    expect(mockState.initialPageRequestOrder.sort((a, b) => a - b)).toEqual([
+      1, 2, 3,
+    ]);
+    // Pages 2 and 3 were dispatched together in the fan-out (a serial await
+    // chain would not have issued page 3 until page 2 resolved).
+    expect(mockState.initialPageRequestOrder).toContain(2);
+    expect(mockState.initialPageRequestOrder).toContain(3);
+  }, 10000);
+
+  it("forwards an explicit stable `sort` to EVERY initial getList page (A1)", async () => {
+    // Offset pagination over the LIVE-mutating `status` collection drops or
+    // duplicates rows across page boundaries unless every page request carries
+    // the SAME stable sort key. PocketBase orders by `created DESC` by default,
+    // which is NOT stable as rows are inserted — a row created between the
+    // page-1 and page-2 reads shifts every subsequent row down a slot, so a row
+    // can fall off the end of one page and reappear at the top of the next
+    // (duplicate) or vanish entirely (drop). This asserts the contract
+    // BEHAVIORALLY: the mock's pageResponse sorts `mockState.initial` by the
+    // requested `sort` key before slicing (exactly as PB applies `?sort=`), so
+    // a missing/inconsistent sort on any page would scramble the merged order.
+    // The source rows are SHUFFLED here so the only way the merged result comes
+    // back in `id` order is if the hook actually forwarded `sort: "id"` to
+    // every page.
+    const built = Array.from({ length: 1300 }, (_, i) => ({
+      id: `r${String(i).padStart(4, "0")}`,
+      key: `smoke:int/f${i}`,
+      dimension: "smoke",
+      state: "green",
+      signal: {},
+      observed_at: "2026-04-20T00:00:00Z",
+      transitioned_at: "2026-04-20T00:00:00Z",
+      fail_count: 0,
+      first_failure_at: null,
+    }));
+    // Deterministic shuffle (reverse) so the source array is NOT pre-sorted by
+    // id — the sorted page response must do the ordering work.
+    mockState.initial = [...built].reverse();
+    const { result } = renderHook(() => useLiveStatus("smoke"));
+    await waitFor(() => expect(result.current.status).toBe("live"));
+    // Exactly the 3 data pages were requested — no probe.
+    expect(mockState.initialPageOpts).toHaveLength(3);
+    // EVERY initial getList request must carry a non-empty sort key. Without
+    // it, offset pagination over the live-mutating collection drops/duplicates
+    // rows across boundaries.
+    for (const opts of mockState.initialPageOpts) {
+      expect(opts.sort).toBeTruthy();
+    }
+    // All requests must use the SAME sort key (mixing keys across pages would
+    // itself reorder boundaries).
+    const sortKeys = new Set(mockState.initialPageOpts.map((o) => o.sort));
+    expect(sortKeys.size).toBe(1);
+    // BEHAVIORAL proof: because the sort was forwarded to every page, the
+    // merged rows come back in ascending `id` order even though the source
+    // array was shuffled.
+    const expectedIdOrder = built.map((r) => r.id);
+    expect(result.current.rows.map((r) => r.id)).toEqual(expectedIdOrder);
   });
 
   it("unmount during pending subscribe() resolves cleanly (HF-C1)", async () => {
@@ -439,14 +674,6 @@ describe("useLiveStatus", () => {
     const subscribePending = new Promise<void>((resolve) => {
       resolveSubscribe = resolve;
     });
-
-    // Monkey-patch the subscribe mock for this test only: gate on our
-    // external promise before resolving, so we can unmount in between.
-    const originalSubscribe =
-      // Bypass: we rewire through mockState so subsequent tests aren't
-      // affected (beforeEach resets mockState, not mock fns themselves).
-      (() => null)();
-    void originalSubscribe;
 
     // Seed one row so fetchInitial resolves quickly.
     mockState.initial = [

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
@@ -224,7 +224,13 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
     async function heartbeat(): Promise<void> {
       if (!alive || reconnecting) return;
       try {
-        await pb.collection("status").getList(1, 1, { filter });
+        // `requestKey: null` for the same reason as fetchInitial: this ping
+        // hits the SAME path (`/api/collections/status/records`), so the
+        // SDK's default auto-key would let a heartbeat and an in-flight
+        // initial/fan-out read cancel each other.
+        await pb
+          .collection("status")
+          .getList(1, 1, { filter, requestKey: null });
       } catch (err) {
         if (!alive) return;
         // SSE socket is probably dead too — re-establish the whole
@@ -266,9 +272,18 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
       // monotonic, so a row inserted in the brief fetch→subscribe window sorts
       // into a random position and is reconciled by the live SSE subscription
       // (which delivers all future deltas), not by this fetch.
+      // `requestKey: null` DISABLES the PocketBase SDK's auto-cancellation.
+      // By default the SDK derives a request key from the HTTP method + path
+      // and auto-cancels any in-flight request that shares it. Our fan-out
+      // fires pages 2..N at the SAME path (`/api/collections/status/records`)
+      // concurrently, so every page after the first would cancel its
+      // predecessor — the cancelled promises reject and `Promise.all` rejects,
+      // dropping the whole hook to OFFLINE. Opting out per-request lets all
+      // concurrent same-path reads complete. Forwarded to page 1 too so it
+      // can't be cancelled by the fan-out either.
       const listOpts = filter
-        ? { filter, sort: INITIAL_SORT }
-        : { sort: INITIAL_SORT };
+        ? { filter, sort: INITIAL_SORT, requestKey: null }
+        : { sort: INITIAL_SORT, requestKey: null };
       const first = await pb
         .collection("status")
         .getList<StatusRow>(1, INITIAL_PAGE_SIZE, listOpts);

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
@@ -302,7 +302,7 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
         );
       }
       const rest = await Promise.all(restRequests);
-      return [first, ...rest].flatMap((r) => r.items);
+      return [first.items, ...rest.map((r) => r.items)].flat();
     }
 
     async function connect(): Promise<void> {

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { startTransition, useEffect, useState } from "react";
 import { getPb, pbIsMisconfigured, PB_MISCONFIG_MESSAGE } from "../lib/pb";
 import type { StatusRow } from "../lib/live-status";
 import { upsertByKey } from "../lib/live-status";
@@ -13,14 +13,25 @@ export interface UseLiveStatusResult {
 }
 
 const MAX_RECONNECT_ATTEMPTS = 3;
-// Hard cap on initial fetch size. The `status` collection contains ~1300+
-// records across all probe dimensions (smoke, health, agent, e2e per-cell,
-// d5 per-feature, chat, tools, image-drift, etc.). Records are fetched in
-// rowid order; with a cap below the total, later-created dimensions (e2e
-// per-cell) get truncated and those cells show D2 instead of D4.
-// 2000 covers the current surface with headroom for growth.
-const INITIAL_CAP = 2000;
-const INITIAL_PAGE_SIZE = 200;
+// PocketBase clamps `perPage` to 500 server-side regardless of what the client
+// asks for, so 500 is the largest page the REST API will actually return. The
+// `status` collection holds ~2455 rows across all probe dimensions (smoke,
+// health, agent, e2e per-cell, d5/d6 per-feature, chat, tools, starter,
+// image-drift, etc.), so the initial fetch spans ~5 pages. We fetch page 1 to
+// learn `totalPages`, then fan out pages 2..N CONCURRENTLY (see fetchInitial).
+const INITIAL_PAGE_SIZE = 500;
+// Sort key for the initial paged fetch. PocketBase's default order is
+// `created DESC`, which is NOT stable as rows are inserted: a row created
+// between two concurrent page reads shifts every later row down a slot, so a
+// boundary row can drop off one page and reappear at the top of the next. We
+// pin `sort: "id"` so all concurrent page requests share the SAME ordering and
+// a stable collection paginates cleanly across the fan-out (no drop/duplicate
+// at a boundary). This is NOT a growth-completeness guarantee — PocketBase
+// `id` is a RANDOM 15-char string, not monotonic, so a row inserted mid-fetch
+// sorts into a random position and can still shift a boundary. The initial
+// fetch is therefore a best-effort consistent snapshot; rows created in the
+// brief fetch→subscribe window are reconciled by the live SSE subscription.
+const INITIAL_SORT = "id";
 // Heartbeat interval for detecting silent SSE drops. PB's realtime client
 // auto-reconnects internally but gives no explicit error callback; if the
 // SSE socket dies and reconnect ultimately fails, record updates stop
@@ -233,22 +244,77 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
     }
 
     async function fetchInitial(): Promise<StatusRow[]> {
-      // Single-call fetch: getFullList with batch=INITIAL_CAP fetches all
-      // ~1300 records in one HTTP request (1300 < 2000). Previously used
-      // 7 sequential getList calls at 200/page = ~1050ms latency.
-      // Single call = ~150ms. If the collection grows past INITIAL_CAP,
-      // the SDK auto-paginates internally.
-      const filterOpts = filter ? { filter } : {};
-      return pb
+      // Best-effort consistent snapshot via a stable-sorted CONCURRENT paged
+      // fetch.
+      //
+      // The `status` collection spans ~5 pages (PB clamps perPage to 500), so a
+      // single `getFullList` paginates in N SERIAL round-trips — each page
+      // awaited before the next — and blocks first paint for the full chain.
+      // Instead:
+      //
+      //   1. Fetch page 1, which also reports `totalPages`.
+      //   2. If there is more than one page, fan out pages 2..totalPages and
+      //      `await Promise.all(...)` — all in flight at once.
+      //   3. Merge `[first, ...rest]` by ARRAY INDEX (page order), independent
+      //      of which HTTP response resolves first.
+      //
+      // `sort: "id"` is forwarded to EVERY page request so all the concurrent
+      // reads share the same ordering: for a STABLE collection that means no
+      // boundary row is dropped or duplicated across the fan-out (PB's default
+      // `created DESC` is NOT stable under inserts). This is a snapshot, NOT a
+      // growth-completeness guarantee — PocketBase `id` is a RANDOM string, not
+      // monotonic, so a row inserted in the brief fetch→subscribe window sorts
+      // into a random position and is reconciled by the live SSE subscription
+      // (which delivers all future deltas), not by this fetch.
+      const listOpts = filter
+        ? { filter, sort: INITIAL_SORT }
+        : { sort: INITIAL_SORT };
+      const first = await pb
         .collection("status")
-        .getFullList<StatusRow>({ batch: INITIAL_CAP, ...filterOpts });
+        .getList<StatusRow>(1, INITIAL_PAGE_SIZE, listOpts);
+      if (first.totalPages <= 1) {
+        return first.items;
+      }
+      // Fan out the remaining pages concurrently. `Promise.all` preserves
+      // request (array-index) order regardless of resolution order, so the
+      // merge below is deterministic page order — not resolution order.
+      const restRequests: Promise<{ items: StatusRow[] }>[] = [];
+      for (let page = 2; page <= first.totalPages; page++) {
+        restRequests.push(
+          pb
+            .collection("status")
+            .getList<StatusRow>(page, INITIAL_PAGE_SIZE, listOpts),
+        );
+      }
+      const rest = await Promise.all(restRequests);
+      return [first, ...rest].flatMap((r) => r.items);
     }
 
     async function connect(): Promise<void> {
       try {
         const initial = await fetchInitial();
         if (!alive) return;
-        setRows(initial);
+        // The first time real data lands, every cell in the matrix has to
+        // re-render: the empty-map → populated-map transition invalidates the
+        // per-key memo checks on every cell, so this is a hundreds-of-cells
+        // walk in one synchronous React commit. Flag it as a transition so
+        // React 19 can yield to user input (scroll, click, keyboard) mid-walk
+        // instead of blocking the main thread for the whole render. `setStatus`
+        // stays URGENT so the "connecting → live" indicator flips immediately,
+        // before the heavy commit lands — and so the loading-state guard in the
+        // column tallies (connecting + empty map) releases as soon as data is
+        // live. The initial rows come from `fetchInitial`'s stable-sorted
+        // CONCURRENT paged fetch (page 1 + Promise.all over the remaining
+        // pages, merged in strict page order). That is the real latency win —
+        // the serial getFullList page chain blocked first paint. The merge
+        // order is deterministic (page order, not resolution order); the fetch
+        // is a best-effort consistent snapshot and the live SSE subscription
+        // reconciles any rows created in the brief fetch→subscribe window. This
+        // is where #4504's reverted resolution-order merge + early length
+        // `break` was not safe.
+        startTransition(() => {
+          setRows(initial);
+        });
         setStatus("live");
         setError(null);
         // Reset the reconnect counter on a SUCCESSFUL connection. This is


### PR DESCRIPTION
## Summary
The coverage dashboard's initial load was slow and briefly rendered misleading data. Root cause: `useLiveStatus` fetched the entire (growing) PocketBase `status` collection via a single `getFullList`, which PocketBase serial-paginates at perPage≤500 — ~5 sequential blocking round-trips before first paint. During that window the grid rendered authoritative `D0` cells and `✓0 ~0 ✗0` column tallies (not a loading state), and a transient amber-D5/D6 toggle flash appeared pre-hydration.

## Changes
- **perf:** concurrent paged fetch — page 1 then `Promise.all` over pages 2..N, merged by array index (deterministic regardless of resolution order), with a stable `sort: "id"` on every page so concurrent requests share one ordering. Initial `setRows` wrapped in `startTransition` to avoid a synchronous full-matrix re-render. Best-effort snapshot; the live SSE subscription reconciles anything created in the brief fetch→subscribe window (PocketBase `id` is random, not monotonic — no growth-completeness claim).
- **fix:** `connecting` + empty-map now renders a loading affordance instead of authoritative zeros (the §5.3 "no stale-green/fake-zero lie" guarantee); `loading` made required on the tally type; fail-safe undefined-tally fallback defaults to loading rather than zeros.

## Test plan
- [x] Order-safety: pages merge deterministically even when page 1 resolves last (out-of-order resolution)
- [x] Stable sort forwarded to every page request (behavioral — mock sorts before slicing)
- [x] Loading-state quadrants on both `computeColumnTally` and `computeColumnTallyDetail` (connecting+empty → loading; connecting+rows → authoritative; live+empty → authoritative; error → offline)
- [x] `OverlayColumnHeader` renders loading/offline affordance, not zero glyphs
- [x] Full dashboard suite: 827 passed / 1 skipped; tsc clean; next build green