### PR TITLE
fix(showcase): add showcase-harness-worker to Railway SSOT (railway-envs.ts)

### DIFF
--- a/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
@@ -25,7 +25,7 @@ describe("emit-railway-envs-json", () => {
     expect(json.projectId).toBe("6f8c6bff-a80d-4f8f-b78d-50b32bcf4479");
     expect(json.envIds.staging).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
     expect(json.envIds.prod).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");
-    expect(json.services.length).toBe(27);
+    expect(json.services.length).toBe(28);
     const docs = json.services.find((s: { name: string }) => s.name === "docs");
     expect(docs.domains.staging).toBe("docs.staging.copilotkit.ai");
     expect(docs.domains.prod).toBe("docs.copilotkit.ai");

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -21,9 +21,18 @@ import type { ServiceEntry } from "../railway-envs";
 
 describe("ServiceEntry gateIgnore field", () => {
   it("is optional on the type and defaults to falsy when unset", () => {
-    // Every real SSOT entry has gateIgnore unset (undefined / falsy).
+    // Every real SSOT entry has gateIgnore unset (undefined / falsy),
+    // EXCEPT the staging-only `showcase-harness-worker` pool-fleet worker,
+    // which is deliberately gateIgnore:true (no prod instance, no public
+    // domain — it does not fit the symmetric dual-env shape the gate
+    // validates). See its SSOT entry in railway-envs.ts for the rationale.
+    const GATE_IGNORED = new Set(["showcase-harness-worker"]);
     for (const [name, entry] of Object.entries(SERVICES)) {
       const gi = (entry as ServiceEntry).gateIgnore;
+      if (GATE_IGNORED.has(name)) {
+        expect(gi, `${name} gateIgnore`).toBe(true);
+        continue;
+      }
       expect(gi === undefined || gi === false, `${name} gateIgnore`).toBe(true);
     }
   });
@@ -214,7 +223,7 @@ describe("summarizeFailures", () => {
   });
 });
 
-describe("WS-C: all 27 services gateValidated, with correct overrides", () => {
+describe("WS-C: all gate-managed services gateValidated, with correct overrides", () => {
   const FIVE_NEW = [
     ["dashboard", "showcase-shell-dashboard"],
     ["docs", "showcase-shell-docs"],
@@ -223,13 +232,17 @@ describe("WS-C: all 27 services gateValidated, with correct overrides", () => {
     ["harness", "showcase-harness"],
   ] as const;
 
-  it("has 27 services in the SSOT", () => {
-    expect(Object.keys(SERVICES)).toHaveLength(27);
+  it("has 28 services in the SSOT", () => {
+    expect(Object.keys(SERVICES)).toHaveLength(28);
   });
 
-  it("marks every service gateValidated (no Phase-2 holdouts)", () => {
+  it("marks every gate-managed service gateValidated (no Phase-2 holdouts)", () => {
+    // The staging-only `showcase-harness-worker` is the sole intentional
+    // gateValidated:false entry (it is gateIgnore:true — no prod instance,
+    // no public domain). Every OTHER service must be gateValidated:true.
+    const GATE_IGNORED = new Set(["showcase-harness-worker"]);
     const unvalidated = Object.entries(SERVICES)
-      .filter(([, entry]) => !entry.gateValidated)
+      .filter(([name, entry]) => !entry.gateValidated && !GATE_IGNORED.has(name))
       .map(([name]) => name);
     expect(unvalidated).toEqual([]);
   });

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -242,7 +242,9 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
     // no public domain). Every OTHER service must be gateValidated:true.
     const GATE_IGNORED = new Set(["showcase-harness-worker"]);
     const unvalidated = Object.entries(SERVICES)
-      .filter(([name, entry]) => !entry.gateValidated && !GATE_IGNORED.has(name))
+      .filter(
+        ([name, entry]) => !entry.gateValidated && !GATE_IGNORED.has(name),
+      )
       .map(([name]) => name);
     expect(unvalidated).toEqual([]);
   });

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -286,6 +286,27 @@
       }
     },
     {
+      "name": "showcase-harness-worker",
+      "serviceId": "c2aa8a0b-350e-4b76-8541-3012dfac41d0",
+      "prodInstanceId": "c2aa8a0b-350e-4b76-8541-3012dfac41d0",
+      "stagingInstanceId": "362c1e37-5f40-45f2-ac7b-0e5adac565f8",
+      "ciBuilt": false,
+      "gateValidated": false,
+      "repoNameOverride": {
+        "prod": "showcase-harness",
+        "staging": "showcase-harness"
+      },
+      "domains": {
+        "staging": "harness-staging-2ee4.up.railway.app",
+        "prod": "showcase-harness-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": false,
+        "driver": "harness"
+      }
+    },
+    {
       "name": "showcase-langgraph-fastapi",
       "serviceId": "06cccb5c-59f4-46b5-8adc-7113e77011a4",
       "prodInstanceId": "105b7e01-acd0-48e2-9a09-541e2103e8d2",

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -54,9 +54,9 @@ describe("railway-envs SSOT", () => {
     expect(ENV_IDS.staging).toBe(STAGING_ENV_ID);
   });
 
-  it("contains exactly 27 services", () => {
+  it("contains exactly 28 services", () => {
     const names = listServiceNames();
-    expect(names.length).toBe(27);
+    expect(names.length).toBe(28);
   });
 
   it("contains the expected canonical services", () => {

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -277,6 +277,61 @@ export const SERVICES: Record<
     },
     probe: { staging: true, prod: true, driver: "harness" },
   },
+  "showcase-harness-worker": {
+    serviceId: "c2aa8a0b-350e-4b76-8541-3012dfac41d0",
+    // STAGING-ONLY worker (pool-fleet cutover). There is no prod
+    // serviceInstance — the pool-fleet runs in staging only for now.
+    // The schema requires a distinct, valid prod UUID per entry, so we
+    // mirror the env-independent serviceId here as a non-functional
+    // placeholder; it is never dereferenced because (a) gateIgnore skips
+    // both gate directions, (b) ciBuilt:false keeps it out of the default
+    // CI_BUILT_SERVICES redeploy scope, and (c) prodInstanceId would only
+    // be read by an explicit `redeploy-env.ts prod --services
+    // showcase-harness-worker`, which is never invoked for a staging-only
+    // service. If/when a prod worker is provisioned, replace this with the
+    // real prod serviceInstance ID and flip gateIgnore off.
+    prodInstanceId: "c2aa8a0b-350e-4b76-8541-3012dfac41d0",
+    stagingInstanceId: "362c1e37-5f40-45f2-ac7b-0e5adac565f8",
+    // The worker runs the SAME `showcase-harness` GHCR image that the
+    // existing `harness` (control-plane) service runs — it is NOT a
+    // separately-built image. The single `showcase-harness` build slot in
+    // showcase_build.yml produces the image both services consume; there
+    // is no `showcase-harness-worker` build slot. Hence ciBuilt:false
+    // (no dedicated build) and a repoNameOverride to `showcase-harness`
+    // so the image-ref shape (`ghcr.io/copilotkit/showcase-harness:latest`)
+    // resolves correctly if the gate ever validates it.
+    ciBuilt: false,
+    // gateIgnore: deliberately-untracked for the image-ref gate. The
+    // worker is staging-only (no prod instance) and domain-less (it pulls
+    // jobs from the control-plane queue rather than serving HTTP), so it
+    // does not fit the symmetric dual-env / public-domain shape the gate
+    // validates. Listing it here (with gateIgnore) is what clears the
+    // "untracked Railway service" failure — findUntrackedServices treats
+    // any SSOT entry as known — WITHOUT triggering a false "missing from
+    // prod" failure from findMissingServices (which only checks
+    // gateValidated:true entries).
+    gateValidated: false,
+    gateIgnore: true,
+    repoNameOverride: {
+      prod: "showcase-harness",
+      staging: "showcase-harness",
+    },
+    // No public domain on Railway (queue worker, not HTTP-exposed). The
+    // schema requires both domains be set; we point both at the
+    // control-plane harness staging/prod hosts purely to satisfy the
+    // no-scheme domain invariant. domainFor() is never called for this
+    // service because its probe is disabled in both envs (below) and
+    // verify-deploy skips probe:false services.
+    domains: {
+      staging: "harness-staging-2ee4.up.railway.app",
+      prod: "showcase-harness-production.up.railway.app",
+    },
+    // probe disabled in BOTH envs: the worker has no health endpoint that
+    // verify-deploy's `harness` driver can hit from outside (it has no
+    // public domain). Its liveness is covered by the control-plane harness
+    // probe and the Railway-internal /health healthcheck.
+    probe: { staging: false, prod: false, driver: "harness" },
+  },
   pocketbase: {
     serviceId: "ba11e854-d695-4738-9a45-2b0776788824",
     prodInstanceId: "1ee376e2-13f2-4464-801e-d0aa0bf76532",


### PR DESCRIPTION
## Summary

The pool-fleet cutover manually created a new staging-only Railway service `showcase-harness-worker` (HARNESS_ROLE=worker, 2 replicas) and flipped the existing `harness` service to HARNESS_ROLE=control-plane. The new service was **not in the SSOT** (`showcase/scripts/railway-envs.ts`), so `verify-railway-image-refs.ts` failed the "Showcase: Build & Push" workflow on every push to main:

```
✗ [railway] showcase-harness-worker
    reason: Railway service "showcase-harness-worker" is not in the SSOT.
```

Because the `build` job `needs: [verify-image-refs]`, that gate failure **skipped the harness build** — meaning recent harness fixes (e.g. #5279's chat-rung probe) never rebuilt to staging. The secondary `Aggregate build results` ENOENT failure was a downstream consequence of the skipped build.

This PR adds `showcase-harness-worker` to `SERVICES`, matching the live Railway service:

- **`ciBuilt: false`** — the worker runs the SAME `showcase-harness` GHCR image the existing harness build slot produces; there is no separate worker build slot.
- **`gateIgnore: true` / `gateValidated: false`** — the worker is staging-only (no prod serviceInstance) and domain-less (it pulls jobs from the control-plane queue rather than serving HTTP), so it does not fit the symmetric dual-env / public-domain shape the image-ref gate validates. `gateIgnore` clears the "untracked Railway service" failure (any SSOT entry counts as known) **without** triggering a false "missing from prod" failure (`findMissingServices` only checks `gateValidated: true` entries).
- **`repoNameOverride` → `showcase-harness`** so the image-ref shape resolves correctly.
- **probe disabled in both envs** — no externally-reachable health endpoint.

The existing `harness` (now control-plane) entry is unchanged and remains correct (it still builds + serves the `showcase-harness` image on its public domain).

Also regenerates `railway-envs.generated.json` and updates the SSOT-count / gate-coverage test invariants (27 → 28 services; the worker is the sole intentional `gateIgnore`/`gateValidated:false` entry).

## Proof

Against live Railway (CLI auth):

- Before: `✗ Railway image-ref drift detected (... 1 untracked Railway services ...)`
- After: `✓ 54 env-scoped instances verified (1 skipped)` — worker is the 1 skipped (gateIgnore), 0 untracked.
- `emit-railway-envs-json.ts --check`: up to date.

## Test plan

- [x] `verify-railway-image-refs.ts` passes against live Railway (0 untracked)
- [x] `emit-railway-envs-json.ts --check` passes (generated JSON regenerated)
- [x] Full `showcase/scripts` vitest suite: 1772 passed (49 files)
- [ ] CI green on "Showcase: Build & Push" after merge (the gate failure that skipped the harness build is removed)