### PR TITLE
fix(react): resolve package types under bundler/node16/nodenext

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -71,7 +71,7 @@
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global",
     "publint": "publint .",
-    "attw": "attw --pack . --profile node16 --ignore-rules internal-resolution-error"
+    "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
     "@ag-ui/client": "0.0.53",

--- a/packages/react-core/src/v2/headless.ts
+++ b/packages/react-core/src/v2/headless.ts
@@ -8,6 +8,9 @@
 // Re-export from context (which is external in this build) so the .d.ts
 // references the same type declaration. This avoids a nominal type mismatch
 // caused by private class members being declared in two separate .d.ts files.
+// The relative "./context" specifier is rewritten to the external package path
+// in the emitted declarations by the tsdown `build:done` hook (a relative
+// extensionless import is invalid in ESM declarations).
 export { CopilotKitCoreReact } from "./context";
 export type { CopilotKitCoreReactConfig } from "./context";
 

--- a/packages/react-core/tsdown.config.ts
+++ b/packages/react-core/tsdown.config.ts
@@ -1,10 +1,48 @@
+/// <reference types="node" />
 import { defineConfig } from "tsdown";
+import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 
 // Resolved path to src/v2/context.ts — used to redirect the headless build's
 // relative ../context imports to the external @copilotkit/react-core/v2/context
 // package path, ensuring a shared React context instance at runtime.
