### PR TITLE
fix(integrations): self-heal missing intelligence_app DB in _intelligence overlay

### DIFF
--- a/examples/integrations/_intelligence/docker-compose.yml
+++ b/examples/integrations/_intelligence/docker-compose.yml
@@ -24,12 +24,14 @@ services:
     environment:
       POSTGRES_USER: intelligence
       POSTGRES_PASSWORD: intelligence
-      POSTGRES_DB: postgres
+      # Created on first init of an empty data volume. Volumes initialized
+      # before this default existed are healed by the provision-db one-shot
+      # below, so do not rely on this alone.
+      POSTGRES_DB: intelligence_app
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ./docker/init-db:/docker-entrypoint-initdb.d:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U intelligence -d postgres"]
+      test: ["CMD-SHELL", "pg_isready -U intelligence -d intelligence_app"]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -49,6 +51,33 @@ services:
       timeout: 3s
       retries: 5
     restart: unless-stopped
+    networks:
+      - intelligence
+
+  # ---------------------------------------------------------------------------
+  # Database provisioning (one-shot)
+  # ---------------------------------------------------------------------------
+  # Ensures the intelligence_app database exists before the composite runs its
+  # migrations. POSTGRES_DB only takes effect on first init of an EMPTY data
+  # volume, and the postgres-data volume is shared across every project that
+  # uses this compose file (fixed project name above) — so a volume created by
+  # an earlier compose revision may not have the database. CREATE DATABASE has
+  # no IF NOT EXISTS, hence the pg_database existence check. Idempotent.
+  provision-db:
+    image: postgres:16-alpine
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: intelligence
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        psql -h postgres -U intelligence -d postgres -v ON_ERROR_STOP=1 -tAc \
+          "SELECT 1 FROM pg_database WHERE datname = 'intelligence_app'" | grep -q 1 \
+        || psql -h postgres -U intelligence -d postgres -v ON_ERROR_STOP=1 \
+          -c "CREATE DATABASE intelligence_app"
+    restart: "no"
     networks:
       - intelligence
 
@@ -77,8 +106,8 @@ services:
       THREAD_STALE_HOURS: "${THREAD_STALE_HOURS:-3}"
       THREAD_CULL_BATCH_SIZE: "${THREAD_CULL_BATCH_SIZE:-1000}"
     depends_on:
-      postgres:
-        condition: service_healthy
+      provision-db:
+        condition: service_completed_successfully
       redis:
         condition: service_healthy
     restart: unless-stopped

--- a/examples/integrations/_intelligence/docker/init-db/01-create-databases.sql
+++ b/examples/integrations/_intelligence/docker/init-db/01-create-databases.sql
@@ -1,2 +1,0 @@
-CREATE DATABASE intelligence_app;
-CREATE DATABASE intelligence_app_shadow;


### PR DESCRIPTION
## Problem

CLI starters for Mastra, Agno, PydanticAI, AWS Strands, Google ADK, MS Agent Framework, and LlamaIndex fail on `npm run dev` with:

```
Error: dependency failed to start: container copilotkit-intelligence-intelligence-1 is unhealthy
intelligence-1  | error: database "intelligence_app" does not exist
```

## Root cause

The overlay compose relied on a bind-mounted `docker/init-db/` script to create `intelligence_app`, but the CLI's Intelligence activation copies **only** `docker-compose.yml` into scaffolded projects. The mount source never exists there, so Docker creates it as an empty directory, postgres initializes with only the default DB, and the composite's migrations fail.

`langgraph-python-threads` was unaffected because its template ships its own compose + `docker/init-db/` in-repo.

## Why it keeps biting internal testers

The compose project name is fixed (`copilotkit-intelligence`), so **every starter on a machine shares one `postgres-data` volume** — and postgres only honors `POSTGRES_DB`/init scripts on first init of an *empty* volume. One broken run poisons the volume for every subsequent starter, regardless of framework.

## Fix (self-contained + self-healing)

- `POSTGRES_DB: intelligence_app` and drop the `docker/init-db` bind mount + script (the shadow DB it also created is only used by repo-local dev tooling, never by the composite)
- Add an idempotent `provision-db` one-shot (same pattern as the existing `provision-user`) that creates `intelligence_app` when missing — this heals already-poisoned volumes on the next `docker compose up`, with no manual `down -v`
- Gate `intelligence` on `provision-db` completion; align the postgres healthcheck dbname

Because the CLI fetches this overlay live from `main` at scaffold time, merging this fixes every CLI version in the wild immediately — no CLI release needed.

## Verification

Tested with real Docker on isolated compose projects:

1. **Poisoned volume** (reproduced by running the old compose revision with the empty `init-db` dir the CLI leaves behind → volume with no `intelligence_app`): new compose → `provision-db` exits 0, migrations run, composite **Healthy**, `up -d --wait` exits 0
2. **Fresh volume**: DB created via `POSTGRES_DB`, `provision-db` no-ops, composite **Healthy**
3. **Idempotency**: second `up -d --wait` on a running stack exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)