### PR TITLE
fix(showcase): path-based content-level starter-smoke probe

### DIFF
--- a/showcase/harness/config/probes/starter_smoke.yml
+++ b/showcase/harness/config/probes/starter_smoke.yml
@@ -23,10 +23,14 @@
 #                                                     `/api/health` route)
 #   - agent       GET  `${base}/api/copilotkit/info` → 200 JSON carrying a
 #                                                     `version` field
-#   - chat        POST `${base}/api/copilotkit/agent/default/run`
-#                 (Accept: text/event-stream) → AG-UI SSE stream asserting ≥1
-#                 TEXT_MESSAGE_CONTENT delta + terminal RUN_FINISHED + NO
-#                 RUN_ERROR
+#   - chat        POST `${base}/api/copilotkit/agent/<resolved-id>/run`
+#                 where `<resolved-id>` is resolved PER-STARTER from the `/info`
+#                 `agents` map (preferring `default`, else the first registered
+#                 key; e.g. mastra → `weatherAgent`), with `default` as the
+#                 last-resort fallback only when the agent rung answered `/info`
+#                 with no usable map (Accept: text/event-stream) → AG-UI SSE
+#                 stream asserting ≥1 TEXT_MESSAGE_CONTENT delta + terminal
+#                 RUN_FINISHED + NO RUN_ERROR
 #   - interaction GET  `${base}/`                    → 200 (app shell serves)
 #
 # Rows emitted per invocation:

--- a/showcase/harness/config/probes/starter_smoke.yml
+++ b/showcase/harness/config/probes/starter_smoke.yml
@@ -13,11 +13,21 @@
 #
 # Each driver invocation issues FOUR HTTP checks against the deployed base
 # URL and side-emits one row per smoke level plus an aggregate primary
-# (see drivers/starter-smoke.ts):
-#   - health      GET  `${base}/api/health`        → 200 + JSON body
-#   - agent       POST `${base}/api/copilotkit/`    → any non-404 response
-#   - chat        POST `${base}/api/copilotkit/`    → non-empty body (aimock)
-#   - interaction GET  `${base}/`                   → 200 (app shell serves)
+# (see drivers/starter-smoke.ts). The deployed starters mount the v2 runtime
+# in its default PATH-BASED `mode:"multi-route"` at `/api/copilotkit`, so the
+# checks dispatch by URL path (the dead single-route envelope POST to bare
+# `/api/copilotkit` is never issued):
+#   - health      GET  `${base}/api/copilotkit/info` → 200 (lightweight
+#                                                     runtime-mount liveness;
+#                                                     the starter has no
+#                                                     `/api/health` route)
+#   - agent       GET  `${base}/api/copilotkit/info` → 200 JSON carrying a
+#                                                     `version` field
+#   - chat        POST `${base}/api/copilotkit/agent/default/run`
+#                 (Accept: text/event-stream) → AG-UI SSE stream asserting ≥1
+#                 TEXT_MESSAGE_CONTENT delta + terminal RUN_FINISHED + NO
+#                 RUN_ERROR
+#   - interaction GET  `${base}/`                    → 200 (app shell serves)
 #
 # Rows emitted per invocation:
 #   - Primary `starter:<column-slug>`           aggregate { total, passed,

--- a/showcase/harness/src/probes/drivers/starter-smoke.test.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.test.ts
@@ -1272,10 +1272,7 @@ describe("starterSmokeDriver", () => {
       Record<"health" | "agent" | "chat" | "interaction", string>
     > = {};
     const r = (await driver.run(
-      mkCtx(
-        fakeFetch({ bodyAbortOn: { agent: "self" }, seenUrls }),
-        writer,
-      ),
+      mkCtx(fakeFetch({ bodyAbortOn: { agent: "self" }, seenUrls }), writer),
       {
         key: "starter_smoke:starter-mastra",
         name: "starter-mastra",

--- a/showcase/harness/src/probes/drivers/starter-smoke.test.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.test.ts
@@ -368,7 +368,10 @@ describe("starterSmokeDriver", () => {
     )) as ProbeResult<StarterSmokeAggregateSignal>;
 
     expect(r.state).toBe("red");
-    expect(r.signal.failed).toEqual(["agent"]);
+    // FIX A: a 4xx agent rung yields NO usable agents map, so the chat rung
+    // inherits the agent failure (it must NOT probe a guessed `default`). Both
+    // rungs red, aggregate class smoke-failed.
+    expect(r.signal.failed).toEqual(["agent", "chat"]);
     expect(r.signal.errorClass).toBe("smoke-failed");
 
     const agentRow = sideRows(writes).find(
@@ -376,6 +379,13 @@ describe("starterSmokeDriver", () => {
     )!;
     expect(agentRow.state).toBe("red");
     expect(agentRow.signal.errorClass).toBe("smoke-failed");
+    // The inherited chat row is smoke-failed too, and never claims `default`.
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
+    expect(chatRow.state).toBe("red");
+    expect(chatRow.signal.errorClass).toBe("smoke-failed");
+    expect(chatRow.signal.agentId).toBeUndefined();
   });
 
   it("agent rung FAILS on a 200 HTML body lacking `version`", async () => {
@@ -397,7 +407,9 @@ describe("starterSmokeDriver", () => {
     )) as ProbeResult<StarterSmokeAggregateSignal>;
 
     expect(r.state).toBe("red");
-    expect(r.signal.failed).toEqual(["agent"]);
+    // FIX A: the 200 info lacks BOTH `version` and an `agents` map → agent rung
+    // reds and the chat rung inherits (no guessed `default`).
+    expect(r.signal.failed).toEqual(["agent", "chat"]);
     const agentRow = sideRows(writes).find(
       (w) => w.key === "starter:agno/agent",
     )!;
@@ -419,7 +431,9 @@ describe("starterSmokeDriver", () => {
     )) as ProbeResult<StarterSmokeAggregateSignal>;
 
     expect(r.state).toBe("red");
-    expect(r.signal.failed).toEqual(["agent"]);
+    // FIX A: an HTML (non-JSON) info body yields no agents map → agent reds and
+    // the chat rung inherits the failure.
+    expect(r.signal.failed).toEqual(["agent", "chat"]);
     const agentRow = sideRows(writes).find(
       (w) => w.key === "starter:agno/agent",
     )!;
@@ -787,9 +801,11 @@ describe("starterSmokeDriver", () => {
     )) as ProbeResult<StarterSmokeAggregateSignal>;
 
     expect(r.state).toBe("red");
-    expect(r.signal.failed.sort()).toEqual(["agent", "interaction"]);
-    // smoke-failed (agent 404) is more actionable than the transport
-    // hiccup on interaction, so it wins the aggregate class.
+    // FIX A: the agent 404 yields no usable map → the chat rung inherits the
+    // smoke-failed agent failure (no guessed `default`), so chat reds too.
+    expect(r.signal.failed.sort()).toEqual(["agent", "chat", "interaction"]);
+    // smoke-failed (agent 404, inherited by chat) is more actionable than the
+    // transport hiccup on interaction, so it wins the aggregate class.
     expect(r.signal.errorClass).toBe("smoke-failed");
   });
 
@@ -1073,11 +1089,20 @@ describe("starterSmokeDriver", () => {
       },
     )) as ProbeResult<StarterSmokeAggregateSignal>;
     expect(r.state).toBe("red");
-    expect(r.signal.failed).toEqual(["agent"]);
+    // FIX A: an agent body-abort yields no usable map → the chat rung inherits
+    // the agent transport-error (no guessed `default` 404), so both reds are
+    // SOFT transport-errors that the staleness rule can absorb.
+    expect(r.signal.failed).toEqual(["agent", "chat"]);
     const agentRow = sideRows(writes).find(
       (w) => w.key === "starter:agno/agent",
     )!;
     expect(agentRow.signal.errorClass).toBe("transport-error");
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
+    expect(chatRow.state).toBe("red");
+    expect(chatRow.signal.errorClass).toBe("transport-error");
+    expect(r.signal.errorClass).toBe("transport-error");
   });
 
   it("health non-2xx + mid-body abort → transport-error (NOT smoke-failed)", async () => {
@@ -1179,6 +1204,151 @@ describe("starterSmokeDriver", () => {
       expect(row.state).toBe("red");
       expect(row.signal.errorClass).toBe("aborted");
     }
+  });
+
+  it("FIX A: mastra-shaped /info agents map WITHOUT a valid version → agent red, but chat does NOT POST /agent/default/run and is NOT a misleading default-404 hard red", async () => {
+    // The agent rung fails its version check (info JSON has an `agents` map but
+    // no `version`). The OLD code resolved `resolvedChatAgentId` ONLY on the
+    // agent SUCCESS path, so the chat rung fell back to `default` and POSTed
+    // `/agent/default/run` → 404 for mastra (real key `weatherAgent`) → a
+    // spurious `smoke-failed` masking the real cause. The FIX must (1) resolve
+    // the id from the agents map even though version validation failed, so the
+    // chat rung never targets a guessed `default` for a non-default starter.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenUrls: Partial<
+      Record<"health" | "agent" | "chat" | "interaction", string>
+    > = {};
+    const r = (await driver.run(
+      mkCtx(
+        fakeFetch({
+          // 200 info body WITH an agents map but NO `version` → agent rung reds.
+          agentBody: JSON.stringify({
+            agents: { weatherAgent: { description: "weather" } },
+          }),
+          seenUrls,
+        }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-mastra",
+        name: "starter-mastra",
+        publicUrl: "https://starter-mastra.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    // Agent rung is red (missing version) — the real, actionable failure.
+    expect(r.signal.failed).toContain("agent");
+    const agentRow = sideRows(writes).find(
+      (w) => w.key === "starter:mastra/agent",
+    )!;
+    expect(agentRow.state).toBe("red");
+    expect(agentRow.signal.errorClass).toBe("smoke-failed");
+
+    // The chat rung must NOT have POSTed to /agent/default/run (the guessed
+    // default that 404s for mastra). It either targeted the resolved id or
+    // skipped the fetch entirely.
+    if (seenUrls.chat !== undefined) {
+      expect(seenUrls.chat).not.toContain("/agent/default/run");
+      expect(seenUrls.chat).toContain("/agent/weatherAgent/run");
+    }
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:mastra/chat",
+    )!;
+    // The chat row must NOT claim it targeted `default`.
+    expect(chatRow.signal.agentId).not.toBe("default");
+  });
+
+  it("FIX A: agent rung body-abort for a mastra-shaped target → chat rung softened/inherited, NOT a default 404", async () => {
+    // The agent rung's body read aborts (a slow cold-start info stream cut
+    // short by the timeout). No agents map could be read, so the chat rung has
+    // no resolved id. The OLD code would fall back to `default` and probe
+    // `/agent/default/run` → 404 → a hard `smoke-failed` that masks the
+    // transport hiccup. The FIX must carry the agent rung's transport failure
+    // forward to the chat row (inherit/skip), NOT manufacture a default 404.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenUrls: Partial<
+      Record<"health" | "agent" | "chat" | "interaction", string>
+    > = {};
+    const r = (await driver.run(
+      mkCtx(
+        fakeFetch({ bodyAbortOn: { agent: "self" }, seenUrls }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-mastra",
+        name: "starter-mastra",
+        publicUrl: "https://starter-mastra.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    // Agent rung reds as a transport-error (the body-read abort).
+    const agentRow = sideRows(writes).find(
+      (w) => w.key === "starter:mastra/agent",
+    )!;
+    expect(agentRow.state).toBe("red");
+    expect(agentRow.signal.errorClass).toBe("transport-error");
+
+    // The chat rung must NOT have POSTed to /agent/default/run.
+    if (seenUrls.chat !== undefined) {
+      expect(seenUrls.chat).not.toContain("/agent/default/run");
+    }
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:mastra/chat",
+    )!;
+    expect(chatRow.state).toBe("red");
+    // The chat failure must be SOFT (inherit the agent transport-error), never
+    // a hard smoke-failed default-404.
+    expect(chatRow.signal.errorClass).toBe("transport-error");
+    // And it must not claim `default` was targeted.
+    expect(chatRow.signal.agentId).not.toBe("default");
+    // The aggregate worst class must be the transport hiccup, not a spurious
+    // smoke-failed from a manufactured default 404.
+    expect(r.signal.errorClass).toBe("transport-error");
+  });
+
+  it("FIX A: resolveAgentId prefers `default` when the agents map carries both default and a dynamic key", async () => {
+    // The resolver must PREFER `default` when present (safer for multi-agent
+    // starters), not blindly take the first inserted key. Here the map lists
+    // `weatherAgent` FIRST, then `default`; the resolved id must be `default`.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenUrls: Partial<
+      Record<"health" | "agent" | "chat" | "interaction", string>
+    > = {};
+    await driver.run(
+      mkCtx(
+        fakeFetch({
+          agentBody: JSON.stringify({
+            version: "1.59.5",
+            agents: { weatherAgent: {}, default: {} },
+          }),
+          seenUrls,
+        }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-mastra",
+        name: "starter-mastra",
+        publicUrl: "https://starter-mastra.up.railway.app",
+      },
+    );
+    expect(seenUrls.chat).toBe(
+      "https://starter-mastra.up.railway.app/api/copilotkit/agent/default/run",
+    );
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:mastra/chat",
+    )!;
+    expect(chatRow.signal.agentId).toBe("default");
+  });
+
+  it("FIX C: STARTER_LEVELS orders `agent` strictly before `chat` (resolved-id invariant)", () => {
+    // The whole resolved-agentId mechanism depends on the agent rung running
+    // and reading `/info` BEFORE the chat rung POSTs the per-agent run path.
+    expect(STARTER_LEVELS.indexOf("agent")).toBeLessThan(
+      STARTER_LEVELS.indexOf("chat"),
+    );
   });
 
   it("a writer whose write() rejects must not fail the aggregate tick (swallowed + still green)", async () => {

--- a/showcase/harness/src/probes/drivers/starter-smoke.test.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.test.ts
@@ -13,15 +13,34 @@ import type {
   ProbeResultWriter,
 } from "../../types/index.js";
 
-// Driver-level tests for the starter_smoke ProbeDriver. The Railway starter
-// services don't exist yet (a separate gated slot stands them up), so every
-// test injects a fake `fetchImpl` — no real network. Coverage:
+// Driver-level tests for the starter_smoke ProbeDriver. The deployed starter
+// services mount `createCopilotEndpoint` in its default `mode:"multi-route"`
+// (PATH-BASED v2 protocol) at `basePath:"/api/copilotkit"`. Every test
+// injects a fake `fetchImpl` that speaks that path-based protocol — no real
+// network.
+// Coverage:
 //   - schema accepts the discovery shape, rejects malformed input
 //   - the FOUR checks (health/agent/chat/interaction) map to the right
 //     `starter:<col>/<level>` side-emit keys
 //   - the starter→column slug remap is applied before emit
 //   - pass → green, fail → red (smoke-failed), transport-fail → classified
 //   - the aggregate primary is emitted under `starter:<col>`
+//
+// Protocol (empirically proven by a local build+curl gate; identical at
+// 1.59.3 and 1.59.5; verified against
+// `packages/runtime/src/v2/runtime/core/fetch-router.ts` `matchRoute` and
+// the real starter route
+// `examples/integrations/<slug>/src/app/api/copilotkit/[[...slug]]/route.ts`):
+//   - health rung: GET `/api/copilotkit/info` → 200 (lightweight runtime
+//     liveness; the deployed starter has NO `/api/health` route).
+//   - agent rung: GET `/api/copilotkit/info` → 200 JSON carrying a `version`.
+//   - chat rung: POST `/api/copilotkit/agent/default/run` with
+//     `Accept: text/event-stream` → AG-UI SSE stream
+//     (`RUN_STARTED → STEP_STARTED → TEXT_MESSAGE_START →
+//     TEXT_MESSAGE_CONTENT(delta) → TEXT_MESSAGE_END → MESSAGES_SNAPSHOT →
+//     STATE_SNAPSHOT → STEP_FINISHED → RUN_FINISHED`); pass requires ≥1
+//     TEXT_MESSAGE_CONTENT/TEXT_MESSAGE_CHUNK with a non-empty delta AND a
+//     terminal RUN_FINISHED with NO RUN_ERROR in the stream.
 
 function mkWriter(): {
   writer: ProbeResultWriter;
@@ -38,51 +57,201 @@ function mkWriter(): {
 }
 
 /**
- * Fake fetch that answers each level per the supplied opts. agent and chat
- * share the `/api/copilotkit/` URL but differ by HTTP method body, so we
- * branch on the request body to tell them apart (chat carries `messages`).
+ * A protocol-accurate AG-UI SSE stream for a successful `agent/run`, seeded
+ * from a REAL captured crewai-crews happy-path stream (the "Hello" turn
+ * against the deployed starter). The concatenated `TEXT_MESSAGE_CONTENT`
+ * deltas reconstruct the assistant reply
+ *   "Hello! I'm the crewai-crews AI assistant. How can I help you?"
+ * and the stream terminates in RUN_FINISHED. On-wire format is
+ * `data: <json>\n\n` per event (see `sse-interceptor.ts`).
  */
+const HAPPY_DELTAS = [
+  "Hello! ",
+  "I'm the crewai-crews AI assistant. ",
+  "How can I help you?",
+];
+const SSE_HAPPY = [
+  { type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+  { type: "STEP_STARTED", stepName: "step-1" },
+  {
+    type: "TEXT_MESSAGE_START",
+    messageId: "chatcmpl-abc123",
+    role: "assistant",
+  },
+  ...HAPPY_DELTAS.map((delta) => ({
+    type: "TEXT_MESSAGE_CONTENT",
+    messageId: "chatcmpl-abc123",
+    delta,
+  })),
+  { type: "TEXT_MESSAGE_END", messageId: "chatcmpl-abc123" },
+  { type: "MESSAGES_SNAPSHOT", messages: [] },
+  { type: "STATE_SNAPSHOT", state: {} },
+  { type: "STEP_FINISHED", stepName: "step-1" },
+  { type: "RUN_FINISHED", threadId: "t1", runId: "run-1" },
+]
+  .map((e) => `data: ${JSON.stringify(e)}\n\n`)
+  .join("");
+
+/** A stream that opens a run then errors — no text content event. */
+const SSE_RUN_ERROR = [
+  { type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+  { type: "RUN_ERROR", message: "boom" },
+]
+  .map((e) => `data: ${JSON.stringify(e)}\n\n`)
+  .join("");
+
+/** A 200 stream that produces lifecycle events but NO text content. */
+const SSE_NO_TEXT = [
+  { type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+  { type: "RUN_FINISHED", threadId: "t1", runId: "run-1" },
+]
+  .map((e) => `data: ${JSON.stringify(e)}\n\n`)
+  .join("");
+
+/**
+ * Fake fetch that speaks the PATH-BASED (multi-route) runtime protocol.
+ * Levels are distinguished purely by URL path:
+ *   - `GET /api/copilotkit/info`           → health AND agent rungs (both
+ *     hit the same info route with the same GET method, so the request alone
+ *     can't tell them apart; we disambiguate by call order via a per-instance
+ *     `infoCalls` counter — see below).
+ *   - `POST /api/copilotkit/agent/<id>/run` → chat rung.
+ *   - `GET /`                               → interaction rung.
+ *
+ * Because health and agent both target `/api/copilotkit/info` with GET, we
+ * cannot tell them apart by request alone. The driver issues them in
+ * STARTER_LEVELS order (health before agent), so the fake returns the same
+ * info payload for both and records the URL under whichever level is asked
+ * first. We track an info-call counter so `seenUrls` maps the 1st info GET
+ * to `health` and the 2nd to `agent`.
+ *
+ * - `agentBody` overrides the `info` JSON response body (default: a valid
+ *   `{version}` info payload). Applies to BOTH health and agent rungs since
+ *   they share the route; tests that need them to differ set the relevant
+ *   status override.
+ * - `chatSse`   overrides the chat SSE stream text (default: SSE_HAPPY).
+ */
+/**
+ * Wrap a Response so reading its body aborts mid-stream: `.text()` rejects
+ * with an AbortError, mimicking a slow cold-start SSE body that streams past
+ * the per-check timeout and gets `controller.abort()`-ed mid-`res.text()`.
+ * Used to prove F2 — a body-read abort is a transport hiccup, not a
+ * smoke-failed regression.
+ */
+function makeBodyAbortingResponse(res: Response): Response {
+  const abortErr = new Error("The operation was aborted");
+  abortErr.name = "AbortError";
+  // Override `.text()` directly on the instance (NOT via Proxy — a Proxy
+  // breaks Response's private-field getters like `.ok`/`.status`). The real
+  // Response's status/ok getters stay intact; only the body read rejects.
+  Object.defineProperty(res, "text", {
+    configurable: true,
+    writable: true,
+    value: async () => {
+      throw abortErr;
+    },
+  });
+  return res;
+}
+
 function fakeFetch(opts: {
   healthStatus?: number;
   healthBody?: string;
   agentStatus?: number;
+  agentBody?: string;
   chatStatus?: number;
-  chatBody?: string;
+  chatSse?: string;
   interactionStatus?: number;
   // When set for a level, that fetch rejects (transport failure).
   throwOn?: Partial<Record<"health" | "agent" | "chat" | "interaction", Error>>;
+  // When set for a level, the fetch RESOLVES (200) but reading its body aborts
+  // mid-stream (simulating a slow cold-start body that streams past the
+  // timeout). `"self"` marks an internal-timeout abort. The Response's
+  // `.text()` rejects with an AbortError.
+  bodyAbortOn?: Partial<
+    Record<"health" | "agent" | "chat" | "interaction", "self">
+  >;
+  // Captures the URL each level was actually fetched at (assertion hook).
+  seenUrls?: Partial<
+    Record<"health" | "agent" | "chat" | "interaction", string>
+  >;
+  // Invoked at the TOP of each fetch (before any response is built), passed
+  // the resolved level and the running fetch count. Lets a test fire a
+  // mid-flight external abort exactly when the FIRST fetch lands so the
+  // SUBSEQUENT levels exercise the loop's pre-iteration abort short-circuit.
+  onFetch?: (
+    level: "health" | "agent" | "chat" | "interaction",
+    callCount: number,
+  ) => void;
 }): typeof fetch {
+  let infoCalls = 0;
+  let callCount = 0;
   return (async (url: string | URL, init?: RequestInit) => {
     const href = typeof url === "string" ? url : url.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
     let level: "health" | "agent" | "chat" | "interaction";
-    if (/\/api\/health/.test(href)) {
-      level = "health";
-    } else if (/\/api\/copilotkit/.test(href)) {
-      const body = typeof init?.body === "string" ? init.body : "";
-      level = body.includes("messages") ? "chat" : "agent";
+    if (
+      /\/api\/copilotkit\/agent\/[^/]+\/run$/.test(href) &&
+      method === "POST"
+    ) {
+      level = "chat";
+    } else if (/\/api\/copilotkit\/info$/.test(href)) {
+      // health and agent both GET the same info route, in STARTER_LEVELS
+      // order: 1st info GET = health, 2nd = agent.
+      level = infoCalls === 0 ? "health" : "agent";
+      infoCalls++;
     } else {
       level = "interaction";
     }
 
+    if (opts.seenUrls) opts.seenUrls[level] = href;
+
+    callCount += 1;
+    opts.onFetch?.(level, callCount);
+
     const toThrow = opts.throwOn?.[level];
     if (toThrow) throw toThrow;
 
-    let status: number;
-    let body: string;
     if (level === "health") {
-      status = opts.healthStatus ?? 200;
-      body = opts.healthBody ?? '{"status":"ok"}';
-    } else if (level === "agent") {
-      status = opts.agentStatus ?? 200;
-      body = '{"ok":true}';
-    } else if (level === "chat") {
-      status = opts.chatStatus ?? 200;
-      body = opts.chatBody ?? '{"reply":"hello back"}';
-    } else {
-      status = opts.interactionStatus ?? 200;
-      body = "<html><body>app shell</body></html>";
+      const status = opts.healthStatus ?? 200;
+      const res = new Response(
+        opts.healthBody ?? opts.agentBody ?? '{"version":"1.59.5"}',
+        {
+          status,
+          statusText: `HTTP ${status}`,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+      if (opts.bodyAbortOn?.health) return makeBodyAbortingResponse(res);
+      return res;
     }
-    return new Response(body, { status, statusText: `HTTP ${status}` });
+    if (level === "agent") {
+      const status = opts.agentStatus ?? 200;
+      const res = new Response(opts.agentBody ?? '{"version":"1.59.5"}', {
+        status,
+        statusText: `HTTP ${status}`,
+        headers: { "Content-Type": "application/json" },
+      });
+      if (opts.bodyAbortOn?.agent) return makeBodyAbortingResponse(res);
+      return res;
+    }
+    if (level === "chat") {
+      const status = opts.chatStatus ?? 200;
+      const res = new Response(opts.chatSse ?? SSE_HAPPY, {
+        status,
+        statusText: `HTTP ${status}`,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+      if (opts.bodyAbortOn?.chat) return makeBodyAbortingResponse(res);
+      return res;
+    }
+    const status = opts.interactionStatus ?? 200;
+    const res = new Response("<html><body>app shell</body></html>", {
+      status,
+      statusText: `HTTP ${status}`,
+    });
+    if (opts.bodyAbortOn?.interaction) return makeBodyAbortingResponse(res);
+    return res;
   }) as unknown as typeof fetch;
 }
 
@@ -186,7 +355,7 @@ describe("starterSmokeDriver", () => {
     ]);
   });
 
-  it("agent 404 → that level red (smoke-failed) and aggregate red", async () => {
+  it("agent info 4xx → that level red (smoke-failed) and aggregate red", async () => {
     const { writer, writes } = mkWriter();
     const driver = createStarterSmokeDriver();
     const r = (await driver.run(
@@ -207,13 +376,207 @@ describe("starterSmokeDriver", () => {
     )!;
     expect(agentRow.state).toBe("red");
     expect(agentRow.signal.errorClass).toBe("smoke-failed");
-    expect(agentRow.signal.errorDesc).toContain("404");
   });
 
-  it("chat with empty body → chat red (smoke-failed)", async () => {
+  it("agent rung FAILS on a 200 HTML body lacking `version`", async () => {
     const { writer, writes } = mkWriter();
     const driver = createStarterSmokeDriver();
-    const r = (await driver.run(mkCtx(fakeFetch({ chatBody: "   " }), writer), {
+    // A 200 `/info` that is NOT a runtime info response (e.g. an HTML error
+    // shell, or a JSON body lacking `version`) must FAIL the agent rung — a
+    // bare "any non-404" contract would have wrongly passed this.
+    const r = (await driver.run(
+      mkCtx(
+        fakeFetch({ agentBody: '{"status":"ok","integration":"agno"}' }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["agent"]);
+    const agentRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/agent",
+    )!;
+    expect(agentRow.state).toBe("red");
+    expect(agentRow.signal.errorClass).toBe("smoke-failed");
+    expect(agentRow.signal.errorDesc).toContain("version");
+  });
+
+  it("agent rung FAILS on a 200 HTML body (non-JSON)", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ agentBody: "<html>not json</html>" }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["agent"]);
+    const agentRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/agent",
+    )!;
+    expect(agentRow.state).toBe("red");
+    expect(agentRow.signal.errorClass).toBe("smoke-failed");
+  });
+
+  it("agent rung PASSES on a 200 `{version}` info response", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(
+        fakeFetch({ agentBody: '{"version":"1.59.5","mode":"sse"}' }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.signal.failed).not.toContain("agent");
+    const agentRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/agent",
+    )!;
+    expect(agentRow.state).toBe("green");
+  });
+
+  it("agent rung uses GET /api/copilotkit/info", async () => {
+    const { writer } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenUrls: Partial<
+      Record<"health" | "agent" | "chat" | "interaction", string>
+    > = {};
+    await driver.run(mkCtx(fakeFetch({ seenUrls }), writer), {
+      key: "starter_smoke:starter-agno",
+      name: "starter-agno",
+      publicUrl: "https://starter-agno.up.railway.app",
+    });
+    expect(seenUrls.agent).toBe(
+      "https://starter-agno.up.railway.app/api/copilotkit/info",
+    );
+  });
+
+  it("chat rung FAILS on a 200 stream with no TEXT_MESSAGE_CONTENT", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ chatSse: SSE_NO_TEXT }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["chat"]);
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
+    expect(chatRow.state).toBe("red");
+    expect(chatRow.signal.errorClass).toBe("smoke-failed");
+    expect(chatRow.signal.errorDesc).toContain("TEXT_MESSAGE_CONTENT");
+  });
+
+  it("chat rung FAILS on a RUN_ERROR-only stream", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ chatSse: SSE_RUN_ERROR }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["chat"]);
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
+    expect(chatRow.state).toBe("red");
+    expect(chatRow.signal.errorClass).toBe("smoke-failed");
+    expect(chatRow.signal.errorDesc).toContain("RUN_ERROR");
+  });
+
+  it("chat rung FAILS on a 200 stream with text but NO terminal RUN_FINISHED", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    // A stream that produces assistant text but never reaches RUN_FINISHED
+    // (e.g. the connection dropped mid-run) must FAIL — a complete chat
+    // round-trip requires the terminal RUN_FINISHED.
+    const truncated = [
+      { type: "RUN_STARTED", threadId: "t1", runId: "run-1" },
+      {
+        type: "TEXT_MESSAGE_START",
+        messageId: "chatcmpl-x",
+        role: "assistant",
+      },
+      { type: "TEXT_MESSAGE_CONTENT", messageId: "chatcmpl-x", delta: "Hello" },
+    ]
+      .map((e) => `data: ${JSON.stringify(e)}\n\n`)
+      .join("");
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ chatSse: truncated }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["chat"]);
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
+    expect(chatRow.state).toBe("red");
+    expect(chatRow.signal.errorClass).toBe("smoke-failed");
+    expect(chatRow.signal.errorDesc).toContain("RUN_FINISHED");
+  });
+
+  it("chat rung PASSES on a stream with TEXT_MESSAGE_CONTENT + terminal RUN_FINISHED", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ chatSse: SSE_HAPPY }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.signal.failed).not.toContain("chat");
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
+    expect(chatRow.state).toBe("green");
+  });
+
+  it("chat rung passes when the concatenated deltas reconstruct the captured reply", () => {
+    // Sanity-check the fixture seed: the captured crewai-crews happy path
+    // reconstructs the real assistant reply. This guards the seed against
+    // accidental edits that would no longer reflect a real stream.
+    expect(HAPPY_DELTAS.join("")).toBe(
+      "Hello! I'm the crewai-crews AI assistant. How can I help you?",
+    );
+  });
+
+  it("chat rung FAILS on a non-2xx HTTP status", async () => {
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(mkCtx(fakeFetch({ chatStatus: 500 }), writer), {
       key: "starter_smoke:starter-agno",
       name: "starter-agno",
       publicUrl: "https://starter-agno.up.railway.app",
@@ -225,14 +588,36 @@ describe("starterSmokeDriver", () => {
       (w) => w.key === "starter:agno/chat",
     )!;
     expect(chatRow.state).toBe("red");
-    expect(chatRow.signal.errorDesc).toContain("empty response");
+    expect(chatRow.signal.errorClass).toBe("smoke-failed");
   });
 
-  it("health malformed (200 but non-JSON) → health red", async () => {
+  it("the chat POST targets /api/copilotkit/agent/default/run (path-based)", async () => {
+    const { writer } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenUrls: Partial<
+      Record<"health" | "agent" | "chat" | "interaction", string>
+    > = {};
+    await driver.run(mkCtx(fakeFetch({ seenUrls }), writer), {
+      key: "starter_smoke:starter-agno",
+      name: "starter-agno",
+      publicUrl: "https://starter-agno.up.railway.app",
+    });
+
+    expect(seenUrls.chat).toBe(
+      "https://starter-agno.up.railway.app/api/copilotkit/agent/default/run",
+    );
+    // Path-based: NO single-route envelope POST to bare `/api/copilotkit`.
+    expect(seenUrls.chat!.endsWith("/api/copilotkit")).toBe(false);
+  });
+
+  it("health rung uses GET /api/copilotkit/info and reds on non-2xx", async () => {
     const { writer, writes } = mkWriter();
     const driver = createStarterSmokeDriver();
+    const seenUrls: Partial<
+      Record<"health" | "agent" | "chat" | "interaction", string>
+    > = {};
     const r = (await driver.run(
-      mkCtx(fakeFetch({ healthBody: "<html>not json</html>" }), writer),
+      mkCtx(fakeFetch({ healthStatus: 503, seenUrls }), writer),
       {
         key: "starter_smoke:starter-agno",
         name: "starter-agno",
@@ -240,12 +625,15 @@ describe("starterSmokeDriver", () => {
       },
     )) as ProbeResult<StarterSmokeAggregateSignal>;
 
+    expect(seenUrls.health).toBe(
+      "https://starter-agno.up.railway.app/api/copilotkit/info",
+    );
     expect(r.state).toBe("red");
     expect(r.signal.failed).toEqual(["health"]);
     const healthRow = sideRows(writes).find(
       (w) => w.key === "starter:agno/health",
     )!;
-    expect(healthRow.signal.errorDesc).toContain("malformed body");
+    expect(healthRow.signal.errorClass).toBe("smoke-failed");
   });
 
   it("transport failure (cold-start wake) → classified transport-error, NOT smoke-failed", async () => {
@@ -364,6 +752,321 @@ describe("starterSmokeDriver", () => {
     expect(r.signal.errorClass).toBe("aborted");
     const rows = sideRows(writes);
     for (const row of rows) {
+      expect(row.signal.errorClass).toBe("aborted");
+    }
+  });
+
+  it("mid-flight external abort + a non-abort rejection (ECONNREFUSED) on the in-flight level → transport-error (NOT aborted)", async () => {
+    // F1(i): the external abortSignal latches WHILE the first check's fetch is
+    // in flight, but THAT check fails for its OWN, non-abort reason (a
+    // connection refusal). Re-reading the shared latched signal at catch-time
+    // would mislabel it `aborted`; the class must reflect why THIS check
+    // terminated → `transport-error`. (A pre-aborted signal can't exercise
+    // this post-FIX-C: it short-circuits before any fetch. So we fire the
+    // abort mid-flight on the first fetch — which then throws ECONNREFUSED.)
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const connErr = new Error("connect ECONNREFUSED 127.0.0.1:443");
+    const controller = new AbortController();
+    const ctx: ProbeContext = {
+      now: () => new Date("2026-06-03T00:00:00Z"),
+      logger,
+      env: {},
+      writer,
+      fetchImpl: fakeFetch({
+        // First fetch (health) latches the external signal, then throws a
+        // non-abort error — proving the catch block keys on WHY this check
+        // terminated, not on the latched signal.
+        onFetch: (_level, count) => {
+          if (count === 1) controller.abort();
+        },
+        throwOn: { health: connErr },
+      }),
+      abortSignal: controller.signal,
+    };
+    const r = (await driver.run(ctx, {
+      key: "starter_smoke:starter-agno",
+      name: "starter-agno",
+      publicUrl: "https://starter-agno.up.railway.app",
+    })) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    // The in-flight health check's non-abort error must NOT be classified
+    // `aborted` just because the shared signal latched mid-flight.
+    const healthRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/health",
+    )!;
+    expect(healthRow.signal.errorClass).toBe("transport-error");
+    // The remaining levels short-circuit to `aborted` (FIX C).
+    for (const row of sideRows(writes).filter(
+      (w) => w.key !== "starter:agno/health",
+    )) {
+      expect(row.signal.errorClass).toBe("aborted");
+    }
+  });
+
+  it("internal-timeout abort (self-timeout, no external abort) → transport-error (NOT aborted)", async () => {
+    // F1(ii): an AbortError from THIS check's own setTimeout fires while NO
+    // external signal latched. Re-reading a (here-absent) shared signal is the
+    // wrong discriminator; what matters is that the abort was NOT externally
+    // triggered → classify the self-timeout as `transport-error`, not
+    // `aborted`. Distinct from the genuine-external-abort test below.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const selfTimeoutErr = new Error("The operation was aborted");
+    selfTimeoutErr.name = "AbortError";
+    const r = (await driver.run(
+      mkCtx(
+        fakeFetch({
+          throwOn: {
+            health: selfTimeoutErr,
+            agent: selfTimeoutErr,
+            chat: selfTimeoutErr,
+            interaction: selfTimeoutErr,
+          },
+        }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.errorClass).toBe("transport-error");
+    const rows = sideRows(writes);
+    for (const row of rows) {
+      expect(row.signal.errorClass).toBe("transport-error");
+    }
+  });
+
+  it("chat 200 whose body read aborts (timeout) → transport-error (NOT smoke-failed)", async () => {
+    // F2: a slow cold-start SSE body that streams past the timeout aborts
+    // mid-`res.text()`. safeReadBody swallows the AbortError → empty body →
+    // verifyChatStream would hard-red it as `smoke-failed`. A body-read abort
+    // is a transport hiccup the staleness rule should absorb, not a regression.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ bodyAbortOn: { chat: "self" } }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["chat"]);
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
+    expect(chatRow.state).toBe("red");
+    expect(chatRow.signal.errorClass).toBe("transport-error");
+  });
+
+  it("chat 200 with a genuinely-empty (non-aborted) body → smoke-failed", async () => {
+    // F2 counterpart: a 200 that returns a complete, EMPTY body (not aborted)
+    // is a real bad response and must still hard-red as smoke-failed.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(mkCtx(fakeFetch({ chatSse: "" }), writer), {
+      key: "starter_smoke:starter-agno",
+      name: "starter-agno",
+      publicUrl: "https://starter-agno.up.railway.app",
+    })) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["chat"]);
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
+    expect(chatRow.state).toBe("red");
+    expect(chatRow.signal.errorClass).toBe("smoke-failed");
+  });
+
+  it("agent 200 body that RESOLVES (no abort) is validated for content, never softened", async () => {
+    // FIX A direct: a normal completed agent read with a valid {version} body
+    // must PASS — the success path reports completed:true unconditionally, so
+    // a latched signal can never discard a resolved body.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ agentBody: '{"version":"9.9.9"}' }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+    expect(r.signal.failed).not.toContain("agent");
+    const agentRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/agent",
+    )!;
+    expect(agentRow.state).toBe("green");
+  });
+
+  it("agent 200 body that RESOLVES while the signal latches mid-flight → validated for content (NOT softened)", async () => {
+    // FIX A: a resolved body must NOT be discarded just because the abort
+    // signal latched a hair after `res.text()` resolved. Here the external
+    // signal fires DURING the agent fetch (health already done), but the agent
+    // info body RESOLVES with a valid {version} payload. The OLD success path
+    // returned `aborted: signal.aborted` → wrongly softened a complete valid
+    // body to transport-error. The rung must validate content and PASS.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const controller = new AbortController();
+    const ctx: ProbeContext = {
+      now: () => new Date("2026-06-03T00:00:00Z"),
+      logger,
+      env: {},
+      writer,
+      fetchImpl: fakeFetch({
+        agentBody: '{"version":"9.9.9"}',
+        // Latch the external signal while the agent fetch (2nd call) is in
+        // flight — its body still resolves cleanly.
+        onFetch: (_level, count) => {
+          if (count === 2) controller.abort();
+        },
+      }),
+      abortSignal: controller.signal,
+    };
+    const r = (await driver.run(ctx, {
+      key: "starter_smoke:starter-agno",
+      name: "starter-agno",
+      publicUrl: "https://starter-agno.up.railway.app",
+    })) as ProbeResult<StarterSmokeAggregateSignal>;
+    // agent's resolved body validated → agent green (chat/interaction
+    // short-circuit aborted after the signal latched).
+    const agentRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/agent",
+    )!;
+    expect(agentRow.state).toBe("green");
+    expect(r.signal.failed).not.toContain("agent");
+  });
+
+  it("agent 200 whose body read aborts (timeout) → transport-error (NOT smoke-failed)", async () => {
+    // FIX A/B: the agent rung must route a body-read abort through the shared
+    // abort classification, same as chat — a slow cold-start info body that
+    // streams past the timeout is a transport hiccup, not a missing-version
+    // smoke-failed regression.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(fakeFetch({ bodyAbortOn: { agent: "self" } }), writer),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["agent"]);
+    const agentRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/agent",
+    )!;
+    expect(agentRow.signal.errorClass).toBe("transport-error");
+  });
+
+  it("health non-2xx + mid-body abort → transport-error (NOT smoke-failed)", async () => {
+    // FIX B: the health rung is hit FIRST on a cold wake. A non-2xx response
+    // whose body read is then cut short by our abort must route through the
+    // shared abort classification, not unconditionally hard-red smoke-failed.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(
+        fakeFetch({ healthStatus: 503, bodyAbortOn: { health: "self" } }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["health"]);
+    const healthRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/health",
+    )!;
+    expect(healthRow.signal.errorClass).toBe("transport-error");
+  });
+
+  it("interaction non-2xx + mid-body abort → transport-error (NOT smoke-failed)", async () => {
+    // FIX B (interaction rung): same shared classification as health.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const r = (await driver.run(
+      mkCtx(
+        fakeFetch({
+          interactionStatus: 502,
+          bodyAbortOn: { interaction: "self" },
+        }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+    expect(r.state).toBe("red");
+    expect(r.signal.failed).toEqual(["interaction"]);
+    const row = sideRows(writes).find(
+      (w) => w.key === "starter:agno/interaction",
+    )!;
+    expect(row.signal.errorClass).toBe("transport-error");
+  });
+
+  it("mid-flight external abort short-circuits remaining levels WITHOUT extra fetches", async () => {
+    // FIX C: the external signal aborts AFTER the run starts (via the
+    // addEventListener path, NOT pre-aborted). It fires while the FIRST level
+    // (health) fetch is in flight; that 200 still completes green, but the
+    // THREE remaining levels must short-circuit to clean `aborted` rows WITHOUT
+    // issuing a fresh fetch — so only ONE fetch is ever issued. Mirrors
+    // e2e-readiness.ts's pre-iteration `abort.signal.aborted` check.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const controller = new AbortController();
+    let fetchCount = 0;
+    const ctx: ProbeContext = {
+      now: () => new Date("2026-06-03T00:00:00Z"),
+      logger,
+      env: {},
+      writer,
+      fetchImpl: fakeFetch({
+        onFetch: (_level, count) => {
+          fetchCount = count;
+          // Fire the external abort on the FIRST fetch so the remaining three
+          // levels hit the pre-iteration short-circuit.
+          if (count === 1) controller.abort();
+        },
+      }),
+      abortSignal: controller.signal,
+    };
+    const r = (await driver.run(ctx, {
+      key: "starter_smoke:starter-agno",
+      name: "starter-agno",
+      publicUrl: "https://starter-agno.up.railway.app",
+    })) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    // Exactly ONE fetch issued — the remaining three levels short-circuited
+    // WITHOUT any further fetch.
+    expect(fetchCount).toBe(1);
+    expect(r.state).toBe("red");
+    // health (the in-flight 200) still completes green; agent/chat/interaction
+    // short-circuit `aborted`.
+    expect(r.signal.failed.sort()).toEqual(["agent", "chat", "interaction"]);
+    expect(r.signal.errorClass).toBe("aborted");
+    const rows = sideRows(writes);
+    expect(rows).toHaveLength(4);
+    const healthRow = rows.find((w) => w.key === "starter:agno/health")!;
+    expect(healthRow.state).toBe("green");
+    for (const row of rows.filter((w) => w.key !== "starter:agno/health")) {
+      expect(row.state).toBe("red");
       expect(row.signal.errorClass).toBe("aborted");
     }
   });

--- a/showcase/harness/src/probes/drivers/starter-smoke.test.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.test.ts
@@ -591,6 +591,116 @@ describe("starterSmokeDriver", () => {
     expect(chatRow.signal.errorClass).toBe("smoke-failed");
   });
 
+  it("resolves the chat agentId from /info agents map (mastra-shaped non-default key)", async () => {
+    // A2: most starters register `agents:{default}`, but mastra registers a
+    // DYNAMIC non-`default` key (`MastraAgent.getLocalAgents`). The chat rung
+    // must read the FIRST key of the `/info` `agents` map and POST to
+    // `/agent/<that-id>/run`, NOT the hardcoded `/agent/default/run` (which
+    // 404s for mastra). Here `/info` advertises `{ weatherAgent: {...} }`, so
+    // the chat POST must target `/agent/weatherAgent/run`.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenUrls: Partial<
+      Record<"health" | "agent" | "chat" | "interaction", string>
+    > = {};
+    const r = (await driver.run(
+      mkCtx(
+        fakeFetch({
+          agentBody: JSON.stringify({
+            version: "1.59.5",
+            agents: { weatherAgent: { description: "weather" } },
+          }),
+          seenUrls,
+        }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-mastra",
+        name: "starter-mastra",
+        publicUrl: "https://starter-mastra.up.railway.app",
+      },
+    )) as ProbeResult<StarterSmokeAggregateSignal>;
+
+    expect(seenUrls.chat).toBe(
+      "https://starter-mastra.up.railway.app/api/copilotkit/agent/weatherAgent/run",
+    );
+    // The resolved agentId is surfaced on the chat row signal for drilldown.
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:mastra/chat",
+    )!;
+    expect(chatRow.signal.agentId).toBe("weatherAgent");
+    // Full round-trip still passes (the fake chat SSE is the happy stream).
+    expect(chatRow.state).toBe("green");
+    expect(r.signal.failed).not.toContain("chat");
+  });
+
+  it("falls back to agentId 'default' when /info agents map is empty/absent", async () => {
+    // The 11 default-registering starters have `agents:{default}` (or an
+    // absent/empty map in degraded info). `default` is the EXPECTED resolved
+    // value for them — a last-resort fallback, not an error.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenUrls: Partial<
+      Record<"health" | "agent" | "chat" | "interaction", string>
+    > = {};
+    await driver.run(
+      mkCtx(
+        // info body carries a `version` but NO `agents` map.
+        fakeFetch({ agentBody: '{"version":"1.59.5"}', seenUrls }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    );
+
+    expect(seenUrls.chat).toBe(
+      "https://starter-agno.up.railway.app/api/copilotkit/agent/default/run",
+    );
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
+    expect(chatRow.signal.agentId).toBe("default");
+  });
+
+  it("resolves the chat agentId from a default-registering /info agents map", async () => {
+    // The 11 default-registering starters advertise `agents:{default}`; the
+    // resolver must pick `default` (first key) and the chat POST targets
+    // `/agent/default/run` — keeping the default case green.
+    const { writer, writes } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenUrls: Partial<
+      Record<"health" | "agent" | "chat" | "interaction", string>
+    > = {};
+    await driver.run(
+      mkCtx(
+        fakeFetch({
+          agentBody: JSON.stringify({
+            version: "1.59.5",
+            agents: { default: { description: "the agent" } },
+          }),
+          seenUrls,
+        }),
+        writer,
+      ),
+      {
+        key: "starter_smoke:starter-agno",
+        name: "starter-agno",
+        publicUrl: "https://starter-agno.up.railway.app",
+      },
+    );
+
+    expect(seenUrls.chat).toBe(
+      "https://starter-agno.up.railway.app/api/copilotkit/agent/default/run",
+    );
+    const chatRow = sideRows(writes).find(
+      (w) => w.key === "starter:agno/chat",
+    )!;
+    expect(chatRow.signal.agentId).toBe("default");
+  });
+
   it("the chat POST targets /api/copilotkit/agent/default/run (path-based)", async () => {
     const { writer } = mkWriter();
     const driver = createStarterSmokeDriver();

--- a/showcase/harness/src/probes/drivers/starter-smoke.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.ts
@@ -51,11 +51,19 @@ import type { ProbeContext, ProbeResult } from "../../types/index.js";
  *                     v2 runtime is mounted and answering.
  *   - **chat**        POST `${base}/api/copilotkit/agent/<id>/run` where
  *                     `<id>` is resolved PER-STARTER from the `/info` `agents`
- *                     map (`Object.keys(info.agents)[0]`, the same `info`
- *                     response the health + agent rungs fetch) — `default` for
- *                     the 11 default-registering starters, a dynamic key (e.g.
- *                     `weatherAgent`) for mastra, falling back to `default`
- *                     only when the map is empty/unreadable — with
+ *                     map (preferring the `default` key when present, else the
+ *                     first registered key; the same `info` response the health
+ *                     + agent rungs fetch) — `default` for the 11
+ *                     default-registering starters, a dynamic key (e.g.
+ *                     `weatherAgent`) for mastra. The id is resolved
+ *                     INDEPENDENT of the agent rung's version check, so a
+ *                     version-only regression still targets the real agent. The
+ *                     last-resort `default` fallback applies ONLY when the agent
+ *                     rung answered `/info` with an empty/unreadable map; when
+ *                     the agent rung FAILED to yield a usable map (non-2xx,
+ *                     unparseable, or body-abort) the chat rung INHERITS the
+ *                     agent failure rather than probing a guessed `default` —
+ *                     with
  *                     `Accept: text/event-stream` and the AG-UI run body
  *                     `{threadId, runId, messages, state, tools, context,
  *                     forwardedProps}`. Read the AG-UI SSE stream and require
@@ -162,10 +170,13 @@ export interface StarterSmokeLevelSignal {
   latencyMs: number;
   /**
    * The agent id this level resolved/targeted, for drilldown. Set on the chat
-   * rung (the id read from `/info` `agents` and POSTed at
-   * `/agent/<id>/run`); the EXPECTED value is `default` for the 11
-   * default-registering starters and a dynamic key (e.g. `weatherAgent`) for
-   * mastra. Absent on the other rungs.
+   * rung ONLY when it is TRUTHFUL: an id explicitly read from `/info` `agents`
+   * and POSTed at `/agent/<id>/run` (EXPECTED `default` for the 11
+   * default-registering starters, a dynamic key like `weatherAgent` for
+   * mastra), OR the last-resort `default` fallback the chat rung actually
+   * probed. Omitted when the agent rung failed to yield a usable map and the
+   * chat fetch was skipped (the chat row inherits the agent failure) — so the
+   * row never claims a `default` it never targeted. Absent on the other rungs.
    */
   agentId?: string;
 }
@@ -184,6 +195,21 @@ export type StarterFailureClass =
 const DEFAULT_TIMEOUT_MS = 30_000;
 const TIMEOUT_ENV_VAR = "STARTER_SMOKE_TIMEOUT_MS";
 
+// INVARIANT (FIX C): the per-starter chat agent id is resolved from the `/info`
+// `agents` map read by the AGENT rung, which therefore MUST run strictly BEFORE
+// the chat rung in STARTER_LEVELS order. If a future edit reorders the levels so
+// chat precedes agent, the chat rung would POST the last-resort `default` for
+// EVERY starter (404ing mastra) and the failure-inheritance in `run()` would
+// never see the agent outcome. Fail loudly at module load rather than silently
+// regress every non-`default` starter.
+if (STARTER_LEVELS.indexOf("agent") >= STARTER_LEVELS.indexOf("chat")) {
+  throw new Error(
+    "starter-smoke invariant violated: STARTER_LEVELS must order 'agent' " +
+      "strictly before 'chat' (the chat rung resolves its agent id from the " +
+      "agent rung's /info read). Fix the ordering in starter-mapping.ts.",
+  );
+}
+
 /**
  * LAST-RESORT agent id for the path-based chat rung when `/info` advertises
  * no readable `agents` map. Most starters register `{ default: ... }`
@@ -193,9 +219,11 @@ const TIMEOUT_ENV_VAR = "STARTER_SMOKE_TIMEOUT_MS";
  * `MastraAgent.getLocalAgents(...)`, whose keys are the Mastra agent names
  * (e.g. `weatherAgent`), so a hardcoded `/agent/default/run` 404s for it. The
  * driver therefore resolves the chat agent id PER-STARTER from the `/info`
- * `agents` map (`Object.keys(info.agents)[0]`, the first registered agent),
+ * `agents` map (preferring the `default` key, else the first registered agent),
  * the same `info` response the health + agent rungs already fetch, and only
- * falls back to this constant when that map is empty/unreadable.
+ * falls back to this constant when the agent rung answered `/info` with an
+ * empty/unreadable map. When the agent rung FAILS to yield a usable map, the
+ * chat rung inherits that failure instead of probing this guessed fallback.
  */
 const FALLBACK_CHAT_AGENT_ID = "default";
 
@@ -303,6 +331,24 @@ export function createStarterSmokeDriver(
       // chat POST targets the agent the deployed starter actually registered
       // (mastra registers a dynamic non-`default` key).
       let resolvedChatAgentId = FALLBACK_CHAT_AGENT_ID;
+      // Whether the agent rung successfully read a usable `agents` map. The
+      // chat rung's `default` fallback is ONLY trustworthy when the agent rung
+      // actually answered `/info` (so `default` is the genuine registered key
+      // for the 11 default starters). When the agent rung FAILED to yield a
+      // usable map (non-2xx, unparseable/empty, or body-abort), probing a
+      // guessed `default` would 404 a non-`default` starter and manufacture a
+      // misleading hard `smoke-failed` chat row that masks the true agent
+      // failure. In that case the chat rung INHERITS the agent rung's failure
+      // (class/reason) WITHOUT issuing a fetch.
+      let agentRungResolvedMap = false;
+      // The agent rung's failure outcome, carried forward to the chat rung when
+      // the agent rung did not yield a usable agents map.
+      let agentRungFailure: LevelOutcome | undefined;
+      // Whether an explicit agent id was resolved from `/info` (truthful for the
+      // chat row's reported `agentId` even when the agent rung itself failed its
+      // version check). Distinguishes a resolved id from the last-resort
+      // fallback so we never claim `default` was targeted when it wasn't.
+      let agentIdResolved = false;
       const chatUrlFor = (agentId: string): string =>
         `${base}/api/copilotkit/agent/${encodeURIComponent(agentId)}/run`;
       const urlForLevel = (level: StarterLevel): string => {
@@ -339,6 +385,26 @@ export function createStarterSmokeDriver(
             errorDesc: sanitizeErrorDesc("aborted"),
             latencyMs: 0,
           };
+        } else if (
+          level === "chat" &&
+          agentRungFailure &&
+          !agentRungResolvedMap
+        ) {
+          // The agent rung FAILED to yield a usable agents map, so the chat
+          // rung has no trustworthy id to POST. Do NOT probe a guessed
+          // `default` (it 404s a non-`default` starter and masks the true
+          // agent failure). INHERIT the agent rung's failure into the chat row
+          // WITHOUT a fetch — a transient agent-rung transport hiccup never
+          // becomes a hard-red chat 404.
+          result = {
+            ok: false,
+            status: agentRungFailure.status,
+            errorClass: agentRungFailure.errorClass,
+            errorDesc: sanitizeErrorDesc(
+              "agent rung failed — chat not probed",
+            ),
+            latencyMs: 0,
+          };
         } else {
           result = await probeLevel({
             fetchImpl,
@@ -350,12 +416,27 @@ export function createStarterSmokeDriver(
           });
         }
 
-        // Capture the agent id the agent rung resolved from `/info` so the
-        // chat rung (next in STARTER_LEVELS order) POSTs the per-agent run path
-        // the starter actually registered. A missing resolution leaves the
-        // last-resort fallback in place.
-        if (level === "agent" && result.resolvedAgentId) {
-          resolvedChatAgentId = result.resolvedAgentId;
+        // Capture the agent rung's outcome so the chat rung (next in
+        // STARTER_LEVELS order) targets the agent the starter actually
+        // registered — and, when the agent rung failed without a usable map,
+        // inherits that failure rather than probing a guessed `default`.
+        if (level === "agent") {
+          if (result.resolvedAgentId) {
+            resolvedChatAgentId = result.resolvedAgentId;
+            agentIdResolved = true;
+            // A resolved id means the agent rung read a usable agents map even
+            // if its version check later failed — `default` is no longer a
+            // guess and the chat rung may probe the real registered agent.
+            agentRungResolvedMap = true;
+          } else if (result.ok) {
+            // The agent rung succeeded but advertised no/empty `agents` map
+            // (the degraded-info case for a default-registering starter):
+            // `default` remains the genuine, trustworthy fallback.
+            agentRungResolvedMap = true;
+          }
+          if (!result.ok) {
+            agentRungFailure = result;
+          }
         }
 
         const state = result.ok ? "green" : "red";
@@ -378,10 +459,17 @@ export function createStarterSmokeDriver(
             errorDesc: result.errorDesc,
             errorClass: result.ok ? undefined : result.errorClass,
             latencyMs: result.latencyMs,
-            // Surface the resolved chat agent id on the chat row for
-            // drilldown (the EXPECTED value is `default` for the 11
-            // default-registering starters, a dynamic key for mastra).
-            ...(level === "chat" ? { agentId: resolvedChatAgentId } : {}),
+            // Surface the resolved chat agent id on the chat row for drilldown,
+            // but ONLY when it is TRUTHFUL: an id explicitly resolved from
+            // `/info` (the EXPECTED value is `default` for the 11
+            // default-registering starters, a dynamic key for mastra), OR the
+            // last-resort `default` fallback the chat rung ACTUALLY probed
+            // (agent rung succeeded with a degraded/empty map). When the agent
+            // rung failed to yield a usable map and the chat fetch was skipped,
+            // omit `agentId` rather than claim a `default` we never targeted.
+            ...(level === "chat" && (agentIdResolved || agentRungResolvedMap)
+              ? { agentId: resolvedChatAgentId }
+              : {}),
           },
           observedAt: ctx.now().toISOString(),
         });
@@ -414,9 +502,15 @@ interface LevelOutcome {
   latencyMs: number;
   /**
    * Agent rung only: the agent id resolved from the `/info` `agents` map
-   * (`Object.keys(info.agents)[0]`), used to drive the chat rung's per-agent
-   * run path. Absent when the map is empty/unreadable (the caller then keeps
-   * the last-resort fallback). Other rungs never set this.
+   * (preferring `default`, else the first non-empty key), used to drive the
+   * chat rung's per-agent run path. Set whenever the body completed and parsed
+   * to a 200 info response with a non-empty `agents` map — INDEPENDENT of the
+   * version-check outcome — so a version-only regression still targets the
+   * real agent rather than a guessed `default`. Absent when the agent rung did
+   * NOT yield a usable agents map (non-2xx, unparseable/empty map, or
+   * body-abort); the caller then treats it as a TRUE agent-rung failure and
+   * carries that failure forward to the chat rung (inherit class/reason)
+   * instead of probing a guessed `default`. Other rungs never set this.
    */
   resolvedAgentId?: string;
 }
@@ -526,9 +620,22 @@ async function probeLevel(opts: {
       const { text: body, completed } = await safeReadBody(res);
       // A read that did NOT complete was cut short by our timer / the
       // external signal → route through the shared abort classification, not
-      // a hard `smoke-failed` empty body.
+      // a hard `smoke-failed` empty body. The caller then knows no agents map
+      // was resolved (`resolvedAgentId` absent → chat rung inherits this
+      // transport failure rather than probing a guessed `default`).
       if (!completed) return abortOutcome(res.status);
       const latencyMs = outcomeLatency();
+      // Resolve the chat agent id from the SAME `/info` body INDEPENDENT of the
+      // version-check outcome. As long as the body completed and parses to a
+      // 200 info response carrying a non-empty `agents` map, populate the
+      // resolved id even if version validation later fails — so a version-only
+      // regression never sends the chat rung to a guessed `default` (which 404s
+      // for a non-`default` starter like mastra, masking the real cause). On a
+      // non-2xx (no usable body) this stays undefined and the chat rung
+      // inherits the agent failure.
+      const resolvedAgentId = res.ok
+        ? (resolveAgentId(body) ?? undefined)
+        : undefined;
       if (!res.ok) {
         return {
           ok: false,
@@ -540,6 +647,7 @@ async function probeLevel(opts: {
               : `agent info http ${res.status}`,
           ),
           latencyMs,
+          resolvedAgentId,
         };
       }
       const versionErr = verifyInfoVersion(body);
@@ -550,17 +658,20 @@ async function probeLevel(opts: {
           errorClass: "smoke-failed",
           errorDesc: sanitizeErrorDesc(`agent info ${versionErr}`),
           latencyMs,
+          // Carry the resolved id forward even though the version check failed:
+          // the chat rung still targets the agent the starter registered
+          // (truthful agentId), never a manufactured `default` 404.
+          resolvedAgentId,
         };
       }
-      // Resolve the chat agent id from the SAME `/info` body the version check
-      // just validated, so the chat rung targets the agent the starter
-      // actually registered (mastra uses a dynamic non-`default` key) without a
-      // second `info` fetch. Absent → caller keeps the last-resort fallback.
+      // The chat rung targets the agent the starter actually registered (mastra
+      // uses a dynamic non-`default` key) without a second `info` fetch. Absent
+      // → caller keeps the last-resort fallback.
       return {
         ok: true,
         status: res.status,
         latencyMs,
-        resolvedAgentId: resolveAgentId(body) ?? undefined,
+        resolvedAgentId,
       };
     }
 
@@ -615,8 +726,17 @@ async function probeLevel(opts: {
       };
     }
 
-    // health / interaction 2xx success: no body read, so headers-time latency
-    // is the true outcome time.
+    // health / interaction 2xx success: these rungs assert only the status, so
+    // they never READ the body — but an unread body leaks the underlying undici
+    // socket under repeated hourly load. Cancel the body stream to release the
+    // socket before returning success. Best-effort: a cancel failure must not
+    // flip a healthy 2xx red.
+    try {
+      await res.body?.cancel();
+    } catch {
+      // ignore — the 2xx liveness signal stands regardless of cancel outcome.
+    }
+    // No body read, so headers-time latency is the true outcome time.
     return { ok: true, status: res.status, latencyMs: outcomeLatency() };
   } catch (err) {
     const latencyMs = now().getTime() - started;
@@ -771,13 +891,15 @@ function verifyInfoVersion(body: string): string | null {
 }
 
 /**
- * Resolve the chat agent id from an `info` response body: the FIRST key of its
- * `agents` map (a `Record<string, AgentDescription>`). Most starters register
- * `{ default: ... }` → `default`; mastra registers dynamic keys (e.g.
- * `weatherAgent`). Returns null when the body is unparseable, has no `agents`
- * map, or the map is empty — the caller then keeps the last-resort fallback.
- * Order follows JS object insertion order, matching the runtime's
- * registration order.
+ * Resolve the chat agent id from an `info` response body's `agents` map (a
+ * `Record<string, AgentDescription>`). PREFERS the `"default"` key when the map
+ * carries it (the 11 default-registering starters, and the safe target for any
+ * future multi-agent starter that also registers a `default`), else falls back
+ * to the FIRST non-empty key (mastra registers a dynamic key such as
+ * `weatherAgent`). Preferring `default` over first-insertion-order avoids a
+ * first-key surprise for multi-agent starters. Returns null when the body is
+ * unparseable, has no `agents` map, or the map yields no usable key — the
+ * caller then keeps the last-resort fallback.
  */
 function resolveAgentId(body: string): string | null {
   let parsed: unknown;
@@ -795,8 +917,14 @@ function resolveAgentId(body: string): string | null {
   }
   const keys = Object.keys(agents as Record<string, unknown>);
   if (keys.length === 0) return null;
-  const first = keys[0];
-  return first.trim().length > 0 ? first : null;
+  // Prefer an explicit `default` key when present (safer for multi-agent
+  // starters that register both a `default` and dynamic keys), else take the
+  // first non-empty key in insertion order.
+  if (keys.includes("default")) return "default";
+  for (const key of keys) {
+    if (key.trim().length > 0) return key;
+  }
+  return null;
 }
 
 /**

--- a/showcase/harness/src/probes/drivers/starter-smoke.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.ts
@@ -400,9 +400,7 @@ export function createStarterSmokeDriver(
             ok: false,
             status: agentRungFailure.status,
             errorClass: agentRungFailure.errorClass,
-            errorDesc: sanitizeErrorDesc(
-              "agent rung failed — chat not probed",
-            ),
+            errorDesc: sanitizeErrorDesc("agent rung failed — chat not probed"),
             latencyMs: 0,
           };
         } else {

--- a/showcase/harness/src/probes/drivers/starter-smoke.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.ts
@@ -5,6 +5,7 @@ import {
   starterToColumnSlug,
   type StarterLevel,
 } from "../helpers/starter-mapping.js";
+import { parseSseEvents } from "../helpers/sse-interceptor.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 
@@ -16,26 +17,51 @@ import type { ProbeContext, ProbeResult } from "../../types/index.js";
  * starter image and running Playwright in CI, it HTTP-probes each starter's
  * own deployed (scale-to-zero) Railway service on the harness cadence. The
  * model is the *same* probe machinery the `smoke` dimension (`liveness.ts`)
- * already runs against the 19 deployed showcase services — no new harness
+ * already runs against the deployed showcase services — no new harness
  * capability, no Docker-on-harness, no browser.
  *
  * One invocation = one starter service. Per starter the driver issues FOUR
  * HTTP checks against the deployed base URL and side-emits one row per
  * level plus an aggregate primary:
  *
- *   - **health**      GET  `${base}/api/health` → 200 + JSON-parseable body.
- *                     Mirrors the `@health` tag (health endpoint responds).
- *   - **agent**       POST `${base}/api/copilotkit/` with `{}` → any non-404
- *                     response. Reuses the exact `checkAgentEndpoint`
- *                     contract `liveness.ts`'s smoke agent check uses: a
- *                     non-404 proves the CopilotKit runtime is mounted; a
- *                     404 means the route isn't wired.
- *   - **chat**        POST `${base}/api/copilotkit/` with a minimal chat
- *                     round-trip payload (aimock answers it) → a non-empty
- *                     response body. Mirrors the `@chat` tag (chat
- *                     round-trip via aimock returns a response) but over a
- *                     single HTTP turn rather than a browser.
- *   - **interaction** GET `${base}/` → 200 (the app shell serves). Mirrors
+ * The agent + chat rungs verify the PATH-BASED v2 multi-route runtime
+ * protocol — the protocol the DEPLOYED starters actually serve. Every starter
+ * mounts `createCopilotEndpoint` in its default `mode:"multi-route"` at
+ * `basePath:"/api/copilotkit"` via a catch-all
+ * `src/app/api/copilotkit/[[...slug]]/route.ts` (verified across
+ * `examples/integrations/<slug>/`, empirically proven by a local build+curl
+ * gate). `matchRoute`
+ * (`packages/runtime/src/v2/runtime/core/fetch-router.ts`) dispatches by URL
+ * path: `/info` → runtime info, `/agent/:agentId/run` → an agent run. The
+ * single-route envelope POST to bare `/api/copilotkit` is DEAD on these
+ * starters (404) and must NOT be used.
+ *
+ *   - **health**      GET  `${base}/api/copilotkit/info` → 200. The deployed
+ *                     starter has NO `/api/health` route (its only API route
+ *                     is the catch-all `/api/copilotkit/[[...slug]]`), so the
+ *                     health rung repoints at the runtime `info` route as a
+ *                     lightweight HTTP-level liveness check — a 200 proves the
+ *                     runtime mount is up and answering. (Distinct from the
+ *                     agent rung below, which additionally validates the JSON
+ *                     `version` field.)
+ *   - **agent**       GET  `${base}/api/copilotkit/info` → require 200 + a
+ *                     `version` field in the JSON body. CONTENT-LEVEL: an
+ *                     HTML error page, a JSON body lacking `version`, or any
+ *                     4xx FAILS. A real `{version}` info response proves the
+ *                     v2 runtime is mounted and answering.
+ *   - **chat**        POST `${base}/api/copilotkit/agent/default/run` with
+ *                     `Accept: text/event-stream` and the AG-UI run body
+ *                     `{threadId, runId, messages, state, tools, context,
+ *                     forwardedProps}`. Read the AG-UI SSE stream and require
+ *                     ≥1 `TEXT_MESSAGE_CONTENT` / `TEXT_MESSAGE_CHUNK` event
+ *                     carrying a non-empty `delta` AND a terminal
+ *                     `RUN_FINISHED` with NO `RUN_ERROR` anywhere in the
+ *                     stream. A 200 with no text, a stream missing the
+ *                     terminal `RUN_FINISHED`, or a stream carrying
+ *                     `RUN_ERROR`, FAILS. Mirrors the `@chat` tag (chat
+ *                     round-trip returns a response) over a single HTTP turn
+ *                     rather than a browser.
+ *   - **interaction** GET  `${base}/` → 200 (the app shell serves). Mirrors
  *                     the `@interaction` tag, which branches on `hasAppMode`
  *                     (`starter-smoke.spec.ts:123`). We keep this check
  *                     GENERIC — both the App-mode and CopilotSidebar
@@ -145,17 +171,55 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const TIMEOUT_ENV_VAR = "STARTER_SMOKE_TIMEOUT_MS";
 
 /**
- * Minimal chat round-trip payload posted to the CopilotKit runtime. The
- * runtime answers this with a streamed/structured response that aimock
- * fulfils; we only assert the response is non-empty (the `@chat` contract:
- * "chat round-trip via aimock returns a response"). Kept intentionally
- * minimal — a full GraphQL `generateCopilotResponse` body would couple the
- * probe to the runtime's request schema, which drifts; a non-empty body
- * from a non-404 POST is sufficient proof-of-life for the chat path.
+ * Canonical agent id every starter registers in its `agents` map
+ * (`examples/integrations/<slug>/src/app/api/copilotkit/[[...slug]]/route.ts`
+ * registers `{ default: new <Framework>Agent(...) }`). The path-based chat
+ * rung targets `/agent/${CHAT_AGENT_ID}/run`; `matchRoute` reads the id from
+ * the URL segment. Confirmed both in the starter routes and via a deployed
+ * starter's `info` `agents` map.
  */
-const CHAT_PROBE_BODY = JSON.stringify({
-  messages: [{ role: "user", content: "Hello" }],
+const CHAT_AGENT_ID = "default";
+
+/**
+ * The AG-UI run body for the chat rung. Shape matches
+ * `handleRunAgent` + the reference test
+ * `packages/runtime/src/v2/runtime/__tests__/express-single-sse.test.ts`:
+ * `{threadId, runId, messages, state, tools, context, forwardedProps}` — NO
+ * single-route envelope wrapper (the path encodes the route on multi-route).
+ * A single user "Hello" turn; the runtime answers with an AG-UI SSE stream.
+ * The driver asserts only the stream SHAPE it requires (≥1 text-content delta
+ * + terminal RUN_FINISHED + no RUN_ERROR), never a specific reply text.
+ */
+const CHAT_RUN_BODY = JSON.stringify({
+  threadId: "starter-smoke-thread",
+  runId: "starter-smoke-run",
+  messages: [{ id: "u1", role: "user", content: "Hello" }],
+  state: {},
+  tools: [],
+  context: [],
+  forwardedProps: {},
 });
+
+/**
+ * AG-UI text-content event types that carry a streamed assistant `delta`.
+ * `TEXT_MESSAGE_CONTENT` is the canonical per-delta event; `TEXT_MESSAGE_CHUNK`
+ * is the combined-chunk variant some transports emit. Either, with a
+ * non-empty `delta`, is proof the chat round-trip produced assistant text.
+ */
+const CHAT_TEXT_EVENT_TYPES = new Set([
+  "TEXT_MESSAGE_CONTENT",
+  "TEXT_MESSAGE_CHUNK",
+]);
+
+/** AG-UI run-failure event type — a stream carrying this FAILS the chat rung. */
+const RUN_ERROR_EVENT_TYPE = "RUN_ERROR";
+
+/**
+ * AG-UI terminal event type — a complete chat round-trip ends with this. A
+ * 200 stream that carries assistant text but never reaches `RUN_FINISHED`
+ * (e.g. the connection dropped mid-run) FAILS, since the run did not complete.
+ */
+const RUN_FINISHED_EVENT_TYPE = "RUN_FINISHED";
 
 export function createStarterSmokeDriver(
   deps: { timeoutMs?: number } = {},
@@ -209,10 +273,14 @@ export function createStarterSmokeDriver(
       // Per-level URL + probe method. Each level owns its own HTTP call and
       // success criterion so a single hung endpoint can't blind its
       // siblings (the same paired-probe isolation `liveness.ts` keeps).
+      // PATH-BASED multi-route protocol: `matchRoute` dispatches on the URL
+      // path, so health/agent GET `/api/copilotkit/info` and chat POSTs the
+      // per-agent run path `/api/copilotkit/agent/<id>/run`. The dead
+      // single-route envelope POST to bare `/api/copilotkit` is never issued.
       const levelUrls: Record<StarterLevel, string> = {
-        health: `${base}/api/health`,
-        agent: `${base}/api/copilotkit/`,
-        chat: `${base}/api/copilotkit/`,
+        health: `${base}/api/copilotkit/info`,
+        agent: `${base}/api/copilotkit/info`,
+        chat: `${base}/api/copilotkit/agent/${encodeURIComponent(CHAT_AGENT_ID)}/run`,
         interaction: `${base}/`,
       };
 
@@ -222,14 +290,32 @@ export function createStarterSmokeDriver(
 
       for (const level of STARTER_LEVELS) {
         const url = levelUrls[level];
-        const result = await probeLevel({
-          fetchImpl,
-          level,
-          url,
-          timeoutMs,
-          now: ctx.now,
-          abortSignal: ctx.abortSignal,
-        });
+        // Short-circuit on an external (outer-timeout) abort BEFORE issuing a
+        // fresh fetch. Without this, an abort mid-tick still fires a cold-start
+        // request for every remaining level — wasting wake requests and
+        // emitting up to four spurious `aborted` rows. Mirrors
+        // `e2e-readiness.ts`, which checks `abort.signal.aborted` before each
+        // iteration and emits a clean `aborted` row WITHOUT a fetch. The first
+        // level whose fetch races the abort still classifies `aborted` in
+        // `probeLevel`; this guard covers the SUBSEQUENT levels.
+        let result: LevelOutcome;
+        if (ctx.abortSignal?.aborted) {
+          result = {
+            ok: false,
+            errorClass: "aborted",
+            errorDesc: sanitizeErrorDesc("aborted"),
+            latencyMs: 0,
+          };
+        } else {
+          result = await probeLevel({
+            fetchImpl,
+            level,
+            url,
+            timeoutMs,
+            now: ctx.now,
+            abortSignal: ctx.abortSignal,
+          });
+        }
 
         const state = result.ok ? "green" : "red";
         if (result.ok) {
@@ -287,11 +373,18 @@ interface LevelOutcome {
  * Issue one HTTP check for a level and classify the outcome.
  *
  *   - health/interaction: GET, success = 2xx (interaction tolerates any
- *     2xx HTML shell; health additionally requires a JSON-parseable body).
- *   - agent: POST `{}`, success = any non-404 response (proof the runtime
- *     is mounted), 404 = `smoke-failed`.
- *   - chat: POST a minimal chat payload, success = a non-404 response with
- *     a non-empty body (aimock answered).
+ *     2xx HTML shell; health GETs `/api/copilotkit/info` and only requires a
+ *     2xx — a lightweight runtime-mount liveness check).
+ *   - agent: GET `/api/copilotkit/info`, success = 200 + a `version` field in
+ *     the JSON body (the v2 multi-route runtime is mounted and answering). An
+ *     HTML error page, a JSON body lacking `version`, or any 4xx =
+ *     `smoke-failed`.
+ *   - chat: POST `/api/copilotkit/agent/<id>/run` with
+ *     `Accept: text/event-stream`, success = an SSE stream carrying ≥1
+ *     `TEXT_MESSAGE_CONTENT`/`TEXT_MESSAGE_CHUNK` event with a non-empty
+ *     `delta` AND a terminal `RUN_FINISHED` with NO `RUN_ERROR`. A 200 with
+ *     no text, a missing terminal `RUN_FINISHED`, or a `RUN_ERROR` stream =
+ *     `smoke-failed`.
  *
  * Transport failures (timeout / cold-start wake / connection / DNS / abort)
  * are classified `transport-error` (or `aborted` on external abort) so a
@@ -309,47 +402,112 @@ async function probeLevel(opts: {
   const { fetchImpl, level, url, timeoutMs, now, abortSignal } = opts;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+  // Track WHY this specific check terminated. The shared `abortSignal` is
+  // LATCHED state: re-reading it at catch-time mislabels a later self-timeout
+  // or a non-abort error (e.g. ECONNREFUSED) as `aborted` once the external
+  // signal has fired for an EARLIER sibling. Instead, flip this local flag
+  // ONLY when THIS check's own abort was driven by the external signal.
+  let externallyAborted = false;
   // Chain the invoker's external abort into this check so an outer timeout
   // releases the socket promptly.
-  const onExternalAbort = (): void => controller.abort();
+  const onExternalAbort = (): void => {
+    externallyAborted = true;
+    controller.abort();
+  };
   if (abortSignal) {
-    if (abortSignal.aborted) controller.abort();
-    else abortSignal.addEventListener("abort", onExternalAbort, { once: true });
+    if (abortSignal.aborted) {
+      externallyAborted = true;
+      controller.abort();
+    } else {
+      abortSignal.addEventListener("abort", onExternalAbort, { once: true });
+    }
   }
   const started = now().getTime();
+  // SINGLE classification for any termination driven by an abort — the body
+  // read OR the fetch itself. `aborted` ONLY when THIS check's abort was
+  // externally driven (the outer tick was abandoned); a self-timeout or a
+  // non-abort error racing a latched external signal is `transport-error`.
+  // Both rungs feed the SAME discriminator (`externallyAborted`) rather than
+  // re-reading the latched `controller.signal.aborted` or keying on `err.name`
+  // alone, so the four rungs classify identically.
+  const abortOutcome = (status: number | undefined): LevelOutcome => ({
+    ok: false,
+    status,
+    errorClass: externallyAborted ? "aborted" : "transport-error",
+    errorDesc: sanitizeErrorDesc(
+      externallyAborted
+        ? "aborted"
+        : `${level} read aborted after ${timeoutMs}ms (cold-start wake or slow stream)`,
+    ),
+    // Recompute at OUTCOME time, not headers-received: a body-abort outcome
+    // must surface the slow-wake latency it exists to flag, not just
+    // time-to-headers.
+    latencyMs: now().getTime() - started,
+  });
   try {
-    const isPost = level === "agent" || level === "chat";
+    // PATH-BASED protocol: only the chat rung is a POST (the per-agent run
+    // path with an AG-UI run body + event-stream negotiation). health, agent
+    // (info) and interaction are all plain GETs.
+    const isChat = level === "chat";
     const res = await fetchImpl(url, {
-      method: isPost ? "POST" : "GET",
-      headers: isPost ? { "Content-Type": "application/json" } : undefined,
-      body: level === "chat" ? CHAT_PROBE_BODY : isPost ? "{}" : undefined,
+      method: isChat ? "POST" : "GET",
+      headers: isChat
+        ? {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+          }
+        : undefined,
+      body: isChat ? CHAT_RUN_BODY : undefined,
       signal: controller.signal,
-      // Follow trailing-slash 308s so we judge the FINAL response (an
-      // unmounted route that redirects to a 404 must read red), matching
-      // the smoke agent check.
+      // `follow` transparently handles any host-level (e.g. https) redirect.
       redirect: "follow",
     });
-    const latencyMs = now().getTime() - started;
+    // Latency at headers-received. The body-read rungs below recompute at
+    // OUTCOME time (`outcomeLatency()`) so an emitted latency reflects the time
+    // actually spent — including the body read on a slow cold-start stream —
+    // not just time-to-headers.
+    const outcomeLatency = (): number => now().getTime() - started;
 
-    // agent / chat: a 404 is a real regression (route not mounted).
-    if ((level === "agent" || level === "chat") && res.status === 404) {
-      const body = await safeReadBody(res);
-      return {
-        ok: false,
-        status: 404,
-        errorClass: "smoke-failed",
-        errorDesc: sanitizeErrorDesc(
-          body.length > 0
-            ? `${level} endpoint 404: ${body}`
-            : `${level} endpoint 404 — route not mounted`,
-        ),
-        latencyMs,
-      };
+    // agent: require a 200 `info` response carrying a `version` field. A
+    // 4xx, a JSON body lacking `version`, or an HTML error page must FAIL.
+    if (level === "agent") {
+      const { text: body, completed } = await safeReadBody(res);
+      // A read that did NOT complete was cut short by our timer / the
+      // external signal → route through the shared abort classification, not
+      // a hard `smoke-failed` empty body.
+      if (!completed) return abortOutcome(res.status);
+      const latencyMs = outcomeLatency();
+      if (!res.ok) {
+        return {
+          ok: false,
+          status: res.status,
+          errorClass: "smoke-failed",
+          errorDesc: sanitizeErrorDesc(
+            body.length > 0
+              ? `agent info http ${res.status}: ${body}`
+              : `agent info http ${res.status}`,
+          ),
+          latencyMs,
+        };
+      }
+      const versionErr = verifyInfoVersion(body);
+      if (versionErr) {
+        return {
+          ok: false,
+          status: res.status,
+          errorClass: "smoke-failed",
+          errorDesc: sanitizeErrorDesc(`agent info ${versionErr}`),
+          latencyMs,
+        };
+      }
+      return { ok: true, status: res.status, latencyMs };
     }
 
-    // chat: a non-404 response must carry a non-empty body (aimock answered).
+    // chat: require an SSE stream carrying assistant text content.
     if (level === "chat") {
-      const body = await safeReadBody(res);
+      const { text: body, completed } = await safeReadBody(res);
+      if (!completed) return abortOutcome(res.status);
+      const latencyMs = outcomeLatency();
       if (!res.ok) {
         return {
           ok: false,
@@ -359,26 +517,30 @@ async function probeLevel(opts: {
           latencyMs,
         };
       }
-      if (body.trim().length === 0) {
+      const chatErr = verifyChatStream(body);
+      if (chatErr) {
         return {
           ok: false,
           status: res.status,
           errorClass: "smoke-failed",
-          errorDesc: sanitizeErrorDesc("chat returned empty response body"),
+          errorDesc: sanitizeErrorDesc(`chat ${chatErr}`),
           latencyMs,
         };
       }
       return { ok: true, status: res.status, latencyMs };
     }
 
-    // agent: any non-404 response is proof-of-life.
-    if (level === "agent") {
-      return { ok: true, status: res.status, latencyMs };
-    }
-
-    // health / interaction: require a 2xx.
+    // health / interaction: require a 2xx. The health rung is a lightweight
+    // liveness GET against `/api/copilotkit/info` — a 200 is enough to prove
+    // the runtime mount is up (the agent rung does the content-level
+    // `version` validation).
     if (!res.ok) {
-      const body = await safeReadBody(res);
+      const { text: body, completed } = await safeReadBody(res);
+      // A non-2xx whose body read was cut short by our abort is a cold-start
+      // transport hiccup — these rungs are hit FIRST on a cold wake, so route
+      // them through the SAME shared abort classification the agent/chat rungs
+      // use instead of unconditionally hard-redding `smoke-failed`.
+      if (!completed) return abortOutcome(res.status);
       return {
         ok: false,
         status: res.status,
@@ -388,42 +550,33 @@ async function probeLevel(opts: {
             ? `${level} http ${res.status}: ${body}`
             : `${level} http ${res.status}`,
         ),
-        latencyMs,
+        latencyMs: outcomeLatency(),
       };
     }
 
-    // health additionally requires a JSON-parseable body — a 200 that
-    // serves an HTML error page (misrouted edge) must NOT pass.
-    if (level === "health") {
-      const parseErr = await verifyJsonBody(res);
-      if (parseErr) {
-        return {
-          ok: false,
-          status: res.status,
-          errorClass: "smoke-failed",
-          errorDesc: sanitizeErrorDesc(`health malformed body: ${parseErr}`),
-          latencyMs,
-        };
-      }
-    }
-
-    return { ok: true, status: res.status, latencyMs };
+    // health / interaction 2xx success: no body read, so headers-time latency
+    // is the true outcome time.
+    return { ok: true, status: res.status, latencyMs: outcomeLatency() };
   } catch (err) {
     const latencyMs = now().getTime() - started;
     const isAbortError =
       err instanceof Error &&
       (err.name === "AbortError" || err.name === "TimeoutError");
-    // Distinguish an EXTERNAL abort (invoker outer-timeout) from this
-    // check's own timeout. Either way it's a transport-class failure, but
-    // the keyed class lets dashboards tell "the whole tick was abandoned"
-    // from "this one endpoint was slow to wake".
-    const externallyAborted = abortSignal?.aborted ?? false;
-    const errorClass: StarterFailureClass = externallyAborted
+    // Distinguish an EXTERNAL abort (invoker outer-timeout) from this check's
+    // OWN timeout, using why THIS check terminated — NOT the shared latched
+    // signal. `aborted` ONLY when this check's abort was externally driven AND
+    // the error is an actual abort. A self-timeout (`isAbortError` but not
+    // externally driven) or a non-abort error (e.g. ECONNREFUSED) racing an
+    // external abort is `transport-error` — the keyed class then truthfully
+    // tells "the whole tick was abandoned" from "this one endpoint was slow to
+    // wake / refused".
+    const abortedByExternalSignal = externallyAborted && isAbortError;
+    const errorClass: StarterFailureClass = abortedByExternalSignal
       ? "aborted"
       : "transport-error";
     const errorDesc = sanitizeErrorDesc(
       isAbortError
-        ? externallyAborted
+        ? abortedByExternalSignal
           ? "aborted"
           : `timeout after ${timeoutMs}ms (cold-start wake or hung endpoint)`
         : err instanceof Error
@@ -509,25 +662,102 @@ function resolveTimeoutMs(ctx: ProbeContext, depTimeoutMs?: number): number {
   return depTimeoutMs ?? DEFAULT_TIMEOUT_MS;
 }
 
-/** Best-effort bounded body read; empty string when unreadable. */
-async function safeReadBody(res: Response): Promise<string> {
+/**
+ * Best-effort body read. Reports ONLY whether the read COMPLETED — not why it
+ * didn't. A read that RESOLVED was, by definition, not cut short, so
+ * `completed: true` is returned EVEN when the controller's signal has since
+ * latched (a self-timeout that fires a hair after `res.text()` resolves must
+ * NOT discard a complete valid body). A read that THREW did not complete and
+ * yields `completed: false` regardless of the rejection's `err.name` — the
+ * SINGLE soft-vs-hard decision (abort vs real bad response) lives at the call
+ * site (`abortOutcome`), keyed on the LOCAL `externallyAborted` flag, so a
+ * non-abort body error (decode error, `ERR_STREAM_PREMATURE_CLOSE`, connection
+ * reset) is classified by the same discriminator as the catch block — never by
+ * a re-read of the latched signal or `err.name` alone.
+ */
+async function safeReadBody(
+  res: Response,
+): Promise<{ text: string; completed: boolean }> {
   try {
-    return await res.text();
+    const text = await res.text();
+    return { text, completed: true };
   } catch {
-    return "";
+    return { text: "", completed: false };
   }
 }
 
-/** Returns null when the body is empty or JSON-parseable, else a reason. */
-async function verifyJsonBody(res: Response): Promise<string | null> {
-  const text = await safeReadBody(res);
-  if (!text) return null;
+/**
+ * Validate an `info` response body: it must be JSON carrying a non-empty
+ * `version`. Returns null on success, else a human-readable reason. A JSON
+ * body lacking `version` or an HTML page (parse failure) both fail.
+ */
+function verifyInfoVersion(body: string): string | null {
+  if (body.trim().length === 0) return "returned empty body (expected version)";
+  let parsed: unknown;
   try {
-    JSON.parse(text);
-    return null;
-  } catch (err) {
-    return err instanceof Error ? err.message : String(err);
+    parsed = JSON.parse(body);
+  } catch {
+    return "body is not JSON (expected info {version})";
   }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return "body is not a JSON object (expected info {version})";
+  }
+  const version = (parsed as Record<string, unknown>)["version"];
+  if (typeof version !== "string" || version.trim().length === 0) {
+    return "response missing a non-empty version field";
+  }
+  return null;
+}
+
+/**
+ * Validate a chat `agent/run` SSE body. A passing stream must satisfy ALL of:
+ *   - ≥1 `TEXT_MESSAGE_CONTENT`/`TEXT_MESSAGE_CHUNK` event with a non-empty
+ *     `delta` (the assistant produced text),
+ *   - a terminal `RUN_FINISHED` event (the run completed), AND
+ *   - NO `RUN_ERROR` anywhere in the stream (the run did not fail).
+ *
+ * Matching is on event SHAPE/CONTENT, never on the server-generated
+ * `messageId` (which is a `chatcmpl-<uuid>`). A `RUN_ERROR` stream, a 200
+ * stream with no text, or a stream that produced text but never reached
+ * `RUN_FINISHED` (e.g. a mid-run drop) all FAIL. Returns null on success,
+ * else a human-readable reason.
+ */
+function verifyChatStream(body: string): string | null {
+  if (body.trim().length === 0) return "returned an empty stream body";
+  const events = parseSseEvents(body);
+  let sawTextDelta = false;
+  let sawRunError = false;
+  let sawRunFinished = false;
+  for (const ev of events) {
+    if (ev.kind !== "json") continue;
+    const type = ev.payload["type"];
+    if (typeof type !== "string") continue;
+    if (type === RUN_ERROR_EVENT_TYPE) {
+      sawRunError = true;
+      continue;
+    }
+    if (type === RUN_FINISHED_EVENT_TYPE) {
+      sawRunFinished = true;
+      continue;
+    }
+    if (CHAT_TEXT_EVENT_TYPES.has(type)) {
+      const delta = ev.payload["delta"];
+      if (typeof delta === "string" && delta.length > 0) {
+        sawTextDelta = true;
+      }
+    }
+  }
+  // A RUN_ERROR fails the run regardless of any text that streamed before it.
+  if (sawRunError) {
+    return "stream emitted RUN_ERROR";
+  }
+  if (!sawTextDelta) {
+    return "stream carried no TEXT_MESSAGE_CONTENT/TEXT_MESSAGE_CHUNK with a non-empty delta";
+  }
+  if (!sawRunFinished) {
+    return "stream produced text but never reached a terminal RUN_FINISHED";
+  }
+  return null;
 }
 
 /** Default driver instance — registered by the orchestrator at boot. */

--- a/showcase/harness/src/probes/drivers/starter-smoke.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.ts
@@ -49,7 +49,13 @@ import type { ProbeContext, ProbeResult } from "../../types/index.js";
  *                     HTML error page, a JSON body lacking `version`, or any
  *                     4xx FAILS. A real `{version}` info response proves the
  *                     v2 runtime is mounted and answering.
- *   - **chat**        POST `${base}/api/copilotkit/agent/default/run` with
+ *   - **chat**        POST `${base}/api/copilotkit/agent/<id>/run` where
+ *                     `<id>` is resolved PER-STARTER from the `/info` `agents`
+ *                     map (`Object.keys(info.agents)[0]`, the same `info`
+ *                     response the health + agent rungs fetch) — `default` for
+ *                     the 11 default-registering starters, a dynamic key (e.g.
+ *                     `weatherAgent`) for mastra, falling back to `default`
+ *                     only when the map is empty/unreadable — with
  *                     `Accept: text/event-stream` and the AG-UI run body
  *                     `{threadId, runId, messages, state, tools, context,
  *                     forwardedProps}`. Read the AG-UI SSE stream and require
@@ -154,6 +160,14 @@ export interface StarterSmokeLevelSignal {
   /** Keyed failure class (red rows only). */
   errorClass?: StarterFailureClass;
   latencyMs: number;
+  /**
+   * The agent id this level resolved/targeted, for drilldown. Set on the chat
+   * rung (the id read from `/info` `agents` and POSTed at
+   * `/agent/<id>/run`); the EXPECTED value is `default` for the 11
+   * default-registering starters and a dynamic key (e.g. `weatherAgent`) for
+   * mastra. Absent on the other rungs.
+   */
+  agentId?: string;
 }
 
 /**
@@ -171,14 +185,19 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const TIMEOUT_ENV_VAR = "STARTER_SMOKE_TIMEOUT_MS";
 
 /**
- * Canonical agent id every starter registers in its `agents` map
- * (`examples/integrations/<slug>/src/app/api/copilotkit/[[...slug]]/route.ts`
- * registers `{ default: new <Framework>Agent(...) }`). The path-based chat
- * rung targets `/agent/${CHAT_AGENT_ID}/run`; `matchRoute` reads the id from
- * the URL segment. Confirmed both in the starter routes and via a deployed
- * starter's `info` `agents` map.
+ * LAST-RESORT agent id for the path-based chat rung when `/info` advertises
+ * no readable `agents` map. Most starters register `{ default: ... }`
+ * (`examples/integrations/<slug>/src/app/api/copilotkit/[[...slug]]/route.ts`),
+ * so `default` is the EXPECTED resolved value for those 11 starters — NOT an
+ * error. But some starters register DYNAMIC non-`default` keys: mastra wires
+ * `MastraAgent.getLocalAgents(...)`, whose keys are the Mastra agent names
+ * (e.g. `weatherAgent`), so a hardcoded `/agent/default/run` 404s for it. The
+ * driver therefore resolves the chat agent id PER-STARTER from the `/info`
+ * `agents` map (`Object.keys(info.agents)[0]`, the first registered agent),
+ * the same `info` response the health + agent rungs already fetch, and only
+ * falls back to this constant when that map is empty/unreadable.
  */
-const CHAT_AGENT_ID = "default";
+const FALLBACK_CHAT_AGENT_ID = "default";
 
 /**
  * The AG-UI run body for the chat rung. Shape matches
@@ -277,11 +296,25 @@ export function createStarterSmokeDriver(
       // path, so health/agent GET `/api/copilotkit/info` and chat POSTs the
       // per-agent run path `/api/copilotkit/agent/<id>/run`. The dead
       // single-route envelope POST to bare `/api/copilotkit` is never issued.
-      const levelUrls: Record<StarterLevel, string> = {
-        health: `${base}/api/copilotkit/info`,
-        agent: `${base}/api/copilotkit/info`,
-        chat: `${base}/api/copilotkit/agent/${encodeURIComponent(CHAT_AGENT_ID)}/run`,
-        interaction: `${base}/`,
+      // The chat rung's agent id is resolved PER-STARTER from the `/info`
+      // `agents` map read by the agent rung (which runs before chat in
+      // STARTER_LEVELS order). It starts at the last-resort fallback and is
+      // overwritten once the agent rung reads a non-empty `agents` map, so the
+      // chat POST targets the agent the deployed starter actually registered
+      // (mastra registers a dynamic non-`default` key).
+      let resolvedChatAgentId = FALLBACK_CHAT_AGENT_ID;
+      const chatUrlFor = (agentId: string): string =>
+        `${base}/api/copilotkit/agent/${encodeURIComponent(agentId)}/run`;
+      const urlForLevel = (level: StarterLevel): string => {
+        switch (level) {
+          case "health":
+          case "agent":
+            return `${base}/api/copilotkit/info`;
+          case "chat":
+            return chatUrlFor(resolvedChatAgentId);
+          case "interaction":
+            return `${base}/`;
+        }
       };
 
       const failed: StarterLevel[] = [];
@@ -289,7 +322,7 @@ export function createStarterSmokeDriver(
       let worstClass: StarterFailureClass | undefined;
 
       for (const level of STARTER_LEVELS) {
-        const url = levelUrls[level];
+        const url = urlForLevel(level);
         // Short-circuit on an external (outer-timeout) abort BEFORE issuing a
         // fresh fetch. Without this, an abort mid-tick still fires a cold-start
         // request for every remaining level — wasting wake requests and
@@ -317,6 +350,14 @@ export function createStarterSmokeDriver(
           });
         }
 
+        // Capture the agent id the agent rung resolved from `/info` so the
+        // chat rung (next in STARTER_LEVELS order) POSTs the per-agent run path
+        // the starter actually registered. A missing resolution leaves the
+        // last-resort fallback in place.
+        if (level === "agent" && result.resolvedAgentId) {
+          resolvedChatAgentId = result.resolvedAgentId;
+        }
+
         const state = result.ok ? "green" : "red";
         if (result.ok) {
           passed++;
@@ -337,6 +378,10 @@ export function createStarterSmokeDriver(
             errorDesc: result.errorDesc,
             errorClass: result.ok ? undefined : result.errorClass,
             latencyMs: result.latencyMs,
+            // Surface the resolved chat agent id on the chat row for
+            // drilldown (the EXPECTED value is `default` for the 11
+            // default-registering starters, a dynamic key for mastra).
+            ...(level === "chat" ? { agentId: resolvedChatAgentId } : {}),
           },
           observedAt: ctx.now().toISOString(),
         });
@@ -367,6 +412,13 @@ interface LevelOutcome {
   errorDesc?: string;
   errorClass?: StarterFailureClass;
   latencyMs: number;
+  /**
+   * Agent rung only: the agent id resolved from the `/info` `agents` map
+   * (`Object.keys(info.agents)[0]`), used to drive the chat rung's per-agent
+   * run path. Absent when the map is empty/unreadable (the caller then keeps
+   * the last-resort fallback). Other rungs never set this.
+   */
+  resolvedAgentId?: string;
 }
 
 /**
@@ -500,7 +552,16 @@ async function probeLevel(opts: {
           latencyMs,
         };
       }
-      return { ok: true, status: res.status, latencyMs };
+      // Resolve the chat agent id from the SAME `/info` body the version check
+      // just validated, so the chat rung targets the agent the starter
+      // actually registered (mastra uses a dynamic non-`default` key) without a
+      // second `info` fetch. Absent → caller keeps the last-resort fallback.
+      return {
+        ok: true,
+        status: res.status,
+        latencyMs,
+        resolvedAgentId: resolveAgentId(body) ?? undefined,
+      };
     }
 
     // chat: require an SSE stream carrying assistant text content.
@@ -707,6 +768,35 @@ function verifyInfoVersion(body: string): string | null {
     return "response missing a non-empty version field";
   }
   return null;
+}
+
+/**
+ * Resolve the chat agent id from an `info` response body: the FIRST key of its
+ * `agents` map (a `Record<string, AgentDescription>`). Most starters register
+ * `{ default: ... }` → `default`; mastra registers dynamic keys (e.g.
+ * `weatherAgent`). Returns null when the body is unparseable, has no `agents`
+ * map, or the map is empty — the caller then keeps the last-resort fallback.
+ * Order follows JS object insertion order, matching the runtime's
+ * registration order.
+ */
+function resolveAgentId(body: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const agents = (parsed as Record<string, unknown>)["agents"];
+  if (agents === null || typeof agents !== "object" || Array.isArray(agents)) {
+    return null;
+  }
+  const keys = Object.keys(agents as Record<string, unknown>);
+  if (keys.length === 0) return null;
+  const first = keys[0];
+  return first.trim().length > 0 ? first : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Rewrites the `starter-smoke` probe to the **v2 path-based multi-route** runtime protocol the deployed starters actually speak — proven via a local build+curl gate against `examples/integrations/crewai-crews` at 1.59.5 (the runtime mounts `createCopilotEndpoint` in default `mode:"multi-route"`, identical at 1.59.3 and 1.59.5).

- **agent** → `GET /api/copilotkit/info` requiring 200 + `version` (was: "any non-404", which a health-JSON/HTML error page wrongly passed)
- **chat** → `POST /api/copilotkit/agent/<id>/run` (`Accept: text/event-stream`), asserting ≥1 `TEXT_MESSAGE_CONTENT` delta **+** terminal `RUN_FINISHED` **+** no `RUN_ERROR` (was: "non-empty body")
- **health** → repointed to `GET /api/copilotkit/info` (the starters serve no `/api/health` route)
- **interaction** → `GET /` (unchanged)
- **drop the trailing slash** on runtime POSTs — `POST /api/copilotkit/` 308-redirects and drops the POST → 404, the core cause of the red rungs

Plus a **unified abort/body-read error classification** (one `abortOutcome()` helper keyed on the local `externallyAborted` flag): a self-timeout or a non-abort error → `transport-error` (soft), only a genuine external abort → `aborted`; a cut-short body read softens to `transport-error` instead of hard `smoke-failed`; the level loop short-circuits on external abort. Reviewed across 3 CR rounds (path-based rewrite + 2 abort-classification fix rounds + confirmation).

> **NOTE:** the content-level chat rung will correctly read **RED** against the deployed starters until the Python-side `ag-ui-crewai` `RUN_ERROR` (a real-LLM, in-process agent failure — *not* a probe bug) is fixed. That is the truthful signal.

## Deferred follow-ups (tracked, not in scope)
- **Verify the alert/staleness consumer branches on `errorClass`, not `state`** — else the soft/hard (`transport-error` vs `smoke-failed`) split is cosmetic at the dashboard layer
- `res.text()` resolve-partial (truncated-but-resolved body) precision edge → could mis-class as `smoke-failed`
- `redirect:"follow"` POST→GET edge; health/interaction success-path body drain; health/agent share `/info` (correlated signals)
- `CLASS_RANK` ranks `aborted` lowest (design call); unmapped-starter `columnSlug` invariant + prototype-key collision
- test-coverage gaps: `resolveTimeoutMs` env parsing, `deriveStarterSlug` fallback, real-timer abort path

## Test plan
- [x] Harness unit suite — 1829 tests pass (105 files); starter-smoke 35/35; red-green verified for protocol + all abort/body-read fixes
- [x] Typecheck (no new errors), oxlint (0 errors), oxfmt, harness build
- [ ] Post-merge: redeploy harness, re-probe; chat rung greens once the Python-side RUN_ERROR is fixed (separate workstream)