### PR TITLE
fix(showcase): pin aimock base to 1.28.0 (full-depth fixture recursion)

### DIFF
--- a/showcase/aimock/Dockerfile
+++ b/showcase/aimock/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/copilotkit/aimock:latest
+FROM ghcr.io/copilotkit/aimock:1.28.0
 
 # Depth-organized fixture directories
 COPY shared/ /fixtures/shared/

--- a/showcase/aimock/shared/common.json
+++ b/showcase/aimock/shared/common.json
@@ -5,6 +5,11 @@
   },
   "fixtures": [
     {
+      "_comment": "Starter chat smoke probe greeting. The starter chat rung POSTs {\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]} to a starter's CopilotKit runtime, which proxies to staging aimock running --strict against the baked /fixtures dir. aimock JSON matching is case-sensitive substring .includes(), so the capital-H 'Hello' here is deliberately distinct from the lowercase 'hello' that appears as a substring inside D6 pill prompts — it matches the exact starter probe without shadowing those pills. Placed before 'hello world' to win first-match-by-load-order.",
+      "match": { "userMessage": "Hello" },
+      "response": { "content": "Hello! How can I help you today?" }
+    },
+    {
       "_comment": "Generic greeting — shared across all integrations. Narrowed userMessage from bare 'hello' (substring match) to 'hello world' so it no longer shadows D6 pills whose prompts contain 'hello' as a substring (e.g. langgraph-python headless-simple sends 'Say hello in one short sentence.'). 'hello world' is not used by any current demo pill, so the fixture is effectively a structural placeholder that still serves as a manual-typing fallback.",
       "match": { "userMessage": "hello world" },
       "response": { "content": "Hello! How can I help you today?" }

--- a/showcase/aimock/shared/common.json
+++ b/showcase/aimock/shared/common.json
@@ -5,11 +5,6 @@
   },
   "fixtures": [
     {
-      "_comment": "Starter chat smoke probe greeting. The starter chat rung POSTs {\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]} to a starter's CopilotKit runtime, which proxies to staging aimock running --strict against the baked /fixtures dir. aimock JSON matching is case-sensitive substring .includes(), so the capital-H 'Hello' here is deliberately distinct from the lowercase 'hello' that appears as a substring inside D6 pill prompts — it matches the exact starter probe without shadowing those pills. Placed before 'hello world' to win first-match-by-load-order.",
-      "match": { "userMessage": "Hello" },
-      "response": { "content": "Hello! How can I help you today?" }
-    },
-    {
       "_comment": "Generic greeting — shared across all integrations. Narrowed userMessage from bare 'hello' (substring match) to 'hello world' so it no longer shadows D6 pills whose prompts contain 'hello' as a substring (e.g. langgraph-python headless-simple sends 'Say hello in one short sentence.'). 'hello world' is not used by any current demo pill, so the fixture is effectively a structural placeholder that still serves as a manual-typing fallback.",
       "match": { "userMessage": "hello world" },
       "response": { "content": "Hello! How can I help you today?" }


### PR DESCRIPTION
## Summary

Pin the showcase aimock image base to `ghcr.io/copilotkit/aimock:1.28.0` (was bare `:latest`).

The repo bakes nested `d4/` and `d6/` fixture directories into the image, but bare `:latest`'s fixture loader had shallow recursion and silently skipped the nested dirs. 1.28.0 has full-depth recursion — verified to load all 7165 fixtures including d4/d6.

> **Note:** This PR previously also added a shared "Hello" greeting fixture, which collided with the pre-existing scoped "Hello" fixtures in the d4 chat.json files and failed the Validate Showcase shared-vs-scoped collision check. That fixture has been reverted; the net change here is the Dockerfile pin only. The starter-smoke chat rung is greened separately in #5277 by repointing the probe at the existing collision-free "hello world" shared fixture.

## Proof

- Validate Showcase collision validator: **733/733 pass** (the reverted "Hello" fixture no longer collides).
- Net diff vs `main`: `showcase/aimock/Dockerfile` only (1 line).

## Test plan

- [ ] CI `Validate Showcase` green
- [ ] Post-deploy: aimock image loads full d4/d6 fixture set