### PR TITLE
feat(showcase): harness pool-fleet (control-plane + N workers)

### DIFF
--- a/showcase/bin/showcase
+++ b/showcase/bin/showcase
@@ -43,7 +43,47 @@ cmd_up() {
   require_env
   trap restore_symlinks EXIT
   stage_shared
-  $COMPOSE_CMD up -d --build "$@"
+
+  # Fleet topology: bring up the SAME shape prod runs — the control-plane
+  # container + worker container(s) + PocketBase + demos + aimock — NOT an
+  # in-process pool. The harness control-plane and pool worker(s) live in the
+  # `infra` profile (alongside aimock/pocketbase/dashboard), so always include
+  # `--profile infra`.
+  #
+  # Demo slugs (bare args like `langgraph-python`) select that demo's compose
+  # PROFILE — they must become `--profile <slug>` flags, NOT positional service
+  # names. A positional service arg restricts `up` to only that service + its
+  # deps, which (a) leaves the demo's own profile disabled and (b) makes
+  # `--scale harness-pool-worker=N` fail with "no such service:
+  # harness-pool-worker: disabled" because the worker is no longer in the active
+  # set. Raw compose flags (anything starting with `-`, e.g. `--no-build`) are
+  # passed through verbatim.
+  #
+  # HARNESS_POOL_COUNT drives the worker fleet size. Local default is 1 (a
+  # single worker container); staging/prod export HARNESS_POOL_COUNT=2. The
+  # compose `harness-pool-worker` service is scaled to that count via
+  # `--scale` so the same compose file scales from local (1) to prod (N)
+  # purely by the env var — no per-environment compose edits.
+  local pool_count="${HARNESS_POOL_COUNT:-1}"
+  export HARNESS_POOL_COUNT="$pool_count"
+
+  # Split args: bare slugs → `--profile <slug>`; flags (-*) → pass through.
+  local profile_args=()
+  local passthrough_args=()
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == -* ]]; then
+      passthrough_args+=("$arg")
+    else
+      profile_args+=(--profile "$arg")
+    fi
+  done
+
+  info "Launching fleet topology: control-plane + ${pool_count} worker(s) + PocketBase + demos + aimock (HARNESS_POOL_COUNT=${pool_count})"
+  # bash 3.2 (macOS default) errors on `${arr[@]}` for an EMPTY array under
+  # `set -u`; the `${arr[@]+...}` guard expands to nothing when unset/empty.
+  $COMPOSE_CMD --profile infra ${profile_args[@]+"${profile_args[@]}"} up -d --build \
+    --scale harness-pool-worker="$pool_count" ${passthrough_args[@]+"${passthrough_args[@]}"}
 }
 
 cmd_down() {

--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -29,19 +29,23 @@ services:
   ###########################################################################
   # WARNING: DEV ONLY — DO NOT USE FROM CI/TESTS.
   #
-  # This aimock service is configured with `--proxy-only` (see `command:`
-  # below). In proxy-only mode, unmatched fixture requests FALL THROUGH to
-  # real OpenAI / Anthropic / Gemini using the provider API keys from .env.
+  # This aimock service runs WITHOUT `--proxy-only` (see `command:` below): a
+  # request with no matching fixture FAILS LOUDLY rather than falling through
+  # to a real provider, so a fixture gap surfaces immediately and no real
+  # provider tokens are ever billed. The provider URLs in `command:` only tell
+  # aimock which provider a request targets; without `--proxy-only` no traffic
+  # leaves the container.
   #
-  # That behavior is intentional for INTERACTIVE local dev (so you can add
-  # new fixtures by capturing real responses), but it is DANGEROUS in any
-  # automated context: a missing fixture produces a real LLM response, and
-  # tests/CI see a green check that is actually a false positive — and bill
-  # real provider tokens at the same time.
+  # (Proxy-only mode — where unmatched requests FALL THROUGH to real
+  # OpenAI / Anthropic / Gemini via the .env API keys — is the INTERACTIVE
+  # fixture-capture workflow and is DANGEROUS in any automated context: a
+  # missing fixture would produce a real LLM response, a green check that is a
+  # false positive, and a real provider bill. This compose file deliberately
+  # does NOT enable it.)
   #
-  # Do NOT wire this compose file into CI, e2e suites, or any non-interactive
-  # test pipeline. For deterministic test environments, run aimock without
-  # `--proxy-only` so unmatched requests fail loudly.
+  # Still DEV-ONLY: the volume-mounted fixtures + always-on infra profile are
+  # for interactive local work, not a deterministic CI image. Do NOT wire this
+  # compose file into CI, e2e suites, or any non-interactive test pipeline.
   ###########################################################################
   aimock:
     # Local aimock so the 17 integration containers can hit a stable LLM mock
@@ -65,6 +69,7 @@ services:
       # fixture files are picked up without editing this file.
       - ./aimock/shared:/showcase-fixtures/shared:ro
       - ./aimock/d4:/showcase-fixtures/d4:ro
+      - ./aimock/d5-recorded:/showcase-fixtures/d5-recorded:ro
       - ./aimock/d6:/showcase-fixtures/d6:ro
     # In test mode aimock must NOT proxy to real providers — unmatched
     # requests should fail so fixture gaps are caught immediately instead
@@ -99,6 +104,8 @@ services:
         "--fixtures",
         "/showcase-fixtures/d4",
         "--fixtures",
+        "/showcase-fixtures/d5-recorded",
+        "--fixtures",
         "/showcase-fixtures/d6",
         "--validate-on-load",
       ]
@@ -120,7 +127,7 @@ services:
     image: showcase-pocketbase:local
     container_name: showcase-pocketbase
     environment:
-      - POCKETBASE_SUPERUSER_EMAIL=admin@localhost
+      - POCKETBASE_SUPERUSER_EMAIL=admin@example.com
       - POCKETBASE_SUPERUSER_PASSWORD=showcase-local-dev
     ports:
       - "8090:8090"
@@ -166,7 +173,13 @@ services:
     image: showcase-dashboard:local
     container_name: showcase-dashboard
     environment:
-      - POCKETBASE_URL=http://pocketbase:8090
+      # The dashboard injects POCKETBASE_URL into window.__SHOWCASE_CONFIG__ and
+      # the live-status subscription fetches it FROM THE BROWSER (the host),
+      # which cannot resolve the compose-internal hostname `pocketbase`. Use the
+      # host-published binding so the browser-side live grid actually loads (this
+      # matches the NEXT_PUBLIC_POCKETBASE_URL build arg). Mirrors staging, where
+      # this points at PocketBase's public domain, not its private hostname.
+      - POCKETBASE_URL=http://localhost:8090
       - SHOWCASE_LOCAL=1
     ports:
       - "3200:10000"
@@ -187,6 +200,156 @@ services:
       timeout: 3s
       retries: 5
       start_period: 10s
+
+  ###########################################################################
+  # POOL FLEET — control-plane + worker(s), ONE image, role-selected by env.
+  #
+  # PARITY GOAL: the local docker stack runs the SAME topology as prod. At
+  # N=1 that is a control-plane container PLUS one worker container talking
+  # over the same protocol prod uses — NOT an in-process pool shortcut. The
+  # only thing that changes between local and staging/prod is
+  # HARNESS_POOL_COUNT (local=1, staging/prod=2) and the number of worker
+  # replicas brought up; the images, env contract, and wiring are identical.
+  #
+  # ONE IMAGE, TWO ROLES: both services build/run showcase/harness/Dockerfile.
+  # The role is selected at runtime via HARNESS_ROLE:
+  #   - control-plane: scheduler/queue/aggregator + HTTP API (/api/probes,
+  #     /health). Runs NO Chromium.
+  #   - worker:        runs the BrowserPool (Chromium) and pulls work from the
+  #     PocketBase-backed queue. Reachable on the private compose network.
+  #
+  # ROLE-SELECT DISPATCH (live): the harness entrypoint branches on
+  # HARNESS_ROLE — bootFleet dispatches to the control-plane or worker role
+  # based on the env value, so both services boot the correct role purely
+  # from the env below with no per-service `command:` override. This compose
+  # PASSES HARNESS_ROLE / HARNESS_POOL_COUNT and wires both services for
+  # their roles; no compose-level bypass is needed.
+  ###########################################################################
+  harness-control-plane:
+    build:
+      context: ../
+      dockerfile: showcase/harness/Dockerfile
+    image: showcase-harness:local
+    # container_name preserved as `showcase-harness` so the dashboard's
+    # OPS_BASE_URL (http://showcase-harness:8080, see the `dashboard` build
+    # arg above) resolves the control-plane's HTTP origin over the compose
+    # network — the control-plane is the service that serves /api/probes.
+    container_name: showcase-harness
+    env_file: .env
+    environment:
+      # Role-select contract (consumed by the image entrypoint's bootFleet
+      # role dispatch; see the header note above).
+      - HARNESS_ROLE=control-plane
+      # Fleet size driver. Local=1 worker; staging/prod set this to 2 (and
+      # bring up matching worker replicas). The control-plane reads this to
+      # know how many workers to expect in the pool.
+      - HARNESS_POOL_COUNT=${HARNESS_POOL_COUNT:-1}
+      # Control-plane needs PocketBase (the work queue + status store) but
+      # runs no Chromium, so it does not need demo reachability for browsing.
+      - POCKETBASE_URL=http://pocketbase:8090
+      - POCKETBASE_SUPERUSER_EMAIL=admin@example.com
+      - POCKETBASE_SUPERUSER_PASSWORD=showcase-local-dev
+      # LOCAL SERVICE CATALOG (parity seam). The control-plane enumerates the
+      # showcase service set via the railway-services discovery source; locally
+      # there are no Railway creds, so LOCAL_SERVICES_JSON injects the IDENTICAL
+      # RailwayServiceInfo[] shape (only the URLs differ — local container host
+      # vs Railway public domain). Without it the enumerator queries Railway and
+      # the local N=1 run enqueues nothing. The demos[] is load-bearing: it
+      # drives the d6 feature matrix (demosToFeatureTypes). Scoped here to the
+      # langgraph-python demo's agentic-chat cell for a fast N=1 ramp; add
+      # entries to widen the local fleet.
+      - >-
+        LOCAL_SERVICES_JSON=[{"name":"showcase-langgraph-python","publicUrl":"http://langgraph-python:10000","demos":["agentic-chat"]}]
+      # Producer cron cadence. Default is hourly-at-:40 (prod rhythm). Locally we
+      # drive the SAME enqueue path every minute so an N=1 run doesn't wait up to
+      # an hour for the first tick.
+      - FLEET_PRODUCER_CRON=* * * * *
+      # Heartbeat staleness window fleet-health uses to declare a worker dead and
+      # reclaim its in-flight jobs (REQ-B). Defaults to 180s (prod); locally we
+      # shrink it so a killed worker is detected in seconds during a demo/test.
+      - WORKER_STALE_AFTER_MS=${WORKER_STALE_AFTER_MS:-20000}
+      # LLM mock wiring (parity with the integration defaults) so any
+      # control-plane-side probe that touches an LLM hits aimock, not a real
+      # provider.
+      - OPENAI_BASE_URL=http://aimock:4010/v1
+      - ANTHROPIC_BASE_URL=http://aimock:4010
+      - AIMOCK_URL=http://aimock:4010
+      - PORT=8080
+    ports:
+      # Host-exposed so the dashboard's /api/ops/* proxy and local curls can
+      # reach the control-plane HTTP API. 8081 host → 8080 container (8080 is
+      # the harness/Dockerfile EXPOSE + orchestrator default).
+      - "8081:8080"
+    depends_on:
+      aimock:
+        condition: service_healthy
+      pocketbase:
+        condition: service_healthy
+    profiles: ["infra", "all"]
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://127.0.0.1:8080/health',r=>process.exit(r.statusCode>=200&&r.statusCode<300?0:1)).on('error',()=>process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  harness-pool-worker:
+    build:
+      context: ../
+      dockerfile: showcase/harness/Dockerfile
+    image: showcase-harness:local
+    # NO fixed container_name: the worker is the scalable unit of the fleet
+    # (`--scale harness-pool-worker=N`, N from HARNESS_POOL_COUNT). A fixed
+    # container_name would make Docker refuse to create the 2nd+ replica
+    # ("Conflict. The container name is already in use"). Compose auto-names
+    # replicas `<project>-harness-pool-worker-1`, `-2`, … instead.
+    env_file: .env
+    environment:
+      # Same image, worker role. Runs the BrowserPool (Chromium) and pulls
+      # work from the PB-backed queue — the pull-queue model means the worker
+      # mainly needs PocketBase + demo-network reachability, not an inbound
+      # control-plane connection.
+      - HARNESS_ROLE=worker
+      - HARNESS_POOL_COUNT=${HARNESS_POOL_COUNT:-1}
+      - POCKETBASE_URL=http://pocketbase:8090
+      - POCKETBASE_SUPERUSER_EMAIL=admin@example.com
+      - POCKETBASE_SUPERUSER_PASSWORD=showcase-local-dev
+      # Self-register heartbeat cadence. Defaults to 75s (prod); locally we beat
+      # faster so fleet-health's (shrunk) staleness window is meaningful when a
+      # worker is killed mid-run during a demo/test (REQ-B).
+      - WORKER_HEARTBEAT_MS=${WORKER_HEARTBEAT_MS:-5000}
+      # The worker drives Chromium against the demo services and any LLM
+      # calls those demos make resolve through aimock on the compose network.
+      - OPENAI_BASE_URL=http://aimock:4010/v1
+      - ANTHROPIC_BASE_URL=http://aimock:4010
+      - AIMOCK_URL=http://aimock:4010
+      - PORT=8080
+    depends_on:
+      aimock:
+        condition: service_healthy
+      pocketbase:
+        condition: service_healthy
+    profiles: ["infra", "all"]
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://127.0.0.1:8080/health',r=>process.exit(r.statusCode>=200&&r.statusCode<300?0:1)).on('error',()=>process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   langgraph-python:
     <<: *integration-defaults

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, expectTypeOf } from "vitest";
+import type { BrowserPoolBudget } from "../probes/helpers/browser-pool.js";
+import type { ProbeResult } from "../types/index.js";
+import type { ProbeRunSummary } from "../probes/run-history.js";
+import {
+  POOL_COMM_ERROR_KINDS,
+  isPoolCommErrorKind,
+  commErrorToStatusSignal,
+  commErrorFromStatusSignal,
+  fleetSurfaceState,
+  probeResultsForServiceJobResult,
+  runSummaryForServiceJobResult,
+  isWorkerStale,
+  workerCapacityFromBudget,
+  terminalJobStatus,
+  FLEET_COMM_ERROR_SIGNAL_KEY,
+  WORKERS_COLLECTION,
+  type PoolCommError,
+  type ServiceJobResult,
+  type WorkerCapacity,
+  type FleetStatusRow,
+} from "./contracts.js";
+
+/**
+ * Pins the fleet shared CONTRACTS (S2 gate): the comm-error taxonomy (REQ-B)
+ * and its round-trip into a status-row signal, the result↔storage mappers that
+ * preserve the EXISTING dashboard row shape, worker capacity/staleness, and the
+ * terminal-status mapper the worker hands to S0's releaseJob.
+ */
+
+function makeResult(
+  overrides: Partial<ServiceJobResult> = {},
+): ServiceJobResult {
+  return {
+    jobId: "j1",
+    probeKey: "e2e_d6:langgraph-python",
+    serviceSlug: "langgraph-python",
+    runId: "run-1",
+    workerId: "worker-7",
+    aggregateState: "green",
+    aggregateKey: "e2e_d6:langgraph-python",
+    aggregateSignal: { failedCount: 0 },
+    cells: [
+      {
+        cellId: "shared-state",
+        cellKey: "d6:langgraph-python/shared-state",
+        state: "green",
+        signal: { ok: true },
+        observedAt: "2026-06-04T00:00:01.000Z",
+      },
+    ],
+    rollup: { total: 1, passed: 1, failed: 0 },
+    finishedAt: "2026-06-04T00:00:02.000Z",
+    ...overrides,
+  };
+}
+
+const SAMPLE_COMM_ERROR: PoolCommError = {
+  kind: "worker-unreachable",
+  message: "connect ECONNREFUSED 10.0.0.4:8090",
+  workerId: "worker-7",
+  jobId: "j1",
+  observedAt: "2026-06-04T00:00:00.000Z",
+};
+
+describe("PoolCommError taxonomy (REQ-B)", () => {
+  it("enumerates the five comm-error kinds", () => {
+    expect(POOL_COMM_ERROR_KINDS).toEqual([
+      "worker-unreachable",
+      "claim-comm-failure",
+      "worker-protocol-timeout",
+      "worker-crashed-mid-job",
+      "worker-protocol-violation",
+    ]);
+  });
+
+  it("isPoolCommErrorKind accepts members and rejects non-members", () => {
+    expect(isPoolCommErrorKind("worker-crashed-mid-job")).toBe(true);
+    expect(isPoolCommErrorKind("red")).toBe(false);
+    expect(isPoolCommErrorKind(undefined)).toBe(false);
+  });
+});
+
+describe("comm-error ↔ status-row signal round-trip", () => {
+  it("embeds under the well-known signal key", () => {
+    const sig = commErrorToStatusSignal(SAMPLE_COMM_ERROR);
+    expect(sig[FLEET_COMM_ERROR_SIGNAL_KEY]).toEqual(SAMPLE_COMM_ERROR);
+  });
+
+  it("round-trips a full comm error out of a signal blob", () => {
+    const sig = commErrorToStatusSignal(SAMPLE_COMM_ERROR);
+    expect(commErrorFromStatusSignal(sig)).toEqual(SAMPLE_COMM_ERROR);
+  });
+
+  it("round-trips a minimal comm error (no optional workerId/jobId)", () => {
+    const minimal: PoolCommError = {
+      kind: "claim-comm-failure",
+      message: "fetch failed",
+      observedAt: "2026-06-04T00:00:00.000Z",
+    };
+    const back = commErrorFromStatusSignal(commErrorToStatusSignal(minimal));
+    expect(back).toEqual(minimal);
+  });
+
+  it("returns undefined for a signal with no comm error", () => {
+    expect(commErrorFromStatusSignal({ failedCount: 0 })).toBeUndefined();
+    expect(commErrorFromStatusSignal(null)).toBeUndefined();
+    expect(commErrorFromStatusSignal("nope")).toBeUndefined();
+  });
+
+  it("rejects a malformed embedded comm error (bad kind / missing fields)", () => {
+    expect(
+      commErrorFromStatusSignal({
+        [FLEET_COMM_ERROR_SIGNAL_KEY]: {
+          kind: "bogus",
+          message: "x",
+          observedAt: "t",
+        },
+      }),
+    ).toBeUndefined();
+    expect(
+      commErrorFromStatusSignal({
+        [FLEET_COMM_ERROR_SIGNAL_KEY]: { kind: "worker-unreachable" },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("fleetSurfaceState", () => {
+  const row: FleetStatusRow = {
+    key: "e2e_d6:langgraph-python",
+    dimension: "e2e_d6",
+    state: "green",
+    signal: {},
+    observedAt: "2026-06-04T00:00:00.000Z",
+  };
+
+  it("returns the probe colour when there is no comm error", () => {
+    expect(fleetSurfaceState(row)).toBe("green");
+  });
+
+  it("returns 'unreachable' when a comm error overlays the row", () => {
+    expect(fleetSurfaceState({ ...row, commError: SAMPLE_COMM_ERROR })).toBe(
+      "unreachable",
+    );
+  });
+});
+
+describe("result ↔ storage mappers (preserve dashboard row shape)", () => {
+  it("projects a service result into primary + per-cell ProbeResults", () => {
+    const results = probeResultsForServiceJobResult(makeResult());
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      key: "e2e_d6:langgraph-python",
+      state: "green",
+      signal: { failedCount: 0 },
+      observedAt: "2026-06-04T00:00:02.000Z",
+    });
+    expect(results[1]).toEqual({
+      key: "d6:langgraph-python/shared-state",
+      state: "green",
+      signal: { ok: true },
+      observedAt: "2026-06-04T00:00:01.000Z",
+    });
+  });
+
+  it("maps the rollup onto the ProbeRunSummary shape", () => {
+    const summary = runSummaryForServiceJobResult(
+      makeResult({ rollup: { total: 3, passed: 2, failed: 1 } }),
+    );
+    expect(summary).toEqual({ total: 3, passed: 2, failed: 1 });
+    // structurally assignable to the storage contract
+    const asSummary: ProbeRunSummary = summary;
+    expect(asSummary.total).toBe(3);
+  });
+});
+
+describe("worker capacity + staleness", () => {
+  it("copies a BrowserPoolBudget field-for-field", () => {
+    const budget: BrowserPoolBudget = {
+      inUse: 2,
+      available: 6,
+      max: 8,
+      pidsCurrent: 120,
+      pidsMax: 1000,
+    };
+    expect(workerCapacityFromBudget(budget)).toEqual(budget);
+  });
+
+  it("isWorkerStale flags a heartbeat older than the window", () => {
+    const now = Date.parse("2026-06-04T00:01:00.000Z");
+    expect(isWorkerStale("2026-06-04T00:00:00.000Z", now, 30_000)).toBe(true);
+    expect(isWorkerStale("2026-06-04T00:00:45.000Z", now, 30_000)).toBe(false);
+  });
+
+  it("isWorkerStale treats an unparseable timestamp as not-yet-stale", () => {
+    expect(isWorkerStale("not-a-date", Date.now(), 1_000)).toBe(false);
+  });
+});
+
+describe("terminalJobStatus", () => {
+  it("is done for an all-green result", () => {
+    expect(terminalJobStatus(makeResult())).toBe("done");
+  });
+
+  it("is failed for a red aggregate", () => {
+    expect(terminalJobStatus(makeResult({ aggregateState: "red" }))).toBe(
+      "failed",
+    );
+  });
+
+  it("is failed whenever a comm error is present, regardless of state", () => {
+    expect(
+      terminalJobStatus(makeResult({ commError: SAMPLE_COMM_ERROR })),
+    ).toBe("failed");
+  });
+});
+
+describe("type-level: contract assignability", () => {
+  it("WorkerCapacity is structurally compatible with BrowserPoolBudget", () => {
+    expectTypeOf<BrowserPoolBudget>().toMatchTypeOf<WorkerCapacity>();
+    expectTypeOf<WorkerCapacity>().toMatchTypeOf<BrowserPoolBudget>();
+  });
+
+  it("probeResultsForServiceJobResult returns ProbeResult[]", () => {
+    expectTypeOf(probeResultsForServiceJobResult).returns.toEqualTypeOf<
+      ProbeResult[]
+    >();
+  });
+
+  it("WORKERS_COLLECTION is the workers literal", () => {
+    expect(WORKERS_COLLECTION).toBe("workers");
+  });
+});

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -1,0 +1,640 @@
+/**
+ * Fleet shared CONTRACTS — the type foundation the control-plane, worker,
+ * queue-client, and dashboard all depend on (BLITZ S2, the GATE slot).
+ *
+ * ── WHY PLAIN TS, NOT ZOD ──────────────────────────────────────────────
+ * The sibling fleet modules (`job-claim.ts`, `role-config.ts`) and the
+ * storage modules these contracts bridge to (`writers/status-writer.ts`,
+ * `probes/run-history.ts`) are all plain TS interfaces. Zod in this repo is
+ * reserved for parsing UNTRUSTED YAML at load time (rule schemas, probe
+ * config). These contracts are INTERNAL boundaries between our own
+ * processes, validated structurally by tsc, so we mirror the fleet idiom:
+ * plain TS types + a couple of pure helpers with unit tests.
+ *
+ * ── WHAT BUILDS ON WHAT ────────────────────────────────────────────────
+ * S0 (`job-claim.ts`) gives us the row-level claim primitive: `JobView`,
+ * `JobStatus`, and `JobClaimClient` (claimJob/renewLease/releaseJob over the
+ * PB JSVM transactional CAS endpoints). This module does NOT re-define those.
+ * Instead it layers the SEMANTIC contracts ON TOP:
+ *
+ *   - the per-SERVICE job PAYLOAD (a job = "run all of service X's d6 cells")
+ *   - the per-service RESULT a worker reports and the control-plane aggregates
+ *   - the pool COMM-ERROR taxonomy (REQ-B) — "couldn't reach the pool" as a
+ *     DISTINCT class from "the test went red"
+ *   - the WORKER DESCRIPTOR (registration + heartbeat) for self-register /
+ *     fleet-health
+ *   - the control-plane ↔ worker PROTOCOL (the queue-client interface S3
+ *     implements over S0's JobClaimClient)
+ *
+ * Downstream import map (the fan-out brief):
+ *   queue-client       (S3)  → FleetQueueClient, EnqueueJobInput, JobLease,
+ *                              SweepResult, ReportJobInput
+ *   control-plane prod (S4)  → ServiceJobPayload, EnqueueJobInput,
+ *                              FleetQueueClient
+ *   aggregator         (S5)  → ServiceJobResult, ServiceCellResult,
+ *                              probeResultsForServiceJobResult, FleetStatusRow
+ *   worker loop        (S7)  → ServiceJobPayload, ServiceJobResult,
+ *                              ServiceCellResult, ReportJobInput, FleetQueueClient
+ *   self-register      (S9)  → WorkerDescriptor, WorkerRegistration,
+ *                              WorkerHeartbeat, WORKERS_COLLECTION
+ *   fleet-health       (S10) → WorkerDescriptor, WorkerHealthState,
+ *                              isWorkerStale
+ *   dashboard comm-err (REQ-B) → PoolCommError, PoolCommErrorKind,
+ *                              POOL_COMM_ERROR_KINDS, FleetStatusRow.commError,
+ *                              commErrorToStatusSignal
+ */
+
+import type { BrowserPoolBudget } from "../probes/helpers/browser-pool.js";
+import type { ProbeResult, ProbeState } from "../types/index.js";
+import type { JobStatus, JobView } from "./job-claim.js";
+
+// Re-export the S0 primitives so downstream slots can import the whole fleet
+// contract surface from one module without reaching into job-claim.ts for the
+// low-level row shape.
+export type { JobStatus, JobView } from "./job-claim.js";
+
+// ───────────────────────────────────────────────────────────────────────
+// 1. JOB CONTRACT — the per-SERVICE job payload
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * The decided unit of fleet work: one job = "run all of service X's d6
+ * cells". `probeKey` is the SAME `probe_key` carried on the `probe_jobs` row
+ * (S0's `JobView.probe_key`) so the payload and the claim row are joinable by
+ * a single key. The payload is what the control-plane WRITES when it enqueues
+ * and what the worker READS after it wins the claim.
+ */
+export interface ServiceJobPayload {
+  /**
+   * The probe/service key this job runs — e.g. `"d6:langgraph-python"`. This
+   * is the join key to S0's `JobView.probe_key`; the dashboard's status rows
+   * are keyed `<dimension>:<slug>` (see status-writer's `deriveDimension`), so
+   * `probeKey` for a d6 service job is `d6:<serviceSlug>`.
+   */
+  probeKey: string;
+  /** The showcase service / integration slug, e.g. `"langgraph-python"`. */
+  serviceSlug: string;
+  /**
+   * The d6 driver kind that runs the cells. Always `"e2e_d6"` for the
+   * per-service d6 unit, but carried explicitly so the same job shape can
+   * later host other per-service drivers without a payload migration.
+   */
+  driverKind: string;
+  /**
+   * The cell / feature set to run for this service. When omitted/empty the
+   * worker runs the service's FULL declared cell set (the default d6 fan-out);
+   * when present it restricts the run to the listed feature ids (mirrors
+   * `ProbeContext.featureTypes`). Per-service granularity is the decided unit,
+   * so this is an OPTIONAL narrowing, not the primary partition.
+   */
+  cellIds?: string[];
+  /**
+   * Free-form driver inputs threaded to the d6 driver (timeouts, base URLs,
+   * feature filters). Kept open (`Record<string, unknown>`) so the queue
+   * payload never has to migrate when a driver gains a knob — the worker is
+   * responsible for validating the subset it consumes.
+   */
+  driverInputs?: Record<string, unknown>;
+  /** Run metadata for traceability across the control-plane → worker hop. */
+  meta: ServiceJobMeta;
+}
+
+/** Run metadata attached to every enqueued job. */
+export interface ServiceJobMeta {
+  /**
+   * Stable id for this logical run batch (one control-plane tick may enqueue
+   * many per-service jobs under one runId) — lets the aggregator group the
+   * per-service results back into a single dashboard sweep.
+   */
+  runId: string;
+  /** Whether this run was operator-triggered vs. scheduled (cron). */
+  triggered: boolean;
+  /** ISO timestamp the control-plane enqueued the job. */
+  enqueuedAt: string;
+  /** Optional priority hint; higher pulls first when a worker has a choice. */
+  priority?: number;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// 2. RESULT CONTRACT — what a worker produces, what the control-plane
+//    aggregates. The per-service rollup is computed IN the claiming worker.
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * One cell's outcome within a service job. Maps 1:1 onto a per-cell
+ * `ProbeResult` side-row (the d6 driver already emits `d6:<slug>/<featureId>`
+ * rows — see `types/index.ts` DIMENSIONS comment), so the aggregator can
+ * re-hydrate the EXISTING status/probe_runs contract without inventing a new
+ * row shape.
+ */
+export interface ServiceCellResult {
+  /** Feature / cell id within the service, e.g. `"shared-state"`. */
+  cellId: string;
+  /**
+   * The probe key for this cell's side-row, e.g. `"d6:langgraph-python/shared-state"`.
+   * This is exactly the key the d6 driver side-emits today, so writing it back
+   * through `status-writer` preserves the dashboard's per-cell badge lookup
+   * (`keyFor("d6", slug, featureId)`).
+   */
+  cellKey: string;
+  /** The cell's terminal state — reuses the harness-wide ProbeState enum. */
+  state: ProbeState;
+  /** The opaque signal blob the driver produced for this cell. */
+  signal: unknown;
+  /** ISO timestamp the cell was observed. */
+  observedAt: string;
+}
+
+/**
+ * The per-service rollup a worker reports. The worker computes the rollup
+ * (pass/fail counts) from its cell results — the control-plane does NOT
+ * recompute it, it only AGGREGATES across services into the dashboard sweep.
+ * Shapes are chosen to map cleanly onto the EXISTING storage contract:
+ *   - `rollup` → `ProbeRunSummary` ({ total, passed, failed }) for probe_runs
+ *   - `aggregateState` + `aggregateKey` → the service's primary status row
+ *   - `cells` → per-cell status side-rows via `probeResultsForServiceJobResult`
+ */
+export interface ServiceJobResult {
+  /** The claim row id (S0 `JobView.id`) this result terminates. */
+  jobId: string;
+  /** Echoes the payload's probeKey (the d6 aggregate row key). */
+  probeKey: string;
+  /** The showcase service slug. */
+  serviceSlug: string;
+  /** Echoes the payload's runId so the aggregator can group by batch. */
+  runId: string;
+  /** The worker that produced this result (S0 `JobView.claimed_by`). */
+  workerId: string;
+  /**
+   * The aggregate state for the service's PRIMARY status row. Computed by the
+   * worker from `cells` (any red → red; all green → green; an internal error
+   * → error). NOTE: a pool COMM-ERROR is NOT one of these — that surfaces via
+   * `commError` below and never masquerades as a probe red.
+   */
+  aggregateState: ProbeState;
+  /**
+   * The aggregate (primary) status-row key — the d6 AGGREGATE row key
+   * `d6:<slug>` (e.g. `"d6:langgraph-python"`) on BOTH paths. On the SUCCESS
+   * path the worker emits the d6 aggregate under `d6:<slug>` (and the per-cell
+   * rows under `d6:<slug>/<featureId>`); on the COMM-ERROR path
+   * (`buildCommErrorResult`) there is no driver run, so the worker falls back to
+   * the payload's `probeKey`, which is also the d6 aggregate key `d6:<slug>`.
+   * Either way this is the key the dashboard reads for the integration-level
+   * aggregate (and where a pool `PoolCommError` is mirrored — see
+   * `decodeCellCommError` in the dashboard's `cell-model.ts`). There is NO
+   * `e2e_d6:<slug>` row in the fleet path.
+   */
+  aggregateKey: string;
+  /** The aggregate signal blob for the primary row. */
+  aggregateSignal: unknown;
+  /** Per-cell outcomes (one per d6 feature). */
+  cells: ServiceCellResult[];
+  /** Pass/fail rollup — maps directly onto `ProbeRunSummary`. */
+  rollup: ServiceJobRollup;
+  /** ISO timestamp the worker finished the job. */
+  finishedAt: string;
+  /**
+   * Set ONLY when the control-plane (or the worker's own self-monitor) could
+   * not complete the job because of a POOL COMMUNICATION failure rather than a
+   * test result. When present, the dashboard renders "couldn't reach the pool"
+   * distinctly from a probe red (REQ-B). A well-formed test result that simply
+   * went red leaves this `undefined`.
+   */
+  commError?: PoolCommError;
+}
+
+/**
+ * Pass/fail rollup. Its three fields match `ProbeRunSummary`'s required
+ * `{ total, passed, failed }` exactly, so it maps straight onto a
+ * `ProbeRunSummary` (which is the structural SUPERSET — it adds an optional
+ * `services?` breakdown this rollup omits) via `runSummaryForServiceJobResult`.
+ */
+export interface ServiceJobRollup {
+  total: number;
+  passed: number;
+  failed: number;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// 3. [REQ-B] POOL COMM-ERROR TAXONOMY — control-plane ↔ worker/pool
+//    COMMUNICATION failures, DISTINCT from a probe red.
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * The closed set of control-plane ↔ worker/pool COMMUNICATION failure kinds.
+ * These describe "we couldn't reach / talk to / trust the pool member", which
+ * is categorically different from "the probe ran and went red". The dashboard
+ * (REQ-B slot) renders these distinctly so an operator never confuses a
+ * fleet-plumbing outage with a real product regression.
+ */
+export const POOL_COMM_ERROR_KINDS = [
+  /** Worker host/endpoint did not respond at all (connect refused, DNS, etc). */
+  "worker-unreachable",
+  /** A claim or lease CAS call failed at the transport layer (not a lost CAS). */
+  "claim-comm-failure",
+  /** The worker exceeded the protocol response deadline (hung, no crash). */
+  "worker-protocol-timeout",
+  /** The worker died mid-job: lease expired with no terminal report. */
+  "worker-crashed-mid-job",
+  /** A report arrived but failed schema/shape validation (protocol mismatch). */
+  "worker-protocol-violation",
+] as const;
+
+/** A single pool communication-failure kind. */
+export type PoolCommErrorKind = (typeof POOL_COMM_ERROR_KINDS)[number];
+
+/** Type guard for a valid PoolCommErrorKind. */
+export function isPoolCommErrorKind(
+  value: string | undefined,
+): value is PoolCommErrorKind {
+  return (
+    value !== undefined &&
+    (POOL_COMM_ERROR_KINDS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * A structured pool communication error. This is the type both the
+ * control-plane (which DETECTS the failure) and the dashboard (which RENDERS
+ * it) share.
+ */
+export interface PoolCommError {
+  kind: PoolCommErrorKind;
+  /** Human-readable detail for the dashboard tooltip / operator log. */
+  message: string;
+  /** The worker involved, when known (unreachable workers may be unknown). */
+  workerId?: string;
+  /** The job involved, when the failure is tied to a specific job. */
+  jobId?: string;
+  /** ISO timestamp the failure was observed. */
+  observedAt: string;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+//    STATUS-SCHEMA SURFACING of the comm-error (where REQ-B renders)
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * The fleet introduces a NEW status presentation state — `"unreachable"` —
+ * that lives ALONGSIDE the existing `State` ("green" | "red" | "degraded")
+ * and the per-result `"error"`. It deliberately does NOT widen the persisted
+ * `State` enum (that would force every state-machine consumer — alert engine,
+ * transition detector, flap counter — to learn a new value). Instead a comm
+ * error surfaces on the status row as a SEPARATE field:
+ *
+ *   - the row's `state` continues to carry the LAST-KNOWN probe colour (so the
+ *     dashboard keeps showing the cell's last real result, dimmed), and
+ *   - a new `commError` field (mirrored into the row signal under
+ *     `__fleetCommError`) tells the dashboard to overlay the "couldn't reach
+ *     the pool" treatment.
+ *
+ * `FleetSurfaceState` is the UNION the DASHBOARD computes for rendering — it is
+ * a presentation type, NOT a persisted column. The dashboard derives it:
+ * `commError ? "unreachable" : state`.
+ */
+export type FleetSurfaceState = ProbeState | "unreachable";
+
+/** Signal-blob key under which a comm error is mirrored onto a status row. */
+export const FLEET_COMM_ERROR_SIGNAL_KEY = "__fleetCommError" as const;
+
+/**
+ * A dashboard-facing status row enriched with the optional comm-error overlay.
+ * This is the read shape the aggregator produces and the dashboard consumes —
+ * it is the EXISTING status row (`StatusRecord` fields the dashboard already
+ * reads) plus the optional `commError`. The aggregator writes the underlying
+ * row through the unchanged `status-writer` path; `commError` is carried in the
+ * row's `signal` under `FLEET_COMM_ERROR_SIGNAL_KEY` and re-surfaced here.
+ */
+export interface FleetStatusRow {
+  key: string;
+  dimension: string;
+  /** Last-known probe colour (unchanged persisted `State`). */
+  state: ProbeState;
+  signal: unknown;
+  observedAt: string;
+  /** Present iff the latest attempt failed to reach/trust the pool (REQ-B). */
+  commError?: PoolCommError;
+}
+
+/** Compute the dashboard's surface state from a row's colour + comm error. */
+export function fleetSurfaceState(row: FleetStatusRow): FleetSurfaceState {
+  return row.commError ? "unreachable" : row.state;
+}
+
+/**
+ * Map a `PoolCommError` into the partial status-row SIGNAL patch the
+ * aggregator merges before writing through `status-writer`. The comm error
+ * rides in the signal blob (not a new column) so the persisted `status`
+ * collection schema is unchanged — the dashboard reads it back out by the
+ * well-known `FLEET_COMM_ERROR_SIGNAL_KEY`. Pure; unit-tested.
+ */
+export function commErrorToStatusSignal(
+  err: PoolCommError,
+): Record<string, unknown> {
+  return { [FLEET_COMM_ERROR_SIGNAL_KEY]: err };
+}
+
+/**
+ * Inverse of `commErrorToStatusSignal`: extract a `PoolCommError` from a
+ * status-row signal blob, or `undefined` when none is present / the embedded
+ * value is malformed. Pure; unit-tested. The dashboard slot (REQ-B) uses this
+ * to decide whether to render the "unreachable" overlay.
+ */
+export function commErrorFromStatusSignal(
+  signal: unknown,
+): PoolCommError | undefined {
+  if (signal === null || typeof signal !== "object") return undefined;
+  const raw = (signal as Record<string, unknown>)[FLEET_COMM_ERROR_SIGNAL_KEY];
+  if (raw === null || typeof raw !== "object") return undefined;
+  const candidate = raw as Partial<PoolCommError>;
+  if (
+    !isPoolCommErrorKind(candidate.kind) ||
+    typeof candidate.message !== "string" ||
+    typeof candidate.observedAt !== "string"
+  ) {
+    return undefined;
+  }
+  const out: PoolCommError = {
+    kind: candidate.kind,
+    message: candidate.message,
+    observedAt: candidate.observedAt,
+  };
+  if (typeof candidate.workerId === "string") out.workerId = candidate.workerId;
+  if (typeof candidate.jobId === "string") out.jobId = candidate.jobId;
+  return out;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+//    RESULT ↔ STORAGE mappers — preserve the EXISTING row shapes exactly.
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Project a `ServiceJobResult` into the set of `ProbeResult`s the
+ * `status-writer` already knows how to persist: ONE aggregate (primary) row +
+ * one side row per cell. This is the bridge that lets the aggregator (S5)
+ * write fleet results through the UNCHANGED status pipeline — the dashboard's
+ * row shape is preserved exactly because we emit the same `<dimension>:<slug>`
+ * and `d6:<slug>/<featureId>` keys the in-process d6 driver emits today. Pure;
+ * unit-tested.
+ */
+export function probeResultsForServiceJobResult(
+  result: ServiceJobResult,
+): ProbeResult[] {
+  const primary: ProbeResult = {
+    key: result.aggregateKey,
+    state: result.aggregateState,
+    signal: result.aggregateSignal,
+    observedAt: result.finishedAt,
+  };
+  const cells: ProbeResult[] = result.cells.map((c) => ({
+    key: c.cellKey,
+    state: c.state,
+    signal: c.signal,
+    observedAt: c.observedAt,
+  }));
+  return [primary, ...cells];
+}
+
+/**
+ * Project a `ServiceJobResult`'s rollup into the `ProbeRunSummary` shape the
+ * `run-history` writer persists onto `probe_runs`. Field names match
+ * `ProbeRunSummary` ({ total, passed, failed }) so the aggregator passes the
+ * return value straight to `runWriter.finish`/`update`. Pure; unit-tested.
+ */
+export function runSummaryForServiceJobResult(result: ServiceJobResult): {
+  total: number;
+  passed: number;
+  failed: number;
+} {
+  return {
+    total: result.rollup.total,
+    passed: result.rollup.passed,
+    failed: result.rollup.failed,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// 4. WORKER DESCRIPTOR / REGISTRATION CONTRACT
+//    (self-register S9 + fleet-health S10)
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Canonical PocketBase collection name for the fleet worker registry. The
+ * `workers` collection itself is created by the self-register slot's migration
+ * (`showcase/pocketbase/pb_migrations/<unix>_create_workers.js`); this constant
+ * is the single source of truth for the name so a rename can't go half-applied
+ * (same pattern as `PROBE_RUNS_COLLECTION` in run-history.ts).
+ */
+export const WORKERS_COLLECTION = "workers";
+
+/** A worker's liveness state, derived by fleet-health from its heartbeat. */
+export type WorkerHealthState = "online" | "stale" | "offline";
+
+/**
+ * Capacity the worker advertises at registration / on each heartbeat. This is
+ * the `BrowserPool.budget()` snapshot (S6) — re-exported field-by-field rather
+ * than referencing the class so the contract doesn't drag the pool
+ * implementation into every consumer. Structurally compatible with
+ * `BrowserPoolBudget` (see the type-level test).
+ */
+export interface WorkerCapacity {
+  /** Live contexts currently checked out. */
+  inUse: number;
+  /** Remaining context capacity (never negative). */
+  available: number;
+  /** Global context cap. */
+  max: number;
+  /** cgroup pids.current, or -1 if unreadable. */
+  pidsCurrent: number;
+  /** cgroup pids.max ceiling, or -1 if unbounded/unreadable. */
+  pidsMax: number;
+}
+
+/**
+ * The self-registration payload a worker writes to the `workers` collection on
+ * boot. `workerId` is the SAME id a worker passes to S0's
+ * `claimJob(jobId, workerId, ...)` so the registry row and the claim's
+ * `claimed_by` join on one value.
+ */
+export interface WorkerRegistration {
+  /** Stable worker id (matches S0 `JobView.claimed_by`). */
+  workerId: string;
+  /** Worker's reachable endpoint (host:port) for control-plane probes. */
+  endpoint: string;
+  /** Capacity snapshot at registration time. */
+  capacity: WorkerCapacity;
+  /** ISO timestamp the worker registered. */
+  registeredAt: string;
+}
+
+/**
+ * The periodic heartbeat a worker writes to refresh its liveness + capacity.
+ * fleet-health (S10) reads `lastHeartbeatAt` against a staleness window to
+ * derive `WorkerHealthState`; a worker whose heartbeat lapses is what the
+ * control-plane treats as `worker-crashed-mid-job` (see PoolCommErrorKind).
+ */
+export interface WorkerHeartbeat {
+  workerId: string;
+  /** Fresh capacity snapshot. */
+  capacity: WorkerCapacity;
+  /** Id of the job the worker is currently running, or null when idle. */
+  currentJobId: string | null;
+  /** ISO timestamp of this heartbeat. */
+  lastHeartbeatAt: string;
+}
+
+/**
+ * The full worker registry row as fleet-health reads it back — the union of
+ * the registration fields and the latest heartbeat. Snake-case-free
+ * (camelCase) because, like `ProbeRunRecord`, the read path returns camelCase
+ * to consumers while storage stays snake_case at the PB column layer (the
+ * self-register slot owns the row↔record mapping).
+ */
+export interface WorkerDescriptor {
+  workerId: string;
+  endpoint: string;
+  capacity: WorkerCapacity;
+  registeredAt: string;
+  lastHeartbeatAt: string;
+  currentJobId: string | null;
+  /** Derived liveness (computed by fleet-health, not persisted raw). */
+  health: WorkerHealthState;
+}
+
+/**
+ * Pure staleness check used by fleet-health (S10): a worker is stale when its
+ * last heartbeat is older than `staleAfterMs`. Returns false when the
+ * timestamp is unparseable (treat unknown as not-yet-stale; the next heartbeat
+ * resolves it) so a malformed row can't flap the whole fleet to offline. Pure;
+ * unit-tested.
+ */
+export function isWorkerStale(
+  lastHeartbeatAt: string,
+  nowMs: number,
+  staleAfterMs: number,
+): boolean {
+  const beatMs = Date.parse(lastHeartbeatAt);
+  if (Number.isNaN(beatMs)) return false;
+  return nowMs - beatMs > staleAfterMs;
+}
+
+/**
+ * Build a `WorkerCapacity` from a `BrowserPoolBudget` (S6). Thin, explicit
+ * field copy so the registration/heartbeat path never accidentally widens with
+ * pool-internal fields. Pure; unit-tested.
+ */
+export function workerCapacityFromBudget(
+  budget: BrowserPoolBudget,
+): WorkerCapacity {
+  return {
+    inUse: budget.inUse,
+    available: budget.available,
+    max: budget.max,
+    pidsCurrent: budget.pidsCurrent,
+    pidsMax: budget.pidsMax,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// 5. CONTROL-PLANE ↔ WORKER PROTOCOL — the queue-client interface S3
+//    implements on top of S0's JobClaimClient.
+// ───────────────────────────────────────────────────────────────────────
+
+/** Input the control-plane (S4) passes to enqueue one per-service job. */
+export interface EnqueueJobInput {
+  /** The per-service payload to run. */
+  payload: ServiceJobPayload;
+  /** Optional explicit lease seconds for the eventual claim; default per impl. */
+  leaseSeconds?: number;
+}
+
+/** A lease handle a worker holds while running a claimed job. */
+export interface JobLease {
+  /** The claimed job row (S0 `JobView`). */
+  job: JobView;
+  /** The decoded per-service payload for that job. */
+  payload: ServiceJobPayload;
+  /** ISO timestamp the lease currently expires (from the row). */
+  leaseExpiresAt: string | null;
+}
+
+/** Result of a worker's claim attempt — `lease` is undefined when none was won. */
+export interface ClaimedJob {
+  /** True when this worker won an available job. */
+  claimed: boolean;
+  /** Present iff `claimed` is true. */
+  lease?: JobLease;
+}
+
+/** Input a worker passes to report a finished job back to the control-plane. */
+export interface ReportJobInput {
+  /** The claim row id being terminated (S0 `JobView.id`). */
+  jobId: string;
+  /** The reporting worker (S0 `JobView.claimed_by`). */
+  workerId: string;
+  /** The per-service result, OR a comm-error-only terminal report. */
+  result: ServiceJobResult;
+}
+
+/** Outcome of sweeping expired leases (dead-worker reclamation). */
+export interface SweepResult {
+  /** Number of expired leases reclaimed (jobs re-queued to pending). */
+  reclaimed: number;
+  /** The comm errors synthesized for each reclaimed (crashed) worker job. */
+  commErrors: PoolCommError[];
+}
+
+/**
+ * The control-plane ↔ worker QUEUE protocol. S3 (queue-client) IMPLEMENTS this
+ * on top of S0's `JobClaimClient`:
+ *   - `enqueue` writes a `probe_jobs` row (status `pending`) carrying the
+ *     serialized `ServiceJobPayload`.
+ *   - `claimNext` finds a claimable job and runs S0's `claimJob` CAS, returning
+ *     a `JobLease` to the worker on a win (the exactly-one-winner guarantee
+ *     comes from S0).
+ *   - `renewLease` / `report` delegate to S0's `renewLease` / `releaseJob`.
+ *   - `sweepExpired` reclaims leases from crashed workers and emits the
+ *     `worker-crashed-mid-job` comm errors (REQ-B) the dashboard renders.
+ *
+ * Producers (control-plane S4) use `enqueue` + `sweepExpired`; consumers
+ * (worker loop S7) use `claimNext` + `renewLease` + `report`.
+ */
+export interface FleetQueueClient {
+  /** Producer: enqueue one per-service job (writes a pending probe_jobs row). */
+  enqueue(input: EnqueueJobInput): Promise<JobView>;
+  /**
+   * Consumer: attempt to claim the next available job for `workerId`. Returns
+   * `{ claimed: false }` when nothing was won (no work, or lost the CAS to a
+   * peer — the exactly-one-winner semantics are S0's).
+   */
+  claimNext(workerId: string, leaseSeconds: number): Promise<ClaimedJob>;
+  /** Consumer: extend the lease on a held job (delegates to S0 renewLease). */
+  renewLease(
+    jobId: string,
+    workerId: string,
+    leaseSeconds: number,
+  ): Promise<JobLease | null>;
+  /**
+   * Consumer: report a terminal result for a held job (delegates to S0
+   * releaseJob with the mapped `done`/`failed` status, and persists the
+   * per-service result for the aggregator).
+   */
+  report(input: ReportJobInput): Promise<void>;
+  /** Producer: reclaim expired leases from crashed/unreachable workers. */
+  sweepExpired(nowMs: number): Promise<SweepResult>;
+}
+
+/**
+ * Map a `ServiceJobResult`'s aggregate state onto the terminal `JobStatus` the
+ * worker passes to S0's `releaseJob`. A comm error or any non-green aggregate
+ * is `"failed"`; an all-green result is `"done"`. (S0's `releaseJob` accepts
+ * `"done" | "failed" | "pending"`; this helper only ever returns the two
+ * terminal values — re-queue is the sweeper's job, not the reporter's.) Pure;
+ * unit-tested.
+ */
+export function terminalJobStatus(
+  result: ServiceJobResult,
+): Extract<JobStatus, "done" | "failed"> {
+  if (result.commError) return "failed";
+  return result.aggregateState === "green" ? "done" : "failed";
+}

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "vitest";
+import {
+  createD6ServiceEnumerator,
+  D6_DRIVER_KIND,
+  D6_DISCOVERY_FILTER,
+} from "./catalog-enumerator.js";
+import type { DiscoverySource } from "../../probes/types.js";
+import type { RailwayServiceInfo } from "../../probes/discovery/railway-services.js";
+import type { EnumerateContext } from "./job-producer.js";
+import type { Logger } from "../../types/index.js";
+import { e2eFullDriver } from "../../probes/drivers/d6-all-pills.js";
+
+/**
+ * Pins the real catalog enumerator (S10): it yields ONE ServiceJobSpec per
+ * discovered showcase service, preserving the EXACT d6 keys the dashboard reads
+ * — `probeKey = d6:<slug>`, `driverKind = e2e_d6`, and a `driverInputs` object
+ * the worker re-hydrates into the d6 driver input. The discovery source is an
+ * injected fake (no Railway, no network).
+ */
+
+const SILENT_LOGGER: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+function svc(over: Partial<RailwayServiceInfo> = {}): RailwayServiceInfo {
+  return {
+    name: "showcase-langgraph-python",
+    imageRef: "ghcr.io/org/showcase-langgraph-python:latest",
+    publicUrl: "http://langgraph-python:10000",
+    env: {},
+    shape: "package",
+    deployedDigest: "",
+    demos: ["agentic_chat", "shared_state"],
+    notSupportedFeatures: [],
+    deployedAt: "",
+    ...over,
+  };
+}
+
+function fakeSource(
+  services: RailwayServiceInfo[],
+): DiscoverySource<RailwayServiceInfo> & {
+  configs: unknown[];
+} {
+  const configs: unknown[] = [];
+  return {
+    name: "railway-services",
+    configs,
+    async enumerate(_ctx, config): Promise<RailwayServiceInfo[]> {
+      configs.push(config);
+      return services;
+    },
+  } as DiscoverySource<RailwayServiceInfo> & { configs: unknown[] };
+}
+
+const CTX: EnumerateContext = { triggered: false, runId: "run-1" };
+
+describe("createD6ServiceEnumerator", () => {
+  it("yields one spec per service with the exact d6 keys (probeKey d6:<slug>, kind e2e_d6)", async () => {
+    const source = fakeSource([
+      svc({ name: "showcase-langgraph-python" }),
+      svc({ name: "showcase-crewai", publicUrl: "http://crewai:10000" }),
+    ]);
+    const enumerate = createD6ServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+
+    const specs = await enumerate(CTX);
+
+    expect(specs).toHaveLength(2);
+    const lg = specs.find((s) => s.serviceSlug === "langgraph-python");
+    expect(lg).toBeDefined();
+    expect(lg?.probeKey).toBe("d6:langgraph-python");
+    expect(lg?.driverKind).toBe(D6_DRIVER_KIND);
+    expect(lg?.driverInputs?.key).toBe("d6:langgraph-python");
+    expect(lg?.driverInputs?.backendUrl).toBe("http://langgraph-python:10000");
+    expect(lg?.driverInputs?.demos).toEqual(["agentic_chat", "shared_state"]);
+    expect(lg?.driverInputs?.shape).toBe("package");
+
+    const cr = specs.find((s) => s.serviceSlug === "crewai");
+    expect(cr?.probeKey).toBe("d6:crewai");
+  });
+
+  it("passes the d6 discovery filter (namePrefix + nameExcludes) to the source", async () => {
+    const source = fakeSource([svc()]);
+    const enumerate = createD6ServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+
+    await enumerate(CTX);
+
+    expect(source.configs).toHaveLength(1);
+    const cfg = source.configs[0] as {
+      namePrefix?: string;
+      nameExcludes?: string[];
+    };
+    expect(cfg.namePrefix).toBe(D6_DISCOVERY_FILTER.namePrefix);
+    expect(cfg.nameExcludes).toEqual([...D6_DISCOVERY_FILTER.nameExcludes]);
+  });
+
+  it("carries deployedAt only when the service has one (deploy-churn grace)", async () => {
+    const source = fakeSource([
+      svc({ name: "showcase-fresh", deployedAt: "2026-06-04T00:00:00.000Z" }),
+      svc({ name: "showcase-stable", deployedAt: "" }),
+    ]);
+    const enumerate = createD6ServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+
+    const specs = await enumerate(CTX);
+    const fresh = specs.find((s) => s.serviceSlug === "fresh");
+    const stable = specs.find((s) => s.serviceSlug === "stable");
+    expect(fresh?.driverInputs?.deployedAt).toBe("2026-06-04T00:00:00.000Z");
+    expect(stable?.driverInputs?.deployedAt).toBeUndefined();
+  });
+
+  it("scopes to the operator slug filter on a triggered run (empty when none match)", async () => {
+    const source = fakeSource([
+      svc({ name: "showcase-langgraph-python" }),
+      svc({ name: "showcase-crewai" }),
+    ]);
+    const enumerate = createD6ServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+
+    const scoped = await enumerate({
+      triggered: true,
+      runId: "run-2",
+      filter: { slugs: ["crewai"] },
+    });
+    expect(scoped.map((s) => s.serviceSlug)).toEqual(["crewai"]);
+
+    const none = await enumerate({
+      triggered: true,
+      runId: "run-3",
+      filter: { slugs: ["does-not-exist"] },
+    });
+    expect(none).toEqual([]);
+  });
+
+  it("emits driverInputs that validate against the REAL d6 inputSchema and carry no fields the schema does not list", async () => {
+    // The worker re-hydrates driverInputs THROUGH the d6 driver's own zod
+    // inputSchema (the validation gate). Parse the emitted input through the
+    // real schema — the strongest guard that the enumerator's output matches
+    // the driver's contract. We also assert the enumerator does not emit a
+    // redundant `publicUrl` field: `backendUrl` already carries the live URL
+    // and the driver reads `backendUrl ?? publicUrl`, so the extra key is
+    // dead weight that drifts the emitted shape from the documented contract.
+    const source = fakeSource([
+      svc({
+        name: "showcase-langgraph-python",
+        publicUrl: "http://langgraph-python:10000",
+        deployedAt: "2026-06-04T00:00:00.000Z",
+      }),
+    ]);
+    const enumerate = createD6ServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+
+    const specs = await enumerate(CTX);
+    const lg = specs.find((s) => s.serviceSlug === "langgraph-python");
+    expect(lg).toBeDefined();
+
+    // Parses cleanly through the real d6 inputSchema — the worker's gate.
+    const parsed = e2eFullDriver.inputSchema.safeParse(lg!.driverInputs);
+    expect(parsed.success).toBe(true);
+
+    // No redundant `publicUrl` key — backendUrl carries the value.
+    expect(lg!.driverInputs).not.toHaveProperty("publicUrl");
+    expect(lg!.driverInputs?.backendUrl).toBe("http://langgraph-python:10000");
+  });
+
+  it("produces a NON-EMPTY spec set for the real-shaped service catalog", async () => {
+    // The producer's tick enqueues one job per spec; a non-empty enumerator is
+    // what flips runControlPlane off the empty-run warning.
+    const source = fakeSource([
+      svc({ name: "showcase-langgraph-python" }),
+      svc({ name: "showcase-crewai" }),
+      svc({ name: "showcase-mastra" }),
+    ]);
+    const enumerate = createD6ServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+    const specs = await enumerate(CTX);
+    expect(specs.length).toBeGreaterThan(0);
+    expect(specs.length).toBe(3);
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
@@ -1,0 +1,205 @@
+/**
+ * Control-plane CATALOG ENUMERATOR — the real `ServiceEnumerator` the job
+ * producer (S4) runs each tick (BLITZ S10, the discovery seam in
+ * `runControlPlane`).
+ *
+ * ── WHAT IT PRODUCES ───────────────────────────────────────────────────
+ * One `ServiceJobSpec` per showcase d6 service — the SAME service set and the
+ * SAME per-service granularity the in-process `d6-all-pills-e2e` driver runs
+ * today. Each spec carries:
+ *   - `probeKey`     = `d6:<slug>` — the dashboard's D6 aggregate row key (see
+ *                      contracts.ts §1: "probeKey for a d6 service job is
+ *                      d6:<slug>"). This is the join key to the claim row and
+ *                      the status row the aggregator writes.
+ *   - `serviceSlug`  = the slug (service name minus the `showcase-` prefix),
+ *                      identical to the driver's `deriveSlug`.
+ *   - `driverKind`   = `e2e_d6` (the per-service d6 unit).
+ *   - `driverInputs` = the serialized d6 `E2eFullDriverInput`
+ *                      (`key`/`backendUrl`/`demos`/`notSupportedFeatures`/
+ *                      `shape`/`deployedAt`/`name`) the WORKER re-hydrates via
+ *                      `createD6PayloadToInput`. The d6 driver's own zod schema
+ *                      is the validation gate.
+ *
+ * ── WHY IT REUSES railwayServicesSource ────────────────────────────────
+ * The in-process d6 path discovers its services through the `railway-services`
+ * discovery source filtered by the `d6-all-pills-e2e.yml` `discovery.filter`
+ * block. We reuse the EXACT same source + filter here rather than re-querying
+ * Railway by hand, so:
+ *   - the fleet enumerates the IDENTICAL service set as the legacy probe (no
+ *     drift between the two run paths during the cutover), and
+ *   - the `LOCAL_SERVICES_JSON` local-injection seam the source honors works
+ *     unchanged — the local N=1 d6 gate feeds the identical `RailwayServiceInfo`
+ *     shape and the fleet enumerates against it with zero Railway creds.
+ *
+ * The filter (`D6_DISCOVERY_FILTER`) is the single source of truth mirroring the
+ * YAML; keep it in lockstep with `config/probes/d6-all-pills-e2e.yml` until the
+ * two run paths converge on one config.
+ *
+ * ── INJECTION ──────────────────────────────────────────────────────────
+ * The discovery source, the env snapshot, and the fetch impl are injected so
+ * the enumerator is unit-testable with a fake source (no Railway, no network);
+ * `runControlPlane` wires the real `railwayServicesSource` + `process.env`.
+ */
+
+import type { Logger } from "../../types/index.js";
+import type { DiscoverySource, DiscoveryContext } from "../../probes/types.js";
+import type { RailwayServiceInfo } from "../../probes/discovery/railway-services.js";
+import type {
+  ServiceEnumerator,
+  ServiceJobSpec,
+  EnumerateContext,
+} from "./job-producer.js";
+
+/** The d6 driver kind every enumerated spec runs under. */
+export const D6_DRIVER_KIND = "e2e_d6";
+
+/**
+ * The d6 service-set filter — the SINGLE SOURCE OF TRUTH mirroring
+ * `config/probes/d6-all-pills-e2e.yml`'s `discovery.filter`. Selects the
+ * `showcase-*` demo services and excludes infra/shell services and the
+ * decommissioned starters. Keep this in lockstep with the YAML until the
+ * in-process and fleet run paths converge on one config.
+ */
+export const D6_DISCOVERY_FILTER = {
+  namePrefix: "showcase-",
+  nameExcludes: [
+    "showcase-aimock",
+    "showcase-harness",
+    "showcase-pocketbase",
+    "showcase-shell",
+    "showcase-shell-dashboard",
+    "showcase-shell-docs",
+    "showcase-shell-dojo",
+    // Harness service for .NET integration testing — not a demo service.
+    "showcase-ms-agent-harness-dotnet",
+    // Decommissioned starters.
+    "showcase-starter-ag2",
+    "showcase-starter-agno",
+    "showcase-starter-claude-sdk-python",
+    "showcase-starter-claude-sdk-typescript",
+    "showcase-starter-crewai-crews",
+    "showcase-starter-google-adk",
+    "showcase-starter-langgraph-fastapi",
+    "showcase-starter-langgraph-python",
+    "showcase-starter-langgraph-typescript",
+    "showcase-starter-langroid",
+    "showcase-starter-llamaindex",
+    "showcase-starter-mastra",
+    "showcase-starter-ms-agent-dotnet",
+    "showcase-starter-ms-agent-python",
+    "showcase-starter-pydantic-ai",
+    "showcase-starter-spring-ai",
+    "showcase-starter-strands",
+  ],
+} as const;
+
+export interface D6ServiceEnumeratorDeps {
+  /** The discovery source to enumerate (production: `railwayServicesSource`). */
+  source: DiscoverySource<RailwayServiceInfo>;
+  /** Frozen env snapshot threaded to the discovery context. */
+  env: Readonly<Record<string, string | undefined>>;
+  /** Fetch impl threaded to the discovery context (tests stub network). */
+  fetchImpl: typeof fetch;
+  logger: Logger;
+  /**
+   * Service-set filter. Defaults to `D6_DISCOVERY_FILTER`. Exposed so a test
+   * (or a future operator config) can narrow the set without editing the SSOT.
+   */
+  filter?: { namePrefix?: string; nameExcludes?: readonly string[] };
+}
+
+/**
+ * Strip the `showcase-` prefix to derive the slug — mirrors the d6 driver's
+ * `deriveSlug` and discovery's `deriveSlugFromServiceName` so the enumerated
+ * `serviceSlug` / `probeKey` match the keys the dashboard already reads.
+ */
+function deriveSlug(name: string): string {
+  return name.startsWith("showcase-") ? name.slice("showcase-".length) : name;
+}
+
+/**
+ * Map one discovered `RailwayServiceInfo` into the d6 driver input the worker
+ * re-hydrates. Field names match the d6 `inputSchema`
+ * (`key`/`backendUrl`/`demos`/`notSupportedFeatures`/`shape`/`deployedAt`/
+ * `name`). The driver reads `backendUrl ?? publicUrl`; we set `backendUrl` to
+ * the discovered `publicUrl` (the live URL the spec navigates against — local
+ * container host or Railway public domain) and emit ONLY `backendUrl` — the
+ * driver's `??` fallback never needs a second copy under `publicUrl`, and
+ * emitting both would drift the serialized shape from the documented contract.
+ * `key` is the `d6:<slug>` aggregate key so the driver emits the exact
+ * dashboard row keys.
+ */
+function toDriverInputs(
+  svc: RailwayServiceInfo,
+  slug: string,
+  probeKey: string,
+): Record<string, unknown> {
+  return {
+    key: probeKey,
+    name: svc.name,
+    backendUrl: svc.publicUrl,
+    demos: [...svc.demos],
+    notSupportedFeatures: [...svc.notSupportedFeatures],
+    shape: svc.shape,
+    // Omitted when empty so the driver's deploy-churn grace window only engages
+    // for a genuine timestamp (the driver guards on length/parse anyway).
+    ...(svc.deployedAt ? { deployedAt: svc.deployedAt } : {}),
+  };
+}
+
+/**
+ * Build the real d6 `ServiceEnumerator`. Each call enumerates the discovery
+ * source under the d6 filter and maps every service to one `ServiceJobSpec`.
+ * The `EnumerateContext.filter` (operator slug scoping on a triggered run) is
+ * applied AFTER discovery so an operator can scope a manual run to a subset of
+ * services without re-querying — mirroring the in-process invoker's slug filter.
+ */
+export function createD6ServiceEnumerator(
+  deps: D6ServiceEnumeratorDeps,
+): ServiceEnumerator {
+  const { source, env, fetchImpl, logger } = deps;
+  const filter = deps.filter ?? D6_DISCOVERY_FILTER;
+
+  return async (ctx: EnumerateContext): Promise<ServiceJobSpec[]> => {
+    const discoveryCtx: DiscoveryContext = { fetchImpl, env, logger };
+    const services = await source.enumerate(discoveryCtx, {
+      namePrefix: filter.namePrefix,
+      nameExcludes: filter.nameExcludes ? [...filter.nameExcludes] : undefined,
+    });
+
+    // Optional operator slug scoping (triggered runs only). An explicit filter
+    // with zero matches means "no slugs match" — keep the run honest (empty)
+    // rather than silently running everything.
+    const slugScope = ctx.filter?.slugs;
+    const slugSet =
+      slugScope && slugScope.length > 0 ? new Set(slugScope) : undefined;
+
+    const specs: ServiceJobSpec[] = [];
+    for (const svc of services) {
+      const slug = deriveSlug(svc.name);
+      if (slugSet && !slugSet.has(slug) && !slugSet.has(svc.name)) continue;
+      const probeKey = `d6:${slug}`;
+      const spec: ServiceJobSpec = {
+        probeKey,
+        serviceSlug: slug,
+        driverKind: D6_DRIVER_KIND,
+        driverInputs: toDriverInputs(svc, slug, probeKey),
+      };
+      // Forward the operator feature-type scoping to the worker as a cell
+      // narrowing (the d6 driver filters by ctx.featureTypes); per-service is
+      // still the partition, this only restricts which cells run.
+      if (ctx.filter?.featureTypes && ctx.filter.featureTypes.length > 0) {
+        spec.cellIds = [...ctx.filter.featureTypes];
+      }
+      specs.push(spec);
+    }
+
+    logger.info("fleet.control-plane.catalog-enumerated", {
+      runId: ctx.runId,
+      triggered: ctx.triggered,
+      discovered: services.length,
+      enqueueable: specs.length,
+    });
+    return specs;
+  };
+}

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -1,0 +1,505 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createControlPlane,
+  FLEET_PRODUCER_SCHEDULE_ID,
+  DEFAULT_PRODUCER_CRON,
+} from "./control-plane.js";
+import type { JobProducer, TickResult } from "./job-producer.js";
+import type { ResultConsumer, ConsumeResult } from "./result-consumer.js";
+import type {
+  ResultAggregator,
+  CommErrorAggregateInput,
+} from "./result-aggregator.js";
+import type { FleetHealthMonitor, FleetHealthResult } from "./fleet-health.js";
+import type { Scheduler, ScheduleEntry } from "../../scheduler/scheduler.js";
+import type { Logger } from "../../types/index.js";
+import type { PoolCommError } from "../contracts.js";
+
+/**
+ * Pins the control-plane ASSEMBLY: start() registers the producer's tick as the
+ * scheduler handler AND starts a consumer poll loop; the consumer's
+ * `consumeOnce` runs on the interval; stop() tears both down. All collaborators
+ * are injected fakes — no PocketBase, no scheduler internals, no real timers.
+ */
+
+const SILENT_LOGGER: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+function makeFakeProducer(): JobProducer & {
+  started: boolean;
+  stopped: boolean;
+  ticks: number;
+} {
+  const state = { started: false, stopped: false, ticks: 0 };
+  return {
+    ...state,
+    start() {
+      (this as { started: boolean }).started = true;
+    },
+    async stop() {
+      (this as { stopped: boolean }).stopped = true;
+    },
+    async tick(): Promise<TickResult> {
+      (this as { ticks: number }).ticks += 1;
+      return {
+        runId: "r",
+        enqueued: 0,
+        enqueueFailures: 0,
+        sweptExpired: false,
+        reclaimed: 0,
+      };
+    },
+    isRunning() {
+      return (
+        (this as { started: boolean; stopped: boolean }).started &&
+        !(this as { stopped: boolean }).stopped
+      );
+    },
+  } as JobProducer & { started: boolean; stopped: boolean; ticks: number };
+}
+
+function makeFakeConsumer(
+  impl?: () => Promise<ConsumeResult>,
+): ResultConsumer & { calls: number } {
+  const wrapper = {
+    calls: 0,
+    async consumeOnce(): Promise<ConsumeResult> {
+      wrapper.calls += 1;
+      if (impl) return impl();
+      return { processed: 0, failures: 0 };
+    },
+  };
+  return wrapper;
+}
+
+function makeFakeAggregator(): ResultAggregator & {
+  commErrorCalls: CommErrorAggregateInput[];
+} {
+  const commErrorCalls: CommErrorAggregateInput[] = [];
+  return {
+    commErrorCalls,
+    async aggregate() {
+      throw new Error("fake-aggregator: aggregate not used by these tests");
+    },
+    async aggregateCommError(input) {
+      commErrorCalls.push(input);
+      return { statusOutcomes: [] };
+    },
+  };
+}
+
+function makeFakeFleetHealth(
+  result: FleetHealthResult,
+): FleetHealthMonitor & { calls: number } {
+  const wrapper = {
+    calls: 0,
+    async checkOnce(): Promise<FleetHealthResult> {
+      wrapper.calls += 1;
+      return result;
+    },
+  };
+  return wrapper;
+}
+
+function emptyHealthResult(
+  over: Partial<FleetHealthResult> = {},
+): FleetHealthResult {
+  return {
+    online: 0,
+    unhealthy: 0,
+    reclaimed: 0,
+    commErrors: [],
+    reclaimedOverlays: [],
+    restartsAttempted: 0,
+    ...over,
+  };
+}
+
+function makeFakeScheduler(): Scheduler & {
+  entries: Map<string, ScheduleEntry>;
+} {
+  const entries = new Map<string, ScheduleEntry>();
+  const unsupported = (n: string) => () => {
+    throw new Error(`fake-scheduler: ${n} not implemented`);
+  };
+  const fake = {
+    entries,
+    register(entry: ScheduleEntry) {
+      entries.set(entry.id, entry);
+    },
+    async unregister(id: string): Promise<boolean> {
+      return entries.delete(id);
+    },
+    hasEntry(id: string) {
+      return entries.has(id);
+    },
+    list() {
+      return [...entries.values()];
+    },
+    start() {},
+    async stop() {},
+    isStarted: () => true,
+    isStopped: () => false,
+    getJobCount: () => entries.size,
+    getEntry: unsupported("getEntry"),
+    setEntryTracker: unsupported("setEntryTracker"),
+    seedEntryLastRun: unsupported("seedEntryLastRun"),
+    trigger: unsupported("trigger"),
+    nextRun: unsupported("nextRun"),
+  };
+  return fake as unknown as Scheduler & {
+    entries: Map<string, ScheduleEntry>;
+  };
+}
+
+/** A controllable fake setInterval/clearInterval pair. */
+class FakeTimers {
+  private cb: (() => void) | undefined;
+  cleared = false;
+  setIntervalImpl = ((fn: () => void) => {
+    this.cb = fn;
+    return 1 as unknown as ReturnType<typeof setInterval>;
+  }) as unknown as typeof setInterval;
+  clearIntervalImpl = (() => {
+    this.cleared = true;
+    this.cb = undefined;
+  }) as unknown as typeof clearInterval;
+  async fire(): Promise<void> {
+    this.cb?.();
+    // Let the void-returned async cycle settle.
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+}
+
+function makeFakeTimers(): FakeTimers {
+  return new FakeTimers();
+}
+
+describe("createControlPlane.start", () => {
+  it("starts the producer and registers its tick as the scheduler handler", () => {
+    const producer = makeFakeProducer();
+    const consumer = makeFakeConsumer();
+    const scheduler = makeFakeScheduler();
+    const timers = makeFakeTimers();
+
+    const cp = createControlPlane({
+      producer,
+      consumer,
+      scheduler,
+      logger: SILENT_LOGGER,
+      setIntervalImpl: timers.setIntervalImpl,
+      clearIntervalImpl: timers.clearIntervalImpl,
+    });
+    cp.start();
+
+    expect(producer.started).toBe(true);
+    const entry = scheduler.entries.get(FLEET_PRODUCER_SCHEDULE_ID);
+    expect(entry).toBeDefined();
+    expect(entry?.cron).toBe(DEFAULT_PRODUCER_CRON);
+  });
+
+  it("the registered scheduler handler drives the producer tick", async () => {
+    const producer = makeFakeProducer();
+    const scheduler = makeFakeScheduler();
+    const cp = createControlPlane({
+      producer,
+      consumer: makeFakeConsumer(),
+      scheduler,
+      logger: SILENT_LOGGER,
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+    cp.start();
+
+    const entry = scheduler.entries.get(FLEET_PRODUCER_SCHEDULE_ID);
+    await entry?.handler();
+    expect(producer.ticks).toBe(1);
+  });
+
+  it("runs the consumer on the interval tick", async () => {
+    const consumer = makeFakeConsumer();
+    const timers = makeFakeTimers();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer,
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      setIntervalImpl: timers.setIntervalImpl,
+      clearIntervalImpl: timers.clearIntervalImpl,
+    });
+    cp.start();
+
+    expect(consumer.calls).toBe(0);
+    await timers.fire();
+    expect(consumer.calls).toBe(1);
+  });
+
+  it("is idempotent — a second start() does not double-register", () => {
+    const scheduler = makeFakeScheduler();
+    const registerSpy = vi.spyOn(scheduler, "register");
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler,
+      logger: SILENT_LOGGER,
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+    cp.start();
+    cp.start();
+    expect(registerSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createControlPlane.stop", () => {
+  it("unregisters the producer tick, stops the producer, and clears the consumer timer", async () => {
+    const producer = makeFakeProducer();
+    const scheduler = makeFakeScheduler();
+    const timers = makeFakeTimers();
+    const cp = createControlPlane({
+      producer,
+      consumer: makeFakeConsumer(),
+      scheduler,
+      logger: SILENT_LOGGER,
+      setIntervalImpl: timers.setIntervalImpl,
+      clearIntervalImpl: timers.clearIntervalImpl,
+    });
+    cp.start();
+    await cp.stop();
+
+    expect(scheduler.entries.has(FLEET_PRODUCER_SCHEDULE_ID)).toBe(false);
+    expect(producer.stopped).toBe(true);
+    expect(timers.cleared).toBe(true);
+  });
+
+  it("after stop(), a fired interval no longer ticks the consumer", async () => {
+    const consumer = makeFakeConsumer();
+    const timers = makeFakeTimers();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer,
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      setIntervalImpl: timers.setIntervalImpl,
+      clearIntervalImpl: timers.clearIntervalImpl,
+    });
+    cp.start();
+    await cp.stop();
+    await timers.fire();
+    expect(consumer.calls).toBe(0);
+  });
+});
+
+// ── REQ-B: dead-worker comm-error surfacing through the aggregator ──────────
+describe("createControlPlane — REQ-B comm-error surfacing", () => {
+  const SWEEP_ERR: PoolCommError = {
+    kind: "worker-crashed-mid-job",
+    message: "lease for job j1 expired; re-queued",
+    workerId: "worker-dead",
+    jobId: "j1",
+    observedAt: "2026-06-04T00:00:09.000Z",
+  };
+
+  it("checkFleetHealthOnce feeds each reclaimed overlay to the aggregator with its dashboard key", async () => {
+    const aggregator = makeFakeAggregator();
+    const fleetHealth = makeFakeFleetHealth(
+      emptyHealthResult({
+        unhealthy: 1,
+        reclaimed: 1,
+        commErrors: [SWEEP_ERR],
+        reclaimedOverlays: [
+          { commError: SWEEP_ERR, aggregateKey: "d6:langgraph-python" },
+        ],
+      }),
+    );
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      aggregator,
+      fleetHealth,
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+
+    await cp.checkFleetHealthOnce();
+
+    expect(fleetHealth.calls).toBe(1);
+    expect(aggregator.commErrorCalls).toHaveLength(1);
+    expect(aggregator.commErrorCalls[0]).toEqual({
+      commError: SWEEP_ERR,
+      aggregateKey: "d6:langgraph-python",
+    });
+  });
+
+  it("the fleet-health interval drives checkFleetHealthOnce when a monitor is injected", async () => {
+    const aggregator = makeFakeAggregator();
+    const fleetHealth = makeFakeFleetHealth(emptyHealthResult());
+    const timers = makeFakeTimers();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      aggregator,
+      fleetHealth,
+      // Use the SAME fake timer for both consumer + fleet-health; fire() drives
+      // whichever callback was registered last (fleet-health), proving the loop
+      // is attached. We assert the monitor was invoked.
+      setIntervalImpl: timers.setIntervalImpl,
+      clearIntervalImpl: timers.clearIntervalImpl,
+    });
+    cp.start();
+    await timers.fire();
+    expect(fleetHealth.calls).toBe(1);
+  });
+
+  it("surfaceSweepCommErrors resolves each bare error's dashboard key then writes the overlay", async () => {
+    const aggregator = makeFakeAggregator();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      aggregator,
+      resolveSweepAggregateKey: (err) =>
+        err.jobId === "j1" ? "d6:langgraph-python" : null,
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+
+    await cp.surfaceSweepCommErrors([SWEEP_ERR]);
+
+    expect(aggregator.commErrorCalls).toHaveLength(1);
+    expect(aggregator.commErrorCalls[0]).toEqual({
+      commError: SWEEP_ERR,
+      aggregateKey: "d6:langgraph-python",
+    });
+  });
+
+  it("surfaceSweepCommErrors skips an error whose dashboard key cannot be resolved", async () => {
+    const aggregator = makeFakeAggregator();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      aggregator,
+      resolveSweepAggregateKey: () => null,
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+
+    await cp.surfaceSweepCommErrors([SWEEP_ERR]);
+    expect(aggregator.commErrorCalls).toHaveLength(0);
+  });
+
+  it("is inert (no fleet-health timer, no aggregator calls) when those deps are omitted", async () => {
+    const aggregator = makeFakeAggregator();
+    const timers = makeFakeTimers();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      // no aggregator, no fleetHealth, no resolver
+      setIntervalImpl: timers.setIntervalImpl,
+      clearIntervalImpl: timers.clearIntervalImpl,
+    });
+    cp.start();
+    // surfaceSweepCommErrors is a no-op without aggregator+resolver.
+    await cp.surfaceSweepCommErrors([SWEEP_ERR]);
+    await cp.checkFleetHealthOnce();
+    expect(aggregator.commErrorCalls).toHaveLength(0);
+  });
+
+  it("surfaceSweepCommErrors passes the CURRENT row colour as lastKnownState (red stays red, NOT green)", async () => {
+    const aggregator = makeFakeAggregator();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      aggregator,
+      resolveSweepAggregateKey: () => "d6:langgraph-python",
+      // The service was last observed RED — a crash overlay must preserve it.
+      resolvePriorState: () => "red",
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+
+    await cp.surfaceSweepCommErrors([SWEEP_ERR]);
+
+    expect(aggregator.commErrorCalls).toHaveLength(1);
+    expect(aggregator.commErrorCalls[0].lastKnownState).toBe("red");
+  });
+
+  it("checkFleetHealthOnce passes the CURRENT row colour as lastKnownState (red stays red, NOT green)", async () => {
+    const aggregator = makeFakeAggregator();
+    const fleetHealth = makeFakeFleetHealth(
+      emptyHealthResult({
+        reclaimedOverlays: [
+          { commError: SWEEP_ERR, aggregateKey: "d6:langgraph-python" },
+        ],
+      }),
+    );
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      aggregator,
+      fleetHealth,
+      resolvePriorState: () => "red",
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+
+    await cp.checkFleetHealthOnce();
+
+    expect(aggregator.commErrorCalls).toHaveLength(1);
+    expect(aggregator.commErrorCalls[0].lastKnownState).toBe("red");
+  });
+
+  it("checkFleetHealthOnce skips an overlay with an empty aggregateKey (never writes a row keyed '')", async () => {
+    const aggregator = makeFakeAggregator();
+    const fleetHealth = makeFakeFleetHealth(
+      emptyHealthResult({
+        reclaimedOverlays: [{ commError: SWEEP_ERR, aggregateKey: "" }],
+      }),
+    );
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      aggregator,
+      fleetHealth,
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+
+    await cp.checkFleetHealthOnce();
+
+    expect(aggregator.commErrorCalls).toHaveLength(0);
+  });
+
+  it("a throwing resolvePriorState degrades to no lastKnownState — still writes the overlay (never aborts the leg)", async () => {
+    const aggregator = makeFakeAggregator();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      aggregator,
+      resolveSweepAggregateKey: () => "d6:langgraph-python",
+      resolvePriorState: () => {
+        throw new Error("pb blip");
+      },
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+
+    await cp.surfaceSweepCommErrors([SWEEP_ERR]);
+
+    expect(aggregator.commErrorCalls).toHaveLength(1);
+    expect(aggregator.commErrorCalls[0].lastKnownState).toBeUndefined();
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/control-plane.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.ts
@@ -1,0 +1,434 @@
+/**
+ * Control-plane ASSEMBLY — the non-Chromium half of the harness, wired from
+ * the fan-out slots into one lifecycle.
+ *
+ * The control-plane owns three responsibilities, and this module composes the
+ * slots that implement each:
+ *
+ *   1. PRODUCE work — `createJobProducer` (S4) enqueues one per-service job per
+ *      run. Its `tick` is registered as the scheduler handler so the existing
+ *      cron cadence drives runs (the producer is invoked BY the scheduler, it
+ *      never owns a timer). The producer ALSO runs `sweepExpired` on its own
+ *      cadence gate inside `tick` (dead-worker lease reclamation, REQ-B).
+ *   2. CONSUME results — the result-consumer polls terminal `probe_jobs` rows
+ *      carrying an unprocessed `ServiceJobResult` and feeds each to ...
+ *   3. AGGREGATE — `createResultAggregator` (S5), the ONLY writer of the
+ *      authoritative dashboard status + run-history. The consumer runs on its
+ *      OWN interval (sub-minute, finer than cron) since result latency should
+ *      not be bounded by the producer's cron cadence.
+ *
+ * ── REQ-B: SURFACING DEAD-WORKER COMM ERRORS ───────────────────────────────
+ * Two legs reclaim a crashed / lease-expired worker's job and synthesize a
+ * `worker-crashed-mid-job` `PoolCommError`: the producer's lease-driven
+ * `sweepExpired` (inside `tick`) and the heartbeat-driven fleet-health monitor.
+ * A comm error only reaches the dashboard once it is written onto the job's
+ * STATUS row via `ResultAggregator.aggregateCommError`. The control-plane is
+ * where both legs converge onto that aggregator:
+ *   - FLEET-HEALTH — when a `fleetHealth` monitor is injected, the control-plane
+ *     runs it on its OWN interval (mirrors the consumer loop) and feeds each
+ *     `reclaimedOverlays` entry (comm error + already-known `aggregateKey`)
+ *     straight to the aggregator.
+ *   - PRODUCER SWEEP — the producer FORWARDS its swept comm errors to an
+ *     injected sink; `surfaceSweepCommErrors` is that sink. A bare swept
+ *     `PoolCommError` carries the `jobId` but not the dashboard key, so a
+ *     `resolveSweepAggregateKey` resolver (a job-row lookup) maps each error to
+ *     its `d6:<slug>` key before the aggregator writes the overlay.
+ * Both are OPTIONAL deps so the assembly stays unit-testable and back-compatible
+ * — when omitted, the control-plane is the pure produce/consume assembly it was.
+ *
+ * ── INJECTION ──────────────────────────────────────────────────────────────
+ * Everything is injected (queue, scheduler, aggregator, consumer, enumerator,
+ * timers) so the assembly is unit-testable with fakes and owns no PocketBase /
+ * Chromium of its own — `runControlPlane` constructs the real deps.
+ */
+
+import type { Logger, State } from "../../types/index.js";
+import type { Scheduler } from "../../scheduler/scheduler.js";
+import type { PoolCommError } from "../contracts.js";
+import { createJobProducer } from "./job-producer.js";
+import type {
+  JobProducer,
+  ServiceEnumerator,
+  SweepCommErrorSink,
+} from "./job-producer.js";
+import type { ResultConsumer } from "./result-consumer.js";
+import type { ResultAggregator } from "./result-aggregator.js";
+import type { FleetHealthMonitor } from "./fleet-health.js";
+
+/** Scheduler entry id the producer's tick registers under. */
+export const FLEET_PRODUCER_SCHEDULE_ID = "fleet-job-producer";
+
+/**
+ * Cron cadence the producer runs on by default. Hourly at :40 mirrors the
+ * legacy in-process `d6-all-pills-e2e` probe cadence (config/probes/
+ * d6-all-pills-e2e.yml) so the fleet run rhythm matches what it replaces.
+ */
+export const DEFAULT_PRODUCER_CRON = "40 * * * *";
+
+/** Default result-consumer poll cadence — sub-minute so results land fast. */
+export const DEFAULT_CONSUMER_INTERVAL_MS = 5_000;
+
+/** Default fleet-health poll cadence — finer than cron so dead workers reclaim fast. */
+export const DEFAULT_FLEET_HEALTH_INTERVAL_MS = 15_000;
+
+/**
+ * Resolve a swept `PoolCommError` to the dashboard status-row key (`d6:<slug>`)
+ * the overlay must land on (REQ-B). A bare swept error carries the `jobId` but
+ * not the `probe_key`, so the wiring slot injects a resolver (a `probe_jobs`
+ * row lookup) that maps it. Return null/undefined to SKIP an error whose key
+ * can't be resolved (e.g. the row vanished). The control-plane owns no PB, so
+ * this stays injected.
+ */
+export type SweepAggregateKeyResolver = (
+  commError: PoolCommError,
+) => Promise<string | null | undefined> | string | null | undefined;
+
+/**
+ * Read the CURRENT dashboard status-row colour for an aggregate key (REQ-B).
+ * Both comm-error surfacing legs call this BEFORE writing the crash overlay so
+ * the overlaid row PRESERVES the last observed colour (a `red` service whose
+ * worker crashes stays `red` + unreachable) instead of stomping it to green.
+ * Returns `undefined`/`null` for a never-observed key (no row), in which case
+ * the aggregator writes the no-data ("error") path — never a fabricated green.
+ * The control-plane owns no PB, so this stays injected.
+ */
+export type PriorStateResolver = (
+  aggregateKey: string,
+) => Promise<State | null | undefined> | State | null | undefined;
+
+export interface ControlPlaneDeps {
+  /** Job producer (S4). Injected pre-built so tests pass a fake. */
+  producer: JobProducer;
+  /** Result consumer (worker->aggregator bridge). Injected pre-built. */
+  consumer: ResultConsumer;
+  /** The harness scheduler — the producer's tick registers as a handler. */
+  scheduler: Scheduler;
+  logger: Logger;
+  /** Producer cron cadence. Default `DEFAULT_PRODUCER_CRON`. */
+  producerCron?: string;
+  /** Result-consumer poll interval (ms). Default `DEFAULT_CONSUMER_INTERVAL_MS`. */
+  consumerIntervalMs?: number;
+  /**
+   * The S5 aggregator. Required to surface dead-worker comm errors (REQ-B) via
+   * the producer sweep + fleet-health legs. Optional: when omitted the
+   * control-plane is the pure produce/consume assembly (the consumer holds its
+   * own aggregator reference), and the comm-error surfacing legs are inert.
+   */
+  aggregator?: ResultAggregator;
+  /**
+   * The S10 fleet-health monitor. When injected, the control-plane runs it on
+   * its own interval and feeds reclaimed-worker comm errors to the aggregator
+   * (REQ-B). Optional — omit to leave fleet-health unattached.
+   */
+  fleetHealth?: FleetHealthMonitor;
+  /** Fleet-health poll interval (ms). Default `DEFAULT_FLEET_HEALTH_INTERVAL_MS`. */
+  fleetHealthIntervalMs?: number;
+  /**
+   * Resolve a swept `PoolCommError` to its `d6:<slug>` dashboard key (REQ-B).
+   * Required for the producer-sweep surfacing leg (a bare swept error lacks the
+   * key); omit when the producer does not forward swept errors here.
+   */
+  resolveSweepAggregateKey?: SweepAggregateKeyResolver;
+  /**
+   * Read the current status-row colour for an aggregate key so the crash
+   * overlay preserves it (REQ-B) instead of stomping it to green. Optional —
+   * when omitted, both legs treat every key as never-observed and the
+   * aggregator writes the no-data ("error") path rather than fabricating green.
+   */
+  resolvePriorState?: PriorStateResolver;
+  /** Injectable timer scheduler (tests). Defaults to setInterval. */
+  setIntervalImpl?: typeof setInterval;
+  /** Injectable timer canceller (tests). Defaults to clearInterval. */
+  clearIntervalImpl?: typeof clearInterval;
+}
+
+/** A running control-plane: producer registered + consumer loop ticking. */
+export interface ControlPlane {
+  /** Start the producer + register its scheduler tick + start the consumer loop. */
+  start(): void;
+  /** Stop the consumer loop, unregister the producer tick, stop the producer. */
+  stop(): Promise<void>;
+  /** Run one consumer cycle NOW (exposed for tests + opportunistic drains). */
+  consumeOnce(): Promise<void>;
+  /**
+   * Surface the producer's swept `worker-crashed-mid-job` comm errors onto the
+   * dashboard (REQ-B). This is the sink the producer's `onSweepCommErrors`
+   * forwards to: it resolves each error's `d6:<slug>` key (via
+   * `resolveSweepAggregateKey`) and writes the overlay through the aggregator.
+   * A no-op when no aggregator/resolver is injected. Best-effort — never throws.
+   */
+  surfaceSweepCommErrors(commErrors: PoolCommError[]): Promise<void>;
+  /**
+   * Run one fleet-health cycle NOW and surface its reclaimed-worker comm errors
+   * (REQ-B) onto the dashboard via the aggregator. A no-op when no fleet-health
+   * monitor is injected. Exposed for tests + opportunistic checks; the start()
+   * loop calls this on the fleet-health interval. Best-effort — never throws.
+   */
+  checkFleetHealthOnce(): Promise<void>;
+}
+
+/**
+ * Build the producer from its raw deps (queue + enumerator). A convenience for
+ * `runControlPlane` so it doesn't import job-producer directly; tests build the
+ * producer themselves and use `createControlPlane`.
+ */
+export function buildJobProducer(deps: {
+  queue: Parameters<typeof createJobProducer>[0]["queue"];
+  enumerate: ServiceEnumerator;
+  logger: Logger;
+  /**
+   * Sink the producer forwards its lease-sweep comm errors to (REQ-B). The
+   * wiring slot passes `controlPlane.surfaceSweepCommErrors` so a swept
+   * (crashed/lease-expired) job's "unreachable" overlay reaches the dashboard.
+   * Omit to keep the legacy log-only behaviour.
+   */
+  onSweepCommErrors?: SweepCommErrorSink;
+}): JobProducer {
+  return createJobProducer({
+    queue: deps.queue,
+    enumerate: deps.enumerate,
+    logger: deps.logger,
+    ...(deps.onSweepCommErrors
+      ? { onSweepCommErrors: deps.onSweepCommErrors }
+      : {}),
+  });
+}
+
+export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
+  const { producer, consumer, scheduler, logger } = deps;
+  const producerCron = deps.producerCron ?? DEFAULT_PRODUCER_CRON;
+  const consumerIntervalMs =
+    deps.consumerIntervalMs ?? DEFAULT_CONSUMER_INTERVAL_MS;
+  const fleetHealthIntervalMs =
+    deps.fleetHealthIntervalMs ?? DEFAULT_FLEET_HEALTH_INTERVAL_MS;
+  const setIntervalFn = deps.setIntervalImpl ?? setInterval;
+  const clearIntervalFn = deps.clearIntervalImpl ?? clearInterval;
+  const {
+    aggregator,
+    fleetHealth,
+    resolveSweepAggregateKey,
+    resolvePriorState,
+  } = deps;
+
+  /**
+   * Read the current status-row colour for an aggregate key so the crash
+   * overlay preserves it (REQ-B). Best-effort: a missing resolver or a lookup
+   * throw degrades to `undefined` (the never-observed / no-data path) — reading
+   * the prior colour must never abort a surfacing leg.
+   */
+  async function priorStateFor(
+    aggregateKey: string,
+  ): Promise<State | undefined> {
+    if (!resolvePriorState) return undefined;
+    try {
+      return (await resolvePriorState(aggregateKey)) ?? undefined;
+    } catch (err) {
+      logger.warn("fleet.control-plane.prior-state-read-failed", {
+        aggregateKey,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return undefined;
+    }
+  }
+
+  let consumerTimer: ReturnType<typeof setIntervalFn> | undefined;
+  let fleetHealthTimer: ReturnType<typeof setIntervalFn> | undefined;
+  let started = false;
+  /** Guards against overlapping consumer cycles when one runs long. */
+  let consuming = false;
+  /** Guards against overlapping fleet-health cycles when one runs long. */
+  let checkingHealth = false;
+
+  async function runConsumerCycle(): Promise<void> {
+    if (consuming) return;
+    consuming = true;
+    try {
+      const out = await consumer.consumeOnce();
+      if (out.processed > 0 || out.failures > 0) {
+        logger.debug("fleet.control-plane.consumed", {
+          processed: out.processed,
+          failures: out.failures,
+        });
+      }
+    } catch (err) {
+      // consumeOnce never throws by contract, but guard anyway — a consumer
+      // crash must never kill the interval (it would silently stop draining
+      // results). Log and let the next tick retry.
+      logger.error("fleet.control-plane.consume-cycle-failed", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      consuming = false;
+    }
+  }
+
+  /**
+   * Surface the producer's swept comm errors onto the dashboard (REQ-B). Each
+   * bare swept error lacks the dashboard key, so resolve it via the injected
+   * resolver, then write the overlay through the aggregator. Best-effort
+   * per-error: one unresolved/failed error must not block the others.
+   */
+  async function surfaceSweepCommErrors(
+    commErrors: PoolCommError[],
+  ): Promise<void> {
+    if (!aggregator || !resolveSweepAggregateKey) return;
+    for (const commError of commErrors) {
+      try {
+        const aggregateKey = await resolveSweepAggregateKey(commError);
+        if (!aggregateKey) {
+          logger.warn("fleet.control-plane.sweep-commerror-unresolved", {
+            jobId: commError.jobId,
+            workerId: commError.workerId,
+          });
+          continue;
+        }
+        // Read the CURRENT row colour first so the overlay PRESERVES it (a red
+        // service that crashes stays red) instead of stomping it to green.
+        const lastKnownState = await priorStateFor(aggregateKey);
+        await aggregator.aggregateCommError({
+          commError,
+          aggregateKey,
+          ...(lastKnownState !== undefined ? { lastKnownState } : {}),
+        });
+        logger.debug("fleet.control-plane.sweep-commerror-surfaced", {
+          jobId: commError.jobId,
+          aggregateKey,
+          kind: commError.kind,
+        });
+      } catch (err) {
+        logger.warn("fleet.control-plane.sweep-commerror-surface-failed", {
+          jobId: commError.jobId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  /**
+   * Run one fleet-health cycle and surface its reclaimed-worker comm errors
+   * (REQ-B). Each `reclaimedOverlays` entry already carries the dashboard key
+   * (the reclaimed job's `probe_key`), so no resolver is needed. The monitor's
+   * `checkOnce` never throws by contract, but the per-overlay aggregate write
+   * might, so each is best-effort.
+   */
+  async function runFleetHealthCycle(): Promise<void> {
+    if (!fleetHealth) return;
+    if (checkingHealth) return;
+    checkingHealth = true;
+    try {
+      const result = await fleetHealth.checkOnce();
+      if (!aggregator) return;
+      for (const overlay of result.reclaimedOverlays) {
+        try {
+          // Guard an empty aggregate key (the reclaimed job's probe_key) before
+          // writing — mirror the sweep leg's `!aggregateKey` skip so a blank key
+          // never lands a status row keyed "".
+          if (!overlay.aggregateKey) {
+            logger.warn("fleet.control-plane.health-commerror-no-key", {
+              jobId: overlay.commError.jobId,
+              workerId: overlay.commError.workerId,
+            });
+            continue;
+          }
+          // Read the CURRENT row colour first so the overlay PRESERVES it
+          // instead of stomping it to green.
+          const lastKnownState = await priorStateFor(overlay.aggregateKey);
+          await aggregator.aggregateCommError({
+            commError: overlay.commError,
+            aggregateKey: overlay.aggregateKey,
+            ...(lastKnownState !== undefined ? { lastKnownState } : {}),
+          });
+          logger.debug("fleet.control-plane.health-commerror-surfaced", {
+            jobId: overlay.commError.jobId,
+            aggregateKey: overlay.aggregateKey,
+            kind: overlay.commError.kind,
+          });
+        } catch (err) {
+          logger.warn("fleet.control-plane.health-commerror-surface-failed", {
+            jobId: overlay.commError.jobId,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    } catch (err) {
+      // checkOnce never throws by contract, but guard anyway — a monitor crash
+      // must never kill the interval (it would silently stop reclaiming).
+      logger.error("fleet.control-plane.health-cycle-failed", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      checkingHealth = false;
+    }
+  }
+
+  return {
+    start() {
+      if (started) return;
+      started = true;
+      producer.start();
+      // The producer's tick is the scheduler handler — cron cadence drives
+      // runs; the tick also gates sweepExpired internally.
+      scheduler.register({
+        id: FLEET_PRODUCER_SCHEDULE_ID,
+        cron: producerCron,
+        // The scheduler handler returns void|RunSummary; the producer's tick
+        // returns a richer TickResult, so adapt by awaiting + discarding it
+        // (the producer logs its own per-tick outcome). Errors are swallowed
+        // by the scheduler's per-tick isolation, same as legacy handlers.
+        handler: async () => {
+          await producer.tick();
+        },
+      });
+      // The consumer runs on its own finer interval so result latency isn't
+      // bounded by the producer's cron cadence.
+      consumerTimer = setIntervalFn(() => {
+        void runConsumerCycle();
+      }, consumerIntervalMs);
+      // When a fleet-health monitor is injected, run it on its OWN interval
+      // (finer than cron) so a dead worker's jobs are reclaimed promptly and
+      // its "unreachable" overlay reaches the dashboard (REQ-B).
+      if (fleetHealth) {
+        fleetHealthTimer = setIntervalFn(() => {
+          void runFleetHealthCycle();
+        }, fleetHealthIntervalMs);
+      }
+      logger.info("fleet.control-plane.started", {
+        producerCron,
+        consumerIntervalMs,
+        fleetHealth: fleetHealth !== undefined,
+      });
+    },
+
+    async stop() {
+      if (!started) return;
+      started = false;
+      if (consumerTimer !== undefined) {
+        clearIntervalFn(consumerTimer);
+        consumerTimer = undefined;
+      }
+      if (fleetHealthTimer !== undefined) {
+        clearIntervalFn(fleetHealthTimer);
+        fleetHealthTimer = undefined;
+      }
+      await scheduler.unregister(FLEET_PRODUCER_SCHEDULE_ID).catch((err) =>
+        logger.warn("fleet.control-plane.unregister-failed", {
+          err: err instanceof Error ? err.message : String(err),
+        }),
+      );
+      await producer.stop();
+      logger.info("fleet.control-plane.stopped");
+    },
+
+    async consumeOnce() {
+      await runConsumerCycle();
+    },
+
+    async surfaceSweepCommErrors(commErrors) {
+      await surfaceSweepCommErrors(commErrors);
+    },
+
+    async checkFleetHealthOnce() {
+      await runFleetHealthCycle();
+    },
+  };
+}

--- a/showcase/harness/src/fleet/control-plane/fleet-health.test.ts
+++ b/showcase/harness/src/fleet/control-plane/fleet-health.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createFleetHealthMonitor,
+  DEFAULT_WORKER_STALE_AFTER_MS,
+} from "./fleet-health.js";
+import type {
+  PbClient,
+  ListOpts,
+  ListResult,
+} from "../../storage/pb-client.js";
+import type { JobClaimClient, JobView, ReleaseResult } from "../job-claim.js";
+import type { Logger } from "../../types/index.js";
+
+/**
+ * Pins the control-plane FLEET-HEALTH monitor (S10): a stale worker's in-flight
+ * jobs are reclaimed (released back to pending via the S0 CAS) and a
+ * `worker-crashed-mid-job` comm error is emitted per reclaimed job (REQ-B); a
+ * healthy worker is left entirely untouched. Restart is a best-effort injected
+ * hook (default no-op locally). All collaborators are injected fakes — no
+ * PocketBase, no Railway, no real timers.
+ */
+
+const SILENT_LOGGER: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+interface WorkerRow {
+  id: string;
+  worker_id: string;
+  last_heartbeat_at: string;
+  current_job_id?: string;
+}
+
+function jobView(over: Partial<JobView> = {}): JobView {
+  return {
+    id: "j1",
+    probe_key: "d6:langgraph-python",
+    status: "claimed",
+    claimed_by: "worker-dead",
+    lease_expires_at: "2999-01-01T00:00:00.000Z",
+    version: 2,
+    ...over,
+  };
+}
+
+/**
+ * Fake PB serving two collections: `workers` (the roster) and `probe_jobs` (the
+ * in-flight queue rows). The job filter honors the monitor's
+ * `(status = "claimed" || status = "running") && claimed_by = "<id>"` shape so
+ * only the targeted worker's in-flight jobs are returned.
+ */
+function makeFakePb(opts: { workers: WorkerRow[]; jobs: JobView[] }): {
+  pb: PbClient;
+  listCalls: Array<{ collection: string; opts: ListOpts }>;
+} {
+  const listCalls: Array<{ collection: string; opts: ListOpts }> = [];
+  const unsupported = (n: string) => () => {
+    throw new Error(`fake-pb: ${n} not implemented`);
+  };
+  const pb = {
+    async list<T>(
+      collection: string,
+      listOpts: ListOpts = {},
+    ): Promise<ListResult<T>> {
+      listCalls.push({ collection, opts: listOpts });
+      let items: unknown[];
+      if (collection === "workers") {
+        items = opts.workers;
+      } else {
+        const filter = listOpts.filter ?? "";
+        const statuses = [...filter.matchAll(/status\s*=\s*"(\w+)"/g)].map(
+          (m) => m[1],
+        );
+        const wantStatus = new Set(statuses);
+        const ownerMatch = /claimed_by\s*=\s*"([^"]*)"/.exec(filter);
+        const wantOwner = ownerMatch?.[1];
+        items = opts.jobs.filter((j) => {
+          if (wantStatus.size > 0 && !wantStatus.has(j.status)) return false;
+          if (wantOwner !== undefined && j.claimed_by !== wantOwner) {
+            return false;
+          }
+          return true;
+        });
+      }
+      return {
+        page: 1,
+        perPage: listOpts.perPage ?? items.length,
+        totalPages: 1,
+        totalItems: items.length,
+        items: items as T[],
+      };
+    },
+    getOne: unsupported("getOne"),
+    getFirst: unsupported("getFirst"),
+    create: unsupported("create"),
+    update: unsupported("update"),
+    upsertByField: unsupported("upsertByField"),
+    delete: unsupported("delete"),
+    deleteByFilter: unsupported("deleteByFilter"),
+    health: unsupported("health"),
+    createBackup: unsupported("createBackup"),
+    downloadBackup: unsupported("downloadBackup"),
+    deleteBackup: unsupported("deleteBackup"),
+  } as unknown as PbClient;
+  return { pb, listCalls };
+}
+
+/**
+ * Fake claim CAS. `releaseJob` records each call and returns `released:true`
+ * unless the job id is in `losing` (a sweep/late-report race won by a peer).
+ */
+function makeFakeClaim(losing: Set<string> = new Set()): JobClaimClient & {
+  releases: Array<{ jobId: string; workerId: string; status: string }>;
+} {
+  const releases: Array<{
+    jobId: string;
+    workerId: string;
+    status: string;
+  }> = [];
+  return {
+    releases,
+    async claimJob() {
+      throw new Error("fake-claim: claimJob not used by fleet-health");
+    },
+    async renewLease() {
+      throw new Error("fake-claim: renewLease not used by fleet-health");
+    },
+    async releaseJob(
+      jobId: string,
+      workerId: string,
+      status: "done" | "failed" | "pending",
+    ): Promise<ReleaseResult> {
+      releases.push({ jobId, workerId, status });
+      return { released: !losing.has(jobId) };
+    },
+  } as JobClaimClient & {
+    releases: Array<{ jobId: string; workerId: string; status: string }>;
+  };
+}
+
+const NOW = Date.parse("2026-06-04T00:10:00.000Z");
+const FRESH = new Date(NOW - 1_000).toISOString();
+const STALE = new Date(
+  NOW - DEFAULT_WORKER_STALE_AFTER_MS - 1_000,
+).toISOString();
+
+describe("createFleetHealthMonitor.checkOnce", () => {
+  it("reclaims a stale worker's in-flight jobs and emits a comm error per job", async () => {
+    const { pb } = makeFakePb({
+      workers: [
+        { id: "w1", worker_id: "worker-dead", last_heartbeat_at: STALE },
+      ],
+      jobs: [
+        jobView({ id: "j1", claimed_by: "worker-dead", status: "claimed" }),
+        jobView({ id: "j2", claimed_by: "worker-dead", status: "running" }),
+      ],
+    });
+    const claim = makeFakeClaim();
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+    });
+
+    const out = await monitor.checkOnce();
+
+    expect(out.unhealthy).toBe(1);
+    expect(out.online).toBe(0);
+    expect(out.reclaimed).toBe(2);
+    // Both jobs released back to pending on behalf of the dead worker.
+    expect(claim.releases).toEqual([
+      { jobId: "j1", workerId: "worker-dead", status: "pending" },
+      { jobId: "j2", workerId: "worker-dead", status: "pending" },
+    ]);
+    // One worker-crashed-mid-job comm error per reclaimed job (REQ-B).
+    expect(out.commErrors).toHaveLength(2);
+    for (const ce of out.commErrors) {
+      expect(ce.kind).toBe("worker-crashed-mid-job");
+      expect(ce.workerId).toBe("worker-dead");
+    }
+    expect(out.commErrors.map((c) => c.jobId).sort()).toEqual(["j1", "j2"]);
+  });
+
+  it("[REQ-B] pairs each reclaimed comm error with the job's probe_key as the dashboard overlay key", async () => {
+    // The bare PoolCommError carries jobId/workerId but NOT the d6:<slug>
+    // dashboard key the overlay must land on. reclaimedOverlays pairs each
+    // error with the reclaimed job's probe_key so the control-plane can feed
+    // it to the aggregator without a second PB lookup. Previously this pairing
+    // did not exist, so the overlay key was unrecoverable downstream (the red
+    // state: the dashboard overlay was never written for the worker-death leg).
+    const { pb } = makeFakePb({
+      workers: [
+        { id: "w1", worker_id: "worker-dead", last_heartbeat_at: STALE },
+      ],
+      jobs: [
+        jobView({
+          id: "j1",
+          claimed_by: "worker-dead",
+          status: "claimed",
+          probe_key: "d6:langgraph-python",
+        }),
+        jobView({
+          id: "j2",
+          claimed_by: "worker-dead",
+          status: "running",
+          probe_key: "d6:crewai",
+        }),
+      ],
+    });
+    const claim = makeFakeClaim();
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+    });
+
+    const out = await monitor.checkOnce();
+
+    expect(out.reclaimedOverlays).toHaveLength(2);
+    // Each overlay pairs the comm error with the job's d6:<slug> dashboard key.
+    const byJob = new Map(
+      out.reclaimedOverlays.map((o) => [o.commError.jobId, o.aggregateKey]),
+    );
+    expect(byJob.get("j1")).toBe("d6:langgraph-python");
+    expect(byJob.get("j2")).toBe("d6:crewai");
+    for (const o of out.reclaimedOverlays) {
+      expect(o.commError.kind).toBe("worker-crashed-mid-job");
+    }
+  });
+
+  it("leaves a healthy (fresh-heartbeat) worker untouched — no release, no comm error", async () => {
+    const { pb } = makeFakePb({
+      workers: [
+        { id: "w1", worker_id: "worker-live", last_heartbeat_at: FRESH },
+      ],
+      jobs: [
+        jobView({ id: "j1", claimed_by: "worker-live", status: "running" }),
+      ],
+    });
+    const claim = makeFakeClaim();
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+    });
+
+    const out = await monitor.checkOnce();
+
+    expect(out.online).toBe(1);
+    expect(out.unhealthy).toBe(0);
+    expect(out.reclaimed).toBe(0);
+    expect(out.commErrors).toEqual([]);
+    expect(claim.releases).toEqual([]);
+  });
+
+  it("fires the best-effort restart hook once per stale worker after reclaiming", async () => {
+    const { pb } = makeFakePb({
+      workers: [
+        { id: "w1", worker_id: "worker-dead", last_heartbeat_at: STALE },
+      ],
+      jobs: [
+        jobView({ id: "j1", claimed_by: "worker-dead", status: "claimed" }),
+      ],
+    });
+    const claim = makeFakeClaim();
+    const restartWorker = vi.fn(async () => {});
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+      restartWorker,
+    });
+
+    const out = await monitor.checkOnce();
+
+    expect(out.restartsAttempted).toBe(1);
+    expect(restartWorker).toHaveBeenCalledTimes(1);
+    expect(restartWorker).toHaveBeenCalledWith("worker-dead");
+    // Reclaim happened before the restart hook.
+    expect(out.reclaimed).toBe(1);
+  });
+
+  it("does not count a job another sweeper already reclaimed (release lost the race)", async () => {
+    const { pb } = makeFakePb({
+      workers: [
+        { id: "w1", worker_id: "worker-dead", last_heartbeat_at: STALE },
+      ],
+      jobs: [
+        jobView({ id: "j1", claimed_by: "worker-dead", status: "claimed" }),
+        jobView({ id: "j2", claimed_by: "worker-dead", status: "running" }),
+      ],
+    });
+    // j1's release loses the CAS race (producer sweepExpired won it first).
+    const claim = makeFakeClaim(new Set(["j1"]));
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+    });
+
+    const out = await monitor.checkOnce();
+
+    expect(out.reclaimed).toBe(1);
+    expect(out.commErrors).toHaveLength(1);
+    expect(out.commErrors[0]?.jobId).toBe("j2");
+  });
+
+  it("never throws (and processes the remaining workers) when ONE worker's in-flight job read fails", async () => {
+    // checkOnce is documented "never throws". The per-worker probe_jobs read
+    // (pb.list for the worker's claimed/running jobs) is NOT the roster read —
+    // a filter error or transient PB blip on ONE worker's job read must not
+    // abort the whole cycle, skipping every subsequent worker's reclamation.
+    const unsupported = (n: string) => () => {
+      throw new Error(`fake-pb: ${n} not implemented`);
+    };
+    const workers: WorkerRow[] = [
+      // First stale worker: its job read throws.
+      { id: "w1", worker_id: "worker-boom", last_heartbeat_at: STALE },
+      // Second stale worker: its job read succeeds → must still be reclaimed.
+      { id: "w2", worker_id: "worker-dead", last_heartbeat_at: STALE },
+    ];
+    const goodJob = jobView({
+      id: "j-good",
+      claimed_by: "worker-dead",
+      status: "claimed",
+      probe_key: "d6:crewai",
+    });
+    const pb = {
+      async list<T>(
+        collection: string,
+        listOpts: ListOpts = {},
+      ): Promise<ListResult<T>> {
+        if (collection === "workers") {
+          return {
+            page: 1,
+            perPage: workers.length,
+            totalPages: 1,
+            totalItems: workers.length,
+            items: workers as unknown as T[],
+          };
+        }
+        // probe_jobs read: throw for worker-boom, serve worker-dead's job.
+        const filter = listOpts.filter ?? "";
+        if (filter.includes("worker-boom")) {
+          throw new Error("pb list filter error for worker-boom");
+        }
+        const items = filter.includes("worker-dead") ? [goodJob] : [];
+        return {
+          page: 1,
+          perPage: items.length,
+          totalPages: 1,
+          totalItems: items.length,
+          items: items as unknown as T[],
+        };
+      },
+      getOne: unsupported("getOne"),
+      getFirst: unsupported("getFirst"),
+      create: unsupported("create"),
+      update: unsupported("update"),
+      upsertByField: unsupported("upsertByField"),
+      delete: unsupported("delete"),
+      deleteByFilter: unsupported("deleteByFilter"),
+      health: unsupported("health"),
+      createBackup: unsupported("createBackup"),
+      downloadBackup: unsupported("downloadBackup"),
+      deleteBackup: unsupported("deleteBackup"),
+    } as unknown as PbClient;
+    const claim = makeFakeClaim();
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+    });
+
+    // Must not throw, and must process the SECOND worker despite the first's
+    // job read failing.
+    const out = await monitor.checkOnce();
+
+    expect(out.unhealthy).toBe(2);
+    // Only worker-dead's job was reclaimable (worker-boom's read failed).
+    expect(out.reclaimed).toBe(1);
+    expect(out.commErrors).toHaveLength(1);
+    expect(out.commErrors[0]?.workerId).toBe("worker-dead");
+    expect(out.reclaimedOverlays).toHaveLength(1);
+    expect(out.reclaimedOverlays[0]?.aggregateKey).toBe("d6:crewai");
+    expect(claim.releases).toEqual([
+      { jobId: "j-good", workerId: "worker-dead", status: "pending" },
+    ]);
+  });
+
+  it("never throws when the roster read fails — returns an empty cycle", async () => {
+    const unsupported = (n: string) => () => {
+      throw new Error(`fake-pb: ${n} not implemented`);
+    };
+    const pb = {
+      async list(): Promise<never> {
+        throw new Error("pb down");
+      },
+      getOne: unsupported("getOne"),
+      getFirst: unsupported("getFirst"),
+      create: unsupported("create"),
+      update: unsupported("update"),
+      upsertByField: unsupported("upsertByField"),
+      delete: unsupported("delete"),
+      deleteByFilter: unsupported("deleteByFilter"),
+      health: unsupported("health"),
+      createBackup: unsupported("createBackup"),
+      downloadBackup: unsupported("downloadBackup"),
+      deleteBackup: unsupported("deleteBackup"),
+    } as unknown as PbClient;
+    const claim = makeFakeClaim();
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+    });
+
+    const out = await monitor.checkOnce();
+    expect(out).toEqual({
+      online: 0,
+      unhealthy: 0,
+      reclaimed: 0,
+      commErrors: [],
+      reclaimedOverlays: [],
+      restartsAttempted: 0,
+    });
+    expect(claim.releases).toEqual([]);
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/fleet-health.ts
+++ b/showcase/harness/src/fleet/control-plane/fleet-health.ts
@@ -1,0 +1,378 @@
+/**
+ * Control-plane FLEET-HEALTH monitor (BLITZ S10).
+ *
+ * ── WHERE THIS SITS ────────────────────────────────────────────────────
+ * The worker self-register slot (S9, `worker/registration.ts`) UPSERTS one row
+ * per live worker into the `workers` collection (migration
+ * `1779989600_create_workers.js`) and heartbeats its `last_heartbeat_at` on a
+ * ~75s cadence. This module is the CONTROL-PLANE leg that reads those rows back:
+ * it derives each worker's `WorkerHealthState` from its heartbeat age
+ * (`isWorkerStale`, contracts.ts) and, for any worker that has gone STALE /
+ * OFFLINE, REQUEUES that worker's in-flight jobs so a dead worker's claimed work
+ * doesn't sit wedged until its lease independently expires.
+ *
+ * ── DETECT → REQUEUE → RESTART ─────────────────────────────────────────
+ *   DETECT  — list the `workers` roster, compute liveness per row from
+ *             `last_heartbeat_at` vs `staleAfterMs`. A row fresher than the
+ *             window is `online` and left untouched.
+ *   REQUEUE — for a stale/offline worker, find its still-in-flight
+ *             (`claimed`/`running`) `probe_jobs` rows (`claimed_by` = that
+ *             worker) and release each back to `pending` via the SAME S0
+ *             `releaseJob(jobId, deadWorker, "pending")` CAS the queue's
+ *             `sweepExpired` uses — the CAS authorizes on `claimed_by` (still
+ *             the dead worker), so the release is atomic and on-behalf-of the
+ *             dead holder. Each reclaimed job emits a `worker-crashed-mid-job`
+ *             `PoolCommError` (REQ-B) so the dashboard surfaces "couldn't reach
+ *             the pool" distinctly from a probe red.
+ *   RESTART — in staging a wedged worker is recovered by a Railway
+ *             `serviceInstanceRedeploy`; that is injected as a best-effort
+ *             `restartWorker?` hook (env/guarded by the wiring slot). Locally
+ *             (N=1, docker) the default is a NO-OP — docker / the worker's own
+ *             relaunch handles recovery, so local runs need no Railway wiring.
+ *
+ * ── RELATIONSHIP TO THE PRODUCER'S sweepExpired ────────────────────────
+ * The producer's `sweepExpired` (S4) reclaims jobs whose LEASE has expired —
+ * it is lease-timeout-driven and worker-agnostic. fleet-health is the
+ * HEARTBEAT-driven complement: a worker can stop heartbeating (crashed,
+ * wedged, OOM-killed) while a just-renewed lease still has time on the clock,
+ * which `sweepExpired` would not reclaim until that lease lapses. fleet-health
+ * detects the dead worker FROM ITS HEARTBEAT and reclaims its jobs immediately,
+ * cutting the dead-worker-to-requeue latency from "lease window" to "stale
+ * window". The two paths are idempotent against each other: both release via
+ * the same S0 CAS, and a row already reclaimed by one returns `released:false`
+ * to the other (a benign no-op race, logged at debug).
+ *
+ * ── INJECTION ──────────────────────────────────────────────────────────
+ * Everything is injected (PB read, the S0 claim CAS, clock, staleness window,
+ * the restart hook) so the monitor is unit-testable with fakes and owns no
+ * PocketBase / Railway of its own — `runControlPlane` constructs the real deps.
+ */
+
+import type { Logger } from "../../types/index.js";
+import type { PbClient } from "../../storage/pb-client.js";
+import type { JobClaimClient, JobView } from "../job-claim.js";
+import { PROBE_JOBS_COLLECTION } from "../queue-client.js";
+import {
+  WORKERS_COLLECTION,
+  isWorkerStale,
+  type PoolCommError,
+  type WorkerHealthState,
+} from "../contracts.js";
+
+/**
+ * Default staleness window: a worker whose `last_heartbeat_at` is older than
+ * this is treated as stale/offline and its in-flight jobs are reclaimed. Sized
+ * at ~2.4x the default ~75s heartbeat cadence (DEFAULT_WORKER_HEARTBEAT_MS) so a
+ * single missed beat (e.g. a slow PB write) doesn't flap a healthy worker to
+ * stale — it takes two-plus consecutive missed beats. Env-overridable by the
+ * wiring slot via WORKER_STALE_AFTER_MS.
+ */
+export const DEFAULT_WORKER_STALE_AFTER_MS = 180_000;
+
+/** Max worker rows scanned per monitor cycle — bounds the roster read cost. */
+const WORKERS_PAGE = 100;
+
+/** Max in-flight job rows reclaimed per worker per cycle — bounds the scan. */
+const RECLAIM_PAGE = 100;
+
+/**
+ * The persisted `workers` row shape fleet-health reads. Snake-case columns as
+ * the PB records API returns them (see the create_workers migration). Only the
+ * fields fleet-health consumes are typed; the capacity gauges are ignored here.
+ */
+interface WorkerRecord {
+  id: string;
+  worker_id: string;
+  last_heartbeat_at: string;
+  current_job_id?: string;
+}
+
+/**
+ * Best-effort hook to RESTART a wedged worker (staging: Railway
+ * `serviceInstanceRedeploy`). Invoked once per detected stale/offline worker
+ * after the reclaim attempt (which may have reclaimed zero jobs). MUST never
+ * throw into the monitor loop — the
+ * monitor wraps it, but the implementation should also be self-contained
+ * best-effort. The default is a no-op (local docker handles recovery).
+ */
+export type RestartWorkerHook = (workerId: string) => void | Promise<void>;
+
+/**
+ * A reclaimed job's comm error paired with the dashboard status-row key the
+ * overlay must be written onto (REQ-B). A bare `PoolCommError` carries the
+ * `jobId`/`workerId` but NOT the `probe_key` the dashboard reads, so we pair
+ * each synthesized error with the reclaimed job's `aggregateKey` (its
+ * `probe_key`, i.e. the `d6:<slug>` aggregate row) so the control-plane can
+ * hand it straight to `ResultAggregator.aggregateCommError` without a
+ * second PB lookup.
+ */
+export interface ReclaimedCommError {
+  /** The synthesized `worker-crashed-mid-job` comm error. */
+  commError: PoolCommError;
+  /** The reclaimed job's `probe_key` — the `d6:<slug>` dashboard status-row key. */
+  aggregateKey: string;
+}
+
+/** Outcome of one `checkOnce()` monitor cycle. */
+export interface FleetHealthResult {
+  /** Workers whose heartbeat is fresh (left untouched). */
+  online: number;
+  /** Workers detected stale/offline this cycle. */
+  unhealthy: number;
+  /** In-flight jobs reclaimed (released back to pending) this cycle. */
+  reclaimed: number;
+  /** Comm errors synthesized for the reclaimed (crashed-worker) jobs. */
+  commErrors: PoolCommError[];
+  /**
+   * The reclaimed-job comm errors paired with the dashboard status-row key the
+   * overlay must land on (REQ-B). One entry per entry in `commErrors`, in the
+   * same order — the control-plane feeds these to the aggregator so a crashed
+   * worker's "unreachable" overlay actually reaches the dashboard.
+   */
+  reclaimedOverlays: ReclaimedCommError[];
+  /** Restart-hook invocations attempted this cycle. */
+  restartsAttempted: number;
+}
+
+export interface FleetHealthDeps {
+  pb: PbClient;
+  /** S0's atomic claim/release primitive — release-to-pending reclaims jobs. */
+  claim: JobClaimClient;
+  logger: Logger;
+  /** Staleness window (ms). Default `DEFAULT_WORKER_STALE_AFTER_MS`. */
+  staleAfterMs?: number;
+  /** Injectable clock (tests). Returns ms-since-epoch. Defaults to Date.now. */
+  now?: () => number;
+  /**
+   * Best-effort restart hook for a wedged worker (staging Railway redeploy).
+   * Default no-op — local docker / the worker's own relaunch handles recovery.
+   */
+  restartWorker?: RestartWorkerHook;
+}
+
+/** The control-plane's fleet-health monitor — drives the detect/requeue cycle. */
+export interface FleetHealthMonitor {
+  /**
+   * Scan the worker roster, reclaim the in-flight jobs of every stale/offline
+   * worker, and fire the restart hook for each. Returns per-cycle counts. Never
+   * throws — a single bad row / failed reclaim is logged and skipped so one
+   * poison worker can't wedge the whole monitor.
+   */
+  checkOnce(): Promise<FleetHealthResult>;
+}
+
+/** Derive a worker's liveness from its heartbeat age. */
+function deriveHealth(
+  lastHeartbeatAt: string,
+  nowMs: number,
+  staleAfterMs: number,
+): WorkerHealthState {
+  // OFFLINE is a stronger stale: heartbeat older than 2x the window. We don't
+  // act differently on stale vs offline (both reclaim), but the distinction is
+  // surfaced in logs so an operator can tell a briefly-missed-beat worker from
+  // a long-dead one.
+  if (isWorkerStale(lastHeartbeatAt, nowMs, staleAfterMs * 2)) return "offline";
+  if (isWorkerStale(lastHeartbeatAt, nowMs, staleAfterMs)) return "stale";
+  return "online";
+}
+
+export function createFleetHealthMonitor(
+  deps: FleetHealthDeps,
+): FleetHealthMonitor {
+  const { pb, claim, logger } = deps;
+  const staleAfterMs = deps.staleAfterMs ?? DEFAULT_WORKER_STALE_AFTER_MS;
+  const now = deps.now ?? Date.now;
+  // Default restart is a no-op (local docker handles recovery). The wiring slot
+  // injects the Railway serviceInstanceRedeploy hook in staging.
+  const restartWorker: RestartWorkerHook = deps.restartWorker ?? (() => {});
+
+  /**
+   * Reclaim a single stale/offline worker's in-flight jobs: list its
+   * claimed/running `probe_jobs` rows and release each back to pending via the
+   * S0 CAS on behalf of the dead holder, synthesizing one
+   * `worker-crashed-mid-job` comm error per reclaimed job.
+   */
+  async function reclaimWorkerJobs(
+    workerId: string,
+    nowMs: number,
+  ): Promise<{
+    reclaimed: number;
+    commErrors: PoolCommError[];
+    overlays: ReclaimedCommError[];
+  }> {
+    const commErrors: PoolCommError[] = [];
+    const overlays: ReclaimedCommError[] = [];
+    let reclaimed = 0;
+    // The dead worker's still-in-flight jobs. PB lacks an OR-of-equals shortcut,
+    // so filter the two in-flight states + the dead worker's id server-side.
+    // checkOnce is documented "never throws": a filter error or transient
+    // pb.list failure for ONE worker must NOT abort the whole cycle (which would
+    // skip every subsequent worker's reclamation). Treat a failed read as "no
+    // reclaimable jobs for this worker this cycle" — log and return empty so the
+    // monitor moves on to the next worker; the next cycle (or the producer's
+    // sweepExpired) retries this worker.
+    let page: { items: JobView[] };
+    try {
+      page = await pb.list<JobView>(PROBE_JOBS_COLLECTION, {
+        filter: `(status = "claimed" || status = "running") && claimed_by = "${workerId}"`,
+        perPage: RECLAIM_PAGE,
+        skipTotal: true,
+      });
+    } catch (err) {
+      logger.warn("fleet.health.reclaim-list-failed", {
+        workerId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return { reclaimed: 0, commErrors, overlays };
+    }
+    const observedAt = new Date(nowMs).toISOString();
+    for (const row of page.items) {
+      let released: boolean;
+      try {
+        const r = await claim.releaseJob(row.id, workerId, "pending");
+        released = r.released;
+      } catch (err) {
+        // A transport blip on one row must not abort the rest — the next cycle
+        // (or the producer's sweepExpired) retries.
+        logger.warn("fleet.health.reclaim-failed", {
+          workerId,
+          jobId: row.id,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        continue;
+      }
+      if (!released) {
+        // The producer's sweepExpired or a late worker report won the race —
+        // not an error, nothing for us to reclaim on this row.
+        logger.debug("fleet.health.reclaim-skip", {
+          workerId,
+          jobId: row.id,
+        });
+        continue;
+      }
+      reclaimed += 1;
+      const commError: PoolCommError = {
+        kind: "worker-crashed-mid-job",
+        message: `worker ${workerId} went stale (no heartbeat within ${staleAfterMs}ms); re-queued job ${row.id}`,
+        workerId,
+        jobId: row.id,
+        observedAt,
+      };
+      commErrors.push(commError);
+      // Pair the error with the reclaimed job's `probe_key` — the `d6:<slug>`
+      // dashboard status-row key the overlay must land on (REQ-B). The
+      // control-plane feeds this straight to the aggregator with no second PB
+      // lookup, since the JobView we already listed carries `probe_key`.
+      overlays.push({ commError, aggregateKey: row.probe_key });
+      logger.warn("fleet.health.reclaimed", { workerId, jobId: row.id });
+    }
+    return { reclaimed, commErrors, overlays };
+  }
+
+  return {
+    async checkOnce(): Promise<FleetHealthResult> {
+      const nowMs = now();
+      let page: { items: WorkerRecord[] };
+      try {
+        page = await pb.list<WorkerRecord>(WORKERS_COLLECTION, {
+          perPage: WORKERS_PAGE,
+          skipTotal: true,
+        });
+      } catch (err) {
+        // A roster read failure (missing migration, PB blip) must not throw
+        // into the monitor interval — log and return an empty cycle; the
+        // producer's lease-driven sweepExpired still covers reclamation.
+        logger.warn("fleet.health.roster-read-failed", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+        return {
+          online: 0,
+          unhealthy: 0,
+          reclaimed: 0,
+          commErrors: [],
+          reclaimedOverlays: [],
+          restartsAttempted: 0,
+        };
+      }
+
+      let online = 0;
+      let unhealthy = 0;
+      let reclaimed = 0;
+      let restartsAttempted = 0;
+      const commErrors: PoolCommError[] = [];
+      const reclaimedOverlays: ReclaimedCommError[] = [];
+
+      for (const row of page.items) {
+        const workerId = row.worker_id;
+        if (typeof workerId !== "string" || workerId.length === 0) {
+          // A roster row without a usable worker_id can't be joined to claims —
+          // skip it rather than reclaim against an empty owner.
+          logger.warn("fleet.health.row-missing-worker-id", { rowId: row.id });
+          continue;
+        }
+        // M4 N2: an unparseable last_heartbeat_at makes isWorkerStale return
+        // false (treat-unknown-as-not-yet-stale) so a malformed row can't flap
+        // the whole fleet to offline — but a PERSISTENTLY bad timestamp means
+        // this worker silently never gets reclaimed. Warn so the orphaned row is
+        // visible to an operator (the next valid heartbeat clears it).
+        if (
+          typeof row.last_heartbeat_at !== "string" ||
+          Number.isNaN(Date.parse(row.last_heartbeat_at))
+        ) {
+          logger.warn("fleet.health.unparseable-heartbeat", {
+            workerId,
+            lastHeartbeatAt: row.last_heartbeat_at,
+          });
+        }
+        const health = deriveHealth(row.last_heartbeat_at, nowMs, staleAfterMs);
+        if (health === "online") {
+          online += 1;
+          continue;
+        }
+
+        unhealthy += 1;
+        logger.warn("fleet.health.worker-unhealthy", {
+          workerId,
+          health,
+          lastHeartbeatAt: row.last_heartbeat_at,
+          staleAfterMs,
+        });
+
+        const out = await reclaimWorkerJobs(workerId, nowMs);
+        reclaimed += out.reclaimed;
+        commErrors.push(...out.commErrors);
+        reclaimedOverlays.push(...out.overlays);
+
+        // RESTART (best-effort): recover the wedged worker. Default no-op
+        // locally; staging injects the Railway serviceInstanceRedeploy hook.
+        restartsAttempted += 1;
+        try {
+          await restartWorker(workerId);
+        } catch (err) {
+          logger.warn("fleet.health.restart-failed", {
+            workerId,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      if (unhealthy > 0 || reclaimed > 0) {
+        logger.info("fleet.health.cycle", {
+          online,
+          unhealthy,
+          reclaimed,
+          restartsAttempted,
+        });
+      }
+
+      return {
+        online,
+        unhealthy,
+        reclaimed,
+        commErrors,
+        reclaimedOverlays,
+        restartsAttempted,
+      };
+    },
+  };
+}

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1,0 +1,532 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createJobProducer,
+  DEFAULT_SWEEP_INTERVAL_MS,
+  type JobProducer,
+  type ServiceJobSpec,
+} from "./job-producer.js";
+import type {
+  EnqueueJobInput,
+  FleetQueueClient,
+  JobView,
+  PoolCommError,
+  SweepResult,
+} from "../contracts.js";
+import type { Logger } from "../../types/index.js";
+
+/**
+ * Pins the control-plane JOB PRODUCER contract (BLITZ S4):
+ *   - one tick enqueues exactly one job PER SERVICE for the run, all
+ *     sharing a single runId, with correct ServiceJobPayload/ServiceJobMeta;
+ *   - sweepExpired() is invoked on cadence (fake clock + fake queue client);
+ *   - operator-triggered runs stamp `triggered: true` and forward the filter;
+ *   - per-service enqueue failures + enumeration failures are isolated;
+ *   - start()/stop() bracket the producer's lifecycle (the wiring seams).
+ *
+ * All collaborators are injected fakes — no PocketBase, no Railway, no
+ * Chromium (the control-plane runs none). The clock is injected so the
+ * sweep-cadence gate is deterministic.
+ */
+
+const SILENT_LOGGER: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+/**
+ * Fake FleetQueueClient that records every enqueue + sweep call. Only the
+ * producer-facing methods (enqueue, sweepExpired) carry real behavior; the
+ * consumer methods throw if the producer ever touches them (it must not).
+ */
+function makeFakeQueue(opts?: {
+  enqueueImpl?: (input: EnqueueJobInput) => Promise<JobView>;
+  sweepImpl?: (nowMs: number) => Promise<SweepResult>;
+}): FleetQueueClient & {
+  enqueued: EnqueueJobInput[];
+  sweepCalls: number[];
+} {
+  const enqueued: EnqueueJobInput[] = [];
+  const sweepCalls: number[] = [];
+  let jobSeq = 0;
+  return {
+    enqueued,
+    sweepCalls,
+    async enqueue(input: EnqueueJobInput): Promise<JobView> {
+      enqueued.push(input);
+      if (opts?.enqueueImpl) return opts.enqueueImpl(input);
+      jobSeq += 1;
+      return {
+        id: `job-${jobSeq}`,
+        probe_key: input.payload.probeKey,
+        status: "pending",
+        claimed_by: "",
+        lease_expires_at: null,
+        version: 1,
+      };
+    },
+    async sweepExpired(nowMs: number): Promise<SweepResult> {
+      sweepCalls.push(nowMs);
+      if (opts?.sweepImpl) return opts.sweepImpl(nowMs);
+      return { reclaimed: 0, commErrors: [] };
+    },
+    claimNext() {
+      throw new Error("producer must not call claimNext");
+    },
+    renewLease() {
+      throw new Error("producer must not call renewLease");
+    },
+    report() {
+      throw new Error("producer must not call report");
+    },
+  };
+}
+
+function d6Specs(slugs: string[]): ServiceJobSpec[] {
+  return slugs.map((slug) => ({
+    probeKey: `d6:${slug}`,
+    serviceSlug: slug,
+    driverKind: "e2e_d6",
+    driverInputs: { backendUrl: `https://${slug}.example.com` },
+  }));
+}
+
+/** A producer started and ready to tick, with its fake queue exposed. */
+function startedProducer(overrides?: {
+  specs?: ServiceJobSpec[];
+  now?: () => number;
+  sweepIntervalMs?: number;
+  queue?: ReturnType<typeof makeFakeQueue>;
+  runIdFactory?: () => string;
+}): {
+  producer: JobProducer;
+  queue: ReturnType<typeof makeFakeQueue>;
+} {
+  const queue = overrides?.queue ?? makeFakeQueue();
+  const specs =
+    overrides?.specs ?? d6Specs(["langgraph-python", "crewai", "mastra"]);
+  const producer = createJobProducer({
+    queue,
+    enumerate: () => specs,
+    logger: SILENT_LOGGER,
+    ...(overrides?.now ? { now: overrides.now } : {}),
+    ...(overrides?.sweepIntervalMs !== undefined
+      ? { sweepIntervalMs: overrides.sweepIntervalMs }
+      : {}),
+    ...(overrides?.runIdFactory
+      ? { runIdFactory: overrides.runIdFactory }
+      : {}),
+  });
+  producer.start();
+  return { producer, queue };
+}
+
+describe("job-producer — per-service enqueue", () => {
+  it("enqueues exactly one job per enumerated service on a tick", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a", "b", "c"]),
+    });
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(3);
+    expect(queue.enqueued).toHaveLength(3);
+    expect(queue.enqueued.map((e) => e.payload.serviceSlug)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("stamps every job in a tick with the SAME runId (one run = a set of jobs)", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a", "b"]),
+      runIdFactory: () => "run-fixed",
+    });
+    const result = await producer.tick();
+    expect(result.runId).toBe("run-fixed");
+    const runIds = new Set(queue.enqueued.map((e) => e.payload.meta.runId));
+    expect(runIds).toEqual(new Set(["run-fixed"]));
+  });
+
+  it("gives DIFFERENT runIds to two separate ticks (two runs)", async () => {
+    let n = 0;
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      runIdFactory: () => `run-${++n}`,
+    });
+    await producer.tick();
+    await producer.tick();
+    const runIds = queue.enqueued.map((e) => e.payload.meta.runId);
+    expect(runIds).toEqual(["run-1", "run-2"]);
+  });
+
+  it("builds a correct ServiceJobPayload (probeKey/serviceSlug/driverKind/inputs)", async () => {
+    const { producer, queue } = startedProducer({
+      specs: [
+        {
+          probeKey: "d6:langgraph-python",
+          serviceSlug: "langgraph-python",
+          driverKind: "e2e_d6",
+          cellIds: ["shared-state"],
+          driverInputs: { backendUrl: "https://lg.example.com" },
+          priority: 5,
+          leaseSeconds: 600,
+        },
+      ],
+    });
+    await producer.tick();
+    const input = queue.enqueued[0]!;
+    expect(input.payload.probeKey).toBe("d6:langgraph-python");
+    expect(input.payload.serviceSlug).toBe("langgraph-python");
+    expect(input.payload.driverKind).toBe("e2e_d6");
+    expect(input.payload.cellIds).toEqual(["shared-state"]);
+    expect(input.payload.driverInputs).toEqual({
+      backendUrl: "https://lg.example.com",
+    });
+    expect(input.payload.meta.priority).toBe(5);
+    expect(input.leaseSeconds).toBe(600);
+  });
+
+  it("stamps ServiceJobMeta.enqueuedAt from the injected clock", async () => {
+    const fixedMs = Date.parse("2026-06-04T12:00:00.000Z");
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      now: () => fixedMs,
+    });
+    await producer.tick();
+    expect(queue.enqueued[0]!.payload.meta.enqueuedAt).toBe(
+      "2026-06-04T12:00:00.000Z",
+    );
+  });
+
+  it("marks scheduled (cron) ticks as triggered:false", async () => {
+    const { producer, queue } = startedProducer({ specs: d6Specs(["a"]) });
+    await producer.tick();
+    expect(queue.enqueued[0]!.payload.meta.triggered).toBe(false);
+  });
+
+  it("marks operator-triggered runs as triggered:true and forwards the filter", async () => {
+    const seen: Array<{ triggered: boolean; filter?: unknown }> = [];
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: (ctx) => {
+        seen.push({ triggered: ctx.triggered, filter: ctx.filter });
+        return d6Specs(ctx.filter?.slugs ?? ["a"]);
+      },
+      logger: SILENT_LOGGER,
+    });
+    producer.start();
+    await producer.tick({ triggered: true, filter: { slugs: ["crewai"] } });
+    expect(seen[0]).toEqual({
+      triggered: true,
+      filter: { slugs: ["crewai"] },
+    });
+    expect(queue.enqueued[0]!.payload.serviceSlug).toBe("crewai");
+    expect(queue.enqueued[0]!.payload.meta.triggered).toBe(true);
+  });
+
+  it("enqueues nothing when the enumerator returns no services", async () => {
+    const { producer, queue } = startedProducer({ specs: [] });
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(0);
+    expect(queue.enqueued).toHaveLength(0);
+  });
+});
+
+describe("job-producer — failure isolation", () => {
+  it("isolates a per-service enqueue failure (other services still enqueue)", async () => {
+    const queue = makeFakeQueue({
+      enqueueImpl: async (input) => {
+        if (input.payload.serviceSlug === "b") {
+          throw new Error("PB write blip");
+        }
+        return {
+          id: `job-${input.payload.serviceSlug}`,
+          probe_key: input.payload.probeKey,
+          status: "pending",
+          claimed_by: "",
+          lease_expires_at: null,
+          version: 1,
+        };
+      },
+    });
+    const { producer } = startedProducer({
+      specs: d6Specs(["a", "b", "c"]),
+      queue,
+    });
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(2);
+    expect(result.enqueueFailures).toBe(1);
+  });
+
+  it("does not throw when enumeration fails; still attempts the sweep", async () => {
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => {
+        throw new Error("railway discovery down");
+      },
+      logger: SILENT_LOGGER,
+      now: () => 1_000,
+    });
+    producer.start();
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(0);
+    expect(queue.enqueued).toHaveLength(0);
+    // First tick always sweeps (lastSweepAt seeded null) — reclamation must
+    // not be starved by a flaky enumerator.
+    expect(result.sweptExpired).toBe(true);
+    expect(queue.sweepCalls).toEqual([1_000]);
+  });
+
+  it("a failing sweep does not abort job production", async () => {
+    const queue = makeFakeQueue({
+      sweepImpl: async () => {
+        throw new Error("sweep endpoint 500");
+      },
+    });
+    const { producer } = startedProducer({
+      specs: d6Specs(["a", "b"]),
+      queue,
+    });
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(2);
+    expect(result.reclaimed).toBe(0);
+  });
+});
+
+describe("job-producer — sweep cadence", () => {
+  it("sweeps on the FIRST tick (reclaims orphans from a prior crash)", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      now: () => 5_000,
+    });
+    await producer.tick();
+    expect(queue.sweepCalls).toEqual([5_000]);
+  });
+
+  it("does NOT sweep again before the cadence window elapses", async () => {
+    let t = 0;
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      now: () => t,
+      sweepIntervalMs: 30_000,
+    });
+    t = 0;
+    await producer.tick(); // sweeps (first)
+    t = 10_000; // < 30s later
+    await producer.tick(); // must NOT sweep
+    t = 20_000;
+    await producer.tick(); // must NOT sweep
+    expect(queue.sweepCalls).toEqual([0]);
+  });
+
+  it("sweeps again once the cadence window has elapsed", async () => {
+    let t = 0;
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      now: () => t,
+      sweepIntervalMs: 30_000,
+    });
+    t = 0;
+    await producer.tick(); // sweep @0
+    t = 40_000; // > 30s later
+    await producer.tick(); // sweep @40_000
+    expect(queue.sweepCalls).toEqual([0, 40_000]);
+  });
+
+  it("sweeps on EVERY tick when sweepIntervalMs <= 0", async () => {
+    let t = 0;
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      now: () => t,
+      sweepIntervalMs: 0,
+    });
+    t = 1;
+    await producer.tick();
+    t = 2;
+    await producer.tick();
+    t = 3;
+    await producer.tick();
+    expect(queue.sweepCalls).toEqual([1, 2, 3]);
+  });
+
+  it("surfaces reclaimed lease count from the sweep", async () => {
+    const queue = makeFakeQueue({
+      sweepImpl: async (nowMs) => ({
+        reclaimed: 2,
+        commErrors: [
+          {
+            kind: "worker-crashed-mid-job",
+            message: "lease expired",
+            observedAt: new Date(nowMs).toISOString(),
+          },
+        ],
+      }),
+    });
+    const { producer } = startedProducer({ specs: d6Specs(["a"]), queue });
+    const result = await producer.tick();
+    expect(result.reclaimed).toBe(2);
+  });
+
+  it("[REQ-B] forwards the swept worker-crashed comm errors to the onSweepCommErrors sink", async () => {
+    // The whole point of REQ-B: a crashed/lease-expired worker's job is
+    // reclaimed and produces a worker-crashed-mid-job comm error. Previously
+    // the producer only LOGGED commErrors.length and DISCARDED the array, so
+    // the dashboard overlay was never written (the red state). Now the producer
+    // FORWARDS the array to an injected sink the control-plane routes to the
+    // aggregator.
+    const sweptErrors: PoolCommError[] = [
+      {
+        kind: "worker-crashed-mid-job",
+        message: "lease for job j1 expired; re-queued",
+        workerId: "worker-dead",
+        jobId: "j1",
+        observedAt: "2026-06-04T00:00:09.000Z",
+      },
+    ];
+    const queue = makeFakeQueue({
+      sweepImpl: async () => ({ reclaimed: 1, commErrors: sweptErrors }),
+    });
+    const received: PoolCommError[][] = [];
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+      onSweepCommErrors: (errs) => {
+        received.push(errs);
+      },
+    });
+    producer.start();
+    await producer.tick();
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual(sweptErrors);
+  });
+
+  it("[REQ-B] does NOT call the sink when the sweep produced no comm errors", async () => {
+    const queue = makeFakeQueue({
+      sweepImpl: async () => ({ reclaimed: 0, commErrors: [] }),
+    });
+    let calls = 0;
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+      onSweepCommErrors: () => {
+        calls += 1;
+      },
+    });
+    producer.start();
+    await producer.tick();
+    expect(calls).toBe(0);
+  });
+
+  it("[REQ-B] a throwing comm-error sink does not abort job production", async () => {
+    const queue = makeFakeQueue({
+      sweepImpl: async () => ({
+        reclaimed: 1,
+        commErrors: [
+          {
+            kind: "worker-crashed-mid-job",
+            message: "lease expired",
+            jobId: "j1",
+            observedAt: "2026-06-04T00:00:09.000Z",
+          },
+        ],
+      }),
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a", "b"]),
+      logger: SILENT_LOGGER,
+      onSweepCommErrors: () => {
+        throw new Error("aggregator down");
+      },
+    });
+    producer.start();
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(2);
+    expect(result.reclaimed).toBe(1);
+  });
+
+  it("defaults the sweep cadence to DEFAULT_SWEEP_INTERVAL_MS", async () => {
+    let t = 0;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+      now: () => t,
+    });
+    producer.start();
+    t = 0;
+    await producer.tick(); // first sweep @0
+    t = DEFAULT_SWEEP_INTERVAL_MS - 1; // just inside the window
+    await producer.tick(); // no sweep
+    t = DEFAULT_SWEEP_INTERVAL_MS; // window reached
+    await producer.tick(); // sweep
+    expect(queue.sweepCalls).toEqual([0, DEFAULT_SWEEP_INTERVAL_MS]);
+  });
+});
+
+describe("job-producer — lifecycle seams (start/stop/tick)", () => {
+  it("isRunning reflects start()/stop()", async () => {
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => [],
+      logger: SILENT_LOGGER,
+    });
+    expect(producer.isRunning()).toBe(false);
+    producer.start();
+    expect(producer.isRunning()).toBe(true);
+    await producer.stop();
+    expect(producer.isRunning()).toBe(false);
+  });
+
+  it("a tick before start() enqueues nothing", async () => {
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+    });
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(0);
+    expect(queue.enqueued).toHaveLength(0);
+  });
+
+  it("a tick after stop() enqueues nothing (no jobs leak past lifecycle)", async () => {
+    const { producer, queue } = startedProducer({ specs: d6Specs(["a"]) });
+    await producer.stop();
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(0);
+    expect(queue.enqueued).toHaveLength(0);
+  });
+
+  it("does not restart after stop() (start-after-stop is a no-op)", async () => {
+    const { producer } = startedProducer({ specs: d6Specs(["a"]) });
+    await producer.stop();
+    producer.start();
+    expect(producer.isRunning()).toBe(false);
+  });
+
+  it("never touches consumer-side queue methods (claimNext/renewLease/report)", async () => {
+    const queue = makeFakeQueue();
+    const claimSpy = vi.spyOn(queue, "claimNext");
+    const renewSpy = vi.spyOn(queue, "renewLease");
+    const reportSpy = vi.spyOn(queue, "report");
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a", "b"]),
+      logger: SILENT_LOGGER,
+    });
+    producer.start();
+    await producer.tick();
+    expect(claimSpy).not.toHaveBeenCalled();
+    expect(renewSpy).not.toHaveBeenCalled();
+    expect(reportSpy).not.toHaveBeenCalled();
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -1,0 +1,422 @@
+/**
+ * Fleet control-plane JOB PRODUCER (BLITZ S4).
+ *
+ * ── WHAT THIS IS ───────────────────────────────────────────────────────
+ * In the single-process harness a probe "run" is a scheduler tick that, in
+ * one process, enumerates every showcase service for a probe family (d6,
+ * and later other per-service families) and runs each service's cell set
+ * in-process against a pooled Chromium. The pool-fleet splits that into a
+ * CONTROL-PLANE (this code) that owns the scheduler/cron + run triggering
+ * and a set of WORKERS that own Chromium. The control-plane runs NO
+ * Chromium — instead of executing a service's cells, on each tick it
+ * ENQUEUES one per-service JOB (`ServiceJobPayload`) onto the fleet pull
+ * queue via `FleetQueueClient.enqueue`; a worker later claims and runs it.
+ *
+ * ── THE DECIDED UNIT: ONE JOB PER SERVICE ──────────────────────────────
+ * Per-service granularity is the decided partition (see contracts.ts §1).
+ * A single control-plane tick = one logical RUN = a SET of per-service
+ * jobs, all sharing one `ServiceJobMeta.runId` so the aggregator (S5) can
+ * group the workers' per-service results back into one dashboard sweep.
+ * This preserves the existing run-trigger semantics: a cron tick that used
+ * to fan a probe out across N services now enqueues N jobs; an
+ * operator-triggered run sets `ServiceJobMeta.triggered = true`.
+ *
+ * ── SEAMS (what the control-plane WIRING slot calls) ───────────────────
+ * `start()` / `stop()` bracket the producer's lifecycle; `tick(opts?)`
+ * runs one production cycle and is what the wiring slot registers as the
+ * scheduler handler (cron passes nothing; an operator trigger passes
+ * `{ triggered: true, ... }`). The producer NEVER owns the scheduler — it
+ * is invoked BY it, mirroring how the in-process probe-invoker's `invoke`
+ * is wrapped by `scheduler.register({ handler })`.
+ *
+ * ── INJECTION (no Chromium, no concrete discovery) ─────────────────────
+ * The producer types against the `FleetQueueClient` INTERFACE (S3
+ * implements it) and a `ServiceEnumerator` callback that yields the
+ * per-service units for a run. Both are injected so this module has zero
+ * dependency on Railway discovery, the d6 driver, or PocketBase — the
+ * wiring slot supplies the real enumerator (railway-services → one entry
+ * per showcase service) and the real queue client. Tests inject fakes +
+ * a fake clock.
+ */
+
+import type { Logger } from "../../types/index.js";
+import type {
+  EnqueueJobInput,
+  FleetQueueClient,
+  PoolCommError,
+  ServiceJobMeta,
+  ServiceJobPayload,
+} from "../contracts.js";
+
+/**
+ * Sink the producer hands its lease-sweep comm errors to (REQ-B). `sweepExpired`
+ * reclaims a crashed/lease-expired worker's job and synthesizes one
+ * `worker-crashed-mid-job` `PoolCommError` per reclaimed job; those errors only
+ * reach the dashboard once they are written onto the job's status row. The
+ * producer does NOT own the status pipeline (it owns no PB/aggregator), so it
+ * FORWARDS the swept errors to this injected sink — the wiring slot
+ * (control-plane) routes them to `ResultAggregator.aggregateCommError`. Called
+ * best-effort: the producer awaits it but never lets a sink failure abort job
+ * production (the next tick retries the sweep). Injected so the producer stays
+ * dependency-free and unit-testable with a fake sink.
+ */
+export type SweepCommErrorSink = (
+  commErrors: PoolCommError[],
+) => void | Promise<void>;
+
+/**
+ * The per-service unit the enumerator yields for a run. This is the
+ * payload-shaping subset the producer turns into a `ServiceJobPayload`
+ * (the producer attaches the run `meta` — runId/triggered/enqueuedAt —
+ * itself so the enumerator stays unaware of run batching). Mirrors the
+ * fields the in-process d6 path derives per service (probeKey
+ * `d6:<slug>`, the service slug, the driver kind `e2e_d6`, and the
+ * opaque driver inputs the worker threads to the driver).
+ */
+export interface ServiceJobSpec {
+  /** Join key to the claim row + dashboard status row, e.g. `d6:langgraph-python`. */
+  probeKey: string;
+  /** Showcase service / integration slug, e.g. `langgraph-python`. */
+  serviceSlug: string;
+  /** Driver kind that runs the cells; `e2e_d6` for the d6 per-service unit. */
+  driverKind: string;
+  /** Optional narrowing to a subset of the service's cells (feature ids). */
+  cellIds?: string[];
+  /** Free-form driver inputs threaded to the worker's driver. */
+  driverInputs?: Record<string, unknown>;
+  /** Optional per-job priority hint (higher pulls first). */
+  priority?: number;
+  /** Optional explicit lease seconds for the eventual claim. */
+  leaseSeconds?: number;
+}
+
+/**
+ * Enumerate the per-service units for one run. Injected by the wiring
+ * slot (production: railway-services discovery → one spec per showcase
+ * service for the probe family). Receives the run's `triggered` flag and
+ * optional operator filter so an operator-triggered run can scope to a
+ * subset of services / cells, mirroring `TriggerOptions.filter` in the
+ * in-process scheduler.
+ *
+ * Async because production enumeration hits Railway discovery; the
+ * producer awaits it before enqueueing.
+ */
+export type ServiceEnumerator = (
+  ctx: EnumerateContext,
+) => Promise<ServiceJobSpec[]> | ServiceJobSpec[];
+
+/** Context handed to the enumerator for one run. */
+export interface EnumerateContext {
+  /** True for operator-triggered runs, false for scheduled (cron) ticks. */
+  triggered: boolean;
+  /** Stable id of this run batch (same id stamped onto every job's meta). */
+  runId: string;
+  /** Optional operator filter (slug / feature scoping), trigger-only. */
+  filter?: { slugs?: string[]; featureTypes?: string[] };
+}
+
+/** Options for a single `tick()`. Cron ticks pass nothing. */
+export interface TickOptions {
+  /** True when an operator triggered this run; default false (scheduled). */
+  triggered?: boolean;
+  /** Operator filter forwarded to the enumerator (trigger-only). */
+  filter?: { slugs?: string[]; featureTypes?: string[] };
+}
+
+/** Outcome of one production cycle, returned to the wiring/scheduler layer. */
+export interface TickResult {
+  /** The run batch id every enqueued job in this tick shares. */
+  runId: string;
+  /** Number of per-service jobs enqueued (== services enumerated, minus failures). */
+  enqueued: number;
+  /** Number of enqueue attempts that threw (a service that failed to enqueue). */
+  enqueueFailures: number;
+  /** True iff a lease sweep ran during this tick. */
+  sweptExpired: boolean;
+  /** Expired leases reclaimed by the sweep, when one ran (else 0). */
+  reclaimed: number;
+}
+
+export interface JobProducerOptions {
+  /** Queue protocol (S3 implements it). Injected — never constructed here. */
+  queue: FleetQueueClient;
+  /** Yields the per-service units to enqueue for a run. Injected. */
+  enumerate: ServiceEnumerator;
+  logger: Logger;
+  /**
+   * How often to run `sweepExpired()` for dead-worker reclamation, in ms.
+   * The sweep runs at most once per `sweepIntervalMs` window, evaluated on
+   * each tick against the clock — the producer never owns its own timer
+   * (the scheduler drives cadence; the producer just gates). Default
+   * `DEFAULT_SWEEP_INTERVAL_MS`. Set <= 0 to sweep on EVERY tick.
+   */
+  sweepIntervalMs?: number;
+  /**
+   * Clock, injectable for tests. Returns ms-since-epoch. Used for the
+   * sweep cadence gate and `ServiceJobMeta.enqueuedAt`. Defaults to
+   * `Date.now`.
+   */
+  now?: () => number;
+  /**
+   * Run-id factory, injectable for deterministic tests. Each call returns
+   * a unique run batch id. Defaults to a timestamp+counter composite
+   * (same idiom as the scheduler's `nextRunId`).
+   */
+  runIdFactory?: () => string;
+  /**
+   * Sink for the lease-sweep's `worker-crashed-mid-job` comm errors (REQ-B).
+   * When omitted, swept errors are logged only (the legacy behaviour) — but the
+   * wiring slot injects this so a crashed worker's "unreachable" overlay reaches
+   * the dashboard via the aggregator. Failures are swallowed (logged) and never
+   * abort job production.
+   */
+  onSweepCommErrors?: SweepCommErrorSink;
+}
+
+/**
+ * The control-plane job producer. The wiring slot calls `start()` once,
+ * registers `tick` as the scheduler handler, and calls `stop()` on
+ * shutdown.
+ */
+export interface JobProducer {
+  /** Begin producing. Idempotent; after `stop()` it stays stopped. */
+  start(): void;
+  /** Stop producing. After this, `tick()` is a no-op (returns 0 enqueued). */
+  stop(): Promise<void>;
+  /**
+   * Run one production cycle: enumerate per-service units, enqueue one job
+   * per service (all sharing one runId), and sweep expired leases if the
+   * cadence window elapsed. This is the scheduler handler seam.
+   */
+  tick(opts?: TickOptions): Promise<TickResult>;
+  /** True once `start()` ran and `stop()` has not. */
+  isRunning(): boolean;
+}
+
+/** Default lease-sweep cadence: reclaim dead-worker leases every 30s. */
+export const DEFAULT_SWEEP_INTERVAL_MS = 30_000;
+
+export function createJobProducer(opts: JobProducerOptions): JobProducer {
+  const { queue, enumerate, logger } = opts;
+  const now = opts.now ?? (() => Date.now());
+  const sweepIntervalMs = opts.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
+  const runIdFactory = opts.runIdFactory ?? defaultRunIdFactory();
+  const onSweepCommErrors = opts.onSweepCommErrors;
+
+  let running = false;
+  let stopped = false;
+  /**
+   * ms-since-epoch of the last sweep, or null if none has run. Gates the
+   * cadence: a sweep runs on a tick only when `now - lastSweepAt >=
+   * sweepIntervalMs` (or always, when the interval is <= 0). null seeds
+   * the FIRST tick to sweep so a control-plane that just booted with
+   * orphaned leases from a prior crash reclaims them on its first cycle.
+   */
+  let lastSweepAt: number | null = null;
+
+  /** Build a `ServiceJobPayload` from a spec + the run's shared meta. */
+  function toEnqueueInput(
+    spec: ServiceJobSpec,
+    meta: ServiceJobMeta,
+  ): EnqueueJobInput {
+    const payload: ServiceJobPayload = {
+      probeKey: spec.probeKey,
+      serviceSlug: spec.serviceSlug,
+      driverKind: spec.driverKind,
+      meta,
+    };
+    if (spec.cellIds !== undefined) payload.cellIds = spec.cellIds;
+    if (spec.driverInputs !== undefined)
+      payload.driverInputs = spec.driverInputs;
+    const input: EnqueueJobInput = { payload };
+    if (spec.leaseSeconds !== undefined) input.leaseSeconds = spec.leaseSeconds;
+    return input;
+  }
+
+  /**
+   * Run the lease sweep if the cadence window has elapsed. Returns the
+   * sweep outcome (or a no-sweep sentinel). Sweep failures are logged and
+   * swallowed — a transient PB blip on the reclamation path must NEVER
+   * abort job production (the next tick retries).
+   */
+  async function maybeSweep(
+    nowMs: number,
+  ): Promise<{ swept: boolean; reclaimed: number }> {
+    const due =
+      sweepIntervalMs <= 0 ||
+      lastSweepAt === null ||
+      nowMs - lastSweepAt >= sweepIntervalMs;
+    if (!due) return { swept: false, reclaimed: 0 };
+    lastSweepAt = nowMs;
+    try {
+      const result = await queue.sweepExpired(nowMs);
+      if (result.reclaimed > 0 || result.commErrors.length > 0) {
+        logger.warn("fleet.producer.sweep-reclaimed", {
+          reclaimed: result.reclaimed,
+          commErrors: result.commErrors.length,
+        });
+      }
+      // REQ-B: forward the swept `worker-crashed-mid-job` comm errors to the
+      // injected sink so each reclaimed job's "unreachable" overlay reaches the
+      // dashboard (the producer owns no status pipeline of its own). Previously
+      // these were DROPPED after logging their count — the crash/lease-expiry
+      // overlay never surfaced. Best-effort: a sink failure must not abort job
+      // production, so we log and swallow (the next sweep retries).
+      if (onSweepCommErrors && result.commErrors.length > 0) {
+        try {
+          await onSweepCommErrors(result.commErrors);
+        } catch (sinkErr) {
+          logger.error("fleet.producer.sweep-commerror-sink-failed", {
+            commErrors: result.commErrors.length,
+            err: sinkErr instanceof Error ? sinkErr.message : String(sinkErr),
+          });
+        }
+      }
+      return { swept: true, reclaimed: result.reclaimed };
+    } catch (err) {
+      logger.error("fleet.producer.sweep-failed", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      // A failed sweep still counts as "swept" for cadence purposes — we
+      // don't want a persistently-failing sweep to fire on every tick and
+      // bury the logs; the window already advanced via lastSweepAt.
+      return { swept: true, reclaimed: 0 };
+    }
+  }
+
+  return {
+    start() {
+      if (stopped) {
+        logger.warn("fleet.producer.start-after-stop");
+        return;
+      }
+      if (running) return;
+      running = true;
+      logger.info("fleet.producer.start", { sweepIntervalMs });
+    },
+
+    async stop() {
+      if (!running) {
+        stopped = true;
+        return;
+      }
+      running = false;
+      stopped = true;
+      logger.info("fleet.producer.stop");
+    },
+
+    isRunning() {
+      return running;
+    },
+
+    async tick(tickOpts?: TickOptions): Promise<TickResult> {
+      const runId = runIdFactory();
+      if (!running) {
+        // Defensive: a tick that arrives after stop() (or before start())
+        // produces nothing. Mirrors the scheduler's drain-after-stop
+        // discipline — no jobs leak past the producer's lifecycle.
+        logger.warn("fleet.producer.tick-while-stopped", { runId });
+        return {
+          runId,
+          enqueued: 0,
+          enqueueFailures: 0,
+          sweptExpired: false,
+          reclaimed: 0,
+        };
+      }
+
+      const triggered = tickOpts?.triggered === true;
+      const nowMs = now();
+      const enqueuedAt = new Date(nowMs).toISOString();
+
+      const enumerateCtx: EnumerateContext = { triggered, runId };
+      if (tickOpts?.filter !== undefined) enumerateCtx.filter = tickOpts.filter;
+
+      let specs: ServiceJobSpec[];
+      try {
+        specs = await enumerate(enumerateCtx);
+      } catch (err) {
+        // Enumeration failure short-circuits production (no services →
+        // nothing to enqueue). Still attempt the sweep so dead-worker
+        // reclamation isn't starved by a flaky discovery upstream.
+        logger.error("fleet.producer.enumerate-failed", {
+          runId,
+          triggered,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        const sweep = await maybeSweep(nowMs);
+        return {
+          runId,
+          enqueued: 0,
+          enqueueFailures: 0,
+          sweptExpired: sweep.swept,
+          reclaimed: sweep.reclaimed,
+        };
+      }
+
+      logger.info("fleet.producer.tick-start", {
+        runId,
+        triggered,
+        services: specs.length,
+      });
+
+      let enqueued = 0;
+      let enqueueFailures = 0;
+      for (const spec of specs) {
+        const meta: ServiceJobMeta = {
+          runId,
+          triggered,
+          enqueuedAt,
+        };
+        if (spec.priority !== undefined) meta.priority = spec.priority;
+        try {
+          await queue.enqueue(toEnqueueInput(spec, meta));
+          enqueued++;
+        } catch (err) {
+          // One service failing to enqueue must NOT abort the rest of the
+          // run — the other services' jobs still get queued, mirroring the
+          // in-process invoker's per-target isolation.
+          enqueueFailures++;
+          logger.error("fleet.producer.enqueue-failed", {
+            runId,
+            probeKey: spec.probeKey,
+            serviceSlug: spec.serviceSlug,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      const sweep = await maybeSweep(nowMs);
+
+      logger.info("fleet.producer.tick-complete", {
+        runId,
+        triggered,
+        enqueued,
+        enqueueFailures,
+        sweptExpired: sweep.swept,
+        reclaimed: sweep.reclaimed,
+      });
+
+      return {
+        runId,
+        enqueued,
+        enqueueFailures,
+        sweptExpired: sweep.swept,
+        reclaimed: sweep.reclaimed,
+      };
+    },
+  };
+}
+
+/**
+ * Default run-id factory: timestamp + monotonic counter composite,
+ * matching the scheduler's `nextRunId` idiom so two runs that land in the
+ * same ms still get distinct ids.
+ */
+function defaultRunIdFactory(): () => string {
+  let counter = 0;
+  return () => {
+    counter += 1;
+    return `frun_${Date.now().toString(36)}_${counter.toString(36)}`;
+  };
+}

--- a/showcase/harness/src/fleet/control-plane/result-aggregator.test.ts
+++ b/showcase/harness/src/fleet/control-plane/result-aggregator.test.ts
@@ -1,0 +1,673 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type {
+  ProbeResult,
+  State,
+  WriteOutcome,
+  Logger,
+} from "../../types/index.js";
+import type {
+  ProbeRunSummary,
+  ProbeRunWriter,
+  ProbeRunRecord,
+} from "../../probes/run-history.js";
+import type { StatusWriter } from "../../writers/status-writer.js";
+import {
+  FLEET_COMM_ERROR_SIGNAL_KEY,
+  commErrorFromStatusSignal,
+  type PoolCommError,
+  type ServiceJobResult,
+} from "../contracts.js";
+import { createResultAggregator } from "./result-aggregator.js";
+
+/**
+ * Pins the control-plane RESULT AGGREGATOR (S5): consuming a worker's
+ * `ServiceJobResult` and WRITING it through the EXISTING status-writer
+ * (per-cell + aggregate `ProbeResult`s) and run-history (`ProbeRunSummary`)
+ * so the dashboard contract is unchanged, plus the REQ-B comm-error overlay.
+ */
+
+// ── Fakes ──────────────────────────────────────────────────────────────
+
+interface RecordedWrite {
+  result: ProbeResult<unknown>;
+}
+
+function makeFakeStatusWriter(): {
+  writer: StatusWriter;
+  writes: RecordedWrite[];
+} {
+  const writes: RecordedWrite[] = [];
+  const writer: StatusWriter = {
+    async write(result) {
+      writes.push({ result });
+      const outcome: WriteOutcome = {
+        previousState: null,
+        newState: result.state === "error" ? "error" : result.state,
+        transition: "first",
+        firstFailureAt: null,
+        failCount: 0,
+      };
+      return outcome;
+    },
+  };
+  return { writer, writes };
+}
+
+/**
+ * A fake that mimics the REAL status-writer's error-path routing (see
+ * `status-writer.ts` `doWrite`): a write whose `state === "error"` is routed to
+ * `status_history` ONLY — its `signal` is NEVER persisted to the STATUS ROW.
+ * Only a NON-error write lands the `signal` on the status row (`statusRows`).
+ * This is the fake that actually reproduces the worker-self-report comm-error
+ * bug: a naive fake that records EVERY write into one array (`makeFakeStatusWriter`)
+ * silently passes even when the overlay never reaches the status row the
+ * dashboard reads.
+ */
+function makeErrorRoutingFakeStatusWriter(): {
+  writer: StatusWriter;
+  /** What the dashboard reads back: key → the persisted status-row signal. */
+  statusRows: Map<string, { state: State; signal: unknown }>;
+  /** Every write, error or not (for write-count assertions). */
+  writes: RecordedWrite[];
+} {
+  const statusRows = new Map<string, { state: State; signal: unknown }>();
+  const writes: RecordedWrite[] = [];
+  const writer: StatusWriter = {
+    async write(result) {
+      writes.push({ result });
+      if (result.state === "error") {
+        // REAL error-path: signal → status_history only. The STATUS ROW's
+        // signal is NOT updated (status-writer only refreshes observed_at on
+        // the error path, and only when a prior row exists). So the overlay
+        // carried in this signal is LOST to the dashboard.
+        const outcome: WriteOutcome = {
+          previousState: statusRows.get(result.key)?.state ?? null,
+          newState: "error",
+          errorStatePrev: statusRows.get(result.key)?.state ?? "green",
+          transition: "error",
+          firstFailureAt: null,
+          failCount: 0,
+        };
+        return outcome;
+      }
+      // Non-error: the signal lands on the status row the dashboard reads.
+      statusRows.set(result.key, {
+        state: result.state,
+        signal: result.signal,
+      });
+      const outcome: WriteOutcome = {
+        previousState: null,
+        newState: result.state,
+        transition: "first",
+        firstFailureAt: null,
+        failCount: 0,
+      };
+      return outcome;
+    },
+  };
+  return { writer, statusRows, writes };
+}
+
+interface RunWriterCalls {
+  start: {
+    probeId: string;
+    startedAt: number;
+    triggered: boolean;
+    jobId?: string;
+  }[];
+  update: { id: string; summary: ProbeRunSummary }[];
+  finish: {
+    id: string;
+    finishedAt: number;
+    state: "completed" | "failed";
+    summary: ProbeRunSummary | null;
+  }[];
+}
+
+/** A stateful run-row the fake tracks so findByJobId reflects start/finish. */
+interface FakeRunRow {
+  id: string;
+  jobId?: string;
+  terminal: boolean;
+}
+
+function makeFakeRunWriter(): {
+  writer: ProbeRunWriter;
+  calls: RunWriterCalls;
+  rows: FakeRunRow[];
+} {
+  const calls: RunWriterCalls = { start: [], update: [], finish: [] };
+  const rows: FakeRunRow[] = [];
+  let seq = 0;
+  const writer: ProbeRunWriter = {
+    async start(opts) {
+      calls.start.push(opts);
+      seq += 1;
+      const id = `run-row-${seq}`;
+      rows.push({ id, jobId: opts.jobId, terminal: false });
+      return { id };
+    },
+    async findByJobId(jobId) {
+      if (!jobId) return null;
+      // Newest-first, mirroring the real -started_at sort.
+      const match = [...rows].reverse().find((r) => r.jobId === jobId);
+      return match ? { id: match.id, terminal: match.terminal } : null;
+    },
+    async update(opts) {
+      calls.update.push(opts);
+    },
+    async finish(opts) {
+      calls.finish.push(opts);
+      const row = rows.find((r) => r.id === opts.id);
+      if (row) row.terminal = true;
+    },
+    async recent(): Promise<ProbeRunRecord[]> {
+      return [];
+    },
+  };
+  return { writer, calls, rows };
+}
+
+function makeLogger(): Logger {
+  return { info() {}, warn() {}, error() {}, debug() {} };
+}
+
+function makeResult(
+  overrides: Partial<ServiceJobResult> = {},
+): ServiceJobResult {
+  return {
+    jobId: "job-1",
+    probeKey: "d6:langgraph-python",
+    serviceSlug: "langgraph-python",
+    runId: "run-1",
+    workerId: "worker-7",
+    aggregateState: "red",
+    aggregateKey: "d6:langgraph-python",
+    aggregateSignal: { failedCount: 1 },
+    cells: [
+      {
+        cellId: "shared-state",
+        cellKey: "d6:langgraph-python/shared-state",
+        state: "green",
+        signal: { ok: true },
+        observedAt: "2026-06-04T00:00:01.000Z",
+      },
+      {
+        cellId: "human-in-the-loop",
+        cellKey: "d6:langgraph-python/human-in-the-loop",
+        state: "red",
+        signal: { ok: false },
+        observedAt: "2026-06-04T00:00:02.000Z",
+      },
+    ],
+    rollup: { total: 2, passed: 1, failed: 1 },
+    finishedAt: "2026-06-04T00:00:03.000Z",
+    ...overrides,
+  };
+}
+
+const SAMPLE_COMM_ERROR: PoolCommError = {
+  kind: "worker-unreachable",
+  message: "connect ECONNREFUSED 10.0.0.4:8090",
+  workerId: "worker-7",
+  jobId: "job-1",
+  observedAt: "2026-06-04T00:00:05.000Z",
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("createResultAggregator", () => {
+  let statusFake: ReturnType<typeof makeFakeStatusWriter>;
+  let runFake: ReturnType<typeof makeFakeRunWriter>;
+  let now: number;
+
+  beforeEach(() => {
+    statusFake = makeFakeStatusWriter();
+    runFake = makeFakeRunWriter();
+    now = 1_000;
+  });
+
+  function makeAggregator() {
+    return createResultAggregator({
+      statusWriter: statusFake.writer,
+      runWriter: runFake.writer,
+      logger: makeLogger(),
+      now: () => now,
+    });
+  }
+
+  it("writes the aggregate primary row + one side row per cell, preserving keys", async () => {
+    const agg = makeAggregator();
+    await agg.aggregate(makeResult());
+
+    const keys = statusFake.writes.map((w) => w.result.key);
+    // Primary aggregate row first, then one side row per cell.
+    expect(keys).toEqual([
+      "d6:langgraph-python",
+      "d6:langgraph-python/shared-state",
+      "d6:langgraph-python/human-in-the-loop",
+    ]);
+
+    const primary = statusFake.writes[0].result;
+    expect(primary.state).toBe("red");
+    expect(primary.signal).toEqual({ failedCount: 1 });
+    expect(primary.observedAt).toBe("2026-06-04T00:00:03.000Z");
+
+    const cellGreen = statusFake.writes[1].result;
+    expect(cellGreen.state).toBe("green");
+    expect(cellGreen.observedAt).toBe("2026-06-04T00:00:01.000Z");
+
+    const cellRed = statusFake.writes[2].result;
+    expect(cellRed.state).toBe("red");
+  });
+
+  it("persists the rollup to run-history under the aggregate key (state failed when red)", async () => {
+    const agg = makeAggregator();
+    await agg.aggregate(makeResult());
+
+    expect(runFake.calls.start).toHaveLength(1);
+    expect(runFake.calls.start[0].probeId).toBe("d6:langgraph-python");
+    expect(runFake.calls.start[0].triggered).toBe(false);
+
+    expect(runFake.calls.finish).toHaveLength(1);
+    const finish = runFake.calls.finish[0];
+    expect(finish.id).toBe("run-row-1");
+    expect(finish.state).toBe("failed");
+    expect(finish.summary).toEqual({ total: 2, passed: 1, failed: 0 + 1 });
+  });
+
+  it("marks the run completed when the aggregate state is green", async () => {
+    const agg = makeAggregator();
+    await agg.aggregate(
+      makeResult({
+        aggregateState: "green",
+        rollup: { total: 2, passed: 2, failed: 0 },
+        cells: [
+          {
+            cellId: "shared-state",
+            cellKey: "d6:langgraph-python/shared-state",
+            state: "green",
+            signal: { ok: true },
+            observedAt: "2026-06-04T00:00:01.000Z",
+          },
+        ],
+      }),
+    );
+    expect(runFake.calls.finish[0].state).toBe("completed");
+    expect(runFake.calls.finish[0].summary).toEqual({
+      total: 2,
+      passed: 2,
+      failed: 0,
+    });
+  });
+
+  it("[REQ-B] merges the comm-error signal onto the primary row when commError is set", async () => {
+    const agg = makeAggregator();
+    await agg.aggregate(
+      makeResult({
+        commError: SAMPLE_COMM_ERROR,
+        aggregateSignal: { failedCount: 0 },
+      }),
+    );
+
+    const primary = statusFake.writes[0].result;
+    // The comm error must ride in the primary row signal under the
+    // well-known key so the dashboard can re-surface "unreachable".
+    const recovered = commErrorFromStatusSignal(primary.signal);
+    expect(recovered).toEqual(SAMPLE_COMM_ERROR);
+    // The original aggregate signal fields must be preserved alongside it.
+    expect((primary.signal as Record<string, unknown>).failedCount).toBe(0);
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        primary.signal,
+        FLEET_COMM_ERROR_SIGNAL_KEY,
+      ),
+    ).toBe(true);
+  });
+
+  it("[REQ-B] does NOT add a comm-error signal when commError is absent", async () => {
+    const agg = makeAggregator();
+    await agg.aggregate(makeResult());
+    const primary = statusFake.writes[0].result;
+    expect(commErrorFromStatusSignal(primary.signal)).toBeUndefined();
+  });
+
+  it("[REQ-B] still writes per-cell rows and run-history on a comm-error result", async () => {
+    const agg = makeAggregator();
+    await agg.aggregate(makeResult({ commError: SAMPLE_COMM_ERROR }));
+    // primary + 2 cells
+    expect(statusFake.writes).toHaveLength(3);
+    // a comm error is a failed terminal run
+    expect(runFake.calls.finish[0].state).toBe("failed");
+  });
+
+  it("[REQ-B] lands the worker-self-report comm-error overlay on the STATUS ROW (aggregateState=error must NOT route to history-only)", async () => {
+    // The CRITICAL bug: a worker that self-reports a comm error sets
+    // aggregateState:"error" (buildCommErrorResult/buildDriverErrorResult). If
+    // the aggregator writes the primary row with state:"error", the REAL
+    // status-writer routes it to status_history ONLY — the overlay never lands
+    // on the STATUS ROW the dashboard reads (commErrorFromStatusSignal on the
+    // live row). This fake reproduces that exact routing.
+    const errorFake = makeErrorRoutingFakeStatusWriter();
+    const agg = createResultAggregator({
+      statusWriter: errorFake.writer,
+      runWriter: runFake.writer,
+      logger: makeLogger(),
+      now: () => now,
+    });
+
+    await agg.aggregate(
+      makeResult({
+        commError: SAMPLE_COMM_ERROR,
+        aggregateState: "error",
+        aggregateSignal: { failedCount: 0 },
+      }),
+    );
+
+    // The dashboard reads the overlay off the persisted STATUS ROW. It MUST be
+    // present — i.e. the primary row was written with a NON-error carried
+    // colour so the signal landed on the status row, not history-only.
+    const persisted = errorFake.statusRows.get("d6:langgraph-python");
+    expect(persisted).toBeDefined();
+    expect(persisted!.state).not.toBe("error");
+    expect(commErrorFromStatusSignal(persisted!.signal)).toEqual(
+      SAMPLE_COMM_ERROR,
+    );
+  });
+
+  it("[REQ-B] does NOT carry a worker-reported 'green' aggregateState onto a comm-error primary row (corrupt/untrusted result must never fabricate green)", async () => {
+    // CRITICAL false-green: a persisted/decoded result that carries a commError
+    // but a (corrupt / untrusted) aggregateState:"green" must NOT write a GREEN
+    // status row for a service we could not reach. A commError means we did NOT
+    // get a trustworthy result, so the worker's "green" cannot be carried — we
+    // fall back to the prior observed colour (none here) or "degraded", NEVER
+    // green. This violates REQ-B's "never fabricate green for a service we
+    // couldn't reach" invariant otherwise.
+    const errorFake = makeErrorRoutingFakeStatusWriter();
+    const agg = createResultAggregator({
+      statusWriter: errorFake.writer,
+      runWriter: runFake.writer,
+      logger: makeLogger(),
+      now: () => now,
+      // No prior observed colour → must fall back to degraded, never green.
+    });
+
+    await agg.aggregate(
+      makeResult({
+        commError: SAMPLE_COMM_ERROR,
+        aggregateState: "green",
+        aggregateSignal: { failedCount: 0 },
+      }),
+    );
+
+    const persisted = errorFake.statusRows.get("d6:langgraph-python");
+    expect(persisted).toBeDefined();
+    expect(persisted!.state).not.toBe("green");
+    expect(persisted!.state).toBe("degraded");
+    // The overlay still lands on the status row the dashboard reads.
+    expect(commErrorFromStatusSignal(persisted!.signal)).toEqual(
+      SAMPLE_COMM_ERROR,
+    );
+  });
+
+  it("[REQ-B] carries the PRIOR observed colour (not 'green') when a comm-error result reports aggregateState 'green'", async () => {
+    // Same corrupt-green path, but with a prior observed colour available: a red
+    // service whose decoded comm-error result claims green must stay red +
+    // unreachable overlay, never flip to the untrusted green.
+    const errorFake = makeErrorRoutingFakeStatusWriter();
+    const agg = createResultAggregator({
+      statusWriter: errorFake.writer,
+      runWriter: runFake.writer,
+      logger: makeLogger(),
+      now: () => now,
+      resolvePriorState: async (): Promise<State> => "red",
+    });
+
+    await agg.aggregate(
+      makeResult({
+        commError: SAMPLE_COMM_ERROR,
+        aggregateState: "green",
+        aggregateSignal: { failedCount: 0 },
+      }),
+    );
+
+    const persisted = errorFake.statusRows.get("d6:langgraph-python");
+    expect(persisted).toBeDefined();
+    expect(persisted!.state).toBe("red");
+    expect(persisted!.state).not.toBe("green");
+    expect(commErrorFromStatusSignal(persisted!.signal)).toEqual(
+      SAMPLE_COMM_ERROR,
+    );
+  });
+
+  it("[REQ-B] preserves the prior status-row colour on a worker-self-report comm error (never stomps to green/error)", async () => {
+    // When a prior colour is observable, the comm-error primary row keeps it
+    // (a red service whose worker then reports a comm error stays red +
+    // unreachable overlay) — never error, never a fabricated green.
+    const errorFake = makeErrorRoutingFakeStatusWriter();
+    const agg = createResultAggregator({
+      statusWriter: errorFake.writer,
+      runWriter: runFake.writer,
+      logger: makeLogger(),
+      now: () => now,
+      resolvePriorState: async (): Promise<State> => "red",
+    });
+
+    await agg.aggregate(
+      makeResult({
+        commError: SAMPLE_COMM_ERROR,
+        aggregateState: "error",
+        aggregateSignal: { failedCount: 0 },
+      }),
+    );
+
+    const persisted = errorFake.statusRows.get("d6:langgraph-python");
+    expect(persisted).toBeDefined();
+    expect(persisted!.state).toBe("red");
+    expect(commErrorFromStatusSignal(persisted!.signal)).toEqual(
+      SAMPLE_COMM_ERROR,
+    );
+  });
+
+  it("returns the per-write outcomes and the run-row id", async () => {
+    const agg = makeAggregator();
+    const outcome = await agg.aggregate(makeResult());
+    expect(outcome.runRowId).toBe("run-row-1");
+    expect(outcome.statusOutcomes).toHaveLength(3);
+    expect(outcome.skipped).toBe(false);
+  });
+
+  it("stamps the originating jobId on the run row so re-process can dedupe", async () => {
+    const agg = makeAggregator();
+    await agg.aggregate(makeResult({ jobId: "job-XYZ" }));
+    expect(runFake.calls.start).toHaveLength(1);
+    expect(runFake.calls.start[0].jobId).toBe("job-XYZ");
+  });
+
+  // ── REQ-B: control-plane-detected comm error (no worker result) ──────────
+  describe("aggregateCommError (crash/lease-expiry overlay, no worker result)", () => {
+    const SWEEP_ERR: PoolCommError = {
+      kind: "worker-crashed-mid-job",
+      message:
+        "lease for job job-1 expired (worker worker-7 crashed mid-job); re-queued",
+      workerId: "worker-7",
+      jobId: "job-1",
+      observedAt: "2026-06-04T00:00:09.000Z",
+    };
+
+    it("writes the comm-error overlay onto the aggregate (d6:<slug>) status row the dashboard reads", async () => {
+      const agg = makeAggregator();
+      await agg.aggregateCommError({
+        commError: SWEEP_ERR,
+        aggregateKey: "d6:langgraph-python",
+      });
+
+      // Exactly one status write, onto the d6:<slug> aggregate key.
+      expect(statusFake.writes).toHaveLength(1);
+      const written = statusFake.writes[0].result;
+      expect(written.key).toBe("d6:langgraph-python");
+      // The comm error rides in the signal under the well-known key so the
+      // dashboard re-surfaces "unreachable" — this is the bug fix: previously
+      // the sweep/fleet-health comm errors were DROPPED and this overlay was
+      // NEVER written (the red state).
+      expect(commErrorFromStatusSignal(written.signal)).toEqual(SWEEP_ERR);
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          written.signal,
+          FLEET_COMM_ERROR_SIGNAL_KEY,
+        ),
+      ).toBe(true);
+      // observed_at comes from the comm error.
+      expect(written.observedAt).toBe("2026-06-04T00:00:09.000Z");
+    });
+
+    it("writes the no-data ('error') state for a never-observed key — NEVER fabricates green", async () => {
+      // REQ-B: a never-observed key (no lastKnownState) must NOT invent a green
+      // status row for a service that has never been probed. The no-data
+      // representation is "error" (status-writer routes it to status_history
+      // only), so the dashboard shows no fabricated colour.
+      const agg = makeAggregator();
+      await agg.aggregateCommError({
+        commError: SWEEP_ERR,
+        aggregateKey: "d6:langgraph-python",
+      });
+      const written = statusFake.writes[0].result;
+      expect(written.state).toBe("error");
+      expect(written.state).not.toBe("green");
+    });
+
+    it("preserves a red last-known colour on a crash (does NOT stomp it to green)", async () => {
+      // The CRITICAL false-green bug: a red service whose worker crashes must
+      // stay red + unreachable overlay, not flip to green.
+      const agg = makeAggregator();
+      await agg.aggregateCommError({
+        commError: SWEEP_ERR,
+        aggregateKey: "d6:langgraph-python",
+        lastKnownState: "red",
+      });
+      const written = statusFake.writes[0].result;
+      expect(written.state).toBe("red");
+      expect(written.state).not.toBe("green");
+      expect(commErrorFromStatusSignal(written.signal)).toEqual(SWEEP_ERR);
+    });
+
+    it("carries an explicit last-known colour when supplied (comm error never reads as fresh red)", async () => {
+      const agg = makeAggregator();
+      await agg.aggregateCommError({
+        commError: SWEEP_ERR,
+        aggregateKey: "d6:langgraph-python",
+        lastKnownState: "red",
+      });
+      const written = statusFake.writes[0].result;
+      // The row keeps the prior colour; the dashboard derives "unreachable"
+      // from the overlay, not from the colour.
+      expect(written.state).toBe("red");
+      expect(commErrorFromStatusSignal(written.signal)).toEqual(SWEEP_ERR);
+    });
+
+    it("also overlays the per-cell row when a cellKey is supplied", async () => {
+      const agg = makeAggregator();
+      await agg.aggregateCommError({
+        commError: SWEEP_ERR,
+        aggregateKey: "d6:langgraph-python",
+        cellKey: "d6:langgraph-python/shared-state",
+      });
+      const keys = statusFake.writes.map((w) => w.result.key);
+      expect(keys).toEqual([
+        "d6:langgraph-python",
+        "d6:langgraph-python/shared-state",
+      ]);
+      for (const w of statusFake.writes) {
+        expect(commErrorFromStatusSignal(w.result.signal)).toEqual(SWEEP_ERR);
+      }
+    });
+
+    it("returns the per-write outcomes", async () => {
+      const agg = makeAggregator();
+      const out = await agg.aggregateCommError({
+        commError: SWEEP_ERR,
+        aggregateKey: "d6:langgraph-python",
+      });
+      expect(out.statusOutcomes).toHaveLength(1);
+    });
+
+    it("does NOT touch run-history (no result to roll up on the crash leg)", async () => {
+      const agg = makeAggregator();
+      await agg.aggregateCommError({
+        commError: SWEEP_ERR,
+        aggregateKey: "d6:langgraph-python",
+      });
+      expect(runFake.calls.start).toHaveLength(0);
+      expect(runFake.calls.finish).toHaveLength(0);
+    });
+
+    it("does NOT blind-trust a bogus lastKnownState — falls back to the no-data ('error') path", async () => {
+      // A malformed/legacy value (not in the known State set) must not be
+      // re-persisted as a bogus colour; it degrades to no-data.
+      const agg = makeAggregator();
+      await agg.aggregateCommError({
+        commError: SWEEP_ERR,
+        aggregateKey: "d6:langgraph-python",
+        // Force a bogus value past the type via the public input contract.
+        lastKnownState: "bogus" as unknown as "green",
+      });
+      const written = statusFake.writes[0].result;
+      expect(written.state).toBe("error");
+    });
+  });
+
+  // ── M4 N1: idempotency under a failed latch / crash-pre-latch retry ──────
+  describe("re-processing the same job's result is an idempotent no-op", () => {
+    it("does NOT double-write status, double-bump run-history, or mint a duplicate run row", async () => {
+      const agg = makeAggregator();
+      const result = makeResult({ jobId: "job-dup", aggregateState: "red" });
+
+      // First aggregate: full write path runs (terminal run row created).
+      const first = await agg.aggregate(result);
+      expect(first.skipped).toBe(false);
+      const statusWritesAfterFirst = statusFake.writes.length;
+      const startsAfterFirst = runFake.calls.start.length;
+      const finishesAfterFirst = runFake.calls.finish.length;
+      expect(statusWritesAfterFirst).toBe(3); // primary + 2 cells
+      expect(startsAfterFirst).toBe(1);
+      expect(finishesAfterFirst).toBe(1);
+
+      // Simulate the latch write having failed: the SAME result is re-handed
+      // to the aggregator next tick. It must be a true no-op.
+      const second = await agg.aggregate(result);
+
+      expect(second.skipped).toBe(true);
+      // NO additional status writes → no fail_count bump, no duplicate
+      // status_history row, no re-emitted status.changed.
+      expect(statusFake.writes.length).toBe(statusWritesAfterFirst);
+      // NO duplicate probe_runs row (start not called again).
+      expect(runFake.calls.start.length).toBe(startsAfterFirst);
+      // NO second finish either.
+      expect(runFake.calls.finish.length).toBe(finishesAfterFirst);
+      // The no-op still reports the original run row id.
+      expect(second.runRowId).toBe(first.runRowId);
+    });
+
+    it("RESUMES (does not duplicate) when a prior attempt crashed mid-aggregate (running row)", async () => {
+      // Pre-seed a still-RUNNING run row for this job (start succeeded, the
+      // process died before status writes / finish).
+      runFake.rows.push({
+        id: "run-row-crashed",
+        jobId: "job-crash",
+        terminal: false,
+      });
+
+      const agg = makeAggregator();
+      const out = await agg.aggregate(makeResult({ jobId: "job-crash" }));
+
+      // It resumes on the existing row — no new start() (no duplicate row).
+      expect(out.skipped).toBe(false);
+      expect(runFake.calls.start).toHaveLength(0);
+      expect(out.runRowId).toBe("run-row-crashed");
+      // Status + finish DO run (the crashed attempt never completed them).
+      expect(statusFake.writes.length).toBe(3);
+      expect(runFake.calls.finish).toHaveLength(1);
+      expect(runFake.calls.finish[0].id).toBe("run-row-crashed");
+    });
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/result-aggregator.ts
+++ b/showcase/harness/src/fleet/control-plane/result-aggregator.ts
@@ -1,0 +1,479 @@
+/**
+ * Control-plane RESULT AGGREGATOR (BLITZ S5).
+ *
+ * ── WHAT THIS DOES ─────────────────────────────────────────────────────
+ * Workers (S7) compute the per-service rollup and report a `ServiceJobResult`
+ * back through the queue protocol (S3 `FleetQueueClient.report`). This module
+ * is the control-plane side that PERSISTS that result so the dashboard sees it.
+ * It deliberately writes through the EXISTING storage path — it does NOT invent
+ * a new row shape:
+ *
+ *   - the per-cell + aggregate `ProbeResult`s go through the unchanged
+ *     `status-writer` (`createStatusWriter`), so the dashboard's status rows
+ *     keep their exact keys: the aggregate `d6:<slug>` primary row and one
+ *     `d6:<slug>/<featureId>` side row per cell. (The worker emits `d6:<slug>`
+ *     as the primary key on BOTH the success and comm-error legs — the same key
+ *     the dashboard reads back — so the overlay always lands where the
+ *     dashboard looks.) The status-writer owns the state machine (transition
+ *     detection, flap counting, history) — we do not reimplement any of it.
+ *   - the pass/fail rollup goes through the unchanged `run-history`
+ *     (`ProbeRunWriter`) as a `ProbeRunSummary`, keyed by `probeId =
+ *     aggregateKey` (same `probeId` the in-process d6 driver uses today via
+ *     `probe-invoker`), so the dashboard's run-history widget is unchanged.
+ *
+ * ── REQ-B: COMM-ERROR OVERLAY ──────────────────────────────────────────
+ * When a job carries a `PoolCommError` (the control-plane or worker self-
+ * monitor could not REACH/TRUST the pool — distinct from a probe red), we
+ * merge `commErrorToStatusSignal(err)` into the PRIMARY row's signal before
+ * writing. The persisted `status` schema is unchanged (the comm error rides in
+ * the signal blob under `FLEET_COMM_ERROR_SIGNAL_KEY`); the dashboard reads it
+ * back via `commErrorFromStatusSignal` and renders "couldn't reach the pool"
+ * distinctly. The row's `state` continues to carry the last-known probe colour
+ * (we pass the worker's `aggregateState` through), so we never let a comm error
+ * masquerade as a fresh probe red.
+ *
+ * ── SEAMS the control-plane WIRING slot (S4) calls ─────────────────────
+ * The wiring slot constructs a `ResultAggregator` with a live `StatusWriter`
+ * (`createStatusWriter({ pb, bus, logger })`), a live `ProbeRunWriter`
+ * (`createProbeRunWriter(pb)`), and a clock, then calls `aggregate(result)`
+ * for each `ServiceJobResult` the queue-client surfaces. This module owns NO
+ * PocketBase access of its own — it is pure orchestration over the two
+ * injected writers, which keeps it trivially unit-testable with fakes.
+ */
+
+import type {
+  Logger,
+  ProbeResult,
+  ProbeState,
+  State,
+  WriteOutcome,
+} from "../../types/index.js";
+import type { ProbeRunWriter } from "../../probes/run-history.js";
+import type { StatusWriter } from "../../writers/status-writer.js";
+import {
+  commErrorToStatusSignal,
+  probeResultsForServiceJobResult,
+  runSummaryForServiceJobResult,
+  terminalJobStatus,
+  type PoolCommError,
+  type ServiceJobResult,
+} from "../contracts.js";
+
+/** Outcome of aggregating one `ServiceJobResult`. */
+export interface AggregateOutcome {
+  /** The run-history row id created for this result, or null if start failed. */
+  runRowId: string | null;
+  /** The per-write outcomes the status-writer returned, in write order. */
+  statusOutcomes: WriteOutcome[];
+  /**
+   * True when this call was a dedup NO-OP: a terminal `probe_runs` row already
+   * existed for this `jobId` (the result was already fully aggregated on a
+   * prior tick whose latch write later failed), so we wrote NOTHING — no status
+   * row, no history, no duplicate run row, no `status.changed`. Lets the
+   * consumer/tests assert idempotency.
+   */
+  skipped: boolean;
+}
+
+export interface ResultAggregator {
+  /**
+   * Persist one worker-reported `ServiceJobResult` to the dashboard storage:
+   * the aggregate primary row + per-cell side rows through the status-writer,
+   * and the rollup through run-history. When the result carries a
+   * `PoolCommError`, the comm-error overlay is merged onto the primary row
+   * signal (REQ-B). Resolves once all writes are attempted.
+   */
+  aggregate(result: ServiceJobResult): Promise<AggregateOutcome>;
+  /**
+   * [REQ-B] Surface a CONTROL-PLANE-DETECTED comm error (no worker result to
+   * aggregate) onto the dashboard. The producer's `sweepExpired` and the
+   * fleet-health monitor both reclaim a crashed/lease-expired worker's job and
+   * synthesize a `worker-crashed-mid-job` `PoolCommError` — but that error only
+   * reaches the dashboard once it is written onto the job's STATUS row under
+   * `FLEET_COMM_ERROR_SIGNAL_KEY`. The worker-self-report leg does this inside
+   * `aggregate` (via the result's `commError`); this is the equivalent sink for
+   * the no-result crash/lease-expiry leg.
+   *
+   * It writes the overlay onto the aggregate status row (`aggregateKey`, the
+   * `d6:<slug>` key the dashboard reads) — and, when a `cellKey` is supplied,
+   * also onto that per-cell row — through the SAME unchanged status-writer the
+   * worker-self-report leg uses, carrying the comm error in the row's `signal`
+   * via `commErrorToStatusSignal`. The row's `state` keeps the last-known probe
+   * colour (`lastKnownState`) so a comm error never masquerades as a fresh probe
+   * red AND never STOMPS an observed colour to green — the dashboard derives
+   * "unreachable" from the overlay, not from the colour. For a NEVER-observed
+   * key (no `lastKnownState`), the row is written as `"error"` (the codebase's
+   * no-data representation) so no green status row is invented. Best-effort:
+   * resolves once the writes are attempted.
+   */
+  aggregateCommError(
+    input: CommErrorAggregateInput,
+  ): Promise<CommErrorAggregateOutcome>;
+}
+
+/** Input to {@link ResultAggregator.aggregateCommError}. */
+export interface CommErrorAggregateInput {
+  /** The control-plane-detected comm error to surface. */
+  commError: PoolCommError;
+  /**
+   * The aggregate (primary) status-row key the overlay is written onto — the
+   * `d6:<slug>` key the dashboard reads back. For the sweep leg this is the
+   * reclaimed job's `probe_key`; for fleet-health it is the reclaimed job's
+   * `probe_key`. Required because a bare `PoolCommError` does not carry it.
+   */
+  aggregateKey: string;
+  /**
+   * Optional per-cell status-row key (`d6:<slug>/<featureId>`) to ALSO overlay.
+   * Omitted for the crash/lease-expiry legs (which reclaim a whole-service job,
+   * not a single cell).
+   */
+  cellKey?: string;
+  /**
+   * Last-known probe colour to keep on the overlaid row(s) so the comm error
+   * never reads as a fresh probe red — and, critically, never STOMPS an
+   * observed colour to green (a `red` service whose worker crashes must stay
+   * `red` + unreachable overlay). The caller reads the CURRENT status row's
+   * state and passes it here. When OMITTED (a never-observed key), the row is
+   * written as `"error"` — the no-data representation — so NO green status row
+   * is fabricated. Never defaults to a green baseline for an observed row.
+   */
+  lastKnownState?: State;
+}
+
+/** Outcome of {@link ResultAggregator.aggregateCommError}. */
+export interface CommErrorAggregateOutcome {
+  /** The per-write outcomes the status-writer returned, in write order. */
+  statusOutcomes: WriteOutcome[];
+}
+
+/**
+ * Read the CURRENT dashboard status-row colour for an aggregate key. Returns
+ * the last observed `State` (green/red/degraded), or `null`/`undefined` for a
+ * never-observed key (no row). The aggregator uses this on the comm-error legs
+ * so the overlay PRESERVES the last observed colour instead of stomping it.
+ * Mirrors the control-plane's `PriorStateResolver` (kept as a local type to
+ * avoid a control-plane ↔ aggregator import cycle).
+ */
+export type AggregatorPriorStateResolver = (
+  aggregateKey: string,
+) => Promise<State | null | undefined> | State | null | undefined;
+
+export interface ResultAggregatorDeps {
+  statusWriter: StatusWriter;
+  runWriter: ProbeRunWriter;
+  logger: Logger;
+  /** Monotonic-ish clock (epoch ms) for run-history timing. */
+  now: () => number;
+  /**
+   * [REQ-B] Read the current status-row colour for an aggregate key so the
+   * WORKER-SELF-REPORT comm-error overlay (in `aggregate`) preserves the last
+   * observed colour. Optional — when omitted, a never-observed key falls back
+   * to the no-data colour and an observed key cannot be consulted, so the
+   * worker-reported `aggregateState` (forced off `"error"`) is used directly.
+   */
+  resolvePriorState?: AggregatorPriorStateResolver;
+}
+
+/**
+ * Merge the REQ-B comm-error overlay into a primary-row signal. The original
+ * aggregate signal is preserved (spread first) and the comm error is layered
+ * under `FLEET_COMM_ERROR_SIGNAL_KEY` so the dashboard can re-surface it. Only
+ * object-shaped signals are merged into; a non-object aggregate signal is
+ * replaced by the overlay object (the comm error is the operative payload).
+ */
+function withCommErrorOverlay(
+  aggregateSignal: unknown,
+  result: ServiceJobResult,
+): unknown {
+  if (!result.commError) return aggregateSignal;
+  const overlay = commErrorToStatusSignal(result.commError);
+  if (
+    aggregateSignal !== null &&
+    typeof aggregateSignal === "object" &&
+    !Array.isArray(aggregateSignal)
+  ) {
+    return { ...(aggregateSignal as Record<string, unknown>), ...overlay };
+  }
+  return overlay;
+}
+
+/** The known {@link State} set, for validating a value read back from PB. */
+const KNOWN_STATES: ReadonlySet<string> = new Set<State>([
+  "green",
+  "red",
+  "degraded",
+]);
+
+/**
+ * Validate an arbitrary value (e.g. a `state` string read back from PB) against
+ * the known {@link State} set rather than blind-casting it. Returns the value
+ * typed as `State` when it is one of the known colours, else `undefined` — so
+ * a malformed/legacy PB string degrades to the no-data ("error") path instead
+ * of being persisted as a bogus colour.
+ */
+export function asKnownState(value: unknown): State | undefined {
+  return typeof value === "string" && KNOWN_STATES.has(value)
+    ? (value as State)
+    : undefined;
+}
+
+/**
+ * The non-error no-data colour the worker-self-report comm-error leg falls back
+ * to when the worker's own `aggregateState` is `"error"` AND no prior colour is
+ * observable. It must be a real `State` (NEVER `"error"`, which would route the
+ * row to history-only and LOSE the overlay) and must NOT be `"green"` (which
+ * would fabricate a healthy row for a service we could not actually reach).
+ * `"degraded"` is the least-wrong no-data colour; the dashboard dims it and
+ * derives the "unreachable" surface from the overlay, not the colour.
+ */
+const COMM_ERROR_NO_DATA_STATE: State = "degraded";
+
+export function createResultAggregator(
+  deps: ResultAggregatorDeps,
+): ResultAggregator {
+  const { statusWriter, runWriter, logger, now } = deps;
+
+  /**
+   * Resolve the NON-error colour the worker-self-report comm-error primary row
+   * carries (REQ-B). Precedence:
+   *   1. The worker's own `aggregateState` when it is a real NON-GREEN colour
+   *      (red/degraded) — the worker DID reach us, so a NEGATIVE rollup colour
+   *      stands. A worker-reported `"green"` is DELIBERATELY NOT carried here:
+   *      this function only runs when a `commError` is present, which means we
+   *      did NOT get a trustworthy result (a corrupt/decoded row can carry
+   *      `aggregateState:"green"` alongside a `commError`). Carrying that green
+   *      would write a GREEN status row for a service we could not reach,
+   *      violating REQ-B's "never fabricate green for a service we couldn't
+   *      reach" invariant. So an (untrusted) green falls through to the prior
+   *      observed colour / no-data path below, exactly like `"error"`.
+   *   2. Otherwise (worker reported `"error"` OR an untrusted `"green"`) the
+   *      prior OBSERVED status-row colour — which MAY legitimately be green if
+   *      we actually observed green before — so a red service whose worker then
+   *      reports a comm error stays red, and a previously-green service is only
+   *      ever green because WE observed it, not because the untrusted result
+   *      claimed it.
+   *   3. Otherwise a non-error no-data colour (`"degraded"`, never green, never
+   *      error).
+   * The result is NEVER `"error"`: that would route the row to status_history
+   * only and LOSE the overlay the dashboard reads off the status row.
+   */
+  async function commErrorCarriedState(
+    aggregateKey: string,
+    aggregateState: ProbeState,
+  ): Promise<State> {
+    // A comm error means the result is untrusted, so a worker-reported "green"
+    // is NOT carried — only a negative (red/degraded) colour is trusted enough
+    // to stand. An untrusted green falls through to the prior-observed path.
+    const workerColour = asKnownState(aggregateState);
+    if (workerColour && workerColour !== "green") return workerColour;
+    return (
+      asKnownState((await readPriorState(aggregateKey)) ?? undefined) ??
+      COMM_ERROR_NO_DATA_STATE
+    );
+  }
+
+  /**
+   * Read the prior OBSERVED status-row colour via the injected resolver,
+   * best-effort. A missing resolver or a lookup throw degrades to `undefined`
+   * (the no-data path) — reading the prior colour must never abort aggregation.
+   */
+  async function readPriorState(
+    aggregateKey: string,
+  ): Promise<State | null | undefined> {
+    if (!deps.resolvePriorState) return undefined;
+    try {
+      return await deps.resolvePriorState(aggregateKey);
+    } catch (err) {
+      logger.warn("fleet.aggregator.prior-state-read-failed", {
+        aggregateKey,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return undefined;
+    }
+  }
+
+  return {
+    async aggregate(result) {
+      // ── IDEMPOTENCY GATE ────────────────────────────────────────────────
+      // The consumer aggregates-then-latches `result_processed`. If that latch
+      // write fails (or the process crashes before it), the SAME job's result
+      // is re-handed to us next tick. Re-applying it is NOT free: status-writer
+      // would bump fail_count again (inflating "red for N"), append a spurious
+      // status_history row, and re-emit `status.changed`; run-history would
+      // mint a DUPLICATE probe_runs row. So before doing anything, check for an
+      // existing run row stamped with this jobId:
+      //   - TERMINAL row  → this result was already fully aggregated on a prior
+      //     tick (only the latch failed). SKIP entirely — a true no-op.
+      //   - RUNNING row   → a prior attempt crashed mid-aggregate. RESUME on the
+      //     SAME row (reuse its id) so we don't mint a duplicate; the status
+      //     re-writes in this narrow window are acceptable (the first attempt
+      //     never completed them).
+      // findByJobId failing must not wedge aggregation, so we treat a lookup
+      // error as "no prior row" and proceed (at-least-once, same as before).
+      let resumeRunRowId: string | null = null;
+      try {
+        const prior = await runWriter.findByJobId(result.jobId);
+        if (prior && prior.terminal) {
+          logger.debug("fleet.aggregator.dedup-skip", {
+            probeKey: result.aggregateKey,
+            jobId: result.jobId,
+            runRowId: prior.id,
+          });
+          return { runRowId: prior.id, statusOutcomes: [], skipped: true };
+        }
+        if (prior) resumeRunRowId = prior.id;
+      } catch (err) {
+        logger.warn("fleet.aggregator.dedup-lookup-failed", {
+          probeKey: result.aggregateKey,
+          jobId: result.jobId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      // Project the worker result onto the EXISTING status-row shapes: the
+      // primary aggregate row first, then one side row per cell. We overlay
+      // the comm error (REQ-B) onto the PRIMARY row only — the per-cell rows
+      // keep their real probe colours so the dashboard's per-cell badges
+      // remain accurate even while the pool is unreachable.
+      const probeResults: ProbeResult[] =
+        probeResultsForServiceJobResult(result);
+      if (result.commError && probeResults.length > 0) {
+        // CRITICAL (REQ-B): the worker-self-report comm-error leg sets
+        // aggregateState:"error" (buildCommErrorResult/buildDriverErrorResult).
+        // If we wrote the primary row with state:"error", the status-writer
+        // routes it to status_history ONLY and NEVER persists the signal to the
+        // STATUS ROW — so the comm-error overlay the dashboard reads from the
+        // status row (commErrorFromStatusSignal) would be silently LOST. We
+        // FORCE the primary row to a NON-error carried colour (mirroring
+        // aggregateCommError's lastKnownState discipline): preserve the prior
+        // observed colour when one exists (a red service whose worker then
+        // reports a comm error stays red + unreachable), else fall back to a
+        // non-error no-data colour. NEVER "error" — the overlay MUST land on the
+        // status row. The colour itself is dimmed by the dashboard, which
+        // derives "unreachable" from the overlay, not the colour.
+        const carriedState = await commErrorCarriedState(
+          result.aggregateKey,
+          result.aggregateState,
+        );
+        probeResults[0] = {
+          ...probeResults[0],
+          state: carriedState,
+          signal: withCommErrorOverlay(probeResults[0].signal, result),
+        };
+      }
+
+      // Open a run-history row up-front so its started_at brackets the writes
+      // (mirrors probe-invoker), stamping the jobId so a re-process dedupes via
+      // findByJobId above. When RESUMING a crashed-mid-aggregate run we reuse
+      // the existing row id instead of minting a second. Best-effort —
+      // observability must never tank the aggregation; a failed start just
+      // means no run-history row.
+      const startedAt = now();
+      let runRowId: string | null = resumeRunRowId;
+      if (!runRowId) {
+        try {
+          const created = await runWriter.start({
+            probeId: result.aggregateKey,
+            startedAt,
+            triggered: false,
+            jobId: result.jobId,
+          });
+          runRowId = created.id;
+        } catch (err) {
+          logger.error("fleet.aggregator.run-start-failed", {
+            probeKey: result.aggregateKey,
+            jobId: result.jobId,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      // Write every projected row through the unchanged status pipeline.
+      const statusOutcomes: WriteOutcome[] = [];
+      for (const pr of probeResults) {
+        const outcome = await statusWriter.write(pr);
+        statusOutcomes.push(outcome);
+      }
+
+      // Persist the rollup. `terminalJobStatus` maps green→done / anything
+      // else (incl. comm error) →failed; run-history's narrower enum is
+      // completed/failed, so a "done" job is a "completed" run.
+      if (runRowId) {
+        const status = terminalJobStatus(result);
+        const runState = status === "done" ? "completed" : "failed";
+        try {
+          await runWriter.finish({
+            id: runRowId,
+            finishedAt: now(),
+            state: runState,
+            summary: runSummaryForServiceJobResult(result),
+          });
+        } catch (err) {
+          logger.error("fleet.aggregator.run-finish-failed", {
+            probeKey: result.aggregateKey,
+            jobId: result.jobId,
+            runRowId,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      logger.debug("fleet.aggregator.aggregated", {
+        probeKey: result.aggregateKey,
+        serviceSlug: result.serviceSlug,
+        jobId: result.jobId,
+        cells: result.cells.length,
+        commError: result.commError?.kind,
+      });
+
+      return { runRowId, statusOutcomes, skipped: false };
+    },
+
+    async aggregateCommError(input) {
+      const { commError, aggregateKey } = input;
+      // Keep the caller-supplied last-known colour (validated against the known
+      // State set — never blind-trust an arbitrary value). For a never-observed
+      // key (no lastKnownState) fall back to "error" (no-data) so we NEVER
+      // invent a green row and NEVER stomp an observed colour to green.
+      const carriedState: ProbeState =
+        asKnownState(input.lastKnownState) ?? "error";
+      const overlay = commErrorToStatusSignal(commError);
+
+      // Write the overlay onto the aggregate row first, then the optional cell
+      // row. When an observed colour is carried (green/red/degraded) the write
+      // goes through the UNCHANGED non-error status-writer path so the signal
+      // lands on the `status` row the dashboard reads, preserving the observed
+      // colour (a crashed `red` service stays `red` + unreachable overlay). For
+      // a never-observed key `carriedState` is "error" — the no-data path,
+      // which writes to `status_history` only and never fabricates a green
+      // `status` row for a service that has never been probed.
+      const keys: string[] = [aggregateKey];
+      if (input.cellKey !== undefined && input.cellKey !== aggregateKey) {
+        keys.push(input.cellKey);
+      }
+
+      const statusOutcomes: WriteOutcome[] = [];
+      for (const key of keys) {
+        const pr: ProbeResult = {
+          key,
+          state: carriedState,
+          signal: overlay,
+          observedAt: commError.observedAt,
+        };
+        const outcome = await statusWriter.write(pr);
+        statusOutcomes.push(outcome);
+      }
+
+      logger.debug("fleet.aggregator.commerror-surfaced", {
+        aggregateKey,
+        cellKey: input.cellKey,
+        kind: commError.kind,
+        jobId: commError.jobId,
+        workerId: commError.workerId,
+        carriedState,
+      });
+
+      return { statusOutcomes };
+    },
+  };
+}

--- a/showcase/harness/src/fleet/control-plane/result-consumer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/result-consumer.test.ts
@@ -1,0 +1,811 @@
+import { describe, it, expect, vi } from "vitest";
+import { createResultConsumer } from "./result-consumer.js";
+import type {
+  ResultAggregator,
+  AggregateOutcome,
+} from "./result-aggregator.js";
+import type {
+  PbClient,
+  ListOpts,
+  ListResult,
+} from "../../storage/pb-client.js";
+import type { JobView } from "../job-claim.js";
+import type { ServiceJobResult } from "../contracts.js";
+import { logger } from "../../logger.js";
+
+/**
+ * Pins the control-plane RESULT CONSUMER — the worker->aggregator bridge that
+ * makes the dashboard contract hold across the process split. The two
+ * load-bearing behaviors: it aggregates a terminal row's persisted result and
+ * latches it processed, and it never aggregates the SAME result twice (the
+ * consume-once invariant) even across repeated cycles.
+ */
+
+interface JobRow extends JobView {
+  result?: unknown;
+  result_processed?: boolean;
+  /** PB's auto-maintained mtime; the grace check reads this. */
+  updated?: string;
+  /** PB's auto-maintained ctime; the deterministic page sort reads this. */
+  created?: string;
+}
+
+function jobView(over: Partial<JobView> = {}): JobView {
+  return {
+    id: "j1",
+    probe_key: "e2e_d6:langgraph-python",
+    status: "done",
+    claimed_by: "worker-7",
+    lease_expires_at: null,
+    version: 4,
+    ...over,
+  };
+}
+
+function sampleResult(over: Partial<ServiceJobResult> = {}): ServiceJobResult {
+  return {
+    jobId: "j1",
+    probeKey: "e2e_d6:langgraph-python",
+    serviceSlug: "langgraph-python",
+    runId: "run-1",
+    workerId: "worker-7",
+    aggregateState: "green",
+    aggregateKey: "e2e_d6:langgraph-python",
+    aggregateSignal: { failedCount: 0 },
+    cells: [],
+    rollup: { total: 1, passed: 1, failed: 0 },
+    finishedAt: "2026-06-04T00:00:02.000Z",
+    ...over,
+  };
+}
+
+/**
+ * Fake PB honoring the consumer's filter: `(status = "done" || status =
+ * "failed") && result_processed != true`. Implements the status alternation +
+ * the result_processed latch the way the real client would so the consume-once
+ * loop is exercised faithfully.
+ */
+function makeFakePb(rows: JobRow[]): { pb: PbClient; rows: JobRow[] } {
+  const store = [...rows];
+  const unsupported = (n: string) => () => {
+    throw new Error(`fake-pb: ${n} not implemented`);
+  };
+  const pb: PbClient = {
+    async list<T>(_c: string, opts: ListOpts = {}): Promise<ListResult<T>> {
+      const statuses = [
+        ...(opts.filter ?? "").matchAll(/status\s*=\s*"(\w+)"/g),
+      ].map((m) => m[1]);
+      const wantStatus = new Set(statuses);
+      const wantUnprocessed = /result_processed\s*!=\s*true/.test(
+        opts.filter ?? "",
+      );
+      const items = store.filter((r) => {
+        if (wantStatus.size > 0 && !wantStatus.has(r.status)) return false;
+        if (wantUnprocessed && r.result_processed === true) return false;
+        return true;
+      });
+      return {
+        page: 1,
+        perPage: opts.perPage ?? items.length,
+        totalPages: 1,
+        totalItems: items.length,
+        items: items as unknown as T[],
+      };
+    },
+    async update<T>(
+      _c: string,
+      id: string,
+      record: Record<string, unknown>,
+    ): Promise<T> {
+      const row = store.find((r) => r.id === id);
+      if (!row) throw new Error(`fake-pb: update of missing row ${id}`);
+      Object.assign(row as unknown as Record<string, unknown>, record);
+      return row as unknown as T;
+    },
+    getOne: unsupported("getOne") as PbClient["getOne"],
+    getFirst: unsupported("getFirst") as PbClient["getFirst"],
+    create: unsupported("create") as PbClient["create"],
+    upsertByField: unsupported("upsertByField") as PbClient["upsertByField"],
+    delete: unsupported("delete") as PbClient["delete"],
+    deleteByFilter: unsupported("deleteByFilter") as PbClient["deleteByFilter"],
+    health: unsupported("health") as PbClient["health"],
+    createBackup: unsupported("createBackup") as PbClient["createBackup"],
+    downloadBackup: unsupported("downloadBackup") as PbClient["downloadBackup"],
+    deleteBackup: unsupported("deleteBackup") as PbClient["deleteBackup"],
+  };
+  return { pb, rows: store };
+}
+
+/**
+ * Fake PB that, unlike `makeFakePb`, HONORS `perPage` + a `created,id` `sort`
+ * so the consume poll's pagination is exercised faithfully. Used to reproduce
+ * the >CONSUME_PAGE resultless-backlog starvation: with a stable sort + a
+ * scoped prune, a row on the first page must keep its first-seen grace basis
+ * across cycles (it isn't reset just because the backlog spills past the page).
+ */
+function makePaginatingFakePb(rows: JobRow[]): {
+  pb: PbClient;
+  rows: JobRow[];
+} {
+  const store = [...rows];
+  const unsupported = (n: string) => () => {
+    throw new Error(`fake-pb: ${n} not implemented`);
+  };
+  const pb: PbClient = {
+    async list<T>(_c: string, opts: ListOpts = {}): Promise<ListResult<T>> {
+      const statuses = [
+        ...(opts.filter ?? "").matchAll(/status\s*=\s*"(\w+)"/g),
+      ].map((m) => m[1]);
+      const wantStatus = new Set(statuses);
+      const wantUnprocessed = /result_processed\s*!=\s*true/.test(
+        opts.filter ?? "",
+      );
+      let items = store.filter((r) => {
+        if (wantStatus.size > 0 && !wantStatus.has(r.status)) return false;
+        if (wantUnprocessed && r.result_processed === true) return false;
+        return true;
+      });
+      // Honor a `created,id` sort (the consumer's deterministic page order).
+      if (opts.sort) {
+        items = [...items].sort((a, b) => {
+          const ac = String(a.created ?? "");
+          const bc = String(b.created ?? "");
+          if (ac !== bc) return ac < bc ? -1 : 1;
+          return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+        });
+      }
+      const perPage = opts.perPage ?? items.length;
+      const slice = items.slice(0, perPage);
+      return {
+        page: 1,
+        perPage,
+        totalPages: 1,
+        totalItems: items.length,
+        items: slice as unknown as T[],
+      };
+    },
+    async update<T>(
+      _c: string,
+      id: string,
+      record: Record<string, unknown>,
+    ): Promise<T> {
+      const row = store.find((r) => r.id === id);
+      if (!row) throw new Error(`fake-pb: update of missing row ${id}`);
+      Object.assign(row as unknown as Record<string, unknown>, record);
+      return row as unknown as T;
+    },
+    getOne: unsupported("getOne") as PbClient["getOne"],
+    getFirst: unsupported("getFirst") as PbClient["getFirst"],
+    create: unsupported("create") as PbClient["create"],
+    upsertByField: unsupported("upsertByField") as PbClient["upsertByField"],
+    delete: unsupported("delete") as PbClient["delete"],
+    deleteByFilter: unsupported("deleteByFilter") as PbClient["deleteByFilter"],
+    health: unsupported("health") as PbClient["health"],
+    createBackup: unsupported("createBackup") as PbClient["createBackup"],
+    downloadBackup: unsupported("downloadBackup") as PbClient["downloadBackup"],
+    deleteBackup: unsupported("deleteBackup") as PbClient["deleteBackup"],
+  };
+  return { pb, rows: store };
+}
+
+function makeFakeAggregator(): ResultAggregator & {
+  calls: ServiceJobResult[];
+} {
+  const calls: ServiceJobResult[] = [];
+  const agg = {
+    calls,
+    aggregate: vi.fn(
+      async (result: ServiceJobResult): Promise<AggregateOutcome> => {
+        calls.push(result);
+        return { runRowId: "run-row-1", statusOutcomes: [], skipped: false };
+      },
+    ),
+    // The consumer never calls aggregateCommError (that's the producer-sweep /
+    // fleet-health leg); present only to satisfy the ResultAggregator interface.
+    aggregateCommError: vi.fn(async () => ({ statusOutcomes: [] })),
+  };
+  return agg as ResultAggregator & { calls: ServiceJobResult[] };
+}
+
+function row(over: Partial<JobRow> = {}): JobRow {
+  return {
+    ...jobView(),
+    result: sampleResult(),
+    result_processed: false,
+    ...over,
+  };
+}
+
+describe("ResultConsumer.consumeOnce", () => {
+  it("aggregates a terminal row's result and latches it processed", async () => {
+    const { pb, rows } = makeFakePb([row()]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    const out = await consumer.consumeOnce();
+
+    expect(out.processed).toBe(1);
+    expect(out.failures).toBe(0);
+    expect(aggregator.calls).toHaveLength(1);
+    expect(aggregator.calls[0].aggregateKey).toBe("e2e_d6:langgraph-python");
+    expect(rows[0].result_processed).toBe(true);
+  });
+
+  it("aggregates each result EXACTLY ONCE across repeated cycles", async () => {
+    const { pb } = makeFakePb([row({ id: "j1" }), row({ id: "j2" })]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    const first = await consumer.consumeOnce();
+    const second = await consumer.consumeOnce();
+
+    expect(first.processed).toBe(2);
+    // Second cycle finds nothing unprocessed — the latch held.
+    expect(second.processed).toBe(0);
+    expect(aggregator.aggregate).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips an already-processed row", async () => {
+    const { pb } = makeFakePb([row({ result_processed: true })]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    const out = await consumer.consumeOnce();
+
+    expect(out.processed).toBe(0);
+    expect(aggregator.aggregate).not.toHaveBeenCalled();
+  });
+
+  it("leaves a row unprocessed when aggregate throws, retrying next cycle", async () => {
+    const { pb, rows } = makeFakePb([row()]);
+    const aggregator = makeFakeAggregator();
+    let calls = 0;
+    aggregator.aggregate = vi.fn(async (_result: ServiceJobResult) => {
+      calls++;
+      if (calls === 1) throw new Error("transient PB blip");
+      return { runRowId: "r", statusOutcomes: [], skipped: false };
+    }) as ResultAggregator["aggregate"];
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    const first = await consumer.consumeOnce();
+    expect(first.processed).toBe(0);
+    expect(first.failures).toBe(1);
+    expect(rows[0].result_processed).toBe(false);
+
+    // Retry succeeds and latches.
+    const second = await consumer.consumeOnce();
+    expect(second.processed).toBe(1);
+    expect(rows[0].result_processed).toBe(true);
+  });
+
+  it("does NOT latch a FRESH terminal-but-resultless row (within grace)", async () => {
+    // DATA-LOSS RACE: report() flips the row terminal, then writes `result` in a
+    // SEPARATE pb.update milliseconds later. If the consumer scans in that
+    // window it sees result === undefined; latching immediately would drop the
+    // real result landing right after. Within the grace window we must LEAVE it
+    // unprocessed so the next cycle picks up the worker's result write.
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const { pb, rows } = makeFakePb([
+      row({
+        result: undefined,
+        status: "failed",
+        // Became terminal 5s ago — well inside a 30s grace window.
+        updated: "2026-06-04T00:04:55.000Z",
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({
+      pb,
+      aggregator,
+      logger,
+      now: () => now,
+    });
+
+    const out = await consumer.consumeOnce();
+
+    expect(aggregator.aggregate).not.toHaveBeenCalled();
+    expect(out.processed).toBe(0);
+    // Left unprocessed — the result write will land and be aggregated next tick.
+    expect(rows[0].result_processed).toBeFalsy();
+  });
+
+  it("latches a terminal-but-resultless row PAST the grace window AND surfaces a comm error", async () => {
+    // Genuinely resultless (a report whose result write never landed). The row
+    // is ALREADY terminal, so the claimed|running sweepers never see it — the
+    // consumer itself must synthesize the dashboard signal. Once aged past
+    // grace, it SYNTHESIZES a `worker-crashed-mid-job` comm error (REQ-B, keyed
+    // on the row's probe_key) and THEN latches so it doesn't re-scan forever.
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const { pb, rows } = makeFakePb([
+      row({
+        result: undefined,
+        status: "failed",
+        // Terminal 60s ago — past a 30s grace window.
+        updated: "2026-06-04T00:04:00.000Z",
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({
+      pb,
+      aggregator,
+      logger,
+      now: () => now,
+    });
+
+    const out = await consumer.consumeOnce();
+
+    // The normal aggregate path is NOT taken (there is no result to aggregate).
+    expect(aggregator.aggregate).not.toHaveBeenCalled();
+    // The comm-error path IS taken, keyed on the row's d6 aggregate key.
+    expect(aggregator.aggregateCommError).toHaveBeenCalledTimes(1);
+    const arg = (aggregator.aggregateCommError as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(arg.commError.kind).toBe("worker-crashed-mid-job");
+    expect(arg.commError.jobId).toBe(rows[0].id);
+    expect(arg.aggregateKey).toBe("e2e_d6:langgraph-python");
+    expect(out.processed).toBe(0);
+    expect(rows[0].result_processed).toBe(true);
+  });
+
+  it("carries the PRIOR OBSERVED colour onto the result-lost comm error (REQ-B)", async () => {
+    // REQ-B (Fix A1): a service PREVIOUSLY observed green/red/degraded whose
+    // worker crashes mid-job (result lost past grace) must keep its observed
+    // colour on the overlay so the comm error lands on the LIVE status row (not
+    // history-only) and the dashboard renders ⚡ "unreachable". Without a
+    // resolvePriorState resolver the consumer omits lastKnownState, the
+    // aggregator falls back to "error", and the overlay routes to status_history
+    // only — silently lost. The consumer must resolve the row's probe_key prior
+    // colour and thread it as lastKnownState.
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const { pb, rows } = makeFakePb([
+      row({
+        result: undefined,
+        status: "failed",
+        updated: "2026-06-04T00:04:00.000Z",
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const resolvePriorState = vi.fn(async (_key: string) => "green" as const);
+    const consumer = createResultConsumer({
+      pb,
+      aggregator,
+      logger,
+      now: () => now,
+      resolvePriorState,
+    });
+
+    const out = await consumer.consumeOnce();
+
+    expect(aggregator.aggregateCommError).toHaveBeenCalledTimes(1);
+    // The resolver was consulted for the row's d6 aggregate key.
+    expect(resolvePriorState).toHaveBeenCalledWith("e2e_d6:langgraph-python");
+    const arg = (aggregator.aggregateCommError as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    // The observed colour is carried so the overlay lands on the LIVE status row.
+    expect(arg.lastKnownState).toBe("green");
+    expect(arg.aggregateKey).toBe("e2e_d6:langgraph-python");
+    expect(out.processed).toBe(0);
+    expect(rows[0].result_processed).toBe(true);
+  });
+
+  it("omits lastKnownState for a NEVER-observed result-lost row (no green fabrication)", async () => {
+    // REQ-B (Fix A1): a never-observed key (resolver returns null) must NOT
+    // carry a lastKnownState — the aggregator then writes the no-data ("error")
+    // path and never fabricates a green status row for a service we never saw.
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const { pb } = makeFakePb([
+      row({
+        result: undefined,
+        status: "failed",
+        updated: "2026-06-04T00:04:00.000Z",
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const resolvePriorState = vi.fn(async (_key: string) => null);
+    const consumer = createResultConsumer({
+      pb,
+      aggregator,
+      logger,
+      now: () => now,
+      resolvePriorState,
+    });
+
+    await consumer.consumeOnce();
+
+    expect(aggregator.aggregateCommError).toHaveBeenCalledTimes(1);
+    const arg = (aggregator.aggregateCommError as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(arg.lastKnownState).toBeUndefined();
+  });
+
+  it("does NOT latch a resultless-past-grace row if the comm-error surface FAILS (retries next cycle)", async () => {
+    // The comm error MUST reach the dashboard before we latch. If surfacing
+    // throws, latching anyway would drop the REQ-B signal silently. So a failed
+    // surface leaves the row unlatched for the next cycle to retry.
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const { pb, rows } = makeFakePb([
+      row({
+        result: undefined,
+        status: "failed",
+        updated: "2026-06-04T00:04:00.000Z",
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    aggregator.aggregateCommError = vi.fn(async () => {
+      throw new Error("transient overlay write blip");
+    }) as ResultAggregator["aggregateCommError"];
+    const consumer = createResultConsumer({
+      pb,
+      aggregator,
+      logger,
+      now: () => now,
+    });
+
+    const out = await consumer.consumeOnce();
+
+    expect(out.processed).toBe(0);
+    // Surface failed → NOT latched, so the next cycle re-attempts the comm error.
+    expect(rows[0].result_processed).toBeFalsy();
+  });
+
+  it("latches a resultless row by FIRST-SEEN time, immune to a moving row.updated", async () => {
+    // STABLE-BASIS regression: the grace window must measure from when the
+    // consumer FIRST saw the row resultless, NOT from PB's `updated` mtime.
+    // Here `row.updated` keeps advancing every cycle (as if any write touched
+    // the row), which under the old mtime-based logic would keep the row
+    // perpetually "young" and re-scanning forever. With the first-seen basis it
+    // latches once 30s elapse since the first sighting regardless of `updated`.
+    let clock = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb, rows } = makeFakePb([
+      row({
+        result: undefined,
+        status: "failed",
+        updated: "2026-06-04T00:00:00.000Z",
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({
+      pb,
+      aggregator,
+      logger,
+      now: () => clock,
+    });
+
+    // Cycle 1: first sighting at t0 — within grace, not latched. Bump `updated`
+    // to NOW so the old mtime logic would treat it as freshly-terminal forever.
+    await consumer.consumeOnce();
+    expect(rows[0].result_processed).toBeFalsy();
+
+    // Advance 10s, touch `updated` to "now" again (mtime keeps moving).
+    clock += 10_000;
+    rows[0].updated = new Date(clock).toISOString();
+    await consumer.consumeOnce();
+    expect(rows[0].result_processed).toBeFalsy();
+
+    // Advance past 30s SINCE FIRST SEEN (t0+31s) — even though `updated` is
+    // current — the row must now latch on the stable first-seen basis.
+    clock += 21_000;
+    rows[0].updated = new Date(clock).toISOString();
+    const out = await consumer.consumeOnce();
+
+    expect(rows[0].result_processed).toBe(true);
+    expect(out.processed).toBe(0);
+    expect(aggregator.aggregate).not.toHaveBeenCalled();
+  });
+
+  it("prunes a firstSeenResultless entry when its row vanishes from the page (sweeper re-queue)", async () => {
+    // MAP-LEAK regression: the in-memory grace Map is pruned on result-arrival
+    // and on successful latch, but a resultless terminal row that the sweeper
+    // RE-QUEUES (status done|failed -> pending) silently leaves the consumer's
+    // done|failed filter — it is never seen again, so without a reconcile its
+    // first-seen entry leaks forever. Each cycle must prune entries whose jobId
+    // is not in the current page's scanned row-id set.
+    let clock = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb, rows } = makeFakePb([
+      row({
+        id: "j1",
+        result: undefined,
+        status: "failed",
+        updated: "2026-06-04T00:00:00.000Z",
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({
+      pb,
+      aggregator,
+      logger,
+      now: () => clock,
+    });
+
+    // Cycle 1: first sighting at t0 — seeds firstSeenResultless["j1"], within
+    // grace, not latched.
+    await consumer.consumeOnce();
+    expect(rows[0].result_processed).toBeFalsy();
+
+    // The sweeper re-queues j1: status flips failed -> pending, so it no longer
+    // matches the consumer's done|failed filter and vanishes from the page.
+    rows[0].status = "pending";
+
+    // Cycle 2 (only 5s later, well inside grace): the page is now empty. The
+    // reconcile must DROP the stale j1 entry since it isn't in the scanned set.
+    clock += 5_000;
+    await consumer.consumeOnce();
+
+    // Prove the entry was pruned: re-queue j1 back to a resultless terminal row
+    // and advance the clock so that 31s have elapsed since the ORIGINAL t0
+    // sighting. Set `updated` to "now" so the mtime-seed reflects a FRESH
+    // terminal (the row just became terminal again). If the stale t0 entry had
+    // leaked (survived), the row would latch immediately on this cycle (t0+31s
+    // past the original grace). Because it was pruned, this is a FRESH
+    // first-sighting at t0+31s — still within a new 30s window — so it must NOT
+    // latch yet.
+    rows[0].status = "failed";
+    clock += 26_000; // t0 + 31s
+    rows[0].updated = new Date(clock).toISOString();
+    const out = await consumer.consumeOnce();
+    expect(out.processed).toBe(0);
+    expect(rows[0].result_processed).toBeFalsy();
+
+    // And it latches only after a full grace window from the FRESH sighting.
+    clock += 31_000; // (t0+31s) + 31s
+    await consumer.consumeOnce();
+    expect(rows[0].result_processed).toBe(true);
+  });
+
+  it("aggregates a terminal row WITH a result normally (grace irrelevant)", async () => {
+    // A row that carries a result is aggregated regardless of age — grace only
+    // gates the resultless branch.
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const { pb, rows } = makeFakePb([
+      row({ updated: "2026-06-04T00:04:59.000Z" }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({
+      pb,
+      aggregator,
+      logger,
+      now: () => now,
+    });
+
+    const out = await consumer.consumeOnce();
+
+    expect(out.processed).toBe(1);
+    expect(aggregator.aggregate).toHaveBeenCalledTimes(1);
+    expect(rows[0].result_processed).toBe(true);
+  });
+
+  it("treats an invalid aggregateState as a decode failure (fails loud)", async () => {
+    // A garbage aggregateState ("grene") must NOT flow into the status state
+    // machine. decodeResult validates it against the known ProbeState set and
+    // fails at the boundary; the row is left unprocessed (counted a failure).
+    const { pb, rows } = makeFakePb([
+      row({
+        result: sampleResult({
+          aggregateState: "grene" as ServiceJobResult["aggregateState"],
+        }),
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    const out = await consumer.consumeOnce();
+
+    expect(out.processed).toBe(0);
+    expect(out.failures).toBe(1);
+    expect(aggregator.aggregate).not.toHaveBeenCalled();
+    // Not latched — a decode failure is a poison row, surfaced via metrics.
+    expect(rows[0].result_processed).toBeFalsy();
+  });
+
+  it("treats a non-numeric rollup as a decode failure (fails loud)", async () => {
+    const { pb } = makeFakePb([
+      row({
+        result: sampleResult({
+          rollup: {
+            total: "1",
+            passed: 1,
+            failed: 0,
+          } as unknown as ServiceJobResult["rollup"],
+        }),
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    const out = await consumer.consumeOnce();
+
+    expect(out.failures).toBe(1);
+    expect(aggregator.aggregate).not.toHaveBeenCalled();
+  });
+
+  it("treats a present-but-malformed commError as a decode failure (fails loud)", async () => {
+    // A row read from the untrusted `result` JSON column may carry a garbage
+    // `commError`. If decodeResult lets it through, it flows into aggregate() ->
+    // withCommErrorOverlay -> commErrorToStatusSignal and embeds garbage under
+    // the signal key; the dashboard's commErrorFromStatusSignal then rejects it
+    // -> SILENT LOSS. decodeResult must validate commError at the boundary using
+    // the same checks the dashboard's defensive decoder uses (valid kind +
+    // string message/observedAt) and fail LOUD when present-but-malformed.
+    const { pb, rows } = makeFakePb([
+      row({
+        result: sampleResult({
+          commError: {
+            kind: "not-a-kind",
+            message: "oops",
+            observedAt: "2026-06-04T00:00:03.000Z",
+          } as unknown as ServiceJobResult["commError"],
+        }),
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    const out = await consumer.consumeOnce();
+
+    expect(out.processed).toBe(0);
+    expect(out.failures).toBe(1);
+    expect(aggregator.aggregate).not.toHaveBeenCalled();
+    // Not latched — a decode failure is a poison row, surfaced via metrics.
+    expect(rows[0].result_processed).toBeFalsy();
+  });
+
+  it("aggregates a result carrying a WELL-FORMED commError normally", async () => {
+    // A present-AND-valid commError must pass decodeResult and flow into the
+    // aggregator unchanged — the boundary check only rejects malformed ones.
+    const { pb, rows } = makeFakePb([
+      row({
+        result: sampleResult({
+          commError: {
+            kind: "worker-unreachable",
+            message: "connect refused",
+            observedAt: "2026-06-04T00:00:03.000Z",
+            workerId: "worker-7",
+          },
+        }),
+      }),
+    ]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    const out = await consumer.consumeOnce();
+
+    expect(out.processed).toBe(1);
+    expect(out.failures).toBe(0);
+    expect(aggregator.calls).toHaveLength(1);
+    expect(aggregator.calls[0].commError?.kind).toBe("worker-unreachable");
+    expect(rows[0].result_processed).toBe(true);
+  });
+
+  it("aggregates a result with NO commError normally (commError stays optional)", async () => {
+    // The common, happy path: no commError present. The added boundary check
+    // must not reject results that simply omit it.
+    const { pb, rows } = makeFakePb([row({ result: sampleResult() })]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    const out = await consumer.consumeOnce();
+
+    expect(out.processed).toBe(1);
+    expect(out.failures).toBe(0);
+    expect(aggregator.calls[0].commError).toBeUndefined();
+    expect(rows[0].result_processed).toBe(true);
+  });
+
+  it("never throws when the poll list read fails (contract)", async () => {
+    // consumeOnce is documented "Never throws". A PB blip on the initial poll
+    // list must yield {processed:0,failures:0}, not reject the cycle (the
+    // control-plane caller relies on the no-throw contract to keep draining).
+    const { pb } = makeFakePb([row()]);
+    pb.list = vi.fn(async () => {
+      throw new Error("transient PB list blip");
+    }) as PbClient["list"];
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    const out = await consumer.consumeOnce();
+
+    expect(out).toEqual({ processed: 0, failures: 0 });
+  });
+
+  it("requests a DETERMINISTIC page sort (created,id) so paging is stable", async () => {
+    // Fix 1a: an unsorted poll lets a >page resultless backlog rotate through
+    // the first page; the consumer must request a stable `created,id` sort so
+    // each page is a consistent prefix of the pending set.
+    const { pb } = makeFakePb([row()]);
+    const listSpy = vi.spyOn(pb, "list");
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({ pb, aggregator, logger });
+
+    await consumer.consumeOnce();
+
+    expect(listSpy).toHaveBeenCalledWith(
+      "probe_jobs",
+      expect.objectContaining({ sort: "created,id" }),
+    );
+  });
+
+  it("does NOT reset the grace basis of a pending row that fell off a FULL page (no starvation)", async () => {
+    // Fix 1b (STARVATION regression): when the resultless-terminal backlog
+    // exceeds one page, a genuinely-pending row beyond the current page is
+    // absent from the scan. The OLD prune deleted EVERY Map entry absent from
+    // the page — so such a row's first-seen basis was wiped on the cycles it
+    // wasn't paged, and its grace timer kept restarting → result-lost was NEVER
+    // declared (it starved). With the prune scoped to NON-FULL pages only, a
+    // full-page scan no longer prunes by absence, so the beyond-page row keeps
+    // its basis and latches the moment it is paged again past grace.
+    //
+    // CONSUME_PAGE is 50. We seed "jTARGET" plus 50 filler rows. jTARGET sorts
+    // FIRST (earliest created) on cycle 1 so its basis is seeded, then we make
+    // it sort LAST (latest created) so it falls off the full 50-row page on the
+    // mid cycles, then bring it back to the front past grace.
+    let clock = Date.parse("2026-06-04T00:00:00.000Z");
+    const base = Date.parse("2026-06-04T00:00:00.000Z");
+    const target: JobRow = row({
+      id: "jTARGET",
+      result: undefined,
+      status: "failed",
+      created: new Date(base).toISOString(), // earliest → page 1 on cycle 1
+      updated: "2026-06-04T00:00:00.000Z",
+    });
+    const fillers: JobRow[] = [];
+    for (let i = 0; i < 50; i++) {
+      fillers.push(
+        row({
+          id: `f${String(i).padStart(2, "0")}`,
+          result: undefined,
+          status: "failed",
+          created: new Date(base + 1000 + i).toISOString(), // after target initially
+          updated: "2026-06-04T00:00:00.000Z",
+        }),
+      );
+    }
+    const { pb, rows: store } = makePaginatingFakePb([target, ...fillers]);
+    const aggregator = makeFakeAggregator();
+    const consumer = createResultConsumer({
+      pb,
+      aggregator,
+      logger,
+      now: () => clock,
+    });
+    const t = () => store.find((r) => r.id === "jTARGET")!;
+
+    // Cycle 1 at t0: 51 rows, page holds 50; jTARGET sorts first so it's on the
+    // page and its grace basis is seeded.
+    await consumer.consumeOnce();
+    expect(t().result_processed).toBeFalsy();
+
+    // Push jTARGET to the BACK of the sort so it falls OFF the full 50-row page.
+    t().created = new Date(base + 999_999).toISOString();
+
+    // Mid cycles WITHIN grace: jTARGET is absent from the full page. Bump its
+    // `updated` mtime to "now" each cycle (as if any write touched it) so the
+    // first-sighting mtime SEED can't silently recover a reset basis — the ONLY
+    // thing that can keep jTARGET aged across these cycles is the in-memory
+    // first-seen entry SURVIVING. The OLD unscoped prune deletes it here (the
+    // page is full and jTARGET is absent), so a later re-sighting would seed a
+    // FRESH (current-mtime) basis and never latch; the scoped prune keeps it.
+    clock += 10_000;
+    t().updated = new Date(clock).toISOString();
+    await consumer.consumeOnce();
+    expect(t().result_processed).toBeFalsy();
+
+    clock += 10_000;
+    t().updated = new Date(clock).toISOString();
+    await consumer.consumeOnce();
+    expect(t().result_processed).toBeFalsy();
+
+    // Drain the page so jTARGET is paged again, now past 30s since FIRST sight
+    // (t0+31s). Its `updated` mtime is CURRENT, so the mtime seed cannot age it;
+    // only a SURVIVING first-seen basis can. If the basis had been pruned on the
+    // mid cycles, this is a fresh sighting (new grace window) and it must NOT
+    // latch. Because the scoped prune kept the basis, it latches now.
+    for (const f of fillers) {
+      const r = store.find((x) => x.id === f.id)!;
+      r.result_processed = true; // resolve fillers so jTARGET is back on page 1
+    }
+    clock += 11_000; // t0 + 31s
+    t().updated = new Date(clock).toISOString();
+    await consumer.consumeOnce();
+    expect(t().result_processed).toBe(true);
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/result-consumer.ts
+++ b/showcase/harness/src/fleet/control-plane/result-consumer.ts
@@ -1,0 +1,493 @@
+/**
+ * Control-plane RESULT CONSUMER (the worker->aggregator bridge).
+ *
+ * ── WHERE THIS SITS ────────────────────────────────────────────────────
+ * The worker (S7) computes a per-service `ServiceJobResult` and REPORTs it
+ * through the queue protocol; the queue-client (S3) persists that result onto
+ * the now-terminal `probe_jobs` row (migration 1779989700: `result` +
+ * `result_processed`). The worker writes NO authoritative dashboard status —
+ * by design, only the CONTROL-PLANE does. This module is that control-plane
+ * leg: it polls terminal rows carrying an UNPROCESSED result, hands each to the
+ * S5 aggregator (which writes the authoritative status + run-history — the
+ * dashboard contract), then LATCHES `result_processed = true` so the same
+ * result is aggregated EXACTLY ONCE.
+ *
+ * ── CONSUME-ONCE MECHANISM ─────────────────────────────────────────────
+ * The latch is a boolean column on the row, not an in-memory set, so the
+ * once-only guarantee survives a control-plane restart (a result written while
+ * the control-plane was down is still unprocessed on reboot and gets picked up).
+ * We aggregate FIRST, then set the flag: if the flag write fails after a
+ * successful aggregate, the worst case is a re-aggregate next tick. That
+ * re-aggregate is a TRUE no-op: the aggregator is idempotent per `jobId` — it
+ * stamps the originating job id onto its `probe_runs` row and short-circuits
+ * when a terminal row for that job already exists, so a re-process does NOT
+ * re-bump `fail_count`, does NOT append a duplicate `status_history` row, does
+ * NOT mint a duplicate `probe_runs` row, and does NOT re-emit `status.changed`
+ * (see result-aggregator.ts's idempotency gate). At-least-once with a
+ * best-effort latch is therefore the safe failure mode. We never set the flag
+ * BEFORE aggregating (that would risk dropping a result on an aggregate crash).
+ *
+ * ── ONLY THE CONTROL-PLANE WRITES AUTHORITATIVE STATUS ─────────────────
+ * The aggregator is injected (S5 `ResultAggregator`), so this module owns no
+ * PocketBase writes beyond the latch + the read poll. It is a thin, testable
+ * orchestration over the injected PbClient + aggregator.
+ */
+
+import type { Logger, ProbeState, State } from "../../types/index.js";
+import type { PbClient } from "../../storage/pb-client.js";
+import type { JobView } from "../job-claim.js";
+import { PROBE_JOBS_COLLECTION } from "../queue-client.js";
+import type { PoolCommError, ServiceJobResult } from "../contracts.js";
+import { isPoolCommErrorKind } from "../contracts.js";
+import type { ResultAggregator } from "./result-aggregator.js";
+
+/**
+ * Read the CURRENT dashboard status-row colour for an aggregate key (REQ-B).
+ * The result-lost leg calls this BEFORE writing the crash overlay so the
+ * overlaid row PRESERVES the last observed colour (a `red` service whose worker
+ * crashes mid-job stays `red` + unreachable) instead of routing the overlay to
+ * history-only. Returns `undefined`/`null` for a never-observed key (no row), in
+ * which case the aggregator writes the no-data ("error") path — never fabricated
+ * green. Mirrors the control-plane's `PriorStateResolver`; kept as a local type
+ * to avoid a consumer ↔ control-plane import cycle.
+ */
+export type ConsumerPriorStateResolver = (
+  aggregateKey: string,
+) => Promise<State | null | undefined> | State | null | undefined;
+
+/** Max terminal rows scanned per consume cycle — bounds the poll cost. */
+const CONSUME_PAGE = 50;
+
+/**
+ * Deterministic page sort for the consume poll. The grace Map prunes entries
+ * not resolved this cycle, so the SAME rows must page consistently across
+ * cycles — an unsorted query lets the >CONSUME_PAGE resultless backlog rotate
+ * through the first page, starving entries beyond it (their grace timer resets
+ * every cycle, so result-lost is never declared). Sort by `created` then `id`
+ * (stable tiebreak) so the page is a stable prefix of the pending set.
+ */
+const CONSUME_SORT = "created,id";
+
+/**
+ * Anchor the PB space→"T" date-separator rewrite to the canonical PB shape
+ * (`YYYY-MM-DD ` then time) so only the canonical date/time boundary is
+ * normalized, never an arbitrary first space. Kept byte-for-byte consistent
+ * with the JSVM hook (`fleet-claim.pb.js`) and the queue-client's
+ * `leaseExpired` so every PB-timestamp parse in the fleet agrees.
+ */
+const PB_DATE_SEP_RE = /^(\d{4}-\d{2}-\d{2}) /;
+
+/**
+ * Grace window (ms) before a terminal-but-resultless row is latched processed.
+ *
+ * report() (queue-client) flips a row terminal via the release CAS FIRST, then
+ * writes `result` + `result_processed:false` in a SEPARATE pb.update a few
+ * milliseconds later. If the consumer scans in that window it sees an empty
+ * `result` and, if it latched immediately, would drop the real result landing
+ * right after (the dashboard then silently never updates). So we only latch a
+ * resultless terminal row once this window has elapsed since the consumer FIRST
+ * observed it resultless (a STABLE in-memory basis, NOT PB's `updated` mtime
+ * which any later write resets); within it we leave the row unprocessed for the
+ * next cycle to pick up the worker's result write. Sized well above the
+ * report() inter-write gap.
+ */
+const RESULTLESS_GRACE_MS = 30_000;
+
+/**
+ * The known terminal aggregate states (== the `ProbeState` union). A result
+ * carrying anything outside this set is garbage that must NOT flow into the
+ * status state machine, so `decodeResult` rejects it at the boundary.
+ */
+const PROBE_STATES: ReadonlySet<ProbeState> = new Set<ProbeState>([
+  "green",
+  "red",
+  "degraded",
+  "error",
+]);
+
+/** The persisted `probe_jobs` row shape with the result-flow columns. */
+interface ResultJobRecord extends JobView {
+  result?: unknown;
+  result_processed?: boolean;
+  /**
+   * PB's auto-maintained mtime. NO LONGER used as the resultless grace basis
+   * (any later write resets it, so a touched row would never latch); the
+   * consumer now tracks a stable in-memory first-seen time per jobId instead.
+   * Retained on the read shape only for diagnostics.
+   */
+  updated?: string;
+}
+
+/** Outcome of one `consumeOnce()` cycle. */
+export interface ConsumeResult {
+  /** Rows whose result was aggregated + latched this cycle. */
+  processed: number;
+  /** Rows that errored during aggregate/latch (left unprocessed for retry). */
+  failures: number;
+}
+
+export interface ResultConsumerDeps {
+  pb: PbClient;
+  aggregator: ResultAggregator;
+  logger: Logger;
+  /** Injectable clock for the resultless grace window. Defaults to Date.now. */
+  now?: () => number;
+  /**
+   * [REQ-B] Read the current status-row colour for an aggregate key so the
+   * result-lost crash overlay (the resultless-past-grace leg) PRESERVES the last
+   * observed colour instead of routing the overlay to history-only. The sweep +
+   * fleet-health legs in `control-plane.ts` already thread this; without it the
+   * consumer leg omits `lastKnownState`, the aggregator falls back to "error",
+   * and a previously-observed service's ⚡ "unreachable" overlay never lands on
+   * the live status row the dashboard reads. Optional — when omitted, the leg
+   * behaves as a never-observed key (no-data "error" path; never fabricates
+   * green).
+   */
+  resolvePriorState?: ConsumerPriorStateResolver;
+}
+
+/** The control-plane's result-consumer — drives the aggregate-once cycle. */
+export interface ResultConsumer {
+  /**
+   * Scan terminal rows carrying an unprocessed result, aggregate each exactly
+   * once, and latch it processed. Returns per-cycle counts. Never throws — a
+   * single bad row is logged and skipped so one poison result can't wedge the
+   * whole consumer.
+   */
+  consumeOnce(): Promise<ConsumeResult>;
+}
+
+/**
+ * Decode a row's `result` JSON into a typed `ServiceJobResult`. PB returns the
+ * JSON column already-parsed. A structural check fails LOUD (caught by the
+ * caller per-row) so a malformed result is skipped rather than dereferenced
+ * deep in the aggregator.
+ */
+function decodeResult(jobId: string, raw: unknown): ServiceJobResult {
+  if (raw === null || typeof raw !== "object") {
+    throw new Error(`result-consumer: job ${jobId} has no decodable result`);
+  }
+  const c = raw as Partial<ServiceJobResult>;
+  if (
+    typeof c.jobId !== "string" ||
+    typeof c.aggregateKey !== "string" ||
+    typeof c.aggregateState !== "string" ||
+    !Array.isArray(c.cells) ||
+    c.rollup === undefined
+  ) {
+    throw new Error(
+      `result-consumer: job ${jobId} result is missing required fields (jobId/aggregateKey/aggregateState/cells/rollup)`,
+    );
+  }
+  // `aggregateState` is typed `ProbeState`, but the JSON column is untrusted: a
+  // garbage string ("grene") satisfies the typeof-string check and would flow
+  // straight into the status state machine. Validate against the known set and
+  // fail LOUD at this boundary instead.
+  if (!PROBE_STATES.has(c.aggregateState as ProbeState)) {
+    throw new Error(
+      `result-consumer: job ${jobId} result has invalid aggregateState "${c.aggregateState}" (expected one of ${[...PROBE_STATES].join("/")})`,
+    );
+  }
+  // `rollup` rides the dashboard's ProbeRunSummary — its three counts must be
+  // real numbers, not strings/NaN, or the aggregator math silently corrupts.
+  const rollup = c.rollup as Partial<ServiceJobResult["rollup"]>;
+  if (
+    !Number.isFinite(rollup.total) ||
+    !Number.isFinite(rollup.passed) ||
+    !Number.isFinite(rollup.failed)
+  ) {
+    throw new Error(
+      `result-consumer: job ${jobId} result has a non-numeric rollup (total/passed/failed must be finite numbers)`,
+    );
+  }
+  // `commError` is OPTIONAL, but when present it rides the same untrusted JSON
+  // column — a garbage value (bad `kind`, missing `message`/`observedAt`) would
+  // satisfy the typeof-object check here, flow through aggregate() ->
+  // withCommErrorOverlay -> commErrorToStatusSignal, and embed garbage under the
+  // signal key; the dashboard's defensive `commErrorFromStatusSignal` then
+  // rejects it -> SILENT LOSS (the very boundary this decoder exists to hold).
+  // Validate it with the SAME checks that decoder uses (the shared
+  // `isPoolCommErrorKind` guard + required string `message`/`observedAt` per the
+  // `PoolCommError` contract; `workerId`/`jobId` are optional). A result with NO
+  // commError stays valid; a present-but-malformed one fails LOUD here.
+  if (c.commError !== undefined && c.commError !== null) {
+    const e = c.commError as Partial<PoolCommError>;
+    if (
+      !isPoolCommErrorKind(e.kind) ||
+      typeof e.message !== "string" ||
+      typeof e.observedAt !== "string"
+    ) {
+      throw new Error(
+        `result-consumer: job ${jobId} result carries a malformed commError (need a valid kind + string message/observedAt)`,
+      );
+    }
+  }
+  return c as ServiceJobResult;
+}
+
+export function createResultConsumer(deps: ResultConsumerDeps): ResultConsumer {
+  const { pb, aggregator, logger } = deps;
+  const now = deps.now ?? Date.now;
+
+  /**
+   * Read the prior OBSERVED status-row colour for an aggregate key so the
+   * result-lost overlay preserves it (REQ-B). Best-effort: a missing resolver or
+   * a lookup throw degrades to `undefined` (the never-observed / no-data path) —
+   * reading the prior colour must never wedge the consumer. Mirrors
+   * `control-plane.ts`'s `priorStateFor`.
+   */
+  async function priorStateFor(
+    aggregateKey: string,
+  ): Promise<State | undefined> {
+    if (!deps.resolvePriorState) return undefined;
+    try {
+      return (await deps.resolvePriorState(aggregateKey)) ?? undefined;
+    } catch (err) {
+      logger.warn("fleet.consumer.prior-state-read-failed", {
+        aggregateKey,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return undefined;
+    }
+  }
+
+  // STABLE grace basis for terminal-but-resultless rows, keyed by jobId. We
+  // CANNOT measure age from `row.updated` (PB's mtime): ANY later write to the
+  // row — including our own — resets it, so a genuinely-resultless row could be
+  // perpetually "young" and re-scanned forever, never latching. Instead we
+  // record the FIRST tick we observed each resultless terminal row and latch
+  // only once the grace window has elapsed since THAT first sighting, which no
+  // subsequent write can move. Entries are pruned when a row gains a result or
+  // is latched, so this stays bounded to the currently-pending resultless set.
+  const firstSeenResultless = new Map<string, number>();
+
+  return {
+    async consumeOnce(): Promise<ConsumeResult> {
+      // Terminal rows (done|failed) whose result is present + not yet
+      // processed. PB has no IS-NOT-NULL on a json column shortcut here, so we
+      // filter status + the latch and guard the result presence in-process.
+      // The poll read is GUARDED: consumeOnce is documented "Never throws" and
+      // the control-plane caller relies on that to keep draining — a PB blip on
+      // this list must yield an empty cycle, not reject the whole tick.
+      let page;
+      try {
+        page = await pb.list<ResultJobRecord>(PROBE_JOBS_COLLECTION, {
+          filter:
+            '(status = "done" || status = "failed") && result_processed != true',
+          // DETERMINISTIC page order (Fix 1a): without a stable sort, PB's
+          // default ordering lets a >CONSUME_PAGE resultless backlog rotate
+          // through the first page, so an entry beyond it is absent some cycles
+          // and present others — under a prune-by-absence its grace timer keeps
+          // resetting and result-lost is never declared. A stable
+          // `created,id` sort makes each page a consistent prefix of the
+          // pending set, so a given row is seen every cycle until it resolves.
+          sort: CONSUME_SORT,
+          perPage: CONSUME_PAGE,
+          skipTotal: true,
+        });
+      } catch (err) {
+        logger.error("fleet.consumer.poll-failed", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+        return { processed: 0, failures: 0 };
+      }
+
+      // Reconcile the in-memory grace Map against the rows actually scanned this
+      // cycle. A resultless terminal row that the sweeper RE-QUEUES (status
+      // done|failed -> pending) silently drops out of this poll's filter — it is
+      // never seen here again, so its first-seen entry would leak forever (it's
+      // only pruned on result-arrival or successful latch, neither of which a
+      // re-queued row ever reaches). Pruning entries whose jobId is absent from
+      // the current page's scanned id set keeps the Map bounded across such
+      // re-queues.
+      //
+      // BUT (Fix 1b) absence-from-page only means "resolved/re-queued" when this
+      // page is the COMPLETE pending set. When the page is FULL
+      // (length === CONSUME_PAGE) there is a backlog LARGER than one page, so a
+      // genuinely-still-pending row beyond this page is also absent — pruning it
+      // by absence would reset its grace timer every cycle and starve
+      // result-lost forever (exactly the determinism bug the stable sort above
+      // addresses). So only prune-by-absence on a NON-FULL page, where the
+      // scanned set provably covers every pending resultless row. On a full
+      // page we hold all entries; the stable sort guarantees each row is
+      // eventually scanned (and then pruned the normal way on resolve) as the
+      // backlog drains from the front.
+      const pageWasFull = page.items.length >= CONSUME_PAGE;
+      if (!pageWasFull) {
+        const scannedIds = new Set<string>(page.items.map((r) => r.id));
+        for (const id of firstSeenResultless.keys()) {
+          if (!scannedIds.has(id)) firstSeenResultless.delete(id);
+        }
+      }
+
+      let processed = 0;
+      let failures = 0;
+      for (const row of page.items) {
+        if (row.result === undefined || row.result === null) {
+          // Terminal but no result (yet). This is the DATA-LOSS RACE window:
+          // report() flips the row terminal, THEN writes the result a few ms
+          // later. Latching here immediately would drop that imminent result
+          // (the dashboard then silently never updates). So only latch once the
+          // row has been resultless-terminal LONGER than the grace window.
+          //
+          // The grace basis is a STABLE first-seen timestamp tracked in-memory
+          // per jobId — NOT a live read of `row.updated` (PB mtime) every
+          // cycle, which any later write RESETS FORWARD, letting a
+          // perpetually-touched resultless row re-scan forever and never latch.
+          // On the FIRST sighting we seed the basis from the EARLIER of the
+          // row's mtime and now (so a row that was already terminal long before
+          // this process started — e.g. a result write that never landed before
+          // a control-plane restart — is correctly aged on first sight), then
+          // FREEZE it: no subsequent mtime bump can push the deadline later.
+          const nowMs = now();
+          let firstSeen = firstSeenResultless.get(row.id);
+          if (firstSeen === undefined) {
+            // ANCHOR the PB space→"T" rewrite to the canonical date/time
+            // boundary (`YYYY-MM-DD `) — same shape the JSVM hook + queue-client
+            // `leaseExpired` use — so only the canonical PB mtime is normalized,
+            // never an arbitrary first space (which could coerce a malformed
+            // value into a parseable mtime and mis-age the grace basis).
+            const mtimeMs = Date.parse(
+              String(row.updated ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+            );
+            firstSeen =
+              Number.isFinite(mtimeMs) && mtimeMs < nowMs ? mtimeMs : nowMs;
+            firstSeenResultless.set(row.id, firstSeen);
+          }
+          const aged = nowMs - firstSeen >= RESULTLESS_GRACE_MS;
+          if (!aged) {
+            // Still within grace — wait for the result write to land.
+            logger.debug("fleet.consumer.resultless-within-grace", {
+              jobId: row.id,
+              firstSeen,
+            });
+            continue;
+          }
+          // Genuinely resultless past grace. This row was claimed, the worker
+          // ran it (or tried to), and a terminal report flipped it done|failed —
+          // but the per-service RESULT write never landed (report()'s post-
+          // release result write exhausted its retries, or the process died in
+          // the gap). The row is ALREADY terminal, so the producer/fleet-health
+          // sweepers — which only scan claimed|running rows for EXPIRED leases —
+          // will NEVER see it: there is no other leg that surfaces this to the
+          // dashboard. Latching silently here would DROP it (REQ-B violation:
+          // the dashboard would just never update for this service). So before
+          // latching we SYNTHESIZE a `worker-crashed-mid-job` comm error and
+          // surface it through the aggregator so the dashboard renders "couldn't
+          // reach the pool" (⚡ unreachable) for this service's aggregate row.
+          //
+          // Keyed on the row's `probe_key` (the `d6:<slug>` aggregate key the
+          // dashboard reads). REQ-B (Fix A1): read the CURRENT row colour first
+          // and pass it as `lastKnownState` so the overlay PRESERVES the last
+          // observed colour (a previously-green/red/degraded service whose worker
+          // crashes stays that colour + ⚡ unreachable) and the overlay lands on
+          // the LIVE status row — NOT history-only. For a NEVER-observed key the
+          // resolver returns undefined, so we omit `lastKnownState` and the
+          // aggregator writes the no-data ("error") path: it NEVER fabricates a
+          // green row. This mirrors how `control-plane.ts` wires the sweep +
+          // fleet-health legs. aggregateCommError is best-effort by contract, but
+          // guard anyway so a surfacing blip cannot wedge the consumer
+          // (consumeOnce never throws).
+          const observedAt = new Date(nowMs).toISOString();
+          const lastKnownState = await priorStateFor(row.probe_key);
+          try {
+            await aggregator.aggregateCommError({
+              commError: {
+                kind: "worker-crashed-mid-job",
+                message: `job ${row.id} (${row.probe_key}) went terminal but its result never landed within ${RESULTLESS_GRACE_MS}ms; result lost — pool unreachable`,
+                jobId: row.id,
+                observedAt,
+              },
+              aggregateKey: row.probe_key,
+              ...(lastKnownState !== undefined ? { lastKnownState } : {}),
+            });
+            logger.warn("fleet.consumer.result-lost-commerror", {
+              jobId: row.id,
+              aggregateKey: row.probe_key,
+            });
+          } catch (err) {
+            // Surfacing failed — do NOT latch, so the next cycle retries the
+            // comm-error surface (the row is still resultless-terminal and its
+            // first-seen basis is past grace). Leaving it unlatched is the safe
+            // failure mode: re-surfacing the same overlay is harmless, dropping
+            // it is not.
+            logger.error("fleet.consumer.result-lost-commerror-failed", {
+              jobId: row.id,
+              aggregateKey: row.probe_key,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            continue;
+          }
+          // Comm error surfaced — now latch so the row doesn't re-scan forever.
+          try {
+            await pb.update(PROBE_JOBS_COLLECTION, row.id, {
+              result_processed: true,
+            });
+            // Latched — drop the first-seen entry so the Map stays bounded.
+            firstSeenResultless.delete(row.id);
+          } catch (err) {
+            logger.warn("fleet.consumer.latch-empty-failed", {
+              jobId: row.id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
+          continue;
+        }
+        // The row now carries a result — its earlier resultless sighting (if
+        // any) is moot, so prune the first-seen entry to keep the Map bounded.
+        firstSeenResultless.delete(row.id);
+
+        let result: ServiceJobResult;
+        try {
+          result = decodeResult(row.id, row.result);
+        } catch (err) {
+          failures++;
+          logger.error("fleet.consumer.decode-failed", {
+            jobId: row.id,
+            err: err instanceof Error ? err.message : String(err),
+          });
+          continue;
+        }
+
+        try {
+          // AGGREGATE FIRST (authoritative status + run-history), THEN latch.
+          await aggregator.aggregate(result);
+        } catch (err) {
+          failures++;
+          logger.error("fleet.consumer.aggregate-failed", {
+            jobId: row.id,
+            probeKey: result.aggregateKey,
+            err: err instanceof Error ? err.message : String(err),
+          });
+          // Leave unprocessed — the next cycle retries (at-least-once).
+          continue;
+        }
+
+        try {
+          await pb.update(PROBE_JOBS_COLLECTION, row.id, {
+            result_processed: true,
+          });
+        } catch (err) {
+          // Aggregate succeeded but the latch failed: worst case a re-aggregate
+          // next cycle, which the aggregator's per-jobId dedup makes a true
+          // no-op. Count it as a failure so the cadence/metrics surface the
+          // latch trouble.
+          failures++;
+          logger.warn("fleet.consumer.latch-failed", {
+            jobId: row.id,
+            err: err instanceof Error ? err.message : String(err),
+          });
+          continue;
+        }
+
+        processed++;
+        logger.debug("fleet.consumer.processed", {
+          jobId: row.id,
+          probeKey: result.aggregateKey,
+        });
+      }
+
+      return { processed, failures };
+    },
+  };
+}

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from "vitest";
+import { createJobClaimClient, type JobView } from "./job-claim.js";
+import { logger } from "../logger.js";
+
+function makeFetch(
+  handler: (
+    url: string,
+    init: RequestInit | undefined,
+  ) => Response | Promise<Response>,
+): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    return handler(String(input), init);
+  }) as unknown as typeof fetch;
+}
+
+const SAMPLE_JOB: JobView = {
+  id: "j1",
+  probe_key: "svc:liveness",
+  status: "claimed",
+  claimed_by: "worker-7",
+  lease_expires_at: "2026-06-04T18:00:00.000Z",
+  version: 1,
+};
+
+function authedFetch(
+  routeHandler: (url: string, init: RequestInit | undefined) => Response,
+): typeof fetch {
+  return makeFetch((url, init) => {
+    if (url.includes("auth-with-password")) {
+      return new Response(JSON.stringify({ token: "tok", record: {} }), {
+        status: 200,
+      });
+    }
+    return routeHandler(url, init);
+  });
+}
+
+describe("job-claim client", () => {
+  it("authenticates as superuser before calling the claim endpoint", async () => {
+    const calls: string[] = [];
+    const fetchImpl = authedFetch((url) => {
+      calls.push(url);
+      return new Response(JSON.stringify({ claimed: true, job: SAMPLE_JOB }), {
+        status: 200,
+      });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.claimJob("j1", "worker-7", 30);
+    expect(r.won).toBe(true);
+    expect(r.job?.id).toBe("j1");
+    expect(calls[0]).toContain("/api/fleet/claim");
+  });
+
+  it("falls back to /api/admins on a 404 from /_superusers", async () => {
+    const authPaths: string[] = [];
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("/_superusers/auth-with-password")) {
+        authPaths.push(url);
+        return new Response("not found", { status: 404 });
+      }
+      if (url.includes("/api/admins/auth-with-password")) {
+        authPaths.push(url);
+        return new Response(JSON.stringify({ token: "tok" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ claimed: false }), { status: 200 });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    await client.claimJob("j1", "worker-7", 30);
+    expect(authPaths.some((p) => p.includes("/api/admins"))).toBe(true);
+  });
+
+  it("reports won=false when the endpoint says the row was already taken", async () => {
+    const fetchImpl = authedFetch(
+      () => new Response(JSON.stringify({ claimed: false }), { status: 200 }),
+    );
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.claimJob("j1", "loser", 30);
+    expect(r.won).toBe(false);
+    expect(r.job).toBeUndefined();
+  });
+
+  it("renewLease reports renewed and surfaces the updated job", async () => {
+    const fetchImpl = authedFetch((url) => {
+      expect(url).toContain("/api/fleet/renew");
+      return new Response(
+        JSON.stringify({
+          renewed: true,
+          job: { ...SAMPLE_JOB, status: "running", version: 2 },
+        }),
+        { status: 200 },
+      );
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.renewLease("j1", "worker-7", 30);
+    expect(r.renewed).toBe(true);
+    expect(r.job?.status).toBe("running");
+    expect(r.job?.version).toBe(2);
+  });
+
+  it("renewLease reports renewed=false when the lease was lost", async () => {
+    const fetchImpl = authedFetch(
+      () => new Response(JSON.stringify({ renewed: false }), { status: 200 }),
+    );
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.renewLease("j1", "worker-7", 30);
+    expect(r.renewed).toBe(false);
+  });
+
+  it("releaseJob posts the target status and reports released", async () => {
+    let sentBody: unknown;
+    const fetchImpl = authedFetch((url, init) => {
+      expect(url).toContain("/api/fleet/release");
+      sentBody = JSON.parse(String(init?.body));
+      return new Response(
+        JSON.stringify({
+          released: true,
+          job: { ...SAMPLE_JOB, status: "done" },
+        }),
+        { status: 200 },
+      );
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.releaseJob("j1", "worker-7", "done");
+    expect(r.released).toBe(true);
+    expect(r.job?.status).toBe("done");
+    expect(sentBody).toMatchObject({
+      jobId: "j1",
+      workerId: "worker-7",
+      status: "done",
+    });
+  });
+
+  it("re-authenticates once on a 401 then retries the request", async () => {
+    let claimCalls = 0;
+    let authCalls = 0;
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        authCalls += 1;
+        return new Response(JSON.stringify({ token: `tok${authCalls}` }), {
+          status: 200,
+        });
+      }
+      claimCalls += 1;
+      if (claimCalls === 1)
+        return new Response("unauthorized", { status: 401 });
+      return new Response(JSON.stringify({ claimed: true, job: SAMPLE_JOB }), {
+        status: 200,
+      });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.claimJob("j1", "worker-7", 30);
+    expect(r.won).toBe(true);
+    expect(authCalls).toBe(2);
+    expect(claimCalls).toBe(2);
+  });
+
+  it("throws a descriptive error on a non-401 failure status", async () => {
+    const fetchImpl = authedFetch(() => new Response("boom", { status: 500 }));
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    await expect(client.claimJob("j1", "worker-7", 30)).rejects.toThrow(
+      /\/api\/fleet\/claim failed: 500/,
+    );
+  });
+
+  it("throws when superuser credentials are not configured", async () => {
+    const fetchImpl = makeFetch(() => new Response("{}", { status: 200 }));
+    const client = createJobClaimClient({
+      url: "http://pb",
+      logger,
+      fetchImpl,
+    });
+    await expect(client.claimJob("j1", "worker-7", 30)).rejects.toThrow(
+      /POCKETBASE_SUPERUSER_EMAIL\/PASSWORD not set/,
+    );
+  });
+
+  it("throws when the auth endpoint returns an empty token", async () => {
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        return new Response(JSON.stringify({ token: "" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    await expect(client.claimJob("j1", "worker-7", 30)).rejects.toThrow(
+      /empty or non-string token/,
+    );
+  });
+
+  it("treats an empty auth body as a missing token and throws", async () => {
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        // 200 with an empty body — observed on PB restarts.
+        return new Response("", { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    await expect(client.claimJob("j1", "worker-7", 30)).rejects.toThrow(
+      /empty or non-string token/,
+    );
+  });
+
+  it("treats an empty endpoint body as a non-win without throwing", async () => {
+    const fetchImpl = authedFetch(() => new Response("", { status: 200 }));
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.claimJob("j1", "worker-7", 30);
+    expect(r.won).toBe(false);
+    expect(r.job).toBeUndefined();
+  });
+
+  it("throws when the auth endpoint itself fails", async () => {
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        return new Response("bad creds", { status: 400 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    await expect(client.claimJob("j1", "worker-7", 30)).rejects.toThrow(
+      /auth failed: 400/,
+    );
+  });
+});

--- a/showcase/harness/src/fleet/job-claim.ts
+++ b/showcase/harness/src/fleet/job-claim.ts
@@ -1,0 +1,232 @@
+import type { Logger } from "../types/index.js";
+
+/**
+ * Fleet job-claim primitive.
+ *
+ * ── WHY THIS IS NOT A PLAIN PATCH ──────────────────────────────────────
+ * The harness authenticates to PocketBase as a SUPERUSER, and superuser
+ * writes BYPASS collection `updateRule`s. So the obvious design — guard
+ * `probe_jobs.updateRule` with `status = "pending"` and let workers PATCH
+ * the row — does NOT yield an atomic claim. An empirical spike against PB
+ * 0.22.21 with 20 concurrent claimers proved it:
+ *
+ *   - superuser naive PATCH .................. 20/20 "win" (rules bypassed)
+ *   - worker-auth rule-guarded PATCH ......... 4–10 winners (rule admission
+ *                                              is not transactional with the
+ *                                              write; all claimers pass the
+ *                                              `pending` check, then all write)
+ *   - JSVM routerAdd + runInTransaction CAS .. EXACTLY 1 winner, every run
+ *
+ * Therefore the claim/renew/release operations are implemented as
+ * server-side transactional compare-and-set endpoints in PocketBase
+ * (`showcase/pocketbase/pb_hooks/fleet-claim.pb.js`, backed by the
+ * `probe_jobs` collection from `1779989400_create_probe_jobs.js`). SQLite
+ * serializes the write transaction, making the read-compare-write atomic
+ * across all callers regardless of auth subject.
+ *
+ * This module is a thin, typed client over those endpoints that reuses the
+ * harness's existing superuser auth + a minimal retry-free request (the
+ * endpoints are fast, idempotent-on-failure CAS calls — a caller that gets
+ * a transport error simply re-claims).
+ */
+
+export type JobStatus = "pending" | "claimed" | "running" | "done" | "failed";
+
+/** A snapshot of a `probe_jobs` row as returned by the claim endpoints. */
+export interface JobView {
+  id: string;
+  probe_key: string;
+  status: JobStatus;
+  claimed_by: string;
+  lease_expires_at: string | null;
+  version: number;
+}
+
+export interface JobClaimConfig {
+  /** PocketBase base URL, e.g. http://127.0.0.1:8090 */
+  url: string;
+  /** Superuser email (PB ≤0.22 admin). */
+  email?: string;
+  /** Superuser password. */
+  password?: string;
+  logger: Logger;
+  /** Injectable for tests. Defaults to the global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+/** Result of a claim attempt. `won` is the exactly-one-winner signal. */
+export interface ClaimResult {
+  won: boolean;
+  job?: JobView;
+}
+
+export interface RenewResult {
+  renewed: boolean;
+  job?: JobView;
+}
+
+export interface ReleaseResult {
+  released: boolean;
+  job?: JobView;
+}
+
+export interface JobClaimClient {
+  /**
+   * Attempt to claim `jobId` for `workerId` with a lease of `leaseSeconds`.
+   * Exactly one of N concurrent claimers will get `won: true`; the rest get
+   * `won: false`. The CAS itself ALSO admits a row whose lease has already
+   * expired even if it is in a claimed/running state, so it CAN reclaim a dead
+   * worker's row. Note the worker claim loop does not drive that path: the
+   * queue-client's `claimNext` only lists `status = "pending"` candidates, so it
+   * never hands a claimed/running id here. Expired-row reclamation is instead
+   * producer-sweep / fleet-health driven (they re-queue to `pending` first); the
+   * expired-claim admission is the CAS's safety net, not the normal hot path.
+   */
+  claimJob(
+    jobId: string,
+    workerId: string,
+    leaseSeconds: number,
+  ): Promise<ClaimResult>;
+  /**
+   * Extend the lease on a job the caller currently holds. Fails (`renewed:
+   * false`) if the caller is not the lease holder, the lease already
+   * expired (it was stolen), or the job is no longer in a claimed/running
+   * state. Promotes a `claimed` row to `running` on first renew.
+   */
+  renewLease(
+    jobId: string,
+    workerId: string,
+    leaseSeconds: number,
+  ): Promise<RenewResult>;
+  /**
+   * Record a terminal result for a job the caller holds. `status` is
+   * `done` | `failed` to finish, or `pending` to re-queue. Fails
+   * (`released: false`) if the caller is not the lease holder or the job
+   * is not in a running state.
+   */
+  releaseJob(
+    jobId: string,
+    workerId: string,
+    status: "done" | "failed" | "pending",
+  ): Promise<ReleaseResult>;
+}
+
+interface ClaimEndpointBody {
+  claimed?: boolean;
+  renewed?: boolean;
+  released?: boolean;
+  job?: JobView;
+  error?: string;
+}
+
+export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const baseUrl = config.url.replace(/\/$/, "");
+  const logger = config.logger;
+  let authToken: string | null = null;
+
+  async function ensureAuth(): Promise<void> {
+    if (authToken) return;
+    if (!config.email || !config.password) {
+      // No creds → the endpoints require auth; surface the gap loudly
+      // rather than silently producing 401s the caller can't diagnose.
+      throw new Error(
+        "job-claim: POCKETBASE_SUPERUSER_EMAIL/PASSWORD not set — claim endpoints require auth",
+      );
+    }
+    const authBody = JSON.stringify({
+      identity: config.email,
+      password: config.password,
+    });
+    // PB v0.23+ → /_superusers; v0.22 → /api/admins. Match pb-client.ts.
+    let res = await fetchImpl(
+      `${baseUrl}/api/collections/_superusers/auth-with-password`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: authBody,
+      },
+    );
+    if (res.status === 404) {
+      res = await fetchImpl(`${baseUrl}/api/admins/auth-with-password`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: authBody,
+      });
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`job-claim auth failed: ${res.status} ${text}`);
+    }
+    const text = await res.text();
+    const body: { token?: unknown } = text
+      ? (JSON.parse(text) as { token?: unknown })
+      : {};
+    if (typeof body.token !== "string" || body.token.length === 0) {
+      throw new Error("job-claim auth returned empty or non-string token");
+    }
+    authToken = body.token;
+  }
+
+  async function postFleet(
+    path: string,
+    payload: Record<string, unknown>,
+  ): Promise<ClaimEndpointBody> {
+    await ensureAuth();
+    const doPost = async (): Promise<Response> =>
+      fetchImpl(`${baseUrl}${path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: authToken ?? "",
+        },
+        body: JSON.stringify(payload),
+      });
+    let res = await doPost();
+    // Single re-auth on 401 — token may have expired between calls.
+    if (res.status === 401) {
+      authToken = null;
+      await ensureAuth();
+      res = await doPost();
+    }
+    const text = await res.text().catch(() => "");
+    if (!res.ok) {
+      logger.warn("job-claim.endpoint-error", {
+        path,
+        status: res.status,
+        body: text,
+      });
+      throw new Error(`job-claim ${path} failed: ${res.status} ${text}`);
+    }
+    return text ? (JSON.parse(text) as ClaimEndpointBody) : {};
+  }
+
+  return {
+    async claimJob(jobId, workerId, leaseSeconds): Promise<ClaimResult> {
+      const body = await postFleet("/api/fleet/claim", {
+        jobId,
+        workerId,
+        leaseSeconds,
+      });
+      return { won: body.claimed === true, job: body.job };
+    },
+
+    async renewLease(jobId, workerId, leaseSeconds): Promise<RenewResult> {
+      const body = await postFleet("/api/fleet/renew", {
+        jobId,
+        workerId,
+        leaseSeconds,
+      });
+      return { renewed: body.renewed === true, job: body.job };
+    },
+
+    async releaseJob(jobId, workerId, status): Promise<ReleaseResult> {
+      const body = await postFleet("/api/fleet/release", {
+        jobId,
+        workerId,
+        status,
+      });
+      return { released: body.released === true, job: body.job };
+    },
+  };
+}

--- a/showcase/harness/src/fleet/orchestrator.ts
+++ b/showcase/harness/src/fleet/orchestrator.ts
@@ -1,0 +1,265 @@
+/**
+ * Fleet WORKER entrypoint (BLITZ S7 — the body for S8's `runWorker` stub).
+ *
+ * `runWorker` is the worker-role boot path: it constructs the worker's own
+ * `BrowserPool` (the self-bounded context budget that keeps the worker under
+ * the cgroup `pids.max` ceiling), wires the EXISTING per-service d6 driver onto
+ * that pool via `createPooledE2eFullLauncher`, and runs the S7 worker LOOP
+ * (`startWorkerLoop`) which claims per-service jobs, runs all their cells,
+ * heartbeat-renews the lease, and reports the per-service result.
+ *
+ * It returns the `{ stop, port, bus }` shape the role dispatcher (S8) expects —
+ * symmetric with the control-plane's `boot()` return — so the single harness
+ * image can `await (role === "worker" ? runWorker(...) : boot(...))` and treat
+ * both the same way (await `stop()` on shutdown, read `port` for health checks,
+ * subscribe to `bus`).
+ *
+ * ── INJECTED, NOT HARD-WIRED ───────────────────────────────────────────
+ * The queue client (S3) and the payload→driver-input mapping (the service
+ * catalog) are passed in via `RunWorkerOptions`, not constructed here:
+ *   - the queue client is S3's `FleetQueueClient` impl over PocketBase; the
+ *     worker only consumes the interface (`claimNext`/`renewLease`/`report`).
+ *   - the payload→input mapping needs the showcase service catalog (backend
+ *     URLs, declared demos) which the discovery/control-plane slots own.
+ * Keeping both injected makes this entrypoint testable and keeps S7 from
+ * reaching into slots it doesn't own.
+ */
+
+import { serve } from "@hono/node-server";
+import { createEventBus } from "../events/event-bus.js";
+import { logger as defaultLogger } from "../logger.js";
+import { BrowserPool } from "../probes/helpers/browser-pool.js";
+import {
+  createE2eFullDriver,
+  createPooledE2eFullLauncher,
+} from "../probes/drivers/d6-all-pills.js";
+import type { Logger } from "../types/index.js";
+import type { FleetRoleConfig } from "./role-config.js";
+import type { FleetQueueClient } from "./contracts.js";
+import { buildWorkerHealthServer } from "./worker/worker-health.js";
+import {
+  startWorkerLoop,
+  type PayloadToDriverInput,
+  type ServiceJobDriver,
+  type WorkerLoopHandle,
+} from "./worker/worker-loop.js";
+
+/** The worker boot handle — symmetric with the control-plane `boot()` shape. */
+export interface WorkerHandle {
+  /** Stops the loop, drains the in-flight job, and shuts down the pool. */
+  stop: () => Promise<void>;
+  /** The port the worker's liveness endpoint binds (for fleet-health probes). */
+  port: number;
+  /** Event bus — symmetric with `boot()`; reserved for fleet observability. */
+  bus: ReturnType<typeof createEventBus>;
+}
+
+export interface RunWorkerOptions {
+  /** The fleet queue client (S3 impl over the S0 claim endpoints). */
+  queue: FleetQueueClient;
+  /** Maps a claimed per-service payload to the d6 driver's per-service input. */
+  payloadToInput: PayloadToDriverInput;
+  /** Stable worker id (the `claimed_by` on every claim). */
+  workerId?: string;
+  /**
+   * Port the worker's `/health` server binds (and carried back on the handle).
+   * Default from PORT env or DEFAULT_PORT (8080 — matches EXPOSE/Dockerfile/
+   * control-plane; the compose worker sets PORT=8080, so the healthcheck GETs
+   * the right port).
+   */
+  port?: number;
+  logger?: Logger;
+  /**
+   * Reachability probe for the worker's `/health` server: resolves true when
+   * PocketBase is reachable. Injected from the entrypoint that owns the PB
+   * client (orchestrator.ts). When omitted, /health treats pb as reachable
+   * (test path with no PB).
+   */
+  pbHealth?: () => Promise<boolean>;
+  /**
+   * Liveness probe for the worker's `/health` server: true once the worker's
+   * boot self-register upsert succeeded. Injected from the entrypoint that owns
+   * registration. When omitted, /health treats the worker as registered.
+   */
+  registered?: () => boolean;
+  /**
+   * Skip binding the `/health` HTTP server (tests that don't need a real
+   * socket). Production always binds it so the docker/Railway healthcheck on
+   * the resolved port answers and the container isn't restart-looped.
+   */
+  skipHealthServer?: boolean;
+  /** Env snapshot threaded into the driver ctx. Defaults to process.env. */
+  env?: Readonly<Record<string, string | undefined>>;
+  /** Lease seconds requested per claim/renew. */
+  leaseSeconds?: number;
+  /** Heartbeat (renew) cadence while a job runs. */
+  heartbeatMs?: number;
+  /** Idle poll interval when there's no work / no budget. */
+  pollIntervalMs?: number;
+  /**
+   * Fired when the worker's current job changes (claimed jobId, then null when
+   * it settles). The entrypoint wires this to the registration heartbeat so
+   * `workers.current_job_id` reflects the live job. Best-effort — the loop
+   * guards a throwing/rejecting impl.
+   */
+  onCurrentJobChange?: (currentJobId: string | null) => void;
+  /**
+   * Override the per-service driver (tests inject a fake). Defaults to the real
+   * pooled d6 driver wired onto the constructed `BrowserPool`.
+   */
+  driver?: ServiceJobDriver;
+  /**
+   * Skip constructing/initializing the real `BrowserPool` (tests). When a
+   * `driver` is also injected, the worker runs entirely on fakes. The injected
+   * `budgetSource` then gates claiming.
+   */
+  budgetSource?: {
+    budget(): import("../probes/helpers/browser-pool.js").BrowserPoolBudget;
+  };
+}
+
+/**
+ * Default liveness port. 8080 to match the harness Dockerfile `EXPOSE 8080`,
+ * the control-plane boot, and the compose worker's `PORT=8080` healthcheck —
+ * a worker MUST bind the port the healthcheck probes or the container
+ * restart-loops. (Previously 8090 — the PocketBase port — which never matched
+ * the worker healthcheck.)
+ */
+const DEFAULT_PORT = 8080;
+
+/** Resolve the worker id: explicit > HOSTNAME > a stable random fallback. */
+function resolveWorkerId(
+  explicit: string | undefined,
+  env: Readonly<Record<string, string | undefined>>,
+): string {
+  if (explicit && explicit.trim().length > 0) return explicit.trim();
+  const host = env.HOSTNAME?.trim();
+  if (host && host.length > 0) return `worker-${host}`;
+  return `worker-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Boot the worker role. Constructs the pool + pooled d6 driver, starts the S7
+ * loop, and returns `{ stop, port, bus }`.
+ *
+ * `config` is the resolved fleet role config (S8) — carried for symmetry and
+ * diagnostics; the worker doesn't branch on `poolCount` (each worker bounds
+ * itself via its own `BrowserPool.budget()`).
+ */
+export async function runWorker(
+  config: FleetRoleConfig,
+  opts: RunWorkerOptions,
+): Promise<WorkerHandle> {
+  const logger = opts.logger ?? defaultLogger;
+  const env = opts.env ?? process.env;
+  const bus = createEventBus();
+  const workerId = resolveWorkerId(opts.workerId, env);
+  const port = opts.port ?? (Number(env.PORT ?? DEFAULT_PORT) || DEFAULT_PORT);
+
+  logger.info("fleet.worker.boot", {
+    workerId,
+    role: config.role,
+    poolCount: config.poolCount,
+    port,
+  });
+
+  // Construct the worker's own pool unless a budget source + driver are
+  // injected (test path). The pool is the self-bounded context budget that
+  // gates claiming and keeps the worker under its pids ceiling.
+  let pool: BrowserPool | undefined;
+  let budgetSource = opts.budgetSource;
+  let driver = opts.driver;
+
+  if (!budgetSource || !driver) {
+    pool = new BrowserPool({ logger });
+    await pool.init();
+    budgetSource = budgetSource ?? pool;
+    driver =
+      driver ??
+      createE2eFullDriver({
+        launcher: createPooledE2eFullLauncher(pool, logger),
+      });
+  }
+
+  let loop: WorkerLoopHandle;
+  try {
+    loop = startWorkerLoop({
+      workerId,
+      queue: opts.queue,
+      pool: budgetSource,
+      driver,
+      payloadToInput: opts.payloadToInput,
+      logger,
+      env,
+      leaseSeconds: opts.leaseSeconds,
+      heartbeatMs: opts.heartbeatMs,
+      pollIntervalMs: opts.pollIntervalMs,
+      onCurrentJobChange: opts.onCurrentJobChange,
+    });
+  } catch (err) {
+    // Loop construction is synchronous and shouldn't throw, but if it does,
+    // never strand the pool's chromium processes (PID-ceiling compounding).
+    if (pool) await pool.shutdown().catch(() => {});
+    throw err;
+  }
+
+  // Track loop liveness for /health: the loop's `done` promise resolves when
+  // the loop exits (clean stop OR an unexpected crash). Until then the loop is
+  // alive. A loop that exits WITHOUT a stop() (crash) flips /health to 503 so
+  // the healthcheck reflects a dead worker rather than reporting healthy.
+  let loopAlive = true;
+  void loop.done.finally(() => {
+    loopAlive = false;
+  });
+
+  // Bind the worker's /health server on the resolved port. The docker/Railway
+  // healthcheck GETs this; without it the container is restart-looped. Bind
+  // AFTER the loop is constructed so /health only reports alive once the worker
+  // is actually pulling. Tests pass `skipHealthServer` to avoid a real socket.
+  let server: ReturnType<typeof serve> | undefined;
+  if (!opts.skipHealthServer) {
+    const healthApp = buildWorkerHealthServer({
+      pb: opts.pbHealth ?? (async () => true),
+      loopAlive: () => loopAlive,
+      registered: opts.registered ?? (() => true),
+      logger,
+    });
+    try {
+      server = serve({ fetch: healthApp.fetch, port });
+      logger.info("fleet.worker.health-listening", { workerId, port });
+    } catch (err) {
+      // A bind failure (EADDRINUSE) must not strand the pool's chromium
+      // processes or the loop; tear both down before rethrowing.
+      await loop.stop().catch(() => {});
+      if (pool) await pool.shutdown().catch(() => {});
+      throw err;
+    }
+  }
+
+  return {
+    port,
+    bus,
+    async stop(): Promise<void> {
+      logger.info("fleet.worker.stopping", { workerId });
+      await loop.stop();
+      if (server) {
+        await new Promise<void>((resolve) => {
+          const srv = server as unknown as {
+            close?: (cb?: () => void) => void;
+          };
+          if (typeof srv.close === "function") srv.close(() => resolve());
+          else resolve();
+        });
+      }
+      if (pool) {
+        await pool.shutdown().catch((err) =>
+          logger.error("fleet.worker.pool-shutdown-failed", {
+            workerId,
+            err: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      }
+      logger.info("fleet.worker.stopped", { workerId });
+    },
+  };
+}

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1,0 +1,770 @@
+import { describe, it, expect, vi } from "vitest";
+import { createFleetQueueClient, leaseExpired } from "./queue-client.js";
+import type {
+  JobClaimClient,
+  ClaimResult,
+  RenewResult,
+  ReleaseResult,
+  JobView,
+  JobStatus,
+} from "./job-claim.js";
+import type { PbClient, ListOpts, ListResult } from "../storage/pb-client.js";
+import type {
+  EnqueueJobInput,
+  ServiceJobPayload,
+  ServiceJobResult,
+  ReportJobInput,
+} from "./contracts.js";
+import { logger } from "../logger.js";
+
+/**
+ * Pins the control-plane ↔ worker QUEUE layer (S3): FleetQueueClient layered
+ * over S0's JobClaimClient + the PB client. The three load-bearing behaviors
+ * are an enqueue→claimNext round-trip (payload survives the row), report mapping
+ * a result onto the terminal JobStatus S0's releaseJob expects, and
+ * sweepExpired surfacing `worker-crashed-mid-job` comm errors for leases that
+ * expired mid-run.
+ */
+
+function samplePayload(
+  overrides: Partial<ServiceJobPayload> = {},
+): ServiceJobPayload {
+  return {
+    probeKey: "d6:langgraph-python",
+    serviceSlug: "langgraph-python",
+    driverKind: "e2e_d6",
+    meta: {
+      runId: "run-1",
+      triggered: false,
+      enqueuedAt: "2026-06-04T00:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+function jobView(overrides: Partial<JobView> = {}): JobView {
+  return {
+    id: "j1",
+    probe_key: "d6:langgraph-python",
+    status: "pending",
+    claimed_by: "",
+    lease_expires_at: null,
+    version: 0,
+    ...overrides,
+  };
+}
+
+/** A typed in-memory row the fake PB returns from list/getOne. */
+interface JobRow extends JobView {
+  payload: ServiceJobPayload;
+  /** Result-flow columns (migration 1779989700) the report path writes. */
+  result?: unknown;
+  result_processed?: boolean;
+}
+
+/**
+ * Minimal fake PbClient backed by an in-memory row map. Only the methods the
+ * queue-client actually calls are implemented; the rest throw so an accidental
+ * dependency surfaces loudly rather than silently returning undefined.
+ */
+function makeFakePb(rows: JobRow[] = []): {
+  pb: PbClient;
+  rows: JobRow[];
+} {
+  const store = [...rows];
+  const unsupported = (name: string) => () => {
+    throw new Error(`fake-pb: ${name} not implemented`);
+  };
+  const pb: PbClient = {
+    async create<T>(
+      _collection: string,
+      record: Record<string, unknown>,
+    ): Promise<T> {
+      const row: JobRow = {
+        id: `j${store.length + 1}`,
+        probe_key: String(record.probe_key),
+        status: record.status as JobStatus,
+        claimed_by: String(record.claimed_by ?? ""),
+        lease_expires_at: (record.lease_expires_at as string | null) ?? null,
+        version: Number(record.version ?? 0),
+        payload: record.payload as ServiceJobPayload,
+      };
+      store.push(row);
+      return row as unknown as T;
+    },
+    async list<T>(
+      _collection: string,
+      opts: ListOpts = {},
+    ): Promise<ListResult<T>> {
+      let items = store;
+      // Honor a `status = "x"` / `status = "x" || status = "y"` filter the way
+      // the real client would, so both the claimNext candidate scan and the
+      // sweepExpired claimed-or-running scan are exercised faithfully.
+      const matches = [
+        ...(opts.filter ?? "").matchAll(/status\s*=\s*"(\w+)"/g),
+      ];
+      if (matches.length > 0) {
+        const wanted = new Set(matches.map((mm) => mm[1]));
+        items = store.filter((r) => wanted.has(r.status));
+      }
+      return {
+        page: 1,
+        perPage: opts.perPage ?? items.length,
+        totalPages: 1,
+        totalItems: items.length,
+        items: items as unknown as T[],
+      };
+    },
+    async getOne<T>(_collection: string, id: string): Promise<T | null> {
+      return (store.find((r) => r.id === id) ?? null) as unknown as T | null;
+    },
+    getFirst: unsupported("getFirst") as PbClient["getFirst"],
+    async update<T>(
+      _collection: string,
+      id: string,
+      record: Record<string, unknown>,
+    ): Promise<T> {
+      const row = store.find((r) => r.id === id);
+      if (!row) throw new Error(`fake-pb: update of missing row ${id}`);
+      Object.assign(row as unknown as Record<string, unknown>, record);
+      return row as unknown as T;
+    },
+    upsertByField: unsupported("upsertByField") as PbClient["upsertByField"],
+    delete: unsupported("delete") as PbClient["delete"],
+    deleteByFilter: unsupported("deleteByFilter") as PbClient["deleteByFilter"],
+    health: unsupported("health") as PbClient["health"],
+    createBackup: unsupported("createBackup") as PbClient["createBackup"],
+    downloadBackup: unsupported("downloadBackup") as PbClient["downloadBackup"],
+    deleteBackup: unsupported("deleteBackup") as PbClient["deleteBackup"],
+  };
+  return { pb, rows: store };
+}
+
+/** Configurable fake JobClaimClient — each method is a vi.fn the test wires. */
+function makeFakeClaim(
+  overrides: Partial<JobClaimClient> = {},
+): JobClaimClient {
+  return {
+    claimJob: vi.fn(async (): Promise<ClaimResult> => ({ won: false })),
+    renewLease: vi.fn(async (): Promise<RenewResult> => ({ renewed: false })),
+    releaseJob: vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: false }),
+    ),
+    ...overrides,
+  };
+}
+
+function sampleResult(
+  overrides: Partial<ServiceJobResult> = {},
+): ServiceJobResult {
+  return {
+    jobId: "j1",
+    probeKey: "e2e_d6:langgraph-python",
+    serviceSlug: "langgraph-python",
+    runId: "run-1",
+    workerId: "worker-7",
+    aggregateState: "green",
+    aggregateKey: "e2e_d6:langgraph-python",
+    aggregateSignal: { failedCount: 0 },
+    cells: [],
+    rollup: { total: 1, passed: 1, failed: 0 },
+    finishedAt: "2026-06-04T00:00:02.000Z",
+    ...overrides,
+  };
+}
+
+describe("FleetQueueClient.enqueue", () => {
+  it("writes a pending probe_jobs row carrying the serialized payload", async () => {
+    const { pb, rows } = makeFakePb();
+    const claim = makeFakeClaim();
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const input: EnqueueJobInput = { payload: samplePayload() };
+    const view = await q.enqueue(input);
+
+    expect(view.status).toBe("pending");
+    expect(view.probe_key).toBe("d6:langgraph-python");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("pending");
+    expect(rows[0].claimed_by).toBe("");
+    expect(rows[0].payload).toEqual(samplePayload());
+  });
+});
+
+describe("FleetQueueClient.claimNext", () => {
+  it("claims the next pending job and returns a lease with the decoded payload", async () => {
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView(), payload }]);
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({
+            id: jobId,
+            status: "claimed",
+            claimed_by: workerId,
+            lease_expires_at: "2026-06-04T00:01:00.000Z",
+            version: 1,
+          }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claim.claimJob).toHaveBeenCalledWith("j1", "worker-7", 30);
+    expect(claimed.claimed).toBe(true);
+    expect(claimed.lease?.job.claimed_by).toBe("worker-7");
+    expect(claimed.lease?.payload).toEqual(payload);
+    expect(claimed.lease?.leaseExpiresAt).toBe("2026-06-04T00:01:00.000Z");
+  });
+
+  it("enqueue → claimNext round-trips the payload through the row", async () => {
+    const { pb, rows } = makeFakePb();
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(async (jobId, workerId): Promise<ClaimResult> => {
+        const row = rows.find((r) => r.id === jobId);
+        return {
+          won: true,
+          job: jobView({
+            id: jobId,
+            probe_key: row?.probe_key ?? "",
+            status: "claimed",
+            claimed_by: workerId,
+            lease_expires_at: "2026-06-04T00:01:00.000Z",
+            version: 1,
+          }),
+        };
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const payload = samplePayload({ cellIds: ["shared-state"] });
+    await q.enqueue({ payload });
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(true);
+    expect(claimed.lease?.payload).toEqual(payload);
+  });
+
+  it("reports not-claimed when no pending jobs exist", async () => {
+    const { pb } = makeFakePb();
+    const claim = makeFakeClaim();
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(false);
+    expect(claimed.lease).toBeUndefined();
+    expect(claim.claimJob).not.toHaveBeenCalled();
+  });
+
+  it("releases and skips a won job whose payload fails to decode (never strands it)", async () => {
+    // The CAS WON on j1, but its row payload is garbage (null) → decodePayload
+    // throws. The job is already claimed/owned; if claimNext let the throw
+    // escape, the job would be stranded (re-listed + re-thrown forever, then a
+    // FALSE worker-crashed when the sweeper reclaims it). Instead it must
+    // release the won job as `failed` and fall through to the next candidate.
+    const { pb } = makeFakePb([
+      // j1's payload is non-decodable; cast through unknown to seed garbage.
+      {
+        ...jobView({ id: "j1" }),
+        payload: null as unknown as ServiceJobPayload,
+      },
+      { ...jobView({ id: "j2" }), payload: samplePayload() },
+    ]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({
+      releaseJob,
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    // Must NOT throw — the decode failure on the won j1 is contained.
+    const claimed = await q.claimNext("worker-7", 30);
+
+    // j1 was released as failed (we owned it), then j2 was claimed.
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "failed");
+    expect(claimed.claimed).toBe(true);
+    expect(claimed.lease?.job.id).toBe("j2");
+  });
+
+  it("treats a payload with a non-object meta as a decode failure (releases + skips)", async () => {
+    // decodePayload must assert `meta` is a non-null object with a string
+    // runId, failing LOUD at the boundary — a string/array meta satisfies the
+    // `meta !== undefined` check but would deref to undefined deep in the
+    // aggregator (it groups by meta.runId). The won job is released + skipped.
+    const badMetaPayload = {
+      ...samplePayload(),
+      meta: "not-an-object",
+    } as unknown as ServiceJobPayload;
+    const { pb } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: badMetaPayload },
+      { ...jobView({ id: "j2" }), payload: samplePayload() },
+    ]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({
+      releaseJob,
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "failed");
+    expect(claimed.claimed).toBe(true);
+    expect(claimed.lease?.job.id).toBe("j2");
+  });
+
+  it("falls through to the next candidate when it loses the CAS on the first", async () => {
+    const { pb } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+      { ...jobView({ id: "j2" }), payload: samplePayload() },
+    ]);
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(async (jobId, workerId): Promise<ClaimResult> => {
+        if (jobId === "j1") return { won: false };
+        return {
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        };
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claim.claimJob).toHaveBeenCalledTimes(2);
+    expect(claimed.claimed).toBe(true);
+    expect(claimed.lease?.job.id).toBe("j2");
+  });
+});
+
+describe("FleetQueueClient.renewLease", () => {
+  it("delegates to S0 renewLease and returns the refreshed lease", async () => {
+    const { pb } = makeFakePb([{ ...jobView(), payload: samplePayload() }]);
+    const claim = makeFakeClaim({
+      renewLease: vi.fn(
+        async (): Promise<RenewResult> => ({
+          renewed: true,
+          job: jobView({
+            id: "j1",
+            status: "running",
+            claimed_by: "worker-7",
+            lease_expires_at: "2026-06-04T00:02:00.000Z",
+            version: 2,
+          }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const lease = await q.renewLease("j1", "worker-7", 30);
+
+    expect(claim.renewLease).toHaveBeenCalledWith("j1", "worker-7", 30);
+    expect(lease?.job.status).toBe("running");
+    expect(lease?.leaseExpiresAt).toBe("2026-06-04T00:02:00.000Z");
+    expect(lease?.payload).toEqual(samplePayload());
+  });
+
+  it("returns null when the lease was lost", async () => {
+    const { pb } = makeFakePb([{ ...jobView(), payload: samplePayload() }]);
+    const claim = makeFakeClaim();
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const lease = await q.renewLease("j1", "worker-7", 30);
+
+    expect(lease).toBeNull();
+  });
+
+  it("still renews when the convenience re-read returns null (CAS won)", async () => {
+    // The CAS renewed and returned the lifecycle columns; a momentary PB read
+    // blip makes the convenience getOne return null. The heartbeat must NOT
+    // throw on that blip (throwing permanently stops heartbeating → the sweeper
+    // later reclaims a LIVE job and synthesizes a FALSE worker-crashed comm
+    // error). The payload is re-hydrated from the claim-time cache, so the
+    // re-read is unnecessary and its failure is non-fatal.
+    const payload = samplePayload();
+    // Seed the store so claimNext can populate the payload cache, then the
+    // renew re-read still works against this same row.
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({
+            id: jobId,
+            status: "claimed",
+            claimed_by: workerId,
+            lease_expires_at: "2026-06-04T00:01:00.000Z",
+            version: 1,
+          }),
+        }),
+      ),
+      renewLease: vi.fn(
+        async (): Promise<RenewResult> => ({
+          renewed: true,
+          job: jobView({
+            id: "j1",
+            status: "running",
+            claimed_by: "worker-7",
+            lease_expires_at: "2026-06-04T00:02:00.000Z",
+            version: 2,
+          }),
+        }),
+      ),
+      // getOne is never required for a successful renew.
+    });
+    // Make the convenience re-read fail outright (null) to prove non-fatality.
+    pb.getOne = vi.fn(async () => null) as PbClient["getOne"];
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    // Claim first so the payload cache is populated for this jobId.
+    await q.claimNext("worker-7", 30);
+
+    const lease = await q.renewLease("j1", "worker-7", 30);
+
+    expect(lease).not.toBeNull();
+    expect(lease?.job.status).toBe("running");
+    expect(lease?.leaseExpiresAt).toBe("2026-06-04T00:02:00.000Z");
+    expect(lease?.payload).toEqual(payload);
+  });
+
+  it("returns a lease on a SUCCESSFUL CAS even when cache miss AND reread fail", async () => {
+    // The CAS renewed (won), but there is NO prior same-process claim (cache
+    // empty) AND the convenience re-read THROWS (PB blip). A successful CAS
+    // renew must keep the heartbeat ALIVE — returning null here would make the
+    // heartbeat misread a healthy renew as a lost lease, stop, and let the
+    // sweeper reclaim a LIVE job → a FALSE worker-crashed. So renewLease must
+    // still return a lease (best-effort empty payload from the CAS row); null
+    // is reserved for a FAILED CAS only.
+    const { pb } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+    ]);
+    pb.getOne = vi.fn(async () => {
+      throw new Error("transient PB read blip");
+    }) as PbClient["getOne"];
+    const claim = makeFakeClaim({
+      renewLease: vi.fn(
+        async (): Promise<RenewResult> => ({
+          renewed: true,
+          job: jobView({
+            id: "j1",
+            probe_key: "d6:langgraph-python",
+            status: "running",
+            claimed_by: "worker-7",
+            lease_expires_at: "2026-06-04T00:02:00.000Z",
+            version: 2,
+          }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    // No prior claimNext → payload cache is empty for j1.
+    const lease = await q.renewLease("j1", "worker-7", 30);
+
+    expect(lease).not.toBeNull();
+    expect(lease?.job.status).toBe("running");
+    expect(lease?.leaseExpiresAt).toBe("2026-06-04T00:02:00.000Z");
+    // Best-effort payload carries the join key from the CAS row.
+    expect(lease?.payload.probeKey).toBe("d6:langgraph-python");
+  });
+});
+
+describe("FleetQueueClient.report", () => {
+  /** A terminal-row seed so the post-release `pb.update` has a row to patch. */
+  function seededRow(): JobRow {
+    return { ...jobView({ id: "j1" }), payload: samplePayload() };
+  }
+
+  it("maps an all-green result to releaseJob(done)", async () => {
+    const { pb } = makeFakePb([seededRow()]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({ releaseJob });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const input: ReportJobInput = {
+      jobId: "j1",
+      workerId: "worker-7",
+      result: sampleResult(),
+    };
+    await q.report(input);
+
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "done");
+  });
+
+  it("maps a red aggregate to releaseJob(failed)", async () => {
+    const { pb } = makeFakePb([seededRow()]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({ releaseJob });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.report({
+      jobId: "j1",
+      workerId: "worker-7",
+      result: sampleResult({ aggregateState: "red" }),
+    });
+
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "failed");
+  });
+
+  it("maps a comm-error result to releaseJob(failed) regardless of state", async () => {
+    const { pb } = makeFakePb([seededRow()]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({ releaseJob });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.report({
+      jobId: "j1",
+      workerId: "worker-7",
+      result: sampleResult({
+        aggregateState: "green",
+        commError: {
+          kind: "worker-protocol-violation",
+          message: "bad shape",
+          observedAt: "2026-06-04T00:00:03.000Z",
+        },
+      }),
+    });
+
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "failed");
+  });
+
+  it("persists the ServiceJobResult onto the row, unprocessed, after the release", async () => {
+    const { pb, rows } = makeFakePb([seededRow()]);
+    // Assert ordering: the result is only written AFTER the CAS release wins.
+    let releasedFirst = false;
+    const releaseJob = vi.fn(async (): Promise<ReleaseResult> => {
+      releasedFirst = true;
+      return { released: true };
+    });
+    const claim = makeFakeClaim({ releaseJob });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const result = sampleResult();
+    await q.report({ jobId: "j1", workerId: "worker-7", result });
+
+    expect(releasedFirst).toBe(true);
+    // The control-plane consumer reads this back to aggregate exactly once.
+    expect(rows[0].result).toEqual(result);
+    expect(rows[0].result_processed).toBe(false);
+  });
+
+  it("retries the result write, then throws a DISTINCT 'result lost' error when it keeps failing", async () => {
+    // The release CAS SUCCEEDS (row is now terminal), but the SEPARATE result
+    // write keeps failing. Giving up silently would DROP the result (terminal
+    // row, no result → consumer latches it resultless, dashboard never
+    // updates). report() must retry the write (bounded) and, when exhausted,
+    // throw an error that DISTINGUISHES "release succeeded but result write
+    // FAILED (result lost)" from a refused release.
+    const { pb } = makeFakePb([seededRow()]);
+    let updateAttempts = 0;
+    pb.update = vi.fn(async () => {
+      updateAttempts++;
+      throw new Error("transient PB write blip");
+    }) as PbClient["update"];
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({ releaseJob });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await expect(
+      q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
+    ).rejects.toThrow(/result lost/i);
+    // The release was attempted (and won) before the result write.
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "done");
+    // The write was RETRIED, not attempted once.
+    expect(updateAttempts).toBeGreaterThan(1);
+  });
+
+  it("succeeds when the result write fails once then recovers (bounded retry)", async () => {
+    const { pb, rows } = makeFakePb([seededRow()]);
+    const realUpdate = pb.update.bind(pb);
+    let updateAttempts = 0;
+    pb.update = vi.fn(
+      async (
+        collection: string,
+        id: string,
+        record: Record<string, unknown>,
+      ) => {
+        updateAttempts++;
+        if (updateAttempts === 1) throw new Error("transient blip");
+        return realUpdate(collection, id, record);
+      },
+    ) as PbClient["update"];
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: true }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const result = sampleResult();
+    await q.report({ jobId: "j1", workerId: "worker-7", result });
+
+    expect(updateAttempts).toBe(2);
+    expect(rows[0].result).toEqual(result);
+    expect(rows[0].result_processed).toBe(false);
+  });
+
+  it("does NOT persist a result when the release CAS is refused", async () => {
+    const { pb, rows } = makeFakePb([seededRow()]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: false }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await expect(
+      q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
+    ).rejects.toThrow(/release/i);
+    // A refused release must never leave a result on a row this worker no
+    // longer owns — the consumer would otherwise aggregate a stale result.
+    expect(rows[0].result).toBeUndefined();
+  });
+});
+
+describe("FleetQueueClient.sweepExpired", () => {
+  it("reclaims expired leases and emits worker-crashed-mid-job comm errors", async () => {
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    // One running row with an EXPIRED lease (crashed worker), one with a live
+    // lease that must NOT be swept.
+    const expired: JobRow = {
+      ...jobView({
+        id: "j1",
+        status: "running",
+        claimed_by: "worker-dead",
+        lease_expires_at: "2026-06-04T00:04:00.000Z",
+        version: 3,
+      }),
+      payload: samplePayload(),
+    };
+    const live: JobRow = {
+      ...jobView({
+        id: "j2",
+        status: "running",
+        claimed_by: "worker-alive",
+        lease_expires_at: "2026-06-04T00:06:00.000Z",
+        version: 1,
+      }),
+      payload: samplePayload(),
+    };
+    const { pb } = makeFakePb([expired, live]);
+    // The sweeper re-queues an expired row via S0 releaseJob(pending) on
+    // behalf of the dead holder.
+    const releaseJob = vi.fn(
+      async (
+        jobId: string,
+        workerId: string,
+        status: "done" | "failed" | "pending",
+      ): Promise<ReleaseResult> => ({
+        released: true,
+        job: jobView({ id: jobId, status, claimed_by: "" }),
+      }),
+    );
+    const claim = makeFakeClaim({ releaseJob });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const sweep = await q.sweepExpired(now);
+
+    expect(sweep.reclaimed).toBe(1);
+    expect(sweep.commErrors).toHaveLength(1);
+    expect(sweep.commErrors[0].kind).toBe("worker-crashed-mid-job");
+    expect(sweep.commErrors[0].jobId).toBe("j1");
+    expect(sweep.commErrors[0].workerId).toBe("worker-dead");
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-dead", "pending");
+    // The live lease must be untouched.
+    expect(releaseJob).not.toHaveBeenCalledWith(
+      "j2",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("reports nothing reclaimed when no leases are expired", async () => {
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const live: JobRow = {
+      ...jobView({
+        id: "j2",
+        status: "running",
+        claimed_by: "worker-alive",
+        lease_expires_at: "2026-06-04T00:06:00.000Z",
+      }),
+      payload: samplePayload(),
+    };
+    const { pb } = makeFakePb([live]);
+    const claim = makeFakeClaim();
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const sweep = await q.sweepExpired(now);
+
+    expect(sweep.reclaimed).toBe(0);
+    expect(sweep.commErrors).toHaveLength(0);
+    expect(claim.releaseJob).not.toHaveBeenCalled();
+  });
+});
+
+describe("leaseExpired (anchored PB date-separator parse)", () => {
+  const now = Date.parse("2026-06-04T00:05:00.000Z");
+
+  it("treats null/empty as expired (never wedge the queue)", () => {
+    expect(leaseExpired(null, now)).toBe(true);
+    expect(leaseExpired("", now)).toBe(true);
+  });
+
+  it("parses the canonical PB space-separated form (expired in the past)", () => {
+    // PB stores dates as "YYYY-MM-DD HH:MM:SS.sssZ" (space separator). The
+    // anchored rewrite converts the date/time boundary so the value parses.
+    expect(leaseExpired("2026-06-04 00:04:00.000Z", now)).toBe(true);
+  });
+
+  it("parses the canonical PB space-separated form (live in the future)", () => {
+    expect(leaseExpired("2026-06-04 00:06:00.000Z", now)).toBe(false);
+  });
+
+  it("parses an already-ISO ('T'-separated) value unchanged", () => {
+    expect(leaseExpired("2026-06-04T00:06:00.000Z", now)).toBe(false);
+  });
+
+  it("ANCHORS the space rewrite to the date/time boundary, not the FIRST space anywhere", () => {
+    // A leading-space value is NOT the canonical `^YYYY-MM-DD ` shape, so the
+    // anchored rewrite must leave it UNTOUCHED (the date/time boundary further
+    // in is preserved). A bare String.replace(" ", "T") would rewrite the
+    // LEADING space into "T2099-..." → NaN → wrongly EXPIRED. The anchored
+    // form leaves the (future, year-2099) value parseable → correctly LIVE.
+    // This pins the client to the JSVM hook's anchored regex; it FAILS under a
+    // bare first-space replace.
+    expect(leaseExpired(" 2099-01-01 00:00:00.000Z", now)).toBe(false);
+  });
+
+  it("treats a genuinely-unparseable value as expired (NaN → expired, not coerced)", () => {
+    // An odd shape falls through to NaN → expired BY POLICY (never wedge the
+    // queue) — but only because it genuinely failed to parse, NOT because a
+    // bare first-space replace mangled it into something parseable.
+    expect(leaseExpired("2099-01-01 garbage", now)).toBe(true);
+  });
+});

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -1,0 +1,485 @@
+/**
+ * Fleet control-plane ↔ worker QUEUE client (BLITZ S3).
+ *
+ * This is the SEMANTIC queue layer the control-plane (S4) and worker loop (S7)
+ * talk to. It implements the `FleetQueueClient` contract (S1) on top of two
+ * lower primitives:
+ *
+ *   - S0's `JobClaimClient` (`job-claim.ts`) — the atomic, exactly-one-winner
+ *     claim/renew/release CAS over the PocketBase JSVM transaction endpoints.
+ *     The queue-client NEVER re-implements the CAS; it delegates every
+ *     lifecycle transition to S0 so the proven atomicity invariant is the
+ *     single source of truth.
+ *   - the harness `PbClient` (`storage/pb-client.ts`) — the record-level
+ *     create/list path used for the two things the CAS endpoints don't do:
+ *     WRITING a new pending row (`enqueue`) and READING the queue to find
+ *     candidates / expired leases (`claimNext`, `sweepExpired`).
+ *
+ * ── WHY enqueue/claimNext SPLIT ACROSS TWO CLIENTS ─────────────────────────
+ * S0's `claimJob(jobId, ...)` claims a KNOWN row id — it is the CAS, not a
+ * scheduler. So `claimNext` first LISTS pending rows via the PB client, then
+ * races S0's `claimJob` against each candidate until one wins (or the list is
+ * exhausted). Losing the CAS on a candidate is normal under contention — a
+ * peer won it — so we simply fall through to the next candidate. The
+ * exactly-one-winner guarantee is entirely S0's; this layer only picks the
+ * order to attempt.
+ *
+ * ── WHY THE PAYLOAD LIVES ON THE ROW ───────────────────────────────────────
+ * A job's WORK (`ServiceJobPayload`) is written by the control-plane at
+ * enqueue time and read by the worker AFTER it wins the claim — across a
+ * process boundary. So the payload is persisted in the `probe_jobs.payload`
+ * JSON column (migration `1779989500_probe_jobs_add_payload.js`), not held in
+ * memory. `claimNext`/`renewLease` re-hydrate the typed payload from the row
+ * the PB client returns.
+ *
+ * ── WHY sweepExpired RE-QUEUES VIA S0 releaseJob(pending) ──────────────────
+ * A worker that crashes mid-job leaves its lease to expire with no terminal
+ * report. The sweeper (control-plane S4) finds those rows, re-queues each via
+ * S0's `releaseJob(..., "pending")` ON BEHALF of the dead holder (the CAS
+ * checks `claimed_by`, which is still the dead worker, so the release is
+ * authorized and atomic), and synthesizes a `worker-crashed-mid-job`
+ * `PoolCommError` (REQ-B) per reclaimed job so the dashboard renders
+ * "couldn't reach the pool" distinctly from a probe red.
+ */
+
+import type { Logger } from "../types/index.js";
+import type { PbClient } from "../storage/pb-client.js";
+import type { JobClaimClient, JobView } from "./job-claim.js";
+import {
+  terminalJobStatus,
+  type ClaimedJob,
+  type EnqueueJobInput,
+  type FleetQueueClient,
+  type JobLease,
+  type PoolCommError,
+  type ReportJobInput,
+  type ServiceJobMeta,
+  type ServiceJobPayload,
+  type SweepResult,
+} from "./contracts.js";
+
+/**
+ * Canonical PocketBase collection name for the fleet pull-queue. Single source
+ * of truth for the name so a rename can't go half-applied (mirrors
+ * `PROBE_RUNS_COLLECTION` / `WORKERS_COLLECTION`). S0's `job-claim.ts` talks to
+ * the collection only through the JSVM CAS endpoints (no records API), so this
+ * is the first module to name it for record-level reads/writes.
+ */
+export const PROBE_JOBS_COLLECTION = "probe_jobs";
+
+/** Max pending candidates `claimNext` scans per attempt — bounds the CAS race. */
+const CLAIM_CANDIDATE_PAGE = 50;
+
+/**
+ * Bounded retries for the post-release result write in `report()`. The release
+ * CAS already flipped the row terminal; if the SEPARATE result write fails the
+ * result is lost. The control-plane result-consumer catches this case: the row
+ * is terminal-but-resultless, so once it ages past the consumer's grace window
+ * the consumer synthesizes a `worker-crashed-mid-job` comm error onto the
+ * dashboard (REQ-B) before latching it — the sweepers never see a terminal row.
+ * We still retry a few times here before surfacing a distinct "result lost"
+ * error, so the loss is unmistakable in logs and the common transient blip is
+ * absorbed without dropping the result.
+ */
+const RESULT_WRITE_MAX_ATTEMPTS = 3;
+
+export interface FleetQueueClientConfig {
+  /** Record-level PB access for enqueue (create) + queue reads (list). */
+  pb: PbClient;
+  /** S0's atomic claim/renew/release primitive. */
+  claim: JobClaimClient;
+  logger: Logger;
+}
+
+/** The persisted `probe_jobs` row shape as the PB records API returns it. */
+interface ProbeJobRecord extends JobView {
+  /** The serialized per-service work (migration 1779989500 adds this column). */
+  payload?: unknown;
+}
+
+/**
+ * Decode a row's `payload` JSON into a typed `ServiceJobPayload`. The column is
+ * a structured JSON object; PB returns it already-parsed. We do a minimal
+ * structural check so a malformed/absent payload fails LOUD here (at the
+ * enqueue→claim boundary) rather than surfacing as an `undefined` deref deep in
+ * the worker.
+ */
+function decodePayload(jobId: string, raw: unknown): ServiceJobPayload {
+  if (raw === null || typeof raw !== "object") {
+    throw new Error(
+      `queue-client: job ${jobId} has no decodable payload on its probe_jobs row`,
+    );
+  }
+  const candidate = raw as Partial<ServiceJobPayload>;
+  if (
+    typeof candidate.probeKey !== "string" ||
+    typeof candidate.serviceSlug !== "string" ||
+    typeof candidate.driverKind !== "string" ||
+    candidate.meta === undefined
+  ) {
+    throw new Error(
+      `queue-client: job ${jobId} payload is missing required fields (probeKey/serviceSlug/driverKind/meta)`,
+    );
+  }
+  // `meta` is typed `ServiceJobMeta`, but the JSON column is untrusted: a
+  // non-object `meta` (string/number/array) satisfies the `!== undefined`
+  // check above yet would deref to `undefined` deep in the worker (the
+  // aggregator groups by `meta.runId`). Assert it is a non-null object with a
+  // string `runId` and fail LOUD at this boundary.
+  const meta = candidate.meta as Partial<ServiceJobMeta> | null;
+  if (
+    meta === null ||
+    typeof meta !== "object" ||
+    Array.isArray(meta) ||
+    typeof meta.runId !== "string"
+  ) {
+    throw new Error(
+      `queue-client: job ${jobId} payload.meta must be a non-null object with a string runId`,
+    );
+  }
+  return candidate as ServiceJobPayload;
+}
+
+/** Build the `JobLease` a worker holds from a claimed row + its decoded payload. */
+function leaseFromJob(job: JobView, payload: ServiceJobPayload): JobLease {
+  return { job, payload, leaseExpiresAt: job.lease_expires_at };
+}
+
+/**
+ * Best-effort placeholder payload for a SUCCESSFUL renew whose payload could
+ * not be re-hydrated (neither the claim-time cache nor the convenience re-read
+ * was available). The heartbeat never consumes the payload — it only needs the
+ * lease to stay alive — so a CAS renew that won must still yield a lease rather
+ * than a null that the heartbeat would misread as a lost lease. We seed the
+ * join keys from the authoritative CAS row and leave the rest empty; a renew is
+ * in practice always preceded by a same-process claim, so this path is rare.
+ */
+function emptyPayloadForLease(job: JobView): ServiceJobPayload {
+  return {
+    probeKey: job.probe_key,
+    serviceSlug: "",
+    driverKind: "",
+    meta: { runId: "", triggered: false, enqueuedAt: "" },
+  };
+}
+
+/**
+ * Anchor the PB space→"T" date-separator rewrite to the canonical PB shape
+ * (`YYYY-MM-DD ` then time) so we ONLY convert the date/time boundary, never an
+ * arbitrary first space. MUST stay byte-for-byte identical to the JSVM hook's
+ * `leaseExpired` (`fleet-claim.pb.js`): the hook anchors with
+ * `/^(\d{4}-\d{2}-\d{2}) /` so the client-side reclamation decision and the
+ * server-side CAS gate agree on whether a lease has expired. A bare
+ * `String.replace(" ", "T")` rewrites the FIRST space ANYWHERE, which would
+ * coerce a malformed/non-standard value into something that parses, defeating
+ * the agreement (the client could treat a value live that the hook treats
+ * expired, or vice versa). An odd shape must fall through to NaN → expired
+ * (never wedge the queue), but only because the value genuinely failed to
+ * parse, not because we mangled it into a parseable one.
+ */
+const PB_DATE_SEP_RE = /^(\d{4}-\d{2}-\d{2}) /;
+
+/**
+ * Has `leaseExpiresAt` elapsed as of `nowMs`? A null/empty/unparseable lease is
+ * treated as EXPIRED — mirrors the PB endpoint's `leaseExpired` (never let a
+ * row wedge the queue forever on a malformed timestamp). The PB date form uses
+ * a space separator; normalize ONLY the canonical date/time boundary to ISO "T"
+ * before parsing — ANCHORED exactly as the JSVM hook does so both sides agree.
+ *
+ * Exported for direct unit testing of the anchored-parse contract (the
+ * client↔hook agreement is load-bearing for the exactly-one-winner CAS).
+ */
+export function leaseExpired(
+  leaseExpiresAt: string | null,
+  nowMs: number,
+): boolean {
+  if (!leaseExpiresAt) return true;
+  const t = Date.parse(String(leaseExpiresAt).replace(PB_DATE_SEP_RE, "$1T"));
+  if (Number.isNaN(t)) return true;
+  return t <= nowMs;
+}
+
+export function createFleetQueueClient(
+  config: FleetQueueClientConfig,
+): FleetQueueClient {
+  const { pb, claim, logger } = config;
+
+  // Per-client cache of a claimed job's decoded payload, keyed by jobId. The
+  // renew CAS returns the lifecycle columns but NOT the payload, and the
+  // convenience re-read used to re-hydrate it can momentarily fail (a PB read
+  // blip). Throwing on that blip permanently stops the worker's heartbeat,
+  // after which the sweeper reclaims the still-live job and synthesizes a FALSE
+  // `worker-crashed-mid-job` comm error. So we remember the payload at claim
+  // time and reuse it on renew, making the re-read a non-fatal convenience.
+  const payloadCache = new Map<string, ServiceJobPayload>();
+
+  return {
+    async enqueue(input: EnqueueJobInput): Promise<JobView> {
+      const { payload } = input;
+      // A fresh job is `pending` with no owner and no lease. `probe_key` is the
+      // join key (== payload.probeKey, the d6 aggregate row key); the work
+      // rides in the `payload` JSON column for the worker to read post-claim.
+      const record = await pb.create<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
+        probe_key: payload.probeKey,
+        status: "pending",
+        claimed_by: "",
+        lease_expires_at: null,
+        version: 0,
+        payload,
+      });
+      logger.debug("queue-client.enqueued", {
+        jobId: record.id,
+        probeKey: payload.probeKey,
+        runId: payload.meta.runId,
+      });
+      return record;
+    },
+
+    async claimNext(
+      workerId: string,
+      leaseSeconds: number,
+    ): Promise<ClaimedJob> {
+      // List pending candidates, then race S0's atomic claim against each until
+      // one wins. Losing a CAS means a peer took it — fall through, don't error.
+      const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
+        filter: 'status = "pending"',
+        perPage: CLAIM_CANDIDATE_PAGE,
+        skipTotal: true,
+      });
+      for (const candidate of page.items) {
+        const result = await claim.claimJob(
+          candidate.id,
+          workerId,
+          leaseSeconds,
+        );
+        if (result.won && result.job) {
+          // The CAS already WON — this worker now OWNS the row. Decoding the
+          // payload from the (pre-claim) candidate row can still throw on a
+          // malformed/absent payload; if we let that throw escape, the job is
+          // claimed-but-orphaned: nobody reports it, the sweeper later reclaims
+          // it and synthesizes a FALSE `worker-crashed-mid-job`, and the row is
+          // re-listed → re-thrown forever (a poison row that wedges the queue).
+          // So on a decode failure we RELEASE the won job as `failed` (we own
+          // it, so the CAS authorizes) and fall through to the next candidate —
+          // a decode throw must NEVER strand a job we just won.
+          let payload: ServiceJobPayload;
+          try {
+            payload = decodePayload(candidate.id, candidate.payload);
+          } catch (err) {
+            logger.error("queue-client.claim-decode-failed", {
+              jobId: result.job.id,
+              workerId,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            // Best-effort terminal release so the poison row doesn't re-list
+            // forever. A refused release here is non-fatal — another sweeper or
+            // a later reclaim handles it; we must not throw out of claimNext.
+            try {
+              await claim.releaseJob(result.job.id, workerId, "failed");
+            } catch (releaseErr) {
+              logger.warn("queue-client.claim-decode-release-failed", {
+                jobId: result.job.id,
+                workerId,
+                err:
+                  releaseErr instanceof Error
+                    ? releaseErr.message
+                    : String(releaseErr),
+              });
+            }
+            continue;
+          }
+          // Cache for the renew path so a later heartbeat doesn't depend on a
+          // fresh PB re-read to re-hydrate the payload.
+          payloadCache.set(result.job.id, payload);
+          logger.debug("queue-client.claimed", {
+            jobId: result.job.id,
+            workerId,
+          });
+          return { claimed: true, lease: leaseFromJob(result.job, payload) };
+        }
+      }
+      return { claimed: false };
+    },
+
+    async renewLease(
+      jobId: string,
+      workerId: string,
+      leaseSeconds: number,
+    ): Promise<JobLease | null> {
+      const result = await claim.renewLease(jobId, workerId, leaseSeconds);
+      if (!result.renewed || !result.job) return null;
+      // The renew CAS already returned the authoritative lifecycle columns. The
+      // payload is the only thing it omits, so prefer the claim-time cache. A
+      // momentary PB read blip must NEVER turn a SUCCESSFUL renew into a thrown
+      // error: that would kill the worker's heartbeat and let the sweeper
+      // reclaim a live job, synthesizing a false `worker-crashed-mid-job`. So
+      // the re-read below is a non-fatal convenience used only on a cache miss.
+      let payload = payloadCache.get(jobId);
+      if (!payload) {
+        try {
+          const record = await pb.getOne<ProbeJobRecord>(
+            PROBE_JOBS_COLLECTION,
+            jobId,
+          );
+          if (record) {
+            payload = decodePayload(jobId, record.payload);
+            payloadCache.set(jobId, payload);
+          }
+        } catch (err) {
+          // Read blip — log and fall through to the cache-miss handling below.
+          logger.warn("queue-client.renew-reread-failed", {
+            jobId,
+            workerId,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      if (!payload) {
+        // Renew succeeded (the CAS won) but we have no payload to re-hydrate
+        // (no prior claim in this process AND the convenience re-read was
+        // unavailable). A SUCCESSFUL CAS renew MUST keep the heartbeat alive:
+        // returning null here makes the heartbeat interpret a healthy renew as
+        // a LOST lease, stop heartbeating, and let the sweeper reclaim a LIVE
+        // job → a FALSE `worker-crashed-mid-job`. The heartbeat does not
+        // consume the payload, so return a lease with a best-effort EMPTY
+        // payload synthesized from the authoritative CAS row. We ONLY return
+        // null when the CAS itself failed (handled above).
+        logger.warn("queue-client.renew-no-payload", { jobId, workerId });
+        return leaseFromJob(result.job, emptyPayloadForLease(result.job));
+      }
+      return leaseFromJob(result.job, payload);
+    },
+
+    async report(input: ReportJobInput): Promise<void> {
+      const status = terminalJobStatus(input.result);
+      // The worker is DONE with this job either way (release refused or result
+      // write exhausted), so always evict the cached payload before returning —
+      // a leak here would slowly grow the per-client cache across reports.
+      try {
+        const result = await claim.releaseJob(
+          input.jobId,
+          input.workerId,
+          status,
+        );
+        if (!result.released) {
+          // The CAS refused the release — not the lease holder, or the row is
+          // no longer running (likely already swept/reclaimed). The row is NOT
+          // terminal-by-us and carries NO result, so nothing was lost: the
+          // sweeper's reclaim path (REQ-B) covers the dashboard signal. Fail
+          // loud, but flag it as "release failed (job not lost)".
+          throw new Error(
+            `queue-client: release failed (job not lost) for job ${input.jobId} (worker ${input.workerId}, status ${status}) — not the lease holder or row not running`,
+          );
+        }
+        // PERSIST the per-service result onto the now-terminal row so the
+        // control-plane's result-consumer (a DIFFERENT process) can aggregate
+        // it (migration 1779989700 adds `result` + `result_processed`). The CAS
+        // release above already flipped the row to done/failed and the worker
+        // still owns it (the release authorized on claimed_by), so this is a
+        // plain record write on a row this worker just terminated — it does NOT
+        // touch the claim lifecycle columns the CAS owns. `result_processed`
+        // seeds false: the consumer latches it true after aggregating exactly
+        // once. This write happens AFTER the release so a row never carries a
+        // result while still claimable.
+        //
+        // CRITICAL: the row is ALREADY terminal but the result is what the
+        // consumer aggregates. If this write fails and we just gave up, the
+        // result is SILENTLY DROPPED (terminal row, empty result → the consumer
+        // latches it resultless past grace, the dashboard never updates). So
+        // RETRY the write (bounded) before surfacing a DISTINCT "result lost"
+        // error, so the failure mode is unmistakable in logs vs. a refused
+        // release.
+        let lastErr: unknown;
+        for (let attempt = 1; attempt <= RESULT_WRITE_MAX_ATTEMPTS; attempt++) {
+          try {
+            await pb.update(PROBE_JOBS_COLLECTION, input.jobId, {
+              result: input.result,
+              result_processed: false,
+            });
+            logger.debug("queue-client.reported", {
+              jobId: input.jobId,
+              workerId: input.workerId,
+              status,
+            });
+            return;
+          } catch (err) {
+            lastErr = err;
+            logger.warn("queue-client.result-write-failed", {
+              jobId: input.jobId,
+              workerId: input.workerId,
+              attempt,
+              maxAttempts: RESULT_WRITE_MAX_ATTEMPTS,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+        // Exhausted the retries: the release SUCCEEDED (row is terminal) but the
+        // result write FAILED — the result is LOST. Surface this distinctly so
+        // an operator can tell it apart from a refused release.
+        logger.error("queue-client.result-write-lost", {
+          jobId: input.jobId,
+          workerId: input.workerId,
+          status,
+          err: lastErr instanceof Error ? lastErr.message : String(lastErr),
+        });
+        throw new Error(
+          `queue-client: release succeeded but result write FAILED (result lost) for job ${input.jobId} (worker ${input.workerId}, status ${status}) after ${RESULT_WRITE_MAX_ATTEMPTS} attempts: ${
+            lastErr instanceof Error ? lastErr.message : String(lastErr)
+          }`,
+        );
+      } finally {
+        // Terminal for this worker no matter the outcome — drop the cached
+        // payload here so neither a refused release nor an exhausted result
+        // write leaks the entry.
+        payloadCache.delete(input.jobId);
+      }
+    },
+
+    async sweepExpired(nowMs: number): Promise<SweepResult> {
+      // Scan claimed/running rows for expired leases (crashed/unreachable
+      // workers). PB lacks an OR-of-equals shortcut here, so list both running
+      // states and filter by lease in-process.
+      const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
+        filter: 'status = "claimed" || status = "running"',
+        perPage: CLAIM_CANDIDATE_PAGE,
+        skipTotal: true,
+      });
+      const commErrors: PoolCommError[] = [];
+      let reclaimed = 0;
+      const observedAt = new Date(nowMs).toISOString();
+      for (const row of page.items) {
+        if (!leaseExpired(row.lease_expires_at, nowMs)) continue;
+        // Re-queue on behalf of the dead holder: the CAS authorizes on
+        // `claimed_by` (still the dead worker), so this atomically flips the
+        // row back to pending and drops ownership.
+        const released = await claim.releaseJob(
+          row.id,
+          row.claimed_by,
+          "pending",
+        );
+        if (!released.released) {
+          // Another sweeper or a late worker report won the race — not an
+          // error, just nothing for us to reclaim on this row.
+          logger.debug("queue-client.sweep-skip", {
+            jobId: row.id,
+            workerId: row.claimed_by,
+          });
+          continue;
+        }
+        reclaimed += 1;
+        commErrors.push({
+          kind: "worker-crashed-mid-job",
+          message: `lease for job ${row.id} expired (worker ${row.claimed_by || "unknown"} crashed mid-job); re-queued`,
+          workerId: row.claimed_by || undefined,
+          jobId: row.id,
+          observedAt,
+        });
+        logger.warn("queue-client.sweep-reclaimed", {
+          jobId: row.id,
+          workerId: row.claimed_by,
+        });
+      }
+      return { reclaimed, commErrors };
+    },
+  };
+}

--- a/showcase/harness/src/fleet/role-config.test.ts
+++ b/showcase/harness/src/fleet/role-config.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveFleetRoleConfig,
+  isHarnessRole,
+  DEFAULT_POOL_COUNT,
+  HARNESS_ROLES,
+} from "./role-config.js";
+
+/**
+ * Pins the fleet role-selection contract: HARNESS_ROLE selects the runtime
+ * role (control-plane | worker), missing/invalid role errors clearly, and
+ * HARNESS_POOL_COUNT parses + defaults to 1 + validates >= 1.
+ *
+ * Env is injected via `options.env` so these tests never touch process.env
+ * (parallel-safe — mirrors the harness's env-injection idiom).
+ */
+
+describe("resolveFleetRoleConfig — role selection", () => {
+  it("selects the worker role when HARNESS_ROLE=worker", () => {
+    const cfg = resolveFleetRoleConfig({ env: { HARNESS_ROLE: "worker" } });
+    expect(cfg.role).toBe("worker");
+  });
+
+  it("selects the control-plane role when HARNESS_ROLE=control-plane", () => {
+    const cfg = resolveFleetRoleConfig({
+      env: { HARNESS_ROLE: "control-plane" },
+    });
+    expect(cfg.role).toBe("control-plane");
+  });
+
+  it("trims surrounding whitespace on HARNESS_ROLE", () => {
+    const cfg = resolveFleetRoleConfig({ env: { HARNESS_ROLE: "  worker  " } });
+    expect(cfg.role).toBe("worker");
+  });
+
+  it("throws a fail-loud error naming valid roles when HARNESS_ROLE is unset", () => {
+    expect(() => resolveFleetRoleConfig({ env: {} })).toThrowError(
+      /HARNESS_ROLE must be set to one of: control-plane, worker \(got: <unset>\)\. Every fleet service must set HARNESS_ROLE explicitly\./,
+    );
+  });
+
+  it("throws a fail-loud error when HARNESS_ROLE is empty/whitespace", () => {
+    expect(() =>
+      resolveFleetRoleConfig({ env: { HARNESS_ROLE: "   " } }),
+    ).toThrowError(
+      /HARNESS_ROLE must be set to one of: control-plane, worker \(got: <unset>\)\. Every fleet service must set HARNESS_ROLE explicitly\./,
+    );
+  });
+
+  it("throws a clear error when HARNESS_ROLE is invalid", () => {
+    expect(() =>
+      resolveFleetRoleConfig({ env: { HARNESS_ROLE: "scheduler" } }),
+    ).toThrowError(/HARNESS_ROLE "scheduler" is invalid/);
+  });
+});
+
+describe("resolveFleetRoleConfig — HARNESS_POOL_COUNT", () => {
+  it("defaults to 1 when unset", () => {
+    const cfg = resolveFleetRoleConfig({ env: { HARNESS_ROLE: "worker" } });
+    expect(cfg.poolCount).toBe(1);
+    expect(cfg.poolCount).toBe(DEFAULT_POOL_COUNT);
+  });
+
+  it("defaults to 1 when empty", () => {
+    const cfg = resolveFleetRoleConfig({
+      env: { HARNESS_ROLE: "worker", HARNESS_POOL_COUNT: "  " },
+    });
+    expect(cfg.poolCount).toBe(1);
+  });
+
+  it("parses a valid integer", () => {
+    const cfg = resolveFleetRoleConfig({
+      env: { HARNESS_ROLE: "control-plane", HARNESS_POOL_COUNT: "2" },
+    });
+    expect(cfg.poolCount).toBe(2);
+  });
+
+  it("throws on a value below 1", () => {
+    expect(() =>
+      resolveFleetRoleConfig({
+        env: { HARNESS_ROLE: "worker", HARNESS_POOL_COUNT: "0" },
+      }),
+    ).toThrowError(/HARNESS_POOL_COUNT must be a positive integer/);
+  });
+
+  it("throws on a negative value", () => {
+    expect(() =>
+      resolveFleetRoleConfig({
+        env: { HARNESS_ROLE: "worker", HARNESS_POOL_COUNT: "-3" },
+      }),
+    ).toThrowError(/HARNESS_POOL_COUNT must be a positive integer/);
+  });
+
+  it("throws on a non-numeric value", () => {
+    expect(() =>
+      resolveFleetRoleConfig({
+        env: { HARNESS_ROLE: "worker", HARNESS_POOL_COUNT: "abc" },
+      }),
+    ).toThrowError(/HARNESS_POOL_COUNT must be a positive integer/);
+  });
+
+  it("throws on a partially-numeric value (no silent parseInt truncation)", () => {
+    expect(() =>
+      resolveFleetRoleConfig({
+        env: { HARNESS_ROLE: "worker", HARNESS_POOL_COUNT: "2abc" },
+      }),
+    ).toThrowError(/HARNESS_POOL_COUNT must be a positive integer/);
+  });
+
+  it("throws on a fractional value", () => {
+    expect(() =>
+      resolveFleetRoleConfig({
+        env: { HARNESS_ROLE: "worker", HARNESS_POOL_COUNT: "1.5" },
+      }),
+    ).toThrowError(/HARNESS_POOL_COUNT must be a positive integer/);
+  });
+});
+
+describe("isHarnessRole", () => {
+  it("accepts the known roles", () => {
+    for (const role of HARNESS_ROLES) {
+      expect(isHarnessRole(role)).toBe(true);
+    }
+  });
+
+  it("rejects unknown / undefined values", () => {
+    expect(isHarnessRole("scheduler")).toBe(false);
+    expect(isHarnessRole(undefined)).toBe(false);
+    expect(isHarnessRole("")).toBe(false);
+  });
+});

--- a/showcase/harness/src/fleet/role-config.ts
+++ b/showcase/harness/src/fleet/role-config.ts
@@ -1,0 +1,126 @@
+/**
+ * Fleet role configuration: the single harness image boots in one of two
+ * runtime ROLES, selected by env. This module is the ONE place that parses and
+ * validates the role-selection env so the orchestrator entrypoint (and the
+ * future control-plane/worker modules) share a single, typed contract.
+ *
+ *   HARNESS_ROLE       = "control-plane" | "worker"
+ *   HARNESS_POOL_COUNT = positive integer (default 1)
+ *
+ * Mirrors the harness env-parsing idiom (`resolve*` helpers with explicit-arg >
+ * env > default precedence, parseInt + Number.isNaN guards — see
+ * `probes/helpers/browser-pool.ts`'s `resolveNonNegative`/`resolvePositive`).
+ *
+ * Fail-loud discipline: a missing, empty/whitespace, or explicitly-SET-but-
+ * invalid HARNESS_ROLE (and likewise an invalid HARNESS_POOL_COUNT) throws on
+ * boot rather than silently defaulting, so a misconfigured fleet member dies
+ * immediately (visible in deploy CI / Railway health-check) instead of booting
+ * in the wrong role hours before anyone notices. There is NO default role: an
+ * UNSET HARNESS_ROLE throws so a poolless control-plane that runs no probes can
+ * never boot by accident — every fleet service must declare its role.
+ */
+
+/** The two runtime roles the single harness image can boot as. */
+export type HarnessRole = "control-plane" | "worker";
+
+/** The valid HARNESS_ROLE string values, in a single source of truth. */
+export const HARNESS_ROLES: readonly HarnessRole[] = [
+  "control-plane",
+  "worker",
+] as const;
+
+/** Default worker count the control-plane expects when unset (local). */
+export const DEFAULT_POOL_COUNT = 1;
+
+/** Typed, validated fleet role config — the output of env resolution. */
+export interface FleetRoleConfig {
+  /** Selected runtime role. */
+  readonly role: HarnessRole;
+  /**
+   * Number of WORKER members in the fleet. The control-plane uses this to know
+   * how many workers to expect; a worker carries it for symmetry/diagnostics.
+   * Always >= 1.
+   */
+  readonly poolCount: number;
+}
+
+export interface ResolveFleetRoleOptions {
+  /** Env source (defaults to process.env) — injectable for tests. */
+  env?: Readonly<Record<string, string | undefined>>;
+}
+
+/** Type guard: is `value` a valid HARNESS_ROLE string? */
+export function isHarnessRole(value: string | undefined): value is HarnessRole {
+  return (
+    value !== undefined && (HARNESS_ROLES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Resolve HARNESS_POOL_COUNT to a positive integer.
+ *
+ * Precedence: env > default. Unlike the browser-pool's `resolveNonNegative`
+ * (which tolerates garbage by falling back), an explicitly-SET-but-invalid
+ * value (non-integer, < 1, or non-numeric) is a misconfiguration that must be
+ * caught loudly — so it THROWS rather than silently defaulting. An UNSET value
+ * legitimately defaults to `fallback`.
+ */
+function resolvePoolCount(
+  envRaw: string | undefined,
+  fallback: number,
+): number {
+  if (envRaw === undefined || envRaw.trim() === "") return fallback;
+  const trimmed = envRaw.trim();
+  // parseInt("2abc") === 2 silently — require the WHOLE string to be a base-10
+  // integer so a fat-fingered value fails loud instead of being truncated.
+  if (!/^-?\d+$/.test(trimmed)) {
+    throw new Error(
+      `HARNESS_POOL_COUNT must be a positive integer, got "${envRaw}".`,
+    );
+  }
+  const parsed = parseInt(trimmed, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    throw new Error(
+      `HARNESS_POOL_COUNT must be a positive integer (>= 1), got "${envRaw}".`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Parse + validate the fleet role-selection env into a typed config.
+ *
+ * - HARNESS_ROLE is REQUIRED and must be one of HARNESS_ROLES. There is no
+ *   default: a missing or empty/whitespace value throws (fail loud) so a
+ *   poolless, probe-less control-plane can never boot by accident.
+ * - HARNESS_POOL_COUNT defaults to DEFAULT_POOL_COUNT (1) and validates >= 1.
+ *
+ * Throws a clear, actionable Error on any missing/invalid input.
+ */
+export function resolveFleetRoleConfig(
+  options: ResolveFleetRoleOptions = {},
+): FleetRoleConfig {
+  const env = options.env ?? process.env;
+
+  const rawRole = env.HARNESS_ROLE?.trim();
+  let role: HarnessRole;
+  if (rawRole === undefined || rawRole === "") {
+    throw new Error(
+      `HARNESS_ROLE must be set to one of: ${HARNESS_ROLES.join(", ")} ` +
+        `(got: <unset>). Every fleet service must set HARNESS_ROLE explicitly.`,
+    );
+  } else if (isHarnessRole(rawRole)) {
+    role = rawRole;
+  } else {
+    throw new Error(
+      `HARNESS_ROLE "${rawRole}" is invalid. Must be one of: ${HARNESS_ROLES.join(", ")}.`,
+    );
+  }
+
+  const poolCount = resolvePoolCount(
+    env.HARNESS_POOL_COUNT,
+    DEFAULT_POOL_COUNT,
+  );
+
+  return { role, poolCount };
+}

--- a/showcase/harness/src/fleet/worker/payload-mapper.test.ts
+++ b/showcase/harness/src/fleet/worker/payload-mapper.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createD6PayloadToInput } from "./payload-mapper.js";
+import type { ServiceJobPayload } from "../contracts.js";
+
+function payload(over: Partial<ServiceJobPayload> = {}): ServiceJobPayload {
+  return {
+    probeKey: "d6:langgraph-python",
+    serviceSlug: "langgraph-python",
+    driverKind: "e2e_d6",
+    meta: {
+      runId: "frun_1",
+      triggered: false,
+      enqueuedAt: "2026-01-01T00:00:00Z",
+    },
+    ...over,
+  };
+}
+
+describe("createD6PayloadToInput", () => {
+  it("re-hydrates the serialized driver input verbatim", () => {
+    const map = createD6PayloadToInput();
+    const input = map(
+      payload({
+        driverInputs: {
+          key: "d6-all-pills-e2e:langgraph-python",
+          backendUrl: "https://lg.example.com",
+          demos: ["shared-state", "human-in-the-loop"],
+          shape: "package",
+        },
+      }),
+    ) as Record<string, unknown>;
+
+    expect(input.key).toBe("d6-all-pills-e2e:langgraph-python");
+    expect(input.backendUrl).toBe("https://lg.example.com");
+    expect(input.demos).toEqual(["shared-state", "human-in-the-loop"]);
+    expect(input.shape).toBe("package");
+  });
+
+  it("defaults a missing key to the payload probeKey", () => {
+    const map = createD6PayloadToInput();
+    const input = map(
+      payload({ driverInputs: { backendUrl: "https://lg.example.com" } }),
+    ) as Record<string, unknown>;
+
+    expect(input.key).toBe("d6:langgraph-python");
+    expect(input.backendUrl).toBe("https://lg.example.com");
+  });
+
+  it("does not mutate the payload's driverInputs object", () => {
+    const map = createD6PayloadToInput();
+    const driverInputs: Record<string, unknown> = {
+      backendUrl: "https://lg.example.com",
+    };
+    map(payload({ driverInputs }));
+    expect(driverInputs).toEqual({ backendUrl: "https://lg.example.com" });
+    expect("key" in driverInputs).toBe(false);
+  });
+
+  it("returns undefined when the payload carries no driver inputs", () => {
+    const map = createD6PayloadToInput();
+    expect(map(payload())).toBeUndefined();
+    expect(map(payload({ driverInputs: undefined }))).toBeUndefined();
+  });
+});

--- a/showcase/harness/src/fleet/worker/payload-mapper.ts
+++ b/showcase/harness/src/fleet/worker/payload-mapper.ts
@@ -1,0 +1,59 @@
+/**
+ * Worker payload → d6 driver-input mapper (the catalog-aware seam S7's
+ * `PayloadToDriverInput` types against).
+ *
+ * ── WHY THIS LIVES HERE, NOT IN worker-loop.ts ─────────────────────────────
+ * The worker loop (S7) types its driver-input construction against the
+ * `PayloadToDriverInput` interface and INJECTS the concrete mapping, precisely
+ * so the loop never learns the d6 driver's input shape. This module is that
+ * concrete mapping for the d6 (`e2e_d6`) per-service unit: it re-hydrates the
+ * `E2eFullDriverInput` object the d6 driver's zod schema validates
+ * (`key`/`backendUrl`/`demos`/`shape`/…) from the claimed `ServiceJobPayload`.
+ *
+ * ── WHERE THE INPUT COMES FROM ─────────────────────────────────────────────
+ * The control-plane PRODUCER (S4) is the catalog-aware side: its enumerator
+ * resolves each showcase service (Railway discovery → backendUrl, declared
+ * demos, manifest `not_supported_features`, shape) and serializes that object
+ * into `payload.driverInputs`. So the worker side is a thin re-hydration: take
+ * `driverInputs` as the d6 input, and default the `key` to the payload's
+ * `probeKey` when the producer didn't stamp one (the d6 schema requires `key`).
+ * The d6 driver's own zod schema is the validation gate — a malformed input
+ * fails LOUD inside `driver.run`, surfaced by the loop as a terminal result.
+ *
+ * Returning `undefined` signals "this payload can't be mapped" → the loop
+ * reports a `worker-protocol-violation` terminal result rather than crashing.
+ * We return `undefined` ONLY when the producer attached no `driverInputs` at
+ * all (there's nothing to run); a present-but-incomplete input is forwarded so
+ * the d6 schema produces the precise validation error.
+ */
+
+import type { PayloadToDriverInput } from "./worker-loop.js";
+import type { ServiceJobPayload } from "../contracts.js";
+
+/** The driver kind this mapper knows how to map. */
+export const E2E_D6_DRIVER_KIND = "e2e_d6";
+
+/**
+ * Build the d6 `PayloadToDriverInput` mapping. Re-hydrates the serialized d6
+ * input from `payload.driverInputs`, defaulting `key` to the payload's
+ * `probeKey`. Pure; the returned function captures nothing mutable.
+ */
+export function createD6PayloadToInput(): PayloadToDriverInput {
+  return (payload: ServiceJobPayload): unknown | undefined => {
+    const raw = payload.driverInputs;
+    // No driver inputs → nothing the d6 driver can run. Signal "unmappable" so
+    // the loop reports a protocol violation instead of handing the driver an
+    // input its schema will reject deep inside the run.
+    if (raw === undefined || raw === null || typeof raw !== "object") {
+      return undefined;
+    }
+    const input = { ...(raw as Record<string, unknown>) };
+    // The d6 schema REQUIRES a non-empty `key`. The producer normally stamps
+    // it; default to the payload's probeKey (the join key to the dashboard
+    // row) so a producer that omitted it still yields a runnable input.
+    if (typeof input.key !== "string" || input.key.length === 0) {
+      input.key = payload.probeKey;
+    }
+    return input;
+  };
+}

--- a/showcase/harness/src/fleet/worker/registration.test.ts
+++ b/showcase/harness/src/fleet/worker/registration.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  registerWorker,
+  type RegistrationPbClient,
+  type RegistrationLogger,
+  type WorkerPoolBudgetSource,
+} from "./registration.js";
+import { WORKERS_COLLECTION } from "../contracts.js";
+import type { BrowserPoolBudget } from "../../probes/helpers/browser-pool.js";
+
+/** A fake upsert-by-field PB that records every call and keeps a 1-row state. */
+function makeFakePb(): {
+  pb: RegistrationPbClient;
+  upserts: Array<{
+    collection: string;
+    field: string;
+    value: string;
+    record: Record<string, unknown>;
+  }>;
+  row: () => Record<string, unknown> | undefined;
+} {
+  const upserts: Array<{
+    collection: string;
+    field: string;
+    value: string;
+    record: Record<string, unknown>;
+  }> = [];
+  let state: Record<string, unknown> | undefined;
+  const pb: RegistrationPbClient = {
+    async upsertByField<T>(
+      collection: string,
+      field: string,
+      value: string,
+      record: Record<string, unknown>,
+    ): Promise<T> {
+      upserts.push({ collection, field, value, record });
+      // Merge over existing state (mirrors PB upsert semantics).
+      state = { ...(state ?? {}), [field]: value, ...record };
+      return state as T;
+    },
+  };
+  return { pb, upserts, row: () => state };
+}
+
+function makeBudget(over: Partial<BrowserPoolBudget> = {}): BrowserPoolBudget {
+  return {
+    inUse: 3,
+    available: 21,
+    max: 24,
+    pidsCurrent: 412,
+    pidsMax: 1000,
+    ...over,
+  };
+}
+
+function makePool(budget: BrowserPoolBudget): WorkerPoolBudgetSource {
+  return { budget: () => budget };
+}
+
+function makeLogger(): RegistrationLogger {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe("registerWorker", () => {
+  it("upserts a workers row with the correct id, endpoint and capacity on boot", async () => {
+    const { pb, upserts, row } = makeFakePb();
+    const reg = await registerWorker({
+      pb,
+      pool: makePool(makeBudget()),
+      logger: makeLogger(),
+      workerId: "worker-7",
+      endpoint: "10.0.0.7:8080",
+      now: () => Date.parse("2026-06-04T12:00:00.000Z"),
+      // No real timers in this test.
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+    reg.stop();
+
+    expect(upserts).toHaveLength(1);
+    const call = upserts[0];
+    expect(call.collection).toBe(WORKERS_COLLECTION);
+    expect(call.field).toBe("worker_id");
+    expect(call.value).toBe("worker-7");
+    expect(call.record).toMatchObject({
+      endpoint: "10.0.0.7:8080",
+      capacity_in_use: 3,
+      capacity_available: 21,
+      capacity_max: 24,
+      capacity_pids_current: 412,
+      capacity_pids_max: 1000,
+      current_job_id: "",
+      registered_at: "2026-06-04T12:00:00.000Z",
+      last_heartbeat_at: "2026-06-04T12:00:00.000Z",
+    });
+    expect(row()).toMatchObject({ worker_id: "worker-7" });
+  });
+
+  it("maps the -1 cgroup pids sentinel to null (unavailable, not a count)", async () => {
+    const { pb, upserts } = makeFakePb();
+    const reg = await registerWorker({
+      pb,
+      pool: makePool(makeBudget({ pidsCurrent: -1, pidsMax: -1 })),
+      logger: makeLogger(),
+      workerId: "w1",
+      endpoint: "host:1",
+      now: () => 0,
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+    reg.stop();
+    expect(upserts[0].record.capacity_pids_current).toBeNull();
+    expect(upserts[0].record.capacity_pids_max).toBeNull();
+  });
+
+  it("heartbeats on cadence, updating capacity + last_heartbeat_at (fake clock + timer)", async () => {
+    vi.useFakeTimers();
+    try {
+      const { pb, upserts } = makeFakePb();
+      // Capacity changes between beats so we can prove the heartbeat re-reads it.
+      let budget = makeBudget({ inUse: 1, available: 23 });
+      const pool: WorkerPoolBudgetSource = { budget: () => budget };
+      let clock = Date.parse("2026-06-04T12:00:00.000Z");
+
+      const reg = await registerWorker({
+        pb,
+        pool,
+        logger: makeLogger(),
+        workerId: "w-beat",
+        endpoint: "host:9",
+        heartbeatMs: 75_000,
+        now: () => clock,
+      });
+
+      // Boot upsert only, so far.
+      expect(upserts).toHaveLength(1);
+      expect(upserts[0].record.registered_at).toBe("2026-06-04T12:00:00.000Z");
+
+      // Advance capacity + clock, then fire one cadence tick.
+      budget = makeBudget({ inUse: 9, available: 15 });
+      clock = Date.parse("2026-06-04T12:01:15.000Z");
+      await vi.advanceTimersByTimeAsync(75_000);
+
+      expect(upserts).toHaveLength(2);
+      const beat = upserts[1].record;
+      // Heartbeat patch must NOT re-seed registered_at (preserve original).
+      expect(beat.registered_at).toBeUndefined();
+      expect(beat.capacity_in_use).toBe(9);
+      expect(beat.capacity_available).toBe(15);
+      expect(beat.last_heartbeat_at).toBe("2026-06-04T12:01:15.000Z");
+      expect(beat.current_job_id).toBe("");
+
+      // A second tick produces a third upsert.
+      clock = Date.parse("2026-06-04T12:02:30.000Z");
+      await vi.advanceTimersByTimeAsync(75_000);
+      expect(upserts).toHaveLength(3);
+
+      // stop() cancels the loop: no further beats after more time passes.
+      reg.stop();
+      await vi.advanceTimersByTimeAsync(75_000 * 3);
+      expect(upserts).toHaveLength(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("explicit heartbeat(jobId) records the current job id", async () => {
+    const { pb, upserts } = makeFakePb();
+    const reg = await registerWorker({
+      pb,
+      pool: makePool(makeBudget()),
+      logger: makeLogger(),
+      workerId: "w2",
+      endpoint: "host:2",
+      now: () => 0,
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+    await reg.heartbeat("job-abc");
+    reg.stop();
+    // [0] = boot register, [1] = explicit heartbeat.
+    expect(upserts).toHaveLength(2);
+    expect(upserts[1].record.current_job_id).toBe("job-abc");
+    expect(upserts[1].record.registered_at).toBeUndefined();
+  });
+
+  it("is best-effort: a PB failure on register never throws into the worker", async () => {
+    const logger = makeLogger();
+    const failingPb: RegistrationPbClient = {
+      async upsertByField<T>(): Promise<T> {
+        throw new Error("pb create failed: 400 missing collection");
+      },
+    };
+    // Must resolve (not reject) despite the PB error.
+    const reg = await registerWorker({
+      pb: failingPb,
+      pool: makePool(makeBudget()),
+      logger,
+      workerId: "w3",
+      endpoint: "host:3",
+      now: () => 0,
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+    reg.stop();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "worker.register-failed",
+      expect.objectContaining({ workerId: "w3" }),
+    );
+    // An explicit heartbeat must also swallow.
+    await expect(reg.heartbeat(null)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "worker.heartbeat-failed",
+      expect.objectContaining({ workerId: "w3" }),
+    );
+  });
+});

--- a/showcase/harness/src/fleet/worker/registration.ts
+++ b/showcase/harness/src/fleet/worker/registration.ts
@@ -1,0 +1,244 @@
+/**
+ * Worker self-registration + heartbeat (BLITZ S9).
+ *
+ * On boot a fleet worker UPSERTS a row into the `workers` collection
+ * (pb_migrations/1779989600_create_workers.js) advertising its id, endpoint and
+ * current capacity (BrowserPool.budget() → workerCapacityFromBudget, S6). Then a
+ * self-rescheduling loop heartbeats on a ~60-90s cadence, refreshing
+ * `last_heartbeat_at` and the live capacity snapshot. fleet-health (S10) reads
+ * those rows back: `last_heartbeat_at` against a staleness window →
+ * online | stale | offline (see `isWorkerStale` in contracts.ts), and the
+ * capacity_* fields to know how busy each worker is.
+ *
+ * ── BEST-EFFORT GUARANTEE (the hard requirement) ─────────────────────────
+ * Registration and every heartbeat are wrapped so a missing migration, a PB
+ * hiccup, a 400 from an unrun migration, or any network error is SWALLOWED and
+ * logged — it can NEVER throw into the worker's claim/run loop. This mirrors the
+ * resource-snapshot-writer's best-effort discipline: the registry is
+ * operational metadata, it must degrade silently and never break the worker it
+ * describes. A worker that can't register still pulls and runs jobs; it just
+ * won't show up on the fleet-health roster until PB recovers.
+ *
+ * ── NULL-VS-UNAVAILABLE CONVENTION ───────────────────────────────────────
+ * `capacity.pidsCurrent` / `capacity.pidsMax` degrade to a `-1` sentinel
+ * off-Linux / on an unreadable cgroup (browser-pool.ts budget()). We map that
+ * sentinel to `null` on the PB row (never write -1) so fleet-health can cleanly
+ * separate a MEASURED pids ceiling from an UNAVAILABLE one — a stored -1 would
+ * be indistinguishable from a genuine count.
+ */
+
+import {
+  WORKERS_COLLECTION,
+  workerCapacityFromBudget,
+  type WorkerCapacity,
+} from "../contracts.js";
+import type { BrowserPoolBudget } from "../../probes/helpers/browser-pool.js";
+
+/**
+ * Default heartbeat cadence. 75s sits in the brief's ~60-90s window: frequent
+ * enough that a worker is marked stale promptly after it dies, infrequent enough
+ * that a fleet of workers doesn't hammer PB. Env-overridable via
+ * WORKER_HEARTBEAT_MS.
+ */
+export const DEFAULT_WORKER_HEARTBEAT_MS = 75_000;
+
+/**
+ * Capacity source the worker advertises. The real `BrowserPool` satisfies this
+ * structurally via its `budget()` method (S6); tests pass a tiny fake. Kept to
+ * the single method we consume so the registration path never drags the pool's
+ * full surface into its dependency graph.
+ */
+export interface WorkerPoolBudgetSource {
+  budget(): BrowserPoolBudget;
+}
+
+/**
+ * Minimal PB surface the registration writer needs — a structural subset of the
+ * harness `PbClient` so the real client satisfies it and tests can pass a tiny
+ * fake. `upsertByField` is the find-or-create+update primitive that keeps the
+ * roster at exactly one row per `worker_id` (it handles the TOCTOU race against
+ * the unique index internally — see pb-client.ts).
+ */
+export interface RegistrationPbClient {
+  upsertByField<T>(
+    collection: string,
+    field: string,
+    value: string,
+    record: Record<string, unknown>,
+  ): Promise<T>;
+}
+
+/** Logger surface — matches the harness optional-method idiom. */
+export interface RegistrationLogger {
+  info(msg: string, meta?: Record<string, unknown>): void;
+  warn?(msg: string, meta?: Record<string, unknown>): void;
+  error?(msg: string, meta?: Record<string, unknown>): void;
+}
+
+export interface WorkerRegistrationOptions {
+  pb: RegistrationPbClient;
+  pool: WorkerPoolBudgetSource;
+  logger: RegistrationLogger;
+  /** Stable worker id (matches S0 JobView.claimed_by). */
+  workerId: string;
+  /** Worker's reachable endpoint URL (scheme://host:port) for control-plane probes. */
+  endpoint: string;
+  /** Heartbeat cadence (ms). Defaults to env WORKER_HEARTBEAT_MS or 75s. */
+  heartbeatMs?: number;
+  /** Injectable clock for tests. Defaults to Date.now. */
+  now?: () => number;
+  /** Injectable timer scheduler for tests. Defaults to setInterval. */
+  setIntervalImpl?: typeof setInterval;
+  /** Injectable timer canceller for tests. Defaults to clearInterval. */
+  clearIntervalImpl?: typeof clearInterval;
+}
+
+/**
+ * A running worker registration: the boot upsert has fired and a heartbeat loop
+ * is scheduled. Call `stop()` on worker shutdown to cancel the loop and let the
+ * process exit cleanly.
+ */
+export interface WorkerRegistration {
+  /**
+   * Perform one heartbeat write NOW (best-effort). Exposed so a worker can
+   * heartbeat opportunistically (e.g. right after winning/finishing a job) and
+   * so tests can drive a beat without the timer. `currentJobId` is the job the
+   * worker is running, or null when idle.
+   */
+  heartbeat(currentJobId: string | null): Promise<void>;
+  /** Cancel the heartbeat loop. Idempotent. */
+  stop(): void;
+}
+
+function resolveHeartbeatMs(explicit: number | undefined): number {
+  if (explicit !== undefined && Number.isFinite(explicit) && explicit > 0) {
+    return Math.floor(explicit);
+  }
+  const envRaw = process.env.WORKER_HEARTBEAT_MS;
+  const envParsed = envRaw ? parseInt(envRaw, 10) : NaN;
+  if (Number.isFinite(envParsed) && envParsed > 0) return envParsed;
+  return DEFAULT_WORKER_HEARTBEAT_MS;
+}
+
+/**
+ * Map a capacity gauge to the PB field value: the `-1` "unavailable" sentinel
+ * (off-Linux / unreadable cgroup) becomes `null` so fleet-health can separate a
+ * MEASURED reading from an UNAVAILABLE one. The context counts (inUse /
+ * available / max) are never negative, so only the pids gauges can be sentinels;
+ * applying the same map uniformly is harmless and keeps the row shape obvious.
+ */
+function gaugeOrNull(value: number): number | null {
+  return value < 0 ? null : value;
+}
+
+/**
+ * Build the PB row record for a worker from its capacity snapshot. `nowIso` is
+ * the heartbeat timestamp; `registeredAt` is only written on the boot upsert via
+ * the spread in `register` (upsert merges, so a heartbeat update never clobbers
+ * the original registered_at — we simply omit it from the heartbeat patch).
+ */
+function capacityRecord(
+  capacity: WorkerCapacity,
+  endpoint: string,
+  currentJobId: string | null,
+  nowIso: string,
+): Record<string, unknown> {
+  return {
+    endpoint,
+    capacity_in_use: gaugeOrNull(capacity.inUse),
+    capacity_available: gaugeOrNull(capacity.available),
+    capacity_max: gaugeOrNull(capacity.max),
+    capacity_pids_current: gaugeOrNull(capacity.pidsCurrent),
+    capacity_pids_max: gaugeOrNull(capacity.pidsMax),
+    // PB date fields treat "" as empty; an idle worker writes "" so the column
+    // is cleanly "no current job" rather than a stale id.
+    current_job_id: currentJobId ?? "",
+    last_heartbeat_at: nowIso,
+  };
+}
+
+/**
+ * Register a worker and start its heartbeat loop. Returns a handle whose
+ * `stop()` cancels the loop. The initial registration upsert is performed
+ * synchronously-awaited so a caller can `await registerWorker(...)` and know the
+ * boot row attempt has completed (best-effort: it never rejects). The heartbeat
+ * loop is then scheduled on the cadence.
+ */
+export async function registerWorker(
+  options: WorkerRegistrationOptions,
+): Promise<WorkerRegistration> {
+  const { pb, pool, logger, workerId, endpoint } = options;
+  const heartbeatMs = resolveHeartbeatMs(options.heartbeatMs);
+  const now = options.now ?? Date.now;
+  const setIntervalFn = options.setIntervalImpl ?? setInterval;
+  const clearIntervalFn = options.clearIntervalImpl ?? clearInterval;
+
+  /** One best-effort upsert. `isRegister` adds `registered_at` to the patch. */
+  async function write(
+    currentJobId: string | null,
+    isRegister: boolean,
+  ): Promise<void> {
+    try {
+      const capacity = workerCapacityFromBudget(pool.budget());
+      const nowIso = new Date(now()).toISOString();
+      const record = capacityRecord(capacity, endpoint, currentJobId, nowIso);
+      if (isRegister) {
+        // Only the boot upsert seeds registered_at. A heartbeat update merges
+        // the patch over the existing row, so omitting registered_at on
+        // subsequent beats preserves the original registration time.
+        record.registered_at = nowIso;
+      }
+      await pb.upsertByField(WORKERS_COLLECTION, "worker_id", workerId, record);
+      logger.info(isRegister ? "worker.registered" : "worker.heartbeat", {
+        workerId,
+        endpoint,
+        capacityInUse: capacity.inUse,
+        capacityAvailable: capacity.available,
+        currentJobId,
+      });
+    } catch (err) {
+      // BEST-EFFORT: a missing migration (400), PB outage, or network error
+      // must NEVER break the worker loop. Swallow + warn so the gap is visible
+      // without crashing the thing it observes.
+      logger.warn?.(
+        isRegister ? "worker.register-failed" : "worker.heartbeat-failed",
+        {
+          workerId,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+    }
+  }
+
+  // Boot registration (idle: no job claimed yet).
+  await write(null, true);
+
+  let timer: ReturnType<typeof setIntervalFn> | undefined = setIntervalFn(
+    () => {
+      // The loop heartbeats as IDLE (null) — a worker running a job heartbeats
+      // explicitly via the returned `heartbeat(jobId)` on its run path; the
+      // periodic safety beat just refreshes liveness so fleet-health doesn't mark
+      // a long-idle worker stale.
+      void write(null, false);
+    },
+    heartbeatMs,
+  );
+
+  // Don't let the heartbeat timer keep the process alive on its own (the worker
+  // loop owns process lifetime). `unref` is a no-op for an injected fake timer.
+  if (timer && typeof (timer as { unref?: () => void }).unref === "function") {
+    (timer as { unref: () => void }).unref();
+  }
+
+  return {
+    async heartbeat(currentJobId: string | null): Promise<void> {
+      await write(currentJobId, false);
+    },
+    stop(): void {
+      if (timer !== undefined) {
+        clearIntervalFn(timer);
+        timer = undefined;
+      }
+    },
+  };
+}

--- a/showcase/harness/src/fleet/worker/worker-health.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-health.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { buildWorkerHealthServer } from "./worker-health.js";
+import { logger } from "../../logger.js";
+
+interface HealthBody {
+  status: string;
+  role: string;
+  pb: string;
+  loop: string;
+  registered: boolean;
+}
+
+function build(opts: {
+  pb?: boolean;
+  loopAlive?: boolean;
+  registered?: boolean;
+}) {
+  return buildWorkerHealthServer({
+    pb: async () => opts.pb ?? true,
+    loopAlive: () => opts.loopAlive ?? true,
+    registered: () => opts.registered ?? true,
+    logger,
+  });
+}
+
+describe("fleet worker /health", () => {
+  it("returns 200 when pb reachable, loop alive, and registered", async () => {
+    const app = build({ pb: true, loopAlive: true, registered: true });
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe("ok");
+    expect(body.role).toBe("worker");
+    expect(body.pb).toBe("ok");
+    expect(body.loop).toBe("alive");
+    expect(body.registered).toBe(true);
+  });
+
+  it("returns 503 degraded when PocketBase is unreachable", async () => {
+    const app = build({ pb: false });
+    const res = await app.request("/health");
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe("degraded");
+    expect(body.pb).toBe("down");
+  });
+
+  it("returns 503 degraded when the pull-loop has stopped", async () => {
+    const app = build({ loopAlive: false });
+    const res = await app.request("/health");
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe("degraded");
+    expect(body.loop).toBe("stopped");
+  });
+
+  it("returns 503 degraded when the worker never registered", async () => {
+    const app = build({ registered: false });
+    const res = await app.request("/health");
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe("degraded");
+    expect(body.registered).toBe(false);
+  });
+
+  it("returns 503 degraded (not a thrown 500) when the pb probe REJECTS", async () => {
+    const app = buildWorkerHealthServer({
+      pb: async () => {
+        throw new Error("pb connect refused");
+      },
+      loopAlive: () => true,
+      registered: () => true,
+      logger,
+    });
+    const res = await app.request("/health");
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as HealthBody;
+    expect(body.status).toBe("degraded");
+    expect(body.pb).toBe("down");
+  });
+});

--- a/showcase/harness/src/fleet/worker/worker-health.ts
+++ b/showcase/harness/src/fleet/worker/worker-health.ts
@@ -1,0 +1,79 @@
+/**
+ * Fleet WORKER /health server.
+ *
+ * ── WHY THIS EXISTS ────────────────────────────────────────────────────
+ * The worker container's docker/Railway healthcheck GETs `/health` on the
+ * worker's resolved PORT (8080 in compose/Dockerfile). Without an HTTP server
+ * actually listening there, the healthcheck always fails → 3 retries →
+ * `unhealthy` → `restart: unless-stopped` restart-loops the container (each
+ * restart re-inits a BrowserPool + re-registers — exactly the churn the fleet
+ * exists to avoid). `runWorker` (fleet/orchestrator.ts) binds this server so a
+ * booted worker answers its own liveness probe.
+ *
+ * ── WHY NOT `buildServer({ role: "worker" })` ──────────────────────────
+ * The role-aware `/health` in `http/server.ts` models the in-process harness:
+ * its "worker" role treats probe RULES as the unit of work (`rules > 0` is a
+ * hard 503) and REQUIRES a `schedulerJobCount` callback. A FLEET worker owns
+ * NO probe rules and NO scheduler — its liveness is "can I reach PocketBase,
+ * is my pull-loop alive, did I register?". Reusing that surface would force
+ * dishonest stub callbacks (`ruleCount: () => 1`) just to clear the gate. A
+ * dedicated, minimal worker health handler reflects the worker's ACTUAL
+ * liveness signals instead.
+ *
+ * ── LIVENESS SEMANTICS ─────────────────────────────────────────────────
+ * `GET /health` returns 200 iff ALL of:
+ *   - `pb()` resolves true (the worker can reach PocketBase — it can't claim
+ *     or report a job without it),
+ *   - `loopAlive()` is true (the pull-loop has not exited/crashed), and
+ *   - `registered()` is true (the boot self-register upsert succeeded — a
+ *     worker that never registered won't appear on the fleet roster).
+ * Any false signal returns 503 with a `degraded` body naming the failing leg
+ * so an operator (and the restart policy) can see WHY the worker is unhealthy.
+ */
+
+import { Hono } from "hono";
+import type { Logger } from "../../types/index.js";
+
+/** Liveness probes the worker health surface reflects. Injected so the handler stays pure + unit-testable. */
+export interface WorkerHealthDeps {
+  /** Resolves true when PocketBase is reachable (the worker's claim/report dependency). */
+  pb: () => Promise<boolean>;
+  /** True while the worker's pull-loop is alive (has not exited/crashed). */
+  loopAlive: () => boolean;
+  /** True once the worker's boot self-register upsert succeeded. */
+  registered: () => boolean;
+  logger: Logger;
+}
+
+/**
+ * Build the worker's minimal `/health` Hono app. 200 when pb reachable + loop
+ * alive + registered; 503 (degraded) otherwise. The body names each leg so the
+ * failing signal is visible in the container logs / healthcheck output.
+ */
+export function buildWorkerHealthServer(deps: WorkerHealthDeps): Hono {
+  const app = new Hono();
+
+  app.get("/health", async (c) => {
+    // A rejecting pb() probe (connect refused, transport error) is exactly the
+    // "PocketBase unreachable" condition `/health` exists to surface — degrade
+    // it to `pb:"down"` (503) instead of letting the rejection bubble into a
+    // thrown 500, which an operator/restart-policy would misread as a server
+    // fault rather than the worker's claim/report dependency being down.
+    const pbOk = await deps.pb().catch(() => false);
+    const loopOk = deps.loopAlive();
+    const registeredOk = deps.registered();
+    const ok = pbOk && loopOk && registeredOk;
+    return c.json(
+      {
+        status: ok ? "ok" : "degraded",
+        role: "worker",
+        pb: pbOk ? "ok" : "down",
+        loop: loopOk ? "alive" : "stopped",
+        registered: registeredOk,
+      },
+      ok ? 200 : 503,
+    );
+  });
+
+  return app;
+}

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -1,0 +1,886 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  startWorkerLoop,
+  runClaimedJob,
+  computeRollup,
+  buildServiceJobResult,
+  buildCommErrorResult,
+  type ServiceJobDriver,
+  type ServiceDriverContext,
+  type BudgetSource,
+} from "./worker-loop.js";
+import type {
+  FleetQueueClient,
+  ClaimedJob,
+  JobLease,
+  JobView,
+  ServiceJobPayload,
+  ServiceJobResult,
+  ServiceCellResult,
+} from "../contracts.js";
+import type { ProbeResult, ProbeState, Logger } from "../../types/index.js";
+import type { BrowserPoolBudget } from "../../probes/helpers/browser-pool.js";
+
+/**
+ * S7 worker-loop contract pins. Drives the loop / job-runner with FAKES for the
+ * queue client, the per-service driver, and the pool budget so the claim → run
+ * → report round-trip, the lease heartbeat, and the budget gate are exercised
+ * without a live PocketBase / chromium / cgroup.
+ */
+
+// ── Fakes ──────────────────────────────────────────────────────────────
+
+const silentLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+/**
+ * A sleep fake that yields a MACROTASK (setTimeout(0)) rather than resolving
+ * synchronously. The loop polls in a tight `while`, and `vi.waitFor` checks on
+ * a macrotask timer — an immediately-resolving sleep would starve that timer
+ * (microtask-only) and hang the test. Yielding a macrotask lets `vi.waitFor`
+ * observe progress while keeping the loop fast.
+ */
+function yieldingSleep(): (ms: number, signal?: AbortSignal) => Promise<void> {
+  return (_ms, signal) =>
+    new Promise<void>((resolve) => {
+      if (signal?.aborted) {
+        resolve();
+        return;
+      }
+      const t = setTimeout(resolve, 0);
+      signal?.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(t);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+}
+
+/** A budget source that always reports `available` headroom. */
+function budgetWith(
+  available: number,
+  overrides: Partial<BrowserPoolBudget> = {},
+): BudgetSource {
+  const b: BrowserPoolBudget = {
+    inUse: 0,
+    available,
+    max: 24,
+    pidsCurrent: 10,
+    pidsMax: 1000,
+    ...overrides,
+  };
+  return { budget: () => b };
+}
+
+function makeJobView(overrides: Partial<JobView> = {}): JobView {
+  return {
+    id: "job-1",
+    probe_key: "d6:langgraph-python",
+    status: "claimed",
+    claimed_by: "worker-test",
+    lease_expires_at: "2026-06-04T00:05:00.000Z",
+    version: 1,
+    ...overrides,
+  };
+}
+
+function makePayload(
+  overrides: Partial<ServiceJobPayload> = {},
+): ServiceJobPayload {
+  return {
+    probeKey: "d6:langgraph-python",
+    serviceSlug: "langgraph-python",
+    driverKind: "e2e_d6",
+    meta: {
+      runId: "run-42",
+      triggered: false,
+      enqueuedAt: "2026-06-04T00:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+function makeLease(
+  overrides: {
+    job?: Partial<JobView>;
+    payload?: Partial<ServiceJobPayload>;
+  } = {},
+): JobLease {
+  return {
+    job: makeJobView(overrides.job),
+    payload: makePayload(overrides.payload),
+    leaseExpiresAt: "2026-06-04T00:05:00.000Z",
+  };
+}
+
+/**
+ * A driver fake that side-emits per-cell rows through `ctx.writer` (exactly as
+ * the real d6 driver does) plus the aggregate side row, then returns the
+ * aggregate `ProbeResult` as its primary value.
+ */
+function makeDriver(args: {
+  slug: string;
+  cells: Array<{ featureId: string; state: ProbeState }>;
+  aggregateState: ProbeState;
+  onRun?: (ctx: ServiceDriverContext) => void | Promise<void>;
+}): ServiceJobDriver {
+  return {
+    async run(ctx, _input): Promise<ProbeResult> {
+      await args.onRun?.(ctx);
+      const observedAt = ctx.now().toISOString();
+      for (const cell of args.cells) {
+        await ctx.writer.write({
+          key: `d6:${args.slug}/${cell.featureId}`,
+          state: cell.state,
+          signal: { featureType: cell.featureId },
+          observedAt,
+        });
+      }
+      // Aggregate side row — the loop must NOT count this as a cell.
+      await ctx.writer.write({
+        key: `d6:${args.slug}`,
+        state: args.aggregateState,
+        signal: { shape: "package", slug: args.slug },
+        observedAt,
+      });
+      return {
+        key: `e2e_d6:${args.slug}`,
+        state: args.aggregateState,
+        signal: { shape: "package", slug: args.slug },
+        observedAt,
+      };
+    },
+  };
+}
+
+interface RecordingQueue extends FleetQueueClient {
+  reports: ServiceJobResult[];
+  renewCalls: number;
+}
+
+/** A queue fake that hands out a fixed sequence of claim results. */
+function makeQueue(claims: ClaimedJob[]): RecordingQueue {
+  const reports: ServiceJobResult[] = [];
+  let i = 0;
+  return {
+    reports,
+    renewCalls: 0,
+    async enqueue() {
+      throw new Error("enqueue not used by worker");
+    },
+    async claimNext(): Promise<ClaimedJob> {
+      const next = claims[i] ?? { claimed: false };
+      if (i < claims.length) i++;
+      return next;
+    },
+    async renewLease(
+      _jobId,
+      _workerId,
+      _leaseSeconds,
+    ): Promise<JobLease | null> {
+      this.renewCalls++;
+      return makeLease();
+    },
+    async report({ result }): Promise<void> {
+      reports.push(result);
+    },
+    async sweepExpired() {
+      return { reclaimed: 0, commErrors: [] };
+    },
+  };
+}
+
+const passInput = (): unknown => ({
+  key: "d6:langgraph-python",
+  backendUrl: "http://x",
+});
+
+// ── Pure helpers ─────────────────────────────────────────────────────────
+
+describe("computeRollup", () => {
+  it("counts green as passed and everything else as failed", () => {
+    const cells: ServiceCellResult[] = [
+      {
+        cellId: "a",
+        cellKey: "k/a",
+        state: "green",
+        signal: {},
+        observedAt: "t",
+      },
+      {
+        cellId: "b",
+        cellKey: "k/b",
+        state: "red",
+        signal: {},
+        observedAt: "t",
+      },
+      {
+        cellId: "c",
+        cellKey: "k/c",
+        state: "error",
+        signal: {},
+        observedAt: "t",
+      },
+      {
+        cellId: "d",
+        cellKey: "k/d",
+        state: "degraded",
+        signal: {},
+        observedAt: "t",
+      },
+    ];
+    expect(computeRollup(cells)).toEqual({ total: 4, passed: 1, failed: 3 });
+  });
+
+  it("is zeroed for no cells", () => {
+    expect(computeRollup([])).toEqual({ total: 0, passed: 0, failed: 0 });
+  });
+});
+
+describe("buildServiceJobResult", () => {
+  it("echoes payload identity and folds in the aggregate + rollup", () => {
+    const lease = makeLease();
+    const aggregate: ProbeResult = {
+      key: "e2e_d6:langgraph-python",
+      state: "green",
+      signal: { ok: true },
+      observedAt: "2026-06-04T00:04:00.000Z",
+    };
+    const cells: ServiceCellResult[] = [
+      {
+        cellId: "shared-state",
+        cellKey: "d6:langgraph-python/shared-state",
+        state: "green",
+        signal: {},
+        observedAt: "t",
+      },
+    ];
+    const result = buildServiceJobResult({
+      lease,
+      workerId: "worker-test",
+      aggregate,
+      cells,
+      finishedAt: "2026-06-04T00:04:30.000Z",
+    });
+    expect(result.jobId).toBe("job-1");
+    expect(result.probeKey).toBe("d6:langgraph-python");
+    expect(result.serviceSlug).toBe("langgraph-python");
+    expect(result.runId).toBe("run-42");
+    expect(result.workerId).toBe("worker-test");
+    expect(result.aggregateState).toBe("green");
+    expect(result.aggregateKey).toBe("e2e_d6:langgraph-python");
+    expect(result.cells).toEqual(cells);
+    expect(result.rollup).toEqual({ total: 1, passed: 1, failed: 0 });
+    expect(result.commError).toBeUndefined();
+  });
+
+  it("fails loud when the driver returns an out-of-set aggregate state", () => {
+    // The driver return is untrusted at the producer boundary: a garbage
+    // state ("grene") must NOT flow into the dashboard status state machine
+    // via the in-process path (the cross-process result-consumer validates
+    // the same set, but the in-process path needs its own guard). Validate
+    // at buildServiceJobResult and throw so the worker loop routes it to an
+    // error result instead of persisting junk.
+    const lease = makeLease();
+    const aggregate = {
+      key: "e2e_d6:langgraph-python",
+      state: "grene" as ProbeState,
+      signal: {},
+      observedAt: "2026-06-04T00:04:00.000Z",
+    } as ProbeResult;
+    expect(() =>
+      buildServiceJobResult({
+        lease,
+        workerId: "worker-test",
+        aggregate,
+        cells: [],
+        finishedAt: "2026-06-04T00:04:30.000Z",
+      }),
+    ).toThrow(/invalid aggregateState "grene"/);
+  });
+});
+
+describe("buildCommErrorResult", () => {
+  it("produces an error-state terminal result carrying the comm error", () => {
+    const result = buildCommErrorResult({
+      lease: makeLease(),
+      workerId: "worker-test",
+      commError: {
+        kind: "worker-crashed-mid-job",
+        message: "boom",
+        observedAt: "t",
+      },
+      finishedAt: "t2",
+    });
+    expect(result.aggregateState).toBe("error");
+    expect(result.commError?.kind).toBe("worker-crashed-mid-job");
+    expect(result.cells).toEqual([]);
+    expect(result.rollup).toEqual({ total: 0, passed: 0, failed: 0 });
+  });
+});
+
+// ── runClaimedJob: claim→run→report round-trip ─────────────────────────────
+
+describe("runClaimedJob", () => {
+  const baseDeps = () => ({
+    workerId: "worker-test",
+    queue: makeQueue([]),
+    payloadToInput: passInput,
+    logger: silentLogger,
+    env: {} as Readonly<Record<string, string | undefined>>,
+    now: () => new Date("2026-06-04T00:04:00.000Z"),
+    sleep: async () => {},
+  });
+
+  it("captures per-cell rows, filters the aggregate side row, and computes the result", async () => {
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [
+        { featureId: "shared-state", state: "green" },
+        { featureId: "human-in-the-loop", state: "red" },
+      ],
+      aggregateState: "red",
+    });
+    const result = await runClaimedJob({ ...baseDeps(), driver }, makeLease(), {
+      leaseSeconds: 300,
+      heartbeatMs: 1_000_000,
+    });
+
+    // Two cells captured; aggregate side row NOT counted as a cell.
+    expect(result.cells).toHaveLength(2);
+    expect(result.cells.map((c) => c.cellId).sort()).toEqual([
+      "human-in-the-loop",
+      "shared-state",
+    ]);
+    expect(result.cells.find((c) => c.cellId === "shared-state")?.cellKey).toBe(
+      "d6:langgraph-python/shared-state",
+    );
+    expect(result.rollup).toEqual({ total: 2, passed: 1, failed: 1 });
+    expect(result.aggregateState).toBe("red");
+    expect(result.aggregateKey).toBe("e2e_d6:langgraph-python");
+    expect(result.commError).toBeUndefined();
+  });
+
+  it("classifies a GENUINE BrowserPool-unavailable throw as worker-crashed-mid-job", async () => {
+    const driver: ServiceJobDriver = {
+      async run(): Promise<ProbeResult> {
+        // The browser-pool's OWN unavailability signal is its message prefix
+        // (`BrowserPool ...` / `browser-pool: ...`) on a plain Error — it never
+        // sets a custom `.name`/class. This is the ONLY throw shape that means
+        // "the pool itself is unreachable", so it is the only branch that keeps
+        // a `worker-crashed-mid-job` commError.
+        throw new Error("BrowserPool is shut down");
+      },
+    };
+    const result = await runClaimedJob({ ...baseDeps(), driver }, makeLease(), {
+      leaseSeconds: 300,
+      heartbeatMs: 1_000_000,
+    });
+    expect(result.aggregateState).toBe("error");
+    expect(result.commError?.kind).toBe("worker-crashed-mid-job");
+    expect(result.commError?.message).toContain("BrowserPool is shut down");
+  });
+
+  it("classifies the kebab `browser-pool:` throw prefix as worker-crashed-mid-job", async () => {
+    const driver: ServiceJobDriver = {
+      async run(): Promise<ProbeResult> {
+        // The pool's other genuine-unavailability throws use the kebab prefix.
+        throw new Error("browser-pool: relaunch retries exhausted");
+      },
+    };
+    const result = await runClaimedJob({ ...baseDeps(), driver }, makeLease(), {
+      leaseSeconds: 300,
+      heartbeatMs: 1_000_000,
+    });
+    expect(result.commError?.kind).toBe("worker-crashed-mid-job");
+  });
+
+  it("does NOT masquerade a PlaywrightTimeoutError (a real test failure) as a pool outage", async () => {
+    // REQ-B inversion guard: a genuine in-driver test failure thrown by
+    // Playwright carries a name like `PlaywrightTimeoutError` / `TimeoutError`.
+    // The old broad `/pool|launcher|browser|chromium|playwright/i` name match
+    // wrongly classified this as pool-infra → "couldn't reach the pool",
+    // HIDING a real product/test regression. It MUST classify as a driver
+    // error: aggregateState "error" with NO commError (a probe error, not a
+    // pool-unreachable overlay).
+    const driver: ServiceJobDriver = {
+      async run(): Promise<ProbeResult> {
+        const err = new Error(
+          "locator.click: Timeout 30000ms exceeded waiting for getByRole('button')",
+        );
+        err.name = "PlaywrightTimeoutError";
+        throw err;
+      },
+    };
+    const result = await runClaimedJob({ ...baseDeps(), driver }, makeLease(), {
+      leaseSeconds: 300,
+      heartbeatMs: 1_000_000,
+    });
+    expect(result.aggregateState).toBe("error");
+    expect(result.commError).toBeUndefined();
+    expect(result.aggregateKey).toBe("d6:langgraph-python");
+  });
+
+  it("does NOT masquerade a plain TimeoutError test failure as a pool outage", async () => {
+    const driver: ServiceJobDriver = {
+      async run(): Promise<ProbeResult> {
+        const err = new Error("waiting for selector failed");
+        err.name = "TimeoutError";
+        throw err;
+      },
+    };
+    const result = await runClaimedJob({ ...baseDeps(), driver }, makeLease(), {
+      leaseSeconds: 300,
+      heartbeatMs: 1_000_000,
+    });
+    expect(result.aggregateState).toBe("error");
+    expect(result.commError).toBeUndefined();
+  });
+
+  it("does NOT masquerade a test assertion that merely MENTIONS the browser as a pool outage", async () => {
+    // The error MESSAGE legitimately mentions "browser"/"playwright" (a normal
+    // test assertion about the page), but it is NOT the pool's own throw — it
+    // must stay a driver error, not a comm error.
+    const driver: ServiceJobDriver = {
+      async run(): Promise<ProbeResult> {
+        throw new Error(
+          "expected the browser to navigate to /chat but it stayed on /",
+        );
+      },
+    };
+    const result = await runClaimedJob({ ...baseDeps(), driver }, makeLease(), {
+      leaseSeconds: 300,
+      heartbeatMs: 1_000_000,
+    });
+    expect(result.aggregateState).toBe("error");
+    expect(result.commError).toBeUndefined();
+  });
+
+  it("classifies a zod/schema validation throw as worker-protocol-violation", async () => {
+    const driver: ServiceJobDriver = {
+      async run(): Promise<ProbeResult> {
+        const err = new Error(
+          "Invalid input: expected string, received number",
+        );
+        err.name = "ZodError";
+        throw err;
+      },
+    };
+    const result = await runClaimedJob({ ...baseDeps(), driver }, makeLease(), {
+      leaseSeconds: 300,
+      heartbeatMs: 1_000_000,
+    });
+    expect(result.aggregateState).toBe("error");
+    expect(result.commError?.kind).toBe("worker-protocol-violation");
+    expect(result.commError?.message).toContain("expected string");
+  });
+
+  it("classifies a genuine in-driver test/runtime error as a probe error WITHOUT a commError", async () => {
+    const driver: ServiceJobDriver = {
+      async run(): Promise<ProbeResult> {
+        // A normal in-driver test failure / runtime throw — this is a probe
+        // RED/error, not a "couldn't reach the pool" overlay.
+        throw new Error("expected button to be visible, but it was hidden");
+      },
+    };
+    const result = await runClaimedJob({ ...baseDeps(), driver }, makeLease(), {
+      leaseSeconds: 300,
+      heartbeatMs: 1_000_000,
+    });
+    expect(result.aggregateState).toBe("error");
+    // The key distinction: a real test/runtime error surfaces as a probe error,
+    // NOT a pool-unreachable comm error.
+    expect(result.commError).toBeUndefined();
+    expect(result.aggregateKey).toBe("d6:langgraph-python");
+  });
+
+  it("routes an out-of-set driver aggregate state to an error result (no junk state escapes)", async () => {
+    // The driver returns a garbage aggregate state. buildServiceJobResult
+    // throws at the producer boundary, runClaimedJob catches it as a
+    // driver-error, and the reported result carries a safe "error" state —
+    // never the garbage "grene".
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "grene" as ProbeState,
+    });
+    const result = await runClaimedJob({ ...baseDeps(), driver }, makeLease(), {
+      leaseSeconds: 300,
+      heartbeatMs: 1_000_000,
+    });
+    expect(result.aggregateState).toBe("error");
+    expect(result.commError).toBeUndefined();
+    expect(result.aggregateKey).toBe("d6:langgraph-python");
+  });
+
+  it("returns a protocol-violation comm error when the payload cannot be mapped", async () => {
+    const driver = makeDriver({
+      slug: "x",
+      cells: [],
+      aggregateState: "green",
+    });
+    const result = await runClaimedJob(
+      { ...baseDeps(), driver, payloadToInput: () => undefined },
+      makeLease(),
+      { leaseSeconds: 300, heartbeatMs: 1_000_000 },
+    );
+    expect(result.aggregateState).toBe("error");
+    expect(result.commError?.kind).toBe("worker-protocol-violation");
+  });
+
+  it("returns a protocol-violation comm error when payloadToInput THROWS on a poison payload", async () => {
+    // A poison payload that fails to decode/map by THROWING (not by returning
+    // undefined) must NOT escape runClaimedJob — the worker owns the claimed
+    // row, so it must emit a `worker-protocol-violation` comm-error result the
+    // dashboard surfaces, instead of a bare release-failed (which the dashboard
+    // silently loses after grace) or, worse, rejecting the loop's done-promise
+    // (silent worker death).
+    const driver = makeDriver({
+      slug: "x",
+      cells: [],
+      aggregateState: "green",
+    });
+    const result = await runClaimedJob(
+      {
+        ...baseDeps(),
+        driver,
+        payloadToInput: () => {
+          throw new Error("payload decode failed: malformed driverInputs JSON");
+        },
+      },
+      makeLease(),
+      { leaseSeconds: 300, heartbeatMs: 1_000_000 },
+    );
+    expect(result.aggregateState).toBe("error");
+    expect(result.commError?.kind).toBe("worker-protocol-violation");
+    expect(result.commError?.message).toContain("payload decode failed");
+  });
+
+  it("renews the lease on the heartbeat cadence during a long run", async () => {
+    const queue = makeQueue([]);
+    // Fake sleep that resolves immediately so the heartbeat fires fast.
+    const sleepImpl = vi.fn(async () => {});
+    // A driver that lets the heartbeat fire a couple of times before settling.
+    let renewedDuringRun = 0;
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "green",
+      onRun: async () => {
+        // Let the heartbeat loop (sleep→renew) run a few iterations.
+        for (let i = 0; i < 3; i++) {
+          await Promise.resolve();
+          await Promise.resolve();
+        }
+        renewedDuringRun = queue.renewCalls;
+      },
+    });
+    const result = await runClaimedJob(
+      {
+        workerId: "worker-test",
+        queue,
+        payloadToInput: passInput,
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: sleepImpl,
+        driver,
+      },
+      makeLease(),
+      { leaseSeconds: 300, heartbeatMs: 50 },
+    );
+    expect(result.aggregateState).toBe("green");
+    // The heartbeat fired at least once during the run.
+    expect(queue.renewCalls).toBeGreaterThanOrEqual(1);
+    expect(renewedDuringRun).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ── startWorkerLoop: full poll loop ────────────────────────────────────────
+
+describe("startWorkerLoop", () => {
+  it("throws at construction when heartbeatMs >= leaseSeconds*1000 (lease would expire before first renew)", () => {
+    const start = () =>
+      startWorkerLoop({
+        workerId: "worker-test",
+        queue: makeQueue([]),
+        pool: budgetWith(5),
+        driver: makeDriver({ slug: "x", cells: [], aggregateState: "green" }),
+        payloadToInput: passInput,
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: yieldingSleep(),
+        // 60s heartbeat vs. a 30s lease → the lease expires before the first
+        // renew fires → a false worker-crashed-mid-job.
+        leaseSeconds: 30,
+        heartbeatMs: 60_000,
+      });
+    expect(start).toThrow(/heartbeatMs/);
+  });
+
+  it("does NOT throw at construction for a safe heartbeat/lease combo", () => {
+    const start = () =>
+      startWorkerLoop({
+        workerId: "worker-test",
+        queue: makeQueue([]),
+        pool: budgetWith(5),
+        driver: makeDriver({ slug: "x", cells: [], aggregateState: "green" }),
+        payloadToInput: passInput,
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: yieldingSleep(),
+        leaseSeconds: 300,
+        heartbeatMs: 60_000,
+      }).stop();
+    expect(start).not.toThrow();
+  });
+
+  it("claims a job, runs it, reports a correct ServiceJobResult, then idles", async () => {
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [
+        { featureId: "shared-state", state: "green" },
+        { featureId: "tools", state: "green" },
+      ],
+      aggregateState: "green",
+    });
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      // Large lease so the (very large) heartbeat never fires during the short
+      // test, while keeping heartbeatMs < leaseSeconds*1000 (construction guard).
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+
+    // Wait until the report lands, then stop.
+    await vi.waitFor(() => expect(queue.reports).toHaveLength(1));
+    await handle.stop();
+
+    const report = queue.reports[0]!;
+    expect(report.jobId).toBe("job-1");
+    expect(report.serviceSlug).toBe("langgraph-python");
+    expect(report.runId).toBe("run-42");
+    expect(report.aggregateState).toBe("green");
+    expect(report.rollup).toEqual({ total: 2, passed: 2, failed: 0 });
+    expect(report.cells).toHaveLength(2);
+  });
+
+  it("fires onCurrentJobChange with the jobId on claim and null when it settles", async () => {
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "green",
+    });
+    const changes: Array<string | null> = [];
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      // Large lease so the (very large) heartbeat never fires during the short
+      // test, while keeping heartbeatMs < leaseSeconds*1000 (construction guard).
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+      onCurrentJobChange: (id) => {
+        changes.push(id);
+      },
+    });
+
+    await vi.waitFor(() => expect(queue.reports).toHaveLength(1));
+    await handle.stop();
+
+    // The claimed jobId is reported live, then cleared to null when settled.
+    expect(changes).toEqual(["job-1", null]);
+  });
+
+  it("does not let a throwing onCurrentJobChange break the loop", async () => {
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "green",
+    });
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      // Large lease so the (very large) heartbeat never fires during the short
+      // test, while keeping heartbeatMs < leaseSeconds*1000 (construction guard).
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+      onCurrentJobChange: () => {
+        throw new Error("registration heartbeat boom");
+      },
+    });
+
+    // The job still runs + reports despite the hook throwing.
+    await vi.waitFor(() => expect(queue.reports).toHaveLength(1));
+    await handle.stop();
+    expect(queue.reports[0]!.aggregateState).toBe("green");
+  });
+
+  it("does NOT claim when the pool budget is exhausted", async () => {
+    const claimNext = vi.fn(async () => ({ claimed: false }) as ClaimedJob);
+    const queue: FleetQueueClient = {
+      ...makeQueue([]),
+      claimNext,
+    };
+    const driver = makeDriver({
+      slug: "x",
+      cells: [],
+      aggregateState: "green",
+    });
+    let sleeps = 0;
+    const baseSleep = yieldingSleep();
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(0, { inUse: 24 }), // saturated
+      driver,
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date(),
+      sleep: (ms, signal) => {
+        sleeps++;
+        return baseSleep(ms, signal);
+      },
+      pollIntervalMs: 1,
+    });
+
+    await vi.waitFor(() => expect(sleeps).toBeGreaterThan(2));
+    await handle.stop();
+
+    // Budget exhausted → never claimed.
+    expect(claimNext).not.toHaveBeenCalled();
+  });
+
+  it("logs and continues (does not reject) when pool.budget() throws", async () => {
+    // budget() throws on the first poll, then recovers with headroom so the
+    // loop goes on to claim + report — proving the throw was swallowed, the
+    // loop did not die, and its done-promise did not reject.
+    let budgetCalls = 0;
+    const pool: BudgetSource = {
+      budget() {
+        budgetCalls++;
+        if (budgetCalls === 1) {
+          throw new Error("cgroup pids.current read failed");
+        }
+        return {
+          inUse: 0,
+          available: 5,
+          max: 24,
+          pidsCurrent: 10,
+          pidsMax: 1000,
+        };
+      },
+    };
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "green",
+    });
+    const errors: string[] = [];
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool,
+      driver,
+      payloadToInput: passInput,
+      logger: { ...silentLogger, error: (msg: string) => errors.push(msg) },
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      // Large lease so the (very large) heartbeat never fires during the short
+      // test, while keeping heartbeatMs < leaseSeconds*1000 (construction guard).
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+
+    let rejected = false;
+    handle.done.catch(() => {
+      rejected = true;
+    });
+
+    await vi.waitFor(() => expect(queue.reports).toHaveLength(1));
+    await handle.stop();
+
+    expect(rejected).toBe(false);
+    expect(errors).toContain("fleet.worker.budget-error");
+    expect(budgetCalls).toBeGreaterThanOrEqual(2);
+    expect(queue.reports[0]!.aggregateState).toBe("green");
+  });
+
+  it("continues the loop when a claim throws (transport error)", async () => {
+    let calls = 0;
+    const claimNext = vi.fn(async (): Promise<ClaimedJob> => {
+      calls++;
+      if (calls === 1) throw new Error("transport boom");
+      if (calls === 2) return { claimed: true, lease: makeLease() };
+      return { claimed: false };
+    });
+    const queueBase = makeQueue([]);
+    const reports = queueBase.reports;
+    const queue: FleetQueueClient = { ...queueBase, claimNext };
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "green",
+    });
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      // Large lease so the (very large) heartbeat never fires during the short
+      // test, while keeping heartbeatMs < leaseSeconds*1000 (construction guard).
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+
+    await vi.waitFor(() => expect(reports).toHaveLength(1));
+    await handle.stop();
+    expect(reports[0]!.aggregateState).toBe("green");
+  });
+});

--- a/showcase/harness/src/fleet/worker/worker-loop.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.ts
@@ -1,0 +1,828 @@
+/**
+ * Fleet WORKER loop (BLITZ S7).
+ *
+ * ── WHAT THIS IS ───────────────────────────────────────────────────────
+ * The body of the `worker` role: a self-bounded pull loop that claims
+ * per-SERVICE jobs from the queue (S3's `FleetQueueClient`, typed here against
+ * the S1 interface), runs ALL of a claimed service's d6/d5 cells via the
+ * EXISTING per-service driver (`createE2eFullDriver` / the pooled launcher in
+ * `d6-all-pills.ts`), heartbeat-renews the lease across the long run, computes
+ * the per-service `ServiceJobResult` (per-cell `ServiceCellResult[]` + the
+ * aggregate rollup), and reports it.
+ *
+ * ── WHY SELF-BOUNDED ───────────────────────────────────────────────────
+ * The whole point of the fleet is to stay under the platform-fixed cgroup
+ * `pids.max=1000` thread/PID ceiling (the PROVEN wedge). The worker therefore
+ * NEVER claims new work unless its `BrowserPool.budget()` reports free context
+ * capacity (`available > 0`). When the pool is saturated the loop idles
+ * (sleeps a poll interval) instead of pulling another job — so a single worker
+ * can never overshoot its own context cap and drive `pids.current` past the
+ * ceiling. One job runs at a time per worker (the driver fans out across the
+ * service's cells with its OWN bounded concurrency / pooled launcher), which
+ * keeps the budget gate a simple, honest "do I have any headroom at all?".
+ *
+ * ── LEASE HEARTBEAT ────────────────────────────────────────────────────
+ * A d6 service run is long (the driver's wall-clock budget is minutes) and
+ * exceeds the queue's visibility timeout, so a held lease must be EXTENDED
+ * mid-run or the sweeper would reclaim the job out from under a live worker
+ * (synthesizing a false `worker-crashed-mid-job` comm error). The loop fires
+ * `renewLease` on a fixed cadence (`heartbeatMs`) for the duration of the run
+ * and stops the heartbeat as soon as the run settles. A renew that returns
+ * `null` (lease lost / stolen) stops the heartbeat but does NOT abort the
+ * in-flight run — the result is still computed and reported; the queue's CAS
+ * on `report` is the final arbiter of whether this worker still owns the job.
+ *
+ * ── DELEGATION BOUNDARY ────────────────────────────────────────────────
+ * This module owns the LOOP and the result COMPUTATION only. It does NOT
+ * construct the BrowserPool, the queue client, or the driver — those are
+ * injected (`WorkerLoopDeps`) so the loop is unit-testable with fakes and so
+ * the `runWorker` entrypoint (orchestrator.ts) is the single place that wires
+ * the real pool + driver + queue together.
+ */
+
+import type { ProbeState, ProbeResult, Logger } from "../../types/index.js";
+import type { BrowserPoolBudget } from "../../probes/helpers/browser-pool.js";
+import type {
+  FleetQueueClient,
+  JobLease,
+  ServiceJobPayload,
+  ServiceJobResult,
+  ServiceCellResult,
+  ServiceJobRollup,
+  PoolCommError,
+} from "../contracts.js";
+
+/**
+ * The minimal driver surface the worker invokes per claimed service job. This
+ * is structurally the `run` half of the existing d6/d5 `ProbeDriver`
+ * (`createE2eFullDriver().run`) — the worker hands it a `ProbeContext`-shaped
+ * value and a per-service input and gets back the aggregate `ProbeResult`. The
+ * per-cell side rows the driver emits flow through `ctx.writer.write` (captured
+ * by the loop), NOT the return value.
+ *
+ * Typed as a local interface rather than importing `ProbeDriver` so the loop
+ * doesn't drag the whole probe registry into the worker, and so a test fake is
+ * a one-method object.
+ */
+export interface ServiceJobDriver {
+  /**
+   * Run all of a service's cells. `ctx` carries the side-emit `writer` the
+   * loop installs to capture per-cell rows; `input` is the driver-specific
+   * per-service input (derived from the payload). Returns the aggregate
+   * `ProbeResult` (the primary `d6:<slug>` / `e2e_d6:<slug>` row).
+   */
+  run(ctx: ServiceDriverContext, input: unknown): Promise<ProbeResult>;
+}
+
+/**
+ * The slice of `ProbeContext` the worker supplies to the driver. Mirrors the
+ * fields the d6 driver actually reads (`now`, `logger`, `env`, `writer`,
+ * `abortSignal`, `featureTypes`) so the real `createE2eFullDriver().run`
+ * type-checks against it without a cast.
+ */
+export interface ServiceDriverContext {
+  now: () => Date;
+  logger: Logger;
+  env: Readonly<Record<string, string | undefined>>;
+  writer: { write(result: ProbeResult): Promise<unknown> };
+  abortSignal?: AbortSignal;
+  featureTypes?: string[];
+}
+
+/**
+ * Builds the per-service driver INPUT from a claimed payload. The payload is
+ * an open contract (`driverInputs` is `Record<string, unknown>`), and the
+ * concrete shape the d6 driver wants (key, backendUrl, demos, features, …) is
+ * assembled by the entrypoint that knows the service catalog — so the mapping
+ * is injected rather than hard-coded here. Returning `undefined` signals "this
+ * payload cannot be mapped to a runnable input" → the loop reports a terminal
+ * failure for the job instead of crashing the worker.
+ */
+export type PayloadToDriverInput = (
+  payload: ServiceJobPayload,
+) => unknown | undefined;
+
+/** The pool capacity surface the loop's claim gate consults (S6 `budget()`). */
+export interface BudgetSource {
+  budget(): BrowserPoolBudget;
+}
+
+export interface WorkerLoopDeps {
+  /** Stable worker id — the `claimed_by` on every claim (matches S0). */
+  workerId: string;
+  /** Queue protocol (S3 impl, typed against the S1 interface). */
+  queue: FleetQueueClient;
+  /** The pool whose `budget()` gates claiming (S6). */
+  pool: BudgetSource;
+  /** The per-service d6/d5 driver (e.g. `createE2eFullDriver()`). */
+  driver: ServiceJobDriver;
+  /** Maps a claimed payload to the driver's per-service input. */
+  payloadToInput: PayloadToDriverInput;
+  logger: Logger;
+  /** Frozen env snapshot threaded into the driver ctx. */
+  env: Readonly<Record<string, string | undefined>>;
+  /** Injectable clock (defaults to `Date`). */
+  now?: () => Date;
+  /** Injectable sleep (defaults to setTimeout). Resolves after `ms`. */
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  /** Lease seconds requested on each claim + renew. */
+  leaseSeconds?: number;
+  /** Heartbeat (renew) cadence while a job runs. */
+  heartbeatMs?: number;
+  /** Idle poll interval when there's no work / no budget. */
+  pollIntervalMs?: number;
+  /**
+   * Optional hook fired when the worker's current job changes: the claimed
+   * `jobId` when a job is won, then `null` when it settles (reported/failed).
+   * The entrypoint wires this to the registration heartbeat so the worker's
+   * `workers.current_job_id` reflects the live job instead of always being null
+   * (the periodic registration beat only writes idle/null). Best-effort — it
+   * must never throw into the loop, so the loop swallows its rejection.
+   */
+  onCurrentJobChange?: (currentJobId: string | null) => void;
+}
+
+/** Handle returned by `startWorkerLoop` — `stop()` drains and resolves. */
+export interface WorkerLoopHandle {
+  /** Resolves when the loop has stopped (after the in-flight job settles). */
+  stop(): Promise<void>;
+  /** The promise of the loop's run — resolves when the loop exits. */
+  done: Promise<void>;
+}
+
+/** Default lease window — comfortably exceeds the heartbeat cadence. */
+export const DEFAULT_LEASE_SECONDS = 300;
+/** Default heartbeat cadence — well under the lease window. */
+export const DEFAULT_HEARTBEAT_MS = 60_000;
+/** Default idle poll interval when there's no work / no budget. */
+export const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      cleanup();
+      resolve();
+    };
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Capturing writer: the loop installs this as the driver's `ctx.writer` so the
+ * per-cell `d6:<slug>/<featureId>` side rows the driver emits are collected
+ * into `ServiceCellResult[]` rather than written to storage (the aggregator —
+ * S5 — owns persistence; the worker only REPORTS the result). The aggregate
+ * `d6:<slug>` row the driver also side-emits is filtered out here (it duplicates
+ * the driver's primary return, which the loop captures separately).
+ */
+function createCellCapture(aggregateSlugKey: string): {
+  writer: { write(result: ProbeResult): Promise<unknown> };
+  cells: ServiceCellResult[];
+} {
+  const cells: ServiceCellResult[] = [];
+  return {
+    cells,
+    writer: {
+      async write(result: ProbeResult): Promise<unknown> {
+        // The driver side-emits both per-cell (`d6:<slug>/<featureId>`) and an
+        // aggregate (`d6:<slug>`) row. Keep only the per-cell rows — the
+        // aggregate is captured from the driver's primary return.
+        if (result.key === aggregateSlugKey) return undefined;
+        cells.push({
+          cellId: cellIdFromKey(result.key),
+          cellKey: result.key,
+          state: result.state,
+          signal: result.signal,
+          observedAt: result.observedAt,
+        });
+        return undefined;
+      },
+    },
+  };
+}
+
+/** Extract the trailing `<featureId>` from a `d6:<slug>/<featureId>` cell key. */
+function cellIdFromKey(key: string): string {
+  const slash = key.lastIndexOf("/");
+  return slash >= 0 ? key.slice(slash + 1) : key;
+}
+
+/**
+ * The browser pool's OWN unavailability signal.
+ *
+ * `BrowserPool` (`probes/helpers/browser-pool.ts`) does NOT define a custom
+ * error class or set a custom `err.name` — every genuine-unavailability throw is
+ * a plain `Error` whose MESSAGE is prefixed with `BrowserPool ` / `browser-pool:`
+ * (e.g. `"BrowserPool is shut down"`, `"BrowserPool acquire timeout"`,
+ * `"BrowserPool shut down during launch"`, `"browser-pool: relaunch retries
+ * exhausted"`). That prefix is therefore the pool's identity, and we key the
+ * infra classifier on it (matched against `err.message`) rather than the
+ * worker importing the pool implementation.
+ *
+ * CRITICAL (REQ-B): this must match ONLY the pool's own throws — NOT a broad
+ * substring like `pool|launcher|browser|chromium|playwright`. The old broad
+ * `err.name` match wrongly classified a real in-driver test failure thrown by
+ * Playwright (name `PlaywrightTimeoutError` / `TimeoutError`, or any assertion
+ * whose text mentions the browser) as pool-infra → "couldn't reach the pool",
+ * HIDING a genuine product/test regression as fleet plumbing. A Playwright
+ * assertion/timeout is a real TEST failure and MUST classify as a driver error
+ * (a probe error, no commError), never a pool outage.
+ *
+ * Anchored to the start of the message (after optional leading whitespace) so a
+ * test assertion that merely *mentions* the pool mid-sentence is not mistaken
+ * for the pool's own throw.
+ */
+const POOL_UNAVAILABLE_MESSAGE_RE = /^\s*browser[\s-]?pool\b/i;
+
+/**
+ * The known aggregate states (== the `ProbeState` union). A driver return
+ * carrying anything outside this set is garbage that must NOT flow into the
+ * dashboard status state machine. The cross-process consumer
+ * (`result-consumer.decodeResult`) validates the same set when re-reading the
+ * persisted JSON, but the IN-PROCESS path never round-trips through that
+ * decode — so the producer boundary must validate here too, or a bad driver
+ * state escapes unchecked. Keep this in lock-step with `PROBE_STATES` in
+ * `result-consumer.ts`.
+ */
+const PROBE_STATES: ReadonlySet<ProbeState> = new Set<ProbeState>([
+  "green",
+  "red",
+  "degraded",
+  "error",
+]);
+
+/**
+ * The three error classes a thrown driver run maps to. Mirrors the
+ * probe-invoker idiom (`err.name === "ZodError"` ⇒ input-rejected vs.
+ * driver-error) but at the FLEET boundary, where the extra axis is "was this a
+ * pool-COMM failure or a probe error?" (REQ-B):
+ *
+ *   - `protocol-violation` — a schema/input-validation throw (zod). The payload
+ *     could not be trusted; it surfaces as a `worker-protocol-violation` comm
+ *     error (the same class `runClaimedJob` already emits for an unmappable
+ *     payload).
+ *   - `pool-infra` — a genuine pool/launcher-unreachable failure. Stays
+ *     `worker-crashed-mid-job` so the dashboard shows "couldn't reach the pool".
+ *   - `driver-error` — a real in-driver test/runtime throw. Surfaces as a
+ *     probe `error` result with NO commError, so it reads as a probe error and
+ *     NOT a pool-unreachable overlay. This is the DEFAULT: a driver that throws
+ *     is overwhelmingly failing its own test logic, not the fleet plumbing.
+ */
+type DriverThrowClass = "protocol-violation" | "pool-infra" | "driver-error";
+
+/**
+ * Classify a thrown driver error into one of the three fleet error classes.
+ * Pure; unit-tested via `runClaimedJob`'s branch coverage.
+ */
+export function classifyDriverThrow(err: unknown): DriverThrowClass {
+  const name = err instanceof Error ? err.name : "";
+  if (name === "ZodError") return "protocol-violation";
+  // Pool unreachability is identified by the pool's OWN throw signature — its
+  // `BrowserPool `/`browser-pool:` MESSAGE prefix — NOT a broad name/keyword
+  // match. A Playwright/test error (real product/test regression) therefore
+  // falls through to `driver-error` and surfaces as a probe error, not a false
+  // pool outage (REQ-B).
+  const message = err instanceof Error ? err.message : "";
+  if (POOL_UNAVAILABLE_MESSAGE_RE.test(message)) return "pool-infra";
+  return "driver-error";
+}
+
+/**
+ * Compute the pass/fail rollup from captured cell results. A cell is "passed"
+ * iff its state is green; everything else (red, degraded, error) counts as
+ * failed. Mirrors the d6 aggregate semantic (any non-green → not passed).
+ */
+export function computeRollup(cells: ServiceCellResult[]): ServiceJobRollup {
+  let passed = 0;
+  let failed = 0;
+  for (const c of cells) {
+    if (c.state === "green") passed++;
+    else failed++;
+  }
+  return { total: cells.length, passed, failed };
+}
+
+/**
+ * Build the `ServiceJobResult` from a claimed lease, the driver's aggregate
+ * return, and the captured per-cell rows. Pure — the loop calls it after a
+ * successful run; unit-tested independently of the loop.
+ */
+export function buildServiceJobResult(args: {
+  lease: JobLease;
+  workerId: string;
+  aggregate: ProbeResult;
+  cells: ServiceCellResult[];
+  finishedAt: string;
+}): ServiceJobResult {
+  const { lease, workerId, aggregate, cells, finishedAt } = args;
+  const { job, payload } = lease;
+  // The driver return is untrusted at the producer boundary: a garbage state
+  // ("grene") satisfies the `ProbeState` static type yet would flow straight
+  // into the dashboard status state machine on the in-process path (which
+  // never re-decodes through `result-consumer`). Fail LOUD here so `runClaimedJob`
+  // routes it to an `error` result instead of persisting junk.
+  if (!PROBE_STATES.has(aggregate.state)) {
+    throw new Error(
+      `buildServiceJobResult: job ${job.id} driver returned invalid aggregateState "${aggregate.state}" (expected one of ${[...PROBE_STATES].join("/")})`,
+    );
+  }
+  return {
+    jobId: job.id,
+    probeKey: payload.probeKey,
+    serviceSlug: payload.serviceSlug,
+    runId: payload.meta.runId,
+    workerId,
+    aggregateState: aggregate.state,
+    aggregateKey: aggregate.key,
+    aggregateSignal: aggregate.signal,
+    cells,
+    rollup: computeRollup(cells),
+    finishedAt,
+  };
+}
+
+/**
+ * Build a terminal `ServiceJobResult` carrying a `commError` for a job that
+ * crashed/timed out in the worker (the worker's OWN self-monitor leg of REQ-B).
+ * `aggregateState` carries `"error"` so `terminalJobStatus` maps it to
+ * `"failed"`, and the comm error tells the dashboard to render "couldn't reach
+ * the pool" distinctly from a probe red. Pure; unit-tested.
+ */
+export function buildCommErrorResult(args: {
+  lease: JobLease;
+  workerId: string;
+  commError: PoolCommError;
+  finishedAt: string;
+}): ServiceJobResult {
+  const { lease, workerId, commError, finishedAt } = args;
+  const { job, payload } = lease;
+  const errorState: ProbeState = "error";
+  return {
+    jobId: job.id,
+    probeKey: payload.probeKey,
+    serviceSlug: payload.serviceSlug,
+    runId: payload.meta.runId,
+    workerId,
+    aggregateState: errorState,
+    aggregateKey: payload.probeKey,
+    aggregateSignal: { error: commError.message },
+    cells: [],
+    rollup: { total: 0, passed: 0, failed: 0 },
+    finishedAt,
+    commError,
+  };
+}
+
+/**
+ * Build a terminal `ServiceJobResult` for a genuine IN-DRIVER test/runtime
+ * error (the driver threw while running its own logic, not because the pool was
+ * unreachable). `aggregateState` is `"error"` so `terminalJobStatus` maps it to
+ * `"failed"`, but there is deliberately NO `commError` — this surfaces as a
+ * PROBE error on the dashboard, not the "couldn't reach the pool" overlay
+ * (REQ-B: a real test/runtime failure must not masquerade as a pool outage).
+ * `aggregateKey` falls back to the payload's `probeKey` (the `d6:<slug>`
+ * aggregate row key) since there is no driver result to echo. Pure; unit-tested.
+ */
+export function buildDriverErrorResult(args: {
+  lease: JobLease;
+  workerId: string;
+  message: string;
+  finishedAt: string;
+}): ServiceJobResult {
+  const { lease, workerId, message, finishedAt } = args;
+  const { job, payload } = lease;
+  const errorState: ProbeState = "error";
+  return {
+    jobId: job.id,
+    probeKey: payload.probeKey,
+    serviceSlug: payload.serviceSlug,
+    runId: payload.meta.runId,
+    workerId,
+    aggregateState: errorState,
+    aggregateKey: payload.probeKey,
+    aggregateSignal: { error: message },
+    cells: [],
+    rollup: { total: 0, passed: 0, failed: 0 },
+    finishedAt,
+  };
+}
+
+/**
+ * Run ONE claimed job to completion: install the cell-capturing writer, run the
+ * driver with a lease-renewal heartbeat in flight, and return the computed
+ * `ServiceJobResult`. On a driver crash/timeout, returns a comm-error terminal
+ * result instead of throwing — the loop always has a result to report so a
+ * crashed job never silently strands its lease until the sweeper reclaims it.
+ *
+ * Exported for direct unit testing of the claim→run→report round-trip without
+ * driving the full poll loop.
+ */
+export async function runClaimedJob(
+  deps: Pick<
+    WorkerLoopDeps,
+    "workerId" | "queue" | "driver" | "payloadToInput" | "logger" | "env"
+  > & { now: () => Date; sleep: NonNullable<WorkerLoopDeps["sleep"]> },
+  lease: JobLease,
+  opts: { leaseSeconds: number; heartbeatMs: number },
+): Promise<ServiceJobResult> {
+  const { workerId, queue, driver, payloadToInput, logger, env, now } = deps;
+  const { job, payload } = lease;
+
+  // Map the claimed payload to a driver input. A poison payload can fail either
+  // by RETURNING undefined ("cannot map this") or by THROWING (decode/parse
+  // blew up). Both are protocol violations the WORKER owns (it won the claim),
+  // so both must emit a `worker-protocol-violation` comm-error result the
+  // dashboard surfaces — NOT a bare release-failed (silently lost after grace)
+  // and NOT an uncaught throw (which would reject the loop's done-promise =
+  // silent worker death). The throw is caught HERE rather than in the run
+  // try/catch below so it is never misread as a driver/test error.
+  let input: unknown;
+  try {
+    input = payloadToInput(payload);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error("fleet.worker.payload-decode-error", {
+      workerId,
+      jobId: job.id,
+      probeKey: payload.probeKey,
+      err: msg,
+    });
+    return buildCommErrorResult({
+      lease,
+      workerId,
+      commError: {
+        kind: "worker-protocol-violation",
+        message: `worker could not decode payload for probeKey "${payload.probeKey}": ${msg}`,
+        workerId,
+        jobId: job.id,
+        observedAt: now().toISOString(),
+      },
+      finishedAt: now().toISOString(),
+    });
+  }
+  if (input === undefined) {
+    logger.warn("fleet.worker.payload-unmappable", {
+      workerId,
+      jobId: job.id,
+      probeKey: payload.probeKey,
+    });
+    return buildCommErrorResult({
+      lease,
+      workerId,
+      commError: {
+        kind: "worker-protocol-violation",
+        message: `worker could not map payload for probeKey "${payload.probeKey}" to a driver input`,
+        workerId,
+        jobId: job.id,
+        observedAt: now().toISOString(),
+      },
+      finishedAt: now().toISOString(),
+    });
+  }
+
+  // The driver's aggregate side-emit uses `d6:<serviceSlug>` — filter that one
+  // out of the captured cells (the loop captures the aggregate from the primary
+  // return). Per-cell rows are `d6:<slug>/<featureId>` and are kept.
+  const aggregateSlugKey = `d6:${payload.serviceSlug}`;
+  const capture = createCellCapture(aggregateSlugKey);
+
+  // Heartbeat-renew the lease while the (long) driver run is in flight. A renew
+  // that returns null (lease lost/stolen) stops the heartbeat but does not
+  // abort the run — `report` is the final CAS arbiter.
+  const heartbeatAbort = new AbortController();
+  const heartbeat = (async (): Promise<void> => {
+    while (!heartbeatAbort.signal.aborted) {
+      await deps.sleep(opts.heartbeatMs, heartbeatAbort.signal);
+      if (heartbeatAbort.signal.aborted) break;
+      try {
+        const renewed = await queue.renewLease(
+          job.id,
+          workerId,
+          opts.leaseSeconds,
+        );
+        if (renewed === null) {
+          logger.warn("fleet.worker.lease-lost", {
+            workerId,
+            jobId: job.id,
+          });
+          break;
+        }
+        logger.debug("fleet.worker.lease-renewed", {
+          workerId,
+          jobId: job.id,
+          leaseExpiresAt: renewed.leaseExpiresAt,
+        });
+      } catch (err) {
+        logger.warn("fleet.worker.lease-renew-error", {
+          workerId,
+          jobId: job.id,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        break;
+      }
+    }
+  })();
+
+  try {
+    const ctx: ServiceDriverContext = {
+      now,
+      logger,
+      env,
+      writer: capture.writer,
+      featureTypes:
+        payload.cellIds && payload.cellIds.length > 0
+          ? payload.cellIds
+          : undefined,
+    };
+    const aggregate = await driver.run(ctx, input);
+    return buildServiceJobResult({
+      lease,
+      workerId,
+      aggregate,
+      cells: capture.cells,
+      finishedAt: now().toISOString(),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const errName = err instanceof Error ? err.name : undefined;
+    const cls = classifyDriverThrow(err);
+
+    // A schema/input-validation throw is a protocol violation, not a crash —
+    // the payload could not be trusted (same class as an unmappable payload).
+    if (cls === "protocol-violation") {
+      logger.error("fleet.worker.job-protocol-violation", {
+        workerId,
+        jobId: job.id,
+        probeKey: payload.probeKey,
+        errName,
+        err: msg,
+      });
+      return buildCommErrorResult({
+        lease,
+        workerId,
+        commError: {
+          kind: "worker-protocol-violation",
+          message: `worker rejected job ${job.id} input: ${msg}`,
+          workerId,
+          jobId: job.id,
+          observedAt: now().toISOString(),
+        },
+        finishedAt: now().toISOString(),
+      });
+    }
+
+    // A true infra/pool-unreachable failure stays `worker-crashed-mid-job` so
+    // the dashboard renders the "couldn't reach the pool" overlay (REQ-B).
+    if (cls === "pool-infra") {
+      logger.error("fleet.worker.job-crashed", {
+        workerId,
+        jobId: job.id,
+        probeKey: payload.probeKey,
+        errName,
+        err: msg,
+      });
+      return buildCommErrorResult({
+        lease,
+        workerId,
+        commError: {
+          kind: "worker-crashed-mid-job",
+          message: `worker crashed running job ${job.id}: ${msg}`,
+          workerId,
+          jobId: job.id,
+          observedAt: now().toISOString(),
+        },
+        finishedAt: now().toISOString(),
+      });
+    }
+
+    // Default: a genuine in-driver test/runtime error. This is a PROBE error,
+    // not a pool-comm failure — surface it as an `error`-state result with NO
+    // commError so the dashboard shows a probe error, not a pool-unreachable
+    // overlay (REQ-B inversion fix).
+    logger.error("fleet.worker.job-driver-error", {
+      workerId,
+      jobId: job.id,
+      probeKey: payload.probeKey,
+      errName,
+      err: msg,
+    });
+    return buildDriverErrorResult({
+      lease,
+      workerId,
+      message: msg,
+      finishedAt: now().toISOString(),
+    });
+  } finally {
+    heartbeatAbort.abort();
+    await heartbeat;
+  }
+}
+
+/**
+ * Start the worker pull loop. Returns immediately with a handle; the loop runs
+ * until `stop()` is called. The loop:
+ *
+ *   1. Checks `pool.budget().available > 0`. If no budget, idles a poll
+ *      interval (NEVER claims past the context cap → stays under the pids
+ *      ceiling).
+ *   2. With budget, `queue.claimNext(workerId, leaseSeconds)`. On no claim,
+ *      idles a poll interval.
+ *   3. On a claim, runs the service's cells via the driver with a lease
+ *      heartbeat in flight, computes the `ServiceJobResult`, and `report`s it.
+ *      A claim-comm failure or a report failure is logged and the loop
+ *      continues (the sweeper reclaims any stranded lease).
+ */
+export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
+  const now = deps.now ?? ((): Date => new Date());
+  const sleep = deps.sleep ?? defaultSleep;
+  const leaseSeconds = deps.leaseSeconds ?? DEFAULT_LEASE_SECONDS;
+  const heartbeatMs = deps.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+  const pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const { workerId, queue, pool, logger } = deps;
+
+  // Fail-loud at construction: the heartbeat must fire (and renew) BEFORE the
+  // lease expires, or the sweeper reclaims a live worker's job and synthesizes a
+  // false `worker-crashed-mid-job` (REQ-B). `heartbeatMs` and `leaseSeconds` are
+  // independently overridable, so an unsafe combo is a misconfiguration — die
+  // immediately (visible in deploy CI / Railway health-check) rather than ship a
+  // worker that drops every long job mid-run. Mirrors the role-config fail-loud
+  // idiom (`resolveFleetRoleConfig` throws on an invalid env combo).
+  if (heartbeatMs >= leaseSeconds * 1000) {
+    throw new Error(
+      `Unsafe fleet worker lease config: heartbeatMs (${heartbeatMs}) must be < leaseSeconds*1000 (${leaseSeconds * 1000}) so the lease is renewed before it expires; otherwise the lease lapses before the first renew and the sweeper reclaims a live job as a false worker-crashed-mid-job.`,
+    );
+  }
+
+  /**
+   * Fire the current-job hook, guarding against a throwing/rejecting impl so a
+   * registration-heartbeat failure can never break the worker loop (mirrors the
+   * best-effort discipline the registration writer itself uses).
+   */
+  function notifyCurrentJob(currentJobId: string | null): void {
+    if (!deps.onCurrentJobChange) return;
+    try {
+      const maybe = deps.onCurrentJobChange(currentJobId) as unknown;
+      if (maybe && typeof (maybe as Promise<unknown>).catch === "function") {
+        (maybe as Promise<unknown>).catch((err) =>
+          logger.warn("fleet.worker.current-job-hook-error", {
+            workerId,
+            err: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      }
+    } catch (err) {
+      logger.warn("fleet.worker.current-job-hook-error", {
+        workerId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const stopAbort = new AbortController();
+  let stopped = false;
+
+  const done = (async (): Promise<void> => {
+    logger.info("fleet.worker.loop-start", { workerId });
+    while (!stopAbort.signal.aborted) {
+      // 1. Budget gate — only claim when we have free context capacity. This
+      //    is what keeps the worker under its cgroup pids ceiling. Reading the
+      //    budget touches the cgroup pids files, so it can throw (unreadable
+      //    /sys, transient FS error). An unreadable budget is treated as "no
+      //    budget" — NOT a worker crash: a throw here must never reject the
+      //    loop's done-promise (silent worker death + restart-loop). Log and
+      //    idle a poll interval, exactly as a saturated budget would.
+      let budget: BrowserPoolBudget;
+      try {
+        budget = pool.budget();
+      } catch (err) {
+        logger.error("fleet.worker.budget-error", {
+          workerId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        await sleep(pollIntervalMs, stopAbort.signal);
+        continue;
+      }
+      if (budget.available <= 0) {
+        logger.debug("fleet.worker.no-budget", {
+          workerId,
+          inUse: budget.inUse,
+          max: budget.max,
+          pidsCurrent: budget.pidsCurrent,
+          pidsMax: budget.pidsMax,
+        });
+        await sleep(pollIntervalMs, stopAbort.signal);
+        continue;
+      }
+
+      // 2. Attempt a claim.
+      let claimed: Awaited<ReturnType<FleetQueueClient["claimNext"]>>;
+      try {
+        claimed = await queue.claimNext(workerId, leaseSeconds);
+      } catch (err) {
+        logger.warn("fleet.worker.claim-error", {
+          workerId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        await sleep(pollIntervalMs, stopAbort.signal);
+        continue;
+      }
+
+      if (!claimed.claimed || !claimed.lease) {
+        await sleep(pollIntervalMs, stopAbort.signal);
+        continue;
+      }
+
+      const lease = claimed.lease;
+      logger.info("fleet.worker.claimed", {
+        workerId,
+        jobId: lease.job.id,
+        probeKey: lease.payload.probeKey,
+        serviceSlug: lease.payload.serviceSlug,
+      });
+
+      // Reflect the now-running job on the registration row so fleet-health
+      // sees a non-null current_job_id while the (long) run is in flight.
+      // Best-effort — a throwing hook must never break the loop.
+      notifyCurrentJob(lease.job.id);
+
+      // 3. Run + report. `runClaimedJob` never throws — it returns a comm-error
+      //    terminal result on crash/timeout so the loop always reports.
+      const result = await runClaimedJob(
+        {
+          workerId,
+          queue,
+          driver: deps.driver,
+          payloadToInput: deps.payloadToInput,
+          logger,
+          env: deps.env,
+          now,
+          sleep,
+        },
+        lease,
+        { leaseSeconds, heartbeatMs },
+      );
+
+      try {
+        await queue.report({ jobId: lease.job.id, workerId, result });
+        logger.info("fleet.worker.reported", {
+          workerId,
+          jobId: lease.job.id,
+          aggregateState: result.aggregateState,
+          passed: result.rollup.passed,
+          failed: result.rollup.failed,
+          commError: result.commError?.kind,
+        });
+      } catch (err) {
+        // A report failure has TWO distinct shapes, and which dashboard leg
+        // covers it depends on whether the release CAS flipped the row terminal:
+        //   - REFUSED RELEASE (row still claimed|running, no result written):
+        //     the lease is left to the producer/fleet-health SWEEPER, which
+        //     scans claimed|running rows for an EXPIRED lease and synthesizes a
+        //     `worker-crashed-mid-job` comm error (REQ-B). The sweeper genuinely
+        //     covers this case.
+        //   - RESULT LOST (release SUCCEEDED → row is terminal, but the result
+        //     write exhausted its retries): the row is done|failed with no
+        //     result. The sweepers only scan claimed|running, so they NEVER see
+        //     it — the control-plane RESULT-CONSUMER's resultless-past-grace leg
+        //     is what synthesizes the comm error for this case (NOT the sweeper).
+        // Either way the dashboard ends up showing "unreachable"; log and keep
+        // pulling.
+        logger.error("fleet.worker.report-error", {
+          workerId,
+          jobId: lease.job.id,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        // The job has settled — clear the current-job marker so the worker
+        // shows idle again on the next heartbeat.
+        notifyCurrentJob(null);
+      }
+    }
+    logger.info("fleet.worker.loop-stopped", { workerId });
+  })();
+
+  return {
+    async stop(): Promise<void> {
+      if (stopped) {
+        await done;
+        return;
+      }
+      stopped = true;
+      stopAbort.abort();
+      await done;
+    },
+    done,
+  };
+}

--- a/showcase/harness/src/http/probes.test.ts
+++ b/showcase/harness/src/http/probes.test.ts
@@ -97,6 +97,7 @@ function makeFakeWriter(): ProbeRunWriter & {
   const recentMap = new Map<string, ProbeRunRecord[]>();
   return {
     start: async () => ({ id: "row1" }),
+    findByJobId: async () => null,
     update: async () => {},
     finish: async () => {},
     recent: async (probeId, _limit) => recentMap.get(probeId) ?? [],
@@ -897,6 +898,7 @@ describe("GET /api/probes/:id — R2-A.9 graceful degradation", () => {
     const sched = makeFakeScheduler();
     const writer: ProbeRunWriter = {
       start: async () => ({ id: "x" }),
+      findByJobId: async () => null,
       update: async () => {},
       finish: async () => {},
       recent: async () => {

--- a/showcase/harness/src/http/server.test.ts
+++ b/showcase/harness/src/http/server.test.ts
@@ -191,6 +191,105 @@ describe("http/server", () => {
     expect(body.loop).toBe("stopped");
   });
 
+  it("GET /health (control-plane role) returns 200 with rules=0 when pb/loop/scheduler ok", async () => {
+    // The control-plane is a scheduler/queue/aggregator — it legitimately
+    // owns NO probe rules, only the single fleet-job-producer scheduler
+    // entry. The default `rules > 0` gate is wrong for that role; with
+    // role:"control-plane" the endpoint reports healthy on its real
+    // liveness signals (pb ok, scheduler started + alive, schedulerJobs>0)
+    // WITHOUT requiring rules.
+    const app = buildServer({
+      pb: fakePb(true),
+      logger,
+      role: "control-plane",
+      ruleCount: () => 0,
+      loopAlive: () => true,
+      schedulerStarted: () => true,
+      schedulerIsStopped: () => false,
+      schedulerJobCount: () => 1,
+    });
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      status: string;
+      rules: number;
+      loop: string;
+      schedulerJobs: number;
+    };
+    expect(body.status).toBe("ok");
+    expect(body.rules).toBe(0);
+    expect(body.loop).toBe("ok");
+    expect(body.schedulerJobs).toBe(1);
+  });
+
+  it("GET /health (control-plane role) still returns 503 when pb is down", async () => {
+    const app = buildServer({
+      pb: fakePb(false),
+      logger,
+      role: "control-plane",
+      ruleCount: () => 0,
+      loopAlive: () => true,
+      schedulerStarted: () => true,
+      schedulerJobCount: () => 1,
+    });
+    const res = await app.request("/health");
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { status: string; pb: string };
+    expect(body.status).toBe("degraded");
+    expect(body.pb).toBe("down");
+  });
+
+  it("GET /health (control-plane role) still returns 503 when scheduler has no jobs", async () => {
+    // Even role-aware, the control-plane MUST surface a dead scheduler: if
+    // the fleet-job-producer entry is missing (schedulerJobs==0) nothing
+    // ticks, so /health must report degraded regardless of the rules gate.
+    const app = buildServer({
+      pb: fakePb(true),
+      logger,
+      role: "control-plane",
+      ruleCount: () => 0,
+      loopAlive: () => true,
+      schedulerStarted: () => true,
+      schedulerJobCount: () => 0,
+    });
+    const res = await app.request("/health");
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { status: string; loop: string };
+    expect(body.status).toBe("degraded");
+    expect(body.loop).toBe("no-jobs");
+  });
+
+  it("GET /health (control-plane role) still returns 503 when loop not alive", async () => {
+    const app = buildServer({
+      pb: fakePb(true),
+      logger,
+      role: "control-plane",
+      ruleCount: () => 0,
+      loopAlive: () => false,
+      schedulerStarted: () => true,
+      schedulerJobCount: () => 1,
+    });
+    const res = await app.request("/health");
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("degraded");
+  });
+
+  it("GET /health (worker/default role) still requires rules>0 (regression guard)", async () => {
+    // The role-aware change must NOT loosen the worker/legacy path: with no
+    // role (or a non-control-plane role) the rules>0 gate stays in force.
+    const app = buildServer({
+      pb: fakePb(true),
+      logger,
+      ruleCount: () => 0,
+      loopAlive: () => true,
+      schedulerStarted: () => true,
+      schedulerJobCount: () => 1,
+    });
+    const res = await app.request("/health");
+    expect(res.status).toBe(503);
+  });
+
   it("GET /metrics exposes Prometheus-format counters when metrics is provided", async () => {
     const metrics = createMetricsRegistry();
     metrics.inc("probe_runs", { dimension: "smoke" });

--- a/showcase/harness/src/http/server.ts
+++ b/showcase/harness/src/http/server.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { PbClient } from "../storage/pb-client.js";
 import type { Logger } from "../types/index.js";
 import type { TypedEventBus } from "../events/event-bus.js";
+import type { HarnessRole } from "../fleet/role-config.js";
 import { registerDeployWebhook } from "./webhooks/deploy.js";
 import { registerProbesRoutes, type ProbesRouteDeps } from "./probes.js";
 import { renderPrometheus, type MetricsRegistry } from "./metrics.js";
@@ -9,6 +10,23 @@ import { renderPrometheus, type MetricsRegistry } from "./metrics.js";
 export interface ServerDeps {
   pb: PbClient;
   logger: Logger;
+  /**
+   * Service role this /health surface represents. Defaults to "worker"
+   * (the legacy in-process harness), for which probe rules are the unit of
+   * work — so /health requires `ruleCount > 0` (a running server with zero
+   * rules means the rule loader silently failed). The "control-plane" role
+   * is a scheduler/queue/aggregator that legitimately owns NO probe rules
+   * (only the single fleet-job-producer scheduler entry), so for it the
+   * `rules > 0` gate is dropped — liveness is governed by pb + the scheduler
+   * signals (`schedulerJobCount`, `schedulerStarted`, `loopAlive`) instead.
+   * Without this, the control-plane container reports degraded/503 forever
+   * (rules is always 0) and Railway restart-loops it.
+   *
+   * Typed via the `HarnessRole` SSOT (fleet/role-config.ts) so a future role
+   * addition flows here automatically rather than drifting from an inline
+   * literal union.
+   */
+  role?: HarnessRole;
   ruleCount: () => number;
   /**
    * Historically exposed as `loop: ok|stopped` on /health, but the flag
@@ -138,7 +156,14 @@ export function buildServer(deps: ServerDeps): Hono {
           : !jobCountOk
             ? "no-jobs"
             : "ok";
-    const ok = pbOk && loopOk && ruleCount > 0;
+    // Role-aware rules gate: the worker (default) role treats probe rules as
+    // its unit of work, so zero rules is a hard 503 (rule-loader crashed).
+    // The control-plane owns no probe rules — its liveness is the scheduler
+    // signals already folded into `loopOk` (schedulerJobCount>0 covers the
+    // fleet-job-producer entry) — so it must not require rules>0, or it would
+    // report degraded forever and Railway would restart-loop it.
+    const rulesOk = deps.role === "control-plane" ? true : ruleCount > 0;
+    const ok = pbOk && loopOk && rulesOk;
     return c.json(
       {
         status: ok ? "ok" : "degraded",

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -16,8 +16,18 @@ import {
   createRailwayAdapter,
   registerAllProbeDrivers,
   hydrateProbeLastRuns,
+  surfaceReclaimedCommErrors,
+  verifyWorkerRegistered,
 } from "./orchestrator.js";
-import type { State } from "./types/index.js";
+import type {
+  CommErrorSurfacePb,
+  WorkerRegistryReadPb,
+} from "./orchestrator.js";
+import type { State, ProbeResult } from "./types/index.js";
+import {
+  FLEET_COMM_ERROR_SIGNAL_KEY,
+  type PoolCommError,
+} from "./fleet/contracts.js";
 import { BrowserPool } from "./probes/helpers/browser-pool.js";
 import { createProbeRegistry } from "./probes/drivers/index.js";
 import type { createScheduler } from "./scheduler/scheduler.js";
@@ -25,6 +35,7 @@ import { createEventBus } from "./events/event-bus.js";
 import { logger } from "./logger.js";
 import type { CompiledRule } from "./rules/rule-loader.js";
 import type { ProbeConfig } from "./probes/loader/schema.js";
+import { buildWorkerHealthServer } from "./fleet/worker/worker-health.js";
 
 /**
  * F1.1 integration coverage: `buildServer` in orchestrator.ts must pass
@@ -2502,6 +2513,726 @@ describe("hydrateProbeLastRuns", () => {
 
     // Entry stays un-seeded because the run is incomplete
     expect(scheduler.seedEntryLastRun).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * CR-FIX #2: surfaceReclaimedCommErrors must NOT invent a green status row for
+ * a NEVER-OBSERVED probe key.
+ *
+ * Pre-fix the surfacer defaulted a never-observed key to `state: "green"` and
+ * wrote that through the status-writer — fabricating a healthy cell for a
+ * service whose worker crashed before it was ever probed. The codebase's
+ * no-data representation is an ABSENT status row (status-writer F2.1: a
+ * first-ever observation that is an "error" writes only status_history and
+ * seeds NO status row). So a comm error on a never-observed key must be written
+ * as state:"error" (never green), and an OBSERVED key must carry its real prior
+ * colour.
+ */
+describe("orchestrator.surfaceReclaimedCommErrors never-observed key (CR-FIX #2)", () => {
+  function makeLogger() {
+    return {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+  }
+
+  function makeCommError(jobId: string): PoolCommError {
+    return {
+      kind: "worker-crashed-mid-job",
+      message: "worker died mid-job",
+      workerId: "worker-abc",
+      jobId,
+      observedAt: "2025-01-01T00:00:00.000Z",
+    };
+  }
+
+  // Build a pb fake satisfying the surfacer's CommErrorSurfacePb. Plain generic
+  // methods (NOT vi.fn, which collapses the type param to unknown) so the canned
+  // rows type-check against getOne<T>/getFirst<T>. The tests assert on the
+  // statusWriter writes, not on these reads, so call-tracking isn't needed.
+  function makeSurfacePb(opts: {
+    jobRow: { probe_key?: string } | null;
+    statusRow: { state?: string; signal?: unknown } | null;
+  }): CommErrorSurfacePb {
+    return {
+      getOne<T>(): Promise<T | null> {
+        return Promise.resolve(opts.jobRow as T | null);
+      },
+      getFirst<T>(): Promise<T | null> {
+        return Promise.resolve(opts.statusRow as T | null);
+      },
+    };
+  }
+
+  it("writes state 'error' (NOT green) when the probe key was never observed", async () => {
+    const writes: ProbeResult<unknown>[] = [];
+    const statusWriter = {
+      write: vi.fn(async (r: ProbeResult<unknown>) => {
+        writes.push(r);
+        return undefined;
+      }),
+    };
+    const pb = makeSurfacePb({
+      // Job row resolves to a probe_key; never observed → no status row.
+      jobRow: { probe_key: "d6:never-seen-service" },
+      statusRow: null,
+    });
+    const logger = makeLogger();
+
+    await surfaceReclaimedCommErrors({ pb, statusWriter, logger }, [
+      makeCommError("job-1"),
+    ]);
+
+    expect(statusWriter.write).toHaveBeenCalledTimes(1);
+    expect(writes).toHaveLength(1);
+    // THE FIX: never-observed key must NOT be reported green.
+    expect(writes[0].state).not.toBe("green");
+    expect(writes[0].state).toBe("error");
+    expect(writes[0].key).toBe("d6:never-seen-service");
+    // The comm-error overlay is still carried on the signal.
+    expect(
+      (writes[0].signal as Record<string, unknown>)[
+        FLEET_COMM_ERROR_SIGNAL_KEY
+      ],
+    ).toBeDefined();
+  });
+
+  it("carries the real prior colour for an OBSERVED key (regression guard)", async () => {
+    const writes: ProbeResult<unknown>[] = [];
+    const statusWriter = {
+      write: vi.fn(async (r: ProbeResult<unknown>) => {
+        writes.push(r);
+        return undefined;
+      }),
+    };
+    const pb = makeSurfacePb({
+      jobRow: { probe_key: "d6:seen-service" },
+      // Observed: a red status row exists.
+      statusRow: { state: "red", signal: { prior: true } },
+    });
+    const logger = makeLogger();
+
+    await surfaceReclaimedCommErrors({ pb, statusWriter, logger }, [
+      makeCommError("job-2"),
+    ]);
+
+    expect(writes).toHaveLength(1);
+    // Observed key carries its real last-known colour, not "error", not green.
+    expect(writes[0].state).toBe("red");
+    // Base signal preserved + overlay added.
+    expect((writes[0].signal as Record<string, unknown>).prior).toBe(true);
+    expect(
+      (writes[0].signal as Record<string, unknown>)[
+        FLEET_COMM_ERROR_SIGNAL_KEY
+      ],
+    ).toBeDefined();
+  });
+});
+
+/**
+ * CR-FIX #4: verifyWorkerRegistered must reflect the ACTUAL upsert outcome.
+ *
+ * registerWorker is best-effort and swallows the boot-upsert failure, so the
+ * worker pre-fix set `registered = true` unconditionally — a failed
+ * registration still reported the worker healthy on the roster. The verifier
+ * reads the row back: present → true; absent OR read-error → false.
+ */
+describe("orchestrator.verifyWorkerRegistered (CR-FIX #4)", () => {
+  function makeLogger() {
+    return {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+  }
+
+  // pb fake satisfying verifyWorkerRegistered's WorkerRegistryReadPb. Plain
+  // generic method (not vi.fn) so getFirst<T> type-checks; the tests assert on
+  // the return value + logger, not on the read call.
+  function makeRegistryPb(row: { id?: string } | null): WorkerRegistryReadPb {
+    return {
+      getFirst<T>(): Promise<T | null> {
+        return Promise.resolve(row as T | null);
+      },
+    };
+  }
+
+  it("returns true when the registration row persisted", async () => {
+    const pb = makeRegistryPb({ id: "rec123" });
+    const logger = makeLogger();
+    const result = await verifyWorkerRegistered({
+      pb,
+      workerId: "worker-1",
+      logger,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("returns false when the upsert did NOT persist a row (best-effort swallow)", async () => {
+    // registerWorker swallowed a PB 400 — no row exists.
+    const pb = makeRegistryPb(null);
+    const logger = makeLogger();
+    const result = await verifyWorkerRegistered({
+      pb,
+      workerId: "worker-2",
+      logger,
+    });
+    // THE FIX: pre-fix this was hardcoded true; now it reflects reality.
+    expect(result).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "showcase-harness.fleet.worker.registration-not-persisted",
+      expect.objectContaining({ workerId: "worker-2" }),
+    );
+  });
+
+  it("returns false (and warns) when the verify read itself errors", async () => {
+    const pb: WorkerRegistryReadPb = {
+      getFirst<T>(): Promise<T | null> {
+        return Promise.reject(new Error("pb unreachable"));
+      },
+    };
+    const logger = makeLogger();
+    const result = await verifyWorkerRegistered({
+      pb,
+      workerId: "worker-3",
+      logger,
+    });
+    expect(result).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "showcase-harness.fleet.worker.registration-verify-failed",
+      expect.objectContaining({ workerId: "worker-3" }),
+    );
+  });
+
+  // WIRING: a failed verify must flow into the /health `registered` probe.
+  // runWorker does `registered = await verifyWorkerRegistered(...)` then passes
+  // `registered: () => registered` into runFleetWorker's health server. This
+  // composes those two seams to prove a failed self-register → /health
+  // registered=false (NOT the pre-fix `() => true` default that reported a
+  // never-registered worker as healthy).
+  it("a failed verify wires through to /health registered=false (NOT defaulted true)", async () => {
+    const pb = makeRegistryPb(null); // upsert swallowed → no row
+    const logger = makeLogger();
+    const registered = await verifyWorkerRegistered({
+      pb,
+      workerId: "worker-w",
+      logger,
+    });
+    expect(registered).toBe(false);
+
+    // This is the exact wiring runWorker uses: the verified value, not () => true.
+    const healthApp = buildWorkerHealthServer({
+      pb: async () => true,
+      loopAlive: () => true,
+      registered: () => registered,
+      logger,
+    });
+    const res = await healthApp.request("/health");
+    const body = (await res.json()) as { registered: boolean };
+    expect(res.status).toBe(503);
+    expect(body.registered).toBe(false);
+  });
+});
+
+/**
+ * CR-FIX #1: runControlPlane must handle an ASYNC bind failure.
+ *
+ * serve()/server.listen() emits bind errors (EADDRINUSE) ASYNCHRONOUSLY. Pre-fix
+ * runControlPlane only had a synchronous try/catch around serve(), so an async
+ * bind failure resolved runControlPlane() "successfully" while leaving the
+ * scheduler, control-plane consumer loop, and fleet-health interval orphaned.
+ * The fix mirrors boot()'s R4-A.3 listening-vs-error race and tears those down
+ * on the error path. This test mocks serve() to emit 'error' asynchronously
+ * (mirroring the boot() R4-A.3 test) and asserts runControlPlane rejects AND
+ * the scheduler is stopped.
+ */
+describe("orchestrator runControlPlane async bind error cleanup (CR-FIX #1)", () => {
+  let port = 0;
+
+  beforeEach(async () => {
+    port = await pickPort();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("rejects runControlPlane AND stops the scheduler when serve() emits 'error' asynchronously", async () => {
+    vi.resetModules();
+
+    const stopSpy = vi.fn(async () => undefined);
+    vi.doMock("./scheduler/scheduler.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./scheduler/scheduler.js")
+      >("./scheduler/scheduler.js");
+      return {
+        ...actual,
+        createScheduler: (
+          deps: Parameters<typeof actual.createScheduler>[0],
+        ) => {
+          const real = actual.createScheduler(deps);
+          return {
+            ...real,
+            stop: async (...args: unknown[]) => {
+              stopSpy();
+              return (real.stop as (...a: unknown[]) => Promise<void>)(...args);
+            },
+          };
+        },
+      };
+    });
+
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return {
+        ...actual,
+        serve: () => {
+          const listeners: Record<string, Array<(...a: unknown[]) => void>> = {
+            error: [],
+            listening: [],
+          };
+          const stub = {
+            listening: false,
+            once(event: string, cb: (...a: unknown[]) => void) {
+              listeners[event] ??= [];
+              listeners[event].push(cb);
+              return stub;
+            },
+            on(event: string, cb: (...a: unknown[]) => void) {
+              listeners[event] ??= [];
+              listeners[event].push(cb);
+              return stub;
+            },
+            removeListener(event: string, cb: (...a: unknown[]) => void) {
+              const arr = listeners[event];
+              if (arr) {
+                const i = arr.indexOf(cb);
+                if (i >= 0) arr.splice(i, 1);
+              }
+              return stub;
+            },
+            close(cb?: (err?: Error) => void) {
+              if (cb) cb();
+              return stub;
+            },
+          };
+          setTimeout(() => {
+            const errs = listeners.error.slice();
+            for (const cb of errs)
+              cb(new Error("simulated EADDRINUSE from async listen()"));
+          }, 0);
+          return stub as unknown as ReturnType<typeof actual.serve>;
+        },
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+
+    await expect(
+      orchMod.runControlPlane(
+        { role: "control-plane", poolCount: 1 },
+        { port },
+      ),
+    ).rejects.toThrow(/simulated EADDRINUSE from async listen\(\)/);
+
+    // Critical: the scheduler must have been stopped as part of teardown.
+    // Pre-fix the async bind error was unobserved and runControlPlane resolved
+    // with the scheduler (and fleet-health interval) still running.
+    expect(stopSpy).toHaveBeenCalled();
+  });
+});
+
+/**
+ * REQ-B wiring (control-plane integration): a swept/lease-expired job's
+ * `worker-crashed-mid-job` overlay must reach the `d6:<slug>` dashboard status
+ * row through `runControlPlane`'s wiring.
+ *
+ * The control-plane MODULE seams exist (the producer forwards swept comm errors
+ * to an injected `onSweepCommErrors` sink; `createControlPlane` exposes
+ * `surfaceSweepCommErrors` which resolves each error's `d6:<slug>` key via an
+ * injected `resolveSweepAggregateKey` and writes the overlay through the
+ * aggregator), but pre-wiring `runControlPlane` did NOT connect them — the
+ * producer was built with no sink and `createControlPlane` received no
+ * aggregator/resolver, so the crash-path overlay was INERT.
+ *
+ * This drives a real swept job through `runControlPlane`'s assembly: the queue's
+ * `sweepExpired` yields one comm error (jobId `job-swept-1`), pb resolves that
+ * job row to `probe_key = d6:swept-svc`, and the producer tick (the registered
+ * scheduler handler) runs the sweep. The assertion is that the comm-error
+ * overlay landed on the `d6:swept-svc` status row via the status-writer. Against
+ * the unwired state this never fires (no sink, no resolver); once wired it does.
+ */
+describe("orchestrator runControlPlane REQ-B sweep wiring (control-plane integration)", () => {
+  let port = 0;
+
+  beforeEach(async () => {
+    port = await pickPort();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces a swept job's worker-crashed overlay onto its d6:<slug> status row", async () => {
+    vi.resetModules();
+
+    // Immunize against a sibling test's leaked `@hono/node-server` doMock (the
+    // async-bind tests register a serve() stub that rejects via setTimeout): we
+    // need the REAL serve() so this role binds cleanly and the producer tick can
+    // run. vi.doMock registrations persist across the file, so pin it explicitly.
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+
+    const sweptCommError: PoolCommError = {
+      kind: "worker-crashed-mid-job",
+      message: "lease expired; worker presumed crashed",
+      workerId: "worker-dead",
+      jobId: "job-swept-1",
+      observedAt: "2026-06-04T00:00:00.000Z",
+    };
+
+    // Queue fake: sweepExpired yields the swept comm error exactly once (the
+    // producer's first tick sweeps because lastSweepAt is null). enqueue is a
+    // no-op (the enumerator is empty), claimNext/renew/report are unused here.
+    vi.doMock("./fleet/queue-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./fleet/queue-client.js")
+      >("./fleet/queue-client.js");
+      let swept = false;
+      return {
+        ...actual,
+        createFleetQueueClient: () => ({
+          enqueue: async () => ({}) as never,
+          claimNext: async () => ({ claimed: false }) as never,
+          renewLease: async () => null,
+          report: async () => undefined,
+          sweepExpired: async () => {
+            if (swept) return { reclaimed: 0, commErrors: [] };
+            swept = true;
+            return { reclaimed: 1, commErrors: [sweptCommError] };
+          },
+        }),
+      };
+    });
+
+    // pb fake: getOne(probe_jobs, "job-swept-1") resolves the swept job's
+    // probe_key (the resolveSweepAggregateKey lookup); getFirst(status, ...)
+    // is the "never observed" path. health() true so the role boots clean.
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async (_collection: string, id: string) =>
+            id === "job-swept-1" ? { probe_key: "d6:swept-svc" } : null,
+          getFirst: async () => null,
+        }),
+      };
+    });
+
+    // Capture every status-writer write so we can assert the overlay landed on
+    // the d6:<slug> row.
+    const writes: ProbeResult<unknown>[] = [];
+    vi.doMock("./writers/status-writer.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./writers/status-writer.js")
+      >("./writers/status-writer.js");
+      return {
+        ...actual,
+        createStatusWriter: () => ({
+          write: async (r: ProbeResult<unknown>) => {
+            writes.push(r);
+            return undefined;
+          },
+        }),
+      };
+    });
+
+    // run-history writer is irrelevant to the sweep leg; stub it so the
+    // aggregator constructs without a real PB run-history collection.
+    vi.doMock("./probes/run-history.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./probes/run-history.js")
+      >("./probes/run-history.js");
+      return {
+        ...actual,
+        createProbeRunWriter: () => ({
+          findByJobId: async () => null,
+          start: async () => ({}) as never,
+          finishTerminal: async () => undefined,
+        }),
+      };
+    });
+
+    // Capture the producer's scheduler handler so we can drive a tick (which
+    // runs the sweep) deterministically without waiting on cron.
+    let producerHandler: (() => Promise<unknown>) | undefined;
+    vi.doMock("./scheduler/scheduler.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./scheduler/scheduler.js")
+      >("./scheduler/scheduler.js");
+      return {
+        ...actual,
+        createScheduler: (
+          deps: Parameters<typeof actual.createScheduler>[0],
+        ) => {
+          const real = actual.createScheduler(deps);
+          return {
+            ...real,
+            register: (entry: {
+              id: string;
+              cron: string;
+              handler: () => Promise<unknown>;
+            }) => {
+              producerHandler = entry.handler;
+              return (real.register as (...a: unknown[]) => unknown)(entry);
+            },
+          };
+        },
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      // Empty enumerator → no enqueue churn; the sweep still runs on tick.
+      { port, fleetEnumerate: async () => [] },
+    );
+
+    try {
+      expect(producerHandler).toBeDefined();
+      // Drive one producer tick → maybeSweep → onSweepCommErrors →
+      // surfaceSweepCommErrors → resolveSweepAggregateKey → aggregateCommError.
+      await producerHandler!();
+
+      const overlayWrite = writes.find((w) => w.key === "d6:swept-svc");
+      expect(overlayWrite).toBeDefined();
+      const signal = overlayWrite!.signal as Record<string, unknown>;
+      const overlay = signal[FLEET_COMM_ERROR_SIGNAL_KEY] as
+        | PoolCommError
+        | undefined;
+      expect(overlay).toBeDefined();
+      expect(overlay!.kind).toBe("worker-crashed-mid-job");
+      expect(overlay!.jobId).toBe("job-swept-1");
+    } finally {
+      await handle.stop();
+    }
+  });
+});
+
+/**
+ * REQ-B worker-self-report wiring: `runControlPlane` must pass its
+ * `resolvePriorState` resolver into `createResultAggregator`, not only into
+ * `createControlPlane`.
+ *
+ * The aggregator's `aggregate()` leg preserves the prior observed colour on a
+ * worker-self-report comm error (aggregateState:"error" + commError) — BUT only
+ * if it was constructed WITH `resolvePriorState`. Pre-wiring, `runControlPlane`
+ * built the aggregator with `{ statusWriter, runWriter, logger, now }` and NO
+ * resolver, so the self-report leg fell back to the "degraded" no-data colour
+ * and STOMPED a previously-RED service to degraded. The sibling sweep-wiring
+ * test above only exercises `aggregateCommError` (the crash leg, fed through
+ * `createControlPlane`); nothing proved the `aggregate()` leg got the resolver.
+ *
+ * This drives a real worker-self-report result through `runControlPlane`'s
+ * assembled aggregator (captured at the `createResultConsumer` seam, where the
+ * orchestrator injects the very aggregator it built). pb's `getFirst(status,…)`
+ * resolves the service's prior row to state:"red". The assertion is that the
+ * primary status write lands state:"red" + the comm-error overlay — NOT
+ * degraded, NOT green. Against the unwired aggregator the resolver is absent and
+ * the row writes "degraded"; once wired it preserves "red".
+ */
+describe("orchestrator runControlPlane REQ-B worker-self-report wiring (aggregate leg prior-colour)", () => {
+  let port = 0;
+
+  beforeEach(async () => {
+    port = await pickPort();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("preserves a previously-RED service's colour on a worker-self-report comm error (not degraded)", async () => {
+    vi.resetModules();
+
+    // Pin the REAL serve() (immunize against a sibling test's leaked
+    // @hono/node-server doMock) so this role binds cleanly.
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+
+    const selfReportCommError: PoolCommError = {
+      kind: "worker-protocol-violation",
+      message: "worker could not reach the pool mid-run",
+      workerId: "worker-1",
+      jobId: "job-selfreport-1",
+      observedAt: "2026-06-04T00:00:05.000Z",
+    };
+
+    // Queue fake: no sweep churn — this leg is the consumer, not the producer.
+    vi.doMock("./fleet/queue-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./fleet/queue-client.js")
+      >("./fleet/queue-client.js");
+      return {
+        ...actual,
+        createFleetQueueClient: () => ({
+          enqueue: async () => ({}) as never,
+          claimNext: async () => ({ claimed: false }) as never,
+          renewLease: async () => null,
+          report: async () => undefined,
+          sweepExpired: async () => ({ reclaimed: 0, commErrors: [] }),
+        }),
+      };
+    });
+
+    // pb fake: getFirst(status, key=d6:selfreport-svc) returns a prior RED row
+    // so the wired resolvePriorState reads "red"; getOne unused on this leg;
+    // health() true so the role boots clean.
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async (collection: string, filter: string) => {
+            if (
+              collection === "status" &&
+              filter.includes("d6:selfreport-svc")
+            ) {
+              return { state: "red" as State };
+            }
+            return null;
+          },
+        }),
+      };
+    });
+
+    // Capture every status-writer write so we can assert the carried colour.
+    const writes: ProbeResult<unknown>[] = [];
+    vi.doMock("./writers/status-writer.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./writers/status-writer.js")
+      >("./writers/status-writer.js");
+      return {
+        ...actual,
+        createStatusWriter: () => ({
+          write: async (r: ProbeResult<unknown>) => {
+            writes.push(r);
+            return undefined;
+          },
+        }),
+      };
+    });
+
+    // run-history writer is irrelevant to the carried-colour assertion; stub it
+    // so the aggregator constructs and aggregate() runs end-to-end.
+    vi.doMock("./probes/run-history.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./probes/run-history.js")
+      >("./probes/run-history.js");
+      return {
+        ...actual,
+        createProbeRunWriter: () => ({
+          findByJobId: async () => null,
+          start: async () => ({ id: "run-selfreport-1" }) as never,
+          finish: async () => undefined,
+          finishTerminal: async () => undefined,
+        }),
+      };
+    });
+
+    // Capture the aggregator the orchestrator injects into the consumer — this
+    // is the very aggregator built by createResultAggregator, so invoking its
+    // aggregate() exercises runControlPlane's real wiring (incl. resolvePriorState).
+    let injectedAggregator:
+      | import("./fleet/control-plane/result-aggregator.js").ResultAggregator
+      | undefined;
+    vi.doMock("./fleet/control-plane/result-consumer.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./fleet/control-plane/result-consumer.js")
+      >("./fleet/control-plane/result-consumer.js");
+      return {
+        ...actual,
+        createResultConsumer: (
+          deps: Parameters<typeof actual.createResultConsumer>[0],
+        ) => {
+          injectedAggregator = deps.aggregator;
+          return { consumeOnce: async () => ({}) as never };
+        },
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      { port, fleetEnumerate: async () => [] },
+    );
+
+    try {
+      expect(injectedAggregator).toBeDefined();
+
+      // A worker-self-report comm error on a service whose worker could not
+      // reach the pool: aggregateState:"error" + a commError. With the resolver
+      // wired, aggregate() reads the prior RED row and carries "red".
+      await injectedAggregator!.aggregate({
+        jobId: "job-selfreport-1",
+        serviceSlug: "selfreport-svc",
+        driverKind: "e2e_d6",
+        aggregateKey: "d6:selfreport-svc",
+        aggregateState: "error",
+        aggregateSignal: { failedCount: 0 },
+        cells: [],
+        rollup: { total: 0, passed: 0, failed: 0 },
+        commError: selfReportCommError,
+      } as never);
+
+      const primary = writes.find((w) => w.key === "d6:selfreport-svc");
+      expect(primary).toBeDefined();
+      // The carried colour is the prior RED — NOT the degraded no-data fallback
+      // (which is what an unwired aggregator would write), and NOT green.
+      expect(primary!.state).toBe("red");
+      expect(primary!.state).not.toBe("degraded");
+      expect(primary!.state).not.toBe("green");
+      // The comm-error overlay still rides on the row the dashboard reads.
+      const signal = primary!.signal as Record<string, unknown>;
+      const overlay = signal[FLEET_COMM_ERROR_SIGNAL_KEY] as
+        | PoolCommError
+        | undefined;
+      expect(overlay).toBeDefined();
+      expect(overlay!.kind).toBe("worker-protocol-violation");
+      expect(overlay!.jobId).toBe("job-selfreport-1");
+    } finally {
+      await handle.stop();
+    }
   });
 });
 

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -70,12 +70,61 @@ import { DiscoveryAuthTracker } from "./probes/discovery/auth-tracker.js";
 import { logger, reloadLogLevel } from "./logger.js";
 import { logErrorWithStack } from "./probes/loader/probe-invoker.js";
 import { makeGql } from "./probes/discovery/railway-services.js";
-import type { Logger, State, StatusRecord, Target } from "./types/index.js";
+import type {
+  Logger,
+  ProbeResult,
+  State,
+  StatusRecord,
+  Target,
+} from "./types/index.js";
+import { resolveFleetRoleConfig } from "./fleet/role-config.js";
+import type { FleetRoleConfig } from "./fleet/role-config.js";
+import { createJobClaimClient } from "./fleet/job-claim.js";
+import {
+  createFleetQueueClient,
+  PROBE_JOBS_COLLECTION,
+} from "./fleet/queue-client.js";
+import {
+  commErrorToStatusSignal,
+  WORKERS_COLLECTION,
+  type PoolCommError,
+} from "./fleet/contracts.js";
+import { runWorker as runFleetWorker } from "./fleet/orchestrator.js";
+import { createD6PayloadToInput } from "./fleet/worker/payload-mapper.js";
+import { registerWorker } from "./fleet/worker/registration.js";
+import {
+  asKnownState,
+  createResultAggregator,
+} from "./fleet/control-plane/result-aggregator.js";
+import { createResultConsumer } from "./fleet/control-plane/result-consumer.js";
+import {
+  createFleetHealthMonitor,
+  DEFAULT_WORKER_STALE_AFTER_MS,
+  type RestartWorkerHook,
+} from "./fleet/control-plane/fleet-health.js";
+import { createD6ServiceEnumerator } from "./fleet/control-plane/catalog-enumerator.js";
+import {
+  buildJobProducer,
+  createControlPlane,
+} from "./fleet/control-plane/control-plane.js";
+import type {
+  ControlPlane,
+  PriorStateResolver,
+  SweepAggregateKeyResolver,
+} from "./fleet/control-plane/control-plane.js";
+import type { ServiceEnumerator } from "./fleet/control-plane/job-producer.js";
 
 export interface BootOptions {
   configDir?: string;
   port?: number;
   bootstrapWindowMs?: number;
+  /**
+   * Fleet control-plane ONLY: the catalog-aware per-service enumerator the job
+   * producer (S4) runs each tick. Injected so the discovery slot can supply the
+   * real railway-services enumerator; when absent, `runControlPlane` produces
+   * empty runs (see the enumeration seam there). Ignored by `boot()` / worker.
+   */
+  fleetEnumerate?: ServiceEnumerator;
 }
 
 export async function boot(opts: BootOptions = {}): Promise<{
@@ -1825,10 +1874,756 @@ export function createRailwayAdapter(
   return { listServices: cachedListServices, getServiceEnv };
 }
 
-// Only run boot() when executed directly (not when imported). Use fileURLToPath
-// so symlinks and cross-platform path normalization don't break the check.
+// ---------------------------------------------------------------------------
+// FLEET ROLE DISPATCH
+//
+// The single harness image boots in one of two runtime ROLES, selected by
+// HARNESS_ROLE (see fleet/role-config.ts):
+//
+//   control-plane — scheduler / queue / aggregator; runs NO Chromium.
+//   worker        — runs the BrowserPool, pulls jobs from the control-plane.
+//
+// `boot()` above is the CURRENT single-process orchestrator (scheduler + pool
+// in one process). The fleet split moves those responsibilities into the two
+// role bodies below. Those bodies are built in PARALLEL slots — the stubs here
+// are intentionally minimal and clearly marked; this slot (S8) owns ONLY the
+// config + role-based dispatch wiring so the image boots in the selected mode.
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal PB surface `surfaceReclaimedCommErrors` reads — a structural subset
+ * of `PbClient` so the real client satisfies it and tests can pass a tiny fake.
+ * Exported so unit tests can type their fake against it without `as any`.
+ */
+export interface CommErrorSurfacePb {
+  getOne<T>(collection: string, id: string): Promise<T | null>;
+  getFirst<T>(collection: string, filter: string): Promise<T | null>;
+}
+
+/** Deps for the REQ-B comm-error surfacer (injectable for unit tests). */
+export interface SurfaceReclaimedCommErrorsDeps {
+  pb: CommErrorSurfacePb;
+  statusWriter: { write(result: ProbeResult<unknown>): Promise<unknown> };
+  logger: Logger;
+}
+
+/**
+ * REQ-B surfacing: fleet-health DETECTS a dead worker and reclaims its in-flight
+ * jobs, returning a `worker-crashed-mid-job` PoolCommError per reclaimed job —
+ * but a comm error only reaches the dashboard once it is mirrored onto the job's
+ * STATUS row (under FLEET_COMM_ERROR_SIGNAL_KEY). The worker-self-report path
+ * does that via the aggregator; the control-plane-detected (worker-death) path
+ * has no result to aggregate, so we persist it here.
+ *
+ * Per reclaimed job we resolve the job row's `probe_key` (the dashboard status-
+ * row key) and surface the comm error under FLEET_COMM_ERROR_SIGNAL_KEY. HOW
+ * depends on whether the cell was EVER OBSERVED:
+ *
+ *   OBSERVED (a status row exists): re-write the existing row's last-known
+ *   colour carrying the overlaid signal. We deliberately do NOT write state
+ *   "error" here — the status-writer's error path persists the signal only to
+ *   `status_history`, not the `status` row the dashboard reads — so to get the
+ *   overlay onto the readable row while PRESERVING its colour we re-write the
+ *   real prior state.
+ *
+ *   NEVER OBSERVED (no status row): there is NO last-known colour to carry. The
+ *   previous code INVENTED "green" here, a false green — a service whose worker
+ *   crashed before it was ever probed would be reported healthy. Instead we
+ *   route an "error"-state result through the writer. Per the writer's F2.1
+ *   discipline this records the comm error to `status_history` WITHOUT seeding a
+ *   status row, so the cell stays "no data" (the codebase's no-data
+ *   representation: absent status row) rather than a fabricated green. The first
+ *   real worker observation then establishes the true baseline.
+ */
+export async function surfaceReclaimedCommErrors(
+  deps: SurfaceReclaimedCommErrorsDeps,
+  commErrors: readonly PoolCommError[],
+): Promise<void> {
+  const { pb, statusWriter, logger } = deps;
+  for (const err of commErrors) {
+    if (!err.jobId) continue;
+    try {
+      const job = await pb.getOne<{ probe_key?: string }>(
+        PROBE_JOBS_COLLECTION,
+        err.jobId,
+      );
+      const probeKey = job?.probe_key;
+      if (!probeKey) {
+        logger.warn("fleet.control-plane.commerror-no-probekey", {
+          jobId: err.jobId,
+        });
+        continue;
+      }
+      const existing = await pb.getFirst<{ state?: string; signal?: unknown }>(
+        "status",
+        `key = ${JSON.stringify(probeKey)}`,
+      );
+      const baseSignal =
+        existing?.signal && typeof existing.signal === "object"
+          ? (existing.signal as Record<string, unknown>)
+          : {};
+      const overlaidSignal = { ...baseSignal, ...commErrorToStatusSignal(err) };
+      // Validate the PB string against the known State set rather than
+      // blind-casting it — a malformed/legacy `state` degrades to the no-data
+      // ("error") path below instead of being re-persisted as a bogus colour.
+      const priorState = asKnownState(existing?.state);
+      // Never observed → write as "error" so NO green status row is invented;
+      // observed → re-write the real prior colour carrying the overlay.
+      await statusWriter.write({
+        key: probeKey,
+        state: priorState ?? "error",
+        signal: overlaidSignal,
+        observedAt: err.observedAt,
+      });
+      logger.info("fleet.control-plane.commerror-surfaced", {
+        jobId: err.jobId,
+        probeKey,
+        kind: err.kind,
+        carriedState: priorState ?? "no-data",
+      });
+    } catch (writeErr) {
+      // Best-effort: a failed surface must not wedge the monitor — the job is
+      // already reclaimed; the next cycle's worker run re-establishes the row.
+      logger.warn("fleet.control-plane.commerror-surface-failed", {
+        jobId: err.jobId,
+        err: writeErr instanceof Error ? writeErr.message : String(writeErr),
+      });
+    }
+  }
+}
+
+/**
+ * Control-plane role entrypoint: scheduler / queue / aggregator. Runs NO
+ * Chromium / BrowserPool.
+ *
+ * Fully implemented. It:
+ *   - stands up the scheduler + the fleet job producer (the non-pool half of
+ *     `boot()`), driving enqueue on the producer cron cadence,
+ *   - exposes the PocketBase-backed job queue the workers pull from,
+ *   - aggregates worker results into the existing status/alert write path via
+ *     the result-consumer→aggregator bridge,
+ *   - runs the fleet-health monitor that reclaims a dead worker's in-flight
+ *     jobs and surfaces the resulting comm errors onto the dashboard, and
+ *   - returns the same `{ stop, port, bus }` shape `boot()` returns so the
+ *     entrypoint's lifecycle handling stays uniform.
+ */
+export async function runControlPlane(
+  config: FleetRoleConfig,
+  opts: BootOptions = {},
+): Promise<Awaited<ReturnType<typeof boot>>> {
+  logger.info("showcase-harness.fleet.role-selected", {
+    role: config.role,
+    poolCount: config.poolCount,
+  });
+
+  const env = process.env;
+  const port = opts.port ?? (Number(env.PORT ?? 8080) || 8080);
+
+  const pbCfg = resolveFleetPbConfig();
+  const pb = createPbClient({
+    url: pbCfg.url,
+    email: pbCfg.email,
+    password: pbCfg.password,
+    logger,
+  });
+  const claim = createJobClaimClient({
+    url: pbCfg.url,
+    email: pbCfg.email,
+    password: pbCfg.password,
+    logger,
+  });
+  const bus = createEventBus();
+  const queue = createFleetQueueClient({ pb, claim, logger });
+  const scheduler = createScheduler({ logger });
+
+  // S5 aggregator — the ONLY authoritative dashboard writer — over the
+  // UNCHANGED status + run-history pipelines (preserves the dashboard row
+  // shapes exactly; see result-aggregator.ts). It is the single sink for BOTH
+  // worker-self-report results AND the REQ-B crash-path comm-error overlays:
+  // the control-plane feeds the producer-sweep + fleet-health legs into its
+  // `aggregateCommError`.
+  const statusWriter = createStatusWriter({ pb, bus, logger });
+  // REQ-B: read the CURRENT dashboard status-row colour for an aggregate key so
+  // EVERY comm-error leg preserves it on the overlay (a `red` service whose
+  // worker crashes — or whose worker self-reports a comm error — stays `red` +
+  // unreachable) instead of stomping it to green/degraded. Validates the read
+  // value against the known State set; a never-observed key (no row) returns
+  // null → the no-data ("error") path, never a fabricated green. Self-defensive:
+  // a lookup throw returns null. This SAME resolver is passed into BOTH the
+  // aggregator (its `aggregate()` worker-self-report leg) AND the control-plane
+  // (its `aggregateCommError` crash/lease-expiry legs) so all three legs share
+  // identical prior-colour semantics.
+  const statusReader = createStatusReader(pb);
+  const resolvePriorState: PriorStateResolver = async (
+    aggregateKey,
+  ): Promise<State | null> => {
+    try {
+      const state = await statusReader.getStateByKey(aggregateKey);
+      return asKnownState(state) ?? null;
+    } catch (err) {
+      logger.warn("fleet.control-plane.prior-state-lookup-failed", {
+        aggregateKey,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  };
+  const aggregator = createResultAggregator({
+    statusWriter,
+    runWriter: createProbeRunWriter(pb),
+    logger,
+    now: () => Date.now(),
+    // Preserve the prior observed colour on the worker-self-report comm-error
+    // leg (REQ-B): without this, `aggregate()` falls back to the "degraded"
+    // no-data colour for a service whose worker reports a comm error, stomping
+    // a previously-RED service. Sharing the control-plane's resolver keeps the
+    // aggregate() leg consistent with the aggregateCommError() crash legs.
+    resolvePriorState,
+  });
+  // The worker->aggregator bridge: polls terminal rows carrying an unprocessed
+  // ServiceJobResult and aggregates each exactly once. REQ-B (Fix A1): share the
+  // SAME prior-state resolver the aggregator + control-plane legs use so the
+  // consumer's result-lost leg preserves a previously-observed service's colour
+  // on its ⚡ "unreachable" overlay (lands on the LIVE status row, not
+  // history-only) instead of falling back to the no-data "error" path.
+  const consumer = createResultConsumer({
+    pb,
+    aggregator,
+    logger,
+    resolvePriorState,
+  });
+
+  // S10 fleet-health: a HEARTBEAT-driven monitor (the complement to the
+  // producer's lease-driven sweepExpired) that reads the `workers` roster,
+  // detects stale/offline workers, and reclaims their in-flight jobs back to
+  // pending — emitting a `worker-crashed-mid-job` comm error (REQ-B) per
+  // reclaimed job so the dashboard surfaces the pool outage. The restart hook is
+  // best-effort and env-guarded (Railway serviceInstanceRedeploy in staging);
+  // locally it stays a no-op so N=1 docker needs no Railway wiring.
+  const fleetHealth = createFleetHealthMonitor({
+    pb,
+    claim,
+    logger,
+    staleAfterMs: resolveWorkerStaleAfterMs(),
+    restartWorker: resolveWorkerRestartHook(logger),
+  });
+
+  // CATALOG-AWARE ENUMERATION: the per-service unit enumerator resolves the
+  // showcase service catalog (Railway discovery → backendUrl, declared demos,
+  // manifest NSF, shape) into one ServiceJobSpec per service, with the d6 driver
+  // input serialized into `driverInputs` (the worker re-hydrates it via
+  // createD6PayloadToInput). This is the SAME `railway-services` source + d6
+  // filter the in-process `d6-all-pills-e2e` probe uses, so the fleet enumerates
+  // the IDENTICAL service set (and the LOCAL_SERVICES_JSON local-injection seam
+  // works unchanged for the N=1 gate). `opts.fleetEnumerate` still overrides for
+  // tests / bespoke runs.
+  const enumerate: ServiceEnumerator =
+    opts.fleetEnumerate ??
+    createD6ServiceEnumerator({
+      source: railwayServicesSource,
+      env: process.env,
+      fetchImpl: globalThis.fetch,
+      logger,
+    });
+  // REQ-B producer-sweep leg: the producer's lease-driven `sweepExpired`
+  // synthesizes a `worker-crashed-mid-job` comm error per reclaimed job, but a
+  // bare swept error carries only the `jobId`, not the `d6:<slug>` dashboard
+  // key. This resolver maps each error to its aggregate key via the SAME
+  // `probe_jobs` row lookup `surfaceReclaimedCommErrors` used (the job row's
+  // `probe_key` IS the `d6:<slug>` aggregate status-row key). Returns null to
+  // SKIP an error whose row vanished — the control-plane's surfaceSweepCommErrors
+  // logs+skips it. SELF-DEFENSIVE: a lookup throw is caught HERE and returns null
+  // (mirroring surfaceReclaimedCommErrors's own try/catch) so one bad lookup
+  // skips just this error and never aborts the sweep leg — we do NOT delegate
+  // the catch to the caller.
+  const resolveSweepAggregateKey: SweepAggregateKeyResolver = async (
+    commError,
+  ): Promise<string | null> => {
+    if (!commError.jobId) return null;
+    try {
+      const job = await pb.getOne<{ probe_key?: string }>(
+        PROBE_JOBS_COLLECTION,
+        commError.jobId,
+      );
+      return job?.probe_key ?? null;
+    } catch (err) {
+      logger.warn("fleet.control-plane.sweep-aggregate-key-lookup-failed", {
+        jobId: commError.jobId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  };
+
+  // Forward-reference the assembled control-plane so the producer's sweep sink
+  // can call `surfaceSweepCommErrors` (the control-plane needs the producer, the
+  // producer needs the control-plane's sink — break the cycle with a late bind).
+  let controlPlaneRef: ControlPlane | undefined;
+  const producer = buildJobProducer({
+    queue,
+    enumerate,
+    logger,
+    // REQ-B: forward swept comm errors into the control-plane's surfacing sink,
+    // which resolves each `d6:<slug>` key and writes the overlay through the
+    // aggregator. Best-effort; never aborts production.
+    onSweepCommErrors: async (commErrors) => {
+      await controlPlaneRef?.surfaceSweepCommErrors(commErrors);
+    },
+  });
+
+  // Producer cron cadence. Defaults to the hourly-at-:40 rhythm
+  // (DEFAULT_PRODUCER_CRON) that mirrors the legacy in-process d6 probe.
+  // Env-overridable via FLEET_PRODUCER_CRON so a local N=1 run can drive the
+  // SAME enqueue path on a fast cadence (e.g. `* * * * *`) instead of waiting
+  // up to an hour for the top-of-:40 tick — local exercises the identical
+  // producer→queue→worker→consumer chain prod runs, just more often.
+  const producerCron = process.env.FLEET_PRODUCER_CRON?.trim() || undefined;
+
+  // REQ-B: wire the real aggregator + fleet-health monitor + sweep-key resolver
+  // into the control-plane assembly so BOTH crash-path legs surface onto the
+  // dashboard through the proper module seams (the control-plane runs the
+  // fleet-health monitor on its own interval and feeds each reclaimedOverlays
+  // entry — and each swept error via surfaceSweepCommErrors — to the aggregator).
+  const controlPlane = createControlPlane({
+    producer,
+    consumer,
+    scheduler,
+    logger,
+    aggregator,
+    fleetHealth,
+    resolveSweepAggregateKey,
+    resolvePriorState,
+    ...(producerCron ? { producerCron } : {}),
+  });
+  controlPlaneRef = controlPlane;
+
+  // Minimal HTTP surface for the role's liveness `port` (fleet-health probes
+  // hit this). /health reports OK once the producer's scheduler entry is live.
+  const app = buildServer({
+    pb,
+    logger,
+    // The control-plane is a scheduler/queue/aggregator with NO probe rules —
+    // only the single fleet-job-producer scheduler entry. The role flag drops
+    // /health's `rules > 0` gate so the container reports HEALTHY on its real
+    // liveness signals (pb ok, scheduler started + alive, schedulerJobs>0);
+    // without it /health is degraded forever (rules always 0) and Railway
+    // restart-loops the service.
+    role: "control-plane",
+    ruleCount: () => 0,
+    schedulerStarted: () => scheduler.isStarted(),
+    schedulerJobCount: () => scheduler.list().length,
+    schedulerIsStopped: () => scheduler.isStopped(),
+    bus,
+  });
+
+  scheduler.start();
+  // controlPlane.start() ALSO starts the fleet-health monitor on its own
+  // internal interval (REQ-B): because the real `fleetHealth` + `aggregator`
+  // are now injected above, each cycle's `reclaimedOverlays` is fed straight to
+  // `aggregator.aggregateCommError`, and the producer's swept errors flow
+  // through `surfaceSweepCommErrors`. This supersedes the prior ad-hoc
+  // fleet-health timer that lived here (which dropped the producer-sweep leg
+  // entirely) — the surfacing now lives in the proper control-plane module seams.
+  controlPlane.start();
+
+  // Teardown of everything stood up above, used by BOTH bind-failure paths
+  // (the synchronous serve() throw and the async server.listen() 'error') so a
+  // failed bind never leaves the control-plane's fleet-health + consumer loops
+  // and scheduler orphaned (the orphan/restart-loop class boot()'s R4-A.3 race
+  // exists to prevent — see boot() above). controlPlane.stop() clears its own
+  // internal intervals. Best-effort: operators see the original bind error, not
+  // a teardown-failure shadow.
+  async function teardownAfterBindFailure(): Promise<void> {
+    await controlPlane.stop().catch((stopErr) =>
+      logger.error("fleet.control-plane.stop-after-bind-failure", {
+        err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+      }),
+    );
+    await scheduler.stop().catch((stopErr) =>
+      logger.error("fleet.control-plane.scheduler-stop-after-bind-failure", {
+        err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+      }),
+    );
+  }
+
+  let server: ReturnType<typeof serve>;
+  try {
+    server = serve({ fetch: app.fetch, port });
+  } catch (err) {
+    await teardownAfterBindFailure();
+    throw err;
+  }
+
+  // R4-A.3 (mirrors boot()): serve() returns the http.Server SYNCHRONOUSLY but
+  // bind happens via server.listen() which emits 'error' ASYNCHRONOUSLY for
+  // conditions like EADDRINUSE. The try/catch above only catches synchronous
+  // throws — a real async bind failure would resolve runControlPlane()
+  // "successfully" while leaving the control-plane's fleet-health + consumer
+  // loops and scheduler orphaned. Race 'listening' vs 'error' so async bind
+  // errors propagate as a rejection AND tear those down. If the server is
+  // already `listening` by the time we attach (sync bind raced ahead), short-
+  // circuit to resolve.
+  await new Promise<void>((resolve, reject) => {
+    const srv = server as unknown as {
+      listening?: boolean;
+      once(event: string, cb: (...args: unknown[]) => void): unknown;
+      removeListener(event: string, cb: (...args: unknown[]) => void): unknown;
+    };
+    const onListen = (): void => {
+      srv.removeListener("error", onError);
+      resolve();
+    };
+    const onError = (err: unknown): void => {
+      srv.removeListener("listening", onListen);
+      // Fire teardown as its own chain so the rejection below isn't gated on
+      // stop() — operators see the original bind error, not a stop-failure
+      // shadow.
+      void teardownAfterBindFailure();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    };
+    srv.once("listening", onListen);
+    srv.once("error", onError);
+    if (srv.listening === true) {
+      srv.removeListener("error", onError);
+      srv.removeListener("listening", onListen);
+      resolve();
+    }
+  });
+
+  logger.info("showcase-harness.fleet.control-plane.boot", {
+    port,
+    pbUrl: pbCfg.url,
+    poolCount: config.poolCount,
+  });
+
+  return {
+    port,
+    bus,
+    async stop(): Promise<void> {
+      // controlPlane.stop() clears its own internal fleet-health + consumer
+      // intervals (REQ-B seams now own that lifecycle).
+      await controlPlane.stop();
+      await scheduler.stop();
+      await new Promise<void>((resolve) => {
+        const srv = server as unknown as {
+          close?: (cb?: () => void) => void;
+        };
+        if (typeof srv.close === "function") srv.close(() => resolve());
+        else resolve();
+      });
+      logger.info("showcase-harness.fleet.control-plane.stopped");
+    },
+  };
+}
+
+/**
+ * Resolve the heartbeat staleness window (ms): how long since a worker's last
+ * heartbeat before fleet-health treats it as dead and reclaims its jobs.
+ * Env-overridable via WORKER_STALE_AFTER_MS; defaults to
+ * DEFAULT_WORKER_STALE_AFTER_MS. A non-positive / unparseable override falls
+ * back to the default rather than disabling the monitor.
+ */
+function resolveWorkerStaleAfterMs(): number {
+  const raw = process.env.WORKER_STALE_AFTER_MS;
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return DEFAULT_WORKER_STALE_AFTER_MS;
+}
+
+/**
+ * Resolve the best-effort worker-restart hook fleet-health fires for a wedged
+ * worker. In STAGING a wedged worker is recovered by a Railway
+ * `serviceInstanceRedeploy`; the wiring is env-guarded so it only engages when
+ * the Railway recovery creds are present (RAILWAY_TOKEN + RAILWAY_ENVIRONMENT_ID
+ * + the worker service id). LOCALLY (no creds) the hook stays a NO-OP — docker /
+ * the worker's own relaunch handles recovery, so N=1 needs no Railway wiring.
+ *
+ * The actual Railway GraphQL redeploy call is owned by the deploy/ops slot; this
+ * resolver only DECIDES whether a real hook or the no-op is installed, logging
+ * the decision so the recovery posture is greppable at boot.
+ */
+function resolveWorkerRestartHook(log: Logger): RestartWorkerHook | undefined {
+  const hasRailwayRecovery =
+    !!process.env.RAILWAY_TOKEN &&
+    !!process.env.RAILWAY_ENVIRONMENT_ID &&
+    !!process.env.FLEET_WORKER_SERVICE_ID;
+  if (!hasRailwayRecovery) {
+    log.info("fleet.control-plane.health-restart-noop", {
+      msg: "no Railway recovery creds — wedged-worker restart is a no-op (docker handles local recovery)",
+    });
+    // undefined → fleet-health installs its default no-op.
+    return undefined;
+  }
+  log.info("fleet.control-plane.health-restart-armed", {
+    msg: "Railway recovery creds present — wedged workers will be redeployed best-effort",
+  });
+  return async (workerId: string): Promise<void> => {
+    // Best-effort staging recovery: a wedged worker is redeployed via Railway's
+    // serviceInstanceRedeploy. The concrete GraphQL call is owned by the
+    // deploy/ops slot; until that lands we log the intent so the recovery path
+    // is observable without silently pretending it fired.
+    log.warn("fleet.control-plane.health-restart-requested", {
+      workerId,
+      serviceId: process.env.FLEET_WORKER_SERVICE_ID,
+      msg: "wedged worker flagged for Railway serviceInstanceRedeploy (deploy-slot wiring pending)",
+    });
+  };
+}
+
+/**
+ * Resolve the PocketBase URL + superuser creds the fleet clients authenticate
+ * with, mirroring `boot()`'s fail-loud-in-prod discipline so a worker that
+ * can't reach PB dies on boot (visible in deploy CI / Railway health-check)
+ * rather than silently claiming nothing.
+ */
+function resolveFleetPbConfig(): {
+  url: string;
+  email?: string;
+  password?: string;
+} {
+  const rawPbUrl = process.env.POCKETBASE_URL;
+  if (!rawPbUrl && process.env.NODE_ENV === "production") {
+    logger.error("orchestrator.FATAL-CONFIG", {
+      msg: "POCKETBASE_URL required in production",
+      nodeEnv: process.env.NODE_ENV,
+    });
+    throw new Error(
+      "FATAL-CONFIG: POCKETBASE_URL required in production (NODE_ENV=production)",
+    );
+  }
+  return {
+    url: rawPbUrl ?? "http://localhost:8090",
+    email: process.env.POCKETBASE_SUPERUSER_EMAIL,
+    password: process.env.POCKETBASE_SUPERUSER_PASSWORD,
+  };
+}
+
+/**
+ * Minimal PB surface `verifyWorkerRegistered` needs (injectable for tests).
+ * Exported so unit tests can type their fake against it without `as any`.
+ */
+export interface WorkerRegistryReadPb {
+  getFirst<T>(collection: string, filter: string): Promise<T | null>;
+}
+
+/**
+ * Verify a worker's registration row actually PERSISTED, returning the true
+ * `registered` value the worker's /health probe reports.
+ *
+ * `registerWorker` (fleet/worker/registration.ts) is best-effort: it swallows
+ * the boot upsert's failure (missing migration, PB 400/outage) and never
+ * rejects — so "it returned" is NOT proof the row landed. Pre-fix the worker set
+ * `registered = true` regardless, so a failed registration still reported
+ * healthy (or, under a /health hard-gate, silently restart-looped). We instead
+ * read the row back: present → true, absent OR read error → false. Best-effort
+ * by design — a verify failure must not break the worker (it only governs the
+ * /health roster signal), so we warn and return false rather than throw.
+ */
+export async function verifyWorkerRegistered(deps: {
+  pb: WorkerRegistryReadPb;
+  workerId: string;
+  logger: Logger;
+}): Promise<boolean> {
+  const { pb, workerId, logger } = deps;
+  let registered = false;
+  try {
+    const row = await pb.getFirst<{ id?: string }>(
+      WORKERS_COLLECTION,
+      `worker_id = ${JSON.stringify(workerId)}`,
+    );
+    registered = !!row?.id;
+  } catch (err) {
+    logger.warn("showcase-harness.fleet.worker.registration-verify-failed", {
+      workerId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+  if (!registered) {
+    logger.warn("showcase-harness.fleet.worker.registration-not-persisted", {
+      workerId,
+      msg: "worker registration row did not persist — /health will report unregistered until a heartbeat lands it",
+    });
+  }
+  return registered;
+}
+
+/**
+ * Worker role entrypoint: runs the BrowserPool and pulls per-service jobs from
+ * the control-plane queue.
+ *
+ * Assembles the fleet worker from its slots and hands them to S7's real
+ * `runWorker` (fleet/orchestrator.ts), which owns the pool + driver + loop:
+ *   - the queue client (S3 `createFleetQueueClient`) over S0's `JobClaimClient`
+ *     + the harness `PbClient`,
+ *   - the worker's own `BrowserPool` (the self-bounded context budget) + the
+ *     pooled d6 driver wired onto it,
+ *   - self-registration + heartbeat (S9 `registerWorker`) keyed on the same
+ *     workerId the claim CAS stamps as `claimed_by`,
+ *   - the catalog-aware payload→d6-input mapping (`createD6PayloadToInput`).
+ *
+ * Returns the `{ stop, port, bus }` shape symmetric with `boot()` — `stop()`
+ * tears down BOTH the registration heartbeat and the worker loop/pool.
+ */
+export async function runWorker(
+  config: FleetRoleConfig,
+  opts: BootOptions = {},
+): Promise<Awaited<ReturnType<typeof boot>>> {
+  logger.info("showcase-harness.fleet.role-selected", {
+    role: config.role,
+    poolCount: config.poolCount,
+  });
+
+  const env = process.env;
+  const workerId =
+    env.HOSTNAME && env.HOSTNAME.trim().length > 0
+      ? `worker-${env.HOSTNAME.trim()}`
+      : `worker-${Math.random().toString(36).slice(2, 10)}`;
+  // Default to 8080 (the EXPOSE/Dockerfile/healthcheck port the compose worker
+  // sets via PORT=8080) — NOT 8090, which is PocketBase's port and never
+  // matched the worker healthcheck.
+  const port = opts.port ?? (Number(env.PORT ?? 8080) || 8080);
+
+  const pbCfg = resolveFleetPbConfig();
+  const pb = createPbClient({
+    url: pbCfg.url,
+    email: pbCfg.email,
+    password: pbCfg.password,
+    logger,
+  });
+  const claim = createJobClaimClient({
+    url: pbCfg.url,
+    email: pbCfg.email,
+    password: pbCfg.password,
+    logger,
+  });
+  const queue = createFleetQueueClient({ pb, claim, logger });
+
+  // The worker's own pool: the self-bounded context budget that gates claiming
+  // and keeps the worker under its cgroup pids ceiling. We construct it HERE
+  // (rather than letting fleet runWorker construct its own) so the SAME pool
+  // backs both the registration capacity heartbeat (S9) and the driver runs.
+  const pool = new BrowserPool({ logger });
+  await pool.init();
+
+  const driver = createE2eFullDriver({
+    launcher: createPooledE2eFullLauncher(pool, logger),
+  });
+
+  // Self-register + start the capacity heartbeat against this worker's pool.
+  // Best-effort by contract (registerWorker never rejects); a missing workers
+  // migration / PB blip warns but never blocks the loop. The endpoint carries a
+  // scheme (http://) so the control-plane can probe it as a URL rather than
+  // having to synthesize one from a bare host:port.
+  const host = env.HOSTNAME?.trim() || "localhost";
+  let registered = false;
+  const registration = await registerWorker({
+    pb,
+    pool,
+    logger,
+    workerId,
+    endpoint: `http://${host}:${port}`,
+  });
+  // registerWorker's boot upsert is best-effort: it SWALLOWS a PB failure
+  // (missing migration, 400, outage) and never rejects, so the mere fact that
+  // it returned tells us nothing about whether the row actually persisted.
+  // Pre-fix this code set `registered = true` unconditionally — a failed
+  // registration still reported the worker as on the roster (and, combined with
+  // a /health hard-gate, silently restart-looped). Instead VERIFY the row truly
+  // landed by reading it back, so `registered` reflects the ACTUAL upsert
+  // outcome (see `verifyWorkerRegistered`). The worker still runs its claim/loop
+  // regardless; this flag only governs what /health reports.
+  registered = await verifyWorkerRegistered({ pb, workerId, logger });
+
+  let worker: Awaited<ReturnType<typeof runFleetWorker>>;
+  try {
+    worker = await runFleetWorker(config, {
+      queue,
+      payloadToInput: createD6PayloadToInput(),
+      workerId,
+      port,
+      logger,
+      env,
+      // Inject the pool we own as BOTH the budget gate and the driver backing —
+      // fleet runWorker skips constructing its own pool when both are supplied.
+      budgetSource: pool,
+      driver,
+      // Wire the worker /health server's liveness probes: pb reachability +
+      // registration. The fleet runWorker binds /health on the resolved port so
+      // the docker/Railway healthcheck answers (no restart-loop).
+      pbHealth: () => pb.health(),
+      registered: () => registered,
+      // Reflect the live job on the registration row: heartbeat with the
+      // claimed jobId when a job starts, null when it settles. Best-effort —
+      // registration.heartbeat swallows its own errors, and the loop guards
+      // the call, so this can never break the worker.
+      onCurrentJobChange: (currentJobId) => {
+        void registration.heartbeat(currentJobId);
+      },
+    });
+  } catch (err) {
+    // Never strand the registration heartbeat or the pool's chromium processes
+    // if the loop fails to start.
+    registration.stop();
+    await pool.shutdown().catch(() => {});
+    throw err;
+  }
+
+  return {
+    port: worker.port,
+    bus: worker.bus,
+    async stop(): Promise<void> {
+      registration.stop();
+      // We injected BOTH budgetSource and driver, so fleet runWorker did NOT
+      // construct its own pool — its stop() only drains the in-flight job and
+      // stops the loop. WE own the pool, so we shut it down ourselves below.
+      await worker.stop();
+      await pool.shutdown().catch((err) =>
+        logger.error("showcase-harness.fleet.worker.pool-shutdown-failed", {
+          workerId,
+          err: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    },
+  };
+}
+
+/**
+ * Resolve the fleet role from env and dispatch to the matching role body.
+ *
+ * HARNESS_ROLE is REQUIRED — there is no default. An unset or empty/whitespace
+ * HARNESS_ROLE throws at boot (fail loud) rather than silently defaulting to
+ * `control-plane`. This is deliberate: a defaulted control-plane boots POOLLESS
+ * and runs NO Chromium probes itself (it only schedules/queues jobs for workers
+ * and aggregates their results), so an un-migrated deploy that left HARNESS_ROLE
+ * unset would silently stop probing. Failing loud makes that misconfiguration
+ * die immediately (visible in deploy CI / Railway health-check). Every fleet
+ * member MUST set HARNESS_ROLE explicitly (control-plane or worker) — see
+ * docker-compose.local.yml, which sets it on both services.
+ */
+export async function bootFleet(
+  opts: BootOptions = {},
+): Promise<Awaited<ReturnType<typeof boot>>> {
+  const config = resolveFleetRoleConfig();
+  switch (config.role) {
+    case "control-plane":
+      return runControlPlane(config, opts);
+    case "worker":
+      return runWorker(config, opts);
+    default: {
+      // Exhaustiveness guard: a new HarnessRole added without a dispatch arm
+      // is a compile error here, not a silent fall-through.
+      const _exhaustive: never = config.role;
+      throw new Error(`Unhandled HARNESS_ROLE: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+// Only run on direct execution (not when imported). Use fileURLToPath so
+// symlinks and cross-platform path normalization don't break the check. The
+// entrypoint goes through bootFleet() so HARNESS_ROLE selects the runtime mode.
 if (process.argv[1] && url.fileURLToPath(import.meta.url) === process.argv[1]) {
-  boot().catch((err) => {
+  bootFleet().catch((err) => {
     logErrorWithStack(logger, "showcase-harness.boot-failed", err);
     process.exit(1);
   });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -886,9 +886,7 @@ describe("BrowserPool — context pooling over fixed browser set", () => {
 
     // Enqueue a waiter with a SHORT timeout — it pends past the cap.
     let waiterRejected: Error | undefined;
-    const waiterP = pool
-      .acquire(undefined, 20)
-      .catch((e: Error) => (waiterRejected = e));
+    void pool.acquire(undefined, 20).catch((e: Error) => (waiterRejected = e));
     await drainMicrotasks();
 
     // Release c1 → serveNextWaiter() picks the waiter, calls newContext()
@@ -3591,6 +3589,97 @@ describe("BrowserPool — resource-gauge instrumentation (PID-ceiling early warn
     const ctx = await pool.acquire(undefined, 2_000);
     expect(ctx).toBeDefined();
     await pool.release(ctx);
+
+    await pool.shutdown();
+  });
+});
+
+// budget() is the fleet WORKER's live "can I take more work?" signal for the
+// pull-queue claim gate: free context budget (available > 0) AND cgroup-pids
+// headroom keep each worker under its pids ceiling (the PROVEN wedge). These
+// assert the in-memory counts track acquire/release and that the cheap cgroup
+// pids read is folded in (injected reader, no live cgroup filesystem needed).
+describe("BrowserPool — budget() worker capacity gate", () => {
+  it("reflects inUse/available/max as contexts are acquired and released", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 3,
+      launchBrowser,
+      launchStaggerMs: 0,
+      // Injected cgroup reader so the pids fields are deterministic.
+      cgroupPidsReader: () => ({ current: 120, max: 1000 }),
+    });
+    await pool.init();
+
+    // Empty pool: full budget available, nothing in use.
+    expect(pool.budget()).toEqual({
+      inUse: 0,
+      available: 3,
+      max: 3,
+      pidsCurrent: 120,
+      pidsMax: 1000,
+    });
+
+    const c1 = await pool.acquire();
+    expect(pool.budget()).toMatchObject({ inUse: 1, available: 2, max: 3 });
+
+    const c2 = await pool.acquire();
+    expect(pool.budget()).toMatchObject({ inUse: 2, available: 1, max: 3 });
+
+    // At the cap: available hits 0 — the worker must NOT claim more work.
+    const c3 = await pool.acquire();
+    expect(pool.budget()).toMatchObject({ inUse: 3, available: 0, max: 3 });
+
+    // Releasing frees budget back up.
+    await pool.release(c2);
+    expect(pool.budget()).toMatchObject({ inUse: 2, available: 1, max: 3 });
+
+    await pool.release(c1);
+    await pool.release(c3);
+    expect(pool.budget()).toMatchObject({ inUse: 0, available: 3, max: 3 });
+
+    await pool.shutdown();
+  });
+
+  it("folds the cgroup pids reading through (current/max from the reader)", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 4,
+      launchBrowser,
+      launchStaggerMs: 0,
+      cgroupPidsReader: () => ({ current: 873, max: 1000 }),
+    });
+    await pool.init();
+
+    const b = pool.budget();
+    expect(b.pidsCurrent).toBe(873);
+    expect(b.pidsMax).toBe(1000);
+
+    await pool.shutdown();
+  });
+
+  it("degrades pids fields to -1 when the cgroup reader throws", async () => {
+    const { launchBrowser } = makeFakeLauncher();
+    const pool = new BrowserPool({
+      browsers: 1,
+      maxContexts: 2,
+      launchBrowser,
+      launchStaggerMs: 0,
+      cgroupPidsReader: () => {
+        throw new Error("no cgroup controller");
+      },
+    });
+    await pool.init();
+
+    expect(pool.budget()).toEqual({
+      inUse: 0,
+      available: 2,
+      max: 2,
+      pidsCurrent: -1,
+      pidsMax: -1,
+    });
 
     await pool.shutdown();
   });

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -196,6 +196,30 @@ export interface BrowserPoolStats {
 }
 
 /**
+ * The fleet WORKER's live "can I take more work?" signal, returned by
+ * `budget()`. A worker only claims a new pull-queue job when it has free
+ * context budget (`available > 0`) AND headroom under its cgroup pids ceiling
+ * — this is what keeps each worker safely below the platform-fixed
+ * `pids.max=1000` thread/PID ceiling (the PROVEN wedge). Deliberately CHEAP:
+ * in-memory context counts plus the same cheap cgroup-PID-only read the hot
+ * acquire/release path uses — no /proc walk, no `df` (consistent with the
+ * #5234 hot-path subset). `pidsCurrent`/`pidsMax` degrade to -1 when the
+ * cgroup controller is unreadable (e.g. off-Linux).
+ */
+export interface BrowserPoolBudget {
+  /** Live contexts currently checked out across the pool. */
+  inUse: number;
+  /** Remaining context capacity: `max - inUse` (never negative). */
+  available: number;
+  /** Global context cap (`maxContexts`). */
+  max: number;
+  /** cgroup `pids.current` (current PID/thread count), or -1 if unreadable. */
+  pidsCurrent: number;
+  /** cgroup `pids.max` ceiling, or -1 if unbounded/unreadable. */
+  pidsMax: number;
+}
+
+/**
  * Minimal logger surface the pool uses for lifecycle events. Matches the
  * harness-wide `Logger` interface but only the `info` method is required;
  * `warn`/`error` are OPTIONAL so existing callers (tests, legacy boot paths)
@@ -217,6 +241,14 @@ interface PoolLogger {
  * spawning a real chromium process.
  */
 export type LaunchBrowser = () => Promise<Browser>;
+
+/**
+ * Reads the cgroup PID controller counters (`pids.current` / `pids.max`).
+ * Matches `readCgroupPids` from `resource-gauges.ts`; injectable so the fleet
+ * worker's budget gate can be tested without a live cgroup filesystem. `max`
+ * is -1 when the controller is absent or unbounded (cgroup's `max` sentinel).
+ */
+export type CgroupPidsReader = () => { current: number; max: number };
 
 /**
  * One long-lived browser PROCESS in the fixed set. Contexts are pooled over
@@ -288,6 +320,9 @@ export interface BrowserPoolOptions {
   logger?: PoolLogger;
   /** Injected launcher (tests). Defaults to the real chromium launcher. */
   launchBrowser?: LaunchBrowser;
+  /** Injected cgroup PID-counter reader (tests). Powers the hot-path gauge AND
+   *  the worker `budget()` gate. Defaults to the real `readCgroupPids`. */
+  cgroupPidsReader?: CgroupPidsReader;
   /** Stagger between serialized launches (ms). Tests pass 0. */
   launchStaggerMs?: number;
   /** Max crash-recovery relaunch retries before an entry is evicted. Default 5
@@ -439,6 +474,10 @@ export class BrowserPool {
   });
   private readonly logger?: PoolLogger;
   private readonly injectedLaunchBrowser?: LaunchBrowser;
+  // cgroup PID-counter reader for the hot-path gauge AND the worker budget()
+  // gate. Injectable so the budget signal is testable without a live cgroup
+  // filesystem; defaults to the real readCgroupPids.
+  private readonly cgroupPidsReader: CgroupPidsReader;
 
   // Crash-recovery relaunch backpressure (fix #1) + self-heal (fix #2) policy.
   private readonly relaunchMaxRetries: number;
@@ -497,6 +536,8 @@ export class BrowserPool {
   constructor(options: BrowserPoolOptions = {}) {
     this.logger = options.logger;
     this.injectedLaunchBrowser = options.launchBrowser;
+    this.cgroupPidsReader =
+      options.cgroupPidsReader ?? (() => readCgroupPids());
 
     const envBrowsers = process.env.BROWSER_POOL_BROWSERS
       ? parseInt(process.env.BROWSER_POOL_BROWSERS, 10)
@@ -696,11 +737,36 @@ export class BrowserPool {
    */
   private readHotGauges(): { pidsCurrent: number; pidsMax: number } {
     try {
-      const pids = readCgroupPids();
+      const pids = this.cgroupPidsReader();
       return { pidsCurrent: pids.current, pidsMax: pids.max };
     } catch {
       return { pidsCurrent: -1, pidsMax: -1 };
     }
+  }
+
+  /**
+   * The fleet WORKER's live capacity signal for the pull-queue claim gate. A
+   * worker consults this before claiming a new job and only takes more work
+   * when it has free context budget (`available > 0`) AND headroom under its
+   * cgroup pids ceiling — this is what keeps each worker safely below the
+   * platform-fixed `pids.max=1000` thread/PID ceiling (the PROVEN wedge).
+   *
+   * CHEAP by design — in-memory context counts plus the same cheap
+   * cgroup-PID-only read the hot acquire/release path uses (no /proc walk, no
+   * `df`; consistent with the #5234 hot-path subset). Safe to call on every
+   * claim attempt. `available` is clamped at 0 (a transient overshoot never
+   * surfaces as a negative budget); `pidsCurrent`/`pidsMax` degrade to -1 when
+   * the cgroup controller is unreadable.
+   */
+  budget(): BrowserPoolBudget {
+    const { pidsCurrent, pidsMax } = this.readHotGauges();
+    return {
+      inUse: this.liveContextCount,
+      available: Math.max(0, this.maxContexts - this.liveContextCount),
+      max: this.maxContexts,
+      pidsCurrent,
+      pidsMax,
+    };
   }
 
   /**

--- a/showcase/harness/src/probes/loader/probe-invoker.test.ts
+++ b/showcase/harness/src/probes/loader/probe-invoker.test.ts
@@ -2460,6 +2460,9 @@ describe("buildProbeInvoker", () => {
         starts.push(opts);
         return { id: `run-${nextId++}` };
       },
+      async findByJobId() {
+        return null;
+      },
       async update(opts) {
         updates.push({
           id: opts.id,
@@ -2867,6 +2870,9 @@ describe("buildProbeInvoker", () => {
       async start() {
         return { id: "run-1" };
       },
+      async findByJobId() {
+        return null;
+      },
       async update(opts) {
         order.push("update");
         updates.push({ id: opts.id });
@@ -2929,6 +2935,7 @@ describe("buildProbeInvoker", () => {
     const sched = fakeScheduler();
     const failingWriter: ProbeRunWriter = {
       start: vi.fn().mockRejectedValue(new Error("network blip")),
+      findByJobId: vi.fn().mockResolvedValue(null),
       update: vi.fn().mockResolvedValue(undefined),
       finish: vi.fn().mockResolvedValue(undefined),
       recent: vi.fn().mockResolvedValue([]),
@@ -2990,6 +2997,7 @@ describe("buildProbeInvoker", () => {
     const sched = fakeScheduler();
     const failingWriter: ProbeRunWriter = {
       start: vi.fn().mockRejectedValue(new Error("PB down")),
+      findByJobId: vi.fn().mockResolvedValue(null),
       update: vi.fn().mockResolvedValue(undefined),
       finish: vi.fn().mockResolvedValue(undefined),
       recent: vi.fn().mockResolvedValue([]),
@@ -3034,6 +3042,7 @@ describe("buildProbeInvoker", () => {
     const sched = fakeScheduler();
     const failingFinish: ProbeRunWriter = {
       start: vi.fn().mockResolvedValue({ id: "run-x" }),
+      findByJobId: vi.fn().mockResolvedValue(null),
       update: vi.fn().mockResolvedValue(undefined),
       finish: vi.fn().mockRejectedValue(new Error("PB down")),
       recent: vi.fn().mockResolvedValue([]),

--- a/showcase/harness/src/probes/run-history.test.ts
+++ b/showcase/harness/src/probes/run-history.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import {
   PROBE_RUNS_COLLECTION,
   createProbeRunWriter,
@@ -52,6 +52,10 @@ function fakePb(): {
         const m = opts.filter.match(/probe_id\s*=\s*"([^"]+)"/);
         if (m) {
           items = items.filter((r) => r.probe_id === m[1]);
+        }
+        const j = opts.filter.match(/job_id\s*=\s*"([^"]+)"/);
+        if (j) {
+          items = items.filter((r) => r.job_id === j[1]);
         }
       }
       if (opts?.sort) {
@@ -161,6 +165,75 @@ describe("run-history", () => {
         triggered: true,
       });
       expect(fake.createCalls[0]!.record.triggered).toBe(true);
+    });
+
+    it("stamps the fleet jobId (empty string when omitted for in-process runs)", async () => {
+      const writer = createProbeRunWriter(fake.pb);
+      await writer.start({
+        probeId: "e2e_d6:langgraph-python",
+        startedAt: 1_700_000_000_000,
+        triggered: false,
+        jobId: "job-abc",
+      });
+      expect(fake.createCalls[0]!.record.job_id).toBe("job-abc");
+
+      await writer.start({
+        probeId: "smoke",
+        startedAt: 1_700_000_000_000,
+        triggered: false,
+      });
+      // No jobId supplied → empty string, not undefined.
+      expect(fake.createCalls[1]!.record.job_id).toBe("");
+    });
+  });
+
+  describe("findByJobId()", () => {
+    let fake: ReturnType<typeof fakePb>;
+    beforeEach(() => {
+      fake = fakePb();
+    });
+
+    it("returns null when no row carries the jobId", async () => {
+      const writer = createProbeRunWriter(fake.pb);
+      expect(await writer.findByJobId("nope")).toBeNull();
+    });
+
+    it("returns null for an empty jobId without querying PB", async () => {
+      const writer = createProbeRunWriter(fake.pb);
+      const before = fake.listCalls.length;
+      expect(await writer.findByJobId("")).toBeNull();
+      // Empty id short-circuits — never hits the in-process job population.
+      expect(fake.listCalls.length).toBe(before);
+    });
+
+    it("reports a running row as non-terminal", async () => {
+      const writer = createProbeRunWriter(fake.pb);
+      const { id } = await writer.start({
+        probeId: "e2e_d6:x",
+        startedAt: 1_700_000_000_000,
+        triggered: false,
+        jobId: "job-running",
+      });
+      const found = await writer.findByJobId("job-running");
+      expect(found).toEqual({ id, terminal: false });
+    });
+
+    it("reports a finished row as terminal", async () => {
+      const writer = createProbeRunWriter(fake.pb);
+      const { id } = await writer.start({
+        probeId: "e2e_d6:x",
+        startedAt: 1_700_000_000_000,
+        triggered: false,
+        jobId: "job-done",
+      });
+      await writer.finish({
+        id,
+        finishedAt: 1_700_000_005_000,
+        state: "completed",
+        summary: { total: 1, passed: 1, failed: 0 },
+      });
+      const found = await writer.findByJobId("job-done");
+      expect(found).toEqual({ id, terminal: true });
     });
   });
 
@@ -352,6 +425,10 @@ describe("run-history", () => {
   // probe_runs then showed `failed / total:0` instead of reality.
   // ---------------------------------------------------------------------
   describe("sweepStaleRuns() — partial-rollup preservation", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     it("preserves an existing partial summary instead of zeroing it", async () => {
       const fake = fakePb();
       const stale = new Date(Date.now() - 20 * 60 * 1000).toISOString();
@@ -384,6 +461,59 @@ describe("run-history", () => {
       // rollup MUST survive — not be overwritten with zeros.
       expect(updated.record.state).toBe("failed");
       expect(updated.record.summary).toEqual(partialSummary);
+    });
+
+    it("logs (does not silently swallow) when sweeping a row fails, then continues", async () => {
+      // A PB update failure while sweeping a zombie row must be observable —
+      // the previous empty catch discarded it silently despite a comment that
+      // claimed to "log but don't block boot". The sweep must log the failing
+      // row id + error and continue to the next row.
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const fake = fakePb();
+      const stale = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+      await fake.pb.create(PROBE_RUNS_COLLECTION, {
+        probe_id: "smoke-a",
+        started_at: stale,
+        finished_at: null,
+        duration_ms: null,
+        triggered: false,
+        state: "running",
+        summary: null,
+      });
+      const goodRow = await fake.pb.create<{ id: string }>(
+        PROBE_RUNS_COLLECTION,
+        {
+          probe_id: "smoke-b",
+          started_at: stale,
+          finished_at: null,
+          duration_ms: null,
+          triggered: false,
+          state: "running",
+          summary: null,
+        },
+      );
+      // First update (the first stale row) throws; the second succeeds.
+      let updateCount = 0;
+      const realUpdate = fake.pb.update.bind(fake.pb);
+      fake.pb.update = (async (collection, id, record) => {
+        updateCount++;
+        if (updateCount === 1) throw new Error("pb update boom");
+        return realUpdate(collection, id, record);
+      }) as typeof fake.pb.update;
+
+      const swept = await sweepStaleRuns(fake.pb);
+
+      // The failing row did not count; the second row was still swept (the
+      // loop continued past the error instead of aborting boot).
+      expect(swept).toBe(1);
+      // The failure was logged with the row id and the error — not swallowed.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [msg, meta] = warnSpy.mock.calls[0]!;
+      expect(String(msg)).toMatch(/sweepStaleRuns/);
+      expect(meta).toMatchObject({ runId: expect.any(String) });
+      expect(String(JSON.stringify(meta))).toContain("pb update boom");
+      // The surviving row reached a terminal failed state.
+      expect(fake.rows.get(goodRow.id)?.state).toBe("failed");
     });
 
     it("still zeroes the summary for a row that never accumulated partial results", async () => {

--- a/showcase/harness/src/probes/run-history.ts
+++ b/showcase/harness/src/probes/run-history.ts
@@ -52,17 +52,43 @@ export interface ProbeRunRecord {
   summary: ProbeRunSummary | null;
 }
 
+/**
+ * The terminal-vs-running disposition of a `probe_runs` row, returned by
+ * `findByJobId` so the fleet aggregator can decide between SKIP (already fully
+ * applied) and RESUME (a previous attempt crashed mid-aggregate).
+ */
+export interface ProbeRunByJob {
+  id: string;
+  /** True once the row reached a terminal state (`completed` | `failed`). */
+  terminal: boolean;
+}
+
 export interface ProbeRunWriter {
   /**
    * Insert a `running` row. Returns the new row id so the caller can pass
    * it to `finish()` once the probe completes. `startedAt` is a numeric
    * epoch-ms (matching `Date.now()`) — converted to ISO inside.
+   *
+   * `jobId` (optional) stamps the fleet `probe_jobs` row id onto the run so
+   * the aggregator can dedupe a re-processed result (see `findByJobId`). The
+   * in-process probe-invoker omits it (no job); only the fleet aggregator
+   * supplies it.
    */
   start(opts: {
     probeId: string;
     startedAt: number;
     triggered: boolean;
+    jobId?: string;
   }): Promise<{ id: string }>;
+  /**
+   * Find the run row previously stamped with `jobId`, or null when none
+   * exists. The fleet aggregator calls this BEFORE doing any work so a
+   * re-processed result (latch write failed, or crash before latch) is a true
+   * idempotent no-op rather than re-bumping flap counts / appending duplicate
+   * history / minting a duplicate run row. Returns the row id + whether it is
+   * terminal so the caller can SKIP (terminal) vs RESUME (still running).
+   */
+  findByJobId(jobId: string): Promise<ProbeRunByJob | null>;
   /**
    * Persist a partial rollup onto a still-`running` row WITHOUT marking it
    * terminal. Called incrementally as each fan-out target completes so an
@@ -108,6 +134,8 @@ interface ProbeRunRow {
   triggered: boolean;
   state: ProbeRunState;
   summary: ProbeRunSummary | null;
+  /** Fleet job id (empty for in-process probe-invoker runs). */
+  job_id?: string;
 }
 
 function toRecord(row: ProbeRunRow): ProbeRunRecord {
@@ -134,8 +162,33 @@ export function createProbeRunWriter(pb: PbClient): ProbeRunWriter {
         triggered: opts.triggered,
         state: "running",
         summary: null,
+        // Empty string (not undefined) for the no-job in-process path so the
+        // column is cleanly "no job" rather than absent — matches how the
+        // workers row stores an idle current_job_id.
+        job_id: opts.jobId ?? "",
       });
       return { id: created.id };
+    },
+
+    async findByJobId(jobId) {
+      // The fleet aggregator dedupes on a NON-empty job id; an empty/blank id
+      // would match the whole in-process-probe population, so guard it.
+      if (!jobId) return null;
+      const filter = `job_id = ${JSON.stringify(jobId)}`;
+      const result = await pb.list<ProbeRunRow>(PROBE_RUNS_COLLECTION, {
+        filter,
+        // Newest first so if (pathologically) more than one row carries the id,
+        // we report the most recent disposition.
+        sort: "-started_at",
+        perPage: 1,
+        skipTotal: true,
+      });
+      const row = result.items[0];
+      if (!row) return null;
+      return {
+        id: row.id,
+        terminal: row.state === "completed" || row.state === "failed",
+      };
     },
 
     async update(opts) {
@@ -260,8 +313,17 @@ export async function sweepStaleRuns(
         summary,
       });
       swept++;
-    } catch {
-      // best-effort — log but don't block boot
+    } catch (err) {
+      // Best-effort — a single failing sweep update must not block boot, but it
+      // must be OBSERVABLE: a silently-discarded PB failure leaves a zombie
+      // `running` row in place with no trace of why. Log the row id + error
+      // (console.warn, consistent with this file's other PB guards) and
+      // continue to the next stale row.
+      // eslint-disable-next-line no-console
+      console.warn("run-history.sweepStaleRuns: row update failed", {
+        runId: row.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
   return swept;

--- a/showcase/harness/test/integration/fleet/job-claim.integration.test.ts
+++ b/showcase/harness/test/integration/fleet/job-claim.integration.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { createJobClaimClient } from "../../../src/fleet/job-claim.js";
+import { logger } from "../../../src/logger.js";
+
+// Real-PocketBase concurrency proof for the fleet job-claim primitive.
+//
+// This is the S1 spike, frozen as a regression test: it stands up an
+// actual PocketBase 0.22 server using the EXACT production migrations
+// (showcase/pocketbase/pb_migrations) and JSVM hooks
+// (showcase/pocketbase/pb_hooks), then races N concurrent claimers for the
+// same pending row and asserts EXACTLY ONE wins. This is the empirical
+// evidence that the transactional-endpoint mechanism (not a rule-guarded
+// PATCH, which the superuser bypasses) yields exactly-one-winner.
+//
+// Requires a `pocketbase` binary. Set POCKETBASE_BIN to its path, or put it
+// on PATH. The suite skips (not fails) when no binary is available so CI
+// without the binary stays green; the unit suite (src/fleet/job-claim.test.ts)
+// always runs.
+
+const PB_BIN = resolvePbBinary();
+const N = 20;
+const PORT = 8097;
+const BASE = `http://127.0.0.1:${PORT}`;
+const ADMIN_EMAIL = "claim-spike@test.local";
+const ADMIN_PASS = "claimspikepass123";
+
+const REPO_PB_DIR = resolve(__dirname, "../../../../pocketbase");
+const MIGRATIONS_DIR = join(REPO_PB_DIR, "pb_migrations");
+const HOOKS_DIR = join(REPO_PB_DIR, "pb_hooks");
+
+function resolvePbBinary(): string | null {
+  const explicit = process.env.POCKETBASE_BIN;
+  if (explicit && existsSync(explicit)) return explicit;
+  const probe = spawnSync("which", ["pocketbase"], { encoding: "utf8" });
+  if (probe.status === 0 && probe.stdout.trim()) return probe.stdout.trim();
+  // Spike-local default used while developing this primitive.
+  if (existsSync("/tmp/pb022/pocketbase")) return "/tmp/pb022/pocketbase";
+  return null;
+}
+
+async function waitForHealth(timeoutMs = 15_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const r = await fetch(`${BASE}/api/health`);
+      if (r.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error("PocketBase did not become healthy in time");
+}
+
+async function adminToken(): Promise<string> {
+  const r = await fetch(`${BASE}/api/admins/auth-with-password`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ identity: ADMIN_EMAIL, password: ADMIN_PASS }),
+  });
+  if (!r.ok) throw new Error(`admin auth: ${r.status} ${await r.text()}`);
+  const body = (await r.json()) as { token: string };
+  return body.token;
+}
+
+async function mintPendingJob(tok: string, key: string): Promise<string> {
+  const r = await fetch(`${BASE}/api/collections/probe_jobs/records`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: tok },
+    body: JSON.stringify({ probe_key: key, status: "pending", version: 0 }),
+  });
+  if (!r.ok) throw new Error(`mint job: ${r.status} ${await r.text()}`);
+  const body = (await r.json()) as { id: string };
+  return body.id;
+}
+
+async function readJob(
+  tok: string,
+  id: string,
+): Promise<Record<string, unknown>> {
+  const r = await fetch(`${BASE}/api/collections/probe_jobs/records/${id}`, {
+    headers: { authorization: tok },
+  });
+  return (await r.json()) as Record<string, unknown>;
+}
+
+let pb: ChildProcess | undefined;
+let dataDir: string | undefined;
+
+const describeMaybe = PB_BIN ? describe : describe.skip;
+
+describeMaybe("fleet job-claim — real PocketBase concurrency proof", () => {
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "pb-claim-spike-"));
+    // Apply the production migrations against the fresh data dir.
+    const mig = spawnSync(
+      PB_BIN as string,
+      [
+        "migrate",
+        "up",
+        `--dir=${dataDir}`,
+        `--migrationsDir=${MIGRATIONS_DIR}`,
+      ],
+      { encoding: "utf8" },
+    );
+    if (mig.status !== 0) {
+      throw new Error(`pb migrate up failed: ${mig.stderr || mig.stdout}`);
+    }
+    const admin = spawnSync(
+      PB_BIN as string,
+      ["admin", "create", ADMIN_EMAIL, ADMIN_PASS, `--dir=${dataDir}`],
+      { encoding: "utf8" },
+    );
+    if (admin.status !== 0) {
+      throw new Error(
+        `pb admin create failed: ${admin.stderr || admin.stdout}`,
+      );
+    }
+    pb = spawn(
+      PB_BIN as string,
+      [
+        "serve",
+        `--http=127.0.0.1:${PORT}`,
+        `--dir=${dataDir}`,
+        `--migrationsDir=${MIGRATIONS_DIR}`,
+        `--hooksDir=${HOOKS_DIR}`,
+      ],
+      { stdio: "ignore" },
+    );
+    await waitForHealth();
+  }, 30_000);
+
+  afterAll(() => {
+    if (pb) pb.kill("SIGKILL");
+    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  function client() {
+    return createJobClaimClient({
+      url: BASE,
+      email: ADMIN_EMAIL,
+      password: ADMIN_PASS,
+      logger,
+    });
+  }
+
+  it("exactly one of N concurrent claimers wins", async () => {
+    const tok = await adminToken();
+    const jobId = await mintPendingJob(tok, "svc:concurrent-claim");
+    const c = client();
+    const results = await Promise.all(
+      Array.from({ length: N }, (_, i) => c.claimJob(jobId, `worker-${i}`, 30)),
+    );
+    const winners = results.filter((r) => r.won);
+    expect(winners.length).toBe(1);
+    // The persisted row reflects exactly the winner.
+    const row = await readJob(tok, jobId);
+    expect(row.status).toBe("claimed");
+    expect(row.claimed_by).toBe(winners[0].job?.claimed_by);
+    expect(row.version).toBe(1);
+  });
+
+  it("a second claim on an already-claimed (live-lease) row loses", async () => {
+    const tok = await adminToken();
+    const jobId = await mintPendingJob(tok, "svc:second-claim");
+    const c = client();
+    const first = await c.claimJob(jobId, "worker-a", 60);
+    expect(first.won).toBe(true);
+    const second = await c.claimJob(jobId, "worker-b", 60);
+    expect(second.won).toBe(false);
+  });
+
+  it("renewLease extends the lease for the holder and promotes to running", async () => {
+    const tok = await adminToken();
+    const jobId = await mintPendingJob(tok, "svc:renew");
+    const c = client();
+    const claim = await c.claimJob(jobId, "worker-r", 60);
+    expect(claim.won).toBe(true);
+    const renew = await c.renewLease(jobId, "worker-r", 60);
+    expect(renew.renewed).toBe(true);
+    expect(renew.job?.status).toBe("running");
+    expect(renew.job?.version).toBe(2);
+    // A non-holder cannot renew.
+    const bad = await c.renewLease(jobId, "worker-other", 60);
+    expect(bad.renewed).toBe(false);
+  });
+
+  it("an expired lease is reclaimable by a new worker", async () => {
+    const tok = await adminToken();
+    const jobId = await mintPendingJob(tok, "svc:expiry");
+    const c = client();
+    // Claim with a lease that has effectively already expired (1s, then
+    // wait it out) so the reaper/next-claimer path engages.
+    const first = await c.claimJob(jobId, "worker-dead", 1);
+    expect(first.won).toBe(true);
+    await new Promise((r) => setTimeout(r, 1200));
+    const reclaim = await c.claimJob(jobId, "worker-fresh", 30);
+    expect(reclaim.won).toBe(true);
+    expect(reclaim.job?.claimed_by).toBe("worker-fresh");
+    // The original holder can no longer renew — its lease was stolen.
+    const stale = await c.renewLease(jobId, "worker-dead", 30);
+    expect(stale.renewed).toBe(false);
+  });
+
+  it("releaseJob records a terminal status for the holder", async () => {
+    const tok = await adminToken();
+    const jobId = await mintPendingJob(tok, "svc:release");
+    const c = client();
+    await c.claimJob(jobId, "worker-x", 60);
+    await c.renewLease(jobId, "worker-x", 60); // → running
+    const rel = await c.releaseJob(jobId, "worker-x", "done");
+    expect(rel.released).toBe(true);
+    expect(rel.job?.status).toBe("done");
+    // A non-holder cannot release.
+    const jobId2 = await mintPendingJob(tok, "svc:release2");
+    await c.claimJob(jobId2, "worker-y", 60);
+    await c.renewLease(jobId2, "worker-y", 60);
+    const badRel = await c.releaseJob(jobId2, "worker-z", "done");
+    expect(badRel.released).toBe(false);
+  });
+});

--- a/showcase/pocketbase/entrypoint.sh
+++ b/showcase/pocketbase/entrypoint.sh
@@ -18,6 +18,61 @@ set -eu
 # chown on an already-correctly-owned tree is cheap (no-op per inode).
 chown -R pocketbase:pocketbase /pb_data
 
+# Bootstrap the admin/superuser on a FRESH volume so the harness can
+# authenticate. A fresh local volume (and any new Railway volume) has no
+# admin account, so the harness's superuser auth 400s ("validation_is_email" /
+# "Failed to authenticate") and the whole fleet wedges (no enqueue, no consume,
+# no worker roster). Staging volumes that were set up by hand already have one —
+# `admin create` then errors "already exists", which we swallow so this is
+# idempotent.
+#
+# ORDERING IS LOAD-BEARING: `admin create` needs the schema initialized, so
+# migrations MUST run first ("Migration are not initialized yet. Please run
+# 'migrate up'") — otherwise the create fails and, because the worker's initial
+# self-register (the only write that sets the required `registered_at`) then
+# also fails against the missing admin, the worker never appears in the roster.
+# We run `migrate up` then `admin create`, both BEFORE `serve`.
+#
+# PB 0.22 ships `migrate up` + `admin create <email> <password>` (0.23+ renamed
+# the latter `superuser upsert`); this image is pinned to 0.22.21. The email
+# MUST have a TLD — PB 0.22 rejects bare hosts like `admin@localhost` as
+# invalid, which is exactly the misconfig that hid this gap.
+if [ -n "${POCKETBASE_SUPERUSER_EMAIL:-}" ] && [ -n "${POCKETBASE_SUPERUSER_PASSWORD:-}" ]; then
+  # FAIL HARD on a migration error. Previously `migrate up ... || true`
+  # swallowed failures, so a failed/half-applied migration booted a broken PB
+  # silently — surfacing later as opaque write 400s with no boot signal. With
+  # `set -e` and no `|| true`, a real migration failure aborts boot (visible in
+  # docker/Railway logs + healthcheck) instead of serving a corrupt schema. PB
+  # 0.22's `migrate up` exits 0 on the benign "No new migrations to apply" case,
+  # so a clean re-boot is NOT a non-zero we have to tolerate.
+  su-exec pocketbase:pocketbase /usr/local/bin/pocketbase migrate up \
+    --dir=/pb_data --migrationsDir=/pb_migrations 2>&1
+  # `admin create` tolerates EXACTLY ONE failure: "already exists" on a staging
+  # volume that already has a superuser (a fresh volume needs the create; an
+  # existing one must not abort boot). The previous `... | grep -vi "already
+  # exists" || true` swallowed the exit code of EVERY failure (the pipe's status
+  # is grep's, and `|| true` masks even that), so a genuine create failure —
+  # bad password policy, locked DB, disk full — booted a broken PB silently.
+  #
+  # Capture the create's combined output AND its real exit code explicitly. On
+  # success (exit 0) we're done. On failure we ONLY tolerate the case where the
+  # output contains "already exists"; ANY other failure re-emits the output and
+  # aborts boot (set -e would also catch a bare non-zero, but we exit explicitly
+  # so the failure is unmistakable in the logs).
+  admin_create_output=$(su-exec pocketbase:pocketbase /usr/local/bin/pocketbase admin create \
+    "$POCKETBASE_SUPERUSER_EMAIL" "$POCKETBASE_SUPERUSER_PASSWORD" \
+    --dir=/pb_data 2>&1) && admin_create_rc=0 || admin_create_rc=$?
+  printf '%s\n' "$admin_create_output"
+  if [ "$admin_create_rc" -ne 0 ]; then
+    if printf '%s' "$admin_create_output" | grep -qi "already exists"; then
+      echo "entrypoint: superuser already exists — continuing (idempotent boot)"
+    else
+      echo "entrypoint: 'admin create' failed (exit $admin_create_rc) — aborting boot" >&2
+      exit "$admin_create_rc"
+    fi
+  fi
+fi
+
 # su-exec preserves argv verbatim and exec()s, so PocketBase runs as
 # PID 1 and sees the same arguments the ENTRYPOINT line would have
 # passed. Using `exec` here (instead of spawning su-exec as a child)

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -1,0 +1,276 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// Fleet job-claim transactional endpoints (PB 0.22).
+//
+// WHY THIS EXISTS: the harness authenticates to PB as a SUPERUSER, and
+// superuser writes BYPASS collection updateRules — so a rule-guarded PATCH
+// (`status = "pending"`) is NOT atomically enforced. An empirical spike
+// (20 concurrent claimers) confirmed a rule-guarded worker PATCH yields
+// 4–10 winners, while these routerAdd + runInTransaction compare-and-set
+// endpoints yield EXACTLY ONE winner every time. SQLite serializes write
+// transactions, so the read-compare-write below is atomic across callers.
+//
+// IMPLEMENTATION NOTE (PB 0.22 JSVM gotcha): routerAdd handler callbacks
+// are serialized and re-executed inside a POOLED goja runtime that does
+// NOT have this file's module-top-level `function` declarations in scope.
+// Referencing a top-level helper from inside a handler throws
+// "X is not defined" at request time. Therefore every helper a handler
+// needs is defined INSIDE that handler's closure. (Verified against
+// PB 0.22.21 — the "leaseExpiryIso is not defined" failure mode.)
+//
+// Endpoints (all POST, JSON body, superuser/worker auth required):
+//   /api/fleet/claim    { jobId, workerId, leaseSeconds }
+//                       → { claimed: bool, job? }   exactly-one-winner CAS
+//   /api/fleet/renew    { jobId, workerId, leaseSeconds }
+//                       → { renewed: bool, job? }   only the lease holder
+//   /api/fleet/release  { jobId, workerId, status }  status: done|failed|pending
+//                       → { released: bool, job? }   only the lease holder
+
+routerAdd("POST", "/api/fleet/claim", (c) => {
+  const RUNNING_STATES = ["claimed", "running"];
+  const leaseExpiryIso = (leaseSeconds) => {
+    const secs = leaseSeconds && leaseSeconds > 0 ? leaseSeconds : 30;
+    return new Date(Date.now() + secs * 1000).toISOString();
+  };
+  // A claimed/running row is reclaimable once its lease has elapsed. Empty
+  // / unparseable lease is treated as expired (never let a row wedge the
+  // queue forever because of a malformed timestamp).
+  const leaseExpired = (rec) => {
+    const raw = rec.get("lease_expires_at");
+    if (!raw) return true;
+    // PB stores dates as "2006-01-02 15:04:05.000Z" (space separator).
+    // goja's Date.parse is strict and returns NaN for the space form
+    // (unlike V8/Node, which accept it) — so normalize the space to the
+    // ISO "T" separator before parsing. Without this every lease parses
+    // to NaN and is wrongly treated as expired, letting any caller steal
+    // a live claim. (Verified against PB 0.22.21 / goja.)
+    //
+    // ANCHOR the replacement to the date/time boundary
+    // ("YYYY-MM-DD ") so we ONLY rewrite the canonical PB shape. A bare
+    // String.replace(" ", "T") rewrites the FIRST space anywhere, which
+    // would coerce a malformed/non-standard value into something that
+    // parses, silently treating a LIVE claim as expired and defeating the
+    // exactly-one-winner CAS. An odd shape must fall through to NaN →
+    // expired-by-policy is intentional (never wedge the queue), but only
+    // because the value genuinely failed to parse, not because we mangled
+    // it into a parseable one.
+    const t = Date.parse(String(raw).replace(/^(\d{4}-\d{2}-\d{2}) /, "$1T"));
+    if (isNaN(t)) return true;
+    return t <= Date.now();
+  };
+  const jobView = (rec) => ({
+    id: rec.id,
+    probe_key: rec.get("probe_key"),
+    status: rec.get("status"),
+    claimed_by: rec.get("claimed_by"),
+    lease_expires_at: rec.get("lease_expires_at"),
+    version: rec.get("version"),
+  });
+
+  const data = $apis.requestInfo(c).data || {};
+  const jobId = data.jobId;
+  const workerId = data.workerId;
+  const leaseSeconds = data.leaseSeconds;
+  if (!jobId || !workerId) {
+    return c.json(400, { error: "jobId and workerId are required" });
+  }
+
+  let claimed = false;
+  let view = null;
+  $app.dao().runInTransaction((txDao) => {
+    let rec;
+    try {
+      rec = txDao.findRecordById("probe_jobs", jobId);
+    } catch (e) {
+      return; // unknown job → claimed stays false
+    }
+    const status = rec.get("status");
+    // Claimable if pending, OR if its prior claim's lease has expired
+    // (steal the lease from a dead worker). Terminal states never reclaim.
+    const reclaimable =
+      status === "pending" ||
+      (RUNNING_STATES.indexOf(status) !== -1 && leaseExpired(rec));
+    if (!reclaimable) return;
+
+    rec.set("status", "claimed");
+    rec.set("claimed_by", workerId);
+    rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
+    rec.set("version", (rec.get("version") || 0) + 1);
+    txDao.saveRecord(rec);
+    claimed = true;
+    view = jobView(rec);
+  });
+
+  return c.json(
+    200,
+    claimed ? { claimed: true, job: view } : { claimed: false },
+  );
+});
+
+routerAdd("POST", "/api/fleet/renew", (c) => {
+  const RUNNING_STATES = ["claimed", "running"];
+  const leaseExpiryIso = (leaseSeconds) => {
+    const secs = leaseSeconds && leaseSeconds > 0 ? leaseSeconds : 30;
+    return new Date(Date.now() + secs * 1000).toISOString();
+  };
+  const leaseExpired = (rec) => {
+    const raw = rec.get("lease_expires_at");
+    if (!raw) return true;
+    // PB stores dates as "2006-01-02 15:04:05.000Z" (space separator).
+    // goja's Date.parse is strict and returns NaN for the space form
+    // (unlike V8/Node, which accept it) — so normalize the space to the
+    // ISO "T" separator before parsing. Without this every lease parses
+    // to NaN and is wrongly treated as expired, letting any caller steal
+    // a live claim. (Verified against PB 0.22.21 / goja.)
+    //
+    // ANCHOR the replacement to the date/time boundary
+    // ("YYYY-MM-DD ") so we ONLY rewrite the canonical PB shape. A bare
+    // String.replace(" ", "T") rewrites the FIRST space anywhere, which
+    // would coerce a malformed/non-standard value into something that
+    // parses, silently treating a LIVE claim as expired and defeating the
+    // exactly-one-winner CAS. An odd shape must fall through to NaN →
+    // expired-by-policy is intentional (never wedge the queue), but only
+    // because the value genuinely failed to parse, not because we mangled
+    // it into a parseable one.
+    const t = Date.parse(String(raw).replace(/^(\d{4}-\d{2}-\d{2}) /, "$1T"));
+    if (isNaN(t)) return true;
+    return t <= Date.now();
+  };
+  const jobView = (rec) => ({
+    id: rec.id,
+    probe_key: rec.get("probe_key"),
+    status: rec.get("status"),
+    claimed_by: rec.get("claimed_by"),
+    lease_expires_at: rec.get("lease_expires_at"),
+    version: rec.get("version"),
+  });
+
+  const data = $apis.requestInfo(c).data || {};
+  const jobId = data.jobId;
+  const workerId = data.workerId;
+  const leaseSeconds = data.leaseSeconds;
+  if (!jobId || !workerId) {
+    return c.json(400, { error: "jobId and workerId are required" });
+  }
+
+  let renewed = false;
+  let view = null;
+  $app.dao().runInTransaction((txDao) => {
+    let rec;
+    try {
+      rec = txDao.findRecordById("probe_jobs", jobId);
+    } catch (e) {
+      return;
+    }
+    const status = rec.get("status");
+    // Only the current lease holder may renew, and only while the row is
+    // still in a running state and the lease has NOT yet expired. If the
+    // lease already expired the holder lost it (another worker may have
+    // stolen it) — renew must fail so the original worker stops.
+    if (RUNNING_STATES.indexOf(status) === -1) return;
+    if (rec.get("claimed_by") !== workerId) return;
+    if (leaseExpired(rec)) return;
+
+    // Promote claimed → running on first renew so the lifecycle is visible.
+    rec.set("status", "running");
+    rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
+    rec.set("version", (rec.get("version") || 0) + 1);
+    txDao.saveRecord(rec);
+    renewed = true;
+    view = jobView(rec);
+  });
+
+  return c.json(
+    200,
+    renewed ? { renewed: true, job: view } : { renewed: false },
+  );
+});
+
+routerAdd("POST", "/api/fleet/release", (c) => {
+  const RUNNING_STATES = ["claimed", "running"];
+  // A claimed/running row's lease is elapsed once its expiry timestamp has
+  // passed. Empty / unparseable lease is treated as expired (mirrors claim +
+  // renew). Defined INSIDE the handler closure — PB 0.22's pooled goja runtime
+  // does NOT see module-top-level declarations from a handler (the
+  // "X is not defined" gotcha documented at the top of this file).
+  const leaseExpired = (rec) => {
+    const raw = rec.get("lease_expires_at");
+    if (!raw) return true;
+    // PB stores dates as "2006-01-02 15:04:05.000Z" (space separator). goja's
+    // Date.parse is strict and returns NaN for the space form, so normalize the
+    // space to the ISO "T" separator before parsing — ANCHORED to the date/time
+    // boundary so we only rewrite the canonical PB shape (a bare replace would
+    // coerce a malformed value into something parseable, defeating the CAS).
+    const t = Date.parse(String(raw).replace(/^(\d{4}-\d{2}-\d{2}) /, "$1T"));
+    if (isNaN(t)) return true;
+    return t <= Date.now();
+  };
+  const jobView = (rec) => ({
+    id: rec.id,
+    probe_key: rec.get("probe_key"),
+    status: rec.get("status"),
+    claimed_by: rec.get("claimed_by"),
+    lease_expires_at: rec.get("lease_expires_at"),
+    version: rec.get("version"),
+  });
+
+  const data = $apis.requestInfo(c).data || {};
+  const jobId = data.jobId;
+  const workerId = data.workerId;
+  const target = data.status || "done";
+  if (!jobId || !workerId) {
+    return c.json(400, { error: "jobId and workerId are required" });
+  }
+  if (["done", "failed", "pending"].indexOf(target) === -1) {
+    return c.json(400, { error: "status must be done|failed|pending" });
+  }
+
+  let released = false;
+  let view = null;
+  $app.dao().runInTransaction((txDao) => {
+    let rec;
+    try {
+      rec = txDao.findRecordById("probe_jobs", jobId);
+    } catch (e) {
+      return;
+    }
+    // Only the current lease holder may release, and only while the row is in a
+    // running state.
+    if (RUNNING_STATES.indexOf(rec.get("status")) === -1) return;
+    if (rec.get("claimed_by") !== workerId) return;
+    // The lease-expiry gate applies ONLY to TERMINAL targets (done|failed). If
+    // the lease already expired the holder LOST it (the sweeper may have
+    // re-queued it, or another worker may have stolen the claim) — letting a
+    // stale worker clobber terminal state would violate the exactly-one-winner
+    // invariant. Mirror renew's holder-lost-it semantics: reject the terminal
+    // release so the stale worker stops. (`claimed_by` unchanged is NOT
+    // sufficient — a stolen-then-released race can transiently match; the lease
+    // check is the authoritative gate for terminal writes.)
+    //
+    // But target === "pending" is the SWEEPER's re-queue (queue-client
+    // sweepExpired calls releaseJob(jobId, claimed_by, "pending") on EXPIRED
+    // rows on behalf of a crashed worker). That path operates on expired leases
+    // BY DESIGN, so it must be allowed to proceed even when leaseExpired is
+    // true — gating it here makes REQ-B crash reclamation inert (the sweeper
+    // reclaims 0, no worker-crashed-mid-job comm error is ever synthesized). The
+    // claimed_by match above still authorizes it, and re-queue to pending is
+    // always safe: it just resets the row to claimable.
+    if (target !== "pending" && leaseExpired(rec)) return;
+
+    rec.set("status", target);
+    if (target === "pending") {
+      // Re-queue: drop ownership so it's claimable again.
+      rec.set("claimed_by", "");
+      rec.set("lease_expires_at", null);
+    }
+    rec.set("version", (rec.get("version") || 0) + 1);
+    txDao.saveRecord(rec);
+    released = true;
+    view = jobView(rec);
+  });
+
+  return c.json(
+    200,
+    released ? { released: true, job: view } : { released: false },
+  );
+});

--- a/showcase/pocketbase/pb_migrations/1779989400_create_probe_jobs.js
+++ b/showcase/pocketbase/pb_migrations/1779989400_create_probe_jobs.js
@@ -1,0 +1,100 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// Fleet pull-queue: one row per queued probe invocation. Workers pull
+// (CLAIM) pending rows, renew a lease while running, then release on
+// completion/failure. Distinct from `probe_runs` (run-level history) and
+// `status`/`status_history` (per-result state machine) — this collection
+// is the work queue the fleet's workers race over.
+//
+// ── ATOMIC-CLAIM INVARIANT (R2, proven empirically) ──────────────────
+// The harness authenticates to PB as a SUPERUSER, and superuser writes
+// BYPASS collection updateRules. A spike against PB 0.22.21 with 20
+// concurrent claimers showed:
+//   - superuser naive PATCH:           20/20 "win"  (rules bypassed)
+//   - worker-auth rule-guarded PATCH:  4–10 winners (rule admission is
+//                                      NOT transactional with the write —
+//                                      multiple claimers pass the
+//                                      `status = "pending"` check then all
+//                                      write)
+//   - JSVM routerAdd + runInTransaction CAS: EXACTLY 1 winner, every run
+// So the ONLY mechanism that yields exactly-one-winner is a server-side
+// compare-and-set inside a DB transaction (this hook, see
+// pb_hooks/fleet-claim.pb.js). The updateRule below is therefore set to
+// `null` (superuser/endpoint-only) — workers MUST go through the
+// transactional endpoints, never a direct PATCH.
+//
+// Field semantics (mirrored in harness src/fleet/job-claim.ts):
+//   - probe_key       : probe/service identifier this job runs.
+//   - status          : pending|claimed|running|done|failed.
+//   - claimed_by      : worker id that won the claim (empty while pending).
+//   - lease_expires_at: ISO timestamp; the claim/lease is valid until this
+//                       moment. A reaper (or any claimer) may reclaim a
+//                       row whose lease has expired even if status is
+//                       claimed/running — see the endpoint's expiry path.
+//   - version         : monotonic counter bumped on every successful
+//                       state transition; lets callers detect they were
+//                       superseded (lease stolen) without a full re-read.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    // Idempotency: skip when the collection already exists (mirrors the
+    // probe_runs presence-gate pattern). PB JSVM has no typed
+    // ErrCollectionNotFound, so catch broadly.
+    try {
+      dao.findCollectionByNameOrId("probe_jobs");
+      return;
+    } catch (e) {
+      // Not present — fall through to create.
+    }
+    const c = new Collection({
+      name: "probe_jobs",
+      type: "base",
+      schema: [
+        { name: "probe_key", type: "text", required: true },
+        {
+          name: "status",
+          type: "select",
+          required: true,
+          options: {
+            values: ["pending", "claimed", "running", "done", "failed"],
+            maxSelect: 1,
+          },
+        },
+        { name: "claimed_by", type: "text" },
+        { name: "lease_expires_at", type: "date" },
+        { name: "version", type: "number", options: { min: 0 } },
+      ],
+      indexes: [
+        // Primary pull pattern: "find a pending job" — served by the
+        // status index without a sort step.
+        "CREATE INDEX IF NOT EXISTS idx_probe_jobs_status ON probe_jobs (status)",
+        // Reaper pattern: "find expired leases" scans claimed/running rows
+        // by lease_expires_at.
+        "CREATE INDEX IF NOT EXISTS idx_probe_jobs_lease ON probe_jobs (lease_expires_at)",
+      ],
+      // Authed read so a worker (or the dashboard) can enumerate the queue.
+      // Writes are endpoint-only: createRule/updateRule/deleteRule = null.
+      // Claims/renews/releases go through the transactional JSVM endpoints
+      // (pb_hooks/fleet-claim.pb.js) which are the ONLY atomically-safe
+      // path given the superuser-bypass invariant documented above.
+      listRule: '@request.auth.id != ""',
+      viewRule: '@request.auth.id != ""',
+      createRule: null,
+      updateRule: null,
+      deleteRule: null,
+    });
+    dao.saveCollection(c);
+  },
+  (db) => {
+    const dao = new Dao(db);
+    // Narrowed: a real deleteCollection failure must propagate. Absent →
+    // nothing to do.
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch (e) {
+      return;
+    }
+    dao.deleteCollection(c);
+  },
+);

--- a/showcase/pocketbase/pb_migrations/1779989500_probe_jobs_add_payload.js
+++ b/showcase/pocketbase/pb_migrations/1779989500_probe_jobs_add_payload.js
@@ -1,0 +1,67 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// Fleet pull-queue payload column. The S0 collection migration
+// (1779989400_create_probe_jobs.js) shaped `probe_jobs` for the row-level
+// CLAIM primitive (probe_key/status/claimed_by/lease_expires_at/version) —
+// the atomic compare-and-set that decides exactly-one-winner. It deliberately
+// carries NO job body, because the claim CAS only needs the lifecycle columns.
+//
+// The control-plane ↔ worker QUEUE layer (harness src/fleet/queue-client.ts,
+// implementing FleetQueueClient over S0's JobClaimClient) needs the row to
+// also carry the per-service WORK to run: the serialized `ServiceJobPayload`
+// (probeKey/serviceSlug/driverKind/cellIds/driverInputs/meta). The
+// control-plane WRITES it at enqueue time and the worker READS it back after
+// it wins the claim — it must survive the enqueue→claim process boundary, so
+// it lives on the row, not in memory. This migration adds that one JSON column
+// without disturbing the claim-CAS schema S0 owns.
+//
+// JSON (not text): the payload is a structured object the worker re-hydrates
+// into a typed ServiceJobPayload; a JSON column lets PB store/return it as an
+// object rather than a string the client must double-encode. 64KB ceiling
+// matches resource_snapshots.per_browser — a per-service payload is a handful
+// of small fields plus optional cell-id/driver-input lists, comfortably under
+// the cap.
+//
+// Additive + idempotent: a presence-check on the field makes a re-run after a
+// partial apply a no-op (mirrors the collection-presence gate in the create
+// migrations). The down migration drops the column but leaves the collection.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch (e) {
+      // The base collection isn't present yet — nothing to extend. The S0
+      // create migration runs first (lower unix prefix); if it somehow has
+      // not, this is a no-op rather than a hard failure.
+      return;
+    }
+    // Idempotency: skip when the column already exists.
+    if (c.schema.getFieldByName("payload")) {
+      return;
+    }
+    c.schema.addField(
+      new SchemaField({
+        name: "payload",
+        type: "json",
+        options: { maxSize: 65536 },
+      }),
+    );
+    dao.saveCollection(c);
+  },
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch (e) {
+      return;
+    }
+    if (!c.schema.getFieldByName("payload")) {
+      return;
+    }
+    c.schema.removeField(c.schema.getFieldByName("payload").id);
+    dao.saveCollection(c);
+  },
+);

--- a/showcase/pocketbase/pb_migrations/1779989600_create_workers.js
+++ b/showcase/pocketbase/pb_migrations/1779989600_create_workers.js
@@ -1,0 +1,106 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// Fleet worker REGISTRY: one row per live worker process. Each worker
+// self-registers on boot and heartbeats on a ~60-90s cadence (see harness
+// src/fleet/worker/registration.ts), refreshing its capacity + liveness. The
+// control-plane / fleet-health slot (S10) reads this collection to answer "who
+// is in the fleet, how busy are they, and which ones have gone stale?".
+//
+// DISTINCT from the other fleet collections:
+//   - `probe_jobs`  : the work QUEUE the workers race over (S0).
+//   - `probe_runs`  : run-level history.
+//   - `status`/`status_history` : per-result state machine.
+//   - `workers`     : the MEMBERSHIP roster + per-member capacity/liveness.
+//
+// Field semantics (mirrored in harness src/fleet/contracts.ts —
+// WorkerRegistration / WorkerHeartbeat / WorkerDescriptor):
+//   - worker_id         : stable worker id; SAME value the worker passes to S0's
+//                         claimJob(jobId, workerId, ...) so this row and a
+//                         claim's `claimed_by` join on one value. UNIQUE.
+//   - endpoint          : worker's reachable host:port for control-plane probes.
+//   - capacity_*        : the BrowserPool.budget() snapshot (S6) at the last
+//                         register/heartbeat: in_use / available / max context
+//                         counts plus the cgroup pids.current / pids.max
+//                         ceiling gauges (-1 when off-Linux/unreadable).
+//   - current_job_id    : id of the job the worker is running, or empty/idle.
+//   - registered_at     : ISO timestamp the worker first registered.
+//   - last_heartbeat_at : ISO timestamp of the latest heartbeat. fleet-health
+//                         (S10) reads THIS against a staleness window to derive
+//                         online | stale | offline (see isWorkerStale). Indexed
+//                         DESC for "freshest workers first" + the staleness scan.
+//
+// ── CAPACITY / PIDS NULL-VS-UNAVAILABLE CONVENTION ────────────────────────
+// `capacity_pids_current` / `capacity_pids_max` are NULLABLE: the cgroup pids
+// gauges degrade to a `-1` sentinel off-Linux / on an unreadable controller
+// (see browser-pool.ts budget()). The registration writer maps that sentinel to
+// `null` (never writes -1), so a fleet-health query can cleanly separate a
+// MEASURED pids ceiling from an UNAVAILABLE one — a stored `-1` would be
+// indistinguishable from a genuine count.
+//
+// PUBLIC-READ INVARIANT: mirrors `status` / `probe_runs` /
+// `resource_snapshots` — listRule/viewRule = "" (unauthenticated read) so the
+// dashboard / fleet-health can enumerate the roster without a session. The
+// fields are pure operational metadata (id, endpoint, capacity counts,
+// timestamps) — NEVER write secrets, env vars, or auth tokens here. Writes stay
+// superuser-only (createRule/updateRule/deleteRule = null) so only the harness
+// (authed as superuser) can mint/refresh/evict rows.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    // Idempotency: skip when the collection already exists (mirrors the
+    // probe_jobs / probe_runs presence-gate pattern). PB JSVM has no typed
+    // ErrCollectionNotFound, so catch broadly and return on present.
+    try {
+      dao.findCollectionByNameOrId("workers");
+      return;
+    } catch (e) {
+      // Not present — fall through to create.
+    }
+    const c = new Collection({
+      name: "workers",
+      type: "base",
+      schema: [
+        { name: "worker_id", type: "text", required: true },
+        { name: "endpoint", type: "text", required: true },
+        // --- Capacity snapshot (BrowserPool.budget()) ---
+        { name: "capacity_in_use", type: "number" },
+        { name: "capacity_available", type: "number" },
+        { name: "capacity_max", type: "number" },
+        // Nullable cgroup pids gauges: -1 sentinel maps to null (see header).
+        { name: "capacity_pids_current", type: "number" },
+        { name: "capacity_pids_max", type: "number" },
+        // Id of the job the worker is currently running, empty while idle.
+        { name: "current_job_id", type: "text" },
+        { name: "registered_at", type: "date", required: true },
+        { name: "last_heartbeat_at", type: "date", required: true },
+      ],
+      indexes: [
+        // One row per worker: the upsert-by-worker_id path and the
+        // join-to-claimed_by both rely on worker_id being unique.
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_workers_worker_id ON workers (worker_id)",
+        // fleet-health (S10) staleness scan + "freshest workers first".
+        "CREATE INDEX IF NOT EXISTS idx_workers_heartbeat ON workers (last_heartbeat_at DESC)",
+      ],
+      // Public read mirrors status / probe_runs / resource_snapshots; writes
+      // superuser-only (the harness authenticates as a superuser).
+      listRule: "",
+      viewRule: "",
+      createRule: null,
+      updateRule: null,
+      deleteRule: null,
+    });
+    dao.saveCollection(c);
+  },
+  (db) => {
+    const dao = new Dao(db);
+    // Narrowed: a real deleteCollection failure must propagate. Absent →
+    // nothing to do.
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("workers");
+    } catch (e) {
+      return;
+    }
+    dao.deleteCollection(c);
+  },
+);

--- a/showcase/pocketbase/pb_migrations/1779989700_probe_jobs_add_result.js
+++ b/showcase/pocketbase/pb_migrations/1779989700_probe_jobs_add_result.js
@@ -1,0 +1,118 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// Fleet result-flow columns on the pull-queue row.
+//
+// The worker (harness src/fleet/worker) computes a per-service `ServiceJobResult`
+// and REPORTs it through the queue protocol (FleetQueueClient.report). The
+// CONTROL-PLANE aggregator (src/fleet/control-plane/result-aggregator.ts) is the
+// ONLY writer of the authoritative dashboard status + run-history — but it runs
+// in a DIFFERENT process from the worker. So the worker's result must survive
+// the worker->control-plane process boundary the same way the inbound payload
+// does (1779989500): it lives on the `probe_jobs` row, not in memory.
+//
+//   - result            (json) : the serialized ServiceJobResult the worker
+//                                 produced. Written by the queue-client at
+//                                 report time, AFTER the claim-CAS release, so
+//                                 it only ever rides on a terminal (done/failed)
+//                                 row the worker still owned.
+//   - result_processed  (bool) : the consume-once latch. The control-plane's
+//                                 result-consumer loop polls terminal rows whose
+//                                 result is present and result_processed = false,
+//                                 calls aggregate(result) EXACTLY ONCE, then sets
+//                                 result_processed = true so the same result is
+//                                 never re-aggregated (no duplicate dashboard
+//                                 writes / run-history rows).
+//
+// Why a bool latch and not "delete the row": the row is the audit/debug trail of
+// the queue, and deleting it would race the sweeper + lose history. A processed
+// flag is the minimal idempotency marker and indexes cleanly for the consumer's
+// "unprocessed terminal" query.
+//
+// 64KB JSON ceiling matches the sibling `payload` column — a ServiceJobResult is
+// a handful of fields plus one small entry per d6 cell, comfortably under cap.
+//
+// Additive + idempotent: presence-checks make a re-run after a partial apply a
+// no-op (mirrors 1779989500_probe_jobs_add_payload.js). The down migration drops
+// both columns but leaves the collection.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch (e) {
+      // Base collection not present yet (S0 create runs first, lower prefix).
+      // No-op rather than a hard failure.
+      return;
+    }
+    let changed = false;
+    if (!c.schema.getFieldByName("result")) {
+      c.schema.addField(
+        new SchemaField({
+          name: "result",
+          type: "json",
+          options: { maxSize: 65536 },
+        }),
+      );
+      changed = true;
+    }
+    if (!c.schema.getFieldByName("result_processed")) {
+      c.schema.addField(
+        new SchemaField({
+          name: "result_processed",
+          type: "bool",
+        }),
+      );
+      changed = true;
+    }
+    // The consumer's hot query: "terminal rows with an unprocessed result".
+    // Index result_processed so the scan stays cheap as the queue grows.
+    //
+    // Guard the index push by index-PRESENCE, NOT by the field-`changed`
+    // flag. On a partial-apply recovery the field can already exist (added
+    // by a prior run that crashed before saving the index) → `changed` is
+    // false, but the index is still missing. Gating on `changed` would
+    // then NEVER create the index, silently degrading the consumer to a
+    // full-scan forever. Presence-checking (mirrors
+    // 1779989900_probe_runs_add_job_id.js) makes the index creation
+    // idempotent and independent of whether the field add ran this time.
+    c.indexes = c.indexes || [];
+    if (
+      !c.indexes.some(
+        (ix) => ix.indexOf("idx_probe_jobs_result_processed") !== -1,
+      )
+    ) {
+      c.indexes.push(
+        "CREATE INDEX IF NOT EXISTS idx_probe_jobs_result_processed ON probe_jobs (result_processed)",
+      );
+      changed = true;
+    }
+    if (changed) {
+      dao.saveCollection(c);
+    }
+  },
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch (e) {
+      return;
+    }
+    let changed = false;
+    if (c.schema.getFieldByName("result")) {
+      c.schema.removeField(c.schema.getFieldByName("result").id);
+      changed = true;
+    }
+    if (c.schema.getFieldByName("result_processed")) {
+      c.schema.removeField(c.schema.getFieldByName("result_processed").id);
+      changed = true;
+    }
+    if (changed) {
+      c.indexes = c.indexes.filter(
+        (ix) => ix.indexOf("idx_probe_jobs_result_processed") === -1,
+      );
+      dao.saveCollection(c);
+    }
+  },
+);

--- a/showcase/pocketbase/pb_migrations/1779989900_probe_runs_add_job_id.js
+++ b/showcase/pocketbase/pb_migrations/1779989900_probe_runs_add_job_id.js
@@ -1,0 +1,84 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// Add `probe_runs.job_id` + a partial-unique index so the fleet aggregator can
+// dedupe a RE-PROCESSED result into a true no-op.
+//
+// The control-plane result-consumer aggregates a worker result, then latches
+// `probe_jobs.result_processed = true`. If that latch write fails (or the
+// process crashes before it), the SAME job's result is re-handed to the
+// aggregator next tick. Re-aggregating is NOT free: status-writer bumps
+// fail_count again (inflating the dashboard's "red for N" counter), appends a
+// spurious status_history row, and re-emits status.changed; run-history mints a
+// DUPLICATE probe_runs row. So at-least-once corrupts flap counts + history for
+// non-green services.
+//
+// The aggregator (result-aggregator.ts) now stamps the originating fleet job id
+// onto its run row and looks it up (run-history.ts `findByJobId`) BEFORE doing
+// any work: a TERMINAL row for the job → skip entirely; a still-RUNNING row →
+// resume on the same row instead of minting a duplicate. This migration adds
+// the column the dedup keys on, plus a UNIQUE index that is PARTIAL — it only
+// constrains rows with a NON-EMPTY job_id. The legacy in-process probe-invoker
+// writes job_id = "" (no fleet job), and many such rows must coexist, so a
+// blanket unique index would (incorrectly) reject the second empty-id row. The
+// `WHERE job_id != ''` clause scopes uniqueness to real fleet jobs.
+//
+// Additive + idempotent: a field-presence gate makes a re-run after a partial
+// apply a no-op (mirrors the other fleet migrations). The index uses
+// IF NOT EXISTS for the same reason. The down migration drops both.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_runs");
+    } catch (e) {
+      // The base collection isn't present yet — the create migration (lower
+      // unix prefix) runs first; if it somehow hasn't, this is a no-op rather
+      // than a hard failure.
+      return;
+    }
+
+    // Add the field unless it already exists (idempotent re-apply).
+    if (!c.schema.getFieldByName("job_id")) {
+      c.schema.addField(
+        new SchemaField({
+          name: "job_id",
+          type: "text",
+          required: false,
+        }),
+      );
+    }
+
+    // Partial-unique index: uniqueness only over real (non-empty) fleet job
+    // ids, so the legacy job_id="" in-process rows coexist freely.
+    c.indexes = c.indexes || [];
+    const idxSql =
+      "CREATE UNIQUE INDEX IF NOT EXISTS idx_probe_runs_job_id " +
+      "ON probe_runs (job_id) WHERE job_id != ''";
+    if (!c.indexes.some((ix) => ix.indexOf("idx_probe_runs_job_id") !== -1)) {
+      c.indexes.push(idxSql);
+    }
+
+    dao.saveCollection(c);
+  },
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_runs");
+    } catch (e) {
+      return;
+    }
+    // Drop the index first, then the field.
+    if (c.indexes) {
+      c.indexes = c.indexes.filter(
+        (ix) => ix.indexOf("idx_probe_runs_job_id") === -1,
+      );
+    }
+    const field = c.schema.getFieldByName("job_id");
+    if (field) {
+      c.schema.removeField(field.id);
+    }
+    dao.saveCollection(c);
+  },
+);

--- a/showcase/scripts/cli/cmd-test.sh
+++ b/showcase/scripts/cli/cmd-test.sh
@@ -114,7 +114,7 @@ cmd_test() {
 
   # Build the filter description for the info line
   local filter_desc=""
-  for arg in "${harness_args[@]}"; do
+  for arg in ${harness_args[@]+"${harness_args[@]}"}; do
     case "$arg" in
       --d6|--d5|--d4|--smoke) filter_desc="${filter_desc:+$filter_desc,}$arg" ;;
     esac
@@ -140,7 +140,7 @@ cmd_test() {
   date -u +%Y-%m-%dT%H:%M:%SZ > "$SHOWCASE_ROOT/.last-test-ts"
 
   local test_exit=0
-  npx tsx "$SHOWCASE_ROOT/harness/src/cli.ts" test "$slug" "${harness_args[@]}" \
+  npx tsx "$SHOWCASE_ROOT/harness/src/cli.ts" test "$slug" ${harness_args[@]+"${harness_args[@]}"} \
     || test_exit=$?
 
   # --cycle: dump aimock log delta on failure

--- a/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
@@ -199,6 +199,56 @@ describe("DepthChip", () => {
     const chip = getByTestId("depth-chip");
     expect(chip.className).toContain("danger");
   });
+
+  // ── REQ-B: pool comm-error / unreachable treatment ──────────────────
+
+  it("renders a DISTINCT unreachable treatment when unreachable=true", () => {
+    const { getByTestId } = render(
+      <DepthChip
+        depth={5}
+        status="wired"
+        chipColor="green"
+        unreachable
+        commTooltip="pool unreachable: worker-unreachable — worker w-7"
+      />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.getAttribute("data-status")).toBe("unreachable");
+    expect(chip.getAttribute("data-surface-state")).toBe("unreachable");
+    // Tooltip names the comm-error kind + worker.
+    expect(chip.getAttribute("title")).toContain("worker-unreachable");
+    expect(chip.getAttribute("title")).toContain("w-7");
+    // Visually distinct from green/amber/red/gray — uses the indigo overlay,
+    // NOT the emerald/danger/amber/text-muted probe-colour classes.
+    expect(chip.className).toContain("indigo");
+    expect(chip.className).not.toContain("emerald");
+    expect(chip.className).not.toContain("danger");
+  });
+
+  it("unreachable overrides chipColor='red' (comm error ≠ red test)", () => {
+    const { getByTestId } = render(
+      <DepthChip depth={3} status="wired" chipColor="red" unreachable />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.getAttribute("data-status")).toBe("unreachable");
+    // A comm error must never be painted as a red test.
+    expect(chip.className).not.toContain("danger");
+    expect(chip.className).toContain("indigo");
+  });
+
+  it("renders normally (no unreachable) when unreachable=false", () => {
+    const { getByTestId } = render(
+      <DepthChip
+        depth={5}
+        status="wired"
+        chipColor="green"
+        unreachable={false}
+      />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.getAttribute("data-status")).not.toBe("unreachable");
+    expect(chip.className).toContain("emerald");
+  });
 });
 
 describe("depthColorClass (direct)", () => {

--- a/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
@@ -13,12 +13,13 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
-import { UnifiedCell } from "../unified-cell";
+import { UnifiedCell, arePropsEqual } from "../unified-cell";
 import type { UnifiedCellProps } from "../unified-cell";
 import type { CellContext } from "@/components/feature-grid";
-import type { CellModel, TestLevel, ChipColor } from "@/lib/cell-model";
+import type { CellModel, TestLevel } from "@/lib/cell-model";
 import type { Overlay } from "@/lib/overlay-types";
-import type { LiveStatusMap } from "@/lib/live-status";
+import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
+import { keyFor } from "@/lib/live-status";
 
 // ---------------------------------------------------------------------------
 // Mocks -- isolate UnifiedCell's rendering logic from child components
@@ -29,12 +30,21 @@ vi.mock("@/components/depth-chip", () => ({
     ({
       depth,
       chipColor,
+      unreachable,
+      commTooltip,
     }: {
       depth: number;
       status: string;
       chipColor?: string;
+      unreachable?: boolean;
+      commTooltip?: string;
     }) => (
-      <span data-testid="mock-depth-chip" data-chip-color={chipColor ?? ""}>
+      <span
+        data-testid="mock-depth-chip"
+        data-chip-color={chipColor ?? ""}
+        data-unreachable={unreachable ? "1" : "0"}
+        data-comm-tooltip={commTooltip ?? ""}
+      >
         D{depth}
       </span>
     ),
@@ -176,6 +186,7 @@ function makeModel(overrides?: Partial<CellModel>): CellModel {
     ceilingDepth: 5,
     chipColor: "green",
     isRegression: false,
+    surfaceState: "green",
     ...overrides,
   };
 }
@@ -198,7 +209,7 @@ describe("UnifiedCell", () => {
     it("renders only the ban icon with no badges and no depth chip", () => {
       const ctx = makeCtx();
       const model = makeModel({ supported: false });
-      const { getByTestId, queryByTestId, queryAllByTestId } = render(
+      const { getByTestId, queryByTestId } = render(
         <UnifiedCell
           ctx={ctx}
           model={model}
@@ -549,6 +560,112 @@ describe("UnifiedCell", () => {
 
       // A no-data rung emits label "?", which the real Badge hides → no badge.
       expect(queryByTestId("mock-badge-API")).not.toBeInTheDocument();
+    });
+  });
+
+  // ── REQ-B: pool comm-error → unreachable depth chip ─────────────────
+  describe("pool comm-error overlay (REQ-B)", () => {
+    it("renders the depth chip in the unreachable treatment when surfaceState is unreachable", () => {
+      const ctx = makeCtx();
+      const model = makeModel({
+        surfaceState: "unreachable",
+        // chipColor is preserved underneath — the overlay does not recolour it.
+        chipColor: "green",
+        commError: {
+          kind: "worker-unreachable",
+          message: "connect ECONNREFUSED",
+          workerId: "worker-7",
+          observedAt: new Date().toISOString(),
+        },
+      });
+      const { getByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("depth")} />,
+      );
+      const chip = getByTestId("mock-depth-chip");
+      expect(chip.getAttribute("data-unreachable")).toBe("1");
+      // Tooltip names the comm-error kind AND the worker for triage.
+      const tooltip = chip.getAttribute("data-comm-tooltip") ?? "";
+      expect(tooltip).toContain("worker-unreachable");
+      expect(tooltip).toContain("worker-7");
+    });
+
+    it("a normal red cell renders WITHOUT the unreachable treatment", () => {
+      const ctx = makeCtx();
+      const model = makeModel({ chipColor: "red", surfaceState: "red" });
+      const { getByTestId } = render(
+        <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("depth")} />,
+      );
+      const chip = getByTestId("mock-depth-chip");
+      expect(chip.getAttribute("data-unreachable")).toBe("0");
+      expect(chip.getAttribute("data-chip-color")).toBe("red");
+    });
+  });
+
+  // ── REQ-B: arePropsEqual watches the d6 AGGREGATE row (worker-death) ──
+  describe("arePropsEqual aggregate comm-error watch (Fix 2)", () => {
+    function commRow(key: string): StatusRow {
+      return {
+        id: `id-${key}`,
+        key,
+        dimension: "d6",
+        state: "green",
+        signal: {
+          __fleetCommError: {
+            kind: "worker-crashed-mid-job",
+            message: "lease expired with no terminal report",
+            workerId: "fleet-worker-3",
+            observedAt: new Date().toISOString(),
+          },
+        },
+        observed_at: new Date().toISOString(),
+        transitioned_at: new Date().toISOString(),
+        fail_count: 0,
+        first_failure_at: null,
+      };
+    }
+
+    it("forces a re-render when a comm error lands solely on the aggregate d6:<slug> row", () => {
+      const slug = "next";
+      // SAME model reference both renders — isolates the directKeys watch from
+      // the modelsEqual backstop. Without keyFor("d6", slug) in directKeys this
+      // returns true (skips the repaint) and the unreachable overlay is missed.
+      const model = makeModel();
+      const overlays = overlaySet("depth");
+
+      const prevLive: LiveStatusMap = new Map();
+      const nextLive: LiveStatusMap = new Map();
+      // Only the aggregate row differs — it now carries the worker-death signal.
+      nextLive.set(keyFor("d6", slug), commRow(keyFor("d6", slug)));
+
+      // Share ALL ctx fields except liveStatus (arePropsEqual compares the
+      // integration/feature/demo objects by reference, so a fresh makeCtx per
+      // side would short-circuit on those before reaching the directKeys watch).
+      const baseCtx = makeCtx({ liveStatus: prevLive });
+      const prev: UnifiedCellProps = { ctx: baseCtx, model, overlays };
+      const next: UnifiedCellProps = {
+        ctx: { ...baseCtx, liveStatus: nextLive },
+        model,
+        overlays,
+      };
+
+      // false === "props differ, re-render". The aggregate-key watch must catch
+      // the change to the aggregate row even with an identical model reference.
+      expect(arePropsEqual(prev, next)).toBe(false);
+    });
+
+    it("still skips the re-render when nothing the cell reads changed (no false repaint)", () => {
+      const model = makeModel();
+      const overlays = overlaySet("depth");
+      // Two distinct (empty) map identities but no watched key differs. Share
+      // ctx fields so the comparison reaches (and passes) the directKeys loop.
+      const baseCtx = makeCtx({ liveStatus: new Map() });
+      const prev: UnifiedCellProps = { ctx: baseCtx, model, overlays };
+      const next: UnifiedCellProps = {
+        ctx: { ...baseCtx, liveStatus: new Map() },
+        model,
+        overlays,
+      };
+      expect(arePropsEqual(prev, next)).toBe(true);
     });
   });
 });

--- a/showcase/shell-dashboard/src/components/depth-chip.tsx
+++ b/showcase/shell-dashboard/src/components/depth-chip.tsx
@@ -33,6 +33,17 @@ export interface DepthChipProps {
    * already determined the correct color (e.g. green when achieved == ceiling).
    */
   chipColor?: "green" | "amber" | "red" | "gray";
+  /**
+   * Pool COMMUNICATION error (REQ-B). When set, the chip renders a DISTINCT
+   * "couldn't reach the pool" treatment — a purple/indigo fill with a "⚡"
+   * glyph — that is visually unlike green/amber/red/gray, so an operator can
+   * tell "the pool was unreachable" apart from "the test went red". The
+   * underlying depth/colour is intentionally suppressed in favour of the
+   * comm-error overlay; the descriptive tooltip is supplied via `commTooltip`.
+   */
+  unreachable?: boolean;
+  /** Tooltip text for the unreachable treatment (names the comm-error kind). */
+  commTooltip?: string;
 }
 
 /**
@@ -91,7 +102,27 @@ export function DepthChip({
   regression,
   maxDepth,
   chipColor,
+  unreachable,
+  commTooltip,
 }: DepthChipProps) {
+  // Pool comm-error overlay (REQ-B) takes precedence over every probe colour:
+  // a "couldn't reach the pool" state must never be mistaken for a red test.
+  // A distinct indigo fill + ⚡ glyph, resolved BEFORE the unshipped/unsupported
+  // branches so an unreachable cell is always loud.
+  if (unreachable) {
+    return (
+      <span
+        data-testid="depth-chip"
+        data-status="unreachable"
+        data-surface-state="unreachable"
+        className="inline-flex items-center justify-center min-w-[32px] h-5 px-1.5 rounded text-[10px] font-semibold tabular-nums border border-indigo-400/60 bg-indigo-500/20 text-indigo-300"
+        title={commTooltip ?? "pool unreachable — comm error"}
+      >
+        ⚡
+      </span>
+    );
+  }
+
   if (status === "unshipped") {
     return (
       <span

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -14,6 +14,7 @@
 import { memo, useState, useEffect, useRef, useCallback } from "react";
 import type { CellContext } from "@/components/feature-grid";
 import type { CellModel, TestLevel } from "@/lib/cell-model";
+import type { PoolCommError } from "@/lib/live-status";
 import { DepthChip } from "@/components/depth-chip";
 import { Badge, FlashOnChange } from "@/components/badges";
 import type { BadgeTone } from "@/lib/live-status";
@@ -98,6 +99,21 @@ function TestBadge({
 }
 
 // ---------------------------------------------------------------------------
+// Pool comm-error tooltip (REQ-B)
+// ---------------------------------------------------------------------------
+
+/**
+ * Format the "couldn't reach the pool" tooltip for the unreachable chip,
+ * NAMING the `PoolCommErrorKind` and (when known) the worker so an operator
+ * can triage which pool member dropped. Falls back to the raw message when no
+ * structured detail is available.
+ */
+export function commErrorTooltip(err: PoolCommError): string {
+  const worker = err.workerId ? ` — worker ${err.workerId}` : "";
+  return `pool unreachable: ${err.kind}${worker} — ${err.message}`;
+}
+
+// ---------------------------------------------------------------------------
 // Layer renderers
 // ---------------------------------------------------------------------------
 
@@ -173,6 +189,10 @@ function DepthLayer({ ctx, model }: { ctx: CellContext; model: CellModel }) {
           chipColor={model.chipColor}
           depth={model.achievedDepth}
           status="wired"
+          unreachable={model.surfaceState === "unreachable"}
+          commTooltip={
+            model.commError ? commErrorTooltip(model.commError) : undefined
+          }
         />
       </button>
       {drilldownOpen && (
@@ -361,6 +381,10 @@ function modelsEqual(a: CellModel, b: CellModel): boolean {
     a.achievedDepth === b.achievedDepth &&
     a.ceilingDepth === b.ceilingDepth &&
     a.chipColor === b.chipColor &&
+    a.surfaceState === b.surfaceState &&
+    a.commError?.kind === b.commError?.kind &&
+    a.commError?.workerId === b.commError?.workerId &&
+    a.commError?.message === b.commError?.message &&
     a.d6Effective === b.d6Effective &&
     a.isRegression === b.isRegression &&
     testLevelsEqual(a.d3, b.d3) &&
@@ -370,7 +394,13 @@ function modelsEqual(a: CellModel, b: CellModel): boolean {
   );
 }
 
-function arePropsEqual(
+/**
+ * Memo equality used by `UnifiedCell`. Exported for direct unit testing of the
+ * `directKeys` watch (a comm error landing solely on the aggregate `d6:<slug>`
+ * row must force a re-render even when the precomputed `model` reference is
+ * reused). Returns `true` to SKIP the re-render, `false` to re-render.
+ */
+export function arePropsEqual(
   prev: UnifiedCellProps,
   next: UnifiedCellProps,
 ): boolean {
@@ -398,6 +428,17 @@ function arePropsEqual(
     keyFor("e2e", slug, featureId),
     keyFor("chat", slug),
     keyFor("tools", slug),
+    // health:<slug> is a pool comm-error carrier (REQ-B) even though it does
+    // not feed the depth ladder — watch it so an incoming comm-error signal
+    // repaints the cell's unreachable overlay.
+    keyFor("health", slug),
+    // d6:<slug> is the integration-level AGGREGATE row. It does not feed the
+    // per-cell depth ladder (that reads `d6:<slug>/<featureType>`), but it IS
+    // a pool comm-error carrier (REQ-B): a worker-death comm error lands solely
+    // on the aggregate row, and `decodeCellCommError` in buildCellModel reads it
+    // to light the cell's "unreachable" overlay. Watch it here so that signal
+    // actually triggers a re-render — keep in sync with buildCellModel.
+    keyFor("d6", slug),
   ];
 
   // Add D5 + D6 sub-keys from CATALOG_TO_D5_KEY. D6 is per-cell (not the

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -758,6 +758,61 @@ describe("buildCellModel", () => {
       expect(modelChat.chipColor).toBe("amber");
     });
 
+    it("END-TO-END: dashboard surfaces a fleet d6 result from the worker's emitted keys (d6:<slug> aggregate + d6:<slug>/<ft> per-cell)", () => {
+      // VERIFICATION of the worker→dashboard contract: the fleet worker emits
+      // the d6 aggregate at `d6:<slug>` AND per-cell rows at `d6:<slug>/<ft>`
+      // (NOT `e2e_d6:<slug>`). This pins that the dashboard's read side actually
+      // consumes EXACTLY those keys — a green per-cell row drives the green chip,
+      // and a comm error mirrored onto the aggregate row surfaces "unreachable".
+      const slug = "langgraph-python";
+      const ft = "agentic-chat";
+
+      // 1) Healthy fleet result: full ladder green, per-cell d6 green, aggregate
+      //    green. The cell must read its OWN per-cell d6:<slug>/<ft> row green.
+      const healthy = mapOf([
+        row(keyFor("e2e", slug, ft), "e2e", "green"),
+        row(keyFor("chat", slug), "chat", "green"),
+        row(keyFor("tools", slug), "tools", "green"),
+        row(keyFor("d5", slug, ft), "d5", "green"),
+        row(keyFor("d6", slug), "d6", "green"), // aggregate (worker emit)
+        row(keyFor("d6", slug, ft), "d6", "green"), // per-cell (worker emit)
+      ]);
+      const healthyModel = buildCellModel(healthy, wiredInput(slug, ft));
+      expect(healthyModel.d6!.exists).toBe(true);
+      expect(healthyModel.d6!.status).toBe("green");
+      expect(healthyModel.d6!.row?.key).toBe(`d6:${slug}/${ft}`);
+      expect(healthyModel.achievedDepth).toBe(6);
+      expect(healthyModel.chipColor).toBe("green");
+      expect(healthyModel.surfaceState).toBe("green");
+      expect(healthyModel.commError).toBeUndefined();
+
+      // 2) Comm-error fleet result (worker-death): the worker had no driver run,
+      //    so the PoolCommError is mirrored onto the AGGREGATE row `d6:<slug>`
+      //    (per the contract's `aggregateKey` fallback). The dashboard must read
+      //    that aggregate row and surface the "unreachable" overlay.
+      const commErrored = mapOf([
+        row(keyFor("e2e", slug, ft), "e2e", "green"),
+        row(keyFor("chat", slug), "chat", "green"),
+        row(keyFor("tools", slug), "tools", "green"),
+        row(keyFor("d5", slug, ft), "d5", "green"),
+        row(keyFor("d6", slug, ft), "d6", "green"),
+        row(keyFor("d6", slug), "d6", "green", {
+          signal: {
+            __fleetCommError: {
+              kind: "worker-crashed-mid-job",
+              message: "lease expired with no terminal report",
+              workerId: "fleet-worker-3",
+              observedAt: FRESH_OBSERVED_AT,
+            },
+          },
+        }),
+      ]);
+      const commModel = buildCellModel(commErrored, wiredInput(slug, ft));
+      expect(commModel.surfaceState).toBe("unreachable");
+      expect(commModel.commError?.kind).toBe("worker-crashed-mid-job");
+      expect(commModel.commError?.workerId).toBe("fleet-worker-3");
+    });
+
     it("does NOT credit D6 green when one mapped per-cell sub-row is MISSING (strict, mirrors resolveD5)", () => {
       // beautiful-chat maps to 5 D6 sub-keys (same featureTypes as D5). Emit
       // only 4 per-cell D6 rows (bar-chart missing). A missing mapped sub-row
@@ -1468,6 +1523,279 @@ describe("buildCellModel", () => {
       expect(model.d5!.status).toBeNull();
       expect(model.d6Effective).toBeNull();
       expect(model.chipColor).toBe("gray");
+    });
+  });
+
+  // ── REQ-B: pool comm-error → "unreachable" surface state ────────────
+  describe("pool comm-error overlay (REQ-B)", () => {
+    const COMM = {
+      kind: "worker-unreachable" as const,
+      message: "connect ECONNREFUSED",
+      workerId: "worker-7",
+      observedAt: FRESH_OBSERVED_AT,
+    };
+    const commSignal = { __fleetCommError: COMM };
+
+    it("a row carrying __fleetCommError surfaces as unreachable, distinct from red", () => {
+      const live = mapOf([
+        // Last-known probe colour stays green; the comm error rides on the row.
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("tools", "agno"), "tools", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green", {
+          signal: commSignal,
+        }),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.surfaceState).toBe("unreachable");
+      // The probe colour (chipColor) is preserved — comm error is an OVERLAY,
+      // not a recolour. The last-known result stays visible underneath.
+      expect(model.chipColor).toBe("green");
+      // The decoded comm error names the kind + worker for the tooltip.
+      expect(model.commError?.kind).toBe("worker-unreachable");
+      expect(model.commError?.workerId).toBe("worker-7");
+    });
+
+    it("a normal red row (no comm error) is unaffected — surfaceState is red, not unreachable", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("red");
+      expect(model.surfaceState).toBe("red");
+      expect(model.commError).toBeUndefined();
+    });
+
+    it("decodes a comm error riding on the e2e row too", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red", {
+          signal: {
+            __fleetCommError: {
+              kind: "worker-crashed-mid-job",
+              message: "lease expired with no report",
+              observedAt: FRESH_OBSERVED_AT,
+            },
+          },
+        }),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.surfaceState).toBe("unreachable");
+      expect(model.commError?.kind).toBe("worker-crashed-mid-job");
+    });
+
+    it("mirrors the chip colour onto surfaceState when no comm error (amber)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("tools", "agno"), "tools", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        // D5 green, no/failing D6 → chip amber.
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("amber");
+      // surfaceState uses the dashboard's ChipColor vocabulary, so amber maps
+      // straight through (no comm error → no "unreachable" overlay).
+      expect(model.surfaceState).toBe("amber");
+    });
+
+    it("unsupported / unwired cells never surface unreachable", () => {
+      const unsupported = buildCellModel(mapOf([]), {
+        slug: "agno",
+        featureId: "agentic-chat",
+        isSupported: false,
+        isWired: false,
+      });
+      expect(unsupported.surfaceState).toBe("gray");
+      expect(unsupported.commError).toBeUndefined();
+    });
+
+    it("the MOST RECENT comm error wins — a newer aggregate (worker-death) beats a stale per-cell one", () => {
+      // A STALE per-cell comm error (older `observedAt`) lingers on the per-cell
+      // d6 row, scanned BEFORE the aggregate. A NEWER worker-death comm error
+      // landed on the aggregate `d6:<slug>` row. Without a recency tie-break the
+      // fixed scan order returns the stale per-cell error and masks the real,
+      // newer cause. The recency tie-break must surface the aggregate error.
+      // Both timestamps sit inside the comm-error staleness window relative to
+      // the injected `now`, so this exercises the RECENCY tie-break (not the
+      // staleness gate). "STALE" here means older-than-the-other, not aged-out.
+      const STALE = "2026-06-04T11:00:00.000Z";
+      const NEWER = "2026-06-04T12:00:00.000Z";
+      const NOW = Date.parse("2026-06-04T12:30:00.000Z");
+      const live = mapOf([
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green", {
+          signal: {
+            __fleetCommError: {
+              kind: "worker-protocol-timeout",
+              message: "stale per-cell timeout",
+              workerId: "worker-OLD",
+              observedAt: STALE,
+            },
+          },
+        }),
+        row(keyFor("d6", "agno"), "d6", "green", {
+          signal: {
+            __fleetCommError: {
+              kind: "worker-crashed-mid-job",
+              message: "worker died — lease expired",
+              workerId: "worker-NEW",
+              observedAt: NEWER,
+            },
+          },
+        }),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.surfaceState).toBe("unreachable");
+      // The NEWER aggregate (worker-death) error wins despite being scanned LAST.
+      expect(model.commError?.kind).toBe("worker-crashed-mid-job");
+      expect(model.commError?.workerId).toBe("worker-NEW");
+    });
+
+    it("equal timestamps fall back to scan order (per-cell before aggregate)", () => {
+      // Stable tie-break: when two comm errors share an `observedAt`, the
+      // first-in-scan-order one (the per-cell d6 row) is retained, preserving
+      // the prior authority ordering.
+      const SAME = "2026-06-04T12:00:00.000Z";
+      // `now` within the staleness window so this exercises the equal-timestamp
+      // tie-break, not the staleness gate.
+      const NOW = Date.parse("2026-06-04T12:30:00.000Z");
+      const live = mapOf([
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green", {
+          signal: {
+            __fleetCommError: {
+              kind: "worker-protocol-timeout",
+              message: "per-cell",
+              workerId: "worker-PERCELL",
+              observedAt: SAME,
+            },
+          },
+        }),
+        row(keyFor("d6", "agno"), "d6", "green", {
+          signal: {
+            __fleetCommError: {
+              kind: "worker-crashed-mid-job",
+              message: "aggregate",
+              workerId: "worker-AGG",
+              observedAt: SAME,
+            },
+          },
+        }),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.commError?.workerId).toBe("worker-PERCELL");
+    });
+
+    // ── Comm-error staleness window ───────────────────────────────────
+    // A PoolCommError mirrored onto the `d6:<slug>` aggregate row is NOT
+    // overwritten when the pool recovers (recovery writes fresh per-cell
+    // rows; nothing clears the stale comm-error blob). Without a staleness
+    // window the cell renders "unreachable" forever. A comm error older than
+    // the staleness window must be treated as recovered/reachable, mirroring
+    // the resolveD3/D4/D5/D6 staleness downgrade.
+    describe("comm-error staleness window", () => {
+      const NOW = Date.parse("2026-06-04T12:00:00.000Z");
+
+      function commErrorAtAge(ageMs: number) {
+        return {
+          kind: "worker-crashed-mid-job" as const,
+          message: "worker died — lease expired",
+          workerId: "worker-stale",
+          observedAt: new Date(NOW - ageMs).toISOString(),
+        };
+      }
+
+      it("a FRESH comm error → surfaceState unreachable", () => {
+        const live = mapOf([
+          // Pool recovered: fresh green per-cell rows are present.
+          row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green", {
+            observed_at: new Date(NOW).toISOString(),
+            transitioned_at: new Date(NOW).toISOString(),
+          }),
+          row(keyFor("chat", "agno"), "chat", "green", {
+            observed_at: new Date(NOW).toISOString(),
+            transitioned_at: new Date(NOW).toISOString(),
+          }),
+          row(keyFor("tools", "agno"), "tools", "green", {
+            observed_at: new Date(NOW).toISOString(),
+            transitioned_at: new Date(NOW).toISOString(),
+          }),
+          row(keyFor("d5", "agno", "agentic-chat"), "d5", "green", {
+            observed_at: new Date(NOW).toISOString(),
+            transitioned_at: new Date(NOW).toISOString(),
+          }),
+          row(keyFor("d6", "agno", "agentic-chat"), "d6", "green", {
+            observed_at: new Date(NOW).toISOString(),
+            transitioned_at: new Date(NOW).toISOString(),
+          }),
+          // FRESH comm error on the aggregate row.
+          row(keyFor("d6", "agno"), "d6", "green", {
+            signal: { __fleetCommError: commErrorAtAge(0) },
+          }),
+        ]);
+        const model = buildCellModel(
+          live,
+          wiredInput("agno", "agentic-chat"),
+          NOW,
+        );
+        expect(model.surfaceState).toBe("unreachable");
+        expect(model.commError?.kind).toBe("worker-crashed-mid-job");
+      });
+
+      it("the SAME comm error aged past the staleness window → NOT unreachable (recovered)", () => {
+        const live = mapOf([
+          // Pool recovered: fresh green per-cell rows are present and the
+          // ladder is intact through D6 → chip green.
+          row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green", {
+            observed_at: new Date(NOW).toISOString(),
+            transitioned_at: new Date(NOW).toISOString(),
+          }),
+          row(keyFor("chat", "agno"), "chat", "green", {
+            observed_at: new Date(NOW).toISOString(),
+            transitioned_at: new Date(NOW).toISOString(),
+          }),
+          row(keyFor("tools", "agno"), "tools", "green", {
+            observed_at: new Date(NOW).toISOString(),
+            transitioned_at: new Date(NOW).toISOString(),
+          }),
+          row(keyFor("d5", "agno", "agentic-chat"), "d5", "green", {
+            observed_at: new Date(NOW).toISOString(),
+            transitioned_at: new Date(NOW).toISOString(),
+          }),
+          row(keyFor("d6", "agno", "agentic-chat"), "d6", "green", {
+            observed_at: new Date(NOW).toISOString(),
+            transitioned_at: new Date(NOW).toISOString(),
+          }),
+          // STALE comm error blob left over on the aggregate row, never cleared.
+          row(keyFor("d6", "agno"), "d6", "green", {
+            signal: {
+              __fleetCommError: commErrorAtAge(
+                E2E_STALE_AFTER_MS + 60 * 60 * 1000,
+              ),
+            },
+          }),
+        ]);
+        const model = buildCellModel(
+          live,
+          wiredInput("agno", "agentic-chat"),
+          NOW,
+        );
+        // The aged comm error is treated as recovered — the cell reflects its
+        // underlying probe state (green), NOT the sticky "unreachable" overlay.
+        expect(model.surfaceState).not.toBe("unreachable");
+        expect(model.surfaceState).toBe("green");
+        expect(model.commError).toBeUndefined();
+      });
     });
   });
 });

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -7,8 +7,18 @@
  * regression flag.
  */
 
-import type { LiveStatusMap, StatusRow, State } from "./live-status";
-import { keyFor, CATALOG_TO_D5_KEY } from "./live-status";
+import type {
+  LiveStatusMap,
+  StatusRow,
+  State,
+  PoolCommError,
+  FleetSurfaceState,
+} from "./live-status";
+import {
+  keyFor,
+  CATALOG_TO_D5_KEY,
+  commErrorFromStatusSignal,
+} from "./live-status";
 import { E2E_STALE_AFTER_MS, D4_STALE_AFTER_MS, isStale } from "./staleness";
 
 // Re-export the staleness windows so existing consumers that import them from
@@ -57,16 +67,42 @@ export interface CellModel {
    * non-green / no-data D5 collapses D6 to `null`.
    *
    * Derived from the SAME contiguous-ladder algorithm as `chipColor` so the
-   * badge, the stat, and the chip never disagree. Mirrors the chip table:
-   *   chip green  ⇔ d6Effective green   (full ladder, achievedDepth === 6)
-   *   chip amber  ⇔ d6Effective amber/null (D5 green, D6 not green)
-   *   chip red (D5-broken) / gray (unverified) ⇒ d6Effective null (blocked)
+   * badge, the stat, and the chip never disagree. When the ladder is intact
+   * through D5 (`d5.status === "green"`, gate passing), `d6Effective` passes the
+   * RAW `d6.status` straight through, so it tracks the actual D6 result while
+   * the chip collapses every non-green D6 to amber:
+   *   D5 green + D6 green          → chip green, d6Effective green
+   *   D5 green + D6 red            → chip amber, d6Effective RED
+   *   D5 green + D6 amber          → chip amber, d6Effective amber
+   *   D5 green + D6 missing/null   → chip amber, d6Effective null
+   *   gate fails / D5 broken/null  → chip red or gray, d6Effective null (blocked)
+   * The chip is the coarser of the two: amber covers ANY non-green D6 once the
+   * ladder is intact, whereas d6Effective preserves the underlying D6 colour
+   * (a genuine D6 red surfaces as red on the badge/stat).
    */
   d6Effective: TestStatus;
   achievedDepth: 0 | 3 | 4 | 5 | 6;
   ceilingDepth: 0 | 3 | 4 | 5 | 6;
   chipColor: ChipColor;
   isRegression: boolean;
+  /**
+   * Pool COMMUNICATION error (REQ-B), decoded from a status row's signal under
+   * `FLEET_COMM_ERROR_SIGNAL_KEY`, when the latest attempt failed to reach /
+   * trust the worker pool rather than producing a real test result. This is a
+   * SEPARATE overlay from the probe colour — `chipColor` keeps carrying the
+   * last-known result so the cell still shows its prior state, dimmed, while
+   * `surfaceState` flips to `"unreachable"` so the renderer can paint the
+   * distinct "couldn't reach the pool" treatment. `undefined` when the pool was
+   * reachable (the normal case — a real red is NOT a comm error).
+   */
+  commError?: PoolCommError;
+  /**
+   * The dashboard's presentation state: `"unreachable"` when a `commError` is
+   * present, otherwise the cell's underlying probe colour (mapped from
+   * `chipColor`). Lets the renderer branch on ONE value instead of re-deriving
+   * the comm-error precedence. A presentation field only — never persisted.
+   */
+  surfaceState: FleetSurfaceState;
 }
 
 export interface CellModelInput {
@@ -105,6 +141,22 @@ const STATE_RANK: Readonly<Record<State, number>> = {
 };
 
 /**
+ * Worst-state rank for an arbitrary row state (Fix A2). `StatusRow.state` is
+ * typed `State` (green|red|degraded), but the harness CAN persist an
+ * out-of-vocabulary value at runtime — notably `"error"` (the no-data
+ * representation; see harness result-aggregator.ts). A bare `STATE_RANK[state]`
+ * for such a value is `undefined`, and the fold comparison `undefined > n` is
+ * `false`, so the row is SILENTLY DROPPED from the worst-state fold instead of
+ * surfacing. Treat an unknown state as the MOST SEVERE (a rank above every known
+ * state) so it surfaces as the worst rather than vanishing — an unrecognized
+ * signal must never be silently swallowed.
+ */
+const UNKNOWN_STATE_RANK = Number.POSITIVE_INFINITY;
+function rankOfState(state: string): number {
+  return STATE_RANK[state as State] ?? UNKNOWN_STATE_RANK;
+}
+
+/**
  * Resolve the D4 (real-time) test level for `slug`.
  *
  * D4 checks both `chat:<slug>` and `tools:<slug>`. When both exist the
@@ -141,7 +193,7 @@ function resolveD4(live: LiveStatusMap, slug: string, now: number): TestLevel {
         : candidate.state;
     if (
       worstState === null ||
-      STATE_RANK[effectiveState] > STATE_RANK[worstState]
+      rankOfState(effectiveState) > rankOfState(worstState)
     ) {
       winner =
         effectiveState === candidate.state
@@ -224,7 +276,7 @@ function resolveD5(
         : row.state;
     if (
       worstState === null ||
-      STATE_RANK[effectiveState] > STATE_RANK[worstState]
+      rankOfState(effectiveState) > rankOfState(worstState)
     ) {
       // Store the EFFECTIVE (downgraded) row so `.row.state` agrees with
       // `.status` — mirrors `buildBadge` in live-status.ts.
@@ -352,7 +404,7 @@ function resolveD6(
         : row.state;
     if (
       worstState === null ||
-      STATE_RANK[effectiveState] > STATE_RANK[worstState]
+      rankOfState(effectiveState) > rankOfState(worstState)
     ) {
       // Store the EFFECTIVE (downgraded) row so `.row.state` agrees with
       // `.status` — mirrors `buildBadge` in live-status.ts.
@@ -384,6 +436,116 @@ function resolveD6(
   };
 }
 
+/**
+ * Map a derived `ChipColor` onto the presentation surface state. `FleetSurfaceState`
+ * is `ChipColor | "unreachable"`, so every chip colour passes straight through;
+ * the `"unreachable"` overlay is applied separately by the caller when a comm
+ * error is present. Pure; no widening cast needed.
+ */
+function chipColorToSurface(color: ChipColor): FleetSurfaceState {
+  return color;
+}
+
+/**
+ * Decode a pool comm-error (REQ-B) for this cell by scanning the status rows
+ * the cell's overlay depends on: the per-cell D6 (parity) row family, D5
+ * (conversation), the D3/e2e row, the D4 (chat/tools) rows, health, AND the
+ * integration-level d6 AGGREGATE row (`d6:<slug>`). The control-plane mirrors a
+ * `PoolCommError` into the row signal under `FLEET_COMM_ERROR_SIGNAL_KEY` (see
+ * `commErrorFromStatusSignal`).
+ *
+ * RECENCY, not key order, decides the winner. Multiple rows can each carry a
+ * comm error simultaneously (e.g. a STALE per-cell comm error left over from an
+ * earlier attempt, plus a NEWER worker-death error that landed solely on the
+ * aggregate row). A fixed key-order scan would let the stale per-cell error mask
+ * the newer aggregate one, painting the wrong cause. So we decode EVERY
+ * candidate row and return the one with the most recent `observedAt`, falling
+ * back to scan order only as a stable tie-break when timestamps are equal/absent.
+ * Returns `undefined` when no candidate row carries a comm error (pool reachable).
+ *
+ * STALENESS WINDOW: a comm error is only surfaced while it is RECENT. The
+ * control-plane mirrors a `PoolCommError` onto the `d6:<slug>` aggregate row but
+ * NOTHING clears that blob on recovery — recovery just writes fresh green
+ * per-cell rows. Without an age cap a single comm error would pin every cell of
+ * the service to "unreachable" forever, even after the pool recovers. So a
+ * decoded comm error whose `observedAt` is older than `E2E_STALE_AFTER_MS` (the
+ * same window resolveD3/D5/D6 apply to stale-green rows; the comm error rides the
+ * e2e-cadence d6 aggregate) is treated as recovered and skipped — exactly mirror-
+ * ing the resolveDx stale-green downgrade. `now` is threaded in the same way
+ * buildCellModel passes it to the resolveDx resolvers.
+ *
+ * SCOPE NOTE: this intentionally scans the integration-scoped aggregate
+ * (`d6:<slug>`) and the chat/tools/health rows in addition to the cell's own
+ * per-cell rows. A worker-death comm error rides on the aggregate row, not the
+ * per-cell rows, so to surface the "unreachable" overlay at all the cell MUST
+ * consult the aggregate — which means every cell of the affected service lights
+ * up from that one aggregate signal. That is the intended behavior (a pool that
+ * can't be reached cannot have produced any per-cell result), not a leak from "a
+ * row the cell doesn't show".
+ */
+function decodeCellCommError(
+  live: LiveStatusMap,
+  slug: string,
+  featureId: string,
+  now: number,
+): PoolCommError | undefined {
+  // Per-cell D6/D5 rows fan out over the mapped featureType family.
+  const familyKeys = CATALOG_TO_D5_KEY[featureId];
+  const candidateKeys: string[] = [];
+  if (familyKeys) {
+    for (const ft of familyKeys) {
+      candidateKeys.push(keyFor("d6", slug, ft));
+      candidateKeys.push(keyFor("d5", slug, ft));
+    }
+  }
+  // The d6 AGGREGATE row (`d6:<slug>`, no featureId) is where BOTH harness
+  // legs mirror a per-service `PoolCommError` (REQ-B): the result-aggregator
+  // overlays it onto the aggregate primary row (`result.aggregateKey` =
+  // `d6:<slug>`), and the control-plane fleet-health leg writes it to the job's
+  // `probe_key` (also `d6:<slug>`). Without scanning the aggregate key here the
+  // dashboard never surfaces the "unreachable" overlay even though the signal
+  // is persisted. Checked alongside the per-cell rows so a worker-death comm
+  // error lights up every cell of the affected service.
+  candidateKeys.push(keyFor("d6", slug));
+  candidateKeys.push(keyFor("e2e", slug, featureId));
+  candidateKeys.push(keyFor("chat", slug));
+  candidateKeys.push(keyFor("tools", slug));
+  candidateKeys.push(keyFor("health", slug));
+
+  // Decode every candidate and keep the MOST RECENT comm error. A later
+  // candidate only wins if its `observedAt` is strictly newer, so for equal
+  // (or unparseable) timestamps the first-in-scan-order error is retained —
+  // a stable tie-break preserving the prior authority ordering.
+  let winner: PoolCommError | undefined;
+  let winnerTs = Number.NEGATIVE_INFINITY;
+  for (const key of candidateKeys) {
+    const row = live.get(key);
+    if (!row) continue;
+    const commError = commErrorFromStatusSignal(row.signal);
+    if (!commError) continue;
+    // `observedAt` is an ISO string; `Date.parse` yields NaN for a malformed
+    // value. Treat NaN as the oldest possible time so a well-timestamped error
+    // always outranks an untimestamped one, and so the first untimestamped
+    // error still wins over later untimestamped ones (stable scan-order).
+    const parsed = Date.parse(commError.observedAt);
+    // STALENESS GATE: a comm error older than the staleness window is treated
+    // as recovered and skipped — nothing clears the mirrored blob on recovery,
+    // so without this the cell would render "unreachable" forever. Mirrors the
+    // resolveDx stale-green downgrade and `isStale`'s fail-safe: a malformed /
+    // unparseable `observedAt` (NaN) is NOT treated as stale, so such an error
+    // is still surfaced rather than silently dropped.
+    if (!Number.isNaN(parsed) && now - parsed > E2E_STALE_AFTER_MS) {
+      continue;
+    }
+    const ts = Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+    if (winner === undefined || ts > winnerTs) {
+      winner = commError;
+      winnerTs = ts;
+    }
+  }
+  return winner;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -401,6 +563,7 @@ const UNSUPPORTED: CellModel = {
   ceilingDepth: 0,
   chipColor: "gray",
   isRegression: false,
+  surfaceState: "gray",
 };
 
 /**
@@ -435,6 +598,7 @@ export function buildCellModel(
       ceilingDepth: 0,
       chipColor: "gray",
       isRegression: false,
+      surfaceState: "gray",
     };
   }
 
@@ -582,6 +746,16 @@ export function buildCellModel(
     nextRung.exists &&
     nextRung.status !== null;
 
+  // ── Pool comm-error overlay (REQ-B) ───────────────────────────────
+  // Decode "couldn't reach the pool" off the rows this cell reads. When
+  // present it does NOT overwrite chipColor — the cell keeps showing its
+  // last-known probe result; surfaceState flips to "unreachable" so the
+  // renderer paints the distinct comm-error treatment on top.
+  const commError = decodeCellCommError(live, slug, featureId, now);
+  const surfaceState: FleetSurfaceState = commError
+    ? "unreachable"
+    : chipColorToSurface(chipColor);
+
   return {
     supported: true,
     d3,
@@ -593,5 +767,7 @@ export function buildCellModel(
     ceilingDepth,
     chipColor,
     isRegression,
+    ...(commError ? { commError } : {}),
+    surfaceState,
   };
 }

--- a/showcase/shell-dashboard/src/lib/comm-error.test.ts
+++ b/showcase/shell-dashboard/src/lib/comm-error.test.ts
@@ -1,0 +1,114 @@
+/**
+ * REQ-B — dashboard-side decode of the pool COMM-ERROR signal.
+ *
+ * The harness mirrors a `PoolCommError` into a status row's `signal` under
+ * `FLEET_COMM_ERROR_SIGNAL_KEY` (the persisted `State` enum is NOT widened).
+ * These tests pin the dashboard reader (`commErrorFromStatusSignal`) and the
+ * presentation surface (`FleetSurfaceState`) so an operator can tell "couldn't
+ * reach the pool" apart from "the test went red".
+ */
+import { describe, it, expect } from "vitest";
+import {
+  commErrorFromStatusSignal,
+  isPoolCommErrorKind,
+  POOL_COMM_ERROR_KINDS,
+  FLEET_COMM_ERROR_SIGNAL_KEY,
+} from "./live-status";
+import type { PoolCommError } from "./live-status";
+
+function commError(overrides: Partial<PoolCommError> = {}): PoolCommError {
+  return {
+    kind: "worker-unreachable",
+    message: "connect ECONNREFUSED 10.0.0.5:8080",
+    workerId: "worker-7",
+    jobId: "job-42",
+    observedAt: "2026-06-04T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function signalWith(err: unknown): Record<string, unknown> {
+  return { [FLEET_COMM_ERROR_SIGNAL_KEY]: err };
+}
+
+describe("commErrorFromStatusSignal (REQ-B decode)", () => {
+  it("decodes a well-formed comm error off the row signal", () => {
+    const err = commError();
+    const decoded = commErrorFromStatusSignal(signalWith(err));
+    expect(decoded).toEqual(err);
+  });
+
+  it("preserves the kind + workerId so the tooltip can name them", () => {
+    const decoded = commErrorFromStatusSignal(
+      signalWith(
+        commError({ kind: "worker-crashed-mid-job", workerId: "w-99" }),
+      ),
+    );
+    expect(decoded?.kind).toBe("worker-crashed-mid-job");
+    expect(decoded?.workerId).toBe("w-99");
+  });
+
+  it("omits optional fields when absent", () => {
+    const decoded = commErrorFromStatusSignal(
+      signalWith({
+        kind: "claim-comm-failure",
+        message: "CAS transport error",
+        observedAt: "2026-06-04T12:00:00.000Z",
+      }),
+    );
+    expect(decoded).toEqual({
+      kind: "claim-comm-failure",
+      message: "CAS transport error",
+      observedAt: "2026-06-04T12:00:00.000Z",
+    });
+    expect(decoded).not.toHaveProperty("workerId");
+    expect(decoded).not.toHaveProperty("jobId");
+  });
+
+  it("returns undefined when no comm error is present (a normal probe row)", () => {
+    expect(commErrorFromStatusSignal({})).toBeUndefined();
+    expect(commErrorFromStatusSignal({ someOtherField: 1 })).toBeUndefined();
+  });
+
+  it("returns undefined for null / non-object signals (fail-safe)", () => {
+    expect(commErrorFromStatusSignal(null)).toBeUndefined();
+    expect(commErrorFromStatusSignal(undefined)).toBeUndefined();
+    expect(commErrorFromStatusSignal("a string")).toBeUndefined();
+    expect(commErrorFromStatusSignal(42)).toBeUndefined();
+  });
+
+  it("returns undefined for a malformed comm error (bad kind / missing fields)", () => {
+    expect(
+      commErrorFromStatusSignal(
+        signalWith({ kind: "not-a-real-kind", message: "x", observedAt: "y" }),
+      ),
+    ).toBeUndefined();
+    // missing message
+    expect(
+      commErrorFromStatusSignal(
+        signalWith({ kind: "worker-unreachable", observedAt: "y" }),
+      ),
+    ).toBeUndefined();
+    // missing observedAt
+    expect(
+      commErrorFromStatusSignal(
+        signalWith({ kind: "worker-unreachable", message: "x" }),
+      ),
+    ).toBeUndefined();
+    // non-object payload under the key
+    expect(commErrorFromStatusSignal(signalWith("oops"))).toBeUndefined();
+  });
+});
+
+describe("isPoolCommErrorKind", () => {
+  it("accepts every declared kind", () => {
+    for (const kind of POOL_COMM_ERROR_KINDS) {
+      expect(isPoolCommErrorKind(kind)).toBe(true);
+    }
+  });
+
+  it("rejects unknown values and undefined", () => {
+    expect(isPoolCommErrorKind("red")).toBe(false);
+    expect(isPoolCommErrorKind(undefined)).toBe(false);
+  });
+});

--- a/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
+++ b/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Cross-package contract drift test — the dashboard's hand-copied pool
+ * COMM-ERROR contract vs the authoritative harness `contracts.ts`.
+ *
+ * WHY THIS EXISTS: the dashboard carries a STRUCTURAL COPY of the harness fleet
+ * comm-error contract (`PoolCommError`, `POOL_COMM_ERROR_KINDS`,
+ * `FLEET_COMM_ERROR_SIGNAL_KEY`, `commErrorFromStatusSignal`) in
+ * `live-status.ts`, because it imports only `@/*` and never reaches across the
+ * package boundary into harness source at runtime (same rule that makes
+ * `STARTER_COLUMNS` a local copy of a harness producer constant). The harness
+ * OWNS the producer side; the dashboard mirrors the read shape it consumes.
+ * `live-status.ts` claims THIS test guards the two against drift — so it must
+ * actually exist and actually compare them, or a future harness contract change
+ * silently breaks the dashboard's "unreachable" overlay with no failing test.
+ *
+ * The harness lives in a SEPARATE pnpm workspace (`showcase/harness`), so the
+ * dashboard cannot import across the package boundary. We parse the harness
+ * source via `fs` (mirroring `starter-column-equality.test.ts`), reading the
+ * authoritative `POOL_COMM_ERROR_KINDS` values + the signal key + the decode
+ * shape directly so a rename / kind-add / key-change on the harness side reds
+ * this test.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  POOL_COMM_ERROR_KINDS,
+  FLEET_COMM_ERROR_SIGNAL_KEY,
+  commErrorFromStatusSignal,
+} from "./live-status";
+
+const HARNESS_CONTRACTS_FILE = resolve(
+  __dirname,
+  "../../../harness/src/fleet/contracts.ts",
+);
+
+function harnessSource(): string {
+  return readFileSync(HARNESS_CONTRACTS_FILE, "utf8");
+}
+
+/**
+ * Parse the string-literal members of the harness `POOL_COMM_ERROR_KINDS`
+ * array. Throws if the block can't be located so a shape change is loud, not a
+ * silent pass.
+ */
+function parseHarnessKinds(): string[] {
+  const src = harnessSource();
+  const block = src.match(
+    /POOL_COMM_ERROR_KINDS\s*=\s*\[([\s\S]+?)\]\s*as const;/,
+  );
+  if (!block || !block[1]) {
+    throw new Error(
+      "drift parser: could not locate `POOL_COMM_ERROR_KINDS` array literal in " +
+        "harness contracts.ts — if the source shape changed, update this regex.",
+    );
+  }
+  // Each member is a double-quoted kind on its own line (comment lines skipped
+  // because they have no quoted token matched by this pattern at line position).
+  const kinds = Array.from(
+    block[1].matchAll(/"([a-z-]+)"/g),
+    (m) => m[1] as string,
+  );
+  if (kinds.length === 0) {
+    throw new Error(
+      "drift parser: parsed zero kinds from POOL_COMM_ERROR_KINDS — regex " +
+        "likely drifted from the source shape.",
+    );
+  }
+  return kinds;
+}
+
+/**
+ * Parse the harness `FLEET_COMM_ERROR_SIGNAL_KEY` string literal value.
+ */
+function parseHarnessSignalKey(): string {
+  const src = harnessSource();
+  const m = src.match(
+    /FLEET_COMM_ERROR_SIGNAL_KEY\s*=\s*"([^"]+)"\s*as const;/,
+  );
+  if (!m || !m[1]) {
+    throw new Error(
+      "drift parser: could not locate `FLEET_COMM_ERROR_SIGNAL_KEY` literal in " +
+        "harness contracts.ts — if the source shape changed, update this regex.",
+    );
+  }
+  return m[1];
+}
+
+describe("pool comm-error contract cross-package drift", () => {
+  it("dashboard POOL_COMM_ERROR_KINDS exactly equals the harness kind set", () => {
+    const harnessKinds = new Set(parseHarnessKinds());
+    const dashboardKinds = new Set<string>(POOL_COMM_ERROR_KINDS);
+
+    for (const kind of harnessKinds) {
+      expect(
+        dashboardKinds.has(kind),
+        `harness declares comm-error kind "${kind}" but the dashboard ` +
+          `POOL_COMM_ERROR_KINDS has no entry — a worker emitting it would ` +
+          `decode to undefined and render as a normal probe colour, not "unreachable"`,
+      ).toBe(true);
+    }
+    for (const kind of dashboardKinds) {
+      expect(
+        harnessKinds.has(kind),
+        `dashboard POOL_COMM_ERROR_KINDS has "${kind}" but the harness contract ` +
+          `does not declare it — the harness can never produce that kind`,
+      ).toBe(true);
+    }
+    expect(dashboardKinds.size).toBe(harnessKinds.size);
+  });
+
+  it("dashboard FLEET_COMM_ERROR_SIGNAL_KEY exactly equals the harness key", () => {
+    // If these drift, the dashboard reads the comm error out of the WRONG
+    // signal-blob key and the "unreachable" overlay silently never renders.
+    expect(FLEET_COMM_ERROR_SIGNAL_KEY).toBe(parseHarnessSignalKey());
+  });
+
+  it("dashboard decode behavior matches the harness contract on a well-formed signal", () => {
+    // Build a signal exactly as the harness writer does (commErrorToStatusSignal
+    // nests the error under FLEET_COMM_ERROR_SIGNAL_KEY) using the parsed harness
+    // key, then assert the dashboard reader recovers it. This pins the DECODE
+    // contract, not just the constant values: a future change to the nesting /
+    // required fields on either side reds this test.
+    const harnessKey = parseHarnessSignalKey();
+    const err = {
+      kind: parseHarnessKinds()[0],
+      message: "connect ECONNREFUSED 10.0.0.5:8080",
+      workerId: "worker-7",
+      jobId: "job-42",
+      observedAt: "2026-06-04T12:00:00.000Z",
+    };
+    const signal = { [harnessKey]: err };
+    expect(commErrorFromStatusSignal(signal)).toEqual(err);
+  });
+
+  it("dashboard decode rejects an unknown kind (fail-safe to normal colour)", () => {
+    // A kind the harness never declares must decode to undefined so the cell
+    // renders its normal probe colour rather than a half-populated overlay.
+    const harnessKey = parseHarnessSignalKey();
+    const signal = {
+      [harnessKey]: {
+        kind: "not-a-real-harness-kind",
+        message: "x",
+        observedAt: "2026-06-04T12:00:00.000Z",
+      },
+    };
+    expect(commErrorFromStatusSignal(signal)).toBeUndefined();
+  });
+});

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -218,6 +218,48 @@ describe("mergeRowsToMap", () => {
   });
 });
 
+describe("resolveD6Row / resolveD5Row — out-of-vocabulary state tolerance (Fix A2)", () => {
+  // The dashboard State union is green|red|degraded, but the harness CAN persist
+  // a row with state:"error" (the no-data representation; see
+  // result-aggregator.ts). STATE_RANK/WORST_STATE_RANK are Record<State,number>,
+  // so STATE_RANK["error"] is undefined and the fold comparison `undefined > n`
+  // is false — an "error" row is SILENTLY DROPPED instead of surfacing. The fold
+  // must treat an unknown/out-of-vocabulary state as the WORST (most severe) so
+  // such a row surfaces rather than vanishing.
+  const OUT_OF_VOCAB = "error" as unknown as StatusRow["state"];
+
+  it("does NOT silently drop a lone d6 row carrying an out-of-vocabulary state", () => {
+    // `agentic-chat` maps to a single d6 key, so the fold sees exactly one row.
+    const live = mapOf([row("d6:agno/agentic-chat", "d6", OUT_OF_VOCAB)]);
+    const c = resolveCell(live, "agno", "agentic-chat");
+    // Pre-fix: the "error" row is dropped, resolveD6Row returns null → d6.row is
+    // null. Post-fix: the row surfaces as the worst-state winner.
+    expect(c.d6.row).not.toBeNull();
+    expect(c.d6.row?.state).toBe(OUT_OF_VOCAB);
+  });
+
+  it("surfaces an out-of-vocabulary d6 row as WORST over a present green sibling", () => {
+    // `beautiful-chat` maps to multiple d6 keys; an out-of-vocab row must win the
+    // fold over a present green sibling (treated as most severe, not skipped).
+    const live = mapOf([
+      row("d6:agno/beautiful-chat-toggle-theme", "d6", "green"),
+      row("d6:agno/beautiful-chat-pie-chart", "d6", OUT_OF_VOCAB),
+      row("d6:agno/beautiful-chat-bar-chart", "d6", "green"),
+      row("d6:agno/beautiful-chat-search-flights", "d6", "green"),
+      row("d6:agno/beautiful-chat-schedule-meeting", "d6", "green"),
+    ]);
+    const c = resolveCell(live, "agno", "beautiful-chat");
+    expect(c.d6.row?.state).toBe(OUT_OF_VOCAB);
+  });
+
+  it("does NOT silently drop a lone d5 row carrying an out-of-vocabulary state", () => {
+    const live = mapOf([row("d5:agno/agentic-chat", "d5", OUT_OF_VOCAB)]);
+    const c = resolveCell(live, "agno", "agentic-chat");
+    expect(c.d5.row).not.toBeNull();
+    expect(c.d5.row?.state).toBe(OUT_OF_VOCAB);
+  });
+});
+
 describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
   // Order: red > degraded > green > error > unknown.
   // Rollup contributors: health, e2e (Decision #7: smokeRow dropped).

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -24,6 +24,129 @@ import {
 
 export type State = "green" | "red" | "degraded";
 
+/* ------------------------------------------------------------------ */
+/*  Pool comm-error surface (REQ-B)                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Pool COMMUNICATION-failure taxonomy + signal decode — the DASHBOARD-side
+ * mirror of the harness fleet contract (`showcase/harness/src/fleet/contracts.ts`).
+ *
+ * WHY MIRRORED, NOT IMPORTED: the dashboard imports only `@/*` and never
+ * reaches across the package boundary into harness source at runtime (same
+ * rule that makes `CATALOG_TO_D5_KEY` / `STARTER_COLUMNS` local copies of
+ * harness producer constants). The harness owns the producer side; the
+ * dashboard carries a structural copy of the read shape it consumes. The
+ * `commError-contract-drift.test.ts` lint test guards the two against drift.
+ *
+ * The comm error rides in the status-row SIGNAL under the well-known
+ * `FLEET_COMM_ERROR_SIGNAL_KEY` ("__fleetCommError") — the persisted `State`
+ * enum is deliberately NOT widened (that would force every state-machine
+ * consumer — alert engine, transition detector, flap counter — to learn a new
+ * value). The row's `state` keeps carrying the last-known probe colour; the
+ * comm error is a SEPARATE overlay the dashboard renders as the DISTINCT
+ * `"unreachable"` surface state so an operator can tell "couldn't reach the
+ * pool" apart from "the test went red".
+ */
+export const POOL_COMM_ERROR_KINDS = [
+  /** Worker host/endpoint did not respond at all (connect refused, DNS, etc). */
+  "worker-unreachable",
+  /** A claim or lease CAS call failed at the transport layer (not a lost CAS). */
+  "claim-comm-failure",
+  /** The worker exceeded the protocol response deadline (hung, no crash). */
+  "worker-protocol-timeout",
+  /** The worker died mid-job: lease expired with no terminal report. */
+  "worker-crashed-mid-job",
+  /** A report arrived but failed schema/shape validation (protocol mismatch). */
+  "worker-protocol-violation",
+] as const;
+
+/** A single pool communication-failure kind. */
+export type PoolCommErrorKind = (typeof POOL_COMM_ERROR_KINDS)[number];
+
+/** Type guard for a valid PoolCommErrorKind. */
+export function isPoolCommErrorKind(
+  value: string | undefined,
+): value is PoolCommErrorKind {
+  return (
+    value !== undefined &&
+    (POOL_COMM_ERROR_KINDS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * A structured pool communication error — the read shape the dashboard
+ * surfaces. Mirror of the harness `PoolCommError` interface.
+ */
+export interface PoolCommError {
+  kind: PoolCommErrorKind;
+  /** Human-readable detail for the dashboard tooltip / operator log. */
+  message: string;
+  /** The worker involved, when known (unreachable workers may be unknown). */
+  workerId?: string;
+  /** The job involved, when the failure is tied to a specific job. */
+  jobId?: string;
+  /** ISO timestamp the failure was observed. */
+  observedAt: string;
+}
+
+/** Signal-blob key under which a comm error is mirrored onto a status row. */
+export const FLEET_COMM_ERROR_SIGNAL_KEY = "__fleetCommError" as const;
+
+/**
+ * The dashboard's per-cell presentation state: the cell's resolved colour
+ * vocabulary (`green` | `amber` | `red` | `gray`, i.e. the `ChipColor` the cell
+ * already renders) PLUS the comm-error overlay `"unreachable"`. A PRESENTATION
+ * type only — never a persisted column.
+ *
+ * This is the dashboard analogue of the harness `FleetSurfaceState`
+ * (`ProbeState | "unreachable"`). The dashboard's cell render model uses
+ * `ChipColor` (with `gray` for no-data and `amber` for degraded) rather than
+ * the raw probe `State`, so the union is expressed over `ChipColor` to avoid an
+ * unsafe widen of the no-data `gray` case through `State`.
+ */
+export type FleetSurfaceState =
+  | "green"
+  | "amber"
+  | "red"
+  | "gray"
+  | "unreachable";
+
+/**
+ * Extract a `PoolCommError` from a status-row signal blob, or `undefined` when
+ * none is present / the embedded value is malformed. Inverse of the harness
+ * `commErrorToStatusSignal` writer; structurally identical to the harness
+ * `commErrorFromStatusSignal` reader. Pure; unit-tested.
+ *
+ * The dashboard read layer (REQ-B) uses this to decide whether to render the
+ * distinct `"unreachable"` overlay on a cell. Malformed payloads decode to
+ * `undefined` (fail-safe to the normal probe colour) rather than rendering a
+ * half-populated overlay.
+ */
+export function commErrorFromStatusSignal(
+  signal: unknown,
+): PoolCommError | undefined {
+  if (signal === null || typeof signal !== "object") return undefined;
+  const raw = (signal as Record<string, unknown>)[FLEET_COMM_ERROR_SIGNAL_KEY];
+  if (raw === null || typeof raw !== "object") return undefined;
+  const candidate = raw as Partial<PoolCommError>;
+  if (
+    !isPoolCommErrorKind(candidate.kind) ||
+    typeof candidate.message !== "string" ||
+    typeof candidate.observedAt !== "string"
+  ) {
+    return undefined;
+  }
+  const out: PoolCommError = {
+    kind: candidate.kind,
+    message: candidate.message,
+    observedAt: candidate.observedAt,
+  };
+  if (typeof candidate.workerId === "string") out.workerId = candidate.workerId;
+  if (typeof candidate.jobId === "string") out.jobId = candidate.jobId;
+  return out;
+}
+
 export interface StatusRow {
   id: string;
   key: string;
@@ -223,6 +346,23 @@ const WORST_STATE_RANK: Readonly<Record<State, number>> = {
 };
 
 /**
+ * Worst-state rank for an arbitrary row state (Fix A2). `StatusRow.state` is
+ * typed `State` (green|red|degraded), but the harness CAN persist an
+ * out-of-vocabulary value at runtime — notably `"error"` (the no-data
+ * representation; see harness result-aggregator.ts). A bare
+ * `WORST_STATE_RANK[state]` for such a value is `undefined`, and the fold
+ * comparison `undefined > n` is `false`, so the row is SILENTLY DROPPED from the
+ * worst-state fold instead of surfacing. Treat an unknown state as the MOST
+ * SEVERE (a rank above every known state) so it surfaces as the worst rather
+ * than vanishing — an unrecognized signal must never be silently swallowed.
+ * Mirrors `cell-model.ts`'s `rankOfState`.
+ */
+const UNKNOWN_WORST_STATE_RANK = Number.POSITIVE_INFINITY;
+function worstStateRank(state: string): number {
+  return WORST_STATE_RANK[state as State] ?? UNKNOWN_WORST_STATE_RANK;
+}
+
+/**
  * Effective state for staleness folding: a green row whose `observed_at` is
  * older than `maxAgeMs` folds in as `degraded`, so a frozen-green driver can
  * never win the all-green tie and mask a fresh-green sibling. Only green is
@@ -293,7 +433,7 @@ function resolveD5Row(
     const eff = effectiveState(row, now, E2E_STALE_AFTER_MS);
     if (
       worstState === null ||
-      WORST_STATE_RANK[eff] > WORST_STATE_RANK[worstState]
+      worstStateRank(eff) > worstStateRank(worstState)
     ) {
       worst = row;
       worstState = eff;
@@ -350,7 +490,7 @@ function resolveD6Row(
     const eff = effectiveState(row, now, E2E_STALE_AFTER_MS);
     if (
       worstState === null ||
-      WORST_STATE_RANK[eff] > WORST_STATE_RANK[worstState]
+      worstStateRank(eff) > worstStateRank(worstState)
     ) {
       worst = row;
       worstState = eff;


### PR DESCRIPTION
## Summary

Splits the showcase test harness into a **pool-fleet**: ONE Docker image whose runtime role is selected at boot by `HARNESS_ROLE` into either a **control-plane** (scheduler / job-producer / result-consumer / result-aggregator / fleet-health) or a **worker** (BrowserPool + claim/run/report loop). Roles communicate over a **PocketBase-backed pull queue** (`probe_jobs`, `workers`) with a JSVM compare-and-set claim hook (`fleet-claim.pb.js`) guaranteeing exactly-one-winner per claim. Workers self-bound their own BrowserPool under the cgroup PID ceiling; the control-plane runs no Chromium.

Key capabilities:
- **REQ-B — pool communication errors surface to the dashboard.** Worker crashes, lost results, and unreachable-pool conditions are turned into a `⚡` "unreachable" overlay on the affected cells (never silently dropped). Three legs feed it: producer lease-driven sweep, heartbeat-driven fleet-health reclaim, and the result-consumer's resultless-past-grace latch — each preserving the prior observed colour rather than fabricating green.
- **Browser-pool PID-ceiling hardening** carried over from the single-process harness.
- **Role-dispatch is fail-loud:** an unset or invalid `HARNESS_ROLE` (or `HARNESS_POOL_COUNT`) throws on boot, so a misconfigured fleet member dies immediately instead of mis-running.

Reviewed via 5 CR fix rounds + 2 full 9-agent confirmation rounds (cr-loop). 60 files, harness 2041 tests + dashboard 847 tests green, both production builds green.

## Deferred follow-ups (bucket-(b): non-triggerable at N=2 / design tensions, tracked not blocking)
- `isWorkerStale` PB-date parse works on Node V8 but doesn't share the fleet-wide `PB_DATE_SEP_RE` normalization — align for goja-parity / robustness.
- Never-observed-service comm-error coloring (`aggregateCommError` writes `"error"` → history-only vs `aggregate()` using `"degraded"`) — reviewers disagree on the correct direction; revisit as a deliberate design decision.
- Recovered service can show "unreachable" until the next successful aggregate run (self-clears within a producer cycle) — consider a positive clear-on-green for the aggregate row.
- `terminalJobStatus` maps `degraded` → `failed` in run-history (run-history widget over-reports failures for amber).
- Lease-renew guard uses strict `<` rather than a safety margin (only matters at near-lease heartbeat config; defaults are 4× safe).
- Dashboard scans `health:`/`chat:`/`tools:` keys for comm-errors that no harness leg writes (dead/defensive scope).
- `showcase test --isolate <name>` arg-order ambiguity in the CLI.
- Local `docker-compose.local.yml` worker `restart: unless-stopped` can auto-revive a killed worker during the local REQ-B demo (use `docker stop` / `restart: no`).
- Result-lost latch-failure can re-surface the same comm-error each cycle (benign churn; needs result-lost + persistent PB write failure).

## Test plan
- [x] Harness unit suite — 2041 tests pass (119 files)
- [x] Dashboard unit suite — 847 pass / 1 skipped (53 files)
- [x] Typecheck (harness + dashboard), oxlint (0 errors), oxfmt
- [x] Production builds — harness `tsc` + dashboard `next build`
- [ ] Staging cutover to N=2 (gated; plan published separately on Notion)