### PR TITLE
docs(shell-docs): Self-Learning guide + Enterprise Learning self-hosting setup

### DIFF
--- a/showcase/shell-docs/src/components/react/insecure-password-protected.tsx
+++ b/showcase/shell-docs/src/components/react/insecure-password-protected.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+
+interface InsecurePasswordProtectedProps {
+  /**
+   * The gate password. Defaults to `NEXT_PUBLIC_LGC_DOCS_PASSWORD` so a
+   * deployment can gate everything with one env var, but callers
+   * typically pass an explicit per-section password (e.g. early-access
+   * betas) so the section is self-contained.
+   */
+  password?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Insecure, client-side password gate for early-access / not-yet-public
+ * docs content. Ported from the legacy `docs/` site so premium and
+ * early-access sections can live in shell-docs unchanged.
+ *
+ * Intentionally shallow: a single shared password ships in the client
+ * bundle, the unlock is cached in `localStorage`, and it is trivially
+ * bypassable. The goal is to dissuade casual access to content that is
+ * documented but not yet generally available — not to truly secure it
+ * (the content is not sensitive). Falls open (renders children) when no
+ * password is configured, so local/dev builds without the env var are
+ * unaffected.
+ */
+export function InsecurePasswordProtected({
+  password = process.env.NEXT_PUBLIC_LGC_DOCS_PASSWORD,
+  children,
+}: InsecurePasswordProtectedProps) {
+  const [input, setInput] = useState("");
+  const [error, setError] = useState("");
+  const [storedPassword, setStoredPassword] = useState(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("storedPassword") || "";
+    }
+    return "";
+  });
+
+  // No password configured → nothing to gate.
+  if (!password) {
+    return <>{children}</>;
+  }
+
+  // Already unlocked this browser.
+  if (storedPassword === password) {
+    return <>{children}</>;
+  }
+
+  const handleSubmit = (): void => {
+    if (input === password) {
+      setStoredPassword(input);
+      setError("");
+      if (typeof window !== "undefined") {
+        localStorage.setItem("storedPassword", input);
+      }
+    } else {
+      setError("Incorrect password");
+      setInput("");
+    }
+  };
+
+  return (
+    <div className="not-prose my-6 flex flex-col gap-4 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-6">
+      {/* Shallow-by-design notice for anyone reading the source. */}
+      <div className="hidden">
+        This is a very shallow layer of protection, on purpose — it dissuades
+        casual access to not-yet-public content rather than securing it.
+      </div>
+      <div className="space-y-2 text-center">
+        <h3 className="text-lg font-semibold text-[var(--text)]">
+          This content is protected by a password.
+        </h3>
+        <p className="text-sm text-[var(--text-secondary)]">
+          This documents an early-access capability that is not yet publicly
+          available. If you’d like access,{" "}
+          <a
+            href="https://go.copilotkit.ai/earlyaccess"
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            apply for early access
+          </a>
+          . If you’re already in the early-adopter group, enter your password.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="password"
+          autoComplete="off"
+          placeholder="Enter password..."
+          className="w-full rounded-md border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2 text-sm text-[var(--text)]"
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value);
+            setError("");
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              handleSubmit();
+            }
+          }}
+          aria-invalid={!!error}
+          aria-describedby={error ? "cpk-password-error" : undefined}
+        />
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className="shrink-0 rounded-md border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-2 text-sm font-medium text-[var(--text)] transition-colors hover:border-[var(--accent)]"
+        >
+          Submit
+        </button>
+      </div>
+      {error && (
+        <p id="cpk-password-error" className="text-sm text-red-500">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/showcase/shell-docs/src/content/docs/meta.json
+++ b/showcase/shell-docs/src/content/docs/meta.json
@@ -35,6 +35,7 @@
     "premium/threads-explained",
     "premium/observability",
     "premium/self-hosting",
+    "premium/self-learning",
     "threads",
     "---Deploy---",
     "...deploy",

--- a/showcase/shell-docs/src/content/docs/premium/meta.json
+++ b/showcase/shell-docs/src/content/docs/premium/meta.json
@@ -5,6 +5,7 @@
     "intelligence-platform",
     "threads-explained",
     "observability",
-    "self-hosting"
+    "self-hosting",
+    "self-learning"
   ]
 }

--- a/showcase/shell-docs/src/content/docs/premium/self-learning.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/self-learning.mdx
@@ -1,0 +1,115 @@
+---
+title: "Self-Learning"
+icon: "lucide/BrainCircuit"
+description: "Give your agent a memory of how your team actually works. Self-Learning quietly studies real conversations and the actions users take, distills the durable lessons into a shared knowledge base, and lets the agent reuse them — turning yesterday's manual, multi-step workarounds into things it can just do."
+doc_type: explanation
+premium: true
+---
+
+<InsecurePasswordProtected password="cpki-mem-beta">
+
+## An agent that learns how your team works
+
+Your users already know the job. Every product builds up a layer of hard-won, practical knowledge — the workarounds, the conditions that unlock the next step, the multi-step workflows everyone on the team just *knows*. It's the kind of expertise a new hire spends months absorbing, and it's some of the most valuable knowledge your company has.
+
+Today it lives in people's heads and old chat threads, and your agent ships knowing only what fits in its prompt. But that knowledge is being created every single day — in the conversations users have with the agent and the actions they take in your app.
+
+Self-Learning lets your agent pick it up from that everyday use. Instead of staying exactly as capable as the day it launched, it gets better the more your team works — learning your team's workflows by watching how the work *actually* gets done — then runs them for everyone.
+
+## How it works
+
+A learner runs on the Intelligence platform. It reviews conversations and the user actions you record, distills what matters, and makes it available to your agents on their next run. All of this happens automatically. Wiring it into your app comes down to two integration points: a runtime flag that enables Enterprise Learning, and a hook that records the user actions worth learning from.
+
+<Callout type="info" title="This page is about your application code">
+  The learner, the knowledge base, and the scheduling all live on the Intelligence platform. Standing that up — the Helm chart, the worker, the model-provider credentials — is covered in [Self-Hosting Intelligence](/premium/self-hosting). Here we only cover the code in your app.
+</Callout>
+
+## Set it up
+
+### 1. Turn on Intelligence, with learning enabled
+
+On the server, run your agent on an Intelligence runtime and flip a single flag. `enableEnterpriseLearning: true` hands every user-resolved run the platform's built-in tools — recall over the user's past threads, plus read access to the knowledge base the learner maintains.
+
+```ts title="runtime.ts"
+import {
+  CopilotIntelligenceRuntime,
+  CopilotKitIntelligence,
+} from "@copilotkit/runtime/v2";
+
+const intelligence = new CopilotKitIntelligence({
+  apiUrl: process.env.COPILOTKIT_INTELLIGENCE_API_URL!,
+  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+  apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
+  enableEnterpriseLearning: true, // [!code highlight]
+});
+
+const runtime = new CopilotIntelligenceRuntime({
+  agents,
+  intelligence,
+  // Required in Intelligence mode. The resolved user is also how
+  // learning is attributed and recall is scoped — one user never
+  // sees another user's threads.
+  identifyUser: async (req) => ({ userId: await getUserId(req) }),
+});
+```
+
+On the client, point CopilotKit at your runtime and drop in a chat. Conversations flowing through it are picked up by the learner automatically.
+
+```tsx title="app.tsx"
+import { CopilotKitProvider } from "@copilotkit/react-core";
+import { CopilotChat } from "@copilotkit/react-ui";
+
+export function App() {
+  return (
+    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+      <CopilotChat />
+      {/* the rest of your app */}
+    </CopilotKitProvider>
+  );
+}
+```
+
+<Callout type="warn" title="One platform switch is also required">
+  `enableEnterpriseLearning` is the application half. The platform half — `SL_ENABLED` on `app-api` and the self-learning worker — is set when you deploy the chart. Without it, the runtime has nothing to attach to. See [Self-Hosting Intelligence → Enterprise Learning](/premium/self-hosting).
+</Callout>
+
+### 2. Teach it from what your users do
+
+Conversations are only half the story. The richest signal is often a deliberate action a user takes in your UI — the decision, the correction, the workaround they reach for. Record those with one call and the learner reads them alongside the chat history.
+
+```tsx title="incident-form.tsx"
+import { useLearnFromUserActionInCurrentThread } from "@copilotkit/react-core";
+
+function IncidentForm({ order }: { order: Order }) {
+  const learnFromUserAction = useLearnFromUserActionInCurrentThread();
+
+  async function handleSubmit(reason: string) {
+    await createIncident(order.id, { reason });
+
+    // Record what the user did — and, crucially, why.
+    void learnFromUserAction({
+      title: "Filed a damage incident for an order",
+      description: `Reported "${reason}" on order ${order.id}.`,
+      data: { orderId: order.id, reason },
+    });
+  }
+
+  return <IncidentFields onSubmit={handleSubmit} />;
+}
+```
+
+A few things worth knowing:
+
+- **`useLearnFromUserActionInCurrentThread`** binds to the current chat's thread automatically. If you're recording from somewhere outside a chat subtree, reach for [`useLearnFromUserAction`](/reference) instead and pass an explicit `threadId`.
+- Calls are **idempotent-friendly** — a stray double-fire collapses to one event — so you can call it from an event handler without defensive plumbing.
+
+## What you end up with
+
+You haven't built a training pipeline or grown your prompt. You flipped one flag and added a line or two where your users do meaningful work. From there the loop runs itself: the agent watches how your team operates, keeps what matters, and quietly gets better at *your* workflows — so the multi-step things people used to do by hand become things the agent just does.
+
+<Callout type="info" title="Keep going">
+  - [Self-Hosting Intelligence](/premium/self-hosting) — deploy the platform and the self-learning worker.
+  - [Threads](/threads) — the persistent conversations the learner reviews.
+</Callout>
+
+</InsecurePasswordProtected>

--- a/showcase/shell-docs/src/content/snippets/shared/premium/self-hosting.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/premium/self-hosting.mdx
@@ -380,6 +380,120 @@ The chart auto-wires `auth.issuer` to the in-cluster Keycloak service, so leavin
 
 For production self-hosted deployments, leave `keycloak.enabled: false` and point `auth.issuer` at your own IdP.
 
+## Enterprise Learning (self-learning)
+
+<InsecurePasswordProtected password="cpki-mem-beta">
+
+Enterprise Learning lets agent runs use the platform's built-in tools — a sandboxed `bash` tool over a shared, project-scoped **knowledge base** (`/project`) and the calling user's own **thread history** (`/threads`) — and runs a background **self-learning worker** that distills recorded user actions and finished agent runs into that knowledge base on a schedule. The result is an agent that improves over time from how your users actually work.
+
+It is **opt-in** and **off by default**. Turning it on takes two coordinated changes: a flag in your application's runtime, and three pieces of platform configuration in this chart.
+
+<Callout type="info" title="Chart version">
+  Enterprise Learning relies on the `sl-worker` CronJob shipped by the chart. Confirm a `slWorker` block exists in the pulled chart's `values.yaml` before relying on these settings; if it does not, upgrade to a chart version that includes it.
+</Callout>
+
+### 1. Enable it in your runtime (application code)
+
+Construct `CopilotKitIntelligence` with `enableEnterpriseLearning: true`. This attaches the platform's `/mcp` tools to every agent run that resolves a user, uniformly across agent frameworks (via `@ag-ui/mcp-middleware`):
+
+```ts
+const intelligence = new CopilotKitIntelligence({
+  apiUrl: process.env.COPILOTKIT_INTELLIGENCE_API_URL,
+  apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY,
+  enableEnterpriseLearning: true,
+});
+```
+
+The agent's framework must support middleware (expose a `.use()` method). If it does not, the run proceeds without the tools and the runtime logs a warning rather than failing. The flag defaults to `false`, so existing intelligence setups are unaffected until they opt in.
+
+### 2. Enable the platform tools on `app-api`
+
+The `/mcp` endpoint, the annotation connector (which records the learning signal), and the writer-side `/threads` + `/project` paths are gated behind `SL_ENABLED` on the `app-api` service. Set it through the `appApi.env` passthrough in your values file:
+
+```yaml
+appApi:
+  env:
+    - name: SL_ENABLED
+      value: "true" # always quote — Kubernetes rejects non-string env values
+```
+
+Without this, `enableEnterpriseLearning` in your runtime has nothing to attach to: agent runs reach a `/mcp` endpoint that returns `404`, and no user actions are recorded for the worker to learn from.
+
+### 3. Turn on the self-learning worker
+
+The worker is a CronJob that periodically sweeps recorded `user_action` annotations and finished agent runs, then invokes a writer agent (backed by a model provider you choose) to update the knowledge base. Enabling `slWorker` renders the CronJob and runs its pod with `SL_ENABLED=true` automatically — you only need to give it a provider credential:
+
+```yaml
+slWorker:
+  enabled: true # renders the CronJob; the worker pod gets SL_ENABLED=true automatically
+  agentProvider: anthropic # Pi provider id — selects which API-key env var the writer reads
+  # agentModel: "claude-sonnet-4-6"   # optional; empty → the provider's default model
+  env: # inject the provider credential (same shape as appApi.env)
+    - name: ANTHROPIC_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: cpki-sl-provider
+          key: api-key
+```
+
+Create the provider Secret first (or mount it via External Secrets / `selfHostedSecrets`):
+
+```bash
+kubectl create secret generic cpki-sl-provider \
+  --from-literal=api-key='<your provider API key>' \
+  -n copilot-intelligence
+```
+
+`slWorker.agentProvider` selects which credential env var the writer reads: `anthropic → ANTHROPIC_API_KEY`, `openai → OPENAI_API_KEY`, `google → GEMINI_API_KEY`, `groq → GROQ_API_KEY`, and so on. The cloud-IAM providers (`amazon-bedrock`, `google-vertex`) use the ambient AWS / GCP credential chain instead of a key. Match the env var you mount in `slWorker.env` to the provider you set.
+
+<Callout type="warn" title="Provider spend">
+  The writer makes real model-provider calls on every tick that finds work (default every 5 minutes, up to `slWorker.writerMaxTurns` tool-turns per tenant per tick). On an active deployment this is ongoing spend. Tune `slWorker.schedule` and the caps in the configuration table below, or suspend the CronJob when it is not needed:
+
+  ```bash
+  kubectl patch cronjob -n copilot-intelligence \
+    <release>-copilot-intelligence-sl-worker -p '{"spec":{"suspend":true}}'
+  ```
+</Callout>
+
+### Verify
+
+```bash
+# The CronJob exists and is scheduled
+kubectl get cronjob -n copilot-intelligence
+
+# Logs from the most recent sweep
+kubectl logs -n copilot-intelligence \
+  -l app.kubernetes.io/component=sl-worker --tail=50
+
+# Per-tenant cursors advance as work is processed
+kubectl exec -n copilot-intelligence <postgres-pod> -- \
+  psql "$DATABASE_URL" \
+  -c 'SELECT organization_id, project_id, source, last_event_id FROM cpki.sl_cursors;'
+```
+
+A healthy run logs `sl-worker: starting sweep` → `scope discovery complete` → per-scope `scope processed` (with `userActionsCount`, `editCount`, `tokensIn`, `tokensOut`) → `sweep complete`. On a cold install the very first CronJob pod can land in `Error` if it races the migrations Job (the `cpki.sl_annotations` table does not exist yet); it recovers on the next tick once migrations have applied, so a single early failure here is expected and self-healing.
+
+### Configuration
+
+All `slWorker.*` values. The worker only runs when `slWorker.enabled: true` **and** `SL_ENABLED=true` is set on `appApi.env`.
+
+| Key | Description | Default |
+|---|---|---|
+| `slWorker.enabled` | Render the self-learning sweep CronJob (the worker pod runs with `SL_ENABLED=true`) | `false` |
+| `slWorker.schedule` | Cron expression for the sweep | `*/5 * * * *` |
+| `slWorker.agentProvider` | Pi provider id; selects the writer's model provider and which API-key env var it reads | `anthropic` |
+| `slWorker.agentModel` | Writer model id override; empty → the provider's default | `""` |
+| `slWorker.env` | Extra env for the worker pod — mount the provider API-key Secret here (same shape as `appApi.env`) | `[]` |
+| `slWorker.batchCap` | Per-source row cap, applied independently to the `user_actions` and run-event queues, so a mixed tick can hand the writer up to 2× this value | `"100"` |
+| `slWorker.historyCap` | Already-processed user actions passed to the writer as continuity context | `"20"` |
+| `slWorker.safetyLagMs` | Ignore rows newer than this many ms (guards the identity-sequence visibility race) | `"5000"` |
+| `slWorker.writerTimeoutMs` | Wall-clock cap per writer call | `"300000"` |
+| `slWorker.writerMaxTurns` | Hard cap on writer agent tool-turns per tick | `"20"` |
+| `slWorker.activeDeadlineSeconds` | CronJob pod deadline before Kubernetes marks the run failed | `600` |
+| `slWorker.backoffLimit` | Retry count (`0` — the sweep retries failed scopes on the next tick) | `0` |
+
+</InsecurePasswordProtected>
+
 ## Configuration reference
 
 The tables below summarize the most common values. For every option, see `values.yaml` in the pulled chart.

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -32,6 +32,7 @@ import { DemoSource } from "@/components/demo-source";
 import { UnsupportedBox } from "@/components/snippet";
 import { getRegistry } from "@/lib/registry";
 import { PartialLoader } from "@/lib/mdx-registry-loader";
+import { InsecurePasswordProtected } from "@/components/react/insecure-password-protected";
 import { MdxFrameworkOverview } from "@/components/content/landing-pages/mdx-framework-overview";
 import { FrameworkSetup } from "@/lib/setup-concept";
 import {
@@ -259,6 +260,7 @@ export const docsComponents = {
   Card,
   Accordions,
   Accordion,
+  InsecurePasswordProtected,
   PropertyReference,
   OpsPlatformCTA,
   SignupLink,


### PR DESCRIPTION
## What

Documents the self-learning / Enterprise Learning feature in shell-docs, behind the early-access password gate.

- **Ports an insecure password-gate component** from the legacy `docs/` site (`InsecurePasswordProtected`) into shell-docs and registers it for MDX, so premium / early-access content can live here.
- **Self-Hosting Intelligence** — adds a gated **Enterprise Learning** section: the `enableEnterpriseLearning` runtime flag, `SL_ENABLED` on `app-api`, the `sl-worker` CronJob + model-provider secret, a verify block, and a gated `slWorker.*` config table.
- **New "Self-Learning" guide** for app developers (gated) — why it matters, what you get, how it works (high-level), and the runtime-flag + hook setup (`useLearnFromUserAction` / `useLearningContainers`). The learner internals are intentionally out of scope.
- Adds **Self-Learning** to the built-in-agent Premium Features menu (second, after Self-Hosting).

## Notes

- All self-learning content is wrapped in `<InsecurePasswordProtected password="cpki-mem-beta">` (same gate/password as the existing early-access "user memory" content). Only section headings are public, for the TOC.
- Code examples are grounded in the merged `@copilotkit/runtime` v2 API (`CopilotKitIntelligence` + `CopilotIntelligenceRuntime` + `enableEnterpriseLearning`) and the react-core v2 hooks — not invented.

## Verification

- `npm ci` + `tsc --noEmit` (typecheck) ✓
- `next build` ✓ — compiled successfully, 114/114 static pages, no MDX errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)