### PR TITLE
docs: unify theme

### DIFF
--- a/showcase/shell-docs/src/app/[[...slug]]/error.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/error.tsx
@@ -38,7 +38,7 @@ export default function DocsError({
         )}
         <button
           onClick={reset}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] transition-colors"
+          className="shell-docs-radius-control h-10 border border-[var(--border)] px-4 text-sm text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-elevated)]"
         >
           Try again
         </button>

--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -15,7 +15,6 @@ import { LandingSampleTabs } from "@/components/landing-sample-tabs";
 import { ShellDocsLayout } from "@/components/shell-docs-layout";
 import { SidebarFrameworkSelector } from "@/components/sidebar-framework-selector";
 import { UnscopedDocsPage } from "@/components/unscoped-docs-page";
-import { FrameworkLogo } from "@/components/icons/framework-icons";
 import {
   buildFrameworkNav,
   buildFrameworkOnlyNav,
@@ -144,18 +143,7 @@ function DocsOverview() {
         <section className="relative border-b border-[var(--border)] pb-6 sm:pb-7">
           <div className="flex max-w-[765px] flex-col">
             <div>
-              <div className="mb-5 flex items-center gap-3">
-                <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text)]">
-                  <FrameworkLogo
-                    slug={HOME_DEFAULT_FRAMEWORK}
-                    className="h-5 w-5"
-                  />
-                </div>
-                <span className="text-sm font-semibold tracking-tight text-[var(--text)] sm:text-base">
-                  Documentation
-                </span>
-              </div>
-              <h1 className="max-w-[24ch] text-[2rem] font-semibold leading-[1.08] tracking-[-0.02em] text-[var(--text)] sm:text-[2.5rem]">
+              <h1 className="max-w-[24ch] text-[2rem] font-semibold leading-[1.08] tracking-[-0.02em] text-[var(--text)] sm:text-[2.5rem] md:mt-3">
                 CopilotKit
               </h1>
               <p className="mt-3 max-w-[58ch] text-lg font-medium leading-snug text-[var(--text-muted)] sm:text-[1.375rem]">

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -355,7 +355,7 @@ export default async function FrameworkScopedDocsPage({
     : [];
 
   const banner = missingCell ? (
-    <div className="mb-6 rounded-lg border border-yellow-500/40 bg-yellow-500/5 p-4">
+    <div className="shell-docs-radius-surface shell-docs-warning-surface mb-6 border p-4 shadow-[var(--shadow-control)]">
       <div className="text-sm font-semibold text-[var(--text)] mb-1">
         Not available for {frameworkName} yet
       </div>
@@ -653,7 +653,7 @@ function NotAvailableForFrameworkPage({
           <p className="text-base text-[var(--text-muted)] mb-6 leading-relaxed">
             This topic isn't available for {frameworkName}.
           </p>
-          <div className="rounded-lg border border-yellow-500/40 bg-yellow-500/5 p-5 mb-6">
+          <div className="shell-docs-radius-surface shell-docs-warning-surface mb-6 border p-5 shadow-[var(--shadow-control)]">
             <div className="text-sm font-semibold text-[var(--text)] mb-2">
               Available in other integrations
             </div>

--- a/showcase/shell-docs/src/app/ag-ui/[[...slug]]/error.tsx
+++ b/showcase/shell-docs/src/app/ag-ui/[[...slug]]/error.tsx
@@ -38,7 +38,7 @@ export default function AgUiError({
         )}
         <button
           onClick={reset}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] transition-colors"
+          className="shell-docs-radius-control h-10 border border-[var(--border)] px-4 text-sm text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-elevated)]"
         >
           Try again
         </button>

--- a/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
@@ -319,9 +319,9 @@ function OverviewContent() {
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-left mb-10">
         <Link
           href="/ag-ui/concepts/architecture"
-          className="group p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-surface)] hover:border-[var(--violet)] transition-all"
+          className="shell-docs-radius-surface group border border-[var(--border)] bg-[var(--bg-surface)] p-5 shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
         >
-          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--violet)] mb-1">
+          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--accent)] mb-1">
             Concepts
           </h3>
           <p className="text-xs text-[var(--text-muted)]">
@@ -330,9 +330,9 @@ function OverviewContent() {
         </Link>
         <Link
           href="/ag-ui/quickstart/introduction"
-          className="group p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-surface)] hover:border-[var(--violet)] transition-all"
+          className="shell-docs-radius-surface group border border-[var(--border)] bg-[var(--bg-surface)] p-5 shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
         >
-          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--violet)] mb-1">
+          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--accent)] mb-1">
             Quick Start
           </h3>
           <p className="text-xs text-[var(--text-muted)]">
@@ -341,9 +341,9 @@ function OverviewContent() {
         </Link>
         <Link
           href="/ag-ui/sdk/js/core/overview"
-          className="group p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-surface)] hover:border-[var(--violet)] transition-all"
+          className="shell-docs-radius-surface group border border-[var(--border)] bg-[var(--bg-surface)] p-5 shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
         >
-          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--violet)] mb-1">
+          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--accent)] mb-1">
             JavaScript SDK
           </h3>
           <p className="text-xs text-[var(--text-muted)]">
@@ -352,9 +352,9 @@ function OverviewContent() {
         </Link>
         <Link
           href="/ag-ui/sdk/python/core/overview"
-          className="group p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-surface)] hover:border-[var(--violet)] transition-all"
+          className="shell-docs-radius-surface group border border-[var(--border)] bg-[var(--bg-surface)] p-5 shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
         >
-          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--violet)] mb-1">
+          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--accent)] mb-1">
             Python SDK
           </h3>
           <p className="text-xs text-[var(--text-muted)]">
@@ -363,9 +363,9 @@ function OverviewContent() {
         </Link>
         <Link
           href="/ag-ui/tutorials/cursor"
-          className="group p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-surface)] hover:border-[var(--violet)] transition-all"
+          className="shell-docs-radius-surface group border border-[var(--border)] bg-[var(--bg-surface)] p-5 shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
         >
-          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--violet)] mb-1">
+          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--accent)] mb-1">
             Tutorials
           </h3>
           <p className="text-xs text-[var(--text-muted)]">
@@ -376,9 +376,9 @@ function OverviewContent() {
           href="https://github.com/ag-ui-protocol/ag-ui"
           target="_blank"
           rel="noopener noreferrer"
-          className="group p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-surface)] hover:border-[var(--violet)] transition-all"
+          className="shell-docs-radius-surface group border border-[var(--border)] bg-[var(--bg-surface)] p-5 shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
         >
-          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--violet)] mb-1">
+          <h3 className="text-sm font-semibold text-[var(--text)] group-hover:text-[var(--accent)] mb-1">
             GitHub
           </h3>
           <p className="text-xs text-[var(--text-muted)]">

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -18,9 +18,10 @@
 @custom-variant dark (&:is(.dark *));
 
 /* Top-of-layout chrome heights:
- *   - Desktop (md+): BrandNav is rendered in body flow at 88px.
- *   - Mobile (< md): BrandNav is hidden; MobileTopNav (inside
- *     DocsLayout's nav slot, position: fixed) renders at 56px.
+ *   - Desktop (xl+): BrandNav is rendered in body flow at 64px.
+ *   - Tablet/mobile (< xl): BrandNav is hidden; MobileTopNav (inside
+ *     DocsLayout's nav slot, position: fixed) renders as a compact
+ *     single-row header.
  *
  * --fd-nav-height drives:
  *   - Fumadocs sidebar's `top:` offset
@@ -28,22 +29,354 @@
  *     see below — but it's load-bearing on mobile to leave space for
  *     the fixed mobile nav).
  *
- * --fd-banner-height is set dynamically by Banners (54px / 0px). */
+ * --fd-banner-height is set dynamically by Banners (40px / 0px). */
 :root {
-  --fd-nav-height: 56px;
+  --fd-nav-height: 64px;
+  --shell-docs-layout-width: calc(97rem + 11px);
+  --shell-docs-grid-gutter: 0px;
+  --shell-docs-grid-top-offset: 0px;
+  --radius: 0.875rem;
+  --shell-docs-radius: var(--radius);
+  --shell-docs-radius-control: var(--radius);
+  --shell-docs-radius-surface: var(--radius);
+  --shell-docs-radius-icon: var(--radius);
+  --shadow-control: 0 1px 0 rgba(1, 5, 7, 0.03);
+  --shadow-panel: 0 18px 50px rgba(1, 5, 7, 0.18);
+  --shadow-modal:
+    0 24px 70px rgba(1, 5, 7, 0.22), 0 0 0 1px rgba(109, 69, 249, 0.05);
+  --overlay-backdrop: rgba(1, 5, 7, 0.25);
+  --accent-strong: color-mix(in oklch, var(--accent) 88%, black);
+  --nav-control-border: color-mix(in srgb, var(--accent) 24%, var(--border));
+  --nav-control-border-hover: color-mix(
+    in srgb,
+    var(--accent) 42%,
+    var(--border)
+  );
+  --warning: oklch(0.72 0.16 76);
+  --warning-dim: color-mix(in oklch, var(--warning) 10%, transparent);
+  --warning-border: color-mix(in oklch, var(--warning) 46%, var(--border));
+  --warning-text: color-mix(in oklch, var(--warning) 70%, var(--text));
+  --window-control-close: #ff5f57;
+  --window-control-minimize: #ffbd2e;
+  --window-control-zoom: #28c840;
 }
-@media (min-width: 768px) {
+@media (min-width: 1280px) {
   :root {
-    --fd-nav-height: 88px;
+    --fd-nav-height: 64px;
+    --shell-docs-grid-top-offset: 5px;
+    --shell-docs-grid-gutter: max(
+      0px,
+      calc((100% - var(--shell-docs-layout-width)) / 2)
+    );
   }
 }
 
-/* BrandNav's desktop surface uses the same 97rem track as the Fumadocs
- * docs grid plus Chromium's 11px `scrollbar-width: thin` gutter. Keep this
- * as ordinary CSS: Tailwind does not emit the equivalent calc/var arbitrary
- * max-width utility, which would leave the header full-width on wide screens. */
+.shell-docs-mobile-nav {
+  box-sizing: border-box;
+  height: var(--fd-nav-height);
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+}
+
+.shell-docs-mobile-nav-top {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.shell-docs-mobile-brand {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.shell-docs-mobile-brand > span:not([aria-hidden="true"]) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shell-docs-mobile-search {
+  display: none;
+}
+
+.shell-docs-mobile-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  justify-self: end;
+}
+
+.shell-docs-mobile-tabs {
+  display: none;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  overflow-x: auto;
+  padding-bottom: 0.125rem;
+  scrollbar-width: none;
+}
+
+.shell-docs-mobile-tabs::-webkit-scrollbar,
+.shell-docs-mobile-sidebar-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.shell-docs-primary-tab {
+  display: inline-flex;
+  height: 2.25rem;
+  min-width: max-content;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  transition:
+    background-color 150ms ease-out,
+    color 150ms ease-out,
+    box-shadow 150ms ease-out;
+}
+
+@media (min-width: 768px) and (max-width: 1279px) {
+  .shell-docs-mobile-nav {
+    padding: 0 1.25rem;
+  }
+
+  .shell-docs-mobile-search {
+    display: block;
+    justify-self: end;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1279px) {
+  .shell-docs-mobile-nav-top {
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  }
+
+  .shell-docs-mobile-tabs {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .shell-docs-mobile-menu {
+    display: none !important;
+  }
+}
+
+@media (min-width: 1280px) {
+  .shell-docs-mobile-nav {
+    display: none !important;
+  }
+}
+
+.shell-docs-mobile-sidebar-tabs {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  gap: 0.375rem;
+  overflow-x: auto;
+  padding-bottom: 0.75rem;
+  scrollbar-width: none;
+}
+
+.shell-docs-mobile-sidebar-tabs .shell-docs-primary-tab {
+  flex: 1 0 max-content;
+}
+
+@media (min-width: 768px) {
+  .shell-docs-mobile-sidebar-tabs {
+    display: none;
+  }
+}
+
+/* BrandNav keeps its content inset, but the bottom divider should span the
+ * full viewport width instead of stopping at the nav's 22px desktop margins. */
+.shell-docs-brand-nav::after {
+  position: absolute;
+  right: -22px;
+  bottom: 0;
+  left: -22px;
+  height: 1px;
+  background: var(--border);
+  content: "";
+}
+
+/* BrandNav is a full-width top bar. Keep a named hook so layout tests can
+ * assert the header does not regress back to the earlier capped pill chrome. */
 .shell-docs-brand-nav-inner {
-  max-width: calc(97rem + 11px);
+  width: 100%;
+}
+
+.shell-docs-brand-link {
+  margin-left: max(
+    0px,
+    calc((100vw - var(--shell-docs-layout-width)) / 2 - 22px)
+  );
+}
+
+.shell-docs-radius-control {
+  border-radius: var(--shell-docs-radius-control) !important;
+}
+
+.shell-docs-radius-surface {
+  border-radius: var(--shell-docs-radius-surface) !important;
+}
+
+.shell-docs-radius-icon {
+  border-radius: var(--shell-docs-radius-icon) !important;
+}
+
+.shell-docs-surface {
+  border: 1px solid var(--border);
+  border-radius: var(--shell-docs-radius-surface);
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-control);
+}
+
+.shell-docs-icon-surface {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--shell-docs-radius-icon);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+}
+
+.shell-docs-picker-icon-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in oklch, var(--accent) 12%, var(--border));
+  border-radius: 9999px;
+  background: #ffffff;
+  color: var(--accent);
+}
+
+.dark .shell-docs-picker-icon-chip {
+  border-color: color-mix(in oklch, var(--accent) 20%, var(--border));
+  background: color-mix(in oklch, var(--foreground) 94%, var(--accent) 6%);
+  color: var(--accent);
+}
+
+.shell-docs-warning-surface {
+  border-color: var(--warning-border);
+  border-left-color: var(--warning);
+  background: var(--warning-dim);
+}
+
+.shell-docs-commit-label {
+  position: fixed;
+  right: 12px;
+  bottom: 8px;
+  z-index: 9999;
+  color: var(--text-faint);
+  font-family: var(--font-docs-code);
+  font-size: 10px;
+  opacity: 0.55;
+  pointer-events: none;
+  user-select: none;
+}
+
+.reference-content a.shell-docs-cta-link,
+.reference-content a.shell-docs-cta-link:hover {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.reference-content a.shell-docs-cta-accent,
+.reference-content a.shell-docs-cta-accent:hover,
+.reference-content .shell-docs-cta-accent {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.shell-docs-cta-stripe {
+  background: var(--accent);
+}
+
+.shell-docs-course-banner {
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklch, var(--accent) 78%, black) 0%,
+    var(--accent) 52%,
+    color-mix(in oklch, var(--accent) 90%, white) 100%
+  ) !important;
+  border-color: color-mix(in oklch, var(--accent) 70%, white) !important;
+}
+
+.dark .shell-docs-course-banner {
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklch, var(--accent) 72%, black) 0%,
+    color-mix(in oklch, var(--accent) 86%, black) 52%,
+    var(--accent) 100%
+  ) !important;
+  border-color: color-mix(in oklch, var(--accent) 62%, transparent) !important;
+}
+
+#shell-docs-course-banner > button {
+  width: 24px !important;
+  height: 24px !important;
+  border: 1px solid color-mix(in srgb, white 26%, transparent) !important;
+  background: color-mix(in srgb, white 10%, transparent) !important;
+  opacity: 1 !important;
+  color: white !important;
+  cursor: pointer !important;
+}
+
+#shell-docs-course-banner > button:hover {
+  background: color-mix(in srgb, white 16%, transparent) !important;
+}
+
+.shell-docs-nav-link-idle {
+  color: var(--text-muted);
+}
+
+.shell-docs-nav-link-idle:hover {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.shell-docs-nav-link-active {
+  background: color-mix(in oklch, var(--accent) 13%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--accent) 24%, var(--border)),
+    0 1px 0 rgba(1, 5, 7, 0.04);
+  color: var(--accent);
+}
+
+.shell-docs-nav-cta {
+  border-color: var(--nav-control-border);
+  background: color-mix(in oklch, var(--accent) 8%, transparent);
+  color: var(--accent);
+}
+
+.shell-docs-nav-cta:hover {
+  border-color: var(--nav-control-border-hover);
+  background: color-mix(in oklch, var(--accent) 13%, transparent);
+  color: var(--accent);
+}
+
+.dark .shell-docs-nav-link-idle:hover {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.dark .shell-docs-nav-link-active {
+  background: color-mix(in oklch, var(--accent) 20%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--accent) 34%, var(--border)),
+    0 1px 0 rgba(0, 0, 0, 0.25);
+  color: var(--accent);
 }
 
 /* shell-docs sidebar overrides.
@@ -55,11 +388,11 @@
  * column. Hide it so the framework selector (rendered via the `banner`
  * slot) sits flush at the top. */
 /* Sidebar banner (holds the framework picker). Keep horizontal padding at
- * zero so the picker edge aligns with BrandNav's visible surface. The gap
- * between the picker and the first nav link is governed by the scroll
- * viewport's top padding below. */
+ * zero so the picker edge aligns with BrandNav's visible surface. The top
+ * gap keeps the picker aligned under BrandNav; the larger bottom gap gives
+ * the first section header the same breathing room as section breaks below. */
 .shell-docs-sidebar > div:first-child {
-  padding: 0 !important;
+  padding: 0.75rem 0 1.25rem !important;
 }
 /* Hide the empty home-link wrapper Fumadocs ships in the desktop
  * SidebarHeader. Scoped via `:has(> a:only-child:empty)` so it ONLY
@@ -158,12 +491,12 @@
  * GitHub / Discord anchors inside our custom footer row (marked with
  * the `.sidebar-footer-row` class on the wrapper) so the icons feel
  * branded even without a container pill. */
-.shell-docs-sidebar .sidebar-footer-row > a {
+.shell-docs-sidebar .sidebar-footer-row a {
   transition:
     color 150ms ease-out,
     background-color 150ms ease-out;
 }
-.shell-docs-sidebar .sidebar-footer-row > a:hover {
+.shell-docs-sidebar .sidebar-footer-row a:hover {
   background-color: color-mix(
     in srgb,
     var(--accent) 10%,
@@ -173,14 +506,14 @@
 }
 
 /* First separator at the top of the sidebar — Fumadocs v16 emits the
- * separator `<p>` with `first:mt-0`, which zeroes the top margin only
- * on the first one. Restore the standard `mt-6` (1.5rem) so the gap
- * between the framework picker and "Getting Started" matches the gap
- * between every other section header. Selector matches the section-
- * header `<p>` shape (`inline-flex items-center gap-2 ...`) since v16
- * dropped the older `sidebar-item-offset` class fragment. */
+ * separator `<p>` with `first:mt-0`, which is correct for shell-docs
+ * because the picker wrapper owns the top-to-first-section gap. Keep this at
+ * zero so the picker-to-"Getting Started" space does not double up with
+ * the scroll viewport's padding. Selector matches the section-header
+ * `<p>` shape (`inline-flex items-center gap-2 ...`) since v16 dropped
+ * the older `sidebar-item-offset` class fragment. */
 .shell-docs-sidebar p.inline-flex.gap-2:first-of-type {
-  margin-top: 1.5rem !important;
+  margin-top: 0 !important;
 }
 
 /* Section-header icons — accent purple. The lucide icons use
@@ -207,25 +540,24 @@
   letter-spacing: 0 !important;
 }
 
-/* Fumadocs CodeBlock chrome — force a single flat white surface throughout.
+/* Fumadocs CodeBlock chrome — force a single tokenized surface throughout.
  *
  * Out-of-the-box, Fumadocs paints the `<CodeBlock>` figure with
  * `bg-fd-card` (and `bg-fd-secondary` when nested inside CodeBlockTabs),
  * and the CodeBlockTabs container itself uses `bg-fd-card`. Those tints
- * differ subtly from the page bg, giving the title strip a visibly
- * grayer band against the rest of the page. Snap every surface to the
- * page bg so the file caption, the code body, and the tab strip read
- * as one clean rounded box. */
+ * differ subtly from the page theme, giving the title strip a visibly
+ * separate band. Snap every surface to the shared card token so the file
+ * caption, the code body, and the tab strip read as one clean rounded box. */
 figure.shiki,
 .docs-inner-content [data-orientation="horizontal"]:has(> [role="tablist"]) {
-  background-color: #ffffff !important;
+  background-color: var(--bg-surface) !important;
   box-shadow: none !important;
 }
 .dark figure.shiki,
 .dark
   .docs-inner-content
   [data-orientation="horizontal"]:has(> [role="tablist"]) {
-  background-color: #1a1d1f !important;
+  background-color: var(--bg-surface) !important;
 }
 /* Fumadocs's figcaption header ("page.tsx" strip) uses `border-b` which
  * inherits `currentColor` from the parent's `text-fd-muted-foreground`
@@ -238,19 +570,19 @@ figure.shiki > div:first-child[class*="border-b"] {
 
 /* Tighten Fumadocs DocsPage spacing.
  *
- * On desktop (md+), shell-docs's BrandNav sits OUTSIDE DocsLayout in
+ * On desktop (xl+), shell-docs's BrandNav sits OUTSIDE DocsLayout in
  * body flow — so `#nd-docs-layout`'s `pt-(--fd-nav-height)` would be a
  * second 88px stacked on top of BrandNav's 88px (a doubled gap). We
- * zero it on md+ only.
+ * zero it on xl+ only.
  *
- * On mobile (< md), BrandNav is hidden and the fixed-positioned
+ * On tablet/mobile (< xl), BrandNav is hidden and the fixed-positioned
  * MobileTopNav lives INSIDE DocsLayout — `pt-(--fd-nav-height)` (56px)
  * is exactly the space the fixed nav needs.
  *
  * The article-level padding (LayoutBody's `md:[&_#nd-page_article]:pt-12`
  * plus PageArticle's own `pt-8`) is unwanted on both — we always zero
  * those at the #nd-page / article wrappers. */
-/* Mobile (< md): MobileTopNav is `position: fixed` at top:0 of the
+/* Tablet/mobile (< xl): MobileTopNav is `position: fixed` at top:0 of the
  * viewport (56px tall, see --fd-nav-height). Push the docs grid down
  * by that amount so the page title isn't clipped behind it. Fumadocs
  * v16 no longer ships this `pt-(--fd-nav-height)` default on the
@@ -259,11 +591,40 @@ figure.shiki > div:first-child[class*="border-b"] {
   #nd-docs-layout {
     padding-top: var(--fd-nav-height) !important;
     grid-template-columns: minmax(0, 1fr) !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    min-width: 0 !important;
+  }
+
+  #nd-sidebar,
+  #nd-docs-layout > [class*="[grid-area:sidebar]"],
+  #nd-toc {
+    display: none !important;
+  }
+
+  #nd-page {
+    grid-column: 1 / -1 !important;
+    width: 100% !important;
   }
 }
 
-@media (min-width: 768px) {
+@media (min-width: 768px) and (max-width: 1279px) {
   #nd-docs-layout {
+    padding-top: var(--fd-nav-height) !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    min-width: 0 !important;
+  }
+
+  #nd-docs-layout > .docs-inner-content {
+    grid-area: main !important;
+    grid-column: main !important;
+  }
+}
+
+@media (min-width: 1280px) {
+  #nd-docs-layout {
+    margin-top: var(--shell-docs-grid-top-offset) !important;
     padding-top: 0 !important;
     /* Override fumadocs's `--fd-docs-row-1: var(--fd-banner-height, 0px)`.
      * Fumadocs assumes the banner is sticky/fixed at the top of the
@@ -281,8 +642,8 @@ figure.shiki > div:first-child[class*="border-b"] {
     --fd-docs-row-1: 0px !important;
     /* Override fumadocs's default `--fd-docs-height: 100dvh`. That
      * assumes the docs grid spans the whole viewport, but shell-docs
-     * has BrandNav (68px md→xl, 88px xl+) + mt-6 (24px) + mb-3
-     * (12px) above/below `main` in body flow (body itself is
+     * has BrandNav (64px) + mt-3 (12px) + mb-3 (12px) around `main`, plus
+     * a small grid top offset, in body flow (body itself is
      * `overflow: hidden`, fixed 100dvh). We can't use `100%` here:
      * the docs grid uses `min-h-(--fd-docs-height)`, so when the
      * docs content is long it grows past main, and `100%` resolves
@@ -291,21 +652,15 @@ figure.shiki > div:first-child[class*="border-b"] {
      * full content height (3000px+) rather than the visible column.
      * Use a viewport-bound calc that subtracts the chrome instead. */
     --fd-docs-height: calc(
-      100dvh - var(--fd-banner-height, 0px) - 68px - 2.25rem
-    ) !important;
-  }
-}
-
-/* At xl+, BrandNav switches from h-[68px] to h-[88px]. */
-@media (min-width: 1280px) {
-  #nd-docs-layout {
-    --fd-docs-height: calc(
-      100dvh - var(--fd-banner-height, 0px) - 88px - 2.25rem
+      100dvh - var(--fd-banner-height, 0px) - 64px - 1.5rem -
+        var(--shell-docs-grid-top-offset)
     ) !important;
   }
 }
 #nd-page > article,
 #nd-page {
+  min-width: 0 !important;
+  max-width: 100% !important;
   padding-top: 0 !important;
   padding-left: 0.75rem !important;
   margin-top: 0 !important;
@@ -341,11 +696,11 @@ figure.shiki > div:first-child[class*="border-b"] {
   padding-right: 16px !important;
 }
 
-/* Desktop (md+): mirror the sidebar's 0.75rem left/right viewport
+/* Desktop (xl+): mirror the sidebar's 0.75rem left/right viewport
  * inset so the content column has breathing room from both the
  * floating sidebar (on the left) and the viewport edge (on the
  * right). */
-@media (min-width: 768px) {
+@media (min-width: 1280px) {
   .docs-inner-content {
     padding-left: 49px !important;
     padding-right: 49px !important;
@@ -367,17 +722,24 @@ figure.shiki > div:first-child[class*="border-b"] {
   max-width: min(1100px, 100%);
 }
 
-/* Mobile: the docs grid keeps 5 columns (sidebar / sidebar / main /
+/* Tablet/mobile: the docs grid keeps 5 columns (sidebar / sidebar / main /
  * toc / toc) even when the sidebar is `display: none` because it's
  * the named grid template fumadocs ships. With `grid-area: auto`,
  * the content lands in column 1 (a `1fr` outer-left column), so a
  * narrow main column (col 3, no real content placed there) wastes
  * the rest of the viewport on the right. Forcing the content to
  * span the full grid lets it use the whole row. */
-@media (max-width: 767px) {
+@media (max-width: 1279px) {
+  #nd-page,
+  #nd-page > article,
+  .docs-content-wrapper {
+    overflow-x: clip;
+  }
+
   .docs-inner-content {
     grid-column: 1 / -1;
     max-width: 100%;
+    overflow-wrap: anywhere;
   }
 }
 
@@ -389,11 +751,14 @@ figure.shiki > div:first-child[class*="border-b"] {
   box-shadow: none !important;
 }
 
-/* Sidebar scroll viewport — keep vertical padding for the gap below the
- * picker, but remove horizontal padding so the nav content uses the
- * same full column width as the framework picker. */
+/* Sidebar scroll viewport — the picker wrapper owns the top gap, so only
+ * keep bottom padding for scroll-end breathing room. Remove horizontal
+ * padding so the nav content uses the same full column width as the
+ * framework picker. */
 .shell-docs-sidebar [data-radix-scroll-area-viewport] {
-  padding: 1rem 0 !important;
+  padding: 0 0 1rem 0 !important;
+  -webkit-mask-image: none !important;
+  mask-image: none !important;
 }
 
 /* Bridge shell-docs's hand-rolled token names (--bg, --text, --accent, …)
@@ -402,6 +767,15 @@ figure.shiki > div:first-child[class*="border-b"] {
  * (`bg-fd-background`, etc.) and Fumadocs's internal components both
  * resolve to the shell-docs palette. */
 @theme inline {
+  /* Fumadocs ships Tailwind utilities that use rounded-md/lg/xl/2xl in
+   * generated layout chrome. Map those radius tokens back to the shadcn
+   * `--radius` value so custom and Fumadocs surfaces share one shape
+   * instead of each rounded-* utility choosing a different corner size. */
+  --radius-sm: var(--shell-docs-radius);
+  --radius-md: var(--shell-docs-radius);
+  --radius-lg: var(--shell-docs-radius);
+  --radius-xl: var(--shell-docs-radius);
+  --radius-2xl: var(--shell-docs-radius);
   --color-fd-background: var(--bg);
   --color-fd-foreground: var(--text);
   --color-fd-card: var(--bg-surface);
@@ -421,38 +795,59 @@ figure.shiki > div:first-child[class*="border-b"] {
 }
 
 :root {
-  /* Light mode is plain white throughout — sidebar, content, glass surfaces
-   * all share `#ffffff` so the eye reads a single page rather than two
-   * panels with a seam. The dark-mode block below keeps shell-docs's
-   * darker-surface palette unchanged.
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.457 0.24 277.023);
+  --primary-foreground: oklch(0.962 0.018 272.314);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent-token: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.511 0.262 276.966);
+  --sidebar-primary-foreground: oklch(0.962 0.018 272.314);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+  /* Light mode follows a shadcn-style neutral scale: white page/card
+   * surfaces, a very light sidebar, low-chroma borders, and a single
+   * purple primary. shell-docs keeps `--accent` as the primary color
+   * because existing CTAs and link states depend on that contract.
    *
-   * Exception: `--nav-surface` keeps a slight gray-purple tint so the
-   * top BrandNav's two-piece pill (and its slanted SVG separator) reads
-   * as a distinct surface against the white page bg — that's the
-   * canonical CopilotKit chrome look. */
-  --bg: #ffffff;
-  --bg-surface: #ffffff;
-  --bg-elevated: #f5f5f7;
-  --bg-hover: #ececf0;
-  --border: #e5e5ea;
-  --border-dim: #efeff3;
-  --sidebar: #ffffff;
-  --glass-background: #ffffff;
-  --nav-surface: #ffffff;
-  --text: #010507;
-  --text-secondary: #2b3238;
-  --text-muted: #6a7079;
-  --text-faint: #a3a8af;
-  /* Reference primary is oklch(0.55 0.25 285) — a blue-violet. Hex approx. */
-  --accent: #6d45f9;
-  --accent-light: #ede5ff;
-  --accent-dim: rgba(109, 69, 249, 0.06);
+   * Exception: `--nav-surface` remains explicit so the header can keep
+   * tracking the page background independently of elevated surfaces. */
+  --bg: var(--background);
+  --bg-surface: var(--card);
+  --bg-elevated: var(--secondary);
+  --bg-hover: var(--muted);
+  --border: oklch(0.922 0 0);
+  --border-dim: color-mix(in oklch, var(--border) 62%, transparent);
+  --sidebar: oklch(0.985 0 0);
+  --glass-background: var(--card);
+  --nav-surface: var(--background);
+  --text: var(--foreground);
+  --text-secondary: oklch(0.21 0.006 285.885);
+  --text-muted: var(--muted-foreground);
+  --text-faint: oklch(0.708 0 0);
+  --accent: var(--primary);
+  --accent-light: color-mix(in oklch, var(--accent) 14%, white);
+  --accent-dim: color-mix(in oklch, var(--accent) 8%, transparent);
   --blue: #1a5fb4;
   /* Aliased to --accent / --accent-light. Consumed by AG-UI section pages
    * and OpsPlatformCTA. Kept as separate names for backwards compatibility
    * with existing class references; values track the canonical accent. */
-  --violet: #6d45f9;
-  --violet-light: #ede5ff;
+  --violet: var(--accent);
+  --violet-light: var(--accent-light);
   /* Scrollbar tokens — applied to internal scroll containers (sidebar
    * inner scroll, content wrapper) so thumb + track follow theme. */
   --scrollbar-color: rgba(0, 0, 0, 0.2);
@@ -473,31 +868,57 @@ figure.shiki > div:first-child[class*="border-b"] {
     "Liberation Mono", "Courier New", monospace;
 }
 
-/* Dark token set — mirrors canonical docs.copilotkit.ai's `.dark` block.
- * Activates when an ancestor (typically <html>) has class="dark". The
- * navbar theme toggle adds/removes that class and persists the choice
- * in localStorage; the inline script in <head> (see layout.tsx) reads
- * the persisted value before paint to avoid a light-flash on first load. */
+/* Dark token set — same neutral scale, with purple lifted slightly brighter
+ * than the sample's dark primary so text and outline CTAs keep enough
+ * contrast on the docs header. */
 .dark {
-  --bg: #050a0e;
-  --bg-surface: #1a1d1f;
-  --bg-elevated: #1f2326;
-  --bg-hover: #252a2e;
-  --nav-surface: #111618;
-  --border: rgba(255, 255, 255, 0.1);
-  --border-dim: rgba(255, 255, 255, 0.05);
-  --sidebar: #111618;
-  --glass-background: rgba(255, 255, 255, 0.06);
-  --text: #fafafa;
-  --text-secondary: #cbd2d8;
-  --text-muted: #9ba0a8;
-  --text-faint: #5e6168;
-  --accent: #8b6cff;
-  --accent-light: rgba(139, 108, 255, 0.18);
-  --accent-dim: rgba(139, 108, 255, 0.1);
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.585 0.233 277.117);
+  --primary-foreground: oklch(0.962 0.018 272.314);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent-token: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.585 0.233 277.117);
+  --sidebar-primary-foreground: oklch(0.962 0.018 272.314);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+  --bg: var(--background);
+  --bg-surface: var(--card);
+  --bg-elevated: var(--secondary);
+  --bg-hover: color-mix(in oklch, var(--secondary) 82%, white 18%);
+  --nav-surface: var(--background);
+  --border-dim: oklch(1 0 0 / 5%);
+  --glass-background: color-mix(in oklch, var(--card) 70%, transparent);
+  --text: var(--foreground);
+  --text-secondary: oklch(0.82 0.01 286);
+  --text-muted: var(--muted-foreground);
+  --text-faint: oklch(0.556 0 0);
+  --accent: var(--primary);
+  --accent-light: color-mix(in oklch, var(--accent) 24%, transparent);
+  --accent-dim: color-mix(in oklch, var(--accent) 14%, transparent);
+  --warning: oklch(0.76 0.15 76);
+  --warning-dim: color-mix(in oklch, var(--warning) 14%, transparent);
+  --warning-border: color-mix(in oklch, var(--warning) 48%, var(--border));
+  --warning-text: color-mix(in oklch, var(--warning) 72%, var(--text));
   --blue: #6ba6e8;
-  --violet: #8b6cff;
-  --violet-light: rgba(139, 108, 255, 0.18);
+  --violet: var(--accent);
+  --violet-light: var(--accent-light);
   --scrollbar-color: rgba(255, 255, 255, 0.18);
   --scrollbar-track: transparent;
 }
@@ -555,6 +976,7 @@ samp {
   min-width: 0;
   height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
   position: relative;
   background-color: var(--bg);
   scrollbar-width: thin;
@@ -647,7 +1069,7 @@ samp {
   font-size: 0.8125rem;
   background: var(--bg-elevated);
   padding: 0.125rem 0.375rem;
-  border-radius: 0.25rem;
+  border-radius: var(--shell-docs-radius-control);
   font-family: var(--font-docs-code);
   color: var(--text);
 }
@@ -689,7 +1111,7 @@ samp {
   border-collapse: separate;
   border-spacing: 0;
   border: 1px solid var(--border);
-  border-radius: 0.5rem;
+  border-radius: var(--shell-docs-radius-surface);
   overflow: hidden;
   margin-bottom: 1rem;
 }
@@ -751,22 +1173,29 @@ samp {
   opacity: 1;
 }
 
-/* <Steps> / <Step> — CSS counters so numbering survives WhenFrameworkHas
- * gating. The Steps wrapper resets the counter; each visible Step
- * increments and renders its number via ::before. Hidden gates render
- * nothing, so the counter doesn't advance across them. */
-.docs-steps {
-  counter-reset: docs-step;
+/* Fumadocs <Steps> / <Step>, themed to shell-docs tokens. */
+.fd-steps {
+  border-inline-start-color: var(--border);
+  margin-block: 1.5rem;
 }
-.docs-step__badge {
+
+.fd-step {
+  position: relative;
+  padding-bottom: 1.5rem;
+}
+
+.fd-step::before {
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  color: var(--text);
+  border-radius: var(--shell-docs-radius-icon);
+  color: var(--accent);
+  font-size: 0.75rem;
   font-weight: 600;
-}
-.docs-step__badge::before {
-  counter-increment: docs-step;
-  content: counter(docs-step);
+  height: 1.5rem;
+  inset-inline-start: -2.75rem;
+  line-height: 1;
+  top: 0.1875rem;
+  width: 1.5rem;
 }
 
 /* Step heading colors. Previously Step 1's heading carried an
@@ -780,13 +1209,13 @@ samp {
  * `-webkit-text-fill-color` must be reset explicitly — any prior
  * gradient rule that set it to `transparent` would otherwise still
  * override our `color` declaration on WebKit browsers. */
-.docs-steps h3,
-.docs-steps h3 > :is(:not(.docs-heading-anchor)) {
+.fd-steps h3,
+.fd-steps h3 > :is(:not(.docs-heading-anchor)) {
   background-image: none !important;
   color: var(--text) !important;
   -webkit-text-fill-color: var(--text) !important;
 }
-.docs-steps h3 a:not(.docs-heading-anchor) {
+.fd-steps h3 a:not(.docs-heading-anchor) {
   color: var(--text) !important;
   -webkit-text-fill-color: var(--text) !important;
 }
@@ -794,19 +1223,25 @@ samp {
 /* Mute the SignupLink color in Step 1 so it tracks the body prose. The
  * link stays underlined for affordance, inherits hover (opacity: 0.8)
  * from .reference-content a. */
-.docs-steps > div:first-child a[data-cta-surface] {
+.fd-steps > div:first-child a[data-cta-surface] {
   color: var(--text);
 }
 
 /* Align each Step's first heading with its number badge.
  * `.reference-content h2/h3/h4` ship with `margin-top` (1.25–2.5rem) so
- * the heading would otherwise float well below the absolutely-positioned
- * `.docs-step__badge` (anchored at `top: -0.125rem`). Zero out the top
- * margin when the heading is the first thing rendered inside a Step. */
-.docs-steps h2:first-child,
-.docs-steps h3:first-child,
-.docs-steps h4:first-child {
+ * the heading would otherwise float below Fumadocs' numbered marker. */
+.fd-steps h2:first-child,
+.fd-steps h3:first-child,
+.fd-steps h4:first-child,
+.fd-steps .docs-step-title:first-child {
   margin-top: 0;
+}
+
+.fd-steps .docs-step-title {
+  color: var(--text);
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.375rem;
 }
 
 /* Syntax-highlight token colors come from Shiki (Fumadocs's `rehypeCode`)

--- a/showcase/shell-docs/src/app/layout.tsx
+++ b/showcase/shell-docs/src/app/layout.tsx
@@ -206,27 +206,14 @@ export default function RootLayout({
                  * (margin: 0 4px; xl: 0 8px 8px 8px). */}
                 <Banners />
                 <BrandNav />
-                <main className="flex flex-1 min-h-0 overflow-hidden mx-1 md:mx-[22px] mt-2 md:mt-[15px] mb-2 md:mb-3">
+                <main className="flex flex-1 min-h-0 overflow-hidden mx-1 md:mx-[22px] mt-2 md:mt-3 mb-2 md:mb-3">
                   {children}
                 </main>
               </ShellSearchProvider>
             </RootProvider>
           </FrameworkProvider>
         </PostHogProvider>
-        <div
-          aria-hidden="true"
-          style={{
-            position: "fixed",
-            bottom: "8px",
-            right: "12px",
-            fontSize: "10px",
-            fontFamily: "monospace",
-            color: "rgba(0,0,0,0.15)",
-            pointerEvents: "none",
-            zIndex: 9999,
-            userSelect: "none",
-          }}
-        >
+        <div aria-hidden="true" className="shell-docs-commit-label">
           {commitLabel}
         </div>
         <ScarfPixel />

--- a/showcase/shell-docs/src/app/not-found.tsx
+++ b/showcase/shell-docs/src/app/not-found.tsx
@@ -38,13 +38,13 @@ export default function NotFound() {
         <div className="flex justify-center gap-3">
           <Link
             href="/"
-            className="inline-flex items-center px-4 py-2 rounded-lg border border-[var(--accent)] bg-[var(--accent)] text-white text-sm font-medium hover:opacity-90 transition-opacity"
+            className="shell-docs-radius-control inline-flex h-10 items-center border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90"
           >
             Go to docs home
           </Link>
           <Link
             href="/reference"
-            className="inline-flex items-center px-4 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text)] text-sm font-medium hover:border-[var(--accent)] transition-colors"
+            className="shell-docs-radius-control inline-flex h-10 items-center border border-[var(--border)] bg-[var(--bg-surface)] px-4 text-sm font-medium text-[var(--text)] transition-colors hover:border-[var(--accent)]"
           >
             API reference
           </Link>

--- a/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
@@ -82,7 +82,7 @@ const mdxComponents = {
   OpsPlatformCTA,
   LinkIcon,
   Frame: ({ children }: { children: React.ReactNode }) => (
-    <div className="my-6 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4">
+    <div className="shell-docs-radius-surface my-6 border border-[var(--border)] bg-[var(--bg-surface)] p-4 shadow-[var(--shadow-control)]">
       {children}
     </div>
   ),

--- a/showcase/shell-docs/src/app/reference/page.tsx
+++ b/showcase/shell-docs/src/app/reference/page.tsx
@@ -72,13 +72,13 @@ export default function ReferencePage() {
                     <Link
                       key={item.slug}
                       href={item.url}
-                      className="block rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4 hover:bg-[var(--bg-elevated)] transition-colors"
+                      className="shell-docs-radius-surface block min-w-0 border border-[var(--border)] bg-[var(--bg-surface)] p-4 shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
                     >
-                      <div className="font-mono text-sm font-semibold text-[var(--accent)]">
+                      <div className="min-w-0 break-words font-mono text-sm font-semibold text-[var(--accent)] [overflow-wrap:anywhere]">
                         {displayTitle(item)}
                       </div>
                       {item.description && (
-                        <div className="text-xs text-[var(--text-muted)] mt-1">
+                        <div className="mt-1 min-w-0 break-words text-xs text-[var(--text-muted)] [overflow-wrap:anywhere]">
                           {item.description}
                         </div>
                       )}

--- a/showcase/shell-docs/src/components/ai/page-actions.tsx
+++ b/showcase/shell-docs/src/components/ai/page-actions.tsx
@@ -138,7 +138,7 @@ export function MarkdownCopyButton({
         buttonVariants({
           color: "secondary",
           size: "sm",
-          className: "gap-2 [&_svg]:size-3.5 [&_svg]:text-fd-muted-foreground",
+          className: "gap-2 [&_svg]:size-3.5 [&_svg]:text-[var(--text-muted)]",
         }),
         props.className,
       )}
@@ -280,12 +280,12 @@ export function ViewOptionsPopover({
             color: "secondary",
             size: "sm",
           }),
-          "gap-2 data-[state=open]:bg-fd-accent data-[state=open]:text-fd-accent-foreground",
+          "gap-2 data-[state=open]:border-[var(--accent)] data-[state=open]:bg-[var(--accent-dim)] data-[state=open]:text-[var(--accent)]",
           props.className,
         )}
       >
         {props.children ?? "Open"}
-        <ChevronDown className="size-3.5 text-fd-muted-foreground" />
+        <ChevronDown className="size-3.5 text-[var(--text-muted)]" />
       </PopoverTrigger>
       <PopoverContent className="flex flex-col">
         {items.map((item) => (
@@ -311,11 +311,11 @@ export function ViewOptionsPopover({
                 path: pathname,
               })
             }
-            className="text-sm p-2 rounded-lg inline-flex items-center gap-2 hover:text-fd-accent-foreground hover:bg-fd-accent [&_svg]:size-4"
+            className="shell-docs-radius-control inline-flex items-center gap-2 p-2 text-sm text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text)] [&_svg]:size-4"
           >
             {item.icon}
             {item.title}
-            <ExternalLinkIcon className="text-fd-muted-foreground size-3.5 ms-auto" />
+            <ExternalLinkIcon className="ms-auto size-3.5 text-[var(--text-muted)]" />
           </a>
         ))}
       </PopoverContent>

--- a/showcase/shell-docs/src/components/banners.tsx
+++ b/showcase/shell-docs/src/components/banners.tsx
@@ -1,57 +1,48 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { GraduationCap, X } from "lucide-react";
-import { useState, useEffect, useCallback } from "react";
-
-// Time in milliseconds before a dismissed banner reappears
-const BANNER_REAPPEAR_DELAY = 3 * 24 * 60 * 60 * 1000; // 3 days
-const BANNER_DISMISSED_KEY = "nd-banner-rotating-banner";
-const BANNER_DISMISSED_TIME_KEY = "nd-banner-rotating-banner-dismissed-at";
+import { ArrowRight, BookOpenCheck, X } from "lucide-react";
 
 type BannerEntry = {
-  icon: React.ReactNode;
   mobileText: string;
-  desktopText: string;
+  title: string;
+  source: string;
   buttonText: string;
   href: string;
 };
 
 const bannerContent: BannerEntry[] = [
   {
-    icon: <GraduationCap className="w-5 h-5 hidden md:block flex-shrink-0" />,
-    mobileText: "Free Generative UI course on DeepLearning.AI",
-    desktopText:
-      "Build Interactive Agents with Generative UI: our new free DeepLearning.AI course",
-    buttonText: "Start the course",
+    mobileText: "Free Generative UI course",
+    title: "Build Interactive Agents with Generative UI",
+    source: "DeepLearning.AI",
+    buttonText: "Start free course",
     href: "https://www.deeplearning.ai/short-courses/build-interactive-agents-with-generative-ui/",
   },
 ];
 
+const BANNER_REAPPEAR_DELAY = 3 * 24 * 60 * 60 * 1000;
+const BANNER_DISMISSED_KEY = "nd-banner-rotating-banner";
+const BANNER_DISMISSED_TIME_KEY = "nd-banner-rotating-banner-dismissed-at";
+const LEGACY_DISMISSED_STORAGE_KEY = "shell-docs-course-banner-dismissed";
+
+function setBannerHeight(height: "0px" | "40px") {
+  document.documentElement.style.setProperty("--fd-banner-height", height);
+}
+
 export function Banners() {
-  const [currentBanner, setCurrentBanner] = useState(0);
+  const content = bannerContent[0];
   const [dismissed, setDismissed] = useState(false);
-  // Hydration guard — server renders nothing so the banner can't flash
-  // before localStorage state has been read.
   const [hydrated, setHydrated] = useState(false);
 
-  // Rotate banners every 8 seconds (matches canonical implementation).
-  useEffect(() => {
-    if (bannerContent.length <= 1) return;
-    const interval = setInterval(() => {
-      setCurrentBanner((prev) => (prev + 1) % bannerContent.length);
-    }, 8000);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  // Read + maintain dismissal state from localStorage. Banner reappears
-  // after BANNER_REAPPEAR_DELAY has elapsed since dismissal.
   useEffect(() => {
     setHydrated(true);
 
     const checkBannerExpiry = () => {
-      const isDismissed = localStorage.getItem(BANNER_DISMISSED_KEY) === "true";
+      const isDismissed =
+        localStorage.getItem(BANNER_DISMISSED_KEY) === "true" ||
+        localStorage.getItem(LEGACY_DISMISSED_STORAGE_KEY) === "true";
 
       if (!isDismissed) {
         setDismissed(false);
@@ -60,8 +51,6 @@ export function Banners() {
 
       const dismissedAt = localStorage.getItem(BANNER_DISMISSED_TIME_KEY);
       if (!dismissedAt) {
-        // Backfill timestamp if dismissal flag exists without a timestamp
-        // (e.g., set in another tab or by a legacy build).
         localStorage.setItem(BANNER_DISMISSED_TIME_KEY, Date.now().toString());
         setDismissed(true);
         return;
@@ -71,6 +60,7 @@ export function Banners() {
       if (elapsed >= BANNER_REAPPEAR_DELAY) {
         localStorage.removeItem(BANNER_DISMISSED_KEY);
         localStorage.removeItem(BANNER_DISMISSED_TIME_KEY);
+        localStorage.removeItem(LEGACY_DISMISSED_STORAGE_KEY);
         setDismissed(false);
       } else {
         setDismissed(true);
@@ -81,9 +71,6 @@ export function Banners() {
 
     const handleStorage = () => checkBannerExpiry();
     window.addEventListener("storage", handleStorage);
-
-    // Periodic re-check so the banner reappears mid-session once the TTL
-    // expires without requiring a reload.
     const interval = setInterval(checkBannerExpiry, 1000);
 
     return () => {
@@ -92,87 +79,61 @@ export function Banners() {
     };
   }, []);
 
-  // Reflect the banner's visible height into `--fd-banner-height` so
-  // Fumadocs's fixed-positioned sidebar shifts down when the banner is
-  // showing and snaps flush under BrandNav when it's dismissed. ~54px
-  // is the rendered banner height across breakpoints; we set the
-  // variable on <html> so all of Fumadocs's `top:` math picks it up.
   useEffect(() => {
-    if (typeof document === "undefined") return;
-    document.documentElement.style.setProperty(
-      "--fd-banner-height",
-      !hydrated || dismissed ? "0px" : "54px",
-    );
+    setBannerHeight(!hydrated || dismissed ? "0px" : "40px");
   }, [hydrated, dismissed]);
 
-  const handleDismiss = useCallback(() => {
+  const dismissBanner = useCallback(() => {
     localStorage.setItem(BANNER_DISMISSED_KEY, "true");
     localStorage.setItem(BANNER_DISMISSED_TIME_KEY, Date.now().toString());
+    localStorage.setItem(LEGACY_DISMISSED_STORAGE_KEY, "true");
     setDismissed(true);
   }, []);
 
-  if (!hydrated || dismissed) return null;
-
-  const content = bannerContent[currentBanner];
+  if (!hydrated || dismissed) {
+    return null;
+  }
 
   return (
-    <div className="w-full px-[22px] mt-2">
-      <div
-        id="rotating-banner"
-        className="relative w-full max-w-[97rem] mx-auto rounded-2xl py-1.5 md:py-2"
-        style={{
-          background: "var(--bg-elevated)",
-          color: "var(--text-secondary)",
-          border: "1px solid var(--border, rgba(0,0,0,0.08))",
-        }}
-      >
-        <div className="flex flex-row items-center justify-center gap-1.5 md:gap-3 w-full px-1 md:px-4 pr-8 md:pr-10">
-          <div
-            key={currentBanner}
-            className="flex items-center gap-1.5 md:gap-2 flex-shrink min-w-0"
-          >
-            {content.icon}
-            <p
-              className="text-xs md:text-base font-normal md:hidden"
-              style={{ fontWeight: 400 }}
-            >
-              {content.mobileText}
-            </p>
-            <p
-              className="text-sm sm:text-base font-normal hidden md:block"
-              style={{ fontWeight: 400 }}
-            >
-              {content.desktopText}
-            </p>
-          </div>
-          <Link
-            href={content.href}
-            target={content.href.startsWith("http") ? "_blank" : undefined}
-            rel={
-              content.href.startsWith("http")
-                ? "noopener noreferrer"
-                : undefined
-            }
-            className="text-xs md:text-sm items-center flex px-2 py-0.5 md:px-4 md:py-1 no-underline whitespace-nowrap rounded-lg flex-shrink-0 transition-all duration-100"
-            style={{
-              background: "var(--accent-light, rgba(109, 69, 249, 0.12))",
-              color: "var(--accent)",
-              boxShadow: "0 0 0 1px var(--accent-light, rgba(109,69,249,0.2))",
-            }}
-          >
-            {content.buttonText}
-          </Link>
-        </div>
-        <button
-          type="button"
-          onClick={handleDismiss}
-          aria-label="Dismiss banner"
-          className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-60 hover:opacity-100 transition-opacity"
-          style={{ color: "var(--text-secondary)" }}
+    <div
+      id="shell-docs-course-banner"
+      className="sticky top-0 z-40 flex h-10 flex-row items-center justify-center overflow-hidden border-b px-4 text-center text-sm font-medium text-white shadow-none shell-docs-course-banner"
+    >
+      <div className="relative z-1 flex w-full min-w-0 items-center justify-center gap-2 pr-8 md:gap-2.5">
+        <span
+          className="shell-docs-radius-icon hidden h-5 w-5 shrink-0 items-center justify-center border border-white/30 bg-white/16 text-white lg:inline-flex"
+          aria-label="Free course"
         >
-          <X className="w-4 h-4" />
-        </button>
+          <BookOpenCheck className="h-3 w-3" aria-hidden="true" />
+        </span>
+        <p className="min-w-0 truncate text-xs font-medium text-white md:text-[13px]">
+          <span className="md:hidden">{content.mobileText}</span>
+          <span className="hidden md:inline">{content.title}</span>
+          <span className="hidden text-white/72 md:inline">
+            {" "}
+            with {content.source}
+          </span>
+        </p>
+        <Link
+          href={content.href}
+          target={content.href.startsWith("http") ? "_blank" : undefined}
+          rel={
+            content.href.startsWith("http") ? "noopener noreferrer" : undefined
+          }
+          className="shell-docs-radius-control inline-flex h-6 shrink-0 items-center gap-1 bg-white px-2.5 text-[11px] font-semibold text-[var(--accent)] no-underline shadow-[var(--shadow-control)] transition-colors duration-150 hover:bg-white/90 md:px-3"
+        >
+          {content.buttonText}
+          <ArrowRight className="h-3 w-3" aria-hidden="true" />
+        </Link>
       </div>
+      <button
+        type="button"
+        aria-label="Close Banner"
+        onClick={dismissBanner}
+        className="absolute inset-e-2 top-1/2 z-10 inline-flex h-6 w-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full border border-white/25 bg-white/10 text-white/85 transition-colors duration-100 hover:bg-white/20 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/55"
+      >
+        <X className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
     </div>
   );
 }

--- a/showcase/shell-docs/src/components/brand-nav.tsx
+++ b/showcase/shell-docs/src/components/brand-nav.tsx
@@ -3,9 +3,10 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
-import { ChefHat, Lightbulb } from "lucide-react";
+import { CalendarDays, ChefHat } from "lucide-react";
 import { SearchTrigger } from "./search-trigger";
 import { CopilotKitMark } from "./copilotkit-mark";
+import { ThemeSwitch } from "./theme-switch";
 import BookIcon from "./icons/book";
 import ConsoleIcon from "./icons/console";
 import ExternalLinkIcon from "./icons/external-link";
@@ -19,40 +20,29 @@ export const INTELLIGENCE_CTA_HREF =
 export const TALK_TO_ENGINEER_HREF =
   "https://copilotkit.ai/talk-to-an-engineer";
 
-// LEFT cluster — Docs / Reference / Intelligence sign-up. Visual pattern
-// (icon-next-to-label) mirrors canonical. The third slot label matches the
-// in-content OpsPlatformCTA default ("Get Intelligence free") so the
-// conversion path reads consistently from navbar to body to footer.
+// Center cluster — primary docs destinations only. Conversion CTAs live in
+// the right utility cluster so the center nav stays balanced.
 type LeftLink = {
   href: string;
   label: string;
   icon: React.ReactNode;
-  target?: "_blank" | "_self";
-  showExternalLinkIcon?: boolean;
 };
 
 const LEFT_LINKS: LeftLink[] = [
   {
-    icon: <BookIcon className="text-[var(--text-secondary)]" />,
+    icon: <BookIcon className="text-current" />,
     label: "Docs",
     href: "/",
   },
   {
-    icon: <ConsoleIcon className="text-[var(--text-secondary)]" />,
+    icon: <ConsoleIcon className="text-current" />,
     label: "Reference",
     href: "/reference",
   },
   {
-    icon: <ChefHat className="w-5 h-5 text-[var(--text-secondary)]" />,
+    icon: <ChefHat className="w-5 h-5 text-current" />,
     label: "Cookbook",
     href: "/cookbook",
-  },
-  {
-    icon: <Lightbulb className="w-5 h-5 text-[var(--text-secondary)]" />,
-    label: "Get Intelligence free",
-    href: INTELLIGENCE_CTA_HREF,
-    target: "_blank",
-    showExternalLinkIcon: true,
   },
 ];
 
@@ -84,18 +74,15 @@ export function BrandNav(_props: BrandNavProps = {}) {
   };
 
   const handleFreeDeveloperAccessClick = () => {
-    posthog?.capture("try_for_free_clicked", { location: "docs_navbar_left" });
+    posthog?.capture("try_for_free_clicked", { location: "docs_navbar_right" });
   };
 
   return (
-    <nav className="relative hidden h-[86px] bg-[var(--bg)] px-[22px] py-3 md:block">
-      <div
-        className="shell-docs-brand-nav-inner mx-auto flex h-full items-center gap-5 rounded-lg border border-[var(--border)] px-5 shadow-[0_1px_0_rgba(1,5,7,0.03)] backdrop-blur-lg"
-        style={{ backgroundColor: "var(--nav-surface)" }}
-      >
+    <nav className="shell-docs-brand-nav relative hidden h-16 bg-[var(--bg)] xl:mx-[22px] xl:block">
+      <div className="shell-docs-brand-nav-inner relative grid h-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-4 bg-[var(--nav-surface)]">
         <Link
           href="/"
-          className="flex shrink-0 items-center gap-2"
+          className="shell-docs-brand-link flex min-w-0 shrink-0 items-center gap-2 justify-self-start"
           aria-label="CopilotKit Docs"
         >
           <CopilotKitMark />
@@ -103,41 +90,24 @@ export function BrandNav(_props: BrandNavProps = {}) {
             CopilotKit
           </span>
           <span
-            className="ml-1 rounded-lg border border-[var(--border)] bg-[var(--accent-dim)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--accent)]"
+            className="shell-docs-radius-control ml-1 border border-[var(--border)] bg-[var(--accent-dim)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--accent)]"
             aria-hidden="true"
           >
             Docs
           </span>
         </Link>
-        <ul className="hidden h-full items-center gap-1 md:flex">
+        <ul className="hidden min-w-0 items-center gap-2 justify-self-center xl:flex">
           {LEFT_LINKS.map((link) => {
             const isActive = activeRoute === link.href;
-            const isFreeDevAccess = link.label === "Get Intelligence free";
             return (
-              <li
-                key={link.href}
-                className={`relative h-full group ${
-                  isFreeDevAccess ? "hidden [@media(width>=960px)]:block" : ""
-                }`}
-              >
+              <li key={link.href} className="relative h-full group">
                 <Link
                   href={link.href}
-                  target={link.target}
-                  onClick={
-                    isFreeDevAccess ? handleFreeDeveloperAccessClick : undefined
-                  }
-                  className={`flex h-full items-center rounded-lg px-3 transition-colors duration-200 ${
+                  className={`shell-docs-radius-control flex h-10 items-center px-4 transition-colors duration-200 ${
                     isActive
-                      ? "text-[var(--text)]"
-                      : "text-[var(--text-muted)] hover:bg-[var(--bg-elevated)]/70 hover:text-[var(--text)]"
+                      ? "shell-docs-nav-link-active"
+                      : "shell-docs-nav-link-idle"
                   }`}
-                  // HubSpot's analytics tag rewrites the
-                  // dashboard.operations.copilotkit.ai href client-side to
-                  // attach `__hstc` / `__hssc` / `__hsfp` cross-domain
-                  // tracking params, which trips React's hydration diff.
-                  // Suppress only on the Intelligence link so genuine
-                  // mismatches on other nav items still surface.
-                  suppressHydrationWarning={isFreeDevAccess}
                 >
                   <span className="flex items-center gap-2">
                     <span className="[@media(width<808px)]:hidden">
@@ -146,28 +116,33 @@ export function BrandNav(_props: BrandNavProps = {}) {
                     <span className="text-sm font-medium whitespace-nowrap">
                       {link.label}
                     </span>
-                    {link.showExternalLinkIcon && (
-                      <ExternalLinkIcon className="text-current opacity-60" />
-                    )}
                   </span>
                 </Link>
-                <div
-                  className="absolute bottom-0 left-3 right-3 h-[2px] rounded-full bg-[#7076D5] transition-opacity duration-200"
-                  style={{ opacity: isActive ? 1 : 0 }}
-                  aria-hidden="true"
-                />
               </li>
             );
           })}
         </ul>
 
-        <div className="ml-auto flex min-w-0 items-center gap-2 pl-2">
+        <div className="flex min-w-0 items-center gap-2 justify-self-end pl-2">
+          <SearchTrigger iconOnly />
+          <Link
+            href={INTELLIGENCE_CTA_HREF}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleFreeDeveloperAccessClick}
+            className="shell-docs-nav-cta shell-docs-radius-control hidden h-10 cursor-pointer items-center gap-2 whitespace-nowrap border px-4 text-sm font-medium no-underline shadow-[var(--shadow-control)] transition-colors duration-200 [@media(width>=1280px)]:flex"
+            aria-label="Get Intelligence free"
+            suppressHydrationWarning
+          >
+            Get Intelligence free
+            <ExternalLinkIcon className="text-current opacity-70" />
+          </Link>
           {/* Talk to an engineer. Secondary in the docs nav so search can own
            * the far-right utility slot. */}
           <button
             type="button"
             onClick={handleTalkToEngineersClick}
-            className="hidden h-9 cursor-pointer items-center whitespace-nowrap rounded-lg border border-[var(--accent)] bg-[var(--accent-dim)] px-3.5 text-sm font-medium text-[var(--accent)] shadow-[0_1px_0_rgba(1,5,7,0.03)] transition-colors duration-200 hover:bg-[var(--accent)] hover:text-white [@media(width>=1100px)]:flex"
+            className="shell-docs-nav-cta shell-docs-radius-control hidden h-10 cursor-pointer items-center whitespace-nowrap border px-4 text-sm font-medium shadow-[var(--shadow-control)] transition-colors duration-200 [@media(width>=1500px)]:flex"
             aria-label="Talk to an engineer"
           >
             Talk to an engineer
@@ -175,27 +150,13 @@ export function BrandNav(_props: BrandNavProps = {}) {
           <button
             type="button"
             onClick={handleTalkToEngineersClick}
-            className="hidden h-9 w-9 cursor-pointer items-center justify-center rounded-lg border border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)] shadow-[0_1px_0_rgba(1,5,7,0.03)] transition-colors duration-200 hover:bg-[var(--accent)] hover:text-white md:flex [@media(width>=1100px)]:hidden"
+            className="shell-docs-nav-cta shell-docs-radius-control hidden h-10 w-10 cursor-pointer items-center justify-center border shadow-[var(--shadow-control)] transition-colors duration-200 xl:flex [@media(width>=1500px)]:hidden"
             aria-label="Talk to an engineer"
             title="Talk to an engineer"
           >
-            <svg
-              width="17"
-              height="17"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-              <line x1="16" y1="2" x2="16" y2="6" />
-              <line x1="8" y1="2" x2="8" y2="6" />
-              <line x1="3" y1="10" x2="21" y2="10" />
-            </svg>
+            <CalendarDays className="h-4 w-4" />
           </button>
-          <SearchTrigger iconOnly />
+          <ThemeSwitch />
         </div>
       </div>
     </nav>

--- a/showcase/shell-docs/src/components/content/iframe-switcher.tsx
+++ b/showcase/shell-docs/src/components/content/iframe-switcher.tsx
@@ -19,21 +19,14 @@ export function IframeSwitcher({
   codeLabel = "Code",
   height = "600px",
 }: IframeSwitcherProps) {
-  const iframeStyle = {
-    width: "100%",
-    height,
-    border: "none",
-    borderRadius: "0.375rem",
-    background: "var(--bg-surface)",
-  };
-
   return (
     <div id={id}>
       <Tabs items={[exampleLabel, codeLabel]}>
         <Tab value={exampleLabel}>
           <iframe
             src={exampleUrl}
-            style={iframeStyle}
+            className="shell-docs-radius-surface w-full border-0 bg-[var(--bg-surface)]"
+            style={{ height }}
             sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
             loading="lazy"
           />
@@ -41,7 +34,8 @@ export function IframeSwitcher({
         <Tab value={codeLabel}>
           <iframe
             src={codeUrl}
-            style={iframeStyle}
+            className="shell-docs-radius-surface w-full border-0 bg-[var(--bg-surface)]"
+            style={{ height }}
             sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
             loading="lazy"
           />

--- a/showcase/shell-docs/src/components/content/landing-pages/framework-overview.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/framework-overview.tsx
@@ -164,40 +164,6 @@ export function FrameworkOverview({
 
   return (
     <div className="relative pb-24">
-      {/* Hero atmosphere — single restrained accent glow behind the
-          framework name + headline. Sits at zIndex 0 so all hero text
-          renders cleanly on top. Subtle in light mode, more present in
-          dark mode (where the page bg gives the accent room to breathe). */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-0 -z-0 h-[480px] overflow-hidden"
-      >
-        <div
-          className="absolute left-1/2 -translate-x-1/2 -top-40 h-[520px] w-[820px] rounded-full opacity-60 dark:opacity-50"
-          style={{
-            background:
-              "radial-gradient(closest-side, var(--accent-light), transparent 70%)",
-            filter: "blur(48px)",
-          }}
-        />
-        <div
-          className="absolute left-[8%] top-24 h-[260px] w-[260px] rounded-full opacity-40 dark:opacity-30"
-          style={{
-            background:
-              "radial-gradient(closest-side, rgba(190, 194, 255, 0.45), transparent 70%)",
-            filter: "blur(60px)",
-          }}
-        />
-        <div
-          className="absolute right-[6%] top-44 h-[220px] w-[220px] rounded-full opacity-35 dark:opacity-25"
-          style={{
-            background:
-              "radial-gradient(closest-side, rgba(133, 236, 206, 0.4), transparent 70%)",
-            filter: "blur(60px)",
-          }}
-        />
-      </div>
-
       <div className="relative z-10">
         {/* =========================================================
              HERO
@@ -206,7 +172,7 @@ export function FrameworkOverview({
           {/* Framework identity: icon + name in a horizontal lockup. */}
           <div className="flex items-center gap-3 mb-5">
             {hasIcon && (
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]">
+              <div className="shell-docs-radius-icon flex h-10 w-10 items-center justify-center border border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]">
                 {iconOverride ??
                   (IconComponent ? (
                     <IconComponent className="h-6 w-6" />
@@ -233,7 +199,7 @@ export function FrameworkOverview({
           <div className="mt-7 flex flex-col sm:flex-row sm:items-center gap-3">
             <Link
               href={guideLink}
-              className="group inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg border border-[var(--accent)] bg-[var(--accent-dim)] px-4 text-[13.5px] font-semibold text-[var(--accent)] no-underline transition-colors hover:bg-[var(--accent-light)] sm:w-auto"
+              className="shell-docs-radius-control group inline-flex h-11 w-full items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent-dim)] px-4 text-[13.5px] font-semibold text-[var(--accent)] no-underline shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-light)] sm:w-auto"
             >
               Start the quickstart
               <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
@@ -242,7 +208,7 @@ export function FrameworkOverview({
             <button
               type="button"
               onClick={handleCopyCommand}
-              className="inline-flex w-full sm:w-auto items-center justify-between sm:justify-start gap-3 h-11 px-4 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] hover:bg-[var(--bg-elevated)] text-[var(--text)] transition-colors group"
+              className="shell-docs-radius-control group inline-flex h-11 w-full items-center justify-between gap-3 border border-[var(--border)] bg-[var(--bg-surface)] px-4 text-[var(--text)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--bg-elevated)] sm:w-auto sm:justify-start"
               aria-label="Copy install command"
             >
               <span className="flex items-center gap-2 text-[13.5px]">
@@ -323,7 +289,7 @@ export function FrameworkOverview({
                         fallback for sparse data records). */}
                     {hasMedia && (
                       <div className="lg:col-span-7">
-                        <div className="relative rounded-xl overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[0_18px_44px_-22px_rgba(0,0,0,0.4)]">
+                        <div className="shell-docs-radius-surface relative overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
                           <video
                             src={feature.videoUrl}
                             className="w-full block"
@@ -334,7 +300,7 @@ export function FrameworkOverview({
                           />
                           <div
                             aria-hidden
-                            className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-white/5 rounded-xl"
+                            className="shell-docs-radius-surface pointer-events-none absolute inset-0 ring-1 ring-inset ring-white/5"
                           />
                         </div>
                       </div>
@@ -368,7 +334,7 @@ export function FrameworkOverview({
                 your UI down to the agent runtime.
               </p>
             </div>
-            <div className="rounded-2xl overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[0_18px_44px_-22px_rgba(0,0,0,0.4)]">
+            <div className="shell-docs-radius-surface overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
               {architectureImage && (
                 <Image
                   src={architectureImage}
@@ -412,7 +378,7 @@ export function FrameworkOverview({
                 underline. Mirrors the dojo's "view toggle" treatment but
                 in a flatter style that suits a landing page. */}
             {liveDemos.length > 1 && (
-              <div className="mb-6 inline-flex items-center gap-1 p-1 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)]">
+              <div className="shell-docs-radius-control mb-6 inline-flex items-center gap-1 border border-[var(--border)] bg-[var(--bg-surface)] p-1 shadow-[var(--shadow-control)]">
                 {liveDemos.map((demo) => {
                   const active = activeDemo === demo.type;
                   return (
@@ -420,9 +386,9 @@ export function FrameworkOverview({
                       key={demo.type}
                       type="button"
                       onClick={() => setActiveDemo(demo.type)}
-                      className={`h-8 px-4 rounded-md text-[13px] font-medium transition-all ${
+                      className={`shell-docs-radius-control h-8 px-4 text-[13px] font-medium transition-colors ${
                         active
-                          ? "bg-[var(--bg-elevated)] text-[var(--text)] shadow-sm"
+                          ? "bg-[var(--bg-elevated)] text-[var(--text)] shadow-[var(--shadow-control)]"
                           : "bg-transparent text-[var(--text-muted)] hover:text-[var(--text)]"
                       }`}
                     >
@@ -439,7 +405,7 @@ export function FrameworkOverview({
               </p>
             )}
 
-            <div className="relative rounded-2xl overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[0_24px_60px_-30px_rgba(0,0,0,0.4)]">
+            <div className="shell-docs-radius-surface relative overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
               {activeDemoData && (
                 <iframe
                   src={activeDemoData.iframeUrl}
@@ -449,7 +415,7 @@ export function FrameworkOverview({
               )}
               <div
                 aria-hidden
-                className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-white/5 rounded-2xl"
+                className="shell-docs-radius-surface pointer-events-none absolute inset-0 ring-1 ring-inset ring-white/5"
               />
             </div>
           </section>

--- a/showcase/shell-docs/src/components/copy-button.tsx
+++ b/showcase/shell-docs/src/components/copy-button.tsx
@@ -54,26 +54,14 @@ export function CopyButton({ text }: { text: string }) {
         }
       }}
       aria-label={label}
-      style={{
-        padding: "2px 8px",
-        fontSize: "10px",
-        lineHeight: 1.2,
-        border: "1px solid var(--border)",
-        borderRadius: "4px",
-        background: copied
-          ? "var(--accent-light)"
+      className={[
+        "shell-docs-radius-control cursor-pointer border border-[var(--border)] px-2 py-0.5 text-[10px] leading-[1.2] transition-colors",
+        copied
+          ? "bg-[var(--accent-light)] text-[var(--accent)]"
           : error
-            ? "var(--bg-elevated)"
-            : "var(--bg-surface)",
-        color: copied
-          ? "var(--accent)"
-          : error
-            ? "var(--text)"
-            : "var(--text-muted)",
-        cursor: "pointer",
-        fontFamily: "inherit",
-        transition: "background 120ms, color 120ms",
-      }}
+            ? "bg-[var(--bg-elevated)] text-[var(--text)]"
+            : "bg-[var(--bg-surface)] text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]",
+      ].join(" ")}
     >
       {label}
     </button>

--- a/showcase/shell-docs/src/components/demo-source.tsx
+++ b/showcase/shell-docs/src/components/demo-source.tsx
@@ -68,7 +68,7 @@ function basename(p: string): string {
 function WarningBox({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="my-4 rounded-md border-l-4 border-yellow-500/40 bg-yellow-500/5 p-4 text-sm text-[var(--text-secondary)]"
+      className="shell-docs-radius-surface shell-docs-warning-surface my-4 border border-l-4 p-4 text-sm text-[var(--text-secondary)] shadow-[var(--shadow-control)]"
       role="alert"
     >
       <div className="font-semibold mb-1 text-[var(--text)]">

--- a/showcase/shell-docs/src/components/docs-landing-next.tsx
+++ b/showcase/shell-docs/src/components/docs-landing-next.tsx
@@ -64,11 +64,11 @@ function BackendGrid() {
                 ? "/built-in-agent/quickstart"
                 : `/${i.slug}`
             }
-            className="group relative flex min-h-[84px] items-start gap-3 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)]/30 p-3.5 no-underline transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-surface)] sm:min-h-[96px]"
+            className="shell-docs-radius-surface group relative flex min-h-[84px] items-start gap-3 overflow-hidden border border-[var(--border)] bg-[var(--bg-elevated)]/30 p-3.5 no-underline transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-surface)] sm:min-h-[96px]"
           >
             <span
               aria-hidden="true"
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-dim)] text-[var(--accent)] transition-colors group-hover:bg-[var(--accent-light)]"
+              className="shell-docs-radius-icon flex h-8 w-8 shrink-0 items-center justify-center bg-[var(--accent-dim)] text-[var(--accent)] transition-colors group-hover:bg-[var(--accent-light)]"
             >
               <FrameworkLogo
                 slug={i.slug}

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -219,10 +219,10 @@ export async function DocsPageView({
         tableOfContentPopover={{ enabled: false }}
       >
         <div className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-2 pb-6 md:pt-3 xl:pt-4">
-          {/* Breadcrumb styling tracks canonical fumadocs PageBreadcrumb:
-           * text-sm with a ChevronRight separator, intermediate links
-           * muted, last segment in primary text + medium weight. */}
-          <nav className="flex items-center gap-1.5 text-sm text-[var(--text-muted)] mb-4 flex-wrap">
+          {/* Breadcrumb styling tracks canonical fumadocs PageBreadcrumb,
+           * but tighter: this should read as quiet page chrome, not a
+           * second title row above the H1. */}
+          <nav className="mb-2 flex flex-wrap items-center gap-1 text-[11px] font-medium leading-none text-[var(--text-muted)]">
             {breadcrumbs.map((crumb, i) => {
               const isLast = i === breadcrumbs.length - 1;
               const labelClass = `truncate ${isLast ? "text-[var(--text)] font-medium" : ""}`;
@@ -230,7 +230,7 @@ export async function DocsPageView({
                 <React.Fragment key={i}>
                   {i > 0 && (
                     <ChevronRight
-                      className="size-3.5 shrink-0"
+                      className="size-3 shrink-0"
                       aria-hidden="true"
                     />
                   )}
@@ -278,7 +278,7 @@ export async function DocsPageView({
               .replace(/^\/+/, "/");
             const markdownUrl = `${base.replace(/\/$/, "")}.mdx`;
             return (
-              <div className="flex flex-row gap-2 items-center my-6">
+              <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
                 <MarkdownCopyButton markdownUrl={markdownUrl} />
                 <ViewOptionsPopover
                   markdownUrl={markdownUrl}

--- a/showcase/shell-docs/src/components/docs-steps.tsx
+++ b/showcase/shell-docs/src/components/docs-steps.tsx
@@ -1,33 +1,11 @@
-// <Steps>/<Step> — numbered step blocks with a left-side connector line.
-//
-// Reference (docs.copilotkit.ai) uses fumadocs' `Steps`: each step is
-// numbered via a small circle on the left and a thin vertical line
-// connects consecutive steps. We approximate that here in pure CSS —
-// no client-side JS needed, so this works inside RSC-rendered MDX.
-//
-// Numbering is CSS counter-driven (see `.docs-steps` / `.docs-step__badge`
-// in `globals.css`) rather than React-injected indices. That way a
-// `<Step>` hidden by a gate like `<WhenFrameworkHas>` doesn't advance
-// the counter — visible steps stay 1, 2, 3, … in the reader's view
-// regardless of which gates pass.
-
 import React from "react";
+import {
+  Step as FumadocsStep,
+  Steps as FumadocsSteps,
+} from "fumadocs-ui/components/steps";
 
 export function Steps({ children }: { children: React.ReactNode }) {
-  return (
-    <div
-      className="docs-steps"
-      style={{
-        position: "relative",
-        paddingLeft: "2rem",
-        borderLeft: "1px solid var(--border)",
-        marginLeft: "0.75rem",
-        margin: "1.5rem 0 1.5rem 0.75rem",
-      }}
-    >
-      {children}
-    </div>
-  );
+  return <FumadocsSteps>{children}</FumadocsSteps>;
 }
 
 interface StepProps {
@@ -37,51 +15,9 @@ interface StepProps {
 
 export function Step({ title, children }: StepProps) {
   return (
-    <div
-      style={{
-        position: "relative",
-        paddingBottom: "1.5rem",
-      }}
-    >
-      {/* numbered badge — number rendered via CSS counter (globals.css).
-       * Appearance (background/border/color) lives in globals.css so
-       * `.docs-steps > div:first-child .docs-step__badge` can override
-       * it for Step 1 without fighting inline-style specificity. */}
-      <div
-        aria-hidden
-        className="docs-step__badge"
-        style={{
-          position: "absolute",
-          left: "-2.75rem",
-          // Badge center sits ~midway up the first heading line:
-          // h3 is 1.125rem with line-height 1.65 ≈ 29.7px → text center at
-          // ~14.85px from the Step's top. Badge is 1.5rem (24px) so its
-          // half-height is 12px; top = 14.85 − 12 ≈ 0.1875rem.
-          top: "0.1875rem",
-          width: "1.5rem",
-          height: "1.5rem",
-          borderRadius: "999px",
-          fontSize: "0.75rem",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          lineHeight: 1,
-        }}
-      />
-      {title && (
-        <h4
-          style={{
-            fontWeight: 600,
-            marginBottom: "0.375rem",
-            marginTop: 0,
-            fontSize: "1rem",
-            color: "var(--text)",
-          }}
-        >
-          {title}
-        </h4>
-      )}
-      <div style={{ fontSize: "0.9375rem", lineHeight: 1.65 }}>{children}</div>
-    </div>
+    <FumadocsStep>
+      {title && <h4 className="docs-step-title">{title}</h4>}
+      {children}
+    </FumadocsStep>
   );
 }

--- a/showcase/shell-docs/src/components/docs-toc.tsx
+++ b/showcase/shell-docs/src/components/docs-toc.tsx
@@ -33,8 +33,8 @@ const useIsoLayoutEffect =
 // of every item's vertical line segment, so the violet pill paints
 // only along the line path of the active heading.
 //
-// Color tokens kept literal to match canonical's `--color-fd-primary`
-// (#7076D5). Inactive line uses `currentColor/10` via class names.
+// The active line follows the shell accent token while inactive
+// connectors use the shared border token so the TOC tracks theme changes.
 function getItemOffset(depth: number): number {
   if (depth <= 2) return 14;
   if (depth === 3) return 26;
@@ -198,12 +198,11 @@ export function DocsToc({ headings }: DocsTocProps) {
             }}
           >
             <span
-              className="absolute w-full"
+              className="absolute w-full bg-[var(--accent)]"
               style={{
                 top: thumb.top,
                 height: thumb.height,
                 opacity: thumb.visible ? 1 : 0,
-                background: "#7076D5",
                 transition:
                   "top 220ms cubic-bezier(0.4,0,0.2,1), height 220ms cubic-bezier(0.4,0,0.2,1), opacity 120ms ease",
               }}
@@ -235,10 +234,11 @@ export function DocsToc({ headings }: DocsTocProps) {
                 href={`#${h.slug}`}
                 data-active={isActive}
                 onClick={() => setActiveSlug(h.slug)}
-                className="relative py-1.5 transition-colors"
+                className={`relative py-1.5 transition-colors ${
+                  isActive ? "text-[var(--accent)]" : "text-[var(--text-muted)]"
+                }`}
                 style={{
                   paddingInlineStart: padStart,
-                  color: isActive ? "#7076D5" : "var(--text-muted)",
                 }}
               >
                 {/* Diagonal connector when this item's depth differs
@@ -255,7 +255,7 @@ export function DocsToc({ headings }: DocsTocProps) {
                       y1="0"
                       x2={offset}
                       y2="12"
-                      className="stroke-black/10 dark:stroke-white/10"
+                      className="stroke-[var(--border)]"
                       strokeWidth="1"
                     />
                   </svg>
@@ -265,7 +265,7 @@ export function DocsToc({ headings }: DocsTocProps) {
                  * meets it cleanly. */}
                 <span
                   aria-hidden="true"
-                  className="absolute w-px bg-black/10 dark:bg-white/10"
+                  className="absolute w-px bg-[var(--border)]"
                   style={{
                     insetInlineStart: offset,
                     top: lineTopAdjust ? 6 : 0,

--- a/showcase/shell-docs/src/components/framework-selector.tsx
+++ b/showcase/shell-docs/src/components/framework-selector.tsx
@@ -143,21 +143,21 @@ export function FrameworkSelector({
     ? (options.find((o) => o.slug === "built-in-agent") ?? null)
     : null;
 
-  // Sidebar variant: full-width control with integration logo box on the
-  // left, framework name center, chevron right. Mirrors the canonical
-  // docs.copilotkit.ai reference: h-14 pill, lavender bg + accent border
-  // when a framework is active, soft surface bg when nothing is picked.
+  // Sidebar variant: full-width select with integration logo box on the
+  // left, framework name center, chevron right. It uses the global
+  // shadcn radius and a subtle accent wash so it reads as a selected
+  // docs context control without hardcoding a lavender value.
   const sidebarBtnClasses = [
-    "w-full flex items-center gap-2 p-1.5 rounded-lg border h-12",
-    "transition-colors cursor-pointer",
+    "shell-docs-radius-control w-full flex items-center gap-2 p-1.5 border h-12",
+    "shadow-[var(--shadow-control)] transition-colors cursor-pointer",
     "text-[13px] font-medium text-[var(--text)]",
     current
-      ? "bg-[var(--accent-light)] border-[var(--accent)] hover:border-[var(--accent)]"
+      ? "bg-[var(--accent-dim)] border-[var(--nav-control-border)] hover:bg-[var(--accent-light)] hover:border-[var(--nav-control-border-hover)]"
       : "bg-[var(--bg-surface)]/60 border-[var(--border)] hover:border-[var(--accent)]",
   ].join(" ");
 
   const topbarBtnClasses =
-    "flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-[var(--border)] bg-[var(--bg-surface)] text-[12px] font-medium text-[var(--text)] hover:border-[var(--accent)] transition-colors cursor-pointer max-w-[220px]";
+    "shell-docs-radius-control flex items-center gap-1.5 px-2.5 py-1.5 border border-[var(--border)] bg-[var(--bg-surface)] text-[12px] font-medium text-[var(--text)] hover:border-[var(--accent)] transition-colors cursor-pointer max-w-[220px]";
 
   return (
     <div className={`relative ${className ?? ""}`}>
@@ -172,10 +172,8 @@ export function FrameworkSelector({
         {isSidebar ? (
           <>
             <span
-              className={`flex justify-center items-center w-8 h-8 shrink-0 rounded-md ${
-                current
-                  ? "bg-[var(--accent)]/25 dark:bg-white/10"
-                  : "bg-[var(--bg-elevated)]"
+              className={`shell-docs-picker-icon-chip h-8 w-8 shrink-0 ${
+                current ? "" : "border-[var(--border)] text-[var(--text-faint)]"
               }`}
               aria-hidden="true"
             >
@@ -184,10 +182,10 @@ export function FrameworkSelector({
                   slug={current.slug}
                   fallbackSrc={current.logo}
                   size={16}
-                  className="text-[var(--text)]"
+                  className="text-[var(--accent)]"
                 />
               ) : (
-                <span className="w-2.5 h-2.5 rounded-full bg-[var(--accent)] opacity-70" />
+                <span className="h-2.5 w-2.5 bg-current" />
               )}
             </span>
             <span className="flex-1 min-w-0 text-left">
@@ -254,8 +252,8 @@ export function FrameworkSelector({
           role="listbox"
           className={
             isSidebar
-              ? "absolute top-full left-0 right-0 mt-1 max-h-[60vh] overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] shadow-lg z-50 p-2"
-              : "absolute top-full left-0 mt-1 w-[340px] max-h-[70vh] overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] shadow-lg z-50 p-2"
+              ? "shell-docs-radius-surface absolute top-full left-0 right-0 mt-1 max-h-[60vh] overflow-y-auto border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)] z-50 p-2"
+              : "shell-docs-radius-surface absolute top-full left-0 mt-1 w-[340px] max-h-[70vh] overflow-y-auto border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)] z-50 p-2"
           }
         >
           {pinnedBIA && (
@@ -263,9 +261,9 @@ export function FrameworkSelector({
               key={pinnedBIA.slug}
               type="button"
               onClick={() => selectFramework(pinnedBIA.slug)}
-              className={`w-full flex items-center gap-2 px-2 py-1.5 rounded text-[13px] transition-colors cursor-pointer ${
+              className={`shell-docs-radius-control w-full flex items-center gap-2 px-2 py-1.5 text-[13px] transition-colors cursor-pointer ${
                 pinnedBIA.slug === effectiveFramework
-                  ? "bg-[var(--accent-light)] text-[var(--accent)]"
+                  ? "bg-[var(--accent-dim)] text-[var(--accent)]"
                   : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
               }`}
             >
@@ -273,7 +271,7 @@ export function FrameworkSelector({
                 slug={pinnedBIA.slug}
                 fallbackSrc={pinnedBIA.logo}
                 size={16}
-                className="shrink-0"
+                className="shrink-0 text-[var(--accent)]"
               />
               <span className="flex-1 text-left truncate">
                 {displayNameFor(pinnedBIA)}
@@ -289,9 +287,9 @@ export function FrameworkSelector({
                   key={opt.slug}
                   type="button"
                   onClick={() => selectFramework(opt.slug)}
-                  className={`w-full flex items-center gap-2 px-2 py-1.5 rounded text-[13px] transition-colors cursor-pointer ${
+                  className={`shell-docs-radius-control w-full flex items-center gap-2 px-2 py-1.5 text-[13px] transition-colors cursor-pointer ${
                     isActive
-                      ? "bg-[var(--accent-light)] text-[var(--accent)]"
+                      ? "bg-[var(--accent-dim)] text-[var(--accent)]"
                       : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
                   }`}
                 >
@@ -299,7 +297,7 @@ export function FrameworkSelector({
                     slug={opt.slug}
                     fallbackSrc={opt.logo}
                     size={16}
-                    className="shrink-0"
+                    className="shrink-0 text-[var(--accent)]"
                   />
                   <span className="flex-1 text-left truncate">
                     {displayNameFor(opt)}

--- a/showcase/shell-docs/src/components/framework-tabs.tsx
+++ b/showcase/shell-docs/src/components/framework-tabs.tsx
@@ -55,25 +55,10 @@ export function FrameworkTabs({
       .join(" ");
 
   return (
-    <div
-      style={{
-        margin: "1rem 0 1.25rem 0",
-        borderRadius: "0.5rem",
-        border: "1px solid var(--border)",
-        overflow: "hidden",
-        background: "var(--bg-surface)",
-      }}
-    >
+    <div className="shell-docs-radius-surface my-4 mb-5 overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)]">
       <div
         role="tablist"
-        style={{
-          display: "flex",
-          borderBottom: "1px solid var(--border)",
-          background: "var(--bg-elevated)",
-          padding: "0.375rem 0.5rem 0 0.5rem",
-          gap: "0.25rem",
-          flexWrap: "wrap",
-        }}
+        className="flex flex-wrap gap-1 border-b border-[var(--border)] bg-[var(--bg-elevated)] px-2 pt-1.5"
       >
         {frameworks.map((fw) => {
           const isActive = fw === active;
@@ -83,19 +68,12 @@ export function FrameworkTabs({
               role="tab"
               aria-selected={isActive}
               onClick={() => setActive(fw)}
-              style={{
-                padding: "0.5rem 0.875rem",
-                fontSize: "0.8125rem",
-                fontWeight: isActive ? 600 : 500,
-                color: isActive ? "var(--text)" : "var(--text-muted)",
-                background: isActive ? "var(--bg-surface)" : "transparent",
-                borderRadius: "0.375rem 0.375rem 0 0",
-                border: "none",
-                borderBottom: isActive
-                  ? "2px solid var(--accent)"
-                  : "2px solid transparent",
-                cursor: "pointer",
-              }}
+              className={[
+                "cursor-pointer border-0 border-b-2 px-3.5 py-2 text-[0.8125rem] [border-radius:var(--shell-docs-radius-control)_var(--shell-docs-radius-control)_0_0]",
+                isActive
+                  ? "border-[var(--accent)] bg-[var(--bg-surface)] font-semibold text-[var(--text)]"
+                  : "border-transparent bg-transparent font-medium text-[var(--text-muted)] hover:bg-[var(--accent-dim)] hover:text-[var(--accent)]",
+              ].join(" ")}
             >
               {displayLabel(fw)}
             </button>

--- a/showcase/shell-docs/src/components/hero-command-copy.tsx
+++ b/showcase/shell-docs/src/components/hero-command-copy.tsx
@@ -102,7 +102,7 @@ export function HeroCommandCopy({ command }: { command: string }) {
             ? "Command selected"
             : "Copy command"
       }
-      className="group flex h-11 min-w-0 items-center gap-3 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] px-3 text-left transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
+      className="shell-docs-radius-control group flex h-11 min-w-0 items-center gap-3 border border-[var(--border)] bg-[var(--bg-surface)] px-3 text-left transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
       onClick={async () => {
         if (resetTimerRef.current) {
           clearTimeout(resetTimerRef.current);
@@ -132,7 +132,7 @@ export function HeroCommandCopy({ command }: { command: string }) {
         <span ref={commandRef}>{command}</span>
       </code>
       <span
-        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)] transition-colors group-hover:text-[var(--accent)]"
+        className="shell-docs-radius-icon inline-flex h-7 w-7 shrink-0 items-center justify-center border border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)] transition-colors group-hover:text-[var(--accent)]"
         aria-hidden="true"
       >
         {copied ? (

--- a/showcase/shell-docs/src/components/hero-quickstart-dropdown.tsx
+++ b/showcase/shell-docs/src/components/hero-quickstart-dropdown.tsx
@@ -54,7 +54,7 @@ export function HeroQuickstartDropdown({
         type="button"
         aria-expanded={open}
         aria-haspopup="menu"
-        className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg border border-[var(--accent)] bg-[var(--accent-light)] px-4 text-sm font-semibold text-[var(--accent)] transition-colors duration-150 hover:bg-[var(--accent-dim)] sm:w-fit"
+        className="shell-docs-radius-control inline-flex h-11 w-full items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent-light)] px-4 text-sm font-semibold text-[var(--accent)] transition-colors duration-150 hover:bg-[var(--accent-dim)] sm:w-fit"
         onClick={() => setOpen((value) => !value)}
       >
         Quickstart
@@ -64,7 +64,7 @@ export function HeroQuickstartDropdown({
       </button>
       {open ? (
         <div
-          className="absolute left-0 top-[calc(100%+8px)] z-30 w-full min-w-[280px] overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-1.5 shadow-xl shadow-black/10 sm:w-[320px]"
+          className="shell-docs-radius-surface absolute left-0 top-[calc(100%+8px)] z-30 w-full min-w-[280px] overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] p-1.5 shadow-[var(--shadow-panel)] sm:w-[320px]"
           role="menu"
         >
           <div className="max-h-[360px] overflow-y-auto">
@@ -73,7 +73,7 @@ export function HeroQuickstartDropdown({
                 key={option.slug}
                 href={option.href}
                 role="menuitem"
-                className="group flex items-center gap-3 rounded-lg px-2.5 py-2.5 no-underline transition-colors hover:bg-[var(--accent-dim)]"
+                className="shell-docs-radius-control group flex items-center gap-3 px-2.5 py-2.5 no-underline transition-colors hover:bg-[var(--accent-dim)]"
                 onClick={() => {
                   setStoredFramework(option.slug);
                   setOpen(false);
@@ -81,7 +81,7 @@ export function HeroQuickstartDropdown({
               >
                 <span
                   aria-hidden="true"
-                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--accent-dim)] text-[var(--accent)] transition-colors group-hover:bg-[var(--accent-light)]"
+                  className="shell-docs-radius-icon flex h-8 w-8 shrink-0 items-center justify-center border border-[var(--border)] bg-[var(--accent-dim)] text-[var(--accent)] transition-colors group-hover:bg-[var(--accent-light)]"
                 >
                   <FrameworkLogo
                     slug={option.slug}

--- a/showcase/shell-docs/src/components/integration-grid.tsx
+++ b/showcase/shell-docs/src/components/integration-grid.tsx
@@ -28,24 +28,13 @@ export function IntegrationGrid({
     <>
       <h2>Choose your AI backend</h2>
       {description && (
-        <p style={{ marginBottom: "1rem", color: "var(--text-secondary)" }}>
-          {description}
-        </p>
+        <p className="mb-4 text-[var(--text-secondary)]">{description}</p>
       )}
-      <div
-        style={{
-          padding: "1rem",
-          background: "var(--bg-elevated)",
-          borderRadius: "0.5rem",
-          marginBottom: "1rem",
-          fontSize: "0.875rem",
-          color: "var(--text-muted)",
-        }}
-      >
+      <div className="shell-docs-radius-surface mb-4 bg-[var(--bg-elevated)] p-4 text-sm text-[var(--text-muted)]">
         See{" "}
         <a
           href={`${shellHost}/integrations`}
-          style={{ color: "var(--accent)" }}
+          className="text-[var(--accent)]"
           // shellHost is the SSR placeholder during server-render and the
           // real value post-hydration (runtime-config.client.ts). React
           // would otherwise log a hydration mismatch on this href every

--- a/showcase/shell-docs/src/components/landing-sample-tabs.tsx
+++ b/showcase/shell-docs/src/components/landing-sample-tabs.tsx
@@ -195,11 +195,11 @@ export function LandingSampleTabs() {
               key={tab.id}
               href={tab.href}
               data-mobile-sample-card={tab.id}
-              className="group flex min-w-0 items-start gap-3 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-3.5 no-underline shadow-[0_10px_28px_-24px_rgba(1,5,7,0.26)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
+              className="shell-docs-radius-surface group flex min-w-0 items-start gap-3 border border-[var(--border)] bg-[var(--bg-surface)] p-3.5 no-underline shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
             >
               <span
                 aria-hidden="true"
-                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]"
+                className="shell-docs-radius-icon flex h-9 w-9 shrink-0 items-center justify-center border border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]"
               >
                 <Icon className="h-4 w-4" />
               </span>
@@ -216,12 +216,12 @@ export function LandingSampleTabs() {
         })}
       </div>
 
-      <div className="hidden min-w-0 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] shadow-[0_18px_44px_-32px_rgba(1,5,7,0.22)] sm:block sm:rounded-xl">
+      <div className="shell-docs-radius-surface hidden min-w-0 overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-control)] sm:block">
         <div className="flex h-10 items-center justify-between border-b border-[var(--border)] bg-[var(--bg-elevated)] px-4">
           <div className="flex items-center gap-2" aria-hidden="true">
-            <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]" />
-            <span className="h-2.5 w-2.5 rounded-full bg-[#ffbd2e]" />
-            <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--window-control-close)]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--window-control-minimize)]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--window-control-zoom)]" />
           </div>
           <div className="hidden font-mono text-xs text-[var(--text-muted)] sm:block">
             Preview
@@ -249,9 +249,9 @@ export function LandingSampleTabs() {
                     aria-controls={`landing-sample-panel-${tab.id}`}
                     aria-selected={selected}
                     className={cn(
-                      "group flex min-h-11 min-w-[9.75rem] items-center gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors sm:min-h-14 sm:min-w-0 sm:gap-3 sm:px-3 sm:py-2.5",
+                      "shell-docs-radius-control group flex min-h-11 min-w-[9.75rem] items-center gap-2 border px-2.5 py-2 text-left transition-colors sm:min-h-14 sm:min-w-0 sm:gap-3 sm:px-3 sm:py-2.5",
                       selected
-                        ? "border-[var(--accent)] bg-[var(--bg-surface)] text-[var(--text)] shadow-[0_1px_2px_rgba(1,5,7,0.05)]"
+                        ? "border-[var(--accent)] bg-[var(--bg-surface)] text-[var(--text)] shadow-[var(--shadow-control)]"
                         : "border-transparent text-[var(--text-secondary)] hover:bg-[var(--bg-surface)]/70 hover:text-[var(--text)]",
                     )}
                     role="tab"
@@ -259,7 +259,7 @@ export function LandingSampleTabs() {
                   >
                     <span
                       className={cn(
-                        "flex h-7 w-7 shrink-0 items-center justify-center rounded-md border transition-colors sm:h-8 sm:w-8",
+                        "shell-docs-radius-icon flex h-7 w-7 shrink-0 items-center justify-center border transition-colors sm:h-8 sm:w-8",
                         selected
                           ? "border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]"
                           : "border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-muted)] group-hover:text-[var(--accent)]",
@@ -293,12 +293,12 @@ export function LandingSampleTabs() {
               </p>
             </div>
 
-            <div className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--bg-surface)]">
+            <div className="shell-docs-radius-surface min-h-0 min-w-0 flex-1 overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)]">
               <div className="flex h-9 items-center justify-between border-b border-[var(--border)] bg-[var(--bg-elevated)] px-3">
                 <span className="font-mono text-xs text-[var(--text-muted)]">
                   example.tsx
                 </span>
-                <span className="rounded-full bg-[var(--bg-surface)] px-2 py-0.5 font-mono text-[11px] text-[var(--text-muted)]">
+                <span className="shell-docs-radius-control bg-[var(--bg-surface)] px-2 py-0.5 font-mono text-[11px] text-[var(--text-muted)]">
                   tsx
                 </span>
               </div>
@@ -310,7 +310,7 @@ export function LandingSampleTabs() {
             <div className="flex justify-stretch sm:justify-end">
               <Link
                 href={activeTab.href}
-                className="inline-flex h-9 w-full shrink-0 items-center justify-center rounded-lg border border-[var(--accent)] bg-[var(--accent-dim)] px-3 text-sm font-semibold text-[var(--accent)] no-underline transition-colors hover:bg-[var(--accent-light)] sm:w-auto"
+                className="shell-docs-radius-control inline-flex h-9 w-full shrink-0 items-center justify-center border border-[var(--accent)] bg-[var(--accent-dim)] px-3 text-sm font-semibold text-[var(--accent)] no-underline transition-colors hover:bg-[var(--accent-light)] sm:w-auto"
               >
                 {activeTab.hrefLabel}
               </Link>

--- a/showcase/shell-docs/src/components/link-to-copilot-cloud.tsx
+++ b/showcase/shell-docs/src/components/link-to-copilot-cloud.tsx
@@ -50,9 +50,9 @@ export function LinkToCopilotCloud({
 
   if (asButton) {
     cn =
-      "text-indigo-800 dark:text-indigo-300 ring-1 ring-indigo-200 dark:ring-indigo-900 text-sm items-center bg-gradient-to-r from-indigo-200/50 to-purple-200/80 dark:from-indigo-900/40 dark:to-purple-900/50 flex p-3 px-4 no-underline whitespace-nowrap";
+      "shell-docs-radius-control flex items-center whitespace-nowrap border border-[var(--accent)] bg-[var(--accent-dim)] p-3 px-4 text-sm text-[var(--accent)] no-underline shadow-[var(--shadow-control)]";
     cn +=
-      " transition-all duration-100 hover:ring-2 hover:ring-indigo-400 hover:dark:text-indigo-200 rounded-lg";
+      " transition-colors duration-100 hover:bg-[var(--accent)] hover:text-[var(--primary-foreground)]";
   } else {
     cn =
       "_text-primary-600 decoration-from-font underline [text-underline-position:from-font]";

--- a/showcase/shell-docs/src/components/mdx-components.tsx
+++ b/showcase/shell-docs/src/components/mdx-components.tsx
@@ -1,5 +1,8 @@
-import React from "react";
-import Link from "next/link";
+import type React from "react";
+import {
+  Card as FumadocsCard,
+  Cards as FumadocsCards,
+} from "fumadocs-ui/components/card";
 
 // Re-export fumadocs's default `<Callout>` so historical imports from
 // `@/components/mdx-components` keep working. Fumadocs supports the
@@ -9,37 +12,28 @@ import Link from "next/link";
 export { Callout } from "fumadocs-ui/components/callout";
 
 export function Cards({
-  children,
-  className: _className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
+  className,
+  ...props
+}: React.ComponentProps<typeof FumadocsCards>) {
   // `not-prose` opts the wrapped Cards out of the .reference-content
   // prose-link styling (which forces underline + accent color on every
   // <a>). The Card's own className already controls link appearance.
   return (
-    <div className="not-prose grid grid-cols-1 sm:grid-cols-2 gap-4 my-6">
-      {children}
-    </div>
+    <FumadocsCards
+      {...props}
+      className={["not-prose my-6 grid-cols-1 gap-4 sm:grid-cols-2", className]
+        .filter(Boolean)
+        .join(" ")}
+    />
   );
 }
 
 export function Card({
-  title,
-  description,
   href,
-  icon,
   className,
-  children,
-}: {
-  title: string;
-  description?: string;
-  href?: string;
-  icon?: React.ReactNode;
-  className?: string;
-  children?: React.ReactNode;
-}) {
+  style,
+  ...props
+}: React.ComponentProps<typeof FumadocsCard>) {
   // Match the docs-landing pointer-card style:
   // - bordered surface, accent border on hover, subtle shadow on hover
   // - title flips to accent color on hover via `group-hover` so the link
@@ -49,65 +43,26 @@ export function Card({
   //   color: var(--accent)` on every <a>; that rule wins over the
   //   Tailwind `no-underline` class on specificity. `not-prose`
   //   triggers the global escape-hatch rule that drops both.
+  const resolvedHref = href?.replace(/^\/reference\/v2\//, "/reference/");
   const mergedClassName = [
-    "block group rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4",
+    "shell-docs-radius-surface border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text)] shadow-[var(--shadow-control)]",
     href
-      ? "not-prose no-underline hover:border-[var(--accent)] hover:shadow-sm transition"
-      : "transition-colors",
+      ? "not-prose hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]"
+      : null,
     className,
   ]
     .filter(Boolean)
     .join(" ");
-
-  const content = (
-    <>
-      {icon && (
-        <div className="mb-2 text-[var(--text-muted)]" aria-hidden>
-          {icon}
-        </div>
-      )}
-      <div
-        className={`font-semibold text-[var(--text)] text-sm${
-          href ? " group-hover:text-[var(--accent)]" : ""
-        }`}
-      >
-        {title}
-      </div>
-      {description && (
-        <div className="text-xs text-[var(--text-muted)] mt-1">
-          {description}
-        </div>
-      )}
-      {children && (
-        <div className="text-xs text-[var(--text-secondary)] mt-2">
-          {children}
-        </div>
-      )}
-    </>
+  return (
+    <FumadocsCard
+      {...props}
+      href={resolvedHref}
+      className={mergedClassName}
+      style={
+        href ? { textDecoration: "none", color: "inherit", ...style } : style
+      }
+    />
   );
-
-  if (href) {
-    // Rewrite /reference/v2/... paths to /reference/...
-    const resolvedHref = href.replace(/^\/reference\/v2\//, "/reference/");
-    // Inline `textDecoration: none` is the load-bearing override here.
-    // The escape-hatch CSS rule `.reference-content .not-prose a {
-    // text-decoration: none }` only fires when `not-prose` sits on a
-    // *parent* of the <a> (descendant selector). Standalone Cards
-    // outside of a <Cards> wrapper have nothing above them to carry
-    // that class, so the prose-default underline still leaks through.
-    // The inline style wins on specificity in every shape.
-    return (
-      <Link
-        href={resolvedHref}
-        className={mergedClassName}
-        style={{ textDecoration: "none", color: "inherit" }}
-      >
-        {content}
-      </Link>
-    );
-  }
-
-  return <div className={mergedClassName}>{content}</div>;
 }
 
 export function Accordions({ children }: { children: React.ReactNode }) {
@@ -122,8 +77,8 @@ export function Accordion({
   children: React.ReactNode;
 }) {
   return (
-    <details className="group rounded-lg border border-[var(--border)] bg-[var(--bg-surface)]">
-      <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-[var(--text)] select-none hover:bg-[var(--bg-elevated)] transition-colors">
+    <details className="shell-docs-radius-surface group border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-control)]">
+      <summary className="cursor-pointer select-none px-4 py-3 text-sm font-semibold text-[var(--text)] transition-colors hover:bg-[var(--bg-elevated)]">
         {title}
       </summary>
       <div className="px-4 pb-4 text-sm text-[var(--text-secondary)]">

--- a/showcase/shell-docs/src/components/mobile-sidebar-footer-talk.tsx
+++ b/showcase/shell-docs/src/components/mobile-sidebar-footer-talk.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Calendar } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { TALK_TO_ENGINEER_HREF } from "./brand-nav";
+
+export function MobileSidebarFooterTalk() {
+  const posthog = usePostHog();
+
+  const handleTalkToEngineersClick = () => {
+    posthog?.capture("talk_to_us_clicked", {
+      location: "docs_sidebar_mobile_footer",
+    });
+    window.location.href = TALK_TO_ENGINEER_HREF;
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleTalkToEngineersClick}
+      className="shell-docs-radius-control flex h-10 w-full items-center justify-center gap-2 border border-[var(--border)] bg-[var(--bg-surface)] px-3 text-sm font-medium text-[var(--text)] shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] hover:text-[var(--accent)] xl:hidden"
+    >
+      <Calendar className="h-4 w-4" aria-hidden="true" />
+      Talk to an engineer
+    </button>
+  );
+}

--- a/showcase/shell-docs/src/components/mobile-top-nav.tsx
+++ b/showcase/shell-docs/src/components/mobile-top-nav.tsx
@@ -2,20 +2,17 @@
 
 import Link from "next/link";
 // Fumadocs v16 moved `SidebarTrigger` from `components/layout/sidebar`
-// to `components/sidebar/base` — keep the v16 path here while pulling
-// in `main`'s expanded icon set (Calendar / Lightbulb) and PostHog hook
-// for the Talk-to-Engineer + Get-Intelligence-free mobile CTAs.
+// to `components/sidebar/base` — keep the v16 path here.
 import { SidebarTrigger } from "fumadocs-ui/components/sidebar/base";
-import { Calendar, Lightbulb, Menu } from "lucide-react";
-import { usePostHog } from "posthog-js/react";
+import { Menu } from "lucide-react";
 import { SearchTrigger } from "./search-trigger";
 import { CopilotKitMark } from "./copilotkit-mark";
-import { INTELLIGENCE_CTA_HREF, TALK_TO_ENGINEER_HREF } from "./brand-nav";
+import { ThemeSwitch } from "./theme-switch";
+import { PrimaryDocsTabs } from "./primary-docs-tabs";
 
-// Mobile-only top nav. Replaces shell-docs's BrandNav on small viewports
-// because BrandNav's full chrome (3 tabs + Talk-to-Engineer pill +
-// slanted SVG wings) doesn't fit. Rendered via DocsLayout's
-// `nav.component` slot so it sits INSIDE the SidebarProvider —
+// Mobile/tablet top nav. Replaces shell-docs's BrandNav below xl because the
+// full desktop chrome doesn't fit reliably. Rendered via DocsLayout's
+// `nav.component` slot so it sits inside the SidebarProvider —
 // `SidebarTrigger` toggles the Fumadocs mobile sidebar
 // (`#nd-sidebar-mobile`), which natively renders the page tree we pass
 // to DocsLayout.
@@ -25,87 +22,43 @@ import { INTELLIGENCE_CTA_HREF, TALK_TO_ENGINEER_HREF } from "./brand-nav";
 // inside shell-docs's outer `<main className="flex …">` — without
 // fixed positioning, the nav swallows the left half of the viewport.
 //
-// The Talk-to-Engineer and Get-Intelligence-free CTAs mirror the
-// desktop BrandNav cluster: same destinations, same PostHog events
-// (`talk_to_us_clicked` / `try_for_free_clicked`) with `location:
-// "docs_navbar_mobile"` so analytics can split mobile from desktop
-// (which uses `docs_nav` / `docs_navbar_left`). Matches the canonical
-// docs MobileSidebar pattern.
 export function MobileTopNav() {
-  const posthog = usePostHog();
-
-  const handleTalkToEngineersClick = () => {
-    posthog?.capture("talk_to_us_clicked", { location: "docs_navbar_mobile" });
-    window.location.href = TALK_TO_ENGINEER_HREF;
-  };
-
-  const handleIntelligenceClick = () => {
-    posthog?.capture("try_for_free_clicked", {
-      location: "docs_navbar_mobile",
-    });
-  };
-
   return (
     <header
       id="nd-subnav"
-      className="md:hidden fixed top-(--fd-banner-height) left-0 right-0 z-30 flex items-center gap-1 px-3 h-14 border-b border-[var(--border)] bg-[var(--bg)]"
+      className="shell-docs-mobile-nav xl:hidden fixed top-(--fd-banner-height) left-0 right-0 z-30 border-b border-[var(--border)] bg-[var(--bg)]"
     >
-      <Link
-        href="/"
-        className="flex items-center gap-2 mr-auto"
-        aria-label="CopilotKit Docs"
-      >
-        <CopilotKitMark />
-        <span className="font-bold text-[var(--text)] tracking-tight">
-          CopilotKit
-        </span>
-        <span
-          className="rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--accent)] bg-[var(--accent-dim)] border border-[var(--border)]"
-          aria-hidden="true"
+      <div className="shell-docs-mobile-nav-top">
+        <Link
+          href="/"
+          className="shell-docs-mobile-brand"
+          aria-label="CopilotKit Docs"
         >
-          Docs
-        </span>
-      </Link>
-      {/* Get Intelligence free — muted icon, matches the desktop
-       * BrandNav treatment for the same CTA.
-       *
-       * `suppressHydrationWarning` is required because HubSpot's analytics
-       * tag (`js-na2.hs-analytics.net`) rewrites the `href` client-side to
-       * append `__hstc` / `__hssc` / `__hsfp` cross-domain tracking params.
-       * Server-rendered HTML has the bare URL, post-hydration DOM has the
-       * rewritten URL; suppress lets React skip the diff on this one anchor
-       * without masking real mismatches elsewhere. Desktop variant in
-       * `brand-nav.tsx` takes the same fix for the same reason. */}
-      <Link
-        href={INTELLIGENCE_CTA_HREF}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={handleIntelligenceClick}
-        aria-label="Get Intelligence free"
-        title="Get Intelligence free"
-        className="flex items-center justify-center w-10 h-10 rounded-md text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--bg-elevated)]"
-        suppressHydrationWarning
-      >
-        <Lightbulb className="w-5 h-5" />
-      </Link>
-      {/* Talk to an Engineer — compact gradient pill, mirrors the
-       * desktop md-to-1099px calendar button. */}
-      <button
-        type="button"
-        onClick={handleTalkToEngineersClick}
-        aria-label="Talk to an engineer"
-        title="Talk to an Engineer"
-        className="flex justify-center items-center w-9 h-9 rounded-full bg-gradient-to-r from-indigo-500/90 to-purple-500/90 text-white shadow-sm hover:from-indigo-500 hover:to-purple-500 hover:shadow-md transition-all duration-200 cursor-pointer relative overflow-hidden after:content-[''] after:absolute after:inset-0 after:bg-gradient-to-r after:from-transparent after:via-white/30 after:to-transparent after:-translate-x-full hover:after:translate-x-[100%] after:transition-transform after:duration-700 after:pointer-events-none"
-      >
-        <Calendar className="w-[18px] h-[18px]" />
-      </button>
-      <SearchTrigger />
-      <SidebarTrigger
-        className="flex items-center justify-center w-10 h-10 -mr-1 rounded-md text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--bg-elevated)]"
-        aria-label="Toggle navigation"
-      >
-        <Menu className="w-5 h-5" />
-      </SidebarTrigger>
+          <CopilotKitMark />
+          <span className="font-bold text-[var(--text)] tracking-tight">
+            CopilotKit
+          </span>
+          <span
+            className="shell-docs-radius-control border border-[var(--border)] bg-[var(--accent-dim)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--accent)]"
+            aria-hidden="true"
+          >
+            Docs
+          </span>
+        </Link>
+        <PrimaryDocsTabs className="shell-docs-mobile-tabs" />
+        <div className="shell-docs-mobile-actions">
+          <div className="shell-docs-mobile-search">
+            <SearchTrigger iconOnly />
+          </div>
+          <ThemeSwitch />
+          <SidebarTrigger
+            className="shell-docs-mobile-menu shell-docs-radius-control flex h-10 w-10 items-center justify-center text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
+            aria-label="Toggle navigation"
+          >
+            <Menu className="w-5 h-5" />
+          </SidebarTrigger>
+        </div>
+      </div>
     </header>
   );
 }

--- a/showcase/shell-docs/src/components/primary-docs-tabs.tsx
+++ b/showcase/shell-docs/src/components/primary-docs-tabs.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChefHat } from "lucide-react";
+import BookIcon from "./icons/book";
+import ConsoleIcon from "./icons/console";
+
+const PRIMARY_DOCS_LINKS = [
+  {
+    href: "/",
+    label: "Docs",
+    icon: <BookIcon className="h-4 w-4 text-current" />,
+  },
+  {
+    href: "/reference",
+    label: "Reference",
+    icon: <ConsoleIcon className="h-4 w-4 text-current" />,
+  },
+  {
+    href: "/cookbook",
+    label: "Cookbook",
+    icon: <ChefHat className="h-4 w-4 text-current" />,
+  },
+];
+
+function getActiveRoute(pathname: string) {
+  const firstSegment = pathname === "/" ? "/" : `/${pathname.split("/")[1]}`;
+
+  if (firstSegment === "/reference") {
+    return "/reference";
+  }
+
+  if (firstSegment === "/cookbook") {
+    return "/cookbook";
+  }
+
+  return "/";
+}
+
+export function PrimaryDocsTabs({ className }: { className?: string }) {
+  const pathname = usePathname();
+  const activeRoute = getActiveRoute(pathname);
+
+  return (
+    <nav className={className} aria-label="Primary docs sections">
+      {PRIMARY_DOCS_LINKS.map((link) => {
+        const isActive = activeRoute === link.href;
+
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={`shell-docs-radius-control shell-docs-primary-tab ${
+              isActive
+                ? "shell-docs-nav-link-active"
+                : "shell-docs-nav-link-idle"
+            }`}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {link.icon}
+            <span>{link.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/showcase/shell-docs/src/components/property-reference.tsx
+++ b/showcase/shell-docs/src/components/property-reference.tsx
@@ -54,16 +54,16 @@ export function PropertyReference({
   const renderChips = () => {
     return (
       <>
-        <span className="font-mono bg-blue-500/10 text-blue-400 py-0.5 px-2 rounded text-xs font-semibold">
+        <span className="shell-docs-radius-control border border-[var(--accent)] bg-[var(--accent-dim)] px-2 py-0.5 font-mono text-xs font-semibold text-[var(--accent)]">
           {type}
         </span>
         {required && (
-          <span className="font-mono bg-red-500/10 text-red-400 py-0.5 px-2 rounded text-xs font-semibold">
+          <span className="shell-docs-radius-control border border-[var(--destructive)] bg-[color-mix(in_oklch,var(--destructive)_12%,transparent)] px-2 py-0.5 font-mono text-xs font-semibold text-[var(--destructive)]">
             required
           </span>
         )}
         {deprecated && (
-          <span className="font-mono bg-yellow-500/10 text-yellow-400 py-0.5 px-2 rounded text-xs font-semibold">
+          <span className="shell-docs-radius-control border border-[var(--border)] bg-[var(--bg-elevated)] px-2 py-0.5 font-mono text-xs font-semibold text-[var(--text-muted)]">
             deprecated
           </span>
         )}
@@ -98,7 +98,7 @@ export function PropertyReference({
 
         <div>
           {cloudOnly && (
-            <span className="flex space-x-1 items-center justify-center bg-[var(--accent)] text-white py-0.5 px-2 rounded text-xs font-semibold">
+            <span className="shell-docs-radius-control flex items-center justify-center space-x-1 bg-[var(--accent)] px-2 py-0.5 text-xs font-semibold text-[var(--primary-foreground)]">
               <span>COPILOT CLOUD</span>
             </span>
           )}

--- a/showcase/shell-docs/src/components/react/component-previews/new-look-and-feel.tsx
+++ b/showcase/shell-docs/src/components/react/component-previews/new-look-and-feel.tsx
@@ -34,9 +34,8 @@ export function NewLookAndFeelPreview() {
         aria-expanded={open}
         onClick={() => setOpen((value) => !value)}
         className={cn(
-          "fixed bottom-5 right-5 z-50 flex h-14 w-14 items-center justify-center rounded-full border shadow-xl transition",
-          "border-[#d8d0ef] bg-white text-[#4f2c86] hover:-translate-y-0.5 hover:shadow-2xl",
-          "dark:border-white/15 dark:bg-[#1f2230] dark:text-[#d8c8ff]",
+          "shell-docs-radius-icon fixed bottom-5 right-5 z-50 flex h-14 w-14 items-center justify-center border shadow-[var(--shadow-panel)] transition",
+          "border-[var(--border)] bg-[var(--bg-surface)] text-[var(--accent)] hover:-translate-y-0.5 hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)]",
         )}
       >
         {open ? (
@@ -50,43 +49,42 @@ export function NewLookAndFeelPreview() {
         <aside
           aria-label="CopilotKit new look and feel preview"
           className={cn(
-            "fixed bottom-24 left-4 right-4 z-50 mx-auto flex max-h-[min(660px,calc(100vh-8rem))] w-auto max-w-[390px] flex-col overflow-hidden rounded-2xl border shadow-2xl",
-            "border-[#ded8ed] bg-white text-[#202124]",
-            "dark:border-white/15 dark:bg-[#17191f] dark:text-white",
+            "shell-docs-radius-surface fixed bottom-24 left-4 right-4 z-50 mx-auto flex max-h-[min(660px,calc(100vh-8rem))] w-auto max-w-[390px] flex-col overflow-hidden border shadow-[var(--shadow-modal)]",
+            "border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text)]",
             "sm:left-auto sm:right-5 sm:mx-0 sm:w-[390px]",
           )}
         >
-          <div className="flex items-center justify-between border-b border-[#ece7f6] px-4 py-3 dark:border-white/10">
+          <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[#f4efff] dark:bg-white/10">
+              <div className="shell-docs-radius-icon flex h-9 w-9 items-center justify-center bg-[var(--accent-dim)]">
                 <CopilotKitMark className="h-6 w-6" />
               </div>
               <div>
                 <div className="text-sm font-semibold">CopilotKit</div>
-                <div className="text-xs text-[#6b6f76] dark:text-white/55">
+                <div className="text-xs text-[var(--text-muted)]">
                   New look and feel
                 </div>
               </div>
             </div>
-            <div className="flex h-7 items-center gap-1 rounded-full bg-[#eef8f3] px-2 text-xs font-medium text-[#14794f] dark:bg-[#1b3a2d] dark:text-[#8de0b4]">
+            <div className="shell-docs-radius-control flex h-7 items-center gap-1 border border-[var(--accent)] bg-[var(--accent-dim)] px-2 text-xs font-medium text-[var(--accent)]">
               <Sparkles className="h-3.5 w-3.5" />
               Ready
             </div>
           </div>
 
-          <div className="flex-1 space-y-4 overflow-y-auto bg-[#fbfafc] px-4 py-4 dark:bg-[#111318]">
-            <div className="max-w-[82%] rounded-2xl rounded-tl-md border border-[#e6e0ef] bg-white px-4 py-3 text-sm shadow-sm dark:border-white/10 dark:bg-[#20232b]">
+          <div className="flex-1 space-y-4 overflow-y-auto bg-[var(--bg)] px-4 py-4">
+            <div className="shell-docs-radius-surface max-w-[82%] border border-[var(--border)] bg-[var(--bg-surface)] px-4 py-3 text-sm shadow-[var(--shadow-control)]">
               Hey there. Let&apos;s have a fun conversation.
             </div>
 
-            <div className="ml-auto max-w-[78%] rounded-2xl rounded-tr-md bg-[#5b2ca0] px-4 py-3 text-sm text-white shadow-sm">
+            <div className="shell-docs-radius-surface ml-auto max-w-[78%] bg-[var(--accent)] px-4 py-3 text-sm text-[var(--primary-foreground)] shadow-[var(--shadow-control)]">
               What changed in 1.8.2?
             </div>
 
-            <div className="max-w-[88%] rounded-2xl rounded-tl-md border border-[#e6e0ef] bg-white px-4 py-3 text-sm shadow-sm dark:border-white/10 dark:bg-[#20232b]">
+            <div className="shell-docs-radius-surface max-w-[88%] border border-[var(--border)] bg-[var(--bg-surface)] px-4 py-3 text-sm shadow-[var(--shadow-control)]">
               The chat UI has refreshed styling, first-class feedback actions,
               and built-in dark mode support.
-              <div className="mt-3 flex items-center gap-1.5 text-[#6b6f76] dark:text-white/55">
+              <div className="mt-3 flex items-center gap-1.5 text-[var(--text-muted)]">
                 <ActionButton label="Thumbs up">
                   <ThumbsUp className="h-3.5 w-3.5" />
                 </ActionButton>
@@ -117,7 +115,7 @@ export function NewLookAndFeelPreview() {
                 <button
                   key={suggestion}
                   type="button"
-                  className="rounded-full border border-[#dfd7ef] bg-white px-3 py-2 text-left text-xs font-medium text-[#4f2c86] transition hover:border-[#bfa9e3] hover:bg-[#f6f1ff] dark:border-white/10 dark:bg-white/5 dark:text-[#d8c8ff] dark:hover:bg-white/10"
+                  className="shell-docs-radius-control border border-[var(--border)] bg-[var(--bg-surface)] px-3 py-2 text-left text-xs font-medium text-[var(--accent)] transition hover:border-[var(--accent)] hover:bg-[var(--accent-dim)]"
                 >
                   {suggestion}
                 </button>
@@ -125,18 +123,18 @@ export function NewLookAndFeelPreview() {
             </div>
           </div>
 
-          <div className="border-t border-[#ece7f6] bg-white p-3 dark:border-white/10 dark:bg-[#17191f]">
-            <div className="flex items-center gap-2 rounded-2xl border border-[#ded8ed] bg-[#fbfafc] px-3 py-2 dark:border-white/10 dark:bg-white/5">
+          <div className="border-t border-[var(--border)] bg-[var(--bg-surface)] p-3">
+            <div className="shell-docs-radius-control flex items-center gap-2 border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2">
               <input
                 readOnly
                 value="Ask anything..."
                 aria-label="Preview chat input"
-                className="min-w-0 flex-1 bg-transparent text-sm text-[#6b6f76] outline-none dark:text-white/55"
+                className="min-w-0 flex-1 bg-transparent text-sm text-[var(--text-muted)] outline-none"
               />
               <button
                 type="button"
                 aria-label="Send preview message"
-                className="flex h-8 w-8 items-center justify-center rounded-full bg-[#5b2ca0] text-white transition hover:bg-[#4b2387]"
+                className="shell-docs-radius-icon flex h-8 w-8 items-center justify-center bg-[var(--accent)] text-[var(--primary-foreground)] transition hover:bg-[var(--accent-strong)]"
               >
                 <SendHorizontal className="h-4 w-4" />
               </button>
@@ -162,7 +160,7 @@ function ActionButton({
       type="button"
       aria-label={label}
       onClick={onClick}
-      className="flex h-7 w-7 items-center justify-center rounded-full transition hover:bg-[#f1edf8] hover:text-[#4f2c86] dark:hover:bg-white/10 dark:hover:text-white"
+      className="shell-docs-radius-icon flex h-7 w-7 items-center justify-center transition hover:bg-[var(--accent-dim)] hover:text-[var(--accent)]"
     >
       {children}
     </button>

--- a/showcase/shell-docs/src/components/react/ops-platform-cta.tsx
+++ b/showcase/shell-docs/src/components/react/ops-platform-cta.tsx
@@ -95,7 +95,7 @@ export function OpsPlatformCTA({
   if (variant === "info") {
     return (
       <div
-        className={`not-prose my-6 flex gap-3 rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] p-4 ${className ?? ""}`}
+        className={`shell-docs-radius-surface not-prose my-6 flex gap-3 border border-[var(--border)] bg-[var(--bg-elevated)] p-4 shadow-[var(--shadow-control)] ${className ?? ""}`}
       >
         <Info className="h-5 w-5 text-[var(--accent)] mt-0.5 flex-shrink-0" />
         <div className="min-w-0 flex-1">
@@ -112,10 +112,7 @@ export function OpsPlatformCTA({
             // HubSpot's analytics tag rewrites the outbound href client-side;
             // see suppressHydrationWarning note on the card variant below.
             suppressHydrationWarning
-            // Inline color wins over .reference-content .not-prose a { color: inherit }
-            // in globals.css (which would otherwise drag this to the prose text color).
-            style={{ color: "var(--accent)" }}
-            className="inline-flex items-center gap-1 mt-2 text-sm font-medium hover:opacity-80 no-underline"
+            className="shell-docs-cta-accent mt-2 inline-flex items-center gap-1 text-sm font-medium no-underline hover:opacity-80"
             data-cta-surface={surface}
             data-cta-variant={variant}
           >
@@ -131,10 +128,7 @@ export function OpsPlatformCTA({
     // Compact sibling of the `card` variant. Same visual language — light
     // bordered surface, an accent left-edge stripe as the brand signature, the
     // CopilotKit kite as the authored stamp, and a real text-link CTA in
-    // `--accent`. Inline color + textDecoration on the anchor defeat the
-    // .reference-content a { text-decoration: underline; color: accent } rule
-    // from globals.css that would otherwise drag the whole card to look like a
-    // prose link.
+    // `--accent`.
     return (
       <a
         href={href}
@@ -144,38 +138,27 @@ export function OpsPlatformCTA({
         suppressHydrationWarning
         data-cta-surface={surface}
         data-cta-variant={variant}
-        style={{ textDecoration: "none", color: "var(--text)" }}
-        className={`not-prose group relative my-6 flex flex-col gap-3 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4 pl-5 transition-colors duration-150 hover:border-[var(--accent)] sm:flex-row sm:items-center sm:justify-between sm:gap-4 ${className ?? ""}`}
+        className={`shell-docs-cta-link shell-docs-radius-surface not-prose group relative my-6 flex flex-col gap-3 overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] p-4 pl-5 shadow-[var(--shadow-control)] transition-colors duration-150 hover:border-[var(--accent)] sm:flex-row sm:items-center sm:justify-between sm:gap-4 ${className ?? ""}`}
       >
         {/* 2px accent stripe — the structural brand signature. */}
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute left-0 top-0 h-full w-[2px]"
-          style={{ background: "var(--accent)" }}
+          className="shell-docs-cta-stripe pointer-events-none absolute left-0 top-0 h-full w-[2px]"
         />
         <div className="flex items-start gap-3 min-w-0">
           <CopilotKitMark className="mt-0.5 h-5 w-[18px] flex-shrink-0" />
           <div className="min-w-0">
-            <div
-              className="text-[15px] font-semibold leading-snug"
-              style={{ color: "var(--text)" }}
-            >
+            <div className="text-[15px] font-semibold leading-snug text-[var(--text)]">
               {title}
             </div>
             {body ? (
-              <div
-                className="text-[13.5px] leading-relaxed mt-1"
-                style={{ color: "var(--text-muted)" }}
-              >
+              <div className="mt-1 text-[13.5px] leading-relaxed text-[var(--text-muted)]">
                 {body}
               </div>
             ) : null}
           </div>
         </div>
-        <span
-          className="inline-flex items-center gap-1 whitespace-nowrap text-sm font-semibold"
-          style={{ color: "var(--accent)" }}
-        >
+        <span className="shell-docs-cta-accent inline-flex items-center gap-1 whitespace-nowrap text-sm font-semibold">
           {ctaLabel}
           <ArrowRight className="h-3.5 w-3.5 transition-transform duration-150 group-hover:translate-x-0.5" />
         </span>
@@ -193,12 +176,7 @@ export function OpsPlatformCTA({
         suppressHydrationWarning
         data-cta-surface={surface}
         data-cta-variant={variant}
-        // Inline textDecoration wins over .reference-content a { text-decoration: underline }
-        // in globals.css. The Tailwind `no-underline` class loses on specificity here because
-        // `not-prose` is on the <a> itself, not an ancestor — so the descendant exception
-        // .reference-content .not-prose a doesn't apply.
-        style={{ textDecoration: "none" }}
-        className={`not-prose group flex items-start gap-3 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4 transition-colors duration-150 hover:border-[var(--accent)] ${className ?? ""}`}
+        className={`shell-docs-cta-link shell-docs-radius-surface not-prose group flex items-start gap-3 border border-[var(--border)] bg-[var(--bg-surface)] p-4 shadow-[var(--shadow-control)] transition-colors duration-150 hover:border-[var(--accent)] ${className ?? ""}`}
       >
         <CopilotKitMark className="mt-0.5 h-5 w-[18px] flex-shrink-0" />
         <div>
@@ -233,8 +211,6 @@ export function OpsPlatformCTA({
   //  - The accent stripe is the same structural cue Linear uses on important
   //    inline notices — restrained but unmistakable.
   //
-  // Inline color/textDecoration defeat .reference-content a { ... } rules
-  // from globals.css (same battle as the other variants).
   return (
     <a
       href={href}
@@ -247,40 +223,29 @@ export function OpsPlatformCTA({
       suppressHydrationWarning
       data-cta-surface={surface}
       data-cta-variant={variant}
-      style={{ textDecoration: "none", color: "var(--text)" }}
-      className={`not-prose group relative my-8 flex flex-col items-stretch gap-4 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-surface)] p-5 pl-6 transition-colors duration-150 hover:border-[var(--accent)] sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:p-6 sm:pl-7 ${className ?? ""}`}
+      className={`shell-docs-cta-link shell-docs-radius-surface not-prose group relative my-8 flex flex-col items-stretch gap-4 overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] p-5 pl-6 shadow-[var(--shadow-control)] transition-colors duration-150 hover:border-[var(--accent)] sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:p-6 sm:pl-7 ${className ?? ""}`}
     >
       {/* 2px accent stripe — the structural brand signature. Positioned via the
           parent's relative + overflow-hidden so the stripe sits flush against
           the rounded corners without bleeding past them. */}
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute left-0 top-0 h-full w-[2px]"
-        style={{ background: "var(--accent)" }}
+        className="shell-docs-cta-stripe pointer-events-none absolute left-0 top-0 h-full w-[2px]"
       />
       <div className="flex items-start gap-4 min-w-0">
         <CopilotKitMark className="mt-0.5 h-6 w-[22px] flex-shrink-0" />
         <div className="min-w-0">
-          <div
-            className="text-lg font-semibold leading-tight tracking-tight"
-            style={{ color: "var(--text)" }}
-          >
+          <div className="text-lg font-semibold leading-tight tracking-tight text-[var(--text)]">
             {title}
           </div>
           {body ? (
-            <div
-              className="text-sm leading-relaxed mt-1.5"
-              style={{ color: "var(--text-muted)" }}
-            >
+            <div className="mt-1.5 text-sm leading-relaxed text-[var(--text-muted)]">
               {body}
             </div>
           ) : null}
         </div>
       </div>
-      <span
-        className="inline-flex items-center gap-1.5 whitespace-nowrap text-sm font-semibold flex-shrink-0"
-        style={{ color: "var(--accent)" }}
-      >
+      <span className="shell-docs-cta-accent inline-flex flex-shrink-0 items-center gap-1.5 whitespace-nowrap text-sm font-semibold">
         {ctaLabel}
         <ArrowRight className="h-4 w-4 transition-transform duration-150 group-hover:translate-x-0.5" />
       </span>

--- a/showcase/shell-docs/src/components/react/tailored-content.tsx
+++ b/showcase/shell-docs/src/components/react/tailored-content.tsx
@@ -165,11 +165,11 @@ function TailoredContentInner({
   };
 
   const itemCn =
-    "border p-3 pl-4 rounded-md flex-1 flex md:block md:space-y-0.5 items-center md:items-start gap-4 cursor-pointer bg-white dark:bg-[var(--bg-elevated)] relative overflow-hidden group transition-all";
+    "shell-docs-radius-surface flex flex-1 cursor-pointer items-center gap-4 overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] p-3 pl-4 shadow-[var(--shadow-control)] transition-colors md:block md:space-y-0.5 md:items-start";
   const selectedCn =
-    "shadow-lg ring-1 ring-indigo-400 selected bg-gradient-to-r from-slate-50 to-indigo-50/30 dark:from-slate-800/40 dark:to-indigo-950/20";
+    "selected border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]";
   const iconCn =
-    "w-8 h-8 mb-2 top-0 transition-all opacity-20 group-[.selected]:text-indigo-500 group-[.selected]:opacity-60 dark:group-[.selected]:text-indigo-400 dark:group-[.selected]:opacity-60 dark:text-gray-400";
+    "mb-2 h-8 w-8 text-[var(--text-muted)] opacity-35 transition-colors group-[.selected]:text-[var(--accent)] group-[.selected]:opacity-80";
 
   const tablistId = `tailored-content-tablist-${id}`;
   const tabId = (optId: string) => `tailored-content-tab-${id}-${optId}`;

--- a/showcase/shell-docs/src/components/reference-version-selector.tsx
+++ b/showcase/shell-docs/src/components/reference-version-selector.tsx
@@ -54,7 +54,7 @@ export function ReferenceVersionSelector({
   }, [open]);
 
   return (
-    <div className="sticky top-0 z-10 bg-[var(--bg-surface)] backdrop-blur-lg">
+    <div>
       <div className="relative">
         <button
           ref={buttonRef}
@@ -62,10 +62,10 @@ export function ReferenceVersionSelector({
           onClick={() => setOpen((value) => !value)}
           aria-haspopup="listbox"
           aria-expanded={open}
-          className="flex h-12 w-full cursor-pointer items-center gap-2 rounded-xl border border-[var(--accent)] bg-[var(--accent-light)] p-1.5 text-[13px] font-medium text-[var(--text)] transition-colors hover:border-[var(--accent)]"
+          className="shell-docs-radius-control flex h-12 w-full cursor-pointer items-center gap-2 border border-[var(--nav-control-border)] bg-[var(--accent-dim)] p-1.5 text-[13px] font-medium text-[var(--text)] shadow-[var(--shadow-control)] transition-colors hover:border-[var(--nav-control-border-hover)] hover:bg-[var(--accent-light)]"
         >
           <span
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--accent)]/25 text-base dark:bg-white/10"
+            className="shell-docs-picker-icon-chip h-8 w-8 shrink-0 text-base"
             aria-hidden="true"
           >
             🪁
@@ -85,7 +85,7 @@ export function ReferenceVersionSelector({
           <div
             ref={panelRef}
             role="listbox"
-            className="absolute left-0 right-0 top-full z-50 mt-1 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-2 shadow-lg"
+            className="shell-docs-radius-surface absolute left-0 right-0 top-full z-50 mt-1 border border-[var(--border)] bg-[var(--bg-surface)] p-2 shadow-[var(--shadow-panel)]"
           >
             {options.map(({ version, href }) => {
               const active = version === activeVersion;
@@ -96,9 +96,9 @@ export function ReferenceVersionSelector({
                   aria-current={active ? "page" : undefined}
                   onClick={() => setOpen(false)}
                   className={[
-                    "flex w-full items-center gap-2 rounded px-2 py-1.5 text-[13px] transition-colors",
+                    "shell-docs-radius-control flex w-full items-center gap-2 px-2 py-1.5 text-[13px] transition-colors",
                     active
-                      ? "bg-[var(--accent-light)] text-[var(--accent)]"
+                      ? "bg-[var(--accent-dim)] text-[var(--accent)]"
                       : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]",
                   ].join(" ")}
                 >

--- a/showcase/shell-docs/src/components/search-modal.tsx
+++ b/showcase/shell-docs/src/components/search-modal.tsx
@@ -478,7 +478,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
   return (
     <>
       <div
-        className="fixed inset-0 z-[200] bg-black/25 backdrop-blur-sm"
+        className="fixed inset-0 z-[200] bg-[var(--overlay-backdrop)] backdrop-blur-sm"
         onMouseDown={onClose}
       />
       <div
@@ -495,7 +495,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
           }
         }}
       >
-        <div className="overflow-visible rounded-xl border border-[var(--border)] bg-[var(--bg-surface)] shadow-[0_24px_70px_rgba(1,5,7,0.22),0_0_0_1px_rgba(109,69,249,0.05)]">
+        <div className="shell-docs-radius-surface overflow-visible border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-modal)]">
           <div
             aria-hidden="true"
             className="h-px bg-gradient-to-r from-transparent via-[var(--accent)]/70 to-transparent"
@@ -526,7 +526,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
                 e.stopPropagation();
                 onClose();
               }}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)] transition-colors"
+              className="shell-docs-radius-control inline-flex h-7 w-7 items-center justify-center text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
               aria-label="Close search"
             >
               <X className="h-4 w-4" />
@@ -546,7 +546,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
                 type="button"
                 disabled={!hasFrameworkPicker}
                 onClick={() => setFrameworkPickerOpen((open) => !open)}
-                className="inline-flex h-8 max-w-[min(56vw,220px)] items-center justify-between gap-2 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] px-2.5 text-left text-xs font-semibold text-[var(--text)] outline-none transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-hover)] focus-visible:border-[var(--accent)] disabled:opacity-60"
+                className="shell-docs-radius-control inline-flex h-8 max-w-[min(56vw,220px)] items-center justify-between gap-2 border border-[var(--border)] bg-[var(--bg-surface)] px-2.5 text-left text-xs font-semibold text-[var(--text)] outline-none transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-hover)] focus-visible:border-[var(--accent)] disabled:opacity-60"
                 aria-haspopup="listbox"
                 aria-expanded={frameworkPickerOpen}
                 aria-label={`Choose docs framework. Currently ${
@@ -572,7 +572,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
               {frameworkPickerOpen && hasFrameworkPicker && (
                 <div
                   role="listbox"
-                  className="absolute left-0 top-full z-10 mt-2 max-h-[280px] w-[min(360px,calc(100vw-3rem))] overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--bg-surface)] p-1.5 shadow-[0_18px_50px_rgba(1,5,7,0.18)]"
+                  className="shell-docs-radius-surface absolute left-0 top-full z-10 mt-2 max-h-[280px] w-[min(360px,calc(100vw-3rem))] overflow-y-auto border border-[var(--border)] bg-[var(--bg-surface)] p-1.5 shadow-[var(--shadow-panel)]"
                 >
                   {frameworkOptions.map((option) => {
                     const selected = option.slug === selectedFramework;
@@ -583,16 +583,16 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
                         role="option"
                         aria-selected={selected}
                         onClick={() => chooseFramework(option.slug)}
-                        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm transition-colors ${
+                        className={`shell-docs-radius-control flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors ${
                           selected
                             ? "bg-[var(--accent)]/10 text-[var(--text)]"
                             : "text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text)]"
                         }`}
                       >
                         <span
-                          className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border ${
+                          className={`shell-docs-radius-icon inline-flex h-7 w-7 shrink-0 items-center justify-center border ${
                             selected
-                              ? "border-[var(--accent)]/20 bg-[var(--accent)]/10 text-[var(--accent)]"
+                              ? "border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]"
                               : "border-[var(--border)] bg-[var(--bg-elevated)] text-[var(--text-muted)]"
                           }`}
                         >
@@ -634,7 +634,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
                 <button
                   key={r.id}
                   type="button"
-                  className={`w-full text-left rounded-lg px-3 py-3 flex items-center gap-3 transition-colors ${
+                  className={`shell-docs-radius-control flex w-full items-center gap-3 px-3 py-3 text-left transition-colors ${
                     idx === selectedIndex
                       ? "bg-[var(--bg-elevated)]"
                       : "hover:bg-[var(--bg-hover)]"

--- a/showcase/shell-docs/src/components/search-trigger.tsx
+++ b/showcase/shell-docs/src/components/search-trigger.tsx
@@ -78,7 +78,7 @@ export function SearchTrigger({
     return (
       <button
         onClick={toggleShellSearch}
-        className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-muted)] shadow-[0_1px_0_rgba(1,5,7,0.03)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
+        className="shell-docs-radius-control flex h-10 w-10 cursor-pointer items-center justify-center border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-muted)] shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
         aria-label="Search"
         title="Search"
       >
@@ -94,7 +94,7 @@ export function SearchTrigger({
       <button
         onClick={toggleShellSearch}
         aria-label="Search"
-        className="flex h-9 w-9 cursor-pointer items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] px-2.5 text-[var(--text-muted)] shadow-[0_1px_0_rgba(1,5,7,0.03)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)] lg:w-[220px] xl:w-[260px]"
+        className="shell-docs-radius-control flex h-10 w-10 cursor-pointer items-center gap-2 border border-[var(--border)] bg-[var(--bg-surface)] px-2.5 text-[var(--text-muted)] shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)] lg:w-[220px] xl:w-[260px]"
       >
         <Search className="h-4 w-4 shrink-0" aria-hidden="true" />
 
@@ -103,10 +103,9 @@ export function SearchTrigger({
         </span>
 
         <span
-          className="hidden xl:inline-flex items-center justify-center gap-1 font-mono text-[11px] border border-[var(--border)] px-1.5 py-0.5 rounded-md text-[var(--text-faint)] bg-[var(--bg-surface)]"
+          className="shell-docs-radius-control hidden min-w-[3.25rem] items-center justify-center gap-1 border border-[var(--border)] bg-[var(--bg-surface)] px-1.5 py-0.5 font-mono text-[11px] text-[var(--text-faint)] xl:inline-flex"
           // Reserve horizontal room so the button doesn't reflow when the
           // shortcut hint appears after hydration.
-          style={{ minWidth: "3.25rem" }}
           suppressHydrationWarning
         >
           {isMac === null ? (

--- a/showcase/shell-docs/src/components/shell-docs-layout.tsx
+++ b/showcase/shell-docs/src/components/shell-docs-layout.tsx
@@ -4,9 +4,10 @@ import type * as PageTree from "fumadocs-core/page-tree";
 import { MobileTopNav } from "./mobile-top-nav";
 import { SidebarScrollPreserver } from "./sidebar-scroll-preserver";
 import { SidebarFolderStatePreserver } from "./sidebar-folder-state-preserver";
-import { ThemeSwitch } from "./theme-switch";
 import GithubIcon from "./icons/github";
 import DiscordIcon from "./icons/discord";
+import { MobileSidebarFooterTalk } from "./mobile-sidebar-footer-talk";
+import { PrimaryDocsTabs } from "./primary-docs-tabs";
 
 // Shared Fumadocs `DocsLayout` chrome used by every shell-docs route.
 // All five callers (home overview, framework root, framework-scoped MDX
@@ -33,8 +34,7 @@ export function ShellDocsLayout({
       // we have to pass `enabled: false` explicitly to keep the
       // `iconLinks.length > 0 || slots.themeSwitch` branch in
       // `sidebar.js` from rendering the default rounded pill. Our own
-      // single-toggle `<ThemeSwitch>` is mounted via the
-      // `sidebar.footer` slot below instead.
+      // single-toggle `<ThemeSwitch>` is mounted in BrandNav instead.
       themeSwitch={{ enabled: false }}
       // We intentionally do NOT pass `links` here either. Fumadocs would
       // funnel `type: "icon"` entries into the same auto-injected pill
@@ -43,7 +43,12 @@ export function ShellDocsLayout({
       // of truth (the JSX below) and avoids the auto layout fighting
       // our custom one.
       sidebar={{
-        banner,
+        banner: (
+          <div className="flex flex-col">
+            <PrimaryDocsTabs className="shell-docs-mobile-sidebar-tabs" />
+            {banner}
+          </div>
+        ),
         // Hide Fumadocs's collapse toggle — shell-docs has its own chrome.
         collapsible: false,
         className: "shell-docs-sidebar",
@@ -57,27 +62,29 @@ export function ShellDocsLayout({
         footer: (
           <div
             key="shell-docs-sidebar-footer"
-            className="flex items-center gap-1 sidebar-footer-row"
+            className="flex w-full flex-col gap-2 sidebar-footer-row md:w-auto md:flex-row md:items-center md:gap-1"
           >
-            <a
-              href="https://github.com/copilotkit/copilotkit"
-              target="_blank"
-              rel="noreferrer noopener"
-              aria-label="GitHub"
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-fd-muted-foreground transition-colors [&_svg]:size-4"
-            >
-              <GithubIcon />
-            </a>
-            <a
-              href="https://discord.gg/6dffbvGU3D"
-              target="_blank"
-              rel="noreferrer noopener"
-              aria-label="Discord"
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-fd-muted-foreground transition-colors [&_svg]:size-4"
-            >
-              <DiscordIcon />
-            </a>
-            <ThemeSwitch className="ms-auto" />
+            <MobileSidebarFooterTalk />
+            <div className="flex items-center gap-1">
+              <a
+                href="https://github.com/copilotkit/copilotkit"
+                target="_blank"
+                rel="noreferrer noopener"
+                aria-label="GitHub"
+                className="shell-docs-radius-control inline-flex h-7 w-7 items-center justify-center text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text)] [&_svg]:size-4"
+              >
+                <GithubIcon />
+              </a>
+              <a
+                href="https://discord.gg/6dffbvGU3D"
+                target="_blank"
+                rel="noreferrer noopener"
+                aria-label="Discord"
+                className="shell-docs-radius-control inline-flex h-7 w-7 items-center justify-center text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text)] [&_svg]:size-4"
+              >
+                <DiscordIcon />
+              </a>
+            </div>
           </div>
         ),
       }}

--- a/showcase/shell-docs/src/components/sidebar-framework-selector.tsx
+++ b/showcase/shell-docs/src/components/sidebar-framework-selector.tsx
@@ -46,10 +46,10 @@ export function SidebarFrameworkSelector() {
   }));
 
   return (
-    // Sticky so the selector stays visible as the user scrolls long
-    // sidebars. The wrapper bg keeps nav text from showing through the
-    // sticky header while the sidebar remains visually unframed.
-    <div className="sticky top-0 z-10 bg-[var(--bg-surface)] backdrop-blur-lg">
+    // The sidebar column itself is already fixed within the docs layout, so
+    // this selector can stay in normal flow. Keeping it non-sticky avoids a
+    // raised layer overlapping the first selected sidebar item at scroll-top.
+    <div>
       <FrameworkSelector
         options={options}
         categoryOrder={categoryOrder}

--- a/showcase/shell-docs/src/components/snippet.tsx
+++ b/showcase/shell-docs/src/components/snippet.tsx
@@ -131,7 +131,7 @@ interface SnippetProps {
 function WarningBox({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="my-4 rounded-md border-l-4 border-yellow-500/40 bg-yellow-500/5 p-4 text-sm text-[var(--text-secondary)]"
+      className="shell-docs-radius-surface shell-docs-warning-surface my-4 border border-l-4 p-4 text-sm text-[var(--text-secondary)] shadow-[var(--shadow-control)]"
       role="alert"
     >
       <div className="font-semibold mb-1 text-[var(--text)]">
@@ -159,7 +159,7 @@ export function UnsupportedBox({
 }) {
   return (
     <div
-      className="my-4 rounded-md border-l-4 border-blue-500/40 bg-blue-500/5 p-4 text-sm text-[var(--text-secondary)]"
+      className="shell-docs-radius-surface my-4 border border-l-4 border-[var(--accent)] bg-[var(--accent-dim)] p-4 text-sm text-[var(--text-secondary)] shadow-[var(--shadow-control)]"
       role="note"
     >
       <div className="font-semibold mb-1 text-[var(--text)]">
@@ -318,7 +318,7 @@ export function Snippet({
 
   if (!resolvedFramework) {
     return (
-      <div className="my-4 rounded-md border border-[var(--border)] px-4 py-3 text-sm text-[var(--text-muted)] bg-[var(--bg-elevated)]">
+      <div className="shell-docs-radius-surface my-4 border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-3 text-sm text-[var(--text-muted)] shadow-[var(--shadow-control)]">
         Select an AI backend above to see this code example.
       </div>
     );

--- a/showcase/shell-docs/src/components/stored-framework-highlight.tsx
+++ b/showcase/shell-docs/src/components/stored-framework-highlight.tsx
@@ -25,14 +25,8 @@ export function StoredFrameworkHighlight({ slug }: { slug: string }) {
     <>
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 rounded-lg ring-2 ring-[var(--accent)]"
+        className="shell-docs-radius-surface pointer-events-none absolute inset-0 ring-1 ring-inset ring-[var(--nav-control-border)]"
       />
-      <span
-        aria-hidden="true"
-        className="pointer-events-none absolute right-3 top-3 hidden rounded-full border border-[var(--accent)] bg-[var(--accent-dim)] px-2 py-0.5 text-[11px] font-semibold text-[var(--accent)] sm:inline-flex"
-      >
-        Selected
-      </span>
       <span className="sr-only">Current backend selection</span>
     </>
   );

--- a/showcase/shell-docs/src/components/theme-switch.tsx
+++ b/showcase/shell-docs/src/components/theme-switch.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 /**
- * `ThemeSwitch` — single-toggle replacement for Fumadocs's two-icon split.
+ * `ThemeSwitch` — single-button replacement for Fumadocs's two-icon split.
  *
- * Renders a small horizontal switch (track + sliding thumb) that swaps the
- * theme between `light` and `dark` on click. The thumb itself carries the
- * currently-active icon (sun for light, moon for dark) so the control reads
- * as "current state" rather than "two equally weighted options" — same
- * affordance as the iOS-style toggle pattern.
+ * Renders a compact icon button that displays the current resolved theme and
+ * swaps between `light` and `dark` on click. The site itself defaults to the
+ * user's system preference via RootProvider's `defaultTheme: "system"`; once
+ * clicked, this button stores the opposite explicit theme through next-themes.
  *
  * Why not Fumadocs's built-in `ThemeSwitch`?
  *   - The `light-dark` mode renders two `<svg>` buttons side-by-side with a
@@ -15,15 +14,15 @@
  *     toggle. Removing the divider on its own still leaves two icons; we
  *     want a single switch instead.
  *
- * Hydration: `next-themes` only resolves the theme client-side, so the
- * first render is unavoidably "indeterminate". We render the track in a
- * neutral state until `mounted` flips to true to avoid an aria/visual
- * flicker between server (no theme) and client (resolved theme).
+ * Hydration: `next-themes` only resolves the theme client-side, so the first
+ * render is unavoidably indeterminate. We render the light-mode current icon
+ * until `mounted` flips to true; the first-paint script in layout.tsx already
+ * applies the correct html class before this button hydrates.
  */
 
 import * as React from "react";
 import { useTheme } from "next-themes";
-import { Moon, Sun } from "lucide-react";
+import { MoonStar, SunMedium } from "lucide-react";
 
 import { cn } from "@/lib/cn";
 
@@ -35,49 +34,24 @@ export function ThemeSwitch({ className }: { className?: string }) {
     setMounted(true);
   }, []);
 
-  // Before mount we don't know which theme is active, so we render the
-  // track in its un-checked (light) position. `aria-checked` is intentionally
-  // left as `false` here — a screen reader hitting the page mid-mount sees
-  // a benign "switch, off" rather than a misleading state.
   const isDark = mounted && resolvedTheme === "dark";
+  const nextTheme = isDark ? "light" : "dark";
+  const label = isDark ? "Switch to light theme" : "Switch to dark theme";
+  const Icon = isDark ? MoonStar : SunMedium;
 
   return (
     <button
       type="button"
-      role="switch"
-      aria-checked={isDark}
-      aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
-      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label={label}
+      title={label}
+      onClick={() => setTheme(nextTheme)}
       className={cn(
-        // Track: neutral pill (no accent tint) sized to feel like a real
-        // control. Border + bg pull from the project's neutral tokens so
-        // the switch reads as chrome rather than a CTA. 28px tall × 50px
-        // wide leaves enough room for a comfortably-sized thumb without
-        // dominating the footer row.
-        "relative inline-flex h-7 w-[50px] shrink-0 cursor-pointer items-center rounded-full border border-[var(--border)] bg-[var(--bg-elevated,var(--bg-surface))] transition-colors",
-        "hover:bg-[color-mix(in_srgb,var(--border)_60%,transparent)]",
+        "shell-docs-radius-control flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-muted)] shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border)] focus-visible:ring-offset-1",
         className,
       )}
     >
-      <span
-        aria-hidden="true"
-        className={cn(
-          // Thumb: 22×22 circle that slides between the two ends. Light-
-          // state: white surface with the muted-foreground icon. Dark
-          // state: same neutral surface — color tracks the theme so the
-          // thumb keeps reading against the track. Travel = track 50px -
-          // thumb 22px - 2*3px gutters = 22px.
-          "pointer-events-none flex h-[22px] w-[22px] translate-x-[3px] items-center justify-center rounded-full bg-[var(--bg-surface)] text-[var(--text-secondary)] shadow-sm ring-1 ring-[var(--border)] transition-transform duration-150 ease-out",
-          isDark && "translate-x-[25px]",
-        )}
-      >
-        {isDark ? (
-          <Moon className="h-[12px] w-[12px]" strokeWidth={2} />
-        ) : (
-          <Sun className="h-[12px] w-[12px]" strokeWidth={2} />
-        )}
-      </span>
+      <Icon className="h-4 w-4" strokeWidth={2} aria-hidden="true" />
     </button>
   );
 }

--- a/showcase/shell-docs/src/components/ui/button.tsx
+++ b/showcase/shell-docs/src/components/ui/button.tsx
@@ -3,15 +3,17 @@ import type { VariantProps } from "class-variance-authority";
 
 const variants = {
   primary:
-    "bg-fd-primary text-fd-primary-foreground hover:bg-fd-primary/80 disabled:bg-fd-secondary disabled:text-fd-secondary-foreground",
-  outline: "border hover:bg-fd-accent hover:text-fd-accent-foreground",
-  ghost: "hover:bg-fd-accent hover:text-fd-accent-foreground",
+    "border border-[var(--accent)] bg-[var(--accent)] text-[var(--primary-foreground)] hover:bg-[var(--accent-strong)] disabled:border-[var(--border)] disabled:bg-[var(--bg-elevated)] disabled:text-[var(--text-muted)]",
+  outline:
+    "border border-[var(--border)] bg-transparent text-[var(--text-secondary)] hover:border-[var(--accent)] hover:bg-[var(--accent-dim)] hover:text-[var(--accent)]",
+  ghost:
+    "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]",
   secondary:
-    "border bg-fd-secondary text-fd-secondary-foreground hover:bg-fd-accent hover:text-fd-accent-foreground",
+    "border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-secondary)] shadow-[var(--shadow-control)] hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]",
 } as const;
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring",
+  "shell-docs-radius-control inline-flex items-center justify-center p-2 text-sm font-medium transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
   {
     variants: {
       variant: variants,

--- a/showcase/shell-docs/src/components/ui/popover.tsx
+++ b/showcase/shell-docs/src/components/ui/popover.tsx
@@ -20,7 +20,7 @@ export function PopoverContent({
         sideOffset={sideOffset}
         side="bottom"
         className={cn(
-          "z-50 origin-(--radix-popover-content-transform-origin) overflow-y-auto max-h-(--radix-popover-content-available-height) min-w-[240px] max-w-[98vw] rounded-xl border bg-fd-popover/60 backdrop-blur-lg p-2 text-sm text-fd-popover-foreground shadow-lg focus-visible:outline-none data-[state=closed]:animate-fd-popover-out data-[state=open]:animate-fd-popover-in",
+          "shell-docs-radius-surface z-50 origin-(--radix-popover-content-transform-origin) overflow-y-auto max-h-(--radix-popover-content-available-height) min-w-[240px] max-w-[98vw] border border-[var(--border)] bg-[var(--bg-surface)] p-2 text-sm text-[var(--text)] shadow-[var(--shadow-panel)] focus-visible:outline-none data-[state=closed]:animate-fd-popover-out data-[state=open]:animate-fd-popover-in",
           className,
         )}
         {...props}

--- a/showcase/shell-docs/src/lib/mdx-registry-loader.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry-loader.tsx
@@ -99,7 +99,7 @@ export async function PartialLoader({
       // eslint-disable-next-line no-console
       console.warn("[mdx-registry-loader] partial not found:", relativePath);
       return (
-        <div className="my-4 rounded-md border border-dashed border-[var(--border)] px-3 py-2 text-xs font-mono text-[var(--text-faint)]">
+        <div className="shell-docs-radius-surface my-4 border border-dashed border-[var(--border)] px-3 py-2 text-xs font-mono text-[var(--text-faint)]">
           [mdx-registry-loader] partial not found: {relativePath}
         </div>
       );

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -278,7 +278,7 @@ export const docsComponents = {
       );
       if (process.env.NODE_ENV !== "production") {
         return (
-          <div className="my-6 rounded-md border border-dashed border-[var(--border)] px-3 py-2 text-xs font-mono text-[var(--text-faint)]">
+          <div className="shell-docs-radius-surface my-6 border border-dashed border-[var(--border)] px-3 py-2 text-xs font-mono text-[var(--text-faint)]">
             [mdx-registry] No deployed integrations support feature &quot;
             {feature}&quot;.
           </div>
@@ -296,7 +296,7 @@ export const docsComponents = {
             <Link
               key={i.slug}
               href={`/integrations/${i.slug}?demo=${feature}`}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full border border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-secondary)] hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
+              className="shell-docs-radius-control inline-flex items-center gap-1.5 border border-[var(--border)] bg-[var(--bg-surface)] px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)]"
             >
               {i.name}
             </Link>
@@ -417,7 +417,7 @@ export const docsComponents = {
     <div
       style={{
         border: "1px solid var(--border)",
-        borderRadius: "0.5rem",
+        borderRadius: "var(--shell-docs-radius-surface)",
         padding: "1rem",
         marginBottom: "1rem",
       }}
@@ -454,7 +454,7 @@ export const docsComponents = {
     <div
       style={{
         border: "1px solid var(--border)",
-        borderRadius: "0.5rem",
+        borderRadius: "var(--shell-docs-radius-surface)",
         padding: "1rem",
       }}
     >
@@ -469,7 +469,11 @@ export const docsComponents = {
     // immediately overrode it to `undefined`, silently dropping it.
     <video
       {...props}
-      style={{ borderRadius: "0.5rem", width: "100%", marginBottom: "1rem" }}
+      style={{
+        borderRadius: "var(--shell-docs-radius-surface)",
+        width: "100%",
+        marginBottom: "1rem",
+      }}
     />
   ),
   img: (props: Record<string, unknown>) => (
@@ -477,7 +481,11 @@ export const docsComponents = {
     // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
     <img
       {...props}
-      style={{ borderRadius: "0.5rem", maxWidth: "100%", marginBottom: "1rem" }}
+      style={{
+        borderRadius: "var(--shell-docs-radius-surface)",
+        maxWidth: "100%",
+        marginBottom: "1rem",
+      }}
     />
   ),
   CodeGroup: ({ children }: { children: React.ReactNode }) => (
@@ -490,7 +498,7 @@ export const docsComponents = {
     if (process.env.NODE_ENV !== "production") {
       warnSilentNull("Snippet", "runtime override required (base stub)");
       return (
-        <div className="my-4 rounded-md border border-dashed border-[var(--border)] px-3 py-2 text-xs font-mono text-[var(--text-faint)]">
+        <div className="shell-docs-radius-surface my-4 border border-dashed border-[var(--border)] px-3 py-2 text-xs font-mono text-[var(--text-faint)]">
           [Snippet] runtime override required
           {children ? <div className="mt-1">{children}</div> : null}
         </div>
@@ -534,7 +542,7 @@ export const docsComponents = {
       src={src}
       alt={alt || ""}
       style={{
-        borderRadius: "0.5rem",
+        borderRadius: "var(--shell-docs-radius-surface)",
         maxWidth: "100%",
         marginBottom: "1rem",
         cursor: "zoom-in",
@@ -619,7 +627,7 @@ export const docsComponents = {
             width: "100%",
             height: "100%",
             border: "none",
-            borderRadius: "0.5rem",
+            borderRadius: "var(--shell-docs-radius-surface)",
           }}
           sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
           loading="lazy"
@@ -661,7 +669,7 @@ export const docsComponents = {
     <div
       style={{
         border: "1px solid var(--border)",
-        borderRadius: "0.5rem",
+        borderRadius: "var(--shell-docs-radius-surface)",
         padding: "1rem",
         marginBottom: "0.75rem",
       }}
@@ -708,7 +716,7 @@ export const docsComponents = {
       return <div>{children}</div>;
     }
     return (
-      <div className="overflow-x-auto my-6 rounded-lg border border-[var(--border)]">
+      <div className="shell-docs-radius-surface my-6 overflow-x-auto border border-[var(--border)] shadow-[var(--shadow-control)]">
         <table className="w-full text-sm border-collapse">
           <thead>
             <tr>
@@ -775,7 +783,7 @@ export const docsComponents = {
     ];
 
     return (
-      <div className="overflow-x-auto my-6 rounded-lg border border-[var(--border)]">
+      <div className="shell-docs-radius-surface my-6 overflow-x-auto border border-[var(--border)] shadow-[var(--shadow-control)]">
         <table className="w-full text-sm border-collapse">
           <thead>
             <tr>
@@ -867,7 +875,7 @@ export const docsComponents = {
       style={{
         padding: "1rem",
         background: "var(--bg-elevated)",
-        borderRadius: "0.5rem",
+        borderRadius: "var(--shell-docs-radius-surface)",
         marginBottom: "1rem",
       }}
     >
@@ -943,7 +951,11 @@ export const docsComponents = {
       width={width}
       height={height}
       className={className}
-      style={{ borderRadius: "0.5rem", maxWidth: "100%", marginBottom: "1rem" }}
+      style={{
+        borderRadius: "var(--shell-docs-radius-surface)",
+        maxWidth: "100%",
+        marginBottom: "1rem",
+      }}
     />
   ),
   A: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
@@ -980,7 +992,7 @@ export const docsComponents = {
         aria-label={ariaLabel}
         style={{
           padding: "0.5rem 1rem",
-          borderRadius: "0.375rem",
+          borderRadius: "var(--shell-docs-radius-control)",
           border: "1px solid var(--border)",
           background: "var(--bg-surface)",
           cursor: "pointer",


### PR DESCRIPTION
Our previous doc site had a fumadocs/shadcn theme that was a bit hodge-podge. This brings all of it into one clean and visually appealing design. The border radii are standardized, colors are standardized and bunch of passes for mobile/tablet have been done. An added bonus is that the header nav has been redone to feel more natural to the eyes.

<img width="1850" height="1256" alt="Screenshot 2026-06-05 at 7 48 00 AM" src="https://github.com/user-attachments/assets/0c6032f2-e406-4e51-9c31-d69a9d258d61" />
