### PR TITLE
fix(showcase): send X-AIMock-Context from starter-smoke chat probe (match scoped fixtures)

### DIFF
--- a/showcase/harness/src/probes/drivers/starter-smoke.test.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.test.ts
@@ -175,6 +175,13 @@ function fakeFetch(opts: {
   seenUrls?: Partial<
     Record<"health" | "agent" | "chat" | "interaction", string>
   >;
+  // Captures the request headers each level was fetched with (assertion hook).
+  // Headers are normalised to a lowercase-keyed plain object so a test can
+  // assert the chat rung carries `x-aimock-context` regardless of the casing
+  // the driver sent.
+  seenHeaders?: Partial<
+    Record<"health" | "agent" | "chat" | "interaction", Record<string, string>>
+  >;
   // Invoked at the TOP of each fetch (before any response is built), passed
   // the resolved level and the running fetch count. Lets a test fire a
   // mid-flight external abort exactly when the FIRST fetch lands so the
@@ -205,6 +212,24 @@ function fakeFetch(opts: {
     }
 
     if (opts.seenUrls) opts.seenUrls[level] = href;
+    if (opts.seenHeaders) {
+      const normalised: Record<string, string> = {};
+      const rawHeaders = init?.headers;
+      if (rawHeaders) {
+        // The driver passes a plain object literal for the chat rung; normalise
+        // its keys to lowercase so the assertion is casing-agnostic.
+        const entries =
+          rawHeaders instanceof Headers
+            ? [...rawHeaders.entries()]
+            : Array.isArray(rawHeaders)
+              ? rawHeaders
+              : Object.entries(rawHeaders);
+        for (const [k, v] of entries) {
+          normalised[k.toLowerCase()] = String(v);
+        }
+      }
+      opts.seenHeaders[level] = normalised;
+    }
 
     callCount += 1;
     opts.onFetch?.(level, callCount);
@@ -732,6 +757,115 @@ describe("starterSmokeDriver", () => {
     );
     // Path-based: NO single-route envelope POST to bare `/api/copilotkit`.
     expect(seenUrls.chat!.endsWith("/api/copilotkit")).toBe(false);
+  });
+
+  it("chat POST carries X-AIMock-Context = column slug (direct map: agno)", async () => {
+    // The scoped per-integration "Hello" fixture
+    // (`showcase/aimock/d4/agno/chat.json` → `{userMessage:"Hello",
+    // context:"agno"}`) only matches under aimock strict mode when the request
+    // carries `X-AIMock-Context: agno`. The chat POST must send the column slug
+    // as that header (the SAME value the integration's playwright.config.ts
+    // injects), or staging aimock 503s "no fixture matched". agno is a DIRECT
+    // map (starter slug === column slug === context).
+    const { writer } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenHeaders: Partial<
+      Record<
+        "health" | "agent" | "chat" | "interaction",
+        Record<string, string>
+      >
+    > = {};
+    await driver.run(mkCtx(fakeFetch({ seenHeaders }), writer), {
+      key: "starter_smoke:starter-agno",
+      name: "starter-agno",
+      publicUrl: "https://starter-agno.up.railway.app",
+    });
+    expect(seenHeaders.chat?.["x-aimock-context"]).toBe("agno");
+  });
+
+  it("chat POST carries X-AIMock-Context = COLUMN slug, not the starter slug (drift map: langgraph-js → langgraph-typescript)", async () => {
+    // The trust-critical skew case: the probe slug is `langgraph-js` but the
+    // fixture/playwright context is `langgraph-typescript`. The chat POST must
+    // send the REMAPPED column slug, not the raw starter slug — sending
+    // `langgraph-js` would 503 on staging (no such fixture context).
+    const { writer } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenHeaders: Partial<
+      Record<
+        "health" | "agent" | "chat" | "interaction",
+        Record<string, string>
+      >
+    > = {};
+    await driver.run(mkCtx(fakeFetch({ seenHeaders }), writer), {
+      key: "starter_smoke:starter-langgraph-js",
+      name: "starter-langgraph-js",
+      publicUrl: "https://starter-langgraph-js.up.railway.app",
+    });
+    expect(seenHeaders.chat?.["x-aimock-context"]).toBe("langgraph-typescript");
+    // It must NOT send the un-remapped starter slug.
+    expect(seenHeaders.chat?.["x-aimock-context"]).not.toBe("langgraph-js");
+  });
+
+  it("chat POST carries X-AIMock-Context = google-adk for the adk drift map", async () => {
+    // Second skew: probe slug `adk` → column/context `google-adk`.
+    const { writer } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenHeaders: Partial<
+      Record<
+        "health" | "agent" | "chat" | "interaction",
+        Record<string, string>
+      >
+    > = {};
+    await driver.run(mkCtx(fakeFetch({ seenHeaders }), writer), {
+      key: "starter_smoke:starter-adk",
+      name: "starter-adk",
+      publicUrl: "https://starter-adk.up.railway.app",
+    });
+    expect(seenHeaders.chat?.["x-aimock-context"]).toBe("google-adk");
+  });
+
+  it("the X-AIMock-Context header is sent ONLY on the chat POST, never on the GET rungs", async () => {
+    // The browser sends the context only on the chat turn; the GET rungs hit
+    // the runtime `/info` route + the app shell, not aimock. Sending the header
+    // on the GETs would be a needless deviation from what the browser does.
+    const { writer } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenHeaders: Partial<
+      Record<
+        "health" | "agent" | "chat" | "interaction",
+        Record<string, string>
+      >
+    > = {};
+    await driver.run(mkCtx(fakeFetch({ seenHeaders }), writer), {
+      key: "starter_smoke:starter-mastra",
+      name: "starter-mastra",
+      publicUrl: "https://starter-mastra.up.railway.app",
+    });
+    expect(seenHeaders.chat?.["x-aimock-context"]).toBe("mastra");
+    expect(seenHeaders.health?.["x-aimock-context"]).toBeUndefined();
+    expect(seenHeaders.agent?.["x-aimock-context"]).toBeUndefined();
+    expect(seenHeaders.interaction?.["x-aimock-context"]).toBeUndefined();
+  });
+
+  it("chat POST still carries Content-Type + Accept alongside X-AIMock-Context", async () => {
+    // Adding the context header must not drop the existing chat negotiation
+    // headers (JSON body + event-stream Accept).
+    const { writer } = mkWriter();
+    const driver = createStarterSmokeDriver();
+    const seenHeaders: Partial<
+      Record<
+        "health" | "agent" | "chat" | "interaction",
+        Record<string, string>
+      >
+    > = {};
+    await driver.run(mkCtx(fakeFetch({ seenHeaders }), writer), {
+      key: "starter_smoke:starter-agno",
+      name: "starter-agno",
+      publicUrl: "https://starter-agno.up.railway.app",
+    });
+    expect(seenHeaders.chat?.["content-type"]).toBe("application/json");
+    expect(seenHeaders.chat?.["accept"]).toBe("text/event-stream");
+    expect(seenHeaders.chat?.["x-aimock-context"]).toBe("agno");
   });
 
   it("health rung uses GET /api/copilotkit/info and reds on non-2xx", async () => {

--- a/showcase/harness/src/probes/drivers/starter-smoke.ts
+++ b/showcase/harness/src/probes/drivers/starter-smoke.ts
@@ -411,6 +411,20 @@ export function createStarterSmokeDriver(
             timeoutMs,
             now: ctx.now,
             abortSignal: ctx.abortSignal,
+            // The scoped per-integration "Hello" chat fixtures in
+            // `showcase/aimock/d4/<integration>/chat.json` only match when the
+            // request carries `X-AIMock-Context:<context>` — and that context
+            // token IS the dashboard column slug (verified against each
+            // integration's `showcase/integrations/<col>/playwright.config.ts`
+            // `extraHTTPHeaders["X-AIMock-Context"]` and the fixture's
+            // `match.context`). The local browser e2e passes only because
+            // Playwright injects this header, forwarded by the integration's
+            // HeaderForwardingMiddleware to aimock. A raw `fetch()` that omits
+            // it 503s under aimock strict mode ("no fixture matched"). Send the
+            // column slug as the context so the chat rung matches the same
+            // scoped fixture the browser does. Only the chat POST carries it
+            // (matching the browser); the GET rungs never reach aimock.
+            aimockContext: columnSlug,
           });
         }
 
@@ -542,8 +556,18 @@ async function probeLevel(opts: {
   timeoutMs: number;
   now: () => Date;
   abortSignal?: AbortSignal;
+  /**
+   * The `X-AIMock-Context` value the chat POST must carry to match the scoped
+   * per-integration fixture (the dashboard column slug — see the call site).
+   * Applies to the chat rung ONLY (the browser sends it on the chat turn; the
+   * GET rungs hit the runtime `/info` route, not aimock). Absent/empty → no
+   * header is sent (preserves the prior raw-fetch behaviour for any starter
+   * without a scoped fixture context).
+   */
+  aimockContext?: string;
 }): Promise<LevelOutcome> {
-  const { fetchImpl, level, url, timeoutMs, now, abortSignal } = opts;
+  const { fetchImpl, level, url, timeoutMs, now, abortSignal, aimockContext } =
+    opts;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   // Track WHY this specific check terminated. The shared `abortSignal` is
@@ -599,6 +623,15 @@ async function probeLevel(opts: {
         ? {
             "Content-Type": "application/json",
             Accept: "text/event-stream",
+            // Match the scoped per-integration "Hello" fixture: aimock strict
+            // mode keys the fixture on `X-AIMock-Context`, and the value is the
+            // dashboard column slug (the SAME value the integration's
+            // playwright.config.ts injects via `extraHTTPHeaders`). Omit the
+            // header when no context is provided so the prior behaviour is
+            // preserved for any starter without a scoped fixture context.
+            ...(aimockContext && aimockContext.length > 0
+              ? { "X-AIMock-Context": aimockContext }
+              : {}),
           }
         : undefined,
       body: isChat ? CHAT_RUN_BODY : undefined,


### PR DESCRIPTION
## Summary

The harness `starter-smoke` **chat** rung 503'd on staging because its probe is a raw `fetch()` POST that sends only `Content-Type` — it omits `X-AIMock-Context`. The scoped per-integration "Hello" fixtures in `showcase/aimock/d4/<integration>/chat.json` (`{match:{userMessage:"Hello", context:"<ctx>"}}`) only match under aimock **strict mode** when the request carries `x-aimock-context:<ctx>`. The local browser e2e passes only because each integration's `playwright.config.ts` injects `extraHTTPHeaders:{ "X-AIMock-Context": "<ctx>" }`, forwarded by the integration's `HeaderForwardingMiddleware` to aimock.

**Fix:** send `X-AIMock-Context: <columnSlug>` on the chat POST **only** (the GET health/agent/interaction rungs hit the runtime `/info` route + app shell, not aimock — matching what the browser does). The driver already resolves `columnSlug` via `starterToColumnSlug(...)` before the chat rung runs, and that column slug is exactly the fixture/playwright context value, so the slug↔context skews resolve for free.

### Definitive starter → X-AIMock-Context map

The context token equals the **dashboard column slug** for every mapped starter. Verified two ways: each integration's `showcase/integrations/<col>/playwright.config.ts` `extraHTTPHeaders["X-AIMock-Context"]`, and the `showcase/aimock/d4/<col>/chat.json` `match.context` field — both equal the column slug.

| probe starter slug | X-AIMock-Context (= column slug) | skew? |
|---|---|---|
| `langgraph-js` | `langgraph-typescript` | yes |
| `adk` | `google-adk` | yes |
| `strands-python` | `strands` | yes |
| `ms-agent-framework-dotnet` | `ms-agent-dotnet` | yes |
| `ms-agent-framework-python` | `ms-agent-python` | yes |
| `crewai-crews` | `crewai-crews` | no |
| `langgraph-fastapi` | `langgraph-fastapi` | no |
| `langgraph-python` | `langgraph-python` | no |
| `agno` | `agno` | no |
| `llamaindex` | `llamaindex` | no |
| `mastra` | `mastra` | no |
| `pydantic-ai` | `pydantic-ai` | no |

No genuinely-absent contexts: all 12 mapped starters have a `{Hello, <col>}` fixture, and an **unmapped** starter returns a red aggregate *before* any chat probe fires (so `aimockContext` is always populated when the chat POST runs).

## Red → Green proof

**Unit (harness):** 5 new tests assert the chat POST carries `x-aimock-context = column slug` (direct + skew maps), only on the chat rung, alongside `Content-Type`/`Accept`. RED first (5 failed against unfixed source: header `undefined`), GREEN after the fix.

**Live staging aimock** (`https://aimock-staging.up.railway.app/v1/chat/completions`, `Hello` turn):

| starter | RED (no header) | GREEN (`X-AIMock-Context: <col>`) |
|---|---|---|
| `langgraph-js` → `langgraph-typescript` | 503 `no_fixture_match` | 200 |
| `adk` → `google-adk` | 503 `no_fixture_match` | 200 |
| `strands-python` → `strands` | 503 `no_fixture_match` | 200 |
| `langgraph-python` | 503 `no_fixture_match` | 200 |
| `mastra` | 503 `no_fixture_match` | 200 |

## Test plan

- [x] RED: 5 new context tests fail against unfixed source
- [x] GREEN: `starter-smoke.test.ts` 47/47 pass
- [x] Full harness suite: 2073/2073 pass (119 files)
- [x] tsc clean (only the pre-existing `toReversed` lib error remains)
- [x] oxfmt clean, oxlint 0 errors
- [x] Live-staging RED→GREEN for 5 starters incl. 3 skewed names