### PR TITLE
fix(showcase): absent-starter columns render 🚫 unsupported, not grey/red ✗

### DIFF
--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -283,13 +283,16 @@ describe("FeatureGrid — Starter row-group", () => {
     expect(cell.textContent).toContain("?");
   });
 
-  it("an unmapped column renders the not-supported ✗ with the 'no starter' tooltip", () => {
+  it("an unmapped column renders the 🚫 not-supported cell with the framework tooltip", () => {
     expect(unmapped, "registry must have ≥1 unmapped column").toBeDefined();
     const { getByTestId } = renderGrid(new Map());
     const cell = getByTestId(`starter-cell-${unmapped!.slug}-health`);
-    expect(cell.textContent).toContain("✗");
+    // An integration with NO starter renders the 🚫 unsupported treatment —
+    // NOT a grey/no-data `?` and NOT a red smoke-failed `✗`.
+    expect(cell.textContent).toContain("🚫");
+    expect(cell.textContent).not.toContain("✗");
     const chip = cell.querySelector("[title]");
-    expect(chip?.getAttribute("title")).toBe("no starter for this integration");
+    expect(chip?.getAttribute("title")).toBe("Not supported by this framework");
   });
 
   it("✓ green for a passing mapped starter cell", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -992,20 +992,23 @@ describe("buildStarterBadge — 5-state cell vocabulary (§d)", () => {
     expect(b.label).toBe("?");
   });
 
-  it("not-supported ✗: unmapped column → gray ✗, mapping-derived (not data-derived)", () => {
-    // Keyed off isSupported=false, NOT off a missing row — so it is visually
-    // distinct from the gray `?` not-yet-run state (same tone, different glyph)
-    // AND from the red smoke-failed ✗ (different tone).
+  it("not-supported 🚫: unmapped column → 🚫 unsupported chip, mapping-derived (not data-derived)", () => {
+    // Keyed off isSupported=false, NOT off a missing row. An integration with
+    // NO starter is architecturally unsupported in the starter row, so it
+    // renders the SAME 🚫 "Not supported by this framework" treatment the
+    // depth-chip/unified-cell already use — NOT a grey/no-data `?`, and NOT a
+    // red smoke-failed `✗` (which would mis-communicate "we tried and failed").
     const b = buildStarterBadge("health", false, null, NOW, "live");
-    expect(b.tone).toBe("gray");
-    expect(b.label).toBe("✗");
-    expect(b.tooltip).toBe("no starter for this integration");
+    expect(b.label).toBe("🚫");
+    expect(b.tooltip).toBe("Not supported by this framework");
+    // It must be visually distinct from a data-bearing red FAIL: never red.
+    expect(b.tone).not.toBe("red");
     expect(b.row).toBeNull();
   });
 
-  it("not-supported ✗ is independent of any row data (mapping wins)", () => {
+  it("not-supported 🚫 is independent of any row data (mapping wins)", () => {
     // Even if a stray row existed, an unmapped column must still render the
-    // not-supported state — the caller passes row=null for unmapped columns,
+    // not-supported 🚫 state — the caller passes row=null for unmapped columns,
     // but assert buildStarterBadge ignores row entirely when !isSupported.
     const b = buildStarterBadge(
       "health",
@@ -1014,8 +1017,24 @@ describe("buildStarterBadge — 5-state cell vocabulary (§d)", () => {
       NOW,
       "live",
     );
+    expect(b.label).toBe("🚫");
+    expect(b.tone).not.toBe("red");
+  });
+
+  it("supported column with a genuinely-red row still renders red ✗ (NOT masked as 🚫)", () => {
+    // Guard the inverse: only ABSENT starters become 🚫. A starter that exists
+    // and FAILED must keep surfacing its real red ✗ — never reframed as
+    // "unsupported".
+    const b = buildStarterBadge(
+      "chat",
+      true,
+      row("starter:agno/chat", "starter", "red"),
+      NOW,
+      "live",
+    );
+    expect(b.tone).toBe("red");
     expect(b.label).toBe("✗");
-    expect(b.tone).toBe("gray");
+    expect(b.label).not.toBe("🚫");
   });
 
   it("tooltip carries the per-level descriptor for data-bearing states", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -430,10 +430,16 @@ const STARTER_LEVEL_DESCRIPTION: Readonly<Record<StarterLevel, string>> = {
  * Build a `BadgeRender` for one starter sub-cell, applying the FULL 5-state
  * cell vocabulary (§d):
  *
- *   - not-supported  → grey "✗", mapping-derived (`!isSupported`),
- *                      tooltip "no starter for this integration". Distinct
- *                      from the red smoke-failed ✗. Resolved FIRST so it can
- *                      never collide with the gray `?` initial state.
+ *   - not-supported  → 🚫 unsupported chip, mapping-derived (`!isSupported`),
+ *                      tooltip "Not supported by this framework". An
+ *                      integration with NO starter is architecturally
+ *                      unsupported in this row, so it renders the SAME 🚫
+ *                      treatment the depth-chip/unified-cell already use for
+ *                      "framework cannot support this feature" — NOT a
+ *                      grey/no-data `?` ("we expected data and got none") and
+ *                      NOT a red smoke-failed ✗ ("we tried and failed").
+ *                      Resolved FIRST so it can never collide with the gray
+ *                      `?` initial state.
  *   - gray `?`       → no row yet (not-yet-run / initial).
  *   - ✓ green        → last probe passed.
  *   - red ✗          → last probe failed (actionable regression).
@@ -453,13 +459,16 @@ export function buildStarterBadge(
   connection: ConnectionStatus,
 ): BadgeRender {
   if (!isSupported) {
-    // Mapping-derived: this column has no starter (§a). Grey ✗,
-    // visually distinct from a red smoke-failed ✗. NOT data-derived, so it
-    // renders identically before and after the first probe tick.
+    // Mapping-derived: this column has no starter (§a). Renders the 🚫
+    // "unsupported" treatment (matching depth-chip/unified-cell), which is
+    // distinct from BOTH the gray `?` no-data state AND the red smoke-failed
+    // ✗. NOT data-derived, so it renders identically before and after the
+    // first probe tick. Tone stays slate/gray (the muted unsupported fill);
+    // the 🚫 glyph — not the tone — is what communicates "unsupported".
     return {
       tone: "gray",
-      label: "✗",
-      tooltip: "no starter for this integration",
+      label: "🚫",
+      tooltip: "Not supported by this framework",
       row: null,
     };
   }


### PR DESCRIPTION
## Summary

In the dashboard **Starter** row group, an integration that has **no starter at all** (one of the 7 columns absent from `STARTER_TO_COLUMN`) was rendering a grey `✗` with the tooltip "no starter for this integration". That iconography mis-communicates reality:

- grey `✗` / `?` reads as **"we expected data and got none"** (gated/no-data), and
- a red `✗` reads as **"a probe ran and FAILED"**,

when the truth is simply **"this integration is architecturally unsupported in the starter row."**

This change makes a starter-row cell for an integration with **no starter** render the **same `🚫` "Not supported by this framework"** treatment that `depth-chip.tsx` / `unified-cell.tsx` already use for unsupported cells.

Integrations that **do** have a starter are untouched — they keep surfacing their real probe status. A genuinely-red starter still renders red `✗` and is **never masked as `🚫`** (guarded by a paired test).

### Where starter-presence is determined per column
`buildStarterBadge(level, isSupported, …)` in `showcase/shell-dashboard/src/lib/live-status.ts`. `isSupported` is mapping-derived via `starterIsSupported(columnSlug)` → `STARTER_COLUMNS.has(columnSlug)` (the dashboard's mirror of the 12-value set of `STARTER_TO_COLUMN` in `showcase/harness/src/probes/helpers/starter-mapping.ts`). 12 mapped + 7 absent = the 19 columns. The not-supported state is keyed off the **mapping**, never off a missing row, so it never collides with the gray `?` not-yet-run state.

### Change
Only the mapping-derived `!isSupported` branch of `buildStarterBadge` changed: `label: "✗"` → `label: "🚫"`, tooltip `"no starter for this integration"` → `"Not supported by this framework"`. Tone stays slate/gray (the muted unsupported fill); the `🚫` glyph — not the tone — communicates "unsupported". The data-bearing green/red/stale/no-data states are untouched.

## Test plan (red→green TDD)

- [x] `src/lib/live-status.test.ts`: not-supported cell asserts `🚫` + `"Not supported by this framework"`, tone ≠ red — seen failing (`expected '✗' to be '🚫'`) before the fix, green after.
- [x] Added inverse guard: a supported column with a genuinely-red row still renders red `✗`, never `🚫`.
- [x] `src/components/feature-grid.test.tsx`: an unmapped column's `starter-cell` renders `🚫` (not `✗`) with the framework tooltip.
- [x] Full `src/lib` + `src/components` vitest suites green (712 tests).
- [x] `tsc --noEmit` clean.
- [x] oxlint clean on changed files (0 errors).