-const contextModulePath = path.resolve(import.meta.dirname, "src/v2/context");
+const configDir = path.dirname(fileURLToPath(import.meta.url));
+const contextModulePath = path.resolve(configDir, "src/v2/context");
+
+// Post-process the emitted declaration files. tsdown/rolldown-plugin-dts leaves
+// two artifacts in the .d.ts/.d.cts/.d.mts output that break `attw` type
+// resolution but do not affect the JS bundles:
+//   1. Side-effect CSS imports (e.g. `import "./index.css"`) — TypeScript cannot
+//      resolve a `.css` file as a typed module (InternalResolutionError). The CSS
+//      import is intentionally kept in the JS so styles auto-load for bundler
+//      consumers; only the declarations are cleaned.
+//   2. The headless re-export of the externalized context module is emitted as a
+//      relative `./context` import, which is invalid in ESM declarations
+//      (extensionless). Rewrite it to the package subpath so it resolves under
+//      node16/nodenext/bundler — matching how the JS bundle externalizes it.
+// Run from `build:done` so it processes every format's declarations on disk,
+// independent of per-output plugin order (the esm `.d.mts` and cjs `.d.cts` are
+// emitted in separate passes).
+const postProcessDeclarations = (dir: string) => {
+  const cssImport = /^[ \t]*import\s+["'][^"']+\.css["'];?[ \t]*\r?\n/gm;
+  const contextImport = /from\s+["']\.\.?\/context["']/g;
+  const walk = (current: string) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (/\.d\.[cm]?ts$/.test(entry.name)) {
+        const code = fs.readFileSync(full, "utf8");
+        const next = code
+          .replace(cssImport, "")
+          .replace(contextImport, 'from "@copilotkit/react-core/v2/context"');
+        if (next !== code) fs.writeFileSync(full, next);
+      }
+    }
+  };
+  if (fs.existsSync(dir)) walk(dir);
+};
 
 export default defineConfig([
   {
@@ -14,6 +52,9 @@ export default defineConfig([
     sourcemap: true,
     target: "es2022",
     outDir: "dist",
+    hooks: {
+      "build:done": () => postProcessDeclarations(path.resolve("dist")),
+    },
     external: [
       "react",
       "react-dom",
@@ -119,7 +160,6 @@ export default defineConfig([
       "zod",
       /\.css$/,
     ],
-    codeSplitting: false,
     outputOptions(options) {
       options.entryFileNames = "[name].umd.js";
       options.globals = {
@@ -158,7 +198,6 @@ export default defineConfig([
       "zod",
       /\.css$/,
     ],
-    codeSplitting: false,
     outputOptions(options) {
       options.entryFileNames = "[name].umd.js";
       options.globals = {

--- a/packages/react-textarea/tsdown.config.ts
+++ b/packages/react-textarea/tsdown.config.ts
@@ -1,4 +1,29 @@
+/// <reference types="node" />
 import { defineConfig } from "tsdown";
+import fs from "fs";
+import path from "path";
+
+// Side-effect CSS imports are kept in the JS output so styles auto-load for
+// bundler consumers, but rolldown-plugin-dts also leaves them in the emitted
+// declaration files, where TypeScript cannot resolve a `.css` as a typed module
+// (an `attw` InternalResolutionError). Strip them from declarations only, via the
+// `build:done` hook so every format's declarations are post-processed on disk.
+const stripCssTypeImports = (dir: string) => {
+  const cssImport = /^[ \t]*import\s+["'][^"']+\.css["'];?[ \t]*\r?\n/gm;
+  const walk = (current: string) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (/\.d\.[cm]?ts$/.test(entry.name)) {
+        const code = fs.readFileSync(full, "utf8");
+        const next = code.replace(cssImport, "");
+        if (next !== code) fs.writeFileSync(full, next);
+      }
+    }
+  };
+  if (fs.existsSync(dir)) walk(dir);
+};
 
 export default defineConfig([
   {
@@ -8,6 +33,9 @@ export default defineConfig([
     sourcemap: true,
     target: "es2022",
     outDir: "dist",
+    hooks: {
+      "build:done": () => stripCssTypeImports(path.resolve("dist")),
+    },
     external: ["react", "react-dom"],
     exports: {
       customExports: (exports) => ({
@@ -30,7 +58,6 @@ export default defineConfig([
       "@copilotkit/shared",
       "@copilotkit/runtime-client-gql",
     ],
-    codeSplitting: false,
     outputOptions(options) {
       options.entryFileNames = "[name].umd.js";
       options.globals = {

--- a/packages/react-ui/tsdown.config.ts
+++ b/packages/react-ui/tsdown.config.ts
@@ -1,4 +1,29 @@
+/// <reference types="node" />
 import { defineConfig } from "tsdown";
+import fs from "fs";
+import path from "path";
+
+// Side-effect CSS imports are kept in the JS output so styles auto-load for
+// bundler consumers, but rolldown-plugin-dts also leaves them in the emitted
+// declaration files, where TypeScript cannot resolve a `.css` as a typed module
+// (an `attw` InternalResolutionError). Strip them from declarations only, via the
+// `build:done` hook so every format's declarations are post-processed on disk.
+const stripCssTypeImports = (dir: string) => {
+  const cssImport = /^[ \t]*import\s+["'][^"']+\.css["'];?[ \t]*\r?\n/gm;
+  const walk = (current: string) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (/\.d\.[cm]?ts$/.test(entry.name)) {
+        const code = fs.readFileSync(full, "utf8");
+        const next = code.replace(cssImport, "");
+        if (next !== code) fs.writeFileSync(full, next);
+      }
+    }
+  };
+  if (fs.existsSync(dir)) walk(dir);
+};
 
 export default defineConfig([
   {
@@ -8,6 +33,9 @@ export default defineConfig([
     sourcemap: true,
     target: "es2022",
     outDir: "dist",
+    hooks: {
+      "build:done": () => stripCssTypeImports(path.resolve("dist")),
+    },
     external: [
       "react",
       "react-dom",
@@ -36,7 +64,6 @@ export default defineConfig([
       "@copilotkit/shared",
       "@copilotkit/runtime-client-gql",
     ],
-    codeSplitting: false,
     outputOptions(options) {
       options.entryFileNames = "[name].umd.js";
       options.globals = {


### PR DESCRIPTION
## Problem

The published declaration files for `@copilotkit/react-core`, `@copilotkit/react-ui`, and `@copilotkit/react-textarea` contain imports that TypeScript cannot resolve, so **`attw` (Are The Types Wrong) reports `InternalResolutionError` across every resolution mode** (`node10` / `node16` / `bundler`). In `@copilotkit/react-core` this was being **masked in CI** by `--ignore-rules internal-resolution-error` on the package's `attw` script — so the existing `check:packages` gate looked green while consumers under `moduleResolution: bundler`/`node16`/`nodenext` got broken types (the symptom reported in #3324: `has no exported member 'useAgent'`, etc.).

Two distinct artifacts leaked into the emitted `.d.ts` / `.d.cts` / `.d.mts` (neither affects the JS bundles):

1. **Side-effect CSS imports** — `import "./index.css"` is intentionally kept in the JS so styles auto-load for bundler consumers, but `rolldown-plugin-dts` also left it in the declarations, where TypeScript can't resolve a `.css` as a typed module.
2. **Extensionless relative `./context` import** — `@copilotkit/react-core/v2/headless` re-exports the externalized context module; the JS bundle correctly externalizes it to `@copilotkit/react-core/v2/context`, but the declaration kept the relative `./context`, which is invalid in ESM declarations.

> Note: this is **not** the missing-`exports.types`-condition theory from #3324. tsdown deliberately relies on co-located `.d.mts`/`.d.cts` siblings; `@copilotkit/core` already resolves cleanly. The real defects are the two leaked imports above.

## Fix

A small tsdown `build:done` hook post-processes the emitted declarations **on disk** (after every format is written, so it catches both `.d.mts` and `.d.cts`):

- strips side-effect CSS imports from declarations (JS keeps them);
- rewrites the relative `./context` import to the `@copilotkit/react-core/v2/context` package path (matching how the JS bundle externalizes it).

Also:
- **Removed the `--ignore-rules internal-resolution-error` band-aid** from `react-core`'s `attw` script so the existing CI gate validates for real.
- **Dropped the dead `codeSplitting` option** from the UMD configs — tsdown never reads it (it's a rolldown-only key), and it was failing `tsc` in the configs that type-check themselves. UMD output is unchanged (single file).

## Verification

- All three packages build; **no CSS or relative-`./context` imports remain in any declaration**, while the JS bundles still contain them (styles auto-load preserved).
- `attw` + `publint` pass for all packages **with no suppression** (`react-core`'s `/v2`, `/v2/headless`, `/v2/context` are green for node16-cjs/esm/bundler).
- Unit tests pass.
- A standalone consumer project (real tarball install, `skipLibCheck: false`) type-checks the public APIs — including `useAgent` / `useFrontendTool` / `useConfigureSuggestions` — cleanly under **both `bundler` and `nodenext`**, and the headless↔context class is nominally identical.

## Out of scope (follow-ups)

- `@copilotkit/react-native`: its `--ignore-rules internal-resolution-error` currently suppresses nothing (no IRE) and it has a separate `NoResolution` flag.
- `@copilotkit/vue`: a large, genuine set of `.vue`/relative-import declaration errors unrelated to this change.

Relates to #3324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)