### PR TITLE
fix(showcase): green starter-smoke chat rung via collision-free "hello world" fixture

### DIFF
--- a/showcase/harness/src/probes/drivers/starter-smoke.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.ts
@@ -233,14 +233,24 @@ const FALLBACK_CHAT_AGENT_ID = "default";
  * `packages/runtime/src/v2/runtime/__tests__/express-single-sse.test.ts`:
  * `{threadId, runId, messages, state, tools, context, forwardedProps}` — NO
  * single-route envelope wrapper (the path encodes the route on multi-route).
- * A single user "Hello" turn; the runtime answers with an AG-UI SSE stream.
- * The driver asserts only the stream SHAPE it requires (≥1 text-content delta
- * + terminal RUN_FINISHED + no RUN_ERROR), never a specific reply text.
+ * A single user "hello world" turn; the runtime answers with an AG-UI SSE
+ * stream. The driver asserts only the stream SHAPE it requires (≥1
+ * text-content delta + terminal RUN_FINISHED + no RUN_ERROR), never a specific
+ * reply text.
+ *
+ * The user message is "hello world" (NOT bare "Hello") so it matches the
+ * collision-free shared/context-less fixture in
+ * `showcase/aimock/shared/common.json` rather than the per-integration scoped
+ * "Hello" fixtures in `showcase/aimock/d4/<integration>/chat.json`. aimock's
+ * matcher is a case-sensitive substring `.includes()`; a shared fixture whose
+ * `userMessage` duplicates a scoped one fails the Validate Showcase
+ * shared-vs-scoped collision check, so the probe targets the existing
+ * "hello world" shared greeting (no scoped fixture uses that phrase).
  */
 const CHAT_RUN_BODY = JSON.stringify({
   threadId: "starter-smoke-thread",
   runId: "starter-smoke-run",
-  messages: [{ id: "u1", role: "user", content: "Hello" }],
+  messages: [{ id: "u1", role: "user", content: "hello world" }],
   state: {},
   tools: [],
   context: [],


### PR DESCRIPTION
## Summary

- The starter-smoke chat rung (`showcase/harness/src/probes/drivers/starter-smoke.ts`) POSTed an AG-UI run with user message **"Hello"**. There is **no shared (context-less) aimock fixture** for "Hello" — only per-integration **scoped** "Hello" fixtures in `showcase/aimock/d4/<integration>/chat.json` that match only under their `X-AIMock-Context` header. The starter probe doesn't set that header, so against the deployed staging aimock (strict mode) "Hello" returns `503 no_fixture_match` and the chat rung's `verifyChatStream` never sees `TEXT_MESSAGE_CONTENT` / `RUN_FINISHED`.
- This repoints the probe at **"hello world"**, which matches the **existing collision-free shared greeting** in `showcase/aimock/shared/common.json`. No fixtures are added or changed.
- No new shared-vs-scoped collision: **no d4/d6 scoped fixture uses "hello world"**, so the Validate Showcase collision check stays green.

## Why this approach

Preferred no-collision path: reuse the pre-existing shared "hello world" greeting rather than add a new shared fixture. Adding a shared "Hello" (the original attempt, PR #5276) collides with the 18 scoped d4 "Hello" fixtures and fails Validate Showcase. "hello world" already exists, already streams a valid greeting, and is used by zero scoped fixtures.

## Proof

- **aimock local probe** (shared fixtures only, `--strict`): POST `{messages:[{role:user,content:"hello world"}]}` → HTTP 200, streamed `chat.completion.chunk`s with content deltas `"Hello! How can I help you today?"` + terminal `finish_reason:"stop"` + `[DONE]`. The runtime maps these to `TEXT_MESSAGE_CONTENT` + `RUN_FINISHED` (no `RUN_ERROR`) — the exact shape the chat rung asserts.
- Same probe with bare **"Hello"** against shared-only strict → HTTP 503 `no_fixture_match` (root cause confirmed).
- `showcase/scripts` validator (Validate Showcase): **733/733 pass** — no shared-vs-scoped collision.
- `showcase/harness` starter-smoke unit tests: **42/42 pass**.

## Test plan

- [ ] CI `Validate Showcase` green
- [ ] CI showcase-harness build/tests green
- [ ] Post-deploy: starter-smoke chat rung flips green on the dashboard