### PR TITLE
docs: update README for multi-platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ One agent backend. Every frontend.
 
 Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit handles the UI layer for each framework.
 
-## 💬 Beyond the Browser: Slack & Microsoft Teams
+## 💬 Beyond the Browser: Slack & Microsoft Teams (Discord, Google Chat coming soon...)
 
 Your agents can run and generate Generative UI beyond the web app (**[Learn more](https://www.copilotkit.ai/integrations)**).
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3
 - **Generative UI** – Allows agents to generate and update UI components dynamically at runtime based on user intent and agent state.
 - **Shared State** – A synchronized state layer that both agents and UI components can read from and write to in real time.
 - **Human-in-the-Loop** – Lets agents pause execution to request user input, confirmation, or edits before continuing.
-- **Self-Learning** – Agents that continuously improve from user feedback via in-context reinforcement learning (CLHF).
+- **Self-Learning** *(early access)* – Agents that continuously improve from user feedback via in-context reinforcement learning (CLHF).
 
 ## 🧩 Works With Your Stack
 
@@ -111,7 +111,9 @@ With **Continuous Learning from Human Feedback (CLHF)**, part of the [CopilotKit
 
 Available via CopilotKit Cloud or self-hosted.
 
-[Learn more about the Intelligence Platform →](https://www.copilotkit.ai/copilotkit-intelligence)
+🔒 **Early access:** We're onboarding teams now.
+
+👉 **[Request early access →](https://www.copilotkit.ai/copilotkit-intelligence)**
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 
 </div>
 
-Build **agent-native applications** with generative UI, shared state, and human-in-the-loop workflows.
+Build **agent-native applications** — on any framework, on any surface.
+
+Generative UI, shared state, and human-in-the-loop workflows for React, Angular, Vue, React Native — and beyond the browser.
 
 </div>
 
@@ -53,6 +55,8 @@ Build **agent-native applications** with generative UI, shared state, and human-
 
 CopilotKit is a best-in-class SDK for building full-stack agentic applications, Generative UI, and chat applications.
 
+What started as a React library is now a **multi-platform agentic framework**: the same agent can power your web app, your mobile app, and your team's Slack workspace.
+
 We are the company behind the **[AG-UI Protocol](https://github.com/ag-ui-protocol/ag-ui)** - adopted by Google, LangChain, AWS, Microsoft, Mastra, PydanticAI, and more!
 
 https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3
@@ -61,13 +65,39 @@ https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3
 
 **Features:**
 
-- **Chat UI** – A React-based chat interface that supports message streaming, tool calls, and agent responses.
+- **Chat UI** – A fully customizable chat interface that supports message streaming, tool calls, and agent responses.
 - **Backend Tool Rendering** – Enables agents to call backend tools that return UI components rendered directly in the client.
 - **Generative UI** – Allows agents to generate and update UI components dynamically at runtime based on user intent and agent state.
 - **Shared State** – A synchronized state layer that both agents and UI components can read from and write to in real time.
 - **Human-in-the-Loop** – Lets agents pause execution to request user input, confirmation, or edits before continuing.
 
 https://github.com/user-attachments/assets/55bf6714-62a7-4d5d-9232-07747cc0763b
+
+## 🧩 Works With Your Stack
+
+One agent backend. Every frontend.
+
+| Platform           | Status       | Get Started                                                 |
+| ------------------ | ------------ | ----------------------------------------------------------- |
+| ⚛️ React / Next.js | ✅ GA        | [Quickstart](https://docs.copilotkit.ai/?ref=github_readme) |
+| 🅰️ Angular         | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/?ref=github_readme) |
+| 💚 Vue             | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/?ref=github_readme) |
+| 📱 React Native    | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/?ref=github_readme) |
+
+Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit handles the UI layer for each framework.
+
+## 💬 Beyond the Browser: Slack & Microsoft Teams
+
+Your agents shouldn't be locked inside your web app.
+
+CopilotKit now lets you deploy the **same agent** to the places your users already work:
+
+- **Slack** – Agents as first-class Slack apps: threads, tool calls, and human-in-the-loop approvals right in the channel.
+- **Microsoft Teams** – Bring agentic workflows to the enterprise, where your org already lives.
+
+🔒 **Early access:** We're onboarding teams now.
+
+👉 **[Request early access →](EARLY_ACCESS_FORM_LINK)**
 
 ## Quick Start
 
@@ -105,10 +135,11 @@ This enables:
 - Agents that ask users for input
 - Tools that render UI
 - Stateful workflows across steps and sessions
+- One agent, deployed across web, mobile, and chat platforms
 
 ## ⭐️ useAgent Hook
 
-The `useAgent` hook is a proper superset of `useCoAgent` and sits directly on AG-UI, giving more control over the agent connection.
+The `useAgent` hook sits directly on AG-UI, giving you full programmatic control over the agent connection.
 
 ```ts
 // Programmatically access and control your agents
@@ -147,7 +178,7 @@ https://github.com/user-attachments/assets/3cfacac0-4ffd-457a-96f9-d7951e4ab7b6
 
 ## 🖥️ AG-UI: The Agent–User Interaction Protocol
 
-Connect agent workflow to user-facing apps, with deep partnerships and 1st-party integrations across the agentic stack—including LangGraph, CrewAI, and more.
+Connect agent workflows to user-facing apps, with deep partnerships and 1st-party integrations across the agentic stack—including LangChain, CrewAI, Mastra, PydanticAI, and more.
 
 [![AG-UI](https://github.com/user-attachments/assets/a625237a-cfc1-45fc-8d0c-637316b81291)](https://go.copilotkit.ai/ag-ui)
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ CopilotKit now lets you deploy the **same agent** to the places your users alrea
 
 ## 🧠 Self-Learning Agents
 
-Most agents are frozen at deploy time. Yours don't have to be.
+Improve your procuct by learning over time.
 
 With **Continuous Learning from Human Feedback (CLHF)**, part of the [CopilotKit Intelligence Platform](https://www.copilotkit.ai/copilotkit-intelligence), agents improve with every interaction:
 

--- a/README.md
+++ b/README.md
@@ -71,24 +71,22 @@ https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3
 - **Shared State** – A synchronized state layer that both agents and UI components can read from and write to in real time.
 - **Human-in-the-Loop** – Lets agents pause execution to request user input, confirmation, or edits before continuing.
 
-https://github.com/user-attachments/assets/55bf6714-62a7-4d5d-9232-07747cc0763b
-
 ## 🧩 Works With Your Stack
 
 One agent backend. Every frontend.
 
 | Platform           | Status       | Get Started                                                 |
 | ------------------ | ------------ | ----------------------------------------------------------- |
-| ⚛️ React / Next.js | ✅ GA        | [Quickstart](https://docs.copilotkit.ai/?ref=github_readme) |
-| 🅰️ Angular         | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/?ref=github_readme) |
-| 💚 Vue             | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/?ref=github_readme) |
-| 📱 React Native    | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/?ref=github_readme) |
+| ⚛️ React / Next.js | ✅ GA        | [Quickstart](https://docs.copilotkit.ai/built-in-agent/quickstart) |
+| 🅰️ Angular         | ✅ Supported | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular) |
+| 💚 Vue             | ✅ Supported | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue) |
+| 📱 React Native    | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/react-native) |
 
 Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit handles the UI layer for each framework.
 
 ## 💬 Beyond the Browser: Slack & Microsoft Teams
 
-Your agents shouldn't be locked inside your web app.
+Your agents can run and generate Generative UI beyond the web app.
 
 CopilotKit now lets you deploy the **same agent** to the places your users already work:
 
@@ -97,7 +95,7 @@ CopilotKit now lets you deploy the **same agent** to the places your users alrea
 
 🔒 **Early access:** We're onboarding teams now.
 
-👉 **[Request early access →](EARLY_ACCESS_FORM_LINK)**
+👉 **[Request early access →](https://go.copilotkit.ai/beyond-the-web-form)**
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3
 - **Generative UI** – Allows agents to generate and update UI components dynamically at runtime based on user intent and agent state.
 - **Shared State** – A synchronized state layer that both agents and UI components can read from and write to in real time.
 - **Human-in-the-Loop** – Lets agents pause execution to request user input, confirmation, or edits before continuing.
+- **Self-Learning** – Agents that continuously improve from user feedback via in-context reinforcement learning (CLHF).
 
 ## 🧩 Works With Your Stack
 
@@ -96,6 +97,21 @@ CopilotKit now lets you deploy the **same agent** to the places your users alrea
 🔒 **Early access:** We're onboarding teams now.
 
 👉 **[Request early access →](https://go.copilotkit.ai/beyond-the-web-form)**
+
+## 🧠 Self-Learning Agents
+
+Most agents are frozen at deploy time. Yours don't have to be.
+
+With **Continuous Learning from Human Feedback (CLHF)**, part of the [CopilotKit Intelligence Platform](https://www.copilotkit.ai/copilotkit-intelligence), agents improve with every interaction:
+
+- **In-context reinforcement learning** – Agents automatically improve from user interactions, no model fine-tuning required.
+- **Automatic prompt augmentation** – Agent behavior adapts based on recent interactions and outcomes.
+- **Per-user adaptation** – Agents learn individual preferences and get better for each user over time.
+- **Threads & persistence** – Full interaction history — generative UI, human-in-the-loop, shared state — captured across sessions.
+
+Available via CopilotKit Cloud or self-hosted.
+
+[Learn more about the Intelligence Platform →](https://www.copilotkit.ai/copilotkit-intelligence)
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit 
 
 ## 💬 Beyond the Browser: Slack & Microsoft Teams
 
-Your agents can run and generate Generative UI beyond the web app.
+Your agents can run and generate Generative UI beyond the web app (**[Learn more](https://www.copilotkit.ai/integrations)**).
 
 CopilotKit now lets you deploy the **same agent** to the places your users already work:
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Available via CopilotKit Cloud or self-hosted.
 
 🔒 **Early access:** We're onboarding teams now.
 
-👉 **[Request early access →](https://www.copilotkit.ai/copilotkit-intelligence)**
+👉 **[Request early access →](https://go.copilotkit.ai/beyond-the-web-form)**
 
 ## Quick Start
 


### PR DESCRIPTION
## What

Updates the README to reflect CopilotKit's expansion beyond React:

- **New "Works With Your Stack" section** — platform table for React/Next.js, Angular, Vue, and React Native
- **New "Beyond the Browser" section** — Slack & Microsoft Teams support with an early access CTA
- Tagline updated to "on any framework, on any surface"
- "Chat UI" feature bullet made framework-neutral (was "React-based")
- useAgent section no longer anchors to the legacy useCoAgent hook
- AG-UI section: LangGraph → LangChain, added Mastra and PydanticAI to named integrations
- New "How it works" bullet: one agent across web, mobile, and chat platforms

## Before merging (draft)

- [ ] Replace `EARLY_ACCESS_FORM_LINK` placeholder with the real early access form URL
- [ ] Point Angular / Vue / React Native quickstart links at their framework-specific docs pages
- [ ] Confirm status labels (GA vs Supported vs Beta) for Angular / Vue / React Native
- [ ] Confirm `npx copilotkit create -f` accepts the new framework values

Draft content also lives in Notion: https://app.notion.com/p/copilotkit/New-GitHub-README-3763aa38185280788920fc81780c8ad6