### PR TITLE
feat(showcase): worker driver registry (driverKind→driver) for fleet

### DIFF
--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -75,9 +75,14 @@ export interface ServiceJobPayload {
   /** The showcase service / integration slug, e.g. `"langgraph-python"`. */
   serviceSlug: string;
   /**
-   * The d6 driver kind that runs the cells. Always `"e2e_d6"` for the
-   * per-service d6 unit, but carried explicitly so the same job shape can
-   * later host other per-service drivers without a payload migration.
+   * The driver kind that runs the cells. The producer currently stamps
+   * `"e2e_d6"` (the per-service d6 unit), but the WORKER now routes by this
+   * field through its `DriverRegistry` — so any registered kind (e2e_d6 /
+   * e2e_deep / e2e_demos / e2e_smoke) dispatches to the matching driver, and an
+   * unregistered kind is reported as a `worker-protocol-violation`. Kept a
+   * `string` (not narrowed to the worker's `DriverKind` union) because this is
+   * the WIRE boundary that receives whatever the producer serialized; the
+   * runtime unknown-kind guard is the validation gate.
    */
   driverKind: string;
   /**

--- a/showcase/harness/src/fleet/orchestrator.test.ts
+++ b/showcase/harness/src/fleet/orchestrator.test.ts
@@ -11,7 +11,10 @@ import type {
   ServiceJobResult,
 } from "./contracts.js";
 import type { Logger } from "../types/index.js";
-import type { LaunchBrowser, CgroupPidsReader } from "../probes/helpers/browser-pool.js";
+import type {
+  LaunchBrowser,
+  CgroupPidsReader,
+} from "../probes/helpers/browser-pool.js";
 
 /**
  * Fleet WORKER entrypoint (`runWorker`, fleet/orchestrator.ts) — DEFAULT

--- a/showcase/harness/src/fleet/orchestrator.test.ts
+++ b/showcase/harness/src/fleet/orchestrator.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Browser } from "playwright";
+import { runWorker } from "./orchestrator.js";
+import type { FleetRoleConfig } from "./role-config.js";
+import type {
+  FleetQueueClient,
+  ClaimedJob,
+  JobLease,
+  JobView,
+  ServiceJobPayload,
+  ServiceJobResult,
+} from "./contracts.js";
+import type { Logger } from "../types/index.js";
+import type { LaunchBrowser, CgroupPidsReader } from "../probes/helpers/browser-pool.js";
+
+/**
+ * Fleet WORKER entrypoint (`runWorker`, fleet/orchestrator.ts) — DEFAULT
+ * (self-contained) boot equivalence.
+ *
+ * REGRESSION: the default boot path (neither a `drivers` registry nor a legacy
+ * `driver` injected) USED to set a bare `driver = d6Driver` WITHOUT a
+ * `payloadToInput`, so `startWorkerLoop`'s construction guard threw "Fleet
+ * worker has no drivers" and the worker could never boot self-contained. The fix
+ * builds the default d6 as a REGISTRY entry (`e2e_d6 → { driver, payloadToInput,
+ * aggregateSlugKey }`), so the self-contained boot SUCCEEDS and routes an
+ * `e2e_d6` job through the d6 driver.
+ *
+ * The d6 driver is the REAL pooled one; we feed it an input with NO declared
+ * features so it returns its green "no D5 features declared" aggregate WITHOUT
+ * touching chromium (the BrowserPool's launcher is a no-op fake injected via the
+ * test-only `launchBrowser` seam, so no real browser ever spawns).
+ */
+
+const silentLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+/** A no-op connected Browser — the d6 driver never opens a context in this
+ *  test (zero features), so `init()` just needs a launchable fake. */
+function makeNoopLauncher(): LaunchBrowser {
+  return async () =>
+    ({
+      isConnected: () => true,
+      on: () => {},
+      async close() {},
+      async newContext() {
+        return { async close() {} };
+      },
+    }) as unknown as Browser;
+}
+
+/** Always reports plenty of headroom so the claim gate never blocks. */
+const headroomPidsReader: CgroupPidsReader = () => ({ current: 10, max: 1000 });
+
+function makeJobView(overrides: Partial<JobView> = {}): JobView {
+  return {
+    id: "job-1",
+    probe_key: "d6:langgraph-python",
+    status: "claimed",
+    claimed_by: "worker-test",
+    lease_expires_at: "2026-06-04T00:05:00.000Z",
+    version: 1,
+    ...overrides,
+  };
+}
+
+function makePayload(
+  overrides: Partial<ServiceJobPayload> = {},
+): ServiceJobPayload {
+  return {
+    probeKey: "d6:langgraph-python",
+    serviceSlug: "langgraph-python",
+    driverKind: "e2e_d6",
+    // A runnable d6 input with NO declared features → the d6 driver returns its
+    // green "no D5 features declared" aggregate without acquiring a browser.
+    driverInputs: {
+      key: "e2e_d6:langgraph-python",
+      backendUrl: "https://lg.example.com",
+    },
+    meta: {
+      runId: "run-42",
+      triggered: false,
+      enqueuedAt: "2026-06-04T00:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+function makeLease(payload?: Partial<ServiceJobPayload>): JobLease {
+  return {
+    job: makeJobView(),
+    payload: makePayload(payload),
+    leaseExpiresAt: "2026-06-04T00:05:00.000Z",
+  };
+}
+
+interface RecordingQueue extends FleetQueueClient {
+  reports: ServiceJobResult[];
+}
+
+/** A queue fake that hands out a fixed sequence of claims, then idles. */
+function makeQueue(claims: ClaimedJob[]): RecordingQueue {
+  const reports: ServiceJobResult[] = [];
+  let i = 0;
+  return {
+    reports,
+    async enqueue() {
+      throw new Error("enqueue not used by worker");
+    },
+    async claimNext(): Promise<ClaimedJob> {
+      const next = claims[i] ?? { claimed: false };
+      if (i < claims.length) i++;
+      return next;
+    },
+    async renewLease(): Promise<JobLease | null> {
+      return makeLease();
+    },
+    async report({ result }): Promise<void> {
+      reports.push(result);
+    },
+    async sweepExpired() {
+      return { reclaimed: 0, commErrors: [] };
+    },
+  };
+}
+
+const config: FleetRoleConfig = { role: "worker", poolCount: 1 };
+
+describe("runWorker default (self-contained) boot", () => {
+  it("boots WITHOUT an injected registry or driver and routes an e2e_d6 job through the d6 driver", async () => {
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+
+    // No `drivers`, no `driver`, no `budgetSource` → the default boot path
+    // constructs its own pool + the default d6 REGISTRY entry. Pre-fix this
+    // threw "Fleet worker has no drivers"; post-fix it boots and routes.
+    const worker = await runWorker(config, {
+      queue,
+      workerId: "worker-test",
+      logger: silentLogger,
+      env: {},
+      skipHealthServer: true,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+      pollIntervalMs: 1,
+      // Test-only seams so the default-boot BrowserPool never spawns chromium.
+      launchBrowser: makeNoopLauncher(),
+      cgroupPidsReader: headroomPidsReader,
+    });
+
+    try {
+      await vi.waitFor(() => expect(queue.reports).toHaveLength(1), {
+        timeout: 5000,
+      });
+    } finally {
+      await worker.stop();
+    }
+
+    const result = queue.reports[0]!;
+    // The e2e_d6 job was routed to the REAL d6 driver (not a protocol
+    // violation): the d6 driver's green "no D5 features declared" aggregate.
+    expect(result.commError).toBeUndefined();
+    expect(result.aggregateState).toBe("green");
+    expect(result.aggregateKey).toBe("e2e_d6:langgraph-python");
+  });
+});

--- a/showcase/harness/src/fleet/orchestrator.ts
+++ b/showcase/harness/src/fleet/orchestrator.ts
@@ -29,6 +29,10 @@ import { serve } from "@hono/node-server";
 import { createEventBus } from "../events/event-bus.js";
 import { logger as defaultLogger } from "../logger.js";
 import { BrowserPool } from "../probes/helpers/browser-pool.js";
+import type {
+  LaunchBrowser,
+  CgroupPidsReader,
+} from "../probes/helpers/browser-pool.js";
 import {
   createE2eFullDriver,
   createPooledE2eFullLauncher,
@@ -44,6 +48,10 @@ import {
   type DriverRegistry,
   type WorkerLoopHandle,
 } from "./worker/worker-loop.js";
+import {
+  createD6PayloadToInput,
+  E2E_D6_DRIVER_KIND,
+} from "./worker/payload-mapper.js";
 
 /** The worker boot handle — symmetric with the control-plane `boot()` shape. */
 export interface WorkerHandle {
@@ -132,6 +140,20 @@ export interface RunWorkerOptions {
   budgetSource?: {
     budget(): import("../probes/helpers/browser-pool.js").BrowserPoolBudget;
   };
+  /**
+   * Test-only seam: injected chromium launcher forwarded to the `BrowserPool`
+   * the DEFAULT (self-contained) boot path constructs, so the default-boot
+   * equivalence test can exercise that path WITHOUT spawning real chromium.
+   * Production omits it → the pool uses the real launcher. Ignored when a
+   * `budgetSource` + run path are injected (no pool is constructed).
+   */
+  launchBrowser?: LaunchBrowser;
+  /**
+   * Test-only seam: injected cgroup PID reader forwarded to the default-boot
+   * `BrowserPool` (powers `budget()`), so the default-boot test reports
+   * headroom deterministically. Production omits it → the real reader is used.
+   */
+  cgroupPidsReader?: CgroupPidsReader;
 }
 
 /**
@@ -185,8 +207,12 @@ export async function runWorker(
   //      injected `budgetSource`, the worker runs entirely on the caller's wiring
   //      and this entrypoint constructs NO pool of its own.
   //   2. A legacy single `driver` + `budgetSource` (back-compat test path).
-  //   3. Neither → construct the worker's own pool + default pooled d6 driver
-  //      (the original self-contained boot).
+  //   3. Neither → construct the worker's own pool and a DEFAULT REGISTRY holding
+  //      the single pooled d6 driver under its `e2e_d6` kind (the self-contained
+  //      boot). Building it as a registry entry — not a bare `driver` — means the
+  //      self-contained path also routes by driverKind AND carries the d6
+  //      payload mapper, so `startWorkerLoop`'s construction guard is satisfied
+  //      (equivalence with the pre-registry single-d6 worker).
   // The pool is the self-bounded context budget that gates claiming and keeps the
   // worker under its pids ceiling.
   let pool: BrowserPool | undefined;
@@ -196,20 +222,33 @@ export async function runWorker(
 
   // We have all the wiring we need iff a budget source exists AND at least one
   // run path (a registry or a single driver) is supplied. Otherwise build the
-  // default pool + d6 driver so the worker is self-contained.
+  // default pool + d6 registry so the worker is self-contained.
   const haveRunPath = drivers !== undefined || driver !== undefined;
   if (!budgetSource || !haveRunPath) {
-    pool = new BrowserPool({ logger });
+    pool = new BrowserPool({
+      logger,
+      launchBrowser: opts.launchBrowser,
+      cgroupPidsReader: opts.cgroupPidsReader,
+    });
     await pool.init();
     budgetSource = budgetSource ?? pool;
     if (!haveRunPath) {
-      // Default to the single pooled d6 driver registered under its kind, so the
-      // self-contained boot path also routes by driverKind (equivalence with the
-      // pre-registry single-d6 worker).
-      const d6Driver = createE2eFullDriver({
-        launcher: createPooledE2eFullLauncher(pool, logger),
-      });
-      driver = d6Driver;
+      // Default to the single pooled d6 driver registered under its kind, paired
+      // with the d6 payload→input mapper, so the self-contained boot routes by
+      // driverKind through the registry (equivalence with the pre-registry
+      // single-d6 worker) and the loop's construction guard is satisfied.
+      drivers = new Map([
+        [
+          E2E_D6_DRIVER_KIND,
+          {
+            driver: createE2eFullDriver({
+              launcher: createPooledE2eFullLauncher(pool, logger),
+            }),
+            payloadToInput: createD6PayloadToInput(),
+            aggregateSlugKey: (serviceSlug: string) => `d6:${serviceSlug}`,
+          },
+        ],
+      ]);
     }
   }
 

--- a/showcase/harness/src/fleet/orchestrator.ts
+++ b/showcase/harness/src/fleet/orchestrator.ts
@@ -41,6 +41,7 @@ import {
   startWorkerLoop,
   type PayloadToDriverInput,
   type ServiceJobDriver,
+  type DriverRegistry,
   type WorkerLoopHandle,
 } from "./worker/worker-loop.js";
 
@@ -57,8 +58,23 @@ export interface WorkerHandle {
 export interface RunWorkerOptions {
   /** The fleet queue client (S3 impl over the S0 claim endpoints). */
   queue: FleetQueueClient;
-  /** Maps a claimed per-service payload to the d6 driver's per-service input. */
-  payloadToInput: PayloadToDriverInput;
+  /**
+   * The driver REGISTRY: `driverKind` → `{ driver, payloadToInput }`. When
+   * supplied the worker dispatches each claimed job by `payload.driverKind`,
+   * hosting MULTIPLE browser driver families on one worker. Built by the
+   * `runWorker` entrypoint (orchestrator.ts) which wires every pooled driver
+   * onto the shared `BrowserPool`. Takes precedence over the legacy single
+   * `driver`/`payloadToInput` pair below; when omitted the worker falls back to
+   * the single-driver path.
+   */
+  drivers?: DriverRegistry;
+  /**
+   * LEGACY single-driver payload mapper. Used only when `drivers` is omitted.
+   * Optional now that the registry is the primary path; when both `drivers` and
+   * the single `driver` are absent the default pooled d6 driver + this mapper
+   * are constructed below.
+   */
+  payloadToInput?: PayloadToDriverInput;
   /** Stable worker id (the `claimed_by` on every claim). */
   workerId?: string;
   /**
@@ -163,22 +179,38 @@ export async function runWorker(
     port,
   });
 
-  // Construct the worker's own pool unless a budget source + driver are
-  // injected (test path). The pool is the self-bounded context budget that
-  // gates claiming and keeps the worker under its pids ceiling.
+  // Resolve the worker's drivers. Three shapes, in precedence order:
+  //   1. An injected `drivers` registry (the primary path — the entrypoint
+  //      wires every pooled driver family onto the shared pool). Paired with an
+  //      injected `budgetSource`, the worker runs entirely on the caller's wiring
+  //      and this entrypoint constructs NO pool of its own.
+  //   2. A legacy single `driver` + `budgetSource` (back-compat test path).
+  //   3. Neither → construct the worker's own pool + default pooled d6 driver
+  //      (the original self-contained boot).
+  // The pool is the self-bounded context budget that gates claiming and keeps the
+  // worker under its pids ceiling.
   let pool: BrowserPool | undefined;
   let budgetSource = opts.budgetSource;
+  let drivers = opts.drivers;
   let driver = opts.driver;
 
-  if (!budgetSource || !driver) {
+  // We have all the wiring we need iff a budget source exists AND at least one
+  // run path (a registry or a single driver) is supplied. Otherwise build the
+  // default pool + d6 driver so the worker is self-contained.
+  const haveRunPath = drivers !== undefined || driver !== undefined;
+  if (!budgetSource || !haveRunPath) {
     pool = new BrowserPool({ logger });
     await pool.init();
     budgetSource = budgetSource ?? pool;
-    driver =
-      driver ??
-      createE2eFullDriver({
+    if (!haveRunPath) {
+      // Default to the single pooled d6 driver registered under its kind, so the
+      // self-contained boot path also routes by driverKind (equivalence with the
+      // pre-registry single-d6 worker).
+      const d6Driver = createE2eFullDriver({
         launcher: createPooledE2eFullLauncher(pool, logger),
       });
+      driver = d6Driver;
+    }
   }
 
   let loop: WorkerLoopHandle;
@@ -187,6 +219,7 @@ export async function runWorker(
       workerId,
       queue: opts.queue,
       pool: budgetSource,
+      drivers,
       driver,
       payloadToInput: opts.payloadToInput,
       logger,

--- a/showcase/harness/src/fleet/worker/payload-mapper.test.ts
+++ b/showcase/harness/src/fleet/worker/payload-mapper.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   createD6PayloadToInput,
-  createDeepPayloadToInput,
-  createDemosPayloadToInput,
-  createSmokePayloadToInput,
   createPayloadToInput,
   E2E_D6_DRIVER_KIND,
   E2E_DEEP_DRIVER_KIND,
@@ -82,38 +79,32 @@ describe("driver-kind constants", () => {
   });
 });
 
-describe("per-kind payload mappers", () => {
+describe("shared payload mapper", () => {
   // The four browser driver families share the SAME re-hydration logic (each
   // serializes a `{ key, backendUrl, … }` object and validates via its own zod
-  // schema), so the per-kind mappers all re-hydrate the input the same way.
+  // schema), so every registry entry wires the single `createPayloadToInput`.
+  // `createD6PayloadToInput` is retained as a back-compat alias of it.
   const driverInputs = {
     key: "k:langgraph-python",
     backendUrl: "https://lg.example.com",
   };
 
-  it.each([
-    ["deep", createDeepPayloadToInput],
-    ["demos", createDemosPayloadToInput],
-    ["smoke", createSmokePayloadToInput],
-    ["base", createPayloadToInput],
-  ])("%s mapper re-hydrates the serialized input", (_name, factory) => {
-    const map = factory();
+  it("re-hydrates the serialized input", () => {
+    const map = createPayloadToInput();
     const input = map(payload({ driverInputs })) as Record<string, unknown>;
     expect(input.key).toBe("k:langgraph-python");
     expect(input.backendUrl).toBe("https://lg.example.com");
   });
 
-  it("each per-kind mapper defaults a missing key to the payload probeKey", () => {
-    for (const factory of [
-      createDeepPayloadToInput,
-      createDemosPayloadToInput,
-      createSmokePayloadToInput,
-    ]) {
-      const map = factory();
-      const input = map(
-        payload({ driverInputs: { backendUrl: "https://lg.example.com" } }),
-      ) as Record<string, unknown>;
-      expect(input.key).toBe("d6:langgraph-python");
-    }
+  it("defaults a missing key to the payload probeKey", () => {
+    const map = createPayloadToInput();
+    const input = map(
+      payload({ driverInputs: { backendUrl: "https://lg.example.com" } }),
+    ) as Record<string, unknown>;
+    expect(input.key).toBe("d6:langgraph-python");
+  });
+
+  it("createD6PayloadToInput is the same factory (back-compat alias)", () => {
+    expect(createD6PayloadToInput).toBe(createPayloadToInput);
   });
 });

--- a/showcase/harness/src/fleet/worker/payload-mapper.test.ts
+++ b/showcase/harness/src/fleet/worker/payload-mapper.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { createD6PayloadToInput } from "./payload-mapper.js";
+import {
+  createD6PayloadToInput,
+  createDeepPayloadToInput,
+  createDemosPayloadToInput,
+  createSmokePayloadToInput,
+  createPayloadToInput,
+  E2E_D6_DRIVER_KIND,
+  E2E_DEEP_DRIVER_KIND,
+  E2E_DEMOS_DRIVER_KIND,
+  E2E_SMOKE_DRIVER_KIND,
+} from "./payload-mapper.js";
 import type { ServiceJobPayload } from "../contracts.js";
 
 function payload(over: Partial<ServiceJobPayload> = {}): ServiceJobPayload {
@@ -60,5 +70,50 @@ describe("createD6PayloadToInput", () => {
     const map = createD6PayloadToInput();
     expect(map(payload())).toBeUndefined();
     expect(map(payload({ driverInputs: undefined }))).toBeUndefined();
+  });
+});
+
+describe("driver-kind constants", () => {
+  it("expose the four browser driver kinds matching the driver factories", () => {
+    expect(E2E_D6_DRIVER_KIND).toBe("e2e_d6");
+    expect(E2E_DEEP_DRIVER_KIND).toBe("e2e_deep");
+    expect(E2E_DEMOS_DRIVER_KIND).toBe("e2e_demos");
+    expect(E2E_SMOKE_DRIVER_KIND).toBe("e2e_smoke");
+  });
+});
+
+describe("per-kind payload mappers", () => {
+  // The four browser driver families share the SAME re-hydration logic (each
+  // serializes a `{ key, backendUrl, … }` object and validates via its own zod
+  // schema), so the per-kind mappers all re-hydrate the input the same way.
+  const driverInputs = {
+    key: "k:langgraph-python",
+    backendUrl: "https://lg.example.com",
+  };
+
+  it.each([
+    ["deep", createDeepPayloadToInput],
+    ["demos", createDemosPayloadToInput],
+    ["smoke", createSmokePayloadToInput],
+    ["base", createPayloadToInput],
+  ])("%s mapper re-hydrates the serialized input", (_name, factory) => {
+    const map = factory();
+    const input = map(payload({ driverInputs })) as Record<string, unknown>;
+    expect(input.key).toBe("k:langgraph-python");
+    expect(input.backendUrl).toBe("https://lg.example.com");
+  });
+
+  it("each per-kind mapper defaults a missing key to the payload probeKey", () => {
+    for (const factory of [
+      createDeepPayloadToInput,
+      createDemosPayloadToInput,
+      createSmokePayloadToInput,
+    ]) {
+      const map = factory();
+      const input = map(
+        payload({ driverInputs: { backendUrl: "https://lg.example.com" } }),
+      ) as Record<string, unknown>;
+      expect(input.key).toBe("d6:langgraph-python");
+    }
   });
 });

--- a/showcase/harness/src/fleet/worker/payload-mapper.ts
+++ b/showcase/harness/src/fleet/worker/payload-mapper.ts
@@ -30,25 +30,40 @@
 import type { PayloadToDriverInput } from "./worker-loop.js";
 import type { ServiceJobPayload } from "../contracts.js";
 
-/** The driver kind this mapper knows how to map. */
+/**
+ * The browser driver KINDS the worker registry hosts — one per per-service
+ * driver family. These are the `payload.driverKind` keys the producer stamps
+ * and the worker's `DriverRegistry` routes on. Kept in lock-step with the
+ * `kind` each driver factory reports (`createE2eFullDriver().kind === "e2e_d6"`,
+ * etc. in `probes/drivers/*`).
+ */
 export const E2E_D6_DRIVER_KIND = "e2e_d6";
+export const E2E_DEEP_DRIVER_KIND = "e2e_deep";
+export const E2E_DEMOS_DRIVER_KIND = "e2e_demos";
+export const E2E_SMOKE_DRIVER_KIND = "e2e_smoke";
 
 /**
- * Build the d6 `PayloadToDriverInput` mapping. Re-hydrates the serialized d6
- * input from `payload.driverInputs`, defaulting `key` to the payload's
- * `probeKey`. Pure; the returned function captures nothing mutable.
+ * Build a per-service `PayloadToDriverInput` mapping. Re-hydrates the serialized
+ * driver input from `payload.driverInputs`, defaulting `key` to the payload's
+ * `probeKey`. This re-hydration is IDENTICAL across the browser driver families
+ * (d6/d5/demos/smoke): each driver serializes a `{ key, backendUrl, … }`-shaped
+ * object into `driverInputs`, and each driver's OWN zod schema is the validation
+ * gate inside `driver.run` (a malformed input fails LOUD there, surfaced by the
+ * loop as a terminal result). So one shared mapper serves every kind — the
+ * per-kind exports below are named aliases for call-site clarity / future
+ * divergence. Pure; the returned function captures nothing mutable.
  */
-export function createD6PayloadToInput(): PayloadToDriverInput {
+export function createPayloadToInput(): PayloadToDriverInput {
   return (payload: ServiceJobPayload): unknown | undefined => {
     const raw = payload.driverInputs;
-    // No driver inputs → nothing the d6 driver can run. Signal "unmappable" so
-    // the loop reports a protocol violation instead of handing the driver an
-    // input its schema will reject deep inside the run.
+    // No driver inputs → nothing the driver can run. Signal "unmappable" so the
+    // loop reports a protocol violation instead of handing the driver an input
+    // its schema will reject deep inside the run.
     if (raw === undefined || raw === null || typeof raw !== "object") {
       return undefined;
     }
     const input = { ...(raw as Record<string, unknown>) };
-    // The d6 schema REQUIRES a non-empty `key`. The producer normally stamps
+    // The driver schemas REQUIRE a non-empty `key`. The producer normally stamps
     // it; default to the payload's probeKey (the join key to the dashboard
     // row) so a producer that omitted it still yields a runnable input.
     if (typeof input.key !== "string" || input.key.length === 0) {
@@ -57,3 +72,18 @@ export function createD6PayloadToInput(): PayloadToDriverInput {
     return input;
   };
 }
+
+/**
+ * The d6 (`e2e_d6`) payload→input mapper. Alias of {@link createPayloadToInput}
+ * — retained as the original named export so existing call sites keep working.
+ */
+export const createD6PayloadToInput = createPayloadToInput;
+
+/** The d5 (`e2e_deep`) payload→input mapper. */
+export const createDeepPayloadToInput = createPayloadToInput;
+
+/** The e2e-demos (`e2e_demos`) payload→input mapper. */
+export const createDemosPayloadToInput = createPayloadToInput;
+
+/** The d4 chat-roundtrip (`e2e_smoke`) payload→input mapper. */
+export const createSmokePayloadToInput = createPayloadToInput;

--- a/showcase/harness/src/fleet/worker/payload-mapper.ts
+++ b/showcase/harness/src/fleet/worker/payload-mapper.ts
@@ -36,11 +36,26 @@ import type { ServiceJobPayload } from "../contracts.js";
  * and the worker's `DriverRegistry` routes on. Kept in lock-step with the
  * `kind` each driver factory reports (`createE2eFullDriver().kind === "e2e_d6"`,
  * etc. in `probes/drivers/*`).
+ *
+ * `E2E_DRIVER_KINDS` is the closed set; `DriverKind` is its union type. The four
+ * `E2E_*_DRIVER_KIND` constants below are each typed `DriverKind` (not widened to
+ * `string`) so the registry map's key type stays the closed union. NOTE: this is
+ * the WORKER-INTERNAL kind space — `contracts.ts`'s `driverKind: string` stays a
+ * `string` (it's the wire boundary that receives external producer strings; the
+ * runtime unknown-kind guard handles anything off this set).
  */
-export const E2E_D6_DRIVER_KIND = "e2e_d6";
-export const E2E_DEEP_DRIVER_KIND = "e2e_deep";
-export const E2E_DEMOS_DRIVER_KIND = "e2e_demos";
-export const E2E_SMOKE_DRIVER_KIND = "e2e_smoke";
+export const E2E_DRIVER_KINDS = [
+  "e2e_d6",
+  "e2e_deep",
+  "e2e_demos",
+  "e2e_smoke",
+] as const;
+export type DriverKind = (typeof E2E_DRIVER_KINDS)[number];
+
+export const E2E_D6_DRIVER_KIND: DriverKind = "e2e_d6";
+export const E2E_DEEP_DRIVER_KIND: DriverKind = "e2e_deep";
+export const E2E_DEMOS_DRIVER_KIND: DriverKind = "e2e_demos";
+export const E2E_SMOKE_DRIVER_KIND: DriverKind = "e2e_smoke";
 
 /**
  * Build a per-service `PayloadToDriverInput` mapping. Re-hydrates the serialized
@@ -49,9 +64,9 @@ export const E2E_SMOKE_DRIVER_KIND = "e2e_smoke";
  * (d6/d5/demos/smoke): each driver serializes a `{ key, backendUrl, … }`-shaped
  * object into `driverInputs`, and each driver's OWN zod schema is the validation
  * gate inside `driver.run` (a malformed input fails LOUD there, surfaced by the
- * loop as a terminal result). So one shared mapper serves every kind — the
- * per-kind exports below are named aliases for call-site clarity / future
- * divergence. Pure; the returned function captures nothing mutable.
+ * loop as a terminal result). So one shared mapper serves every kind — every
+ * registry entry wires THIS factory directly. Pure; the returned function
+ * captures nothing mutable.
  */
 export function createPayloadToInput(): PayloadToDriverInput {
   return (payload: ServiceJobPayload): unknown | undefined => {
@@ -78,12 +93,3 @@ export function createPayloadToInput(): PayloadToDriverInput {
  * — retained as the original named export so existing call sites keep working.
  */
 export const createD6PayloadToInput = createPayloadToInput;
-
-/** The d5 (`e2e_deep`) payload→input mapper. */
-export const createDeepPayloadToInput = createPayloadToInput;
-
-/** The e2e-demos (`e2e_demos`) payload→input mapper. */
-export const createDemosPayloadToInput = createPayloadToInput;
-
-/** The d4 chat-roundtrip (`e2e_smoke`) payload→input mapper. */
-export const createSmokePayloadToInput = createPayloadToInput;

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -8,6 +8,8 @@ import {
   type ServiceJobDriver,
   type ServiceDriverContext,
   type BudgetSource,
+  type DriverRegistry,
+  type DriverRegistryEntry,
 } from "./worker-loop.js";
 import type {
   FleetQueueClient,
@@ -882,5 +884,149 @@ describe("startWorkerLoop", () => {
     await vi.waitFor(() => expect(reports).toHaveLength(1));
     await handle.stop();
     expect(reports[0]!.aggregateState).toBe("green");
+  });
+});
+
+// ── Driver REGISTRY: dispatch by payload.driverKind ────────────────────────
+
+describe("driver registry (driverKind → driver)", () => {
+  const baseRegistryDeps = (drivers: DriverRegistry) => ({
+    workerId: "worker-test",
+    queue: makeQueue([]),
+    drivers,
+    logger: silentLogger,
+    env: {} as Readonly<Record<string, string | undefined>>,
+    now: () => new Date("2026-06-04T00:04:00.000Z"),
+    sleep: async () => {},
+  });
+
+  /** A driver fake that tags its aggregate row with the kind it represents. */
+  function makeTaggingDriver(kind: string): ServiceJobDriver {
+    return {
+      async run(ctx, _input): Promise<ProbeResult> {
+        const observedAt = ctx.now().toISOString();
+        return {
+          key: `${kind}:routed`,
+          state: "green",
+          signal: { routedKind: kind },
+          observedAt,
+        };
+      },
+    };
+  }
+
+  function entry(kind: string): DriverRegistryEntry {
+    return { driver: makeTaggingDriver(kind), payloadToInput: passInput };
+  }
+
+  function registry(...kinds: string[]): DriverRegistry {
+    const m: DriverRegistry = new Map();
+    for (const k of kinds) m.set(k, entry(k));
+    return m;
+  }
+
+  it("routes an e2e_smoke payload to the smoke driver", async () => {
+    const drivers = registry("e2e_d6", "e2e_deep", "e2e_smoke", "e2e_demos");
+    const result = await runClaimedJob(
+      baseRegistryDeps(drivers),
+      makeLease({ payload: { driverKind: "e2e_smoke" } }),
+      { leaseSeconds: 300, heartbeatMs: 1_000_000 },
+    );
+    expect(result.aggregateState).toBe("green");
+    expect(result.aggregateKey).toBe("e2e_smoke:routed");
+    expect(result.aggregateSignal).toMatchObject({ routedKind: "e2e_smoke" });
+    expect(result.commError).toBeUndefined();
+  });
+
+  it("routes an e2e_deep payload to the deep driver", async () => {
+    const drivers = registry("e2e_d6", "e2e_deep", "e2e_smoke", "e2e_demos");
+    const result = await runClaimedJob(
+      baseRegistryDeps(drivers),
+      makeLease({ payload: { driverKind: "e2e_deep" } }),
+      { leaseSeconds: 300, heartbeatMs: 1_000_000 },
+    );
+    expect(result.aggregateKey).toBe("e2e_deep:routed");
+    expect(result.aggregateSignal).toMatchObject({ routedKind: "e2e_deep" });
+    expect(result.commError).toBeUndefined();
+  });
+
+  it("routes an e2e_d6 payload to the d6 driver (equivalence)", async () => {
+    const drivers = registry("e2e_d6", "e2e_deep", "e2e_smoke", "e2e_demos");
+    const result = await runClaimedJob(
+      baseRegistryDeps(drivers),
+      makeLease({ payload: { driverKind: "e2e_d6" } }),
+      { leaseSeconds: 300, heartbeatMs: 1_000_000 },
+    );
+    expect(result.aggregateKey).toBe("e2e_d6:routed");
+    expect(result.aggregateSignal).toMatchObject({ routedKind: "e2e_d6" });
+    expect(result.commError).toBeUndefined();
+  });
+
+  it("maps an unknown driverKind to a worker-protocol-violation terminal result", async () => {
+    const drivers = registry("e2e_d6", "e2e_deep");
+    const result = await runClaimedJob(
+      baseRegistryDeps(drivers),
+      makeLease({ payload: { driverKind: "e2e_unknown" } }),
+      { leaseSeconds: 300, heartbeatMs: 1_000_000 },
+    );
+    expect(result.aggregateState).toBe("error");
+    expect(result.commError?.kind).toBe("worker-protocol-violation");
+    expect(result.commError?.message).toContain("e2e_unknown");
+  });
+
+  it("uses the matched kind's OWN payloadToInput, not a sibling's", async () => {
+    // Each entry carries its own mapper; the matched kind's mapper must run.
+    const seen: string[] = [];
+    const drivers: DriverRegistry = new Map([
+      [
+        "e2e_d6",
+        {
+          driver: makeTaggingDriver("e2e_d6"),
+          payloadToInput: (p) => {
+            seen.push(`d6:${p.serviceSlug}`);
+            return passInput();
+          },
+        } as DriverRegistryEntry,
+      ],
+      [
+        "e2e_smoke",
+        {
+          driver: makeTaggingDriver("e2e_smoke"),
+          payloadToInput: (p) => {
+            seen.push(`smoke:${p.serviceSlug}`);
+            return passInput();
+          },
+        } as DriverRegistryEntry,
+      ],
+    ]);
+    await runClaimedJob(
+      baseRegistryDeps(drivers),
+      makeLease({ payload: { driverKind: "e2e_smoke" } }),
+      { leaseSeconds: 300, heartbeatMs: 1_000_000 },
+    );
+    expect(seen).toEqual(["smoke:langgraph-python"]);
+  });
+
+  it("startWorkerLoop dispatches a claimed job by driverKind through the registry", async () => {
+    const drivers = registry("e2e_d6", "e2e_deep", "e2e_smoke", "e2e_demos");
+    const queue = makeQueue([
+      { claimed: true, lease: makeLease({ payload: { driverKind: "e2e_deep" } }) },
+    ]);
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      drivers,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+    await vi.waitFor(() => expect(queue.reports).toHaveLength(1));
+    await handle.stop();
+    expect(queue.reports[0]!.aggregateKey).toBe("e2e_deep:routed");
   });
 });

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -1010,7 +1010,10 @@ describe("driver registry (driverKind → driver)", () => {
   it("startWorkerLoop dispatches a claimed job by driverKind through the registry", async () => {
     const drivers = registry("e2e_d6", "e2e_deep", "e2e_smoke", "e2e_demos");
     const queue = makeQueue([
-      { claimed: true, lease: makeLease({ payload: { driverKind: "e2e_deep" } }) },
+      {
+        claimed: true,
+        lease: makeLease({ payload: { driverKind: "e2e_deep" } }),
+      },
     ]);
     const handle = startWorkerLoop({
       workerId: "worker-test",

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -10,7 +10,9 @@ import {
   type BudgetSource,
   type DriverRegistry,
   type DriverRegistryEntry,
+  type WorkerLoopHandle,
 } from "./worker-loop.js";
+import type { DriverKind } from "./payload-mapper.js";
 import type {
   FleetQueueClient,
   ClaimedJob,
@@ -646,6 +648,62 @@ describe("startWorkerLoop", () => {
     expect(start).not.toThrow();
   });
 
+  it("throws at construction when NEITHER a registry NOR the legacy driver pair is supplied", () => {
+    const start = (): WorkerLoopHandle =>
+      startWorkerLoop({
+        workerId: "worker-test",
+        queue: makeQueue([]),
+        pool: budgetWith(5),
+        // No `drivers`, no `driver`/`payloadToInput` → every claim would
+        // terminate as a protocol violation. Fail loud at construction.
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: yieldingSleep(),
+        leaseSeconds: 300,
+        heartbeatMs: 60_000,
+      });
+    expect(start).toThrow(/has no drivers/);
+  });
+
+  it("throws at construction when given an EMPTY registry", () => {
+    const start = (): WorkerLoopHandle =>
+      startWorkerLoop({
+        workerId: "worker-test",
+        queue: makeQueue([]),
+        pool: budgetWith(5),
+        // An empty registry can route NOTHING — same misconfiguration as no
+        // drivers at all.
+        drivers: new Map<DriverKind, DriverRegistryEntry>(),
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: yieldingSleep(),
+        leaseSeconds: 300,
+        heartbeatMs: 60_000,
+      });
+    expect(start).toThrow(/has no drivers/);
+  });
+
+  it("throws at construction when a legacy `driver` is supplied WITHOUT a `payloadToInput`", () => {
+    const start = (): WorkerLoopHandle =>
+      startWorkerLoop({
+        workerId: "worker-test",
+        queue: makeQueue([]),
+        pool: budgetWith(5),
+        // A driver with no mapper is not a usable run path (the loop can't build
+        // a driver input) — the legacy pair requires BOTH halves.
+        driver: makeDriver({ slug: "x", cells: [], aggregateState: "green" }),
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: yieldingSleep(),
+        leaseSeconds: 300,
+        heartbeatMs: 60_000,
+      });
+    expect(start).toThrow(/has no drivers/);
+  });
+
   it("claims a job, runs it, reports a correct ServiceJobResult, then idles", async () => {
     const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
     const driver = makeDriver({
@@ -919,8 +977,8 @@ describe("driver registry (driverKind → driver)", () => {
     return { driver: makeTaggingDriver(kind), payloadToInput: passInput };
   }
 
-  function registry(...kinds: string[]): DriverRegistry {
-    const m: DriverRegistry = new Map();
+  function registry(...kinds: DriverKind[]): DriverRegistry {
+    const m = new Map<DriverKind, DriverRegistryEntry>();
     for (const k of kinds) m.set(k, entry(k));
     return m;
   }
@@ -977,7 +1035,7 @@ describe("driver registry (driverKind → driver)", () => {
   it("uses the matched kind's OWN payloadToInput, not a sibling's", async () => {
     // Each entry carries its own mapper; the matched kind's mapper must run.
     const seen: string[] = [];
-    const drivers: DriverRegistry = new Map([
+    const drivers = new Map<DriverKind, DriverRegistryEntry>([
       [
         "e2e_d6",
         {
@@ -986,7 +1044,7 @@ describe("driver registry (driverKind → driver)", () => {
             seen.push(`d6:${p.serviceSlug}`);
             return passInput();
           },
-        } as DriverRegistryEntry,
+        },
       ],
       [
         "e2e_smoke",
@@ -996,7 +1054,7 @@ describe("driver registry (driverKind → driver)", () => {
             seen.push(`smoke:${p.serviceSlug}`);
             return passInput();
           },
-        } as DriverRegistryEntry,
+        },
       ],
     ]);
     await runClaimedJob(
@@ -1005,6 +1063,85 @@ describe("driver registry (driverKind → driver)", () => {
       { leaseSeconds: 300, heartbeatMs: 1_000_000 },
     );
     expect(seen).toEqual(["smoke:langgraph-python"]);
+  });
+
+  /**
+   * A driver that writes one per-cell row (`<scheme>:<slug>/<feature>`) AND one
+   * aggregate SIDE row (`<scheme>:<slug>`). The loop must filter the aggregate
+   * side row out of captured cells using the entry's `aggregateSlugKey` builder.
+   */
+  function makeSchemeDriver(scheme: string, slug: string): ServiceJobDriver {
+    return {
+      async run(ctx, _input): Promise<ProbeResult> {
+        const observedAt = ctx.now().toISOString();
+        await ctx.writer.write({
+          key: `${scheme}:${slug}/feat-1`,
+          state: "green",
+          signal: { featureType: "feat-1" },
+          observedAt,
+        });
+        // Aggregate side row under the custom scheme — must be filtered.
+        await ctx.writer.write({
+          key: `${scheme}:${slug}`,
+          state: "green",
+          signal: { shape: "package", slug },
+          observedAt,
+        });
+        return {
+          key: `${scheme}:${slug}`,
+          state: "green",
+          signal: { shape: "package", slug },
+          observedAt,
+        };
+      },
+    };
+  }
+
+  it("honors a custom aggregateSlugKey builder when filtering captured cells", async () => {
+    // The entry's aggregate scheme is `custom:` (not d6), so the aggregate side
+    // row is `custom:<slug>` and must be filtered; the per-cell row is kept.
+    const drivers = new Map<DriverKind, DriverRegistryEntry>([
+      [
+        "e2e_deep",
+        {
+          driver: makeSchemeDriver("custom", "langgraph-python"),
+          payloadToInput: passInput,
+          aggregateSlugKey: (serviceSlug) => `custom:${serviceSlug}`,
+        },
+      ],
+    ]);
+    const result = await runClaimedJob(
+      baseRegistryDeps(drivers),
+      makeLease({ payload: { driverKind: "e2e_deep" } }),
+      { leaseSeconds: 300, heartbeatMs: 1_000_000 },
+    );
+    // Exactly the per-cell row is captured; the `custom:<slug>` aggregate side
+    // row was filtered (NOT counted as a cell).
+    expect(result.cells).toHaveLength(1);
+    expect(result.cells[0]!.cellKey).toBe("custom:langgraph-python/feat-1");
+    expect(result.commError).toBeUndefined();
+  });
+
+  it("defaults to the d6 `d6:<slug>` aggregate filter when an entry omits aggregateSlugKey", async () => {
+    // No `aggregateSlugKey` on the entry → the loop defaults to `d6:<slug>`.
+    // The driver emits a `d6:<slug>` aggregate side row, which must be filtered.
+    const drivers = new Map<DriverKind, DriverRegistryEntry>([
+      [
+        "e2e_d6",
+        {
+          driver: makeSchemeDriver("d6", "langgraph-python"),
+          payloadToInput: passInput,
+        },
+      ],
+    ]);
+    const result = await runClaimedJob(
+      baseRegistryDeps(drivers),
+      makeLease({ payload: { driverKind: "e2e_d6" } }),
+      { leaseSeconds: 300, heartbeatMs: 1_000_000 },
+    );
+    expect(result.cells).toHaveLength(1);
+    expect(result.cells[0]!.cellKey).toBe("d6:langgraph-python/feat-1");
+    expect(result.commError).toBeUndefined();
   });
 
   it("startWorkerLoop dispatches a claimed job by driverKind through the registry", async () => {

--- a/showcase/harness/src/fleet/worker/worker-loop.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.ts
@@ -102,6 +102,29 @@ export type PayloadToDriverInput = (
   payload: ServiceJobPayload,
 ) => unknown | undefined;
 
+/**
+ * One entry of the worker's driver REGISTRY: a `ServiceJobDriver` paired with
+ * the `PayloadToDriverInput` mapper that re-hydrates the per-service input that
+ * driver's zod schema validates. The registry is keyed by `driverKind` (e.g.
+ * `e2e_d6`, `e2e_deep`, `e2e_smoke`, `e2e_demos`), so a single worker can host
+ * MULTIPLE browser-driver families — the loop dispatches each claimed job to the
+ * entry whose key matches `payload.driverKind`.
+ */
+export interface DriverRegistryEntry {
+  driver: ServiceJobDriver;
+  payloadToInput: PayloadToDriverInput;
+}
+
+/**
+ * The worker's driver registry: `driverKind` → `{ driver, payloadToInput }`.
+ * Built once at the `runWorker` entrypoint (all driver families wired onto the
+ * shared pool) and injected into the loop. A claimed payload whose `driverKind`
+ * is absent from the map is a `worker-protocol-violation` (the same terminal
+ * failure shape an unmappable payload uses) — the worker won't crash on an
+ * unknown kind, it reports it.
+ */
+export type DriverRegistry = Map<string, DriverRegistryEntry>;
+
 /** The pool capacity surface the loop's claim gate consults (S6 `budget()`). */
 export interface BudgetSource {
   budget(): BrowserPoolBudget;
@@ -114,10 +137,24 @@ export interface WorkerLoopDeps {
   queue: FleetQueueClient;
   /** The pool whose `budget()` gates claiming (S6). */
   pool: BudgetSource;
-  /** The per-service d6/d5 driver (e.g. `createE2eFullDriver()`). */
-  driver: ServiceJobDriver;
-  /** Maps a claimed payload to the driver's per-service input. */
-  payloadToInput: PayloadToDriverInput;
+  /**
+   * The driver REGISTRY: `driverKind` → `{ driver, payloadToInput }`. The loop
+   * dispatches each claimed job to the entry whose key matches
+   * `payload.driverKind`; an unknown kind is reported as a
+   * `worker-protocol-violation` terminal result (never a crash). REQUIRED when
+   * the legacy single-driver pair below is omitted.
+   */
+  drivers?: DriverRegistry;
+  /**
+   * LEGACY single-driver pair. When `drivers` is omitted, the loop runs EVERY
+   * claimed job through this one driver (the pre-registry behavior). Retained so
+   * existing call sites / tests that inject one driver keep working; the
+   * registry path is preferred. Exactly one of `drivers` or this pair must be
+   * supplied.
+   */
+  driver?: ServiceJobDriver;
+  /** Maps a claimed payload to the legacy driver's per-service input. */
+  payloadToInput?: PayloadToDriverInput;
   logger: Logger;
   /** Frozen env snapshot threaded into the driver ctx. */
   env: Readonly<Record<string, string | undefined>>;
@@ -429,16 +466,76 @@ export function buildDriverErrorResult(args: {
  * Exported for direct unit testing of the claim→run→report round-trip without
  * driving the full poll loop.
  */
+/**
+ * Resolve the `{ driver, payloadToInput }` entry that runs a claimed payload.
+ * Dispatch is by `payload.driverKind` against the injected `drivers` registry;
+ * when the registry is omitted the loop falls back to the legacy single
+ * `driver`/`payloadToInput` pair (pre-registry behavior). Returns `undefined`
+ * when neither path can serve the kind — the caller maps that to a
+ * `worker-protocol-violation` terminal result (NOT a crash), the same failure
+ * shape an unmappable payload already uses.
+ *
+ * Pure; exercised through `runClaimedJob`'s routing branches.
+ */
+export function resolveDriverEntry(
+  deps: Pick<WorkerLoopDeps, "drivers" | "driver" | "payloadToInput">,
+  driverKind: string,
+): DriverRegistryEntry | undefined {
+  if (deps.drivers) {
+    return deps.drivers.get(driverKind);
+  }
+  // Legacy single-driver path: one driver handles every kind.
+  if (deps.driver && deps.payloadToInput) {
+    return { driver: deps.driver, payloadToInput: deps.payloadToInput };
+  }
+  return undefined;
+}
+
 export async function runClaimedJob(
   deps: Pick<
     WorkerLoopDeps,
-    "workerId" | "queue" | "driver" | "payloadToInput" | "logger" | "env"
+    | "workerId"
+    | "queue"
+    | "drivers"
+    | "driver"
+    | "payloadToInput"
+    | "logger"
+    | "env"
   > & { now: () => Date; sleep: NonNullable<WorkerLoopDeps["sleep"]> },
   lease: JobLease,
   opts: { leaseSeconds: number; heartbeatMs: number },
 ): Promise<ServiceJobResult> {
-  const { workerId, queue, driver, payloadToInput, logger, env, now } = deps;
+  const { workerId, queue, logger, env, now } = deps;
   const { job, payload } = lease;
+
+  // Dispatch by driverKind: pick the registry entry whose key matches the
+  // payload's `driverKind` (or the legacy single driver when no registry was
+  // injected). An unknown kind is a protocol violation the WORKER owns (it won
+  // the claim) — report it as a `worker-protocol-violation` terminal result so
+  // the dashboard surfaces it, rather than crashing the worker on an unhandled
+  // kind. This mirrors the unmappable-payload failure shape below.
+  const entry = resolveDriverEntry(deps, payload.driverKind);
+  if (!entry) {
+    logger.warn("fleet.worker.unknown-driver-kind", {
+      workerId,
+      jobId: job.id,
+      probeKey: payload.probeKey,
+      driverKind: payload.driverKind,
+    });
+    return buildCommErrorResult({
+      lease,
+      workerId,
+      commError: {
+        kind: "worker-protocol-violation",
+        message: `worker has no driver registered for driverKind "${payload.driverKind}" (job ${job.id}, probeKey "${payload.probeKey}")`,
+        workerId,
+        jobId: job.id,
+        observedAt: now().toISOString(),
+      },
+      finishedAt: now().toISOString(),
+    });
+  }
+  const { driver, payloadToInput } = entry;
 
   // Map the claimed payload to a driver input. A poison payload can fail either
   // by RETURNING undefined ("cannot map this") or by THROWING (decode/parse
@@ -665,6 +762,21 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
     );
   }
 
+  // Fail-loud at construction: a worker with no way to run any claimed job is a
+  // misconfiguration. Exactly one of `drivers` (the registry) or the legacy
+  // single `driver`/`payloadToInput` pair must be supplied; an empty registry or
+  // a missing legacy pair means every claim would terminate as an
+  // unknown-kind/protocol-violation. Die immediately rather than ship a worker
+  // that fails every job (mirrors the lease-config fail-loud idiom above).
+  const hasRegistry = deps.drivers !== undefined && deps.drivers.size > 0;
+  const hasLegacyDriver =
+    deps.driver !== undefined && deps.payloadToInput !== undefined;
+  if (!hasRegistry && !hasLegacyDriver) {
+    throw new Error(
+      "Fleet worker has no drivers: supply either a non-empty `drivers` registry (driverKind → { driver, payloadToInput }) or the legacy `driver`+`payloadToInput` pair; otherwise every claimed job terminates as a protocol violation.",
+    );
+  }
+
   /**
    * Fire the current-job hook, guarding against a throwing/rejecting impl so a
    * registration-heartbeat failure can never break the worker loop (mirrors the
@@ -763,6 +875,7 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
         {
           workerId,
           queue,
+          drivers: deps.drivers,
           driver: deps.driver,
           payloadToInput: deps.payloadToInput,
           logger,

--- a/showcase/harness/src/fleet/worker/worker-loop.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.ts
@@ -51,6 +51,7 @@ import type {
   ServiceJobRollup,
   PoolCommError,
 } from "../contracts.js";
+import type { DriverKind } from "./payload-mapper.js";
 
 /**
  * The minimal driver surface the worker invokes per claimed service job. This
@@ -113,6 +114,17 @@ export type PayloadToDriverInput = (
 export interface DriverRegistryEntry {
   driver: ServiceJobDriver;
   payloadToInput: PayloadToDriverInput;
+  /**
+   * Builds the aggregate side-emit key the loop filters OUT of the captured
+   * per-cell rows (the driver emits ONE aggregate row alongside the per-cell
+   * rows; the loop captures the aggregate from the run's RETURN value, so the
+   * side-emitted aggregate must be dropped from the cell set). Each driver
+   * family stamps its aggregate row under its OWN scheme, so the key derivation
+   * is per-entry. OPTIONAL: when absent the loop defaults to `d6:<serviceSlug>`
+   * (the d6 scheme), keeping the d6 path byte-identical to the pre-registry
+   * behavior. Non-d6 kinds with a different aggregate scheme supply their own.
+   */
+  aggregateSlugKey?: (serviceSlug: string) => string;
 }
 
 /**
@@ -123,7 +135,7 @@ export interface DriverRegistryEntry {
  * failure shape an unmappable payload uses) — the worker won't crash on an
  * unknown kind, it reports it.
  */
-export type DriverRegistry = Map<string, DriverRegistryEntry>;
+export type DriverRegistry = ReadonlyMap<DriverKind, DriverRegistryEntry>;
 
 /** The pool capacity surface the loop's claim gate consults (S6 `budget()`). */
 export interface BudgetSource {
@@ -482,7 +494,11 @@ export function resolveDriverEntry(
   driverKind: string,
 ): DriverRegistryEntry | undefined {
   if (deps.drivers) {
-    return deps.drivers.get(driverKind);
+    // `driverKind` is a wire string (contracts.ts boundary); the registry is
+    // keyed by the closed `DriverKind` union. `.get` returns undefined for any
+    // off-set key, so this narrowing cast is safe — an unknown kind resolves to
+    // undefined and is reported as a protocol violation by the caller.
+    return deps.drivers.get(driverKind as DriverKind);
   }
   // Legacy single-driver path: one driver handles every kind.
   if (deps.driver && deps.payloadToInput) {
@@ -516,7 +532,7 @@ export async function runClaimedJob(
   // kind. This mirrors the unmappable-payload failure shape below.
   const entry = resolveDriverEntry(deps, payload.driverKind);
   if (!entry) {
-    logger.warn("fleet.worker.unknown-driver-kind", {
+    logger.error("fleet.worker.unknown-driver-kind", {
       workerId,
       jobId: job.id,
       probeKey: payload.probeKey,
@@ -536,6 +552,12 @@ export async function runClaimedJob(
     });
   }
   const { driver, payloadToInput } = entry;
+  // The aggregate side-emit key the loop filters out of the captured cells.
+  // Each driver family stamps its aggregate row under its own scheme, so the
+  // resolved entry supplies the derivation; default to d6's `d6:<slug>` when the
+  // entry omits it (keeps the d6 path byte-identical to the pre-registry filter).
+  const buildAggregateSlugKey =
+    entry.aggregateSlugKey ?? ((serviceSlug: string) => `d6:${serviceSlug}`);
 
   // Map the claimed payload to a driver input. A poison payload can fail either
   // by RETURNING undefined ("cannot map this") or by THROWING (decode/parse
@@ -589,10 +611,11 @@ export async function runClaimedJob(
     });
   }
 
-  // The driver's aggregate side-emit uses `d6:<serviceSlug>` — filter that one
+  // The driver's aggregate side-emit (e.g. `d6:<serviceSlug>`) — filter that one
   // out of the captured cells (the loop captures the aggregate from the primary
-  // return). Per-cell rows are `d6:<slug>/<featureId>` and are kept.
-  const aggregateSlugKey = `d6:${payload.serviceSlug}`;
+  // return). Per-cell rows are `<scheme>:<slug>/<featureId>` and are kept. The
+  // key scheme is per-driver-family, resolved from the registry entry above.
+  const aggregateSlugKey = buildAggregateSlugKey(payload.serviceSlug);
   const capture = createCellCapture(aggregateSlugKey);
 
   // Heartbeat-renew the lease while the (long) driver run is in flight. A renew

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -15,10 +15,21 @@ import {
   envForCfg,
   createRailwayAdapter,
   registerAllProbeDrivers,
+  buildPooledBrowserDrivers,
   hydrateProbeLastRuns,
   surfaceReclaimedCommErrors,
   verifyWorkerRegistered,
 } from "./orchestrator.js";
+import { createE2eFullDriver } from "./probes/drivers/d6-all-pills.js";
+import { createE2eDeepDriver } from "./probes/drivers/d5-single-pill.js";
+import { createE2eDemosDriver } from "./probes/drivers/e2e-readiness.js";
+import { createE2eSmokeDriver } from "./probes/drivers/d4-chat-roundtrip.js";
+import {
+  E2E_D6_DRIVER_KIND,
+  E2E_DEEP_DRIVER_KIND,
+  E2E_DEMOS_DRIVER_KIND,
+  E2E_SMOKE_DRIVER_KIND,
+} from "./fleet/worker/payload-mapper.js";
 import type {
   CommErrorSurfacePb,
   WorkerRegistryReadPb,
@@ -2255,6 +2266,40 @@ describe("orchestrator.registerAllProbeDrivers (post-#4292 hotfix guard)", () =>
     const kinds = registry.list();
     expect(kinds).toContain("e2e_deep");
     expect(kinds).toContain("e2e_d6");
+  });
+});
+
+/**
+ * Pins the producer↔worker driver-kind contract for the fleet worker registry.
+ *
+ * Two failure modes guarded:
+ *  1. LOCK-STEP: each driver factory's self-reported `kind` MUST equal the
+ *     `E2E_*_DRIVER_KIND` constant the worker registry / payload producer keys
+ *     on. If a factory's kind and its constant drift, the producer would stamp a
+ *     `driverKind` no registry entry matches → every job of that kind terminates
+ *     as a worker-protocol-violation.
+ *  2. REGISTRY WIRING: the shared `buildPooledBrowserDrivers` (the SINGLE pooled
+ *     construction the worker registry at runWorker ~2528 builds from) must map
+ *     each slot to the factory whose kind matches — catches a key→factory
+ *     copy-paste swap (e.g. wiring the deep driver under the d6 slot).
+ */
+describe("fleet worker driver-kind lock-step + registry wiring", () => {
+  it("each driver factory's self-reported kind equals its constant (lock-step)", () => {
+    expect(createE2eFullDriver().kind).toBe(E2E_D6_DRIVER_KIND);
+    expect(createE2eDeepDriver().kind).toBe(E2E_DEEP_DRIVER_KIND);
+    expect(createE2eDemosDriver().kind).toBe(E2E_DEMOS_DRIVER_KIND);
+    expect(createE2eSmokeDriver().kind).toBe(E2E_SMOKE_DRIVER_KIND);
+  });
+
+  it("buildPooledBrowserDrivers maps each slot to the correctly-kinded factory", () => {
+    // The pooled launchers don't touch the pool at construction, so an
+    // un-init'd pool is sufficient to build the drivers.
+    const pool = new BrowserPool({ logger });
+    const pooled = buildPooledBrowserDrivers(pool, logger);
+    expect(pooled.d6.kind).toBe(E2E_D6_DRIVER_KIND);
+    expect(pooled.deep.kind).toBe(E2E_DEEP_DRIVER_KIND);
+    expect(pooled.demos.kind).toBe(E2E_DEMOS_DRIVER_KIND);
+    expect(pooled.smoke.kind).toBe(E2E_SMOKE_DRIVER_KIND);
   });
 });
 

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -90,7 +90,17 @@ import {
   type PoolCommError,
 } from "./fleet/contracts.js";
 import { runWorker as runFleetWorker } from "./fleet/orchestrator.js";
-import { createD6PayloadToInput } from "./fleet/worker/payload-mapper.js";
+import {
+  createD6PayloadToInput,
+  createDeepPayloadToInput,
+  createDemosPayloadToInput,
+  createSmokePayloadToInput,
+  E2E_D6_DRIVER_KIND,
+  E2E_DEEP_DRIVER_KIND,
+  E2E_DEMOS_DRIVER_KIND,
+  E2E_SMOKE_DRIVER_KIND,
+} from "./fleet/worker/payload-mapper.js";
+import type { DriverRegistry } from "./fleet/worker/worker-loop.js";
 import { registerWorker } from "./fleet/worker/registration.js";
 import {
   asKnownState,
@@ -2506,9 +2516,53 @@ export async function runWorker(
   const pool = new BrowserPool({ logger });
   await pool.init();
 
-  const driver = createE2eFullDriver({
-    launcher: createPooledE2eFullLauncher(pool, logger),
-  });
+  // Build the worker's DRIVER REGISTRY: every per-service browser driver family
+  // wired onto the SAME pooled launcher, keyed by its `driverKind`. The worker
+  // loop dispatches each claimed job by `payload.driverKind` to the matching
+  // entry, so one worker can run d6/d5/demos/smoke jobs. Each kind carries its
+  // own payload→input mapper (currently the shared re-hydration, since the four
+  // driver input shapes are identical and each driver's own zod schema is the
+  // validation gate). Lifted from the legacy `registerAllProbeDrivers` pooled
+  // construction so the fleet worker and the in-process probe registry build the
+  // same pooled drivers the same way.
+  const drivers: DriverRegistry = new Map([
+    [
+      E2E_D6_DRIVER_KIND,
+      {
+        driver: createE2eFullDriver({
+          launcher: createPooledE2eFullLauncher(pool, logger),
+        }),
+        payloadToInput: createD6PayloadToInput(),
+      },
+    ],
+    [
+      E2E_DEEP_DRIVER_KIND,
+      {
+        driver: createE2eDeepDriver({
+          launcher: createPooledE2eDeepLauncher(pool, logger),
+        }),
+        payloadToInput: createDeepPayloadToInput(),
+      },
+    ],
+    [
+      E2E_DEMOS_DRIVER_KIND,
+      {
+        driver: createE2eDemosDriver({
+          launcher: createPooledE2eDemosLauncher(pool, logger),
+        }),
+        payloadToInput: createDemosPayloadToInput(),
+      },
+    ],
+    [
+      E2E_SMOKE_DRIVER_KIND,
+      {
+        driver: createE2eSmokeDriver({
+          launcher: createPooledE2eSmokeLauncher(pool, logger),
+        }),
+        payloadToInput: createSmokePayloadToInput(),
+      },
+    ],
+  ]);
 
   // Self-register + start the capacity heartbeat against this worker's pool.
   // Best-effort by contract (registerWorker never rejects); a missing workers
@@ -2539,15 +2593,15 @@ export async function runWorker(
   try {
     worker = await runFleetWorker(config, {
       queue,
-      payloadToInput: createD6PayloadToInput(),
       workerId,
       port,
       logger,
       env,
-      // Inject the pool we own as BOTH the budget gate and the driver backing —
-      // fleet runWorker skips constructing its own pool when both are supplied.
+      // Inject the pool we own as the budget gate and the driver REGISTRY
+      // (driverKind → { driver, payloadToInput }) we built above — fleet
+      // runWorker skips constructing its own pool when both are supplied.
       budgetSource: pool,
-      driver,
+      drivers,
       // Wire the worker /health server's liveness probes: pb reachability +
       // registration. The fleet runWorker binds /health on the resolved port so
       // the docker/Railway healthcheck answers (no restart-loop).

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -91,10 +91,7 @@ import {
 } from "./fleet/contracts.js";
 import { runWorker as runFleetWorker } from "./fleet/orchestrator.js";
 import {
-  createD6PayloadToInput,
-  createDeepPayloadToInput,
-  createDemosPayloadToInput,
-  createSmokePayloadToInput,
+  createPayloadToInput,
   E2E_D6_DRIVER_KIND,
   E2E_DEEP_DRIVER_KIND,
   E2E_DEMOS_DRIVER_KIND,
@@ -1061,6 +1058,40 @@ export async function boot(opts: BootOptions = {}): Promise<{
 }
 
 /**
+ * Construct the four POOLED per-service browser drivers (smoke/demos/deep/d6)
+ * wired onto the SAME `BrowserPool`. This is the single shared construction
+ * consumed by BOTH `registerAllProbeDrivers` (the in-process probe registry) and
+ * the fleet worker's `DriverRegistry` (orchestrator.ts `runWorker`), so the two
+ * can never drift on how the pooled drivers are built. Returned keyed by each
+ * driver's `driverKind` constant; callers adapt (register the raw driver, or
+ * pair it with a payload mapper for the worker registry).
+ */
+export function buildPooledBrowserDrivers(
+  pool: BrowserPool,
+  log: Logger,
+): {
+  smoke: ReturnType<typeof createE2eSmokeDriver>;
+  demos: ReturnType<typeof createE2eDemosDriver>;
+  deep: ReturnType<typeof createE2eDeepDriver>;
+  d6: ReturnType<typeof createE2eFullDriver>;
+} {
+  return {
+    smoke: createE2eSmokeDriver({
+      launcher: createPooledE2eSmokeLauncher(pool, log),
+    }),
+    demos: createE2eDemosDriver({
+      launcher: createPooledE2eDemosLauncher(pool, log),
+    }),
+    deep: createE2eDeepDriver({
+      launcher: createPooledE2eDeepLauncher(pool, log),
+    }),
+    d6: createE2eFullDriver({
+      launcher: createPooledE2eFullLauncher(pool, log),
+    }),
+  };
+}
+
+/**
  * Register every probe driver this orchestrator knows about onto the
  * given registry. Single source of truth for the registered probe-kind
  * set so YAML probe configs (`config/probes/*.yml`) and orchestrator
@@ -1083,26 +1114,11 @@ export function registerAllProbeDrivers(
   probeRegistry.register(redirectDecommissionDriver);
 
   if (pool) {
-    probeRegistry.register(
-      createE2eSmokeDriver({
-        launcher: createPooledE2eSmokeLauncher(pool, logger),
-      }),
-    );
-    probeRegistry.register(
-      createE2eDemosDriver({
-        launcher: createPooledE2eDemosLauncher(pool, logger),
-      }),
-    );
-    probeRegistry.register(
-      createE2eDeepDriver({
-        launcher: createPooledE2eDeepLauncher(pool, logger),
-      }),
-    );
-    probeRegistry.register(
-      createE2eFullDriver({
-        launcher: createPooledE2eFullLauncher(pool, logger),
-      }),
-    );
+    const pooled = buildPooledBrowserDrivers(pool, logger);
+    probeRegistry.register(pooled.smoke);
+    probeRegistry.register(pooled.demos);
+    probeRegistry.register(pooled.deep);
+    probeRegistry.register(pooled.d6);
   } else {
     probeRegistry.register(e2eChatToolsDriver);
     probeRegistry.register(e2eReadinessDriver);
@@ -2517,49 +2533,63 @@ export async function runWorker(
   await pool.init();
 
   // Build the worker's DRIVER REGISTRY: every per-service browser driver family
-  // wired onto the SAME pooled launcher, keyed by its `driverKind`. The worker
-  // loop dispatches each claimed job by `payload.driverKind` to the matching
-  // entry, so one worker can run d6/d5/demos/smoke jobs. Each kind carries its
-  // own payload→input mapper (currently the shared re-hydration, since the four
-  // driver input shapes are identical and each driver's own zod schema is the
-  // validation gate). Lifted from the legacy `registerAllProbeDrivers` pooled
-  // construction so the fleet worker and the in-process probe registry build the
-  // same pooled drivers the same way.
+  // wired onto the SAME pooled launcher (via the shared `buildPooledBrowserDrivers`
+  // that `registerAllProbeDrivers` also uses, so the fleet worker and the
+  // in-process probe registry build the same pooled drivers the same way), keyed
+  // by its `driverKind`. The worker loop dispatches each claimed job by
+  // `payload.driverKind` to the matching entry, so one worker can run
+  // d6/d5/demos/smoke jobs. Each kind carries the shared re-hydration mapper
+  // (`createPayloadToInput`) since the four driver input shapes are identical and
+  // each driver's own zod schema is the validation gate.
+  const pooled = buildPooledBrowserDrivers(pool, logger);
+
+  // Construction-time fail-loud: each factory's self-reported `kind` MUST equal
+  // the key constant we register it under, BEFORE the concrete `ProbeDriver` is
+  // erased to `ServiceJobDriver` (which drops `.kind`). A key→factory copy-paste
+  // swap would otherwise route silently to the wrong driver. Die immediately
+  // (visible in deploy CI / Railway health-check).
+  const kindChecks: Array<[string, { kind: string }]> = [
+    [E2E_D6_DRIVER_KIND, pooled.d6],
+    [E2E_DEEP_DRIVER_KIND, pooled.deep],
+    [E2E_DEMOS_DRIVER_KIND, pooled.demos],
+    [E2E_SMOKE_DRIVER_KIND, pooled.smoke],
+  ];
+  for (const [key, drv] of kindChecks) {
+    if (drv.kind !== key) {
+      throw new Error(
+        `Fleet worker driver registry mis-wired: driver factory reports kind "${drv.kind}" but is registered under key "${key}" — fix the key→factory mapping in runWorker.`,
+      );
+    }
+  }
+
   const drivers: DriverRegistry = new Map([
     [
       E2E_D6_DRIVER_KIND,
       {
-        driver: createE2eFullDriver({
-          launcher: createPooledE2eFullLauncher(pool, logger),
-        }),
-        payloadToInput: createD6PayloadToInput(),
+        driver: pooled.d6,
+        payloadToInput: createPayloadToInput(),
+        aggregateSlugKey: (serviceSlug: string) => `d6:${serviceSlug}`,
       },
     ],
     [
       E2E_DEEP_DRIVER_KIND,
       {
-        driver: createE2eDeepDriver({
-          launcher: createPooledE2eDeepLauncher(pool, logger),
-        }),
-        payloadToInput: createDeepPayloadToInput(),
+        driver: pooled.deep,
+        payloadToInput: createPayloadToInput(),
       },
     ],
     [
       E2E_DEMOS_DRIVER_KIND,
       {
-        driver: createE2eDemosDriver({
-          launcher: createPooledE2eDemosLauncher(pool, logger),
-        }),
-        payloadToInput: createDemosPayloadToInput(),
+        driver: pooled.demos,
+        payloadToInput: createPayloadToInput(),
       },
     ],
     [
       E2E_SMOKE_DRIVER_KIND,
       {
-        driver: createE2eSmokeDriver({
-          launcher: createPooledE2eSmokeLauncher(pool, logger),
-        }),
-        payloadToInput: createSmokePayloadToInput(),
+        driver: pooled.smoke,
+        payloadToInput: createPayloadToInput(),
       },
     ],
   ]);


### PR DESCRIPTION
## Summary

Generalizes the fleet pool-worker from a single hardwired d6 driver into a driver **registry** keyed by `payload.driverKind`, so a single worker can host all four browser driver families (`e2e_d6`, `e2e_deep`, `e2e_demos`, `e2e_smoke`). Phase-1 framework, item 3a of the harness fleet migration.

- **`worker-loop.ts`** now accepts `drivers: Map<string, { driver; payloadToInput }>` and dispatches each claimed job by `payload.driverKind`. An unknown kind returns a terminal `worker-protocol-violation` result (the same failure shape an unmappable payload uses) — the worker never crashes on an unhandled kind. The legacy single `driver`+`payloadToInput` pair is retained as a fallback (so the pre-registry behavior and all existing callers keep working), and construction fails loud if neither a non-empty registry nor the legacy pair is supplied.
- **`payload-mapper.ts`** generalizes `createD6PayloadToInput` into a shared `createPayloadToInput` plus per-kind aliases (`createDeepPayloadToInput`, `createDemosPayloadToInput`, `createSmokePayloadToInput`) and the four `E2E_*_DRIVER_KIND` constants. The re-hydration is identical across families; each driver's own zod schema is the validation gate.
- **`orchestrator.ts` `runWorker`** builds all four pooled drivers on the shared `BrowserPool` and registers them by kind (lifted from the legacy `registerAllProbeDrivers` pooled construction), then injects the registry into the fleet worker.
- **`fleet/orchestrator.ts` `runWorker`** threads an optional `drivers` registry through to `startWorkerLoop` (registry takes precedence; legacy single-driver and self-contained-boot paths preserved).

**d6 routing is unchanged** — equivalence is the gate.

## Test plan

- [x] Red→green: new tests fail against the reverted implementation, pass with it (verified by stashing the impl files and re-running).
- [x] worker-loop routing tests: `e2e_smoke`→smoke, `e2e_deep`→deep, `e2e_d6`→d6 (equivalence), unknown kind→`worker-protocol-violation`, matched-kind uses its own mapper, `startWorkerLoop` dispatches by kind end-to-end.
- [x] payload-mapper tests: four driver-kind constants, per-kind mapper re-hydration + key defaulting.
- [x] Full harness suite green: **2085 tests** across 119 files.
- [x] `tsc --noEmit` clean except the known pre-existing `toReversed` error (present on `main`).

Do NOT merge — pending 7-agent CR.