### PR TITLE
fix(links): point cloud.copilotkit.ai web links at the Intelligence dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ npx create-ag-ui-app my-agent-app
     <a href="https://docs.copilotkit.ai/?ref=github_readme" target="_blank">
   Read the Docs →
   </a> </br>
-    <a href="https://cloud.copilotkit.ai?ref=github_readme" target="_blank">
-   Try Copilot Cloud →
+    <a href="https://dashboard.operations.copilotkit.ai?ref=github_readme" target="_blank">
+   Try the Enterprise Intelligence Platform →
   </a>
 <h3>Stay up to date with our latest releases!</h3>
   <a href="https://www.linkedin.com/company/copilotkit/" target="_blank">

--- a/docs/components/react/link-to-copilot-cloud.tsx
+++ b/docs/components/react/link-to-copilot-cloud.tsx
@@ -23,7 +23,7 @@ export function LinkToCopilotCloud({
   }, []);
 
   // Build base URL without PostHog session ID to avoid hydration issues
-  const baseUrl = new URL(`https://go.copilotkit.ai/copilot-cloud-button-docs`);
+  const baseUrl = new URL(`https://dashboard.operations.copilotkit.ai/sign-in`);
   baseUrl.searchParams.set("ref", "docs");
 
   if (subPath) {

--- a/docs/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/docs/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -123,7 +123,7 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
     >
         <Step>
             ### Connect to Copilot Cloud
-            1. Go to [Copilot Cloud](https://cloud.copilotkit.ai), sign in and click Get Started
+            1. Go to [Copilot Cloud](https://dashboard.operations.copilotkit.ai), sign in and click Get Started
             2. Click "Add Remote Endpoint" and fill in the details of your CrewAI Flow. Note: If your Agent Name contains multiple words, use underscores (`_`) as separators.
             3. Click "Save Endpoint"
             4. Copy the Copilot Cloud Public API Key

--- a/docs/content/docs/integrations/langgraph/coagent-troubleshooting/error-debugging.mdx
+++ b/docs/content/docs/integrations/langgraph/coagent-troubleshooting/error-debugging.mdx
@@ -72,7 +72,7 @@ export default function App() {
 
 <Callout type="info">
   **Need a publicApiKey?** Go to
-  [https://cloud.copilotkit.ai](https://cloud.copilotkit.ai) and get one for
+  [https://dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai) and get one for
   free!
 </Callout>
 
@@ -150,7 +150,7 @@ import { CopilotErrorEvent } from "@copilotkit/shared";
 
 **Requirements:**
 
-- Requires `publicApiKey` from [Copilot Cloud](https://cloud.copilotkit.ai)
+- Requires `publicApiKey` from [Copilot Cloud](https://dashboard.operations.copilotkit.ai)
 - Part of CopilotKit's enterprise observability offering
 
 <Callout type="info">
@@ -320,7 +320,7 @@ import * as Sentry from "@sentry/react";
 
 To use error observability hooks, you'll need a Copilot Cloud account:
 
-1. **Sign up for free** at [https://cloud.copilotkit.ai](https://cloud.copilotkit.ai)
+1. **Sign up for free** at [https://dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai)
 2. **Get your public API key** from the dashboard
 3. **Add it to your environment variables**:
    ```bash
@@ -377,6 +377,6 @@ If the dev console isn't displaying errors:
 
 ## Next Steps
 
-- Learn about [Copilot Cloud features](https://cloud.copilotkit.ai)
+- Learn about [Copilot Cloud features](https://dashboard.operations.copilotkit.ai)
 - Explore the [CopilotKit reference documentation](/reference/v1/components/CopilotKit)
 - Check out [troubleshooting guides](/troubleshooting/common-issues) for common issues

--- a/docs/content/docs/integrations/langgraph/tutorials/agent-native-app/step-3-setup-copilotkit.mdx
+++ b/docs/content/docs/integrations/langgraph/tutorials/agent-native-app/step-3-setup-copilotkit.mdx
@@ -25,7 +25,7 @@ Now that we have both our application and agent running, let's connect them usin
 <Steps>
 <Step>
 ### Set up Copilot Cloud
-Create a [Copilot Cloud account](https://cloud.copilotkit.ai/sign-in) to get started. This provides a production-ready proxy to your LLMs.
+Create a [Copilot Cloud account](https://dashboard.operations.copilotkit.ai/sign-in) to get started. This provides a production-ready proxy to your LLMs.
 
 <Callout>
 Copilot Cloud includes free LLM credits for development.

--- a/docs/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-3-setup-copilotkit.mdx
+++ b/docs/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-3-setup-copilotkit.mdx
@@ -40,7 +40,7 @@ We're using CopiloKit cloud as a hosted version of the CopilotKit runtime. The r
 <Step>
 ### Create an account on Copilot Cloud
 
-First, you'll need to create an account for Copilot Cloud [here](https://cloud.copilotkit.ai/sign-in). You can
+First, you'll need to create an account for Copilot Cloud [here](https://dashboard.operations.copilotkit.ai/sign-in). You can
 use whatever authentication method you'd like.
 
 </Step>

--- a/docs/content/docs/learn/intelligence-platform.mdx
+++ b/docs/content/docs/learn/intelligence-platform.mdx
@@ -8,7 +8,7 @@ premium: true
 
 ## What is the Enterprise Intelligence Platform?
 
-The Enterprise Intelligence Platform is the backend that powers threads, shared state, the inspector, observability, and other premium capabilities. The same platform architecture runs whether you consume it as a hosted service at [Copilot Cloud](https://cloud.copilotkit.ai) or install it into your own Kubernetes cluster via the `copilot-intelligence` Helm chart — your application code (and the CopilotKit runtime it talks to) does not change based on which one you point at.
+The Enterprise Intelligence Platform is the backend that powers threads, shared state, the inspector, observability, and other premium capabilities. The same platform architecture runs whether you consume it as a hosted service at [Copilot Cloud](https://dashboard.operations.copilotkit.ai) or install it into your own Kubernetes cluster via the `copilot-intelligence` Helm chart — your application code (and the CopilotKit runtime it talks to) does not change based on which one you point at.
 
 This page covers the logical architecture that applies to both deployment modes, plus the operational concerns specific to running the platform in your own cluster. Self-hosting is a premium deployment mode: it gives you data residency and compliance control at the cost of running a production Kubernetes workload.
 

--- a/docs/content/docs/reference/v1/hooks/useCopilotChatHeadless_c.mdx
+++ b/docs/content/docs/reference/v1/hooks/useCopilotChatHeadless_c.mdx
@@ -17,7 +17,7 @@ title: "useCopilotChatHeadless_c"
 `useCopilotChatHeadless_c` is for building fully custom UI (headless UI) implementations.
  
 <Callout title="This is a premium-only feature">
-Sign up for free on [Copilot Cloud](https://cloud.copilotkit.ai) to get your public license key or read more about <a href="/premium/overview">premium features</a>.
+Sign up for free on [Copilot Cloud](https://dashboard.operations.copilotkit.ai) to get your public license key or read more about <a href="/premium/overview">premium features</a>.
  
 Usage is generous, free to get started, and works with either self-hosted or Copilot Cloud environments.
 </Callout>

--- a/docs/snippets/copilot-cloud-configure-remote-endpoint-langgraph.mdx
+++ b/docs/snippets/copilot-cloud-configure-remote-endpoint-langgraph.mdx
@@ -5,7 +5,7 @@ import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 To connect to LangChain agents through Copilot Cloud, we leverage a concept called "Remote Endpoints"
 which allow CopilotKit runtime to connect to various backends.
 
-Navigate to <LinkToCopilotCloud asButton={false}>cloud.copilotkit.ai</LinkToCopilotCloud> and follow the video!
+Navigate to <LinkToCopilotCloud asButton={false}>dashboard.operations.copilotkit.ai</LinkToCopilotCloud> and follow the video!
 
 You'll need a LangSmith API key which you can get with [this guide](https://docs.smith.langchain.com/administration/how_to_guides/organization_management/create_account_api_key#create-an-api-key) on LangSmith's website.
 

--- a/docs/snippets/llm-adapters.mdx
+++ b/docs/snippets/llm-adapters.mdx
@@ -37,7 +37,7 @@ Currently, we support the following LLM adapters natively:
     description="Use our hosted backend endpoint to get started quickly."
     icon={<FaCloud />}
   >
-  Configure the used LLM adapter [on your Copilot Cloud dashboard](https://cloud.copilotkit.ai/)!
+  Configure the used LLM adapter [on your Copilot Cloud dashboard](https://dashboard.operations.copilotkit.ai/)!
 
   </TailoredContentOption>
 

--- a/docs/snippets/self-hosting-copilot-runtime-create-endpoint.mdx
+++ b/docs/snippets/self-hosting-copilot-runtime-create-endpoint.mdx
@@ -87,7 +87,7 @@ If you are not sure yet, simply ignore this note.
               }
             }
             ```
-        2. Use [Copilot Cloud](https://cloud.copilotkit.ai/) to avoid timeout issues entirely
+        2. Use [Copilot Cloud](https://dashboard.operations.copilotkit.ai/) to avoid timeout issues entirely
     </Callout>
 
     <Tabs groupId="endpoint-type" items={[

--- a/docs/snippets/shared/premium/headless-ui.mdx
+++ b/docs/snippets/shared/premium/headless-ui.mdx
@@ -95,7 +95,7 @@ To get there, let's start by building a simple chat interface.
 
   <Step>
     ### Set up your CopilotKit provider
-    You will need to provide your public license key to the `CopilotKit` provider component. Get yours on [Copilot Cloud](https://cloud.copilotkit.ai) or read more about [premium features](/premium).
+    You will need to provide your public license key to the `CopilotKit` provider component. Get yours on [Copilot Cloud](https://dashboard.operations.copilotkit.ai) or read more about [premium features](/premium).
 
     ```tsx title="src/app/layout.tsx"
     <CopilotKit

--- a/docs/snippets/shared/premium/observability.mdx
+++ b/docs/snippets/shared/premium/observability.mdx
@@ -18,7 +18,7 @@ Monitor CopilotKit with first‑class observability hooks that emit structured s
 
 <Callout type="info">
   All observability hooks require a `publicLicenseKey` or `publicAPIkey` - Get yours free at
-  [https://cloud.copilotkit.ai](https://cloud.copilotkit.ai)
+  [https://dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai)
 </Callout>
 
 <Steps>
@@ -181,7 +181,7 @@ import { CopilotChat } from "@copilotkit/react-core/v2";
 
 **Requirements:**
 
-- ✅ Requires a `publicLicenseKey` (when self-hosting) or `publicApiKey` from [Copilot Cloud](https://cloud.copilotkit.ai)
+- ✅ Requires a `publicLicenseKey` (when self-hosting) or `publicApiKey` from [Copilot Cloud](https://dashboard.operations.copilotkit.ai)
 - ✅ Works with `CopilotChat`, `CopilotPopup`, `CopilotSidebar`, and all pre-built components
 
 <Callout type="warn">
@@ -454,7 +454,7 @@ import * as Sentry from "@sentry/react";
 
 To use observability hooks (event hooks and error observability), you'll need a CopilotKit Premium account:
 
-1. **Sign up for free** at [https://cloud.copilotkit.ai](https://cloud.copilotkit.ai)
+1. **Sign up for free** at [https://dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai)
 2. **Get your public license key (for self-hosting), or public API key** from the dashboard
 3. **Add it to your environment variables**:
    ```bash

--- a/docs/snippets/shared/premium/overview.mdx
+++ b/docs/snippets/shared/premium/overview.mdx
@@ -21,7 +21,7 @@ All CopilotKit Premium subscribers get early access to new features, tooling, an
 ## Current Premium Features
 - [Fully Headless Chat UI](headless-ui) - Early Access
 - [Observability Hooks](observability)
-- [Copilot Cloud](https://cloud.copilotkit.ai)
+- [Copilot Cloud](https://dashboard.operations.copilotkit.ai)
 
 ## FAQs
 

--- a/docs/snippets/shared/reference/copilotkit-component.mdx
+++ b/docs/snippets/shared/reference/copilotkit-component.mdx
@@ -25,20 +25,20 @@ import { CopilotKit } from "@copilotkit/react-core";
 <PropertyReference name="publicApiKey" type="string"  >
 Your Copilot Cloud API key.
 
-  Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+  Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
 </PropertyReference>
 
 <PropertyReference name="publicLicenseKey" type="string"  >
 Your public license key for accessing premium CopilotKit features.
 
-  Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+  Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
 </PropertyReference>
 
 <PropertyReference name="guardrails_c" type="{ validTopics?: string[]; invalidTopics?: string[]; }"  >
 Restrict input to specific topics using guardrails.
   @remarks
 
-  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
 </PropertyReference>
 
 <PropertyReference name="runtimeUrl" type="string"  >
@@ -151,7 +151,7 @@ The forwarded parameters to use for the task.
 The auth config to use for the CopilotKit.
   @remarks
 
-  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
 </PropertyReference>
 
 <PropertyReference name="threadId" type="string"  >

--- a/docs/snippets/shared/threads/threads.mdx
+++ b/docs/snippets/shared/threads/threads.mdx
@@ -22,7 +22,7 @@ CopilotKit threads enable persistent, resumable multi-turn conversations. The `u
 ## Prerequisites
 
 - A working CopilotKit setup — see [Quickstart](/quickstart) if you're starting fresh
-- The Enterprise Intelligence Platform (available via [Copilot Cloud](https://cloud.copilotkit.ai) or [self-hosted on your own Kubernetes cluster](/premium/self-hosting))
+- The Enterprise Intelligence Platform (available via [Copilot Cloud](https://dashboard.operations.copilotkit.ai) or [self-hosted on your own Kubernetes cluster](/premium/self-hosting))
 - `@copilotkit/react-core` v1.56+
 
 ## Implementation

--- a/docs/snippets/shared/troubleshooting/observability-connectors.mdx
+++ b/docs/snippets/shared/troubleshooting/observability-connectors.mdx
@@ -39,7 +39,7 @@ export default function App() {
 </Callout>
 
 ## Getting Your License or API Key
-You can get either type of key from [cloud.copilotkit.ai](https://cloud.copilotkit.ai).  Sign up for the Developer plan for free if you aren't already signed up.
+You can get either type of key from [dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai).  Sign up for the Developer plan for free if you aren't already signed up.
 
 1. **For Copilot Cloud hosting**: Login to CopilotCloud and get your `publicApiKey`
 2. **For self-hosted usage**: Login to CopilotCloud and get your `publicLicenseKey`. Self-hosting will not use Copilot Cloud (other than to get your keys).

--- a/examples/showcases/multi-agent-canvas/README.md
+++ b/examples/showcases/multi-agent-canvas/README.md
@@ -33,7 +33,7 @@ Make sure you have:
 
 ### 2. API Keys
 
-- [Copilot Cloud](https://cloud.copilotkit.ai)
+- [Copilot Cloud](https://dashboard.operations.copilotkit.ai)
 
 ## Running the Frontend
 
@@ -50,7 +50,7 @@ cd frontend
 pnpm i
 ```
 
-Need a CopilotKit API key? Get one [here](https://cloud.copilotkit.ai/).
+Need a CopilotKit API key? Get one [here](https://dashboard.operations.copilotkit.ai/).
 
 Then, fire up the Next.js project:
 

--- a/examples/showcases/research-canvas/README.md
+++ b/examples/showcases/research-canvas/README.md
@@ -29,7 +29,7 @@ Running locally, you'll need the following API keys:
 - [OpenAI](https://platform.openai.com/api-keys)
 - [Tavily](https://tavily.com/#pricing)
 - [LangSmith](https://docs.smith.langchain.com/administration/how_to_guides/organization_management/create_account_api_key)
-- [CopilotKit](https://cloud.copilotkit.ai)
+- [CopilotKit](https://dashboard.operations.copilotkit.ai)
 
 ### 3. Start the Agent
 

--- a/examples/showcases/research-canvas/final/README.md
+++ b/examples/showcases/research-canvas/final/README.md
@@ -29,7 +29,7 @@ Running locally, you'll need the following API keys:
 - [OpenAI](https://platform.openai.com/api-keys)
 - [Tavily](https://tavily.com/#pricing)
 - [LangSmith](https://docs.smith.langchain.com/administration/how_to_guides/organization_management/create_account_api_key)
-- [CopilotKit](https://cloud.copilotkit.ai)
+- [CopilotKit](https://dashboard.operations.copilotkit.ai)
 
 ### 3. Start the Agent
 

--- a/examples/showcases/research-canvas/start/README.md
+++ b/examples/showcases/research-canvas/start/README.md
@@ -29,7 +29,7 @@ Running locally, you'll need the following API keys:
 - [OpenAI](https://platform.openai.com/api-keys)
 - [Tavily](https://tavily.com/#pricing)
 - [LangSmith](https://docs.smith.langchain.com/administration/how_to_guides/organization_management/create_account_api_key)
-- [CopilotKit](https://cloud.copilotkit.ai)
+- [CopilotKit](https://dashboard.operations.copilotkit.ai)
 
 ### 3. Start the Agent
 

--- a/examples/v1/_legacy/copilot-fully-custom/README.md
+++ b/examples/v1/_legacy/copilot-fully-custom/README.md
@@ -32,7 +32,7 @@ First, make a `.env` file in the root of the project.
 touch .env
 ```
 
-Now, you can either provide your [Copilot Cloud public API key](https://cloud.copilotkit.ai) or [OpenAI API key](https://platform.openai.com/api-keys).
+Now, you can either provide your [Copilot Cloud public API key](https://dashboard.operations.copilotkit.ai) or [OpenAI API key](https://platform.openai.com/api-keys).
 
 > **Note:** Copilot Cloud will provide you some free OpenAI API credits to get you started!
 

--- a/examples/v1/chat-with-your-data/README.md
+++ b/examples/v1/chat-with-your-data/README.md
@@ -288,4 +288,4 @@ Ready to build your own AI-powered dashboard? Check out these resources:
 
 [CopilotKit Documentation](https://docs.copilotkit.ai) - Comprehensive guides and API references to help you build your own copilots.
 
-[CopilotKit Cloud](https://cloud.copilotkit.ai/) - Deploy your copilots with our managed cloud solution for production-ready AI assistants.
+[CopilotKit Cloud](https://dashboard.operations.copilotkit.ai/) - Deploy your copilots with our managed cloud solution for production-ready AI assistants.

--- a/examples/v1/form-filling/README.md
+++ b/examples/v1/form-filling/README.md
@@ -52,7 +52,7 @@ Transform tedious form-filling into natural conversations. Your AI assistant ask
      ```
    </details>
 
-3. Create a `.env` file in the project root and add your [Copilot Cloud Public API Key](https://cloud.copilotkit.ai):
+3. Create a `.env` file in the project root and add your [Copilot Cloud Public API Key](https://dashboard.operations.copilotkit.ai):
 
    ```
    NEXT_PUBLIC_COPILOT_PUBLIC_API_KEY=your_copilotkit_api_key
@@ -166,4 +166,4 @@ Ready to build your own AI-powered form assistant? Check out these resources:
 
 [CopilotKit Documentation](https://docs.copilotkit.ai) - Comprehensive guides and API references to help you build your own copilots.
 
-[CopilotKit Cloud](https://cloud.copilotkit.ai/) - Deploy your copilots with our managed cloud solution for production-ready AI assistants.
+[CopilotKit Cloud](https://dashboard.operations.copilotkit.ai/) - Deploy your copilots with our managed cloud solution for production-ready AI assistants.

--- a/examples/v1/state-machine/README.md
+++ b/examples/v1/state-machine/README.md
@@ -64,7 +64,7 @@ The example showcases how to implement complex conversational flows using a stat
      ```
    </details>
 
-3. Create a `.env` file in the project root and add your [Copilot Cloud Public API Key](https://cloud.copilotkit.ai):
+3. Create a `.env` file in the project root and add your [Copilot Cloud Public API Key](https://dashboard.operations.copilotkit.ai):
 
    ```
    NEXT_PUBLIC_CPK_PUBLIC_API_KEY=your_api_key_here
@@ -144,7 +144,7 @@ useCopilotAction({
 Ready to build your own AI-powered state machine? Check out these resources:
 
 - [CopilotKit Documentation](https://docs.copilotkit.ai) - Comprehensive guides and API references
-- [CopilotKit Cloud](https://cloud.copilotkit.ai/) - Deploy your copilots with our managed cloud solution
+- [CopilotKit Cloud](https://dashboard.operations.copilotkit.ai/) - Deploy your copilots with our managed cloud solution
 - [React Flow Documentation](https://reactflow.dev/docs/introduction/) - Learn more about building interactive node-based UIs
 
 ## 🤝 Contributing

--- a/examples/v1/travel/README.md
+++ b/examples/v1/travel/README.md
@@ -85,7 +85,7 @@ This application demonstrates the power of CopilotKit working with an Agent Fram
    GOOGLE_MAPS_API_KEY=your_google_maps_api_key
    ```
 
-   Alternatively, use [Copilot Cloud](https://cloud.copilotkit.ai) by setting:
+   Alternatively, use [Copilot Cloud](https://dashboard.operations.copilotkit.ai) by setting:
 
    ```
    NEXT_PUBLIC_CPK_PUBLIC_API_KEY=your_copilotkit_api_key

--- a/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -1,8 +1,8 @@
-import { ForwardedParametersInput } from "@copilotkit/runtime-client-gql";
-import { ReactNode } from "react";
-import { AuthState } from "../../context/copilot-context";
-import { CopilotErrorHandler, DebugConfig } from "@copilotkit/shared";
-import { CopilotKitProviderProps } from "../../v2";
+import type { ForwardedParametersInput } from "@copilotkit/runtime-client-gql";
+import type { ReactNode } from "react";
+import type { AuthState } from "../../context/copilot-context";
+import type { CopilotErrorHandler, DebugConfig } from "@copilotkit/shared";
+import type { CopilotKitProviderProps } from "../../v2";
 /**
  * Props for CopilotKit.
  */
@@ -20,14 +20,14 @@ export interface CopilotKitProps extends Omit<
   /**
    * Your Copilot Cloud API key.
    *
-   * Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+   * Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
    */
   publicApiKey?: string;
 
   /**
    * Your public license key for accessing premium CopilotKit features.
    *
-   * Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+   * Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
    */
   publicLicenseKey?: string;
 
@@ -44,7 +44,7 @@ export interface CopilotKitProps extends Omit<
    * Restrict input to specific topics using guardrails.
    * @remarks
    *
-   * This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+   * This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
    */
   guardrails_c?: {
     validTopics?: string[];
@@ -156,7 +156,7 @@ export interface CopilotKitProps extends Omit<
    * The auth config to use for the CopilotKit.
    * @remarks
    *
-   * This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+   * This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
    */
   authConfig_c?: {
     SignInComponent: React.ComponentType<{

--- a/packages/react-core/src/components/dev-console/developer-console-modal.tsx
+++ b/packages/react-core/src/components/dev-console/developer-console-modal.tsx
@@ -472,7 +472,10 @@ export function DeveloperConsoleModal({
           >
             <button
               onClick={() =>
-                window.open("https://cloud.copilotkit.ai/sign-in", "_blank")
+                window.open(
+                  "https://dashboard.operations.copilotkit.ai/sign-in",
+                  "_blank",
+                )
               }
               style={{
                 // Following button system specifications

--- a/packages/react-core/src/components/usage-banner.tsx
+++ b/packages/react-core/src/components/usage-banner.tsx
@@ -235,7 +235,7 @@ export const getErrorActions = (error: CopilotKitError) => {
           label: "Upgrade",
           onClick: () =>
             window.open(
-              "https://cloud.copilotkit.ai",
+              "https://dashboard.operations.copilotkit.ai",
               "_blank",
               "noopener,noreferrer",
             ),

--- a/packages/react-core/src/hooks/use-copilot-authenticated-action.ts
+++ b/packages/react-core/src/hooks/use-copilot-authenticated-action.ts
@@ -1,7 +1,10 @@
-import { Parameter } from "@copilotkit/shared";
+import type { Parameter } from "@copilotkit/shared";
 import { Fragment, useCallback, useRef } from "react";
 import { useCopilotContext } from "../context/copilot-context";
-import { FrontendAction, ActionRenderProps } from "../types/frontend-action";
+import type {
+  FrontendAction,
+  ActionRenderProps,
+} from "../types/frontend-action";
 import { useCopilotAction } from "./use-copilot-action";
 import React from "react";
 
@@ -10,7 +13,7 @@ import React from "react";
  *
  * @remarks
  * This feature is only available when using CopilotKit's hosted cloud service.
- * To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey.
+ * To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey.
  *
  * @param action - The frontend action to be wrapped with authentication
  * @param dependencies - Optional array of dependencies that will trigger recreation of the action when changed

--- a/packages/react-core/src/hooks/use-copilot-chat-headless_c.ts
+++ b/packages/react-core/src/hooks/use-copilot-chat-headless_c.ts
@@ -2,7 +2,7 @@
  * `useCopilotChatHeadless_c` is for building fully custom UI (headless UI) implementations.
  *
  * <Callout title="This is a premium-only feature">
- * Sign up for free on [Copilot Cloud](https://cloud.copilotkit.ai) to get your public license key or read more about <a href="/premium/overview">premium features</a>.
+ * Sign up for free on [Copilot Cloud](https://dashboard.operations.copilotkit.ai) to get your public license key or read more about <a href="/premium/overview">premium features</a>.
  *
  * Usage is generous, **free** to get started, and works with **either self-hosted or Copilot Cloud** environments.
  * </Callout>
@@ -160,12 +160,14 @@
  */
 import { useEffect } from "react";
 import { useCopilotContext } from "../context/copilot-context";
-import {
-  useCopilotChatInternal,
-  defaultSystemMessage,
+import type {
   UseCopilotChatOptions as UseCopilotChatOptions_c,
   UseCopilotChatReturn as UseCopilotChatReturn_c,
   MCPServerConfig,
+} from "./use-copilot-chat_internal";
+import {
+  useCopilotChatInternal,
+  defaultSystemMessage,
 } from "./use-copilot-chat_internal";
 
 import {
@@ -203,7 +205,7 @@ const createNonFunctionalReturn = (): UseCopilotChatReturn_c => ({
  * Enterprise React hook that provides complete chat functionality for fully custom UI implementations.
  * Includes all advanced features like direct message access, suggestions array, interrupt handling, and MCP support.
  *
- * **Requires a publicApiKey** - Sign up for free at https://cloud.copilotkit.ai/
+ * **Requires a publicApiKey** - Sign up for free at https://dashboard.operations.copilotkit.ai/
  *
  * @param options - Configuration options for the chat
  * @returns Complete chat interface with all enterprise features

--- a/packages/react-core/src/v2/components/license-warning-banner.tsx
+++ b/packages/react-core/src/v2/components/license-warning-banner.tsx
@@ -160,7 +160,7 @@ export function LicenseWarningBanner({
           severity="warning"
           message={`Your CopilotKit license expires in ${graceRemaining} day${graceRemaining !== 1 ? "s" : ""}. Please renew.`}
           actionLabel="Renew"
-          actionUrl="https://cloud.copilotkit.ai"
+          actionUrl="https://dashboard.operations.copilotkit.ai"
           onDismiss={onDismiss}
         />
       );

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -106,7 +106,7 @@ export interface CopilotKitProviderProps {
   publicLicenseKey?: string;
   /**
    * Signed license token for offline verification of premium features.
-   * Obtain from https://cloud.copilotkit.ai.
+   * Obtain from https://dashboard.operations.copilotkit.ai.
    */
   licenseToken?: string;
   properties?: Record<string, unknown>;

--- a/packages/shared/src/utils/console-styling.ts
+++ b/packages/shared/src/utils/console-styling.ts
@@ -55,7 +55,7 @@ export function logCopilotKitPlatformMessage() {
 
 useCopilotChatHeadless_c provides full compatibility with CopilotKit's newly released Headless UI feature set. To enable this premium feature, add your public license key, available for free at:
 
-%chttps://cloud.copilotkit.ai%c
+%chttps://dashboard.operations.copilotkit.ai%c
 
 Alternatively, useCopilotChat is available for basic programmatic control, and does not require an API key.
 
@@ -75,7 +75,7 @@ export function publicApiKeyRequired(feature: string) {
   console.log(
     `
 %cCopilotKit Warning%c \n
-In order to use ${feature}, you need to add your CopilotKit API key, available for free at https://cloud.copilotkit.ai.
+In order to use ${feature}, you need to add your CopilotKit API key, available for free at https://dashboard.operations.copilotkit.ai.
     `.trim(),
     ConsoleStyles.header,
     ConsoleStyles.body,

--- a/packages/vue/src/v2/components/LicenseWarningBanner.vue
+++ b/packages/vue/src/v2/components/LicenseWarningBanner.vue
@@ -61,7 +61,7 @@ const spec = computed<BannerSpec | null>(() => {
         severity: "warning",
         message: `Your CopilotKit license expires in ${days} ${dayLabel}. Please renew.`,
         actionLabel: "Renew",
-        actionUrl: "https://cloud.copilotkit.ai",
+        actionUrl: "https://dashboard.operations.copilotkit.ai",
       };
     }
     case "expired":

--- a/packages/vue/src/v2/providers/CopilotKitProvider.types.ts
+++ b/packages/vue/src/v2/providers/CopilotKitProvider.types.ts
@@ -21,7 +21,7 @@ export interface CopilotKitProviderProps {
   publicLicenseKey?: string;
   /**
    * Signed license token for offline verification of premium features.
-   * Obtain from https://cloud.copilotkit.ai.
+   * Obtain from https://dashboard.operations.copilotkit.ai.
    */
   licenseToken?: string;
   properties?: Record<string, unknown>;

--- a/showcase/shell-docs/src/components/link-to-copilot-cloud.tsx
+++ b/showcase/shell-docs/src/components/link-to-copilot-cloud.tsx
@@ -25,7 +25,7 @@ export function LinkToCopilotCloud({
   }, []);
 
   // Build base URL without PostHog session ID to avoid hydration issues
-  const baseUrl = new URL(`https://go.copilotkit.ai/copilot-cloud-button-docs`);
+  const baseUrl = new URL(`https://dashboard.operations.copilotkit.ai/sign-in`);
   baseUrl.searchParams.set("ref", "docs");
 
   if (subPath) {

--- a/showcase/shell-docs/src/content/docs/concepts/oss-vs-enterprise.mdx
+++ b/showcase/shell-docs/src/content/docs/concepts/oss-vs-enterprise.mdx
@@ -11,7 +11,7 @@ CopilotKit ships in two layers: an **open-source frontend stack** (npm packages,
 
 - **OSS is enough for** building a working agentic React app with hooks, prebuilt chat, frontend tools, gen-UI, and any AG-UI integration. Apache 2.0, runs anywhere.
 - **Enterprise adds** durable threads, persistence across reloads and devices, realtime WebSocket sync, observability connectors, and a hosted admin console.
-- **Enterprise runs two ways** — fully hosted as [Copilot Cloud](https://cloud.copilotkit.ai), or self-hosted via the `copilot-intelligence` Helm chart on your own Kubernetes.
+- **Enterprise runs two ways** — fully hosted as [Copilot Cloud](https://dashboard.operations.copilotkit.ai), or self-hosted via the `copilot-intelligence` Helm chart on your own Kubernetes.
 - **Your app code doesn't change** between OSS-only, Cloud, and Self-Hosted. The boundary is a runtime config switch.
 
 | | OSS only | Needs Enterprise |
@@ -49,7 +49,7 @@ A separate **backend service** that sits beside your runtime and unlocks the cap
 
 Same Enterprise Intelligence Platform — you pick where it runs:
 
-- **[Copilot Cloud](https://cloud.copilotkit.ai)** is the hosted service. Sign up, get an API key, point your runtime at it. Pick this when you want zero ops on the platform side.
+- **[Copilot Cloud](https://dashboard.operations.copilotkit.ai)** is the hosted service. Sign up, get an API key, point your runtime at it. Pick this when you want zero ops on the platform side.
 - **Self-Hosted** installs the `copilot-intelligence` Helm chart into your own Kubernetes cluster. Pick this for data residency, on-prem requirements, or compliance control. You operate the workload (Postgres, Redis, ingress, OIDC, secret rotation); the chart and the same Enterprise image power the install.
 
 Application code doesn't change between Cloud and Self-Hosted — same SDK, same runtime, same hooks. Just a different `INTELLIGENCE_URL` environment variable.
@@ -64,6 +64,6 @@ If your app keeps state in your own backend (Postgres, your own auth) and you're
 
 - **Open-source quickstart** — [Quickstart](/quickstart) gets a working agentic app running in ~10 minutes against the Built-in Agent. No platform credentials needed.
 - **Enterprise overview** — [Premium Overview](/premium/overview) lists every Enterprise capability and the per-feature setup.
-- **Hosted setup** — [Copilot Cloud](https://cloud.copilotkit.ai) for the hosted Enterprise Intelligence Platform.
+- **Hosted setup** — [Copilot Cloud](https://dashboard.operations.copilotkit.ai) for the hosted Enterprise Intelligence Platform.
 - **Self-hosted deployment** — [Self-Hosting Intelligence](/premium/self-hosting) for the Helm-chart install on your own Kubernetes cluster.
 - **Architecture deep-dive** — [Enterprise Intelligence Platform internals](/premium/intelligence-platform) covers the control-plane / data-plane split, the three workloads, and the operational model.

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -93,7 +93,7 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
     >
         <Step>
             ### Connect to Copilot Cloud
-            1. Go to [Copilot Cloud](https://cloud.copilotkit.ai), sign in and click Get Started
+            1. Go to [Copilot Cloud](https://dashboard.operations.copilotkit.ai), sign in and click Get Started
             2. Click "Add Remote Endpoint" and fill in the details of your CrewAI Flow. Note: If your Agent Name contains multiple words, use underscores (`_`) as separators.
             3. Click "Save Endpoint"
             4. Copy the Copilot Cloud Public API Key

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/coagent-troubleshooting/error-debugging.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/coagent-troubleshooting/error-debugging.mdx
@@ -68,7 +68,7 @@ export default function App() {
 
 <Callout type="info">
   **Need a publicApiKey?** Go to
-  [https://cloud.copilotkit.ai](https://cloud.copilotkit.ai) and get one for
+  [https://dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai) and get one for
   free!
 </Callout>
 
@@ -144,7 +144,7 @@ The error observability hooks provide programmatic access to detailed error info
 
 **Requirements:**
 
-- Requires `publicApiKey` from [Copilot Cloud](https://cloud.copilotkit.ai)
+- Requires `publicApiKey` from [Copilot Cloud](https://dashboard.operations.copilotkit.ai)
 - Part of CopilotKit's enterprise observability offering
 
 <Callout type="info">
@@ -313,7 +313,7 @@ interface CopilotErrorEvent {
 
 To use error observability hooks, you'll need a Copilot Cloud account:
 
-1. **Sign up for free** at [https://cloud.copilotkit.ai](https://cloud.copilotkit.ai)
+1. **Sign up for free** at [https://dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai)
 2. **Get your public API key** from the dashboard
 3. **Add it to your environment variables**:
    ```bash
@@ -370,6 +370,6 @@ If the dev console isn't displaying errors:
 
 ## Next Steps
 
-- Learn about [Copilot Cloud features](https://cloud.copilotkit.ai)
+- Learn about [Copilot Cloud features](https://dashboard.operations.copilotkit.ai)
 - Explore the [CopilotKit reference documentation](/reference/v1/components/CopilotKit)
 - Check out [troubleshooting guides](/troubleshooting/common-issues) for common issues

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/agent-native-app/step-3-setup-copilotkit.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/agent-native-app/step-3-setup-copilotkit.mdx
@@ -21,7 +21,7 @@ npm install @copilotkit/react-core
 <Steps>
 <Step>
 ### Set up Copilot Cloud
-Create a [Copilot Cloud account](https://cloud.copilotkit.ai/sign-in) to get started. This provides a production-ready proxy to your LLMs.
+Create a [Copilot Cloud account](https://dashboard.operations.copilotkit.ai/sign-in) to get started. This provides a production-ready proxy to your LLMs.
 
 <Callout>Copilot Cloud includes free LLM credits for development.</Callout>
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-3-setup-copilotkit.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-3-setup-copilotkit.mdx
@@ -36,7 +36,7 @@ We're using CopiloKit cloud as a hosted version of the CopilotKit runtime. The r
 <Step>
 ### Create an account on Copilot Cloud
 
-First, you'll need to create an account for Copilot Cloud [here](https://cloud.copilotkit.ai/sign-in). You can
+First, you'll need to create an account for Copilot Cloud [here](https://dashboard.operations.copilotkit.ai/sign-in). You can
 use whatever authentication method you'd like.
 
 </Step>

--- a/showcase/shell-docs/src/content/docs/premium/headless-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/headless-ui.mdx
@@ -9,7 +9,7 @@ icon: "lucide/Settings"
 CopilotKit offers **fully headless UI** through the `useCopilotChatHeadless_c` hook. By using this hook, you can build your own chat interfaces from the ground up while still utilizing CopilotKit's core features and ease-of-use.
 
 <Callout type="info">
-Fully Headless UI is an **Early Access** Premium feature. Grab a free `publicLicenseKey` at [Copilot Cloud](https://cloud.copilotkit.ai) to unlock it.
+Fully Headless UI is an **Early Access** Premium feature. Grab a free `publicLicenseKey` at [Copilot Cloud](https://dashboard.operations.copilotkit.ai) to unlock it.
 </Callout>
 
 ## Getting started

--- a/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
@@ -7,7 +7,7 @@ premium: true
 ---
 ## What is the Enterprise Intelligence Platform?
 
-The Enterprise Intelligence Platform is the backend that powers threads, shared state, the inspector, observability, and other premium capabilities. The same platform architecture runs whether you consume it as a hosted service at [Copilot Cloud](https://cloud.copilotkit.ai) or install it into your own Kubernetes cluster via the `copilot-intelligence` Helm chart — your application code (and the CopilotKit runtime it talks to) does not change based on which one you point at.
+The Enterprise Intelligence Platform is the backend that powers threads, shared state, the inspector, observability, and other premium capabilities. The same platform architecture runs whether you consume it as a hosted service at [Copilot Cloud](https://dashboard.operations.copilotkit.ai) or install it into your own Kubernetes cluster via the `copilot-intelligence` Helm chart — your application code (and the CopilotKit runtime it talks to) does not change based on which one you point at.
 
 This page covers the logical architecture that applies to both deployment modes, plus the operational concerns specific to running the platform in your own cluster. Self-hosting is a premium deployment mode: it gives you data residency and compliance control at the cost of running a production Kubernetes workload.
 

--- a/showcase/shell-docs/src/content/docs/premium/observability.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/observability.mdx
@@ -11,7 +11,7 @@ Works with Copilot Cloud via `publicApiKey`, or self-hosted via `publicLicenseKe
 ## Quick start
 
 <Callout type="info">
-All observability hooks require a `publicLicenseKey` (self-hosted) or `publicApiKey` (Copilot Cloud) — grab one free at [https://cloud.copilotkit.ai](https://cloud.copilotkit.ai).
+All observability hooks require a `publicLicenseKey` (self-hosted) or `publicApiKey` (Copilot Cloud) — grab one free at [https://dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai).
 </Callout>
 
 <Steps>
@@ -242,7 +242,7 @@ Disable the dev console and route errors to your logging and monitoring services
 
 ## Getting started with Premium
 
-1. **Sign up free** at [https://cloud.copilotkit.ai](https://cloud.copilotkit.ai)
+1. **Sign up free** at [https://dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai)
 2. Grab your **public license key** (self-hosting) or **public API key** (Copilot Cloud) from the dashboard
 3. Add it to your env vars:
 

--- a/showcase/shell-docs/src/content/docs/premium/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/overview.mdx
@@ -31,7 +31,7 @@ Certain features — like the fully headless chat hook — are initially availab
 
 - [Fully Headless Chat UI](./headless-ui) — Early Access
 - [Observability Hooks](./observability)
-- [Copilot Cloud](https://cloud.copilotkit.ai)
+- [Copilot Cloud](https://dashboard.operations.copilotkit.ai)
 - [Inspector](../inspector) — free to use with any valid public license key
 
 ## Getting access
@@ -48,7 +48,7 @@ Access to Premium features requires a public license key. It's free.
 <Step>
 ### Sign up
 
-Create a **free** account on [Copilot Cloud](https://cloud.copilotkit.ai). No credit card required, and you don't have to use Copilot Cloud itself.
+Create a **free** account on [Copilot Cloud](https://dashboard.operations.copilotkit.ai). No credit card required, and you don't have to use Copilot Cloud itself.
 </Step>
 
 <Step>

--- a/showcase/shell-docs/src/content/docs/troubleshooting/observability-connectors.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/observability-connectors.mdx
@@ -45,7 +45,7 @@ export default function App() {
 </Callout>
 
 ## Getting Your License or API Key
-You can get either type of key from [cloud.copilotkit.ai](https://cloud.copilotkit.ai).  Sign up for the Developer plan for free if you aren't already signed up.
+You can get either type of key from [dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai).  Sign up for the Developer plan for free if you aren't already signed up.
 
 1. **For Copilot Cloud hosting**: Login to CopilotCloud and get your `publicApiKey`
 2. **For self-hosted usage**: Login to CopilotCloud and get your `publicLicenseKey`. Self-hosting will not use Copilot Cloud (other than to get your keys).

--- a/showcase/shell-docs/src/content/docs/tutorials/multi-conversation-chat.mdx
+++ b/showcase/shell-docs/src/content/docs/tutorials/multi-conversation-chat.mdx
@@ -28,7 +28,7 @@ A chat application with a thread sidebar — similar to ChatGPT or Claude's conv
 ## Prerequisites
 
 - Node.js 20+
-- A CopilotKit project with the Enterprise Intelligence Platform configured (via [Copilot Cloud](https://cloud.copilotkit.ai) or [self-hosted](/premium/self-hosting))
+- A CopilotKit project with the Enterprise Intelligence Platform configured (via [Copilot Cloud](https://dashboard.operations.copilotkit.ai) or [self-hosted](/premium/self-hosting))
 - `@copilotkit/react-core` v1.50+
 
 ## Steps

--- a/showcase/shell-docs/src/content/reference/components/CopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotKit.mdx
@@ -25,14 +25,14 @@ import { CopilotKit } from "@copilotkit/react-core/v2";
 <PropertyReference name="publicApiKey" type="string"  >
 Your Copilot Cloud API key.
 
-Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
 
 </PropertyReference>
 
 <PropertyReference name="publicLicenseKey" type="string"  >
 Your public license key for accessing premium CopilotKit features.
 
-Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
 
 </PropertyReference>
 
@@ -40,7 +40,7 @@ Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
 Restrict input to specific topics using guardrails.
   @remarks
 
-This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
 
 </PropertyReference>
 
@@ -157,7 +157,7 @@ needed if you want to override the default theme.
 The auth config to use for the CopilotKit.
   @remarks
 
-This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
 
 </PropertyReference>
 

--- a/showcase/shell-docs/src/content/reference/v1/components/CopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/components/CopilotKit.mdx
@@ -29,20 +29,20 @@ import { CopilotKit } from "@copilotkit/react-core";
 <PropertyReference name="publicApiKey" type="string"  > 
 Your Copilot Cloud API key.
  
-  Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+  Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
 </PropertyReference>
 
 <PropertyReference name="publicLicenseKey" type="string"  > 
 Your public license key for accessing premium CopilotKit features.
  
-  Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+  Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
 </PropertyReference>
 
 <PropertyReference name="guardrails_c" type="{ validTopics?: string[]; invalidTopics?: string[]; }"  > 
 Restrict input to specific topics using guardrails.
   @remarks
  
-  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
 </PropertyReference>
 
 <PropertyReference name="runtimeUrl" type="string"  > 
@@ -131,7 +131,7 @@ The forwarded parameters to use for the task.
 The auth config to use for the CopilotKit.
   @remarks
  
-  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
 </PropertyReference>
 
 <PropertyReference name="threadId" type="string"  > 

--- a/showcase/shell-docs/src/content/reference/v1/hooks/useCopilotChatHeadless_c.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/hooks/useCopilotChatHeadless_c.mdx
@@ -12,7 +12,7 @@ title: "useCopilotChatHeadless_c"
 `useCopilotChatHeadless_c` is for building fully custom UI (headless UI) implementations.
  
 <Callout title="This is a premium-only feature">
-Sign up for free on [Copilot Cloud](https://cloud.copilotkit.ai) to get your public license key or read more about <a href="/premium/overview">premium features</a>.
+Sign up for free on [Copilot Cloud](https://dashboard.operations.copilotkit.ai) to get your public license key or read more about <a href="/premium/overview">premium features</a>.
  
 Usage is generous, free to get started, and works with either self-hosted or Copilot Cloud environments.
 </Callout>

--- a/showcase/shell-docs/src/content/snippets/copilot-cloud-configure-remote-endpoint-langgraph.mdx
+++ b/showcase/shell-docs/src/content/snippets/copilot-cloud-configure-remote-endpoint-langgraph.mdx
@@ -5,7 +5,7 @@ import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 To connect to LangGraph agents through Copilot Cloud, we leverage a concept called "Remote Endpoints"
 which allow CopilotKit runtime to connect to various backends.
 
-Navigate to <LinkToCopilotCloud asButton={false}>cloud.copilotkit.ai</LinkToCopilotCloud> and follow the video!
+Navigate to <LinkToCopilotCloud asButton={false}>dashboard.operations.copilotkit.ai</LinkToCopilotCloud> and follow the video!
 
 You'll need a LangSmith API key which you can get with [this guide](https://docs.smith.langchain.com/administration/how_to_guides/organization_management/create_account_api_key#create-an-api-key) on LangSmith's website.
 

--- a/showcase/shell-docs/src/content/snippets/llm-adapters.mdx
+++ b/showcase/shell-docs/src/content/snippets/llm-adapters.mdx
@@ -37,7 +37,7 @@ Currently, we support the following LLM adapters natively:
     description="Use our hosted backend endpoint to get started quickly."
     icon={<FaCloud />}
   >
-  Configure the used LLM adapter [on your Copilot Cloud dashboard](https://cloud.copilotkit.ai/)!
+  Configure the used LLM adapter [on your Copilot Cloud dashboard](https://dashboard.operations.copilotkit.ai/)!
 
   </TailoredContentOption>
 

--- a/showcase/shell-docs/src/content/snippets/self-hosting-copilot-runtime-create-endpoint.mdx
+++ b/showcase/shell-docs/src/content/snippets/self-hosting-copilot-runtime-create-endpoint.mdx
@@ -87,7 +87,7 @@ If you are not sure yet, simply ignore this note.
               }
             }
             ```
-        2. Use [Copilot Cloud](https://cloud.copilotkit.ai/) to avoid timeout issues entirely
+        2. Use [Copilot Cloud](https://dashboard.operations.copilotkit.ai/) to avoid timeout issues entirely
     </Callout>
 
     <Tabs groupId="endpoint-type" items={[

--- a/showcase/shell-docs/src/content/snippets/shared/premium/headless-ui.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/premium/headless-ui.mdx
@@ -106,7 +106,7 @@ To get there, let's start by building a simple chat interface.
 
   <Step>
     ### Set up your CopilotKit provider
-    You will need to provide your public license key to the `CopilotKit` provider component. Get yours on [Copilot Cloud](https://cloud.copilotkit.ai) or read more about [premium features](/premium).
+    You will need to provide your public license key to the `CopilotKit` provider component. Get yours on [Copilot Cloud](https://dashboard.operations.copilotkit.ai) or read more about [premium features](/premium).
 
     ```tsx title="src/app/layout.tsx"
     <CopilotKit

--- a/showcase/shell-docs/src/content/snippets/shared/premium/observability.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/premium/observability.mdx
@@ -17,7 +17,7 @@ Monitor CopilotKit with first‑class observability hooks that emit structured s
 
 <Callout type="info">
   All observability hooks require a `publicLicenseKey` or `publicAPIkey` - Get yours free at
-  [https://cloud.copilotkit.ai](https://cloud.copilotkit.ai)
+  [https://dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai)
 </Callout>
 
 <Steps>
@@ -180,7 +180,7 @@ import { CopilotChat } from "@copilotkit/react-core/v2";
 
 **Requirements:**
 
-- ✅ Requires a `publicLicenseKey` (when self-hosting) or `publicApiKey` from [Copilot Cloud](https://cloud.copilotkit.ai)
+- ✅ Requires a `publicLicenseKey` (when self-hosting) or `publicApiKey` from [Copilot Cloud](https://dashboard.operations.copilotkit.ai)
 - ✅ Works with `CopilotChat`, `CopilotPopup`, `CopilotSidebar`, and all pre-built components
 
 <Callout type="warn">
@@ -453,7 +453,7 @@ import * as Sentry from "@sentry/react";
 
 To use observability hooks (event hooks and error observability), you'll need a CopilotKit Premium account:
 
-1. **Sign up for free** at [https://cloud.copilotkit.ai](https://cloud.copilotkit.ai)
+1. **Sign up for free** at [https://dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai)
 2. **Get your public license key (for self-hosting), or public API key** from the dashboard
 3. **Add it to your environment variables**:
    ```bash

--- a/showcase/shell-docs/src/content/snippets/shared/premium/overview.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/premium/overview.mdx
@@ -21,7 +21,7 @@ All CopilotKit Premium subscribers get early access to new features, tooling, an
 ## Current Premium Features
 - [Fully Headless Chat UI](headless-ui) - Early Access
 - [Observability Hooks](observability)
-- [Copilot Cloud](https://cloud.copilotkit.ai)
+- [Copilot Cloud](https://dashboard.operations.copilotkit.ai)
 
 ## FAQs
 

--- a/showcase/shell-docs/src/content/snippets/shared/reference/copilotkit-component.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/reference/copilotkit-component.mdx
@@ -24,14 +24,14 @@ import { CopilotKit } from "@copilotkit/react-core/v2";
 <PropertyReference name="publicApiKey" type="string"  >
 Your Copilot Cloud API key.
 
-Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
 
 </PropertyReference>
 
 <PropertyReference name="publicLicenseKey" type="string"  >
 Your public license key for accessing premium CopilotKit features.
 
-Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
 
 </PropertyReference>
 
@@ -39,7 +39,7 @@ Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
 Restrict input to specific topics using guardrails.
   @remarks
 
-This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
 
 </PropertyReference>
 
@@ -156,7 +156,7 @@ needed if you want to override the default theme.
 The auth config to use for the CopilotKit.
   @remarks
 
-This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
 
 </PropertyReference>
 

--- a/showcase/shell-docs/src/content/snippets/shared/threads/threads.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/threads/threads.mdx
@@ -22,7 +22,7 @@ CopilotKit threads enable persistent, resumable multi-turn conversations. The `u
 ## Prerequisites
 
 - A working CopilotKit setup — see [Quickstart](/quickstart) if you're starting fresh
-- The Enterprise Intelligence Platform (available via [Copilot Cloud](https://cloud.copilotkit.ai) or [self-hosted on your own Kubernetes cluster](/premium/self-hosting))
+- The Enterprise Intelligence Platform (available via [Copilot Cloud](https://dashboard.operations.copilotkit.ai) or [self-hosted on your own Kubernetes cluster](/premium/self-hosting))
 - `@copilotkit/react-core` v1.56+
 
 ## Implementation

--- a/showcase/shell-docs/src/content/snippets/shared/troubleshooting/observability-connectors.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/troubleshooting/observability-connectors.mdx
@@ -39,7 +39,7 @@ export default function App() {
 
 ## Getting Your License or API Key
 
-You can get either type of key from [cloud.copilotkit.ai](https://cloud.copilotkit.ai). Sign up for the Developer plan for free if you aren't already signed up.
+You can get either type of key from [dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai). Sign up for the Developer plan for free if you aren't already signed up.
 
 1. **For Copilot Cloud hosting**: Login to CopilotCloud and get your `publicApiKey`
 2. **For self-hosted usage**: Login to CopilotCloud and get your `publicLicenseKey`. Self-hosting will not use Copilot Cloud (other than to get your keys).

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -879,13 +879,19 @@ export const docsComponents = {
         marginBottom: "1rem",
       }}
     >
-      <a href="https://cloud.copilotkit.ai" style={{ color: "var(--accent)" }}>
+      <a
+        href="https://dashboard.operations.copilotkit.ai"
+        style={{ color: "var(--accent)" }}
+      >
         Sign up for CopilotKit Cloud →
       </a>
     </div>
   ),
   LinkToCopilotCloud: () => (
-    <a href="https://cloud.copilotkit.ai" style={{ color: "var(--accent)" }}>
+    <a
+      href="https://dashboard.operations.copilotkit.ai"
+      style={{ color: "var(--accent)" }}
+    >
       CopilotKit Cloud
     </a>
   ),


### PR DESCRIPTION
## Why

New users are still finding cloud.copilotkit.ai even though they shouldn't be. An org-wide audit found the live funnels; this PR closes every source in this repo.

## What changed

Replaced all **user-facing web links** to `https://cloud.copilotkit.ai` with `https://dashboard.operations.copilotkit.ai` (the same destination the copilotkit.ai marketing CTAs already use):

- **Live docs pages** (`docs/` + `showcase/shell-docs/`) — premium/observability/threads/oss-vs-enterprise/intelligence-platform pages, integration quickstarts/tutorials, V1 reference pages, shared snippets
- **`LinkToCopilotCloud` component** (both copies) — was routing through `go.copilotkit.ai/copilot-cloud-button-docs` → cloud sign-in; now points at the dashboard directly
- **README** — the `?ref=github_readme` CTA (label updated to "Try the Enterprise Intelligence Platform")
- **Example READMEs** (`examples/v1/*`, showcases)
- **Shipped package code** so future releases stop reseeding the problem: `console-styling.ts` key warnings, `usage-banner.tsx`, `developer-console-modal.tsx`, V2 `license-warning-banner` (React + Vue), provider JSDoc

## Deliberately untouched

- `api.cloud.copilotkit.ai` endpoints (`COPILOT_CLOUD_API_URL`, check-for-updates, telemetry tests) — existing cloud customers depend on these
- "Copilot Cloud" prose/product naming in docs copy — link targets only; copy rewrite is a separate editorial pass

## Out of repo (follow-ups, not in this PR)

- `go.copilotkit.ai/GetStarted` still 302s to cloud — zero code references org-wide, so traffic is from old emails/posts; needs repointing at the shortener
- Already-published npm versions carry the old links forever — only a cloud-side signup gate closes that vector

## Verification

- `nx run-many -t test,build -p @copilotkit/shared @copilotkit/react-core @copilotkit/vue` ✅
- `@copilotkit/sqlite-runner:test` ✅ (failed initially from a stale Node-20 `better-sqlite3` binary in the fresh worktree, unrelated to this change)
- Zero remaining non-`api.` `cloud.copilotkit.ai` references in docs/packages/examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)