### PR TITLE
feat(showcase): two-miss tolerance for soft probe errorClass on dashboard (pool-fleet step C)

### DIFF
--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -1586,6 +1586,152 @@ describe("buildStarterBadge — 5-state cell vocabulary (§d)", () => {
   });
 });
 
+describe("buildStarterBadge — two-miss tolerance for SOFT errorClass (pool-fleet step C)", () => {
+  // The starter-smoke driver keys failures by class (mirror of harness
+  // `StarterFailureClass`): SOFT = `transport-error` / `aborted` (transient
+  // transport / cold-start / abort hiccups), HARD = `smoke-failed` (a real
+  // HTTP-level content regression). A SOFT miss must NOT flip the cell red on
+  // the FIRST occurrence — the producer's `fail_count` (the persisted
+  // consecutive-red counter: 1 on green→red, incremented on sustained red,
+  // 0 on red→green) gates the flip: tolerate while `fail_count <= 1`, flip on
+  // `fail_count >= 2` (two consecutive misses). HARD failures flip immediately
+  // regardless of `fail_count`.
+  //
+  // A tolerated soft miss renders AMBER `~` (degraded), NOT green: the probe
+  // literally just failed, so claiming a green ✓ would be a false-green lie
+  // (the codebase guards against false-green everywhere). Amber says
+  // "transient, not yet actionable" — distinct from both the flap-to-red and
+  // the dishonest green.
+
+  function softRedRow(
+    errorClass: "transport-error" | "aborted",
+    failCount: number,
+  ): StatusRow {
+    return row("starter:agno/agent", "starter", "red", {
+      signal: { errorClass },
+      fail_count: failCount,
+      first_failure_at: FRESH_OBSERVED_AT,
+    });
+  }
+
+  it("(a) single SOFT transport-error miss (fail_count=1) is TOLERATED — does NOT flip red", () => {
+    const b = buildStarterBadge(
+      "agent",
+      true,
+      softRedRow("transport-error", 1),
+      NOW,
+      "live",
+    );
+    expect(b.tone).not.toBe("red");
+    expect(b.label).not.toBe("✗");
+    // Tolerated → amber `~`, not a dishonest green ✓.
+    expect(b.tone).toBe("amber");
+    expect(b.label).toBe("~");
+  });
+
+  it("(a') single SOFT aborted miss (fail_count=1) is TOLERATED — does NOT flip red", () => {
+    const b = buildStarterBadge(
+      "agent",
+      true,
+      softRedRow("aborted", 1),
+      NOW,
+      "live",
+    );
+    expect(b.tone).toBe("amber");
+    expect(b.label).toBe("~");
+  });
+
+  it("(a'') a SOFT first failure with fail_count=0 (legacy/edge) is also tolerated (<= 1)", () => {
+    // fail_count is 1 on the first green→red tick, but guard the boundary: a
+    // legacy/edge row reporting 0 must still be treated as a single soft miss.
+    const b = buildStarterBadge(
+      "agent",
+      true,
+      softRedRow("transport-error", 0),
+      NOW,
+      "live",
+    );
+    expect(b.tone).toBe("amber");
+    expect(b.label).toBe("~");
+  });
+
+  it("(b) TWO consecutive SOFT misses (fail_count=2) FLIP to red ✗", () => {
+    const b = buildStarterBadge(
+      "agent",
+      true,
+      softRedRow("transport-error", 2),
+      NOW,
+      "live",
+    );
+    expect(b.tone).toBe("red");
+    expect(b.label).toBe("✗");
+  });
+
+  it("(b') three+ consecutive SOFT misses (fail_count=3) stay red ✗", () => {
+    const b = buildStarterBadge(
+      "agent",
+      true,
+      softRedRow("aborted", 3),
+      NOW,
+      "live",
+    );
+    expect(b.tone).toBe("red");
+    expect(b.label).toBe("✗");
+  });
+
+  it("(c) a HARD smoke-failed miss FLIPS immediately (fail_count=1, no tolerance)", () => {
+    const hard = row("starter:agno/agent", "starter", "red", {
+      signal: { errorClass: "smoke-failed" },
+      fail_count: 1,
+      first_failure_at: FRESH_OBSERVED_AT,
+    });
+    const b = buildStarterBadge("agent", true, hard, NOW, "live");
+    expect(b.tone).toBe("red");
+    expect(b.label).toBe("✗");
+  });
+
+  it("(d) a SOFT miss followed by a GREEN tick renders green (producer reset fail_count→0)", () => {
+    // After recovery the producer rewrites state→green and fail_count→0. The
+    // dashboard reads the recovered row directly; the soft-miss counter is
+    // gone, so the cell renders a clean green ✓. (No dashboard-side counter to
+    // reset — the producer owns the consecutive-failure count.)
+    const recovered = row("starter:agno/agent", "starter", "green", {
+      signal: {},
+      fail_count: 0,
+      first_failure_at: null,
+    });
+    const b = buildStarterBadge("agent", true, recovered, NOW, "live");
+    expect(b.tone).toBe("green");
+    expect(b.label).toBe("✓");
+  });
+
+  it("a red row with NO errorClass flips immediately (tolerance only softens EXPLICIT soft classes)", () => {
+    // Conservative: we only soften when the producer explicitly tags the
+    // failure transient. An untagged red is treated as a hard fail (preserves
+    // the pre-existing red-row behaviour).
+    const untagged = row("starter:agno/agent", "starter", "red", {
+      signal: {},
+      fail_count: 1,
+    });
+    const b = buildStarterBadge("agent", true, untagged, NOW, "live");
+    expect(b.tone).toBe("red");
+    expect(b.label).toBe("✗");
+  });
+
+  it("tolerance never applies to an UNSUPPORTED column (🚫 wins over soft red)", () => {
+    const b = buildStarterBadge(
+      "agent",
+      false,
+      softRedRow("transport-error", 1),
+      NOW,
+      "live",
+    );
+    expect(b.label).toBe("🚫");
+    expect(b.tone).not.toBe("red");
+    expect(b.tone).not.toBe("amber");
+  });
+});
+
 describe("starter rows are informational — excluded from resolveCell rollup", () => {
   it("a red starter row does NOT make the feature-cell rollup red", () => {
     // resolveCell only reads health + e2e (+ informational badges). A starter

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -779,6 +779,86 @@ export function starterIsSupported(columnSlug: string): boolean {
   return STARTER_COLUMNS.has(columnSlug);
 }
 
+/* ------------------------------------------------------------------ */
+/*  Starter failure-class taxonomy + two-miss tolerance (pool-fleet C) */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Keyed starter-failure taxonomy — the DASHBOARD-side mirror of the harness
+ * `StarterFailureClass` in
+ * `showcase/harness/src/probes/drivers/starter-smoke.ts`. The starter-smoke
+ * driver stamps `errorClass` onto the `signal` of every red `starter:<slug>`
+ * aggregate and `starter:<slug>/<level>` row.
+ *
+ * WHY MIRRORED, NOT IMPORTED: the dashboard imports only `@/*` and never reaches
+ * across the package boundary into harness source at runtime (same rule that
+ * makes `STARTER_COLUMNS` / `CATALOG_TO_D5_KEY` / the comm-error contract local
+ * copies of harness producer constants). The
+ * `starter-error-class-drift.test.ts` lint test guards the two against drift.
+ *
+ * SOFT vs HARD split (the whole point of step C):
+ *   - SOFT (`transport-error`, `aborted`): a transient transport / cold-start
+ *     wake / external-abort hiccup. A SINGLE soft miss must NOT flip the cell
+ *     red — that would flap the dashboard on infra noise. It is tolerated until
+ *     a SECOND consecutive soft miss confirms the failure.
+ *   - HARD (`smoke-failed`): a real HTTP-level content regression. Flips the
+ *     cell red IMMEDIATELY — no tolerance.
+ */
+export const STARTER_FAILURE_CLASSES = [
+  "transport-error",
+  "smoke-failed",
+  "aborted",
+] as const;
+
+/** A single keyed starter-failure class. Mirror of harness `StarterFailureClass`. */
+export type StarterFailureClass = (typeof STARTER_FAILURE_CLASSES)[number];
+
+/**
+ * SOFT (transient) failure classes that earn two-miss tolerance. `smoke-failed`
+ * is deliberately ABSENT — a real content regression is a hard red.
+ */
+const SOFT_STARTER_FAILURE_CLASSES: ReadonlySet<StarterFailureClass> = new Set([
+  "transport-error",
+  "aborted",
+]);
+
+/** Type guard for a valid StarterFailureClass. */
+export function isStarterFailureClass(
+  value: unknown,
+): value is StarterFailureClass {
+  return (
+    typeof value === "string" &&
+    (STARTER_FAILURE_CLASSES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Extract the keyed `errorClass` from a starter row's `signal` blob, or
+ * `undefined` when none is present / the value is unrecognized. The driver
+ * writes `errorClass` at the top level of both the aggregate
+ * (`StarterSmokeAggregateSignal`) and per-level (`StarterSmokeLevelSignal`)
+ * signal shapes. An unrecognized / malformed value decodes to `undefined`
+ * (fail-safe: the row is treated as an untagged failure → hard flip, never a
+ * tolerated soft miss on a value we don't understand).
+ */
+export function starterErrorClassFromSignal(
+  signal: unknown,
+): StarterFailureClass | undefined {
+  if (signal === null || typeof signal !== "object") return undefined;
+  const raw = (signal as Record<string, unknown>).errorClass;
+  return isStarterFailureClass(raw) ? raw : undefined;
+}
+
+/**
+ * The consecutive-miss count below which a SOFT failure is tolerated. The
+ * harness `status-writer` maintains `fail_count` as the persisted
+ * consecutive-red counter (1 on green→red, incremented on sustained red, 0 on
+ * red→green), so `fail_count <= 1` is "this is the FIRST red tick" and
+ * `fail_count >= 2` is "two+ consecutive misses — confirmed". A SOFT failure
+ * flips red only once the count crosses this threshold.
+ */
+const SOFT_MISS_TOLERANCE_THRESHOLD = 2;
+
 /**
  * Resolve the `starter:<columnSlug>/<level>` row for one starter sub-cell.
  *
@@ -833,6 +913,33 @@ const STARTER_LEVEL_DESCRIPTION: Readonly<Record<StarterLevel, string>> = {
  * path supplies the same staleness downgrade + tooltip machinery as every
  * other badge; the per-level descriptor is appended to the tooltip.
  */
+/**
+ * Apply two-miss tolerance to a starter row: a red row keyed with a SOFT
+ * failure class (`transport-error` / `aborted`) whose `fail_count` is below
+ * `SOFT_MISS_TOLERANCE_THRESHOLD` is downgraded to `degraded` (amber `~`) so a
+ * single transient miss does not flip the cell red. Everything else — a
+ * non-red row, a HARD (`smoke-failed`) or untagged red, or a soft red at/over
+ * the threshold — passes through unchanged.
+ *
+ * Only `.state` is rewritten (mirrors `buildBadge`'s stale-green fold); the
+ * spread preserves `fail_count`, `first_failure_at`, `observed_at`, and the
+ * `signal` blob so drilldown metadata is intact and a downstream reader of
+ * `.row.state` sees `degraded` (agreeing with the amber tone), not a latent
+ * false-red.
+ */
+function toleratedSoftMissRow(row: StatusRow | null): StatusRow | null {
+  if (!row || row.state !== "red") return row;
+  const errorClass = starterErrorClassFromSignal(row.signal);
+  if (
+    errorClass === undefined ||
+    !SOFT_STARTER_FAILURE_CLASSES.has(errorClass)
+  ) {
+    return row;
+  }
+  if (row.fail_count >= SOFT_MISS_TOLERANCE_THRESHOLD) return row;
+  return { ...row, state: "degraded" };
+}
+
 export function buildStarterBadge(
   level: StarterLevel,
   isSupported: boolean,
@@ -854,9 +961,20 @@ export function buildStarterBadge(
       row: null,
     };
   }
+  // Two-miss tolerance (pool-fleet step C): a red row whose failure is keyed
+  // SOFT (`transport-error` / `aborted`) and whose consecutive-miss count has
+  // NOT yet reached the threshold is TOLERATED — we downgrade it to `degraded`
+  // so it renders amber `~` ("transient, not yet actionable") instead of
+  // flapping the cell red on a single transport hiccup. HARD (`smoke-failed`)
+  // and untagged failures, and soft failures at/over the threshold, pass
+  // through unchanged and flip red. The downgrade rewrites ONLY `.state` (same
+  // pattern as `buildBadge`'s stale-green→degraded fold) so the connection,
+  // tooltip, and drilldown signal are all preserved; the amber tooltip then
+  // honestly reports a stale/degraded surface rather than a green ✓.
+  const tolerated = toleratedSoftMissRow(row);
   const base = buildBadge(
     "starter",
-    row,
+    tolerated,
     now,
     STARTER_STALE_AFTER_MS,
     connection,

--- a/showcase/shell-dashboard/src/lib/starter-error-class-drift.test.ts
+++ b/showcase/shell-dashboard/src/lib/starter-error-class-drift.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Cross-package contract drift test — the dashboard's hand-copied starter
+ * FAILURE-CLASS taxonomy vs the authoritative harness `StarterFailureClass`.
+ *
+ * WHY THIS EXISTS: the dashboard carries a STRUCTURAL COPY of the harness
+ * starter-smoke `errorClass` taxonomy (`STARTER_FAILURE_CLASSES`,
+ * `StarterFailureClass`) in `live-status.ts`, because it imports only `@/*` and
+ * never reaches across the package boundary into harness source at runtime
+ * (same rule that makes `STARTER_COLUMNS` a local copy of a harness producer
+ * constant, and the comm-error contract a local mirror guarded by
+ * `commError-contract-drift.test.ts`). The harness OWNS the producer side that
+ * stamps `errorClass` onto starter rows; the dashboard mirrors the read
+ * vocabulary so its two-miss tolerance (pool-fleet step C) can classify
+ * soft-vs-hard. If the harness adds / renames / removes a failure class, this
+ * test reds so the soft-vs-hard split can never silently diverge.
+ *
+ * The harness lives in a SEPARATE npm workspace (`showcase/harness`), so the
+ * dashboard cannot import across the package boundary. We parse the harness
+ * source via `fs` (mirroring `commError-contract-drift.test.ts` and
+ * `starter-column-equality.test.ts`), reading the authoritative
+ * `StarterFailureClass` union members directly.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { STARTER_FAILURE_CLASSES } from "./live-status";
+
+const HARNESS_STARTER_SMOKE_FILE = resolve(
+  __dirname,
+  "../../../harness/src/probes/drivers/starter-smoke.ts",
+);
+
+function harnessSource(): string {
+  return readFileSync(HARNESS_STARTER_SMOKE_FILE, "utf8");
+}
+
+/**
+ * Parse the string-literal members of the harness `StarterFailureClass` union.
+ * Throws if the block can't be located so a shape change is loud, not a silent
+ * pass.
+ */
+function parseHarnessClasses(): string[] {
+  const src = harnessSource();
+  const block = src.match(/export type StarterFailureClass\s*=([\s\S]+?);/);
+  if (!block || !block[1]) {
+    throw new Error(
+      "drift parser: could not locate `export type StarterFailureClass` union in " +
+        "harness starter-smoke.ts — if the source shape changed, update this regex.",
+    );
+  }
+  const classes = Array.from(block[1].matchAll(/"([a-z-]+)"/g)).map(
+    (m) => m[1] as string,
+  );
+  if (classes.length === 0) {
+    throw new Error(
+      "drift parser: located the StarterFailureClass union but found no quoted " +
+        "members — the source shape changed; update this regex.",
+    );
+  }
+  return classes;
+}
+
+describe("starter errorClass contract drift (dashboard mirror vs harness)", () => {
+  it("STARTER_FAILURE_CLASSES exactly matches the harness StarterFailureClass union (set-equal)", () => {
+    const harness = new Set(parseHarnessClasses());
+    const dashboard = new Set<string>(STARTER_FAILURE_CLASSES);
+    // Set-equality both directions: a harness-only class (added upstream) and a
+    // dashboard-only class (stale local copy) must BOTH red this test.
+    expect([...dashboard].sort()).toEqual([...harness].sort());
+  });
+
+  it("the soft/hard split the tolerance relies on is present in the harness source", () => {
+    const harness = new Set(parseHarnessClasses());
+    // The two-miss tolerance hinges on these exact spellings — if any of them
+    // is renamed upstream, the soft classifier in live-status.ts goes stale.
+    expect(harness.has("transport-error")).toBe(true); // SOFT
+    expect(harness.has("aborted")).toBe(true); // SOFT
+    expect(harness.has("smoke-failed")).toBe(true); // HARD
+  });
+});


### PR DESCRIPTION
## Summary

Wires the starter-smoke probe's keyed `errorClass` into the dashboard cell-state flip logic (`buildStarterBadge` in `live-status.ts`) so transient SOFT failures get **two-miss tolerance**, reducing dashboard flapping on transport hiccups.

- **SOFT** (`transport-error`, `aborted`): a *single* miss is tolerated — the cell renders **amber `~`** instead of flipping red. Flips red only on a **second consecutive** miss.
- **HARD** (`smoke-failed`): flips red **immediately**, no tolerance.
- A soft miss followed by a green tick renders a clean green ✓ (recovery).

## How the consecutive-miss count works (no new dashboard state)

`errorClass` was previously unused on the dashboard. The flip gate reuses the **producer-maintained `fail_count`** — the harness `status-writer`'s persisted consecutive-red counter (`1` on green→red, incremented on sustained red, `0` on red→green). So `resolveCell`/`buildStarterBadge` stay a **pure function of the current row**: there is no dashboard-side counter to thread or reset. Tolerance is applied as a `state` → `degraded` downgrade inside `buildStarterBadge` (the same additive pattern as the existing stale-green→degraded fold), so the connection/tooltip/drilldown-signal are all preserved and a `.row.state` reader sees `degraded` (agreeing with the amber tone), never a latent false-red.

Threshold: `fail_count >= 2` flips; `fail_count <= 1` tolerates.

## errorClass values used (soft/hard split)

Mirror of the harness `StarterFailureClass` union in `showcase/harness/src/probes/drivers/starter-smoke.ts`:

| class | split | meaning |
|---|---|---|
| `transport-error` | **SOFT** | timeout / cold-start wake / connection failure |
| `aborted` | **SOFT** | external-abort / outer-timeout |
| `smoke-failed` | **HARD** | real HTTP-level content regression |

Added as a dashboard-side mirror `STARTER_FAILURE_CLASSES` (the dashboard imports only `@/*` and cannot reach across the package boundary), guarded by a new **`starter-error-class-drift.test.ts`** set-equality lint against the harness source — mirroring the existing `commError-contract-drift.test.ts` pattern.

## Semantics chosen / ambiguity flagged (conservative defaults)

These were genuinely ambiguous; the most conservative sensible behavior was chosen and is flagged here for review:

1. **A tolerated soft miss renders AMBER `~`, NOT green.** The probe literally just failed, so claiming a green ✓ would be a false-green lie (the codebase guards against false-green everywhere). Amber says "transient, not yet actionable" — distinct from both the flap-to-red and a dishonest green.
2. **Tolerance applies ONLY to an *explicit* soft `errorClass`.** A red row with **no** `errorClass` (or an unrecognized value) flips immediately as before — we only soften when the producer explicitly tags the failure transient. This preserves all pre-existing red-row tests.
3. **`fail_count <= 1` (not strictly `== 1`) is tolerated** to guard the legacy/edge boundary where a first failure reports `0`.
4. **Unsupported columns are unaffected** — the 🚫 mapping-derived state still wins over any row data.

## Test plan (red → green)

- [x] RED first: the 3 single-soft-miss tolerance assertions failed against current `main` (soft single miss flipped red); the 6 behavior-preserving assertions passed.
- [x] GREEN after implementation: all 9 new tests pass.
- [x] New drift guard `starter-error-class-drift.test.ts` passes (set-equal vs harness `StarterFailureClass`).
- [x] Full dashboard vitest suite: **922 passed, 1 skipped (59 files)** — incl. `STATUS_LIST_FIELDS` guard, comm-error contract tests, and all pre-existing starter-badge tests.
- [x] `tsc --noEmit` clean.

## Reconciliation with peer "speedup" work

No speedup-owned symbols were modified: `summarizeSignal`, `STATUS_LIST_FIELDS`, the `rowsAreNoop` signal-presence clause, and `extractSignalFields` (which lives in `cell-drilldown.tsx`, not `live-status.ts`) are all untouched. The tolerance logic is fully self-contained (`toleratedSoftMissRow` + the taxonomy mirror) and layers onto the existing badge path. The diff is `live-status.ts` (+119 additive), its test file, and one new drift test